### PR TITLE
Refactor vault cash balance calculation

### DIFF
--- a/client/src/main/kotlin/net/corda/client/model/ContractStateModel.kt
+++ b/client/src/main/kotlin/net/corda/client/model/ContractStateModel.kt
@@ -8,13 +8,12 @@ import net.corda.client.fxutils.map
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.StateRef
 import net.corda.core.node.services.Vault
 import rx.Observable
 
 data class Diff<out T : ContractState>(
         val added: Collection<StateAndRef<T>>,
-        val removed: Collection<StateRef>
+        val removed: Collection<StateAndRef<T>>
 )
 
 /**
@@ -27,11 +26,10 @@ class ContractStateModel {
         Diff(it.produced, it.consumed)
     }
     private val cashStatesDiff: Observable<Diff<Cash.State>> = contractStatesDiff.map {
-        // We can't filter removed hashes here as we don't have type info
-        Diff(it.added.filterCashStateAndRefs(), it.removed)
+        Diff(it.added.filterCashStateAndRefs(), it.removed.filterCashStateAndRefs())
     }
     val cashStates: ObservableList<StateAndRef<Cash.State>> = cashStatesDiff.fold(FXCollections.observableArrayList()) { list, statesDiff ->
-        list.removeIf { it.ref in statesDiff.removed }
+        list.removeIf { it in statesDiff.removed }
         list.addAll(statesDiff.added)
     }
 

--- a/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt
+++ b/core/src/test/kotlin/net/corda/core/node/VaultUpdateTests.kt
@@ -46,7 +46,7 @@ class VaultUpdateTests {
 
     @Test
     fun `something plus nothing is something`() {
-        val before = Vault.Update(setOf(stateRef0, stateRef1), setOf(stateAndRef2, stateAndRef3))
+        val before = Vault.Update(setOf(stateAndRef0, stateAndRef1), setOf(stateAndRef2, stateAndRef3))
         val after = before + Vault.NoUpdate
         assertEquals(before, after)
     }
@@ -54,32 +54,32 @@ class VaultUpdateTests {
     @Test
     fun `nothing plus something is something`() {
         val before = Vault.NoUpdate
-        val after = before + Vault.Update(setOf(stateRef0, stateRef1), setOf(stateAndRef2, stateAndRef3))
-        val expected = Vault.Update(setOf(stateRef0, stateRef1), setOf(stateAndRef2, stateAndRef3))
+        val after = before + Vault.Update(setOf(stateAndRef0, stateAndRef1), setOf(stateAndRef2, stateAndRef3))
+        val expected = Vault.Update(setOf(stateAndRef0, stateAndRef1), setOf(stateAndRef2, stateAndRef3))
         assertEquals(expected, after)
     }
 
     @Test
     fun `something plus consume state 0 is something without state 0 output`() {
-        val before = Vault.Update(setOf(stateRef2, stateRef3), setOf(stateAndRef0, stateAndRef1))
-        val after = before + Vault.Update(setOf(stateRef0), setOf())
-        val expected = Vault.Update(setOf(stateRef2, stateRef3), setOf(stateAndRef1))
+        val before = Vault.Update(setOf(stateAndRef2, stateAndRef3), setOf(stateAndRef0, stateAndRef1))
+        val after = before + Vault.Update(setOf(stateAndRef0), setOf())
+        val expected = Vault.Update(setOf(stateAndRef2, stateAndRef3), setOf(stateAndRef1))
         assertEquals(expected, after)
     }
 
     @Test
     fun `something plus produce state 4 is something with additional state 4 output`() {
-        val before = Vault.Update(setOf(stateRef2, stateRef3), setOf(stateAndRef0, stateAndRef1))
+        val before = Vault.Update(setOf(stateAndRef2, stateAndRef3), setOf(stateAndRef0, stateAndRef1))
         val after = before + Vault.Update(setOf(), setOf(stateAndRef4))
-        val expected = Vault.Update(setOf(stateRef2, stateRef3), setOf(stateAndRef0, stateAndRef1, stateAndRef4))
+        val expected = Vault.Update(setOf(stateAndRef2, stateAndRef3), setOf(stateAndRef0, stateAndRef1, stateAndRef4))
         assertEquals(expected, after)
     }
 
     @Test
     fun `something plus consume states 0 and 1, and produce state 4, is something without state 0 and 1 outputs and only state 4 output`() {
-        val before = Vault.Update(setOf(stateRef2, stateRef3), setOf(stateAndRef0, stateAndRef1))
-        val after = before + Vault.Update(setOf(stateRef0, stateRef1), setOf(stateAndRef4))
-        val expected = Vault.Update(setOf(stateRef2, stateRef3), setOf(stateAndRef4))
+        val before = Vault.Update(setOf(stateAndRef2, stateAndRef3), setOf(stateAndRef0, stateAndRef1))
+        val after = before + Vault.Update(setOf(stateAndRef0, stateAndRef1), setOf(stateAndRef4))
+        val expected = Vault.Update(setOf(stateAndRef2, stateAndRef3), setOf(stateAndRef4))
         assertEquals(expected, after)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -42,7 +42,7 @@ abstract class ServiceHubInternal : PluginServiceHub {
     abstract val schemaService: SchemaService
 
     abstract override val networkService: MessagingServiceInternal
-    
+
     /**
      * Given a list of [SignedTransaction]s, writes them to the given storage for validated transactions and then
      * sends them to the vault for further processing. This is intended for implementations to call from

--- a/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/ScheduledActivityObserver.kt
@@ -14,7 +14,7 @@ import net.corda.node.services.api.ServiceHubInternal
 class ScheduledActivityObserver(val services: ServiceHubInternal) {
     init {
         services.vaultService.rawUpdates.subscribe { update ->
-            update.consumed.forEach { services.schedulerService.unscheduleStateActivity(it) }
+            update.consumed.forEach { services.schedulerService.unscheduleStateActivity(it.ref) }
             update.produced.forEach { scheduleStateActivity(it, services.flowLogicRefFactory) }
         }
     }


### PR DESCRIPTION
Made vault updates contain full StateAndRef in the consumed set (instead of just StateRef). This allows subscribers to check whether the update contains relevant states.

Cash balances are now calculated by keeping only the aggregate values (it no longer needs to iterate through all states in the vault). The aggregate values are persisted.