### PR TITLE
Fix an error in runnodes when running on Linux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     // Our version: bump this on release.
     ext.corda_version = "0.7-SNAPSHOT"
+    ext.gradle_plugins_version = "0.6.1"
 
-    ext.gradle_plugins_version = "0.5.7"
     ext.kotlin_version = '1.0.5'
     ext.quasar_version = '0.7.6'
     ext.asm_version = '0.5.3'

--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -2,7 +2,7 @@
 // or if you are developing these plugins. See the readme for more information.
 
 buildscript {
-    ext.gradle_plugins_version = "0.6" // Our version: bump this on release.
+    ext.gradle_plugins_version = "0.6.1" // Our version: bump this on release.
     ext.corda_published_version = "0.5" // Depend on our existing published publishing plugin.
 
     repositories {

--- a/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
+++ b/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
@@ -27,11 +27,13 @@ if which osascript >/dev/null; then
 end tell"
     osascript -e "$script"
 else
-    # Some other UNIX, probably Linux
+    # Some other UNIX, probably Linux (does not support msys or cygwin)
+    # TODO: msys and cygwin support
     #
-    # This next line is safe even if JAVA_HOME is unset. If it is set, it means that java overrides the
-    # default system java, which is what we want.
-    export PATH=$JAVA_HOME/bin:$PATH
+    # If it is set, it means that java overrides the default system java, which is what we want.
+    if [ -n "${JAVA_HOME-}" ]; then
+	export PATH="$JAVA_HOME/bin:$PATH"
+    fi
     for dir in `ls`; do
         if [ -d $dir ]; then
             pushd $dir >/dev/null


### PR DESCRIPTION
JAVA_HOME may not be set, and if not the script will exit without running the nodes. This PR fixes it by correctly testing if JAVA_HOME is set (since we have set -o). 

This PR requires a new release of gradle plugins once merged and an update of the cordapp template to fix the issue there too.