### PR TITLE
node: Driver network map starts parallel with other nodes

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/driver/DriverTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/driver/DriverTests.kt
@@ -7,20 +7,23 @@ import net.corda.node.services.api.RegulatorService
 import net.corda.node.services.messaging.ArtemisMessagingComponent
 import net.corda.node.services.transactions.SimpleNotaryService
 import org.junit.Test
+import java.util.concurrent.Executors
 
 
 class DriverTests {
     companion object {
+        val executorService = Executors.newScheduledThreadPool(2)
+
         fun nodeMustBeUp(nodeInfo: NodeInfo) {
             val hostAndPort = ArtemisMessagingComponent.toHostAndPort(nodeInfo.address)
             // Check that the port is bound
-            addressMustBeBound(hostAndPort)
+            addressMustBeBound(executorService, hostAndPort)
         }
 
         fun nodeMustBeDown(nodeInfo: NodeInfo) {
             val hostAndPort = ArtemisMessagingComponent.toHostAndPort(nodeInfo.address)
             // Check that the port is bound
-            addressMustNotBeBound(hostAndPort)
+            addressMustNotBeBound(executorService, hostAndPort)
         }
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftValidatingNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftValidatingNotaryServiceTests.kt
@@ -114,16 +114,15 @@ class RaftValidatingNotaryServiceTests : DriverBasedTest() {
             waitFor()
         }
 
-        // Pay ourselves another 10x5 pounds
-        for (i in 1..10) {
+        // Pay ourselves another 20x5 pounds
+        for (i in 1..20) {
             val payHandle = aliceProxy.startFlow(::CashFlow, CashCommand.PayCash(5.POUNDS.issuedBy(alice.legalIdentity.ref(0)), alice.legalIdentity))
             require(payHandle.returnValue.toBlocking().first() is CashFlowResult.Success)
         }
 
-        // Artemis still dispatches some requests to the dead notary but all others should go through.
         val notarisationsPerNotary = HashMap<Party, Int>()
         notaryStateMachines.expectEvents(isStrict = false) {
-            replicate<Pair<NodeInfo, StateMachineUpdate>>(15) {
+            replicate<Pair<NodeInfo, StateMachineUpdate>>(30) {
                 expect(match = { it.second is StateMachineUpdate.Added }) {
                     val (notary, update) = it
                     update as StateMachineUpdate.Added

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -17,9 +17,9 @@ import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.NET
 import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.NOTIFICATIONS_ADDRESS
 import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.P2P_QUEUE
 import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.PEERS_PREFIX
+import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.RPC_QUEUE_REMOVALS_QUEUE
 import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.RPC_REQUESTS_QUEUE
 import net.corda.node.services.messaging.CordaRPCClientImpl
-import net.corda.node.services.messaging.NodeMessagingClient.Companion.RPC_QUEUE_REMOVALS_QUEUE
 import net.corda.testing.messaging.SimpleMQClient
 import net.corda.testing.node.NodeBasedTest
 import org.apache.activemq.artemis.api.core.ActiveMQNonExistentQueueException

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -142,7 +142,7 @@ class Node(override val configuration: FullNodeConfiguration, networkMapAddress:
             runOnStop += Runnable { messageBroker?.stop() }
             start()
             if (networkMapService is NetworkMapAddress) {
-                bridgeToNetworkMapService(networkMapService)
+                deployBridgeIfAbsent(networkMapService.queueName, networkMapService.hostAndPort)
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingComponent.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingComponent.kt
@@ -39,10 +39,11 @@ abstract class ArtemisMessagingComponent() : SingletonSerializeAsToken() {
         const val CLIENTS_PREFIX = "clients."
         const val P2P_QUEUE = "p2p.inbound"
         const val RPC_REQUESTS_QUEUE = "rpc.requests"
+        const val RPC_QUEUE_REMOVALS_QUEUE = "rpc.qremovals"
         const val NOTIFICATIONS_ADDRESS = "${INTERNAL_PREFIX}activemq.notifications"
 
         @JvmStatic
-        val NETWORK_MAP_ADDRESS = SimpleString("${INTERNAL_PREFIX}networkmap")
+        val NETWORK_MAP_ADDRESS = "${INTERNAL_PREFIX}networkmap"
 
         /**
          * Assuming the passed in target address is actually an ArtemisAddress will extract the host and port of the node. This should
@@ -57,16 +58,16 @@ abstract class ArtemisMessagingComponent() : SingletonSerializeAsToken() {
         }
     }
 
-    protected interface ArtemisAddress : MessageRecipients {
+    interface ArtemisAddress : MessageRecipients {
         val queueName: SimpleString
     }
 
-    protected interface ArtemisPeerAddress : ArtemisAddress, SingleMessageRecipient {
+    interface ArtemisPeerAddress : ArtemisAddress, SingleMessageRecipient {
         val hostAndPort: HostAndPort
     }
 
     data class NetworkMapAddress(override val hostAndPort: HostAndPort) : SingleMessageRecipient, ArtemisPeerAddress {
-        override val queueName: SimpleString get() = NETWORK_MAP_ADDRESS
+        override val queueName = SimpleString(NETWORK_MAP_ADDRESS)
     }
 
     /**


### PR DESCRIPTION
There is no requirement anymore for the nodes to start strictly after the network map, so we can optimise the driver by starting up the network map in parallel.