### PR TITLE
Fix double spending of inputs issue on ledger level in test dsl.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerification.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerification.kt
@@ -107,7 +107,7 @@ sealed class TransactionVerificationException(val tx: LedgerTransaction, cause: 
         override val message: String?
             get() = "Missing required encumbrance ${missing} in ${inOut}"
     }
-
+    class TestDoubleSpentInputs(tx: LedgerTransaction) : TransactionVerificationException(tx, null)
     enum class Direction {
         INPUT,
         OUTPUT

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerification.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerification.kt
@@ -107,7 +107,6 @@ sealed class TransactionVerificationException(val tx: LedgerTransaction, cause: 
         override val message: String?
             get() = "Missing required encumbrance ${missing} in ${inOut}"
     }
-    class TestDoubleSpentInputs(tx: LedgerTransaction) : TransactionVerificationException(tx, null)
     enum class Direction {
         INPUT,
         OUTPUT


### PR DESCRIPTION
Simple fix with tracking of used inputs on a ledger level.