### PR TITLE
Add some hooks to StateMachineManager and NodeSchedulerService

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/DummyContract.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/DummyContract.kt
@@ -9,7 +9,7 @@ import net.corda.core.transactions.TransactionBuilder
 
 val DUMMY_PROGRAM_ID = DummyContract()
 
-class DummyContract : Contract {
+data class DummyContract(override val legalContractReference: SecureHash = SecureHash.sha256("")) : Contract {
 
     interface State : ContractState {
         val magicNumber: Int
@@ -43,9 +43,6 @@ class DummyContract : Contract {
     override fun verify(tx: TransactionForContract) {
         // Always accepts.
     }
-
-    // The "empty contract"
-    override val legalContractReference: SecureHash = SecureHash.sha256("")
 
     companion object {
         @JvmStatic

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -1,8 +1,6 @@
 package net.corda.core.node
 
-import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.TransactionResolutionException
-import net.corda.core.contracts.TransactionState
+import net.corda.core.contracts.*
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowStateMachine
 import net.corda.core.messaging.MessagingService
@@ -46,6 +44,16 @@ interface ServiceHub {
     fun loadState(stateRef: StateRef): TransactionState<*> {
         val definingTx = storageService.validatedTransactions.getTransaction(stateRef.txhash) ?: throw TransactionResolutionException(stateRef.txhash)
         return definingTx.tx.outputs[stateRef.index]
+    }
+
+    /**
+     * Given a [StateRef] loads the referenced transaction and returns a [StateAndRef<T>]
+     *
+     * @throws TransactionResolutionException if the [StateRef] points to a non-existent transaction.
+     */
+    fun <T : ContractState> toStateAndRef(ref: StateRef): StateAndRef<T> {
+        val definingTx =  storageService.validatedTransactions.getTransaction(ref.txhash) ?: throw TransactionResolutionException(ref.txhash)
+        return definingTx.tx.outRef<T>(ref.index)
     }
 
     /**

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
@@ -20,10 +20,6 @@ object WorkflowTransactionBuildTutorial {
 }
 
 // DOCSTART 1
-// Helper method to access the StorageService and expand a StateRef into a StateAndRef
-fun <T : ContractState> ServiceHub.toStateAndRef(ref: StateRef): StateAndRef<T> {
-    return storageService.validatedTransactions.getTransaction(ref.txhash)!!.tx.outRef<T>(ref.index)
-}
 
 // Helper method to locate the latest Vault version of a LinearState from a possibly out of date StateRef
 inline fun <reified T : LinearState> ServiceHub.latest(ref: StateRef): StateAndRef<T> {

--- a/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
+++ b/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
@@ -115,7 +115,7 @@ public class JavaCommercialPaper implements Contract {
         }
 
         public State withoutOwner() {
-            return new State(issuance, CryptoUtilitiesKt.getNullCompositeKey(), faceValue, maturityDate);
+            return new State(issuance, CryptoUtilities.getNullCompositeKey(), faceValue, maturityDate);
         }
 
         @NotNull

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -176,7 +176,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration, val netwo
         get() = _networkMapRegistrationFuture
 
     /** Fetch CordaPluginRegistry classes registered in META-INF/services/net.corda.core.node.CordaPluginRegistry files that exist in the classpath */
-    val pluginRegistries: List<CordaPluginRegistry> by lazy {
+    open val pluginRegistries: List<CordaPluginRegistry> by lazy {
         ServiceLoader.load(CordaPluginRegistry::class.java).toList()
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
@@ -1,0 +1,152 @@
+package net.corda.node.services
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.*
+import net.corda.core.crypto.CompositeKey
+import net.corda.core.crypto.Party
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowLogicRefFactory
+import net.corda.core.node.CordaPluginRegistry
+import net.corda.core.node.services.ServiceInfo
+import net.corda.core.node.services.linearHeadsOfType
+import net.corda.core.utilities.DUMMY_NOTARY
+import net.corda.core.utilities.DUMMY_NOTARY_KEY
+import net.corda.flows.FinalityFlow
+import net.corda.node.services.network.NetworkMapService
+import net.corda.node.services.transactions.ValidatingNotaryService
+import net.corda.node.utilities.databaseTransaction
+import net.corda.testing.node.MockNetwork
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import java.security.PublicKey
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class ScheduledFlowTests {
+    lateinit var net: MockNetwork
+    lateinit var notaryNode: MockNetwork.MockNode
+    lateinit var nodeA: MockNetwork.MockNode
+    lateinit var nodeB: MockNetwork.MockNode
+
+    data class ScheduledState(val creationTime: Instant,
+                              val source: Party,
+                              val destination: Party,
+                              val processed: Boolean = false,
+                              override val linearId: UniqueIdentifier = UniqueIdentifier(),
+                              override val contract: Contract = DummyContract()) : SchedulableState, LinearState {
+        override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
+            if (!processed) {
+                val logicRef = flowLogicRefFactory.create(ScheduledFlow::class.java, thisStateRef)
+                return ScheduledActivity(logicRef, creationTime)
+            } else {
+                return null
+            }
+        }
+
+        override val participants: List<CompositeKey> = listOf(source.owningKey, destination.owningKey)
+
+        override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
+            return participants.any { it.containsAny(ourKeys) }
+        }
+    }
+
+    class InsertInitialStateFlow(val destination: Party) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val scheduledState = ScheduledState(serviceHub.clock.instant(),
+                    serviceHub.myInfo.legalIdentity, destination)
+
+            val notary = serviceHub.networkMapCache.getAnyNotary()
+            val builder = TransactionType.General.Builder(notary)
+            val tx = builder.withItems(scheduledState).
+                    signWith(serviceHub.legalIdentityKey).toSignedTransaction(false)
+            subFlow(FinalityFlow(tx, setOf(serviceHub.myInfo.legalIdentity)))
+        }
+    }
+
+    class ScheduledFlow(val stateRef: StateRef) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val state = serviceHub.toStateAndRef<ScheduledState>(stateRef)
+            val scheduledState = state.state.data
+            // Only run flow over states originating on this node
+            if (scheduledState.source != serviceHub.myInfo.legalIdentity) {
+                return
+            }
+            require(!scheduledState.processed) { "State should not have been previously processed" }
+            val notary = state.state.notary
+            val newStateOutput = scheduledState.copy(processed = true)
+            val builder = TransactionType.General.Builder(notary)
+            val tx = builder.withItems(state, newStateOutput).
+                    signWith(serviceHub.legalIdentityKey).toSignedTransaction(false)
+            subFlow(FinalityFlow(tx, setOf(scheduledState.source, scheduledState.destination)))
+        }
+    }
+
+    class ScheduledFlowTestPlugin : CordaPluginRegistry() {
+        override val requiredFlows: Map<String, Set<String>> = mapOf(
+                InsertInitialStateFlow::class.java.name to setOf(Party::class.java.name),
+                ScheduledFlow::class.java.name to setOf(StateRef::class.java.name)
+        )
+    }
+
+
+    @Before
+    fun setup() {
+        net = MockNetwork(threadPerNode = true)
+        notaryNode = net.createNode(
+                legalName = DUMMY_NOTARY.name,
+                keyPair = DUMMY_NOTARY_KEY,
+                advertisedServices = *arrayOf(ServiceInfo(NetworkMapService.type), ServiceInfo(ValidatingNotaryService.type)))
+        nodeA = net.createNode(notaryNode.info.address, start = false)
+        nodeB = net.createNode(notaryNode.info.address, start = false)
+        nodeA.testPluginRegistries.add(ScheduledFlowTestPlugin())
+        nodeB.testPluginRegistries.add(ScheduledFlowTestPlugin())
+        net.startNodes()
+    }
+
+    @After
+    fun cleanUp() {
+        net.stopNodes()
+    }
+
+    @Test
+    fun `create and run scheduled flow then wait for result`() {
+        nodeA.services.startFlow(InsertInitialStateFlow(nodeB.info.legalIdentity))
+        net.waitQuiescent()
+        val stateFromA = databaseTransaction(nodeA.database) {
+            nodeA.services.vaultService.linearHeadsOfType<ScheduledState>().values.first()
+        }
+        val stateFromB = databaseTransaction(nodeB.database) {
+            nodeB.services.vaultService.linearHeadsOfType<ScheduledState>().values.first()
+        }
+        assertEquals(stateFromA, stateFromB, "Must be same copy on both nodes")
+        assertTrue("Must be processed", stateFromB.state.data.processed)
+    }
+
+    @Ignore
+    @Test
+    // TODO I need to investigate why we get very very occasional SessionInit failures
+    // during notarisation.
+    fun `Run a whole batch of scheduled flows`() {
+        val N = 100
+        for (i in 0..N - 1) {
+            nodeA.services.startFlow(InsertInitialStateFlow(nodeB.info.legalIdentity))
+            nodeB.services.startFlow(InsertInitialStateFlow(nodeA.info.legalIdentity))
+        }
+        net.waitQuiescent()
+        val statesFromA = databaseTransaction(nodeA.database) {
+            nodeA.services.vaultService.linearHeadsOfType<ScheduledState>()
+        }
+        val statesFromB = databaseTransaction(nodeB.database) {
+            nodeB.services.vaultService.linearHeadsOfType<ScheduledState>()
+        }
+        assertEquals(2 * N, statesFromA.count(), "Expect all states to be present")
+        assertEquals(statesFromA, statesFromB, "Expect identical data on both nodes")
+        assertTrue("Expect all states have run the scheduled task", statesFromB.values.all { it.state.data.processed })
+    }
+}


### PR DESCRIPTION
I have added some hooks to the NodeSchedulerService, StateMachineManager and InMemoryNetwork so that unit tests with scheduled actions can pause using net.waitQuiescent() until all node activity has finally ended. I have also added a test which uses a SchedulableState to trigger a flow and move states to another node using the FinalityFlow, so that we actually exercise this activity more than in the rather specialist scheduler tests.