### PR TITLE
Fix errors with multi-thread InMemoryMessagingNetwork

### DIFF
--- a/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -374,7 +374,7 @@ class InMemoryMessagingNetwork(val sendManuallyPumped: Boolean) : SingletonSeria
 
         private fun MessageTransfer.toReceivedMessage() = object : ReceivedMessage {
             override val topicSession: TopicSession get() = message.topicSession
-            override val data: ByteArray get() = message.data
+            override val data: ByteArray get() = message.data.copyOf() // Kryo messes with the buffer so give each client a unique copy
             override val peer: X500Name get() = X509Utilities.getDevX509Name(sender.description)
             override val debugTimestamp: Instant get() = message.debugTimestamp
             override val uniqueMessageId: UUID get() = message.uniqueMessageId


### PR DESCRIPTION
We have been seeing some errors when running unit tests using the InMemoryMessagingNetwork run in multi-threaded mode. It appears that the root cause is that Kryo transiently modifies the source ByteArray when reading strings. Therefore we must give each thread/node in the network a separate message data copy to make it thread safe.