### PR TITLE
Added security to RPC and P2P systems.

### DIFF
--- a/core/src/main/kotlin/net/corda/flows/ValidatingNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ValidatingNotaryFlow.kt
@@ -21,11 +21,11 @@ class ValidatingNotaryFlow(otherSide: Party,
         NotaryFlow.Service(otherSide, timestampChecker, uniquenessProvider) {
 
     @Suspendable
-    override fun beforeCommit(stx: SignedTransaction, reqIdentity: Party) {
+    override fun beforeCommit(stx: SignedTransaction) {
         try {
             checkSignatures(stx)
             val wtx = stx.tx
-            resolveTransaction(reqIdentity, wtx)
+            resolveTransaction(wtx)
             wtx.toLedgerTransaction(serviceHub).verify()
         } catch (e: Exception) {
             when (e) {
@@ -45,7 +45,7 @@ class ValidatingNotaryFlow(otherSide: Party,
     }
 
     @Suspendable
-    private fun resolveTransaction(reqIdentity: Party, wtx: WireTransaction) {
-        subFlow(ResolveTransactionsFlow(wtx, reqIdentity))
+    private fun resolveTransaction(wtx: WireTransaction) {
+        subFlow(ResolveTransactionsFlow(wtx, otherSide))
     }
 }

--- a/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
@@ -145,7 +145,7 @@ class X509UtilitiesTest {
         val caCertAndKey = X509Utilities.loadCertificateAndKey(caKeyStore, "cakeypass", X509Utilities.CORDA_INTERMEDIATE_CA_PRIVATE_KEY)
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverkeypass", caKeyStore, "cakeypass")
+        X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverkeypass", caKeyStore, "cakeypass", "Mega Corp.")
 
         // Load back server certificate
         val serverKeyStore = X509Utilities.loadKeyStore(tmpServerKeyStore, "serverstorepass")
@@ -153,9 +153,8 @@ class X509UtilitiesTest {
 
         serverCertAndKey.certificate.checkValidity(Date())
         serverCertAndKey.certificate.verify(caCertAndKey.certificate.publicKey)
-        val host = InetAddress.getLocalHost()
 
-        assertTrue { serverCertAndKey.certificate.subjectDN.name.contains("CN=" + host.canonicalHostName) }
+        assertTrue { serverCertAndKey.certificate.subjectDN.name.contains("CN=Mega Corp.") }
 
         // Now sign something with private key and verify against certificate public key
         val testData = "123456".toByteArray()
@@ -183,7 +182,7 @@ class X509UtilitiesTest {
                 "trustpass")
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        val keyStore = X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverstorepass", caKeyStore, "cakeypass")
+        val keyStore = X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverstorepass", caKeyStore, "cakeypass", "Mega Corp.")
         val trustStore = X509Utilities.loadKeyStore(tmpTrustStore, "trustpass")
 
         val context = SSLContext.getInstance("TLS")
@@ -257,8 +256,7 @@ class X509UtilitiesTest {
         val peerX500Principal = (peerChain[0] as X509Certificate).subjectX500Principal
         val x500name = X500Name(peerX500Principal.name)
         val cn = x500name.getRDNs(BCStyle.CN).first().first.value.toString()
-        val hostname = InetAddress.getLocalHost().canonicalHostName
-        assertEquals(hostname, cn)
+        assertEquals("Mega Corp.", cn)
 
 
         val output = DataOutputStream(clientSocket.outputStream)

--- a/docs/source/messaging.rst
+++ b/docs/source/messaging.rst
@@ -17,15 +17,6 @@ messaging subsystem directly. Instead you will build on top of the :doc:`flow fr
 which adds a layer on top of raw messaging to manage multi-step flows and let you think in terms of identities
 rather than specific network endpoints.
 
-Messaging types
----------------
-
-Every ``Message`` object has an associated *topic* and may have a *session ID*. These are wrapped in a ``TopicSession``.
-An implementation of ``MessagingService`` can be used to create messages and send them. You can get access to the
-messaging service via the ``ServiceHub`` object that is provided to your app. Endpoints on the network are
-identified at the lowest level using ``SingleMessageRecipient`` which may be e.g. an IP address, or in future
-versions perhaps a routing path through the network.
-
 .. _network-map-service:
 
 Network Map Service
@@ -49,3 +40,71 @@ The network map currently supports:
 * Suggesting a node providing a specific service, based on suitability for a contract and parties, for example suggesting
   an appropriate interest rates oracle for a interest rate swap contract. Currently no recommendation logic is in place.
   The code simply picks the first registered node that supports the required service.
+
+Message queues
+--------------
+
+The node makes use of various queues for its operation. The more important ones are described below. Others are used
+for maintenance and other minor purposes.
+
+:``p2p.inbound``
+    The node listens for messages sent from other peer nodes on this queue. Only clients who are authenticated to be
+    nodes on the same network are given permission to send. Messages which are routed internally are also sent to this
+    queue (e.g. two flows on the same node communicating with each other).
+
+:``internal.peers.$identity``
+     These are a set of private queues only available to the node which it uses to route messages destined to other peers.
+     The queue name ends in the base 58 encoding of the peer's identity key. There is at most one queue per peer. The broker
+     creates a bridge from this queue to the peer's ``p2p.inbound`` queue, using the network map service to lookup the
+     peer's network address.
+
+:``internal.networkmap``
+    This is another private queue just for the node which functions in a similar manner to the ``p2p.peers.*`` queues
+    except this is used to form a connection to the network map node. The node running the network map service is treated
+    differently as it provides information about the rest of the network.
+
+:``rpc.requests``
+     RPC clients send their requests here, and it's only open for sending by clients authenticated as RPC users.
+
+:``clients.$user.rpc.$random``
+     RPC clients are given permission to create a temporary queue incorporating their username (``$user``) and sole
+     permission to receive messages from it. RPC requests are required to include a random number (``$random``) from
+     which the node is able to construct the queue the user is listening on and send the response to that. This mechanism
+     prevents other users from being able listen in on the responses.
+
+Security
+--------
+
+Clients attempting to connect to the node's broker fall in one of four groups:
+
+# Anyone connecting with the username ``SystemUsers/Node`` is treated as the node hosting the broker, or a logical
+component of the node. The TLS certificate they provide must match the one broker has for the node. If that's the case
+they are given full access to all valid queues, otherwise they are rejected.
+
+# Anyone connecting with the username ``SystemUsers/Peer`` is treated as a peer on the same Corda network as the node. Their
+TLS root CA must be the same as the node's root CA - the root CA is the doorman of the network and having the same root CA
+implies we've been let in by the same doorman. If they are part of the same network then they are only given permission
+to send to our ``p2p.inbound`` queue, otherwise they are rejected.
+
+# Every other username is treated as a RPC user and authenticated against the node's list of valid RPC users. If that
+is successful then they are only given sufficient permission to perform RPC, otherwise they are rejected.
+
+# Clients connecting without a username and password are rejected.
+
+Artemis provides a feature of annotating each received message with the validated user. This allows the node's messaging
+service to provide authenticated messages to the rest of the system. For the first two client types described above the
+validated user is the X.500 subject DN of the client TLS certificate and we assume the common name is the legal name of
+the peer. This allows the flow framework to authentically determine the ``Party`` initiating a new flow. For RPC clients
+the validated user is the username itself and the RPC framework uses this to determine what permissions the user has.
+
+.. note:: ``Party`` lookup is currently done by the legal name which isn't guaranteed to be unique. A future version will
+use the full X.500 name as it can provide additional structures for uniqueness.
+
+Messaging types
+---------------
+
+Every ``Message`` object has an associated *topic* and may have a *session ID*. These are wrapped in a ``TopicSession``.
+An implementation of ``MessagingService`` can be used to create messages and send them. You can get access to the
+messaging service via the ``ServiceHub`` object that is provided to your app. Endpoints on the network are
+identified at the lowest level using ``SingleMessageRecipient`` which may be e.g. an IP address, or in future
+versions perhaps a routing path through the network.

--- a/docs/source/setting-up-a-corda-network.rst
+++ b/docs/source/setting-up-a-corda-network.rst
@@ -20,13 +20,8 @@ Setting up your own network
 Certificates
 ------------
 
-If two nodes are to communicate successfully then both need to have
-each other's root certificate in their truststores. The simplest way
-to achieve this is to have all nodes sign off of a single root.
-
-Later R3 will provide this root for production use, but for testing you
-can use ``certSigningRequestUtility.jar`` to generate a node
-certificate with a fixed test root:
+All nodes belonging to the same Corda network must have the same root CA. For testing purposes you can
+use ``certSigningRequestUtility.jar`` to generate a node certificate with a fixed test root:
 
 .. sourcecode:: bash
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -62,6 +62,7 @@ sourceSets {
 dependencies {
     compile project(':finance')
     testCompile project(':test-utils')
+    testCompile project(':client')
 
     compile "com.google.code.findbugs:jsr305:3.0.1"
 

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -1,0 +1,230 @@
+package net.corda.services.messaging
+
+import co.paralleluniverse.fibers.Suspendable
+import com.google.common.net.HostAndPort
+import net.corda.client.impl.CordaRPCClientImpl
+import net.corda.core.crypto.Party
+import net.corda.core.crypto.composite
+import net.corda.core.crypto.generateKeyPair
+import net.corda.core.flows.FlowLogic
+import net.corda.core.getOrThrow
+import net.corda.core.random63BitValue
+import net.corda.core.seconds
+import net.corda.node.internal.Node
+import net.corda.node.services.User
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.CLIENTS_PREFIX
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.NETWORK_MAP_ADDRESS
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.NOTIFICATIONS_ADDRESS
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.P2P_QUEUE
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.PEERS_PREFIX
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.RPC_REQUESTS_QUEUE
+import net.corda.node.services.messaging.CordaRPCOps
+import net.corda.node.services.messaging.NodeMessagingClient.Companion.RPC_QUEUE_REMOVALS_QUEUE
+import net.corda.testing.messaging.SimpleMQClient
+import net.corda.testing.node.NodeBasedTest
+import org.apache.activemq.artemis.api.core.ActiveMQNonExistentQueueException
+import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
+import org.apache.activemq.artemis.api.core.SimpleString
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.*
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Runs a series of MQ-related attacks against a node. Subclasses need to call [startAttacker] to connect
+ * the attacker to [alice].
+ */
+abstract class MQSecurityTest : NodeBasedTest() {
+    val rpcUser = User("user1", "pass", permissions = emptySet())
+    lateinit var alice: Node
+    lateinit var attacker: SimpleMQClient
+    private val clients = ArrayList<SimpleMQClient>()
+
+    @Before
+    fun start() {
+        alice = startNode("Alice", rpcUsers = extraRPCUsers + rpcUser)
+        attacker = SimpleMQClient(alice.configuration.artemisAddress)
+        startAttacker(attacker)
+    }
+
+    open val extraRPCUsers: List<User> get() = emptyList()
+
+    abstract fun startAttacker(attacker: SimpleMQClient)
+
+    @After
+    fun stopClients() {
+        clients.forEach { it.stop() }
+    }
+
+    @Test
+    fun `consume message from P2P queue`() {
+        assertConsumeAttackFails(P2P_QUEUE)
+    }
+
+    @Test
+    fun `consume message from peer queue`() {
+        val bobParty = startBobAndCommunicateWithAlice()
+        assertConsumeAttackFails("$PEERS_PREFIX${bobParty.owningKey.toBase58String()}")
+    }
+
+    @Test
+    fun `send message to peer address`() {
+        val bobParty = startBobAndCommunicateWithAlice()
+        assertSendAttackFails("$PEERS_PREFIX${bobParty.owningKey.toBase58String()}")
+    }
+
+    @Test
+    fun `create queue for unknown peer`() {
+        val invalidPeerQueue = "$PEERS_PREFIX${generateKeyPair().public.composite.toBase58String()}"
+        assertNonTempQueueCreationAttackFails(invalidPeerQueue, durable = true)
+        assertNonTempQueueCreationAttackFails(invalidPeerQueue, durable = false)
+        assertTempQueueCreationAttackFails(invalidPeerQueue)
+    }
+
+    @Test
+    fun `consume message from network map queue`() {
+        assertConsumeAttackFails(NETWORK_MAP_ADDRESS.toString())
+    }
+
+    @Test
+    fun `send message to network map address`() {
+        assertSendAttackFails(NETWORK_MAP_ADDRESS.toString())
+    }
+
+    @Test
+    fun `consume message from RPC requests queue`() {
+        assertConsumeAttackFails(RPC_REQUESTS_QUEUE)
+    }
+
+    @Test
+    fun `consume message from logged in user's RPC queue`() {
+        val user1Queue = loginToRPCAndGetClientQueue()
+        assertConsumeAttackFails(user1Queue)
+    }
+
+    @Test
+    fun `send message on logged in user's RPC address`() {
+        val user1Queue = loginToRPCAndGetClientQueue()
+        assertSendAttackFails(user1Queue)
+    }
+
+    @Test
+    fun `create queue for valid RPC user`() {
+        val user1Queue = "$CLIENTS_PREFIX${rpcUser.username}.rpc.${random63BitValue()}"
+        assertTempQueueCreationAttackFails(user1Queue)
+    }
+
+    @Test
+    fun `create queue for invalid RPC user`() {
+        val invalidRPCQueue = "$CLIENTS_PREFIX${random63BitValue()}.rpc.${random63BitValue()}"
+        assertTempQueueCreationAttackFails(invalidRPCQueue)
+    }
+
+    @Test
+    fun `consume message from RPC queue removals queue`() {
+        assertConsumeAttackFails(RPC_QUEUE_REMOVALS_QUEUE)
+    }
+
+    @Test
+    fun `send message to notifications address`() {
+        assertSendAttackFails(NOTIFICATIONS_ADDRESS)
+    }
+
+    @Test
+    fun `create random queue`() {
+        val randomQueue = random63BitValue().toString()
+        assertNonTempQueueCreationAttackFails(randomQueue, durable = false)
+        assertNonTempQueueCreationAttackFails(randomQueue, durable = true)
+        assertTempQueueCreationAttackFails(randomQueue)
+    }
+
+    fun clientTo(target: HostAndPort): SimpleMQClient {
+        val client = SimpleMQClient(target)
+        clients += client
+        return client
+    }
+
+    fun loginToRPC(target: HostAndPort, rpcUser: User): SimpleMQClient {
+        val client = clientTo(target)
+        client.loginToRPC(rpcUser)
+        return client
+    }
+
+    fun SimpleMQClient.loginToRPC(rpcUser: User): CordaRPCOps {
+        start(rpcUser.username, rpcUser.password)
+        val clientImpl = CordaRPCClientImpl(session, ReentrantLock(), rpcUser.username)
+        return clientImpl.proxyFor(CordaRPCOps::class.java, timeout = 1.seconds)
+    }
+
+    fun loginToRPCAndGetClientQueue(): String {
+        val rpcClient = loginToRPC(alice.configuration.artemisAddress, rpcUser)
+        val clientQueueQuery = SimpleString("$CLIENTS_PREFIX${rpcUser.username}.rpc.*")
+        return rpcClient.session.addressQuery(clientQueueQuery).queueNames.single().toString()
+    }
+
+    fun assertTempQueueCreationAttackFails(queue: String) {
+        assertAttackFails(queue, "CREATE_NON_DURABLE_QUEUE") {
+            attacker.session.createTemporaryQueue(queue, queue)
+        }
+        // Double-check
+        assertThatExceptionOfType(ActiveMQNonExistentQueueException::class.java).isThrownBy {
+            attacker.session.createConsumer(queue)
+        }
+    }
+
+    fun assertNonTempQueueCreationAttackFails(queue: String, durable: Boolean) {
+        val permission = if (durable) "CREATE_DURABLE_QUEUE" else "CREATE_NON_DURABLE_QUEUE"
+        assertAttackFails(queue, permission) {
+            attacker.session.createQueue(queue, queue, durable)
+        }
+        // Double-check
+        assertThatExceptionOfType(ActiveMQNonExistentQueueException::class.java).isThrownBy {
+            attacker.session.createConsumer(queue)
+        }
+    }
+
+    fun assertSendAttackFails(address: String) {
+        val message = attacker.createMessage()
+        assertAttackFails(address, "SEND") {
+            attacker.producer.send(address, message)
+        }
+        // TODO Make sure no actual message is received
+    }
+
+    fun assertConsumeAttackFails(queue: String) {
+        assertAttackFails(queue, "CONSUME") {
+            attacker.session.createConsumer(queue)
+        }
+        assertAttackFails(queue, "BROWSE") {
+            attacker.session.createConsumer(queue, true)
+        }
+    }
+
+    fun assertAttackFails(queue: String, permission: String, attack: () -> Unit) {
+        assertThatExceptionOfType(ActiveMQSecurityException::class.java)
+                .isThrownBy(attack)
+                .withMessageContaining(queue)
+                .withMessageContaining(permission)
+    }
+
+    private fun startBobAndCommunicateWithAlice(): Party {
+        val bob = startNode("Bob")
+        bob.services.registerFlowInitiator(SendFlow::class, ::ReceiveFlow)
+        val bobParty = bob.info.legalIdentity
+        // Perform a protocol exchange to force the peer queue to be created
+        alice.services.startFlow(SendFlow(bobParty, 0)).resultFuture.getOrThrow()
+        return bobParty
+    }
+
+    private class SendFlow(val otherParty: Party, val payload: Any) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() = send(otherParty, payload)
+    }
+
+    private class ReceiveFlow(val otherParty: Party) : FlowLogic<Any>() {
+        @Suspendable
+        override fun call() = receive<Any>(otherParty).unwrap { it }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
@@ -1,0 +1,53 @@
+package net.corda.services.messaging
+
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.NODE_USER
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.PEER_USER
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.RPC_REQUESTS_QUEUE
+import net.corda.testing.messaging.SimpleMQClient
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration
+import org.apache.activemq.artemis.api.core.ActiveMQClusterSecurityException
+import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Test
+
+/**
+ * Runs the security tests with the attacker pretending to be a node on the network.
+ */
+class P2PSecurityTest : MQSecurityTest() {
+
+    override fun startAttacker(attacker: SimpleMQClient) {
+        attacker.start(PEER_USER, PEER_USER)  // Login as a peer
+    }
+
+    @Test
+    fun `send message to RPC requests address`() {
+        assertSendAttackFails(RPC_REQUESTS_QUEUE)
+    }
+
+    @Test
+    fun `only the node running the broker can login using the special node user`() {
+        val attacker = SimpleMQClient(alice.configuration.artemisAddress)
+        assertThatExceptionOfType(ActiveMQSecurityException::class.java).isThrownBy {
+            attacker.start(NODE_USER, NODE_USER)
+        }
+        attacker.stop()
+    }
+
+    @Test
+    fun `login as the default cluster user`() {
+        val attacker = SimpleMQClient(alice.configuration.artemisAddress)
+        assertThatExceptionOfType(ActiveMQClusterSecurityException::class.java).isThrownBy {
+            attacker.start(ActiveMQDefaultConfiguration.getDefaultClusterUser(), ActiveMQDefaultConfiguration.getDefaultClusterPassword())
+        }
+        attacker.stop()
+    }
+
+    @Test
+    fun `login without a username and password`() {
+        val attacker = SimpleMQClient(alice.configuration.artemisAddress)
+        assertThatExceptionOfType(ActiveMQSecurityException::class.java).isThrownBy {
+            attacker.start()
+        }
+        attacker.stop()
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/RPCSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/RPCSecurityTest.kt
@@ -1,0 +1,15 @@
+package net.corda.services.messaging
+
+import net.corda.node.services.User
+import net.corda.testing.messaging.SimpleMQClient
+
+/**
+ * Runs the security tests with the attacker being a valid RPC user of Alice.
+ */
+class RPCSecurityTest : MQSecurityTest() {
+    override val extraRPCUsers = listOf(User("evil", "pass", permissions = emptySet()))
+
+    override fun startAttacker(attacker: SimpleMQClient) {
+        attacker.loginToRPC(extraRPCUsers[0])
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -100,7 +100,9 @@ inline fun <reified T : Any> Config.getListOrElse(path: String, default: Config.
  * Strictly for dev only automatically construct a server certificate/private key signed from
  * the CA certs in Node resources. Then provision KeyStores into certificates folder under node path.
  */
-fun NodeSSLConfiguration.configureWithDevSSLCertificate() {
+fun NodeConfiguration.configureWithDevSSLCertificate() = configureDevKeyAndTrustStores(myLegalName)
+
+private fun NodeSSLConfiguration.configureDevKeyAndTrustStores(myLegalName: String) {
     certificatesPath.createDirectories()
     if (!trustStorePath.exists()) {
         javaClass.classLoader.getResourceAsStream("net/corda/node/internal/certificates/cordatruststore.jks").copyTo(trustStorePath)
@@ -109,7 +111,7 @@ fun NodeSSLConfiguration.configureWithDevSSLCertificate() {
         val caKeyStore = X509Utilities.loadKeyStore(
                 javaClass.classLoader.getResourceAsStream("net/corda/node/internal/certificates/cordadevcakeys.jks"),
                 "cordacadevpass")
-        X509Utilities.createKeystoreForSSL(keyStorePath, keyStorePassword, keyStorePassword, caKeyStore, "cordacadevkeypass")
+        X509Utilities.createKeystoreForSSL(keyStorePath, keyStorePassword, keyStorePassword, caKeyStore, "cordacadevkeypass", myLegalName)
     }
 }
 
@@ -120,6 +122,6 @@ fun configureTestSSL(): NodeSSLConfiguration = object : NodeSSLConfiguration {
     override val trustStorePassword: String get() = "trustpass"
 
     init {
-        configureWithDevSSLCertificate()
+        configureDevKeyAndTrustStores("Mega Corp.")
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -4,14 +4,23 @@ import com.google.common.net.HostAndPort
 import net.corda.core.ThreadBox
 import net.corda.core.crypto.AddressFormatException
 import net.corda.core.crypto.CompositeKey
+import net.corda.core.crypto.X509Utilities
+import net.corda.core.crypto.X509Utilities.CORDA_CLIENT_CA
+import net.corda.core.crypto.X509Utilities.CORDA_ROOT_CA
+import net.corda.core.crypto.newSecureRandom
 import net.corda.core.div
-import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.services.NetworkMapCache
+import net.corda.core.node.services.NetworkMapCache.MapChangeType
+import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import net.corda.node.printBasicNodeInfo
 import net.corda.node.services.RPCUserService
 import net.corda.node.services.config.NodeConfiguration
-import net.corda.node.services.messaging.ArtemisMessagingServer.NodeLoginModule.Companion.NODE_USER
+import net.corda.node.services.messaging.ArtemisMessagingComponent.ConnectionDirection.INBOUND
+import net.corda.node.services.messaging.ArtemisMessagingComponent.ConnectionDirection.OUTBOUND
+import net.corda.node.services.messaging.ArtemisMessagingServer.NodeLoginModule.Companion.NODE_ROLE
+import net.corda.node.services.messaging.ArtemisMessagingServer.NodeLoginModule.Companion.PEER_ROLE
+import net.corda.node.services.messaging.ArtemisMessagingServer.NodeLoginModule.Companion.RPC_ROLE
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.core.config.BridgeConfiguration
 import org.apache.activemq.artemis.core.config.Configuration
@@ -21,11 +30,14 @@ import org.apache.activemq.artemis.core.security.Role
 import org.apache.activemq.artemis.core.server.ActiveMQServer
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager
+import org.apache.activemq.artemis.spi.core.security.jaas.CertificateCallback
 import org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal
 import org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal
 import rx.Subscription
 import java.io.IOException
+import java.math.BigInteger
 import java.security.Principal
+import java.security.PublicKey
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
 import javax.security.auth.Subject
@@ -55,10 +67,8 @@ import javax.security.auth.spi.LoginModule
 @ThreadSafe
 class ArtemisMessagingServer(override val config: NodeConfiguration,
                              val myHostPort: HostAndPort,
-                             val myIdentity: CompositeKey?,
                              val networkMapCache: NetworkMapCache,
                              val userService: RPCUserService) : ArtemisMessagingComponent() {
-
     companion object {
         private val log = loggerFor<ArtemisMessagingServer>()
     }
@@ -70,7 +80,6 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
     private val mutex = ThreadBox(InnerState())
     private lateinit var activeMQServer: ActiveMQServer
     private var networkChangeHandle: Subscription? = null
-    private val myQueueName = toQueueName(toMyAddress(myIdentity, myHostPort))
 
     init {
         config.basedir.expectedOnDefaultFileSystem()
@@ -79,7 +88,7 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
     fun start() = mutex.locked {
         if (!running) {
             configureAndStartServer()
-            networkChangeHandle = networkMapCache.changed.subscribe { onNetworkChange(it) }
+            networkChangeHandle = networkMapCache.changed.subscribe { destroyPossibleStaleBridge(it) }
             running = true
         }
     }
@@ -91,50 +100,29 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
         running = false
     }
 
-    fun bridgeToNetworkMapService(networkMapService: SingleMessageRecipient?) {
-        if ((networkMapService != null) && (networkMapService is NetworkMapAddress)) {
-            val query = activeMQServer.queueQuery(NETWORK_MAP_ADDRESS)
-            if (!query.isExists) {
-                activeMQServer.createQueue(NETWORK_MAP_ADDRESS, NETWORK_MAP_ADDRESS, null, true, false)
-            }
-
-            maybeDeployBridgeForAddress(NETWORK_MAP_ADDRESS, networkMapService)
+    fun bridgeToNetworkMapService(networkMapService: NetworkMapAddress) {
+        val query = activeMQServer.queueQuery(NETWORK_MAP_ADDRESS)
+        if (!query.isExists) {
+            activeMQServer.createQueue(NETWORK_MAP_ADDRESS, NETWORK_MAP_ADDRESS, null, true, false)
         }
+        maybeDeployBridgeForAddress(networkMapService)
     }
 
-    private fun onNetworkChange(change: NetworkMapCache.MapChange) {
-        val address = change.node.address
-        if (address is ArtemisMessagingComponent.ArtemisAddress) {
-            val queueName = address.queueName
-            when (change.type) {
-                NetworkMapCache.MapChangeType.Added -> {
-                    val query = activeMQServer.queueQuery(queueName)
-                    if (query.isExists) {
-                        // Queue exists so now wire up bridge
-                        maybeDeployBridgeForAddress(queueName, change.node.address)
-                    }
-                }
+    private fun destroyPossibleStaleBridge(change: NetworkMapCache.MapChange) {
+        fun removePreviousBridge() {
+            (change.prevNodeInfo?.address as? ArtemisAddress)?.let {
+                maybeDestroyBridge(it.queueName)
+            }
+        }
 
-                NetworkMapCache.MapChangeType.Modified -> {
-                    (change.prevNodeInfo?.address as? ArtemisMessagingComponent.ArtemisAddress)?.let {
-                        // remove any previous possibly different bridge
-                        maybeDestroyBridge(it.queueName)
-                    }
-                    val query = activeMQServer.queueQuery(queueName)
-                    if (query.isExists) {
-                        // Deploy new bridge
-                        maybeDeployBridgeForAddress(queueName, change.node.address)
-                    }
-                }
-
-                NetworkMapCache.MapChangeType.Removed -> {
-                    (change.prevNodeInfo?.address as? ArtemisMessagingComponent.ArtemisAddress)?.let {
-                        // Remove old bridge
-                        maybeDestroyBridge(it.queueName)
-                    }
-                    // just in case of NetworkMapCache version issues
-                    maybeDestroyBridge(queueName)
-                }
+        if (change.type == MapChangeType.Modified) {
+            removePreviousBridge()
+        } else if (change.type == MapChangeType.Removed) {
+            removePreviousBridge()
+            // TODO Fix the network map change data classes so that the remove event doesn't have two NodeInfo fields
+            val address = change.node.address
+            if (address is ArtemisAddress) {
+                maybeDestroyBridge(address.queueName)
             }
         }
     }
@@ -142,71 +130,75 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
     private fun configureAndStartServer() {
         val config = createArtemisConfig()
         val securityManager = createArtemisSecurityManager()
-
         activeMQServer = ActiveMQServerImpl(config, securityManager).apply {
             // Throw any exceptions which are detected during startup
             registerActivationFailureListener { exception -> throw exception }
-
             // Some types of queue might need special preparation on our side, like dialling back or preparing
             // a lazily initialised subsystem.
-            registerPostQueueCreationCallback { queueName ->
-                log.debug("Queue created: $queueName")
-                if (queueName.startsWith(PEERS_PREFIX) && queueName != NETWORK_MAP_ADDRESS && queueName != myQueueName) {
-                    try {
-                        val identity = parseKeyFromQueueName(queueName.toString())
-                        val nodeInfo = networkMapCache.getNodeByCompositeKey(identity)
-                        if (nodeInfo != null) {
-                            maybeDeployBridgeForAddress(queueName, nodeInfo.address)
-                        } else {
-                            log.error("Queue created for a peer that we don't know from the network map: $queueName")
-                        }
-                    } catch (e: AddressFormatException) {
-                        log.error("Flow violation: Could not parse queue name as Base 58: $queueName")
-                    }
-                }
-            }
-
-            registerPostQueueDeletionCallback { address, qName ->
-                if (qName == address)
-                    log.debug("Queue deleted: $qName")
-                else
-                    log.debug("Queue deleted: $qName for $address")
-            }
+            registerPostQueueCreationCallback { deployBridgeFromNewPeerQueue(it) }
+            registerPostQueueDeletionCallback { address, qName -> log.debug { "Queue deleted: $qName for $address" } }
         }
         activeMQServer.start()
         printBasicNodeInfo("Node listening on address", myHostPort.toString())
+    }
+
+    private fun deployBridgeFromNewPeerQueue(queueName: SimpleString) {
+        log.debug { "Queue created: $queueName" }
+        if (!queueName.startsWith(PEERS_PREFIX)) return
+        try {
+            val identity = CompositeKey.parseFromBase58(queueName.substring(PEERS_PREFIX.length))
+            val nodeInfo = networkMapCache.getNodeByCompositeKey(identity)
+            if (nodeInfo != null) {
+                val address = nodeInfo.address
+                if (address is NodeAddress) {
+                    maybeDeployBridgeForAddress(address)
+                } else {
+                    log.error("Don't know how to deal with $address")
+                }
+            } else {
+                log.error("Queue created for a peer that we don't know from the network map: $queueName")
+            }
+        } catch (e: AddressFormatException) {
+            log.error("Flow violation: Could not parse queue name as Base 58: $queueName")
+        }
     }
 
     private fun createArtemisConfig(): Configuration = ConfigurationImpl().apply {
         val artemisDir = config.basedir / "artemis"
         bindingsDirectory = (artemisDir / "bindings").toString()
         journalDirectory = (artemisDir / "journal").toString()
-        largeMessagesDirectory = (artemisDir / "largemessages").toString()
-        acceptorConfigurations = setOf(
-                tcpTransport(ConnectionDirection.INBOUND, "0.0.0.0", myHostPort.port)
-        )
+        largeMessagesDirectory = (artemisDir / "large-messages").toString()
+        acceptorConfigurations = setOf(tcpTransport(INBOUND, "0.0.0.0", myHostPort.port))
         // Enable built in message deduplication. Note we still have to do our own as the delayed commits
         // and our own definition of commit mean that the built in deduplication cannot remove all duplicates.
         idCacheSize = 2000 // Artemis Default duplicate cache size i.e. a guess
         isPersistIDCache = true
         isPopulateValidatedUser = true
-        configureQueueSecurity()
+        managementNotificationAddress = SimpleString(NOTIFICATIONS_ADDRESS)
+        // Artemis allows multiple servers to be grouped together into a cluster for load balancing purposes. The cluster
+        // user is used for connecting the nodes together. It has super-user privileges and so it's imperative that its
+        // password is changed from the default (as warned in the docs). Since we don't need this feature we turn it off
+        // by having its password be an unknown securely random 128-bit value.
+        clusterPassword = BigInteger(128, newSecureRandom()).toString(16)
+        configureAddressSecurity()
     }
 
-    private fun ConfigurationImpl.configureQueueSecurity() {
-        val nodeRPCSendRole = restrictedRole(NODE_USER, send = true)  // The node needs to be able to send responses on the client queues
-
+    /**
+     * Authenticated clients connecting to us fall in one of three groups:
+     * 1. The node hosting us and any of its logically connected components. These are given full access to all valid queues.
+     * 2. Peers on the same network as us. These are only given permission to send to our P2P inbound queue.
+     * 3. RPC users. These are only given sufficient access to perform RPC with us.
+     */
+    private fun ConfigurationImpl.configureAddressSecurity() {
+        val nodeInternalRole = Role(NODE_ROLE, true, true, true, true, true, true, true, true)
+        securityRoles["$INTERNAL_PREFIX#"] = setOf(nodeInternalRole)  // Do not add any other roles here as it's only for the node
+        securityRoles[P2P_QUEUE] = setOf(nodeInternalRole, restrictedRole(PEER_ROLE, send = true))
+        securityRoles[RPC_REQUESTS_QUEUE] = setOf(nodeInternalRole, restrictedRole(RPC_ROLE, send = true))
         for ((username) in userService.users) {
-            // Clients need to be able to consume the responses on their queues, and they're also responsible for creating and destroying them
-            val clientRole = restrictedRole(username, consume = true, createNonDurableQueue = true, deleteNonDurableQueue = true)
-            securityRoles["$CLIENTS_PREFIX$username.rpc.*"] = setOf(nodeRPCSendRole, clientRole)
+            securityRoles["$CLIENTS_PREFIX$username.rpc.*"] = setOf(
+                    nodeInternalRole,
+                    restrictedRole("$CLIENTS_PREFIX$username", consume = true, createNonDurableQueue = true, deleteNonDurableQueue = true))
         }
-
-        // TODO Restrict this down to just what the node needs
-        securityRoles["#"] = setOf(Role(NODE_USER, true, true, true, true, true, true, true, true))
-        securityRoles[RPC_REQUESTS_QUEUE] = setOf(
-                restrictedRole(NODE_USER, createNonDurableQueue = true, deleteNonDurableQueue = true),
-                restrictedRole(RPC_REQUESTS_QUEUE, send = true))  // Clients need to be able to send their requests
     }
 
     private fun restrictedRole(name: String, send: Boolean = false, consume: Boolean = false, createDurableQueue: Boolean = false,
@@ -217,14 +209,22 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
     }
 
     private fun createArtemisSecurityManager(): ActiveMQJAASSecurityManager {
+        val ourRootCAPublicKey = X509Utilities
+                .loadCertificateFromKeyStore(config.trustStorePath, config.trustStorePassword, CORDA_ROOT_CA)
+                .publicKey
+        val ourPublicKey = X509Utilities
+                .loadCertificateFromKeyStore(config.keyStorePath, config.keyStorePassword, CORDA_CLIENT_CA)
+                .publicKey
         val securityConfig = object : SecurityConfiguration() {
             // Override to make it work with our login module
             override fun getAppConfigurationEntry(name: String): Array<AppConfigurationEntry> {
-                val options = mapOf(RPCUserService::class.java.name to userService)
+                val options = mapOf(
+                        RPCUserService::class.java.name to userService,
+                        CORDA_ROOT_CA to ourRootCAPublicKey,
+                        CORDA_CLIENT_CA to ourPublicKey)
                 return arrayOf(AppConfigurationEntry(name, REQUIRED, options))
             }
         }
-
         return ActiveMQJAASSecurityManager(NodeLoginModule::class.java.name, securityConfig)
     }
 
@@ -232,39 +232,39 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
 
     private fun addConnector(hostAndPort: HostAndPort) = activeMQServer.configuration.addConnectorConfiguration(
             hostAndPort.toString(),
-            tcpTransport(
-                    ConnectionDirection.OUTBOUND,
-                    hostAndPort.hostText,
-                    hostAndPort.port
-            )
+            tcpTransport(OUTBOUND, hostAndPort.hostText, hostAndPort.port)
     )
 
     private fun bridgeExists(name: SimpleString) = activeMQServer.clusterManager.bridges.containsKey(name.toString())
 
-    private fun deployBridge(hostAndPort: HostAndPort, name: String) {
-        activeMQServer.deployBridge(BridgeConfiguration().apply {
-            setName(name)
-            queueName = name
-            forwardingAddress = name
-            staticConnectors = listOf(hostAndPort.toString())
-            confirmationWindowSize = 100000 // a guess
-            isUseDuplicateDetection = true // Enable the bridges automatic deduplication logic
-        })
+    private fun maybeDeployBridgeForAddress(address: ArtemisAddress) {
+        if (!connectorExists(address.hostAndPort)) {
+            addConnector(address.hostAndPort)
+        }
+        if (!bridgeExists(address.queueName)) {
+            deployBridge(address)
+        }
     }
 
     /**
-     * For every queue created we need to have a bridge deployed in case the address of the queue
-     * is that of a remote party.
+     * All nodes are expected to have a public facing address called [ArtemisMessagingComponent.P2P_QUEUE] for receiving
+     * messages from other nodes. When we want to send a message to a node we send it to our internal address/queue for it,
+     * as defined by ArtemisAddress.queueName. A bridge is then created to forward messages from this queue to the node's
+     * P2P address.
      */
-    private fun maybeDeployBridgeForAddress(name: SimpleString, nodeInfo: SingleMessageRecipient) {
-        require(name.startsWith(PEERS_PREFIX))
-        val hostAndPort = toHostAndPort(nodeInfo)
-        if (hostAndPort == myHostPort)
-            return
-        if (!connectorExists(hostAndPort))
-            addConnector(hostAndPort)
-        if (!bridgeExists(name))
-            deployBridge(hostAndPort, name.toString())
+    private fun deployBridge(address: ArtemisAddress) {
+        activeMQServer.deployBridge(BridgeConfiguration().apply {
+            name = address.queueName.toString()
+            queueName = address.queueName.toString()
+            forwardingAddress = P2P_QUEUE
+            staticConnectors = listOf(address.hostAndPort.toString())
+            confirmationWindowSize = 100000 // a guess
+            isUseDuplicateDetection = true // Enable the bridge's automatic deduplication logic
+            // As a peer of the target node we must connect to it using the peer user. Actual authentication is done using
+            // our TLS certificate.
+            user = PEER_USER
+            password = PEER_USER
+        })
     }
 
     private fun maybeDestroyBridge(name: SimpleString) {
@@ -273,52 +273,89 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
         }
     }
 
-
-    // We could have used the built-in PropertiesLoginModule but that exposes a roles properties file. Roles are used
-    // for queue access control and our RPC users must only have access to the queues they need and this cannot be allowed
-    // to be modified.
+    /**
+     * Clients must connect to us with a username and password and must use TLS. If a someone connects with
+     * [ArtemisMessagingComponent.NODE_USER] then we confirm it's just us as the node by checking their TLS certificate
+     * is the same as our one in our key store. Then they're given full access to all valid queues. If they connect with
+     * [ArtemisMessagingComponent.PEER_USER] then we confirm they belong on our P2P network by checking their root CA is
+     * the same as our root CA. If that's the case the only access they're given is the ablility send to our P2P address.
+     * In both cases the messages these authenticated nodes send to us are tagged with their subject DN and we assume
+     * the CN within that is their legal name.
+     * Otherwise if the username is neither of the above we assume it's an RPC user and authenticate against our list of
+     * valid RPC users. RPC clients are given permission to perform RPC and nothing else.
+     */
     class NodeLoginModule : LoginModule {
 
         companion object {
-            const val NODE_USER = "Node"
+            // Include forbidden username character to prevent name clash with any RPC usernames
+            const val PEER_ROLE = "SystemRoles/Peer"
+            const val NODE_ROLE = "SystemRoles/Node"
+            const val RPC_ROLE = "SystemRoles/RPC"
         }
 
         private var loginSucceeded: Boolean = false
         private lateinit var subject: Subject
         private lateinit var callbackHandler: CallbackHandler
         private lateinit var userService: RPCUserService
+        private lateinit var ourRootCAPublicKey: PublicKey
+        private lateinit var ourPublicKey: PublicKey
         private val principals = ArrayList<Principal>()
 
         override fun initialize(subject: Subject, callbackHandler: CallbackHandler, sharedState: Map<String, *>, options: Map<String, *>) {
             this.subject = subject
             this.callbackHandler = callbackHandler
             userService = options[RPCUserService::class.java.name] as RPCUserService
+            ourRootCAPublicKey = options[CORDA_ROOT_CA] as PublicKey
+            ourPublicKey = options[CORDA_CLIENT_CA] as PublicKey
         }
 
         override fun login(): Boolean {
             val nameCallback = NameCallback("Username: ")
             val passwordCallback = PasswordCallback("Password: ", false)
+            val certificateCallback = CertificateCallback()
 
             try {
-                callbackHandler.handle(arrayOf(nameCallback, passwordCallback))
+                callbackHandler.handle(arrayOf(nameCallback, passwordCallback, certificateCallback))
             } catch (e: IOException) {
                 throw LoginException(e.message)
             } catch (e: UnsupportedCallbackException) {
                 throw LoginException("${e.message} not available to obtain information from user")
             }
 
-            val username = nameCallback.name ?: throw FailedLoginException("User name is null")
-            val receivedPassword = passwordCallback.password ?: throw FailedLoginException("Password is null")
-            val password = if (username == NODE_USER) "Node" else userService.getUser(username)?.password ?: throw FailedLoginException("User does not exist")
-            if (password != String(receivedPassword)) {
-                throw FailedLoginException("Password does not match")
+            val username = nameCallback.name ?: throw FailedLoginException("Username not provided")
+            val password = String(passwordCallback.password ?: throw FailedLoginException("Password not provided"))
+
+            val validatedUser = if (username == PEER_USER || username == NODE_USER) {
+                val certificates = certificateCallback.certificates ?: throw FailedLoginException("No TLS?")
+                val peerCertificate = certificates.first()
+                val role = if (username == NODE_USER) {
+                    if (peerCertificate.publicKey != ourPublicKey) {
+                        throw FailedLoginException("Only the node can login as $NODE_USER")
+                    }
+                    NODE_ROLE
+                } else {
+                    val theirRootCAPublicKey = certificates.last().publicKey
+                    if (theirRootCAPublicKey != ourRootCAPublicKey) {
+                        throw FailedLoginException("Peer does not belong on our network. Their root CA: $theirRootCAPublicKey")
+                    }
+                    PEER_ROLE  // This enables the peer to send to our P2P address
+                }
+                principals += RolePrincipal(role)
+                peerCertificate.subjectDN.name
+            } else {
+                // Otherwise assume they're an RPC user
+                val rpcUser = userService.getUser(username) ?: throw FailedLoginException("User does not exist")
+                if (password != rpcUser.password) {
+                    // TODO Switch to hashed passwords
+                    // TODO Retrieve client IP address to include in exception message
+                    throw FailedLoginException("Password for user $username does not match")
+                }
+                principals += RolePrincipal(RPC_ROLE)  // This enables the RPC client to send requests
+                principals += RolePrincipal("$CLIENTS_PREFIX$username")  // This enables the RPC client to receive responses
+                username
             }
 
-            principals += UserPrincipal(username)
-            principals += RolePrincipal(username)  // The roles are configured using the usernames
-            if (username != NODE_USER) {
-                principals += RolePrincipal(RPC_REQUESTS_QUEUE)  // This enables the RPC client to send requests
-            }
+            principals += UserPrincipal(validatedUser)
 
             loginSucceeded = true
             return loginSucceeded
@@ -347,5 +384,4 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
             loginSucceeded = false
         }
     }
-
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -196,7 +196,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
         val session = FlowSession(sessionFlow, nodeIdentity, random63BitValue(), null)
         openSessions[Pair(sessionFlow, nodeIdentity)] = session
         val counterpartyFlow = sessionFlow.getCounterpartyMarker(nodeIdentity).name
-        val sessionInit = SessionInit(session.ourSessionId, serviceHub.myInfo.legalIdentity, counterpartyFlow, firstPayload)
+        val sessionInit = SessionInit(session.ourSessionId, counterpartyFlow, firstPayload)
         val sessionInitResponse = sendAndReceiveInternal<SessionInitResponse>(session, sessionInit)
         if (sessionInitResponse is SessionConfirm) {
             session.otherPartySessionId = sessionInitResponse.initiatedSessionId

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -211,7 +211,18 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
             val sessionMessage = message.data.deserialize<SessionMessage>()
             when (sessionMessage) {
                 is ExistingSessionMessage -> onExistingSessionMessage(sessionMessage)
-                is SessionInit -> onSessionInit(sessionMessage)
+                is SessionInit -> {
+                    // TODO SECURITY Look up the party with the full X.500 name instead of just the legal name which
+                    // isn't required to be unique
+                    // TODO For now have the doorman block signups with identical names, and names with characters that
+                    // are used in X.500 name textual serialisation
+                    val otherParty = serviceHub.networkMapCache.getNodeByLegalName(message.peerLegalName)?.legalIdentity
+                    if (otherParty != null) {
+                        onSessionInit(sessionMessage, otherParty)
+                    } else {
+                        logger.error("Unknown peer ${message.peer} in $sessionMessage")
+                    }
+                }
             }
         }
     }
@@ -254,10 +265,8 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         }
     }
 
-    private fun onSessionInit(sessionInit: SessionInit) {
-        logger.trace { "Received $sessionInit" }
-        //TODO Verify the other party are who they say they are from the TLS subsystem
-        val otherParty = sessionInit.initiatorParty
+    private fun onSessionInit(sessionInit: SessionInit, otherParty: Party) {
+        logger.trace { "Received $sessionInit $otherParty" }
         val otherPartySessionId = sessionInit.initiatorSessionId
         try {
             val markerClass = Class.forName(sessionInit.flowName)
@@ -446,10 +455,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         val recipientSessionId: Long
     }
 
-    data class SessionInit(val initiatorSessionId: Long,
-                           val initiatorParty: Party,
-                           val flowName: String,
-                           val firstPayload: Any?) : SessionMessage
+    data class SessionInit(val initiatorSessionId: Long, val flowName: String, val firstPayload: Any?) : SessionMessage
 
     interface SessionInitResponse : ExistingSessionMessage
 

--- a/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/InMemoryMessagingTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("UNUSED_VARIABLE")
-
 package net.corda.node.messaging
 
 import net.corda.core.messaging.Message
@@ -9,7 +7,6 @@ import net.corda.core.node.services.DEFAULT_SESSION_ID
 import net.corda.core.node.services.ServiceInfo
 import net.corda.node.services.network.NetworkMapService
 import net.corda.testing.node.MockNetwork
-import org.junit.Before
 import org.junit.Test
 import java.util.*
 import kotlin.test.assertEquals
@@ -17,12 +14,7 @@ import kotlin.test.assertFails
 import kotlin.test.assertTrue
 
 class InMemoryMessagingTests {
-    lateinit var network: MockNetwork
-
-    @Before
-    fun setUp() {
-        network = MockNetwork()
-    }
+    val network = MockNetwork()
 
     @Test
     fun topicStringValidation() {
@@ -115,6 +107,5 @@ class InMemoryMessagingTests {
         node2.net.send(validMessage2, node1.net.myAddress)
         network.runNetwork()
         assertEquals(2, received)
-
     }
 }

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/NetworkMapVisualiser.kt
@@ -109,7 +109,7 @@ class NetworkMapVisualiser : Application() {
         }
         // Fire the message bullets between nodes.
         simulation.network.messagingNetwork.sentMessages.observeOn(uiThread).subscribe { msg: InMemoryMessagingNetwork.MessageTransfer ->
-            val senderNode: MockNetwork.MockNode = simulation.network.addressToNode(msg.sender.myAddress)
+            val senderNode: MockNetwork.MockNode = simulation.network.addressToNode(msg.sender)
             val destNode: MockNetwork.MockNode = simulation.network.addressToNode(msg.recipients as SingleMessageRecipient)
 
             if (transferIsInteresting(msg)) {
@@ -345,7 +345,7 @@ class NetworkMapVisualiser : Application() {
 
     private fun transferIsInteresting(transfer: InMemoryMessagingNetwork.MessageTransfer): Boolean {
         // Loopback messages are boring.
-        if (transfer.sender.myAddress == transfer.recipients) return false
+        if (transfer.sender == transfer.recipients) return false
         // Network map push acknowledgements are boring.
         if (NetworkMapService.PUSH_ACK_FLOW_TOPIC in transfer.message.topicSession.topic) return false
         val message = transfer.message.data.deserialize<Any>()

--- a/test-utils/src/main/kotlin/net/corda/testing/messaging/SimpleMQClient.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/messaging/SimpleMQClient.kt
@@ -1,0 +1,36 @@
+package net.corda.testing.messaging
+
+import com.google.common.net.HostAndPort
+import net.corda.node.services.config.NodeSSLConfiguration
+import net.corda.node.services.config.configureTestSSL
+import net.corda.node.services.messaging.ArtemisMessagingComponent
+import net.corda.node.services.messaging.ArtemisMessagingComponent.ConnectionDirection.OUTBOUND
+import org.apache.activemq.artemis.api.core.client.*
+
+/**
+ * As the name suggests this is a simple client for connecting to MQ brokers.
+ */
+class SimpleMQClient(val target: HostAndPort) : ArtemisMessagingComponent() {
+    override val config: NodeSSLConfiguration = configureTestSSL()
+    lateinit var sessionFactory: ClientSessionFactory
+    lateinit var session: ClientSession
+    lateinit var producer: ClientProducer
+
+    fun start(username: String? = null, password: String? = null) {
+        val tcpTransport = tcpTransport(OUTBOUND, target.hostText, target.port)
+        val locator = ActiveMQClient.createServerLocatorWithoutHA(tcpTransport).apply {
+            isBlockOnNonDurableSend = true
+            threadPoolMaxSize = 1
+        }
+        sessionFactory = locator.createSessionFactory()
+        session = sessionFactory.createSession(username, password, false, true, true, locator.isPreAcknowledge, locator.ackBatchSize)
+        session.start()
+        producer = session.createProducer()
+    }
+
+    fun createMessage(): ClientMessage = session.createMessage(false)
+
+    fun stop() {
+        sessionFactory.close()
+    }
+}

--- a/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -1,0 +1,69 @@
+package net.corda.testing.node
+
+import net.corda.core.getOrThrow
+import net.corda.node.internal.Node
+import net.corda.node.services.User
+import net.corda.node.services.config.ConfigHelper
+import net.corda.node.services.config.FullNodeConfiguration
+import net.corda.testing.freeLocalHostAndPort
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.util.*
+import kotlin.concurrent.thread
+
+/**
+ * Extend this class if you need to run nodes in a test. You could use the driver DSL but it's extremely slow for testing
+ * purposes.
+ */
+abstract class NodeBasedTest {
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private val nodes = ArrayList<Node>()
+    lateinit var networkMapNode: Node
+
+    @Before
+    fun startNetworkMapNode() {
+        networkMapNode = startNode("Network Map", emptyMap())
+    }
+
+    @After
+    fun stopNodes() {
+        nodes.forEach(Node::stop)
+    }
+
+    fun startNode(legalName: String, rpcUsers: List<User> = emptyList()): Node {
+        return startNode(legalName, mapOf(
+                "networkMapAddress" to networkMapNode.configuration.artemisAddress.toString(),
+                "rpcUsers" to rpcUsers.map { mapOf(
+                        "user" to it.username,
+                        "password" to it.password,
+                        "permissions" to it.permissions)
+                }
+        ))
+    }
+
+    private fun startNode(legalName: String, config: Map<String, Any>): Node {
+        val config = ConfigHelper.loadConfig(
+                baseDirectoryPath = tempFolder.newFolder(legalName).toPath(),
+                allowMissingConfig = true,
+                configOverrides = config + mapOf(
+                        "myLegalName" to legalName,
+                        "artemisAddress" to freeLocalHostAndPort().toString(),
+                        "extraAdvertisedServiceIds" to ""
+                )
+        )
+
+        val node = FullNodeConfiguration(config).createNode()
+        node.start()
+        nodes += node
+        thread(name = legalName) {
+            node.run()
+        }
+        node.networkMapRegistrationFuture.getOrThrow()
+        return node
+    }
+}


### PR DESCRIPTION
This is re-opened from the private repo.

This locks down the Artemis broker to only give the necessary permissions to clients, of which there are three types:
* The node and processes which are logically part of the node - these are given full access to the broker
* Peers on the same Corda network - they are only given permission to send to the node
* RPC users - one of the valid users configured which is given enough permission to do RPC with the node.

Received messages are now tagged with the authenticated user which allows the flow framework to authentically retrieve the sender Party.