### PR TITLE
Adding links to discourse and slack on docsite

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,6 +1,15 @@
+<!-- If you edit this, then please make the same changes to layout_for_doc_website.html, as that is used for the web
+     doc site generation which we put analytics tracking on to identify any potential problem pages  -->
+
+
 {% extends "!layout.html" %}
 {% block sidebartitle %}
 {{ super() }}
 <br>
 <a href="api/index.html">API reference</a>
+<br>
+<a href="https://discourse.corda.net">Discourse Forums</a>
+<br>
+<a href="http://slack.corda.net">Slack</a>
+<br>
 {% endblock %}

--- a/docs/source/_templates/layout_for_doc_website.html
+++ b/docs/source/_templates/layout_for_doc_website.html
@@ -5,6 +5,11 @@
 {{ super() }}
 <br>
 <a href="api/index.html">API reference</a>
+<br>
+<a href="https://discourse.corda.net">Discourse Forums</a>
+<br>
+<a href="http://slack.corda.net">Slack</a>
+<br>
 {% endblock %}
 
 {% block footer %}

--- a/docs/source/getting-set-up.rst
+++ b/docs/source/getting-set-up.rst
@@ -75,6 +75,5 @@ You can catch up with the latest code by selecting "VCS -> Update Project" in th
 Troubleshooting
 ---------------
 
-See :doc:`getting-set-up-fault-finding`.
-
+See :doc:`getting-set-up-fault-finding`, or get in touch with us either on the `forums <https://discourse.corda.net/>`_ or via `slack <http://slack.corda.net/>`_.
 


### PR DESCRIPTION
The doc site has no links to discourse or slack - Added them to be included just below the link the API reference.