### PR TITLE
Change gradle to not need an install step before build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ apply plugin: 'project-report'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'maven-publish'
 apply plugin: 'net.corda.plugins.quasar-utils'
+apply plugin: 'net.corda.plugins.cordformation'
 
 // We need the following three lines even though they're inside an allprojects {} block below because otherwise
 // IntelliJ gets confused when importing the project and ends up erasing and recreating the .idea directory, along
@@ -92,6 +93,7 @@ repositories {
 dependencies {
     compile project(':node')
     compile "com.google.guava:guava:19.0"
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
 }
 
 task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
@@ -119,74 +121,37 @@ tasks.withType(Test) {
     reports.html.destination = file("${reporting.baseDir}/${name}")
 }
 
-// TODO: Move fat JAR building into node subproject.
-task buildCordaJAR(type: FatCapsule, dependsOn: ['jar', 'buildCertSigningRequestUtilityJAR']) {
-    applicationClass 'net.corda.node.MainKt'
-    archiveName "corda-${corda_version}.jar"
-    applicationSource = files(project.tasks.findByName('jar'), 'node/build/classes/main/CordaCaplet.class', 'config/dev/log4j2.xml')
-
-    capsuleManifest {
-        appClassPath = ["jolokia-agent-war-${project.ext.jolokia_version}.war"]
-        javaAgents = ["quasar-core-${quasar_version}-jdk8.jar"]
-        minJavaVersion = '1.8.0'
-        caplets = ['CordaCaplet']
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
+    directory "./build/nodes"
+    networkMap "Controller"
+    node {
+        name "Controller"
+        dirName "controller"
+        nearestCity "London"
+        advertisedServices = ["corda.notary.validating"]
+        artemisPort 10002
+        webPort 10003
+        cordapps = []
     }
-}
-
-task buildCertSigningRequestUtilityJAR(type: FatCapsule, dependsOn: project.jar) {
-    applicationClass 'net.corda.node.utilities.certsigning.CertificateSignerKt'
-    archiveName 'certSigningRequestUtility.jar'
-    capsuleManifest {
-        systemProperties['log4j.configuration'] = 'log4j2.xml'
-        minJavaVersion = '1.8.0'
+    node {
+        name "Bank A"
+        dirName "nodea"
+        nearestCity "London"
+        advertisedServices = []
+        artemisPort 10004
+        webPort 10005
+        cordapps = []
     }
-}
-
-// TODO: Use the Cordformation plugin.
-task deployNodes(dependsOn: 'buildCordaJAR') << {
-    copy {
-        from buildCordaJAR.outputs.getFiles()
-        from 'config/dev/nameservernode.conf'
-        into "${buildDir}/nodes/nameserver"
-        rename 'nameservernode.conf', 'node.conf'
-    }
-
-    copy {
-        from buildCordaJAR.outputs.getFiles()
-        from 'config/dev/generalnodea.conf'
-        into "${buildDir}/nodes/nodea"
-        rename 'generalnodea.conf', 'node.conf'
-    }
-
-    copy {
-        from buildCordaJAR.outputs.getFiles()
-        from 'config/dev/generalnodeb.conf'
-        into "${buildDir}/nodes/nodeb"
-        rename 'generalnodeb.conf', 'node.conf'
-    }
-
-    delete("${buildDir}/nodes/runnodes")
-    def jarName = buildCordaJAR.outputs.getFiles().getSingleFile().getName()
-    copy {
-        from "buildSrc/scripts/runnodes"
-        filter { String line -> line.replace("JAR_NAME", jarName) }
-        filter(org.apache.tools.ant.filters.FixCrLfFilter.class, eol: org.apache.tools.ant.filters.FixCrLfFilter.CrLf.newInstance("lf"))
-        into "${buildDir}/nodes"
+    node {
+        name "Bank B"
+        dirName "nodeb"
+        nearestCity "New York"
+        advertisedServices = []
+        artemisPort 10006
+        webPort 10007
+        cordapps = []
     }
 }
 
 // Aliasing the publishToMavenLocal for simplicity.
-// TODO: Verify this works for gradle plugins.
 task(install, dependsOn: 'publishToMavenLocal')
-
-publishing {
-    publications {
-        corda(MavenPublication) {
-            artifactId 'corda'
-
-            artifact buildCordaJAR {
-                classifier ""
-            }
-        }
-    }
-}

--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -36,17 +36,19 @@ sourceSets {
     }
 }
 
+compileTestJava.dependsOn tasks.getByPath(':node:buildCordaJAR')
+
 dependencies {
     compile project(':core')
     compile project(':client')
-    compile project(':test-utils')
+    testCompile project(':test-utils')
 
     compile "org.graphstream:gs-core:1.3"
     compile("org.graphstream:gs-ui:1.3") {
         exclude group: "bouncycastle"
     }
 
-    runtime "net.corda:corda:$corda_version"
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
 }
 
 mainClassName = "net.corda.docs.ClientRpcTutorialKt"
@@ -70,7 +72,7 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [':install', 'build']) {
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
     directory "./build/nodes"
     networkMap "Notary"
     node {

--- a/docs/source/permissioning.rst
+++ b/docs/source/permissioning.rst
@@ -34,18 +34,18 @@ This process only needs to be done once when the node connects to the network fo
 
 Building the utility
 --------------------
-The utility will be created as part of the main build ``buildCordaJAR``.
+The utility will be created as part of the gradle ``:node`` module ``buildCordaJAR`` task.
 You can also build the utility JAR by run the following command from the Corda project root directory.
 
 **Windows**::
 
-    gradlew.bat buildCertSigningRequestUtilityJAR
+    gradlew.bat :node:buildCertSigningRequestUtilityJAR
 
 **Other**::
 
-    ./gradlew buildCertSigningRequestUtilityJAR
+    ./gradlew :node:buildCertSigningRequestUtilityJAR
 
-The utility JAR will be created in ``<Project Root Dir>/build/libs/certSigningRequestUtility.jar``
+The utility JAR will be created in ``<Project Root Dir>/node/build/libs/certSigningRequestUtility.jar``
 
 
 Running the utility

--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -29,5 +29,5 @@ dependencies {
     compile project(':finance')
 
     testCompile 'junit:junit:4.12'
-    compile project(':test-utils')
+    testCompile project(':test-utils')
 }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'kotlin'
 apply plugin: 'java'
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'us.kirchmeier.capsule'
 
 repositories {
     mavenLocal()
@@ -23,6 +24,8 @@ configurations {
 
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
+
+    runtimeArtifacts.extendsFrom runtime
 }
 
 // Force the Caplet to target Java 6. This ensures that running 'java -jar corda.jar' on any Java 6 VM upwards
@@ -166,6 +169,32 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
+task buildCordaJAR(type: FatCapsule, dependsOn: ['jar', 'buildCertSigningRequestUtilityJAR']) {
+    applicationClass 'net.corda.node.MainKt'
+    archiveName "corda-${corda_version}.jar"
+    applicationSource = files(project.tasks.findByName('jar'), 'build/classes/main/CordaCaplet.class', 'config/dev/log4j2.xml')
+
+    capsuleManifest {
+        appClassPath = ["jolokia-agent-war-${project.rootProject.ext.jolokia_version}.war"]
+        javaAgents = ["quasar-core-${quasar_version}-jdk8.jar"]
+        minJavaVersion = '1.8.0'
+        caplets = ['CordaCaplet']
+    }
+}
+
+task buildCertSigningRequestUtilityJAR(type: FatCapsule, dependsOn: project.jar) {
+    applicationClass 'net.corda.node.utilities.certsigning.CertificateSignerKt'
+    archiveName 'certSigningRequestUtility.jar'
+    capsuleManifest {
+        systemProperties['log4j.configuration'] = 'log4j2.xml'
+        minJavaVersion = '1.8.0'
+    }
+}
+
+artifacts {
+    runtimeArtifacts buildCordaJAR
+}
+
 publishing {
     publications {
         node(MavenPublication) {
@@ -175,5 +204,13 @@ publishing {
             artifact sourceJar
             artifact javadocJar
         }
+        corda(MavenPublication) {
+            artifactId 'corda'
+
+            artifact buildCordaJAR {
+                classifier ""
+            }
+        }
+
     }
 }

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 
     // Corda integration dependencies
-    compile "net.corda:corda:$corda_version"   // TODO
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
     compile project(':core')
     compile project(':client')
     compile project(':node')
@@ -61,7 +61,7 @@ dependencies {
     }
 }
 
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [':install', 'build']) {
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
     directory "./build/nodes"
     networkMap "Controller"
     node {

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 
     // Corda integration dependencies
-    compile "net.corda:corda:$corda_version"   // TODO
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
     compile project(':core')
     compile project(':client')
     compile project(':node')
@@ -63,7 +63,7 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.3.1'
 }
 
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [':install', 'build']) {
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
     directory "./build/nodes"
     networkMap "Notary"
     node {

--- a/samples/network-visualiser/build.gradle
+++ b/samples/network-visualiser/build.gradle
@@ -21,12 +21,12 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 
     // Corda integration dependencies
-    compile "net.corda:corda:$corda_version"   // TODO
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
     compile project(':core')
     compile project(':client')
     compile project(':node')
     compile project(':finance')
-    compile project(':test-utils')
+    testCompile project(':test-utils')
 
     // Javax is required for webapis
     compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"

--- a/samples/raft-notary-demo/build.gradle
+++ b/samples/raft-notary-demo/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 
     // Corda integration dependencies
-    compile "net.corda:corda:$corda_version"   // TODO
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
     compile project(':core')
     compile project(':client')
     compile project(':node')
@@ -81,7 +81,7 @@ task generateNotaryIdentity(type: JavaExec) {
     args = [nodeDirs, notaryType, notaryName]
 }
 
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [':install', 'build', 'generateNotaryIdentity']) {
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build', 'generateNotaryIdentity']) {
     directory deployTo
     networkMap "Notary 1"
     node {

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -41,12 +41,12 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 
     // Corda integration dependencies
-    compile "net.corda:corda:$corda_version"   // TODO
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
     compile project(':core')
     compile project(':client')
     compile project(':node')
     compile project(':finance')
-    compile project(':test-utils')
+    testCompile project(':test-utils')
 
     // Javax is required for webapis
     compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"
@@ -65,7 +65,7 @@ dependencies {
     compile "com.opengamma.strata:strata-math:${strata_version}"
 }
 
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [':install', 'build']) {
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
     directory "./build/nodes"
     networkMap "Controller"
     node {

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 
     // Corda integration dependencies
-    compile "net.corda:corda:$corda_version"   // TODO
+    runtime project(path: ":node", configuration: 'runtimeArtifacts')
     compile project(':core')
     compile project(':client')
     compile project(':node')
@@ -65,7 +65,7 @@ dependencies {
     // Specify your cordapp's dependencies below, including dependent cordapps
 }
 
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [':install', 'build']) {
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
     directory "./build/nodes"
     // This name "Notary" is hard-coded into TraderDemoClientApi so if you change it here, change it there too.
     // In this demo the node that runs a standalone notary also acts as the network map server.


### PR DESCRIPTION
Alter the way that the corda.jar is created to be an artifact of the :node module. Then point at this as a runtime dependency, rather than as a locally published artifact.