### PR TITLE
Making the warning make sense for branches that aren't master

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Welcome to the Corda documentation!
 ===================================
 
-.. warning:: This build of the docs is from the *master branch*, not a milestone release. It may not reflect the
+.. warning:: This build of the docs is from the "|version|" branch, not a milestone release. It may not reflect the
    current state of the code. `Read the docs for M6 <https://docs.corda.net/releases/release-M6.0/>`_.
 
 This is the developer guide for Corda, a proposed architecture for distributed ledgers. Here are the sources


### PR DESCRIPTION
Minor change such that the version parameter is used in the warning instead of h/coded "master" 