### PR TITLE
core: Remove CN from X509 subjectAlternativeNames, always add hostname

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
@@ -380,7 +380,6 @@ object X509Utilities {
                 DERSequence(purposes))
 
         val subjectAlternativeNames = ArrayList<ASN1Encodable>()
-        subjectAlternativeNames.add(GeneralName(GeneralName.dNSName, subject.getRDNs(BCStyle.CN).first().first.value))
 
         for (subjectAlternativeNameDomain in subjectAlternativeNameDomains) {
             subjectAlternativeNames.add(GeneralName(GeneralName.dNSName, subjectAlternativeNameDomain))
@@ -591,7 +590,7 @@ object X509Utilities {
                 getDevX509Name(commonName),
                 serverKey.public,
                 intermediateCA,
-                if (host.canonicalHostName == host.hostName) listOf() else listOf(host.hostName),
+                listOf(host.hostName),
                 listOf(host.hostAddress))
 
         val keyPass = keyPassword.toCharArray()

--- a/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
@@ -61,23 +61,17 @@ class X509UtilitiesTest {
         serverCert.verify(caCertAndKey.keyPair.public) // throws on verification problems
         assertFalse { serverCert.keyUsage[5] } // Bit 5 == keyCertSign according to ASN.1 spec (see full comment on KeyUsage property)
         assertTrue { serverCert.basicConstraints === -1 } // This returns the signing path length should be -1 for non-CA certificate
-        assertEquals(3, serverCert.subjectAlternativeNames.size)
-        var foundMainDnsName = false
+        assertEquals(2, serverCert.subjectAlternativeNames.size)
         var foundAliasDnsName = false
         for (entry in serverCert.subjectAlternativeNames) {
             val typeId = entry[0] as Int
             val value = entry[1] as String
             if (typeId == GeneralName.iPAddress) {
                 assertEquals("10.0.0.54", value)
-            } else if (typeId == GeneralName.dNSName) {
-                if (value == "Server Cert") {
-                    foundMainDnsName = true
-                } else if (value == "alias name") {
+            } else if (value == "alias name") {
                     foundAliasDnsName = true
-                }
             }
         }
-        assertTrue(foundMainDnsName)
         assertTrue(foundAliasDnsName)
     }
 


### PR DESCRIPTION
This PR fixes some issues in the cert code. Some old code still assumed that the CN is the hostname. Should fix ci