### PR TITLE
Add database transactions back onto observations.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -61,7 +61,7 @@ class CordaRPCOpsImpl(
     override fun stateMachinesAndUpdates(): Pair<List<StateMachineInfo>, Observable<StateMachineUpdate>> {
         return databaseTransaction(database) {
             val (allStateMachines, changes) = smm.track()
-            return@databaseTransaction Pair(
+            Pair(
                     allStateMachines.map { stateMachineInfoFromFlowLogic(it.id, it.logic) },
                     changes.map { stateMachineUpdateFromStateMachineChange(it) }
             )

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -15,11 +15,9 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.StateMachineTransactionMapping
 import net.corda.core.node.services.Vault
-import net.corda.core.serialization.serialize
-import net.corda.node.services.messaging.requirePermission
 import net.corda.core.toObservable
 import net.corda.core.transactions.SignedTransaction
-import net.corda.node.services.messaging.createRPCKryo
+import net.corda.node.services.messaging.requirePermission
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.statemachine.FlowStateMachineImpl
 import net.corda.node.services.statemachine.StateMachineManager
@@ -27,12 +25,8 @@ import net.corda.node.utilities.AddOrRemove
 import net.corda.node.utilities.databaseTransaction
 import org.jetbrains.exposed.sql.Database
 import rx.Observable
-import java.io.BufferedInputStream
-import java.io.File
-import java.io.FileInputStream
 import java.io.InputStream
 import java.time.Instant
-import java.time.LocalDateTime
 
 /**
  * Server side implementations of RPCs available to MQ based client tools. Execution takes place on the server
@@ -46,7 +40,9 @@ class CordaRPCOpsImpl(
     override val protocolVersion: Int get() = 0
 
     override fun networkMapUpdates(): Pair<List<NodeInfo>, Observable<NetworkMapCache.MapChange>> {
-        return services.networkMapCache.track()
+        return databaseTransaction(database) {
+            services.networkMapCache.track()
+        }
     }
 
     override fun vaultAndUpdates(): Pair<List<StateAndRef<ContractState>>, Observable<Vault.Update>> {
@@ -63,11 +59,13 @@ class CordaRPCOpsImpl(
     }
 
     override fun stateMachinesAndUpdates(): Pair<List<StateMachineInfo>, Observable<StateMachineUpdate>> {
-        val (allStateMachines, changes) = smm.track()
-        return Pair(
-                allStateMachines.map { stateMachineInfoFromFlowLogic(it.id, it.logic) },
-                changes.map {  stateMachineUpdateFromStateMachineChange(it) }
-        )
+        return databaseTransaction(database) {
+            val (allStateMachines, changes) = smm.track()
+            return@databaseTransaction Pair(
+                    allStateMachines.map { stateMachineInfoFromFlowLogic(it.id, it.logic) },
+                    changes.map { stateMachineUpdateFromStateMachineChange(it) }
+            )
+        }
     }
 
     override fun stateMachineRecordedTransactionMapping(): Pair<List<StateMachineTransactionMapping>, Observable<StateMachineTransactionMapping>> {

--- a/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
@@ -45,7 +45,8 @@ open class InMemoryNetworkMapCache : SingletonSerializeAsToken(), NetworkMapCach
     override val partyNodes: List<NodeInfo> get() = registeredNodes.map { it.value }
     override val networkMapNodes: List<NodeInfo> get() = getNodesWithService(NetworkMapService.type)
     private val _changed = PublishSubject.create<MapChange>()
-    override val changed: Observable<MapChange> get() = _changed.wrapWithDatabaseTransaction()
+    // We use assignment here so that multiple subscribers share the same wrapped Observable.
+    override val changed: Observable<MapChange> = _changed.wrapWithDatabaseTransaction()
     private val changePublisher: rx.Observer<MapChange> get() = _changed.bufferUntilDatabaseCommit()
 
     private val _registrationFuture = SettableFuture.create<Unit>()

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionMappingStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionMappingStorage.kt
@@ -58,7 +58,7 @@ class DBTransactionMappingStorage : StateMachineRecordedTransactionMappingStorag
         mutex.locked {
             return Pair(
                     stateMachineTransactionMap.map { StateMachineTransactionMapping(it.value, it.key) },
-                    updates.bufferUntilSubscribed()
+                    updates.bufferUntilSubscribed().wrapWithDatabaseTransaction()
             )
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -59,12 +59,11 @@ class DBTransactionStorage : TransactionStorage {
     }
 
     val updatesPublisher = PublishSubject.create<SignedTransaction>().toSerialized()
-    override val updates: Observable<SignedTransaction>
-        get() = updatesPublisher.wrapWithDatabaseTransaction()
+    override val updates: Observable<SignedTransaction> = updatesPublisher.wrapWithDatabaseTransaction()
 
     override fun track(): Pair<List<SignedTransaction>, Observable<SignedTransaction>> {
         synchronized(txStorage) {
-            return Pair(txStorage.values.toList(), updates.bufferUntilSubscribed().wrapWithDatabaseTransaction())
+            return Pair(txStorage.values.toList(), updatesPublisher.bufferUntilSubscribed().wrapWithDatabaseTransaction())
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBTransactionStorage.kt
@@ -60,11 +60,11 @@ class DBTransactionStorage : TransactionStorage {
 
     val updatesPublisher = PublishSubject.create<SignedTransaction>().toSerialized()
     override val updates: Observable<SignedTransaction>
-        get() = updatesPublisher
+        get() = updatesPublisher.wrapWithDatabaseTransaction()
 
     override fun track(): Pair<List<SignedTransaction>, Observable<SignedTransaction>> {
         synchronized(txStorage) {
-            return Pair(txStorage.values.toList(), updates.bufferUntilSubscribed())
+            return Pair(txStorage.values.toList(), updates.bufferUntilSubscribed().wrapWithDatabaseTransaction())
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -135,6 +135,8 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
     /**
      * An observable that emits triples of the changing flow, the type of change, and a process-specific ID number
      * which may change across restarts.
+     *
+     * We use assignment here so that multiple subscribers share the same wrapped Observable.
      */
     val changes: Observable<Change> = mutex.content.changesPublisher.wrapWithDatabaseTransaction()
 
@@ -180,8 +182,6 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
      */
     fun track(): Pair<List<FlowStateMachineImpl<*>>, Observable<Change>> {
         return mutex.locked {
-            //val bufferedChanges = UnicastSubject.create<Change>()
-            //changesPublisher.subscribe(bufferedChanges)
             Pair(stateMachines.keys.toList(), changesPublisher.bufferUntilSubscribed().wrapWithDatabaseTransaction())
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -100,7 +100,7 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
 
         val _updatesPublisher = PublishSubject.create<Vault.Update>()
         val _rawUpdatesPublisher = PublishSubject.create<Vault.Update>()
-        val _wrappedPublisher = _updatesPublisher.wrapWithDatabaseTransaction()
+        val _updatesInDbTx = _updatesPublisher.wrapWithDatabaseTransaction().asObservable()
 
         // For use during publishing only.
         val updatesPublisher: rx.Observer<Vault.Update> get() = _updatesPublisher.bufferUntilDatabaseCommit().tee(_rawUpdatesPublisher)
@@ -155,7 +155,7 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
         get() = mutex.locked { _rawUpdatesPublisher }
 
     override val updates: Observable<Vault.Update>
-        get() = mutex.locked { _wrappedPublisher }
+        get() = mutex.locked { _updatesInDbTx }
 
     override fun track(): Pair<Vault, Observable<Vault.Update>> {
         return mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -153,11 +153,11 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
         get() = mutex.locked { _rawUpdatesPublisher }
 
     override val updates: Observable<Vault.Update>
-        get() = mutex.locked { _updatesPublisher }
+        get() = mutex.locked { _updatesPublisher.wrapWithDatabaseTransaction() }
 
     override fun track(): Pair<Vault, Observable<Vault.Update>> {
         return mutex.locked {
-            Pair(Vault(allUnconsumedStates()), _updatesPublisher.bufferUntilSubscribed())
+            Pair(Vault(allUnconsumedStates()), _updatesPublisher.bufferUntilSubscribed().wrapWithDatabaseTransaction())
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -100,6 +100,8 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
 
         val _updatesPublisher = PublishSubject.create<Vault.Update>()
         val _rawUpdatesPublisher = PublishSubject.create<Vault.Update>()
+        val _wrappedPublisher = _updatesPublisher.wrapWithDatabaseTransaction()
+
         // For use during publishing only.
         val updatesPublisher: rx.Observer<Vault.Update> get() = _updatesPublisher.bufferUntilDatabaseCommit().tee(_rawUpdatesPublisher)
 
@@ -153,7 +155,7 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
         get() = mutex.locked { _rawUpdatesPublisher }
 
     override val updates: Observable<Vault.Update>
-        get() = mutex.locked { _updatesPublisher.wrapWithDatabaseTransaction() }
+        get() = mutex.locked { _wrappedPublisher }
 
     override fun track(): Pair<Vault, Observable<Vault.Update>> {
         return mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
@@ -196,67 +196,70 @@ fun <T : Any> rx.Observer<T>.bufferUntilDatabaseCommit(): rx.Observer<T> {
  * that might be in place.
  */
 fun <T : Any> rx.Observable<T>.wrapWithDatabaseTransaction(db: Database? = null): rx.Observable<T> {
-    val op = object : Observable.Operator<T, T> {
-        val shared = object : Subscriber<T>() {
-            // Some unsubscribes happen inside onNext() so need something that supports concurrent modification.
-            val subscribers = CopyOnWriteArrayList<Subscriber<in T>>()
+    // A subscriber that wraps another but does not pass on observations to it.
+    class NoOpSubscriber<U>(t: Subscriber<in U>) : Subscriber<U>(t) {
+        override fun onCompleted() {
+        }
 
-            override fun onCompleted() {
-                databaseTransaction(db ?: StrandLocalTransactionManager.database) {
-                    subscribers.forEach {
-                        if (!it.isUnsubscribed) it.onCompleted()
-                    }
-                }
-            }
+        override fun onError(e: Throwable?) {
+        }
 
-            override fun onError(e: Throwable?) {
-                databaseTransaction(db ?: StrandLocalTransactionManager.database) {
-                    subscribers.forEach {
-                        if (!it.isUnsubscribed) it.onError(e)
-                    }
-                }
-            }
+        override fun onNext(s: U) {
+        }
+    }
 
-            override fun onNext(s: T) {
-                databaseTransaction(db ?: StrandLocalTransactionManager.database) {
-                    subscribers.forEach {
-                        if (!it.isUnsubscribed) it.onNext(s)
-                    }
-                }
-            }
+    // A subscriber that delegates to multiple others, wrapping a database transaction around the combination.
+    class DatabaseTransactionWrappingSubscriber<U>(db: Database?) : Subscriber<T>() {
+        // Some unsubscribes happen inside onNext() so need something that supports concurrent modification.
+        val delegates = CopyOnWriteArrayList<Subscriber<in T>>()
 
-            override fun onStart() {
-                databaseTransaction(db ?: StrandLocalTransactionManager.database) {
-                    subscribers.forEach {
-                        if (!it.isUnsubscribed) it.onStart()
-                    }
-                }
-            }
-
-            fun cleanUp() {
-                if (subscribers.removeIf { it.isUnsubscribed }) {
-                    if (subscribers.isEmpty()) {
-                        unsubscribe()
-                    }
+        fun forEachSubscriberWithDbTx(block: Subscriber<in T>.() -> Unit) {
+            databaseTransaction(db ?: StrandLocalTransactionManager.database) {
+                delegates.filter { !it.isUnsubscribed }.forEach {
+                    it.block()
                 }
             }
         }
 
-        override fun call(t: Subscriber<in T>): Subscriber<in T> {
-            shared.subscribers.add(t)
-            return if (shared.subscribers.size == 1) shared else object : Subscriber<T>(t) {
-                override fun onCompleted() {
-                }
+        override fun onCompleted() {
+            forEachSubscriberWithDbTx { onCompleted() }
+        }
 
-                override fun onError(e: Throwable?) {
-                }
+        override fun onError(e: Throwable?) {
+            forEachSubscriberWithDbTx { onError(e) }
+        }
 
-                override fun onNext(s: T) {
+        override fun onNext(s: T) {
+            forEachSubscriberWithDbTx { onNext(s) }
+        }
+
+        override fun onStart() {
+            forEachSubscriberWithDbTx { onStart() }
+        }
+
+        fun cleanUp() {
+            if (delegates.removeIf { it.isUnsubscribed }) {
+                if (delegates.isEmpty()) {
+                    unsubscribe()
                 }
             }
         }
     }
-    return this.lift<T>(op).doOnUnsubscribe { op.shared.cleanUp() }
+
+    // An operator that adds subscribers to a special subscriber that wraps a database transaction around observations.
+    val op = object : Observable.Operator<T, T> {
+        val wrappingSubscriber = DatabaseTransactionWrappingSubscriber<T>(db)
+
+        // Each subscriber will be passed to this function when they subscribe, at which point we add them to wrapping subscriber.
+        override fun call(toBeWrappedInDbTx: Subscriber<in T>): Subscriber<in T> {
+            // Add the subscriber to the wrapping subscriber, which will invoke the original subscribers together inside a database transaction.
+            wrappingSubscriber.delegates.add(toBeWrappedInDbTx)
+            // If we are the first subscriber, return the shared subscriber, otherwise return a subscriber that does nothing.
+            return if (wrappingSubscriber.delegates.size == 1) wrappingSubscriber else NoOpSubscriber<T>(toBeWrappedInDbTx)
+        }
+    }
+    // Wrap subscribers, and then when they unsubscribe, clean up the shared list of subscribers.
+    return this.lift<T>(op).doOnUnsubscribe { op.wrappingSubscriber.cleanUp() }
 }
 
 // Composite columns for use with below Exposed helpers.

--- a/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
@@ -190,76 +190,73 @@ fun <T : Any> rx.Observer<T>.bufferUntilDatabaseCommit(): rx.Observer<T> {
     return subject
 }
 
+
+// A subscriber that delegates to multiple others, wrapping a database transaction around the combination.
+private class DatabaseTransactionWrappingSubscriber<U>(val db: Database?) : Subscriber<U>() {
+    // Some unsubscribes happen inside onNext() so need something that supports concurrent modification.
+    val delegates = CopyOnWriteArrayList<Subscriber<in U>>()
+
+    fun forEachSubscriberWithDbTx(block: Subscriber<in U>.() -> Unit) {
+        databaseTransaction(db ?: StrandLocalTransactionManager.database) {
+            delegates.filter { !it.isUnsubscribed }.forEach {
+                it.block()
+            }
+        }
+    }
+
+    override fun onCompleted() {
+        forEachSubscriberWithDbTx { onCompleted() }
+    }
+
+    override fun onError(e: Throwable?) {
+        forEachSubscriberWithDbTx { onError(e) }
+    }
+
+    override fun onNext(s: U) {
+        forEachSubscriberWithDbTx { onNext(s) }
+    }
+
+    override fun onStart() {
+        forEachSubscriberWithDbTx { onStart() }
+    }
+
+    fun cleanUp() {
+        if (delegates.removeIf { it.isUnsubscribed }) {
+            if (delegates.isEmpty()) {
+                unsubscribe()
+            }
+        }
+    }
+}
+
+// A subscriber that wraps another but does not pass on observations to it.
+private class NoOpSubscriber<U>(t: Subscriber<in U>) : Subscriber<U>(t) {
+    override fun onCompleted() {
+    }
+
+    override fun onError(e: Throwable?) {
+    }
+
+    override fun onNext(s: U) {
+    }
+}
+
 /**
  * Wrap delivery of observations in a database transaction.  Multiple subscribers will receive the observations inside
  * the same database transaction.  This also lazily subscribes to the source [rx.Observable] to preserve any buffering
  * that might be in place.
  */
 fun <T : Any> rx.Observable<T>.wrapWithDatabaseTransaction(db: Database? = null): rx.Observable<T> {
-    // A subscriber that wraps another but does not pass on observations to it.
-    class NoOpSubscriber<U>(t: Subscriber<in U>) : Subscriber<U>(t) {
-        override fun onCompleted() {
-        }
-
-        override fun onError(e: Throwable?) {
-        }
-
-        override fun onNext(s: U) {
-        }
-    }
-
-    // A subscriber that delegates to multiple others, wrapping a database transaction around the combination.
-    class DatabaseTransactionWrappingSubscriber<U>(db: Database?) : Subscriber<T>() {
-        // Some unsubscribes happen inside onNext() so need something that supports concurrent modification.
-        val delegates = CopyOnWriteArrayList<Subscriber<in T>>()
-
-        fun forEachSubscriberWithDbTx(block: Subscriber<in T>.() -> Unit) {
-            databaseTransaction(db ?: StrandLocalTransactionManager.database) {
-                delegates.filter { !it.isUnsubscribed }.forEach {
-                    it.block()
-                }
-            }
-        }
-
-        override fun onCompleted() {
-            forEachSubscriberWithDbTx { onCompleted() }
-        }
-
-        override fun onError(e: Throwable?) {
-            forEachSubscriberWithDbTx { onError(e) }
-        }
-
-        override fun onNext(s: T) {
-            forEachSubscriberWithDbTx { onNext(s) }
-        }
-
-        override fun onStart() {
-            forEachSubscriberWithDbTx { onStart() }
-        }
-
-        fun cleanUp() {
-            if (delegates.removeIf { it.isUnsubscribed }) {
-                if (delegates.isEmpty()) {
-                    unsubscribe()
-                }
-            }
-        }
-    }
-
-    // An operator that adds subscribers to a special subscriber that wraps a database transaction around observations.
-    val op = object : Observable.Operator<T, T> {
-        val wrappingSubscriber = DatabaseTransactionWrappingSubscriber<T>(db)
-
-        // Each subscriber will be passed to this function when they subscribe, at which point we add them to wrapping subscriber.
-        override fun call(toBeWrappedInDbTx: Subscriber<in T>): Subscriber<in T> {
-            // Add the subscriber to the wrapping subscriber, which will invoke the original subscribers together inside a database transaction.
-            wrappingSubscriber.delegates.add(toBeWrappedInDbTx)
-            // If we are the first subscriber, return the shared subscriber, otherwise return a subscriber that does nothing.
-            return if (wrappingSubscriber.delegates.size == 1) wrappingSubscriber else NoOpSubscriber<T>(toBeWrappedInDbTx)
-        }
-    }
-    // Wrap subscribers, and then when they unsubscribe, clean up the shared list of subscribers.
-    return this.lift<T>(op).doOnUnsubscribe { op.wrappingSubscriber.cleanUp() }
+    val wrappingSubscriber = DatabaseTransactionWrappingSubscriber<T>(db)
+    // Use lift to add subscribers to a special subscriber that wraps a database transaction around observations.
+    // Each subscriber will be passed to this lambda when they subscribe, at which point we add them to wrapping subscriber.
+    return this.lift { toBeWrappedInDbTx: Subscriber<in T> ->
+        // Add the subscriber to the wrapping subscriber, which will invoke the original subscribers together inside a database transaction.
+        wrappingSubscriber.delegates.add(toBeWrappedInDbTx)
+        // If we are the first subscriber, return the shared subscriber, otherwise return a subscriber that does nothing.
+        if (wrappingSubscriber.delegates.size == 1) wrappingSubscriber else NoOpSubscriber<T>(toBeWrappedInDbTx)
+        // Clean up the shared list of subscribers when they unsubscribe.
+    }.doOnUnsubscribe { wrappingSubscriber.cleanUp() }
 }
 
 // Composite columns for use with below Exposed helpers.

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -50,9 +50,11 @@ class CordaRPCOpsImplTest {
         rpc = CordaRPCOpsImpl(aliceNode.services, aliceNode.smm, aliceNode.database)
         CURRENT_RPC_USER.set(User("user", "pwd", permissions = setOf(startFlowPermission<CashFlow>())))
 
-        stateMachineUpdates = rpc.stateMachinesAndUpdates().second
-        transactions = rpc.verifiedTransactions().second
-        vaultUpdates = rpc.vaultAndUpdates().second
+        databaseTransaction(aliceNode.database) {
+            stateMachineUpdates = rpc.stateMachinesAndUpdates().second
+            transactions = rpc.verifiedTransactions().second
+            vaultUpdates = rpc.vaultAndUpdates().second
+        }
     }
 
     @Test

--- a/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
@@ -194,7 +194,7 @@ class ObservablesTests {
     }
 
     @Test
-    fun `check wrapping doesn't eagerly subscribe`() {
+    fun `check wrapping in db tx doesn't eagerly subscribe`() {
         val database = createDatabase()
 
         val source = PublishSubject.create<Int>()
@@ -217,7 +217,7 @@ class ObservablesTests {
     }
 
     @Test
-    fun `check wrapping unsubscribes`() {
+    fun `check wrapping in db tx unsubscribes`() {
         val database = createDatabase()
 
         val source = PublishSubject.create<Int>()

--- a/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
@@ -5,22 +5,39 @@ import net.corda.core.bufferUntilSubscribed
 import net.corda.core.tee
 import net.corda.testing.node.makeTestDataSourceProperties
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.junit.After
 import org.junit.Test
 import rx.Observable
 import rx.subjects.PublishSubject
+import java.io.Closeable
 import java.util.*
 
 class ObservablesTests {
 
     private fun isInDatabaseTransaction(): Boolean = (TransactionManager.currentOrNull() != null)
 
+    val toBeClosed = mutableListOf<Closeable>()
+
+    fun createDatabase(): Database {
+        val (closeable, database) = configureDatabase(makeTestDataSourceProperties())
+        toBeClosed += closeable
+        return database
+    }
+
+    @After
+    fun after() {
+        toBeClosed.forEach { it.close() }
+        toBeClosed.clear()
+    }
+
     @Test
     fun `bufferUntilDatabaseCommit delays until transaction closed`() {
-        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+        val database = createDatabase()
 
-        val subject = PublishSubject.create<Int>()
-        val observable: Observable<Int> = subject
+        val source = PublishSubject.create<Int>()
+        val observable: Observable<Int> = source
 
         val firstEvent = SettableFuture.create<Pair<Int, Boolean>>()
         val secondEvent = SettableFuture.create<Pair<Int, Boolean>>()
@@ -29,10 +46,10 @@ class ObservablesTests {
         observable.skip(1).first().subscribe { secondEvent.set(it to isInDatabaseTransaction()) }
 
         databaseTransaction(database) {
-            val delayedSubject = subject.bufferUntilDatabaseCommit()
-            assertThat(subject).isNotEqualTo(delayedSubject)
+            val delayedSubject = source.bufferUntilDatabaseCommit()
+            assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(0)
-            subject.onNext(1)
+            source.onNext(1)
             assertThat(firstEvent.isDone).isTrue()
             assertThat(secondEvent.isDone).isFalse()
         }
@@ -40,16 +57,14 @@ class ObservablesTests {
 
         assertThat(firstEvent.get()).isEqualTo(1 to true)
         assertThat(secondEvent.get()).isEqualTo(0 to false)
-
-        toBeClosed.close()
     }
 
     @Test
     fun `bufferUntilDatabaseCommit delays until transaction closed repeatable`() {
-        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+        val database = createDatabase()
 
-        val subject = PublishSubject.create<Int>()
-        val observable: Observable<Int> = subject
+        val source = PublishSubject.create<Int>()
+        val observable: Observable<Int> = source
 
         val firstEvent = SettableFuture.create<Pair<Int, Boolean>>()
         val secondEvent = SettableFuture.create<Pair<Int, Boolean>>()
@@ -58,8 +73,8 @@ class ObservablesTests {
         observable.skip(1).first().subscribe { secondEvent.set(it to isInDatabaseTransaction()) }
 
         databaseTransaction(database) {
-            val delayedSubject = subject.bufferUntilDatabaseCommit()
-            assertThat(subject).isNotEqualTo(delayedSubject)
+            val delayedSubject = source.bufferUntilDatabaseCommit()
+            assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(0)
             assertThat(firstEvent.isDone).isFalse()
             assertThat(secondEvent.isDone).isFalse()
@@ -69,33 +84,31 @@ class ObservablesTests {
         assertThat(secondEvent.isDone).isFalse()
 
         databaseTransaction(database) {
-            val delayedSubject = subject.bufferUntilDatabaseCommit()
-            assertThat(subject).isNotEqualTo(delayedSubject)
+            val delayedSubject = source.bufferUntilDatabaseCommit()
+            assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(1)
             assertThat(secondEvent.isDone).isFalse()
         }
         assertThat(secondEvent.isDone).isTrue()
         assertThat(secondEvent.get()).isEqualTo(1 to false)
-
-        toBeClosed.close()
     }
 
     @Test
     fun `tee correctly copies observations to multiple observers`() {
 
-        val subject1 = PublishSubject.create<Int>()
-        val subject2 = PublishSubject.create<Int>()
-        val subject3 = PublishSubject.create<Int>()
+        val source1 = PublishSubject.create<Int>()
+        val source2 = PublishSubject.create<Int>()
+        val source3 = PublishSubject.create<Int>()
 
         val event1 = SettableFuture.create<Int>()
         val event2 = SettableFuture.create<Int>()
         val event3 = SettableFuture.create<Int>()
 
-        subject1.subscribe { event1.set(it) }
-        subject2.subscribe { event2.set(it) }
-        subject3.subscribe { event3.set(it) }
+        source1.subscribe { event1.set(it) }
+        source2.subscribe { event2.set(it) }
+        source3.subscribe { event3.set(it) }
 
-        val tee = subject1.tee(subject2, subject3)
+        val tee = source1.tee(source2, source3)
         tee.onNext(0)
 
         assertThat(event1.isDone).isTrue()
@@ -106,19 +119,19 @@ class ObservablesTests {
         assertThat(event3.get()).isEqualTo(0)
 
         tee.onCompleted()
-        assertThat(subject1.hasCompleted()).isTrue()
-        assertThat(subject2.hasCompleted()).isTrue()
-        assertThat(subject3.hasCompleted()).isTrue()
+        assertThat(source1.hasCompleted()).isTrue()
+        assertThat(source2.hasCompleted()).isTrue()
+        assertThat(source3.hasCompleted()).isTrue()
     }
 
     @Test
     fun `combine tee and bufferUntilDatabaseCommit`() {
-        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+        val database = createDatabase()
 
-        val subject = PublishSubject.create<Int>()
+        val source = PublishSubject.create<Int>()
         val teed = PublishSubject.create<Int>()
 
-        val observable: Observable<Int> = subject
+        val observable: Observable<Int> = source
 
         val firstEvent = SettableFuture.create<Pair<Int, Boolean>>()
         val teedEvent = SettableFuture.create<Pair<Int, Boolean>>()
@@ -128,8 +141,8 @@ class ObservablesTests {
         teed.first().subscribe { teedEvent.set(it to isInDatabaseTransaction()) }
 
         databaseTransaction(database) {
-            val delayedSubject = subject.bufferUntilDatabaseCommit().tee(teed)
-            assertThat(subject).isNotEqualTo(delayedSubject)
+            val delayedSubject = source.bufferUntilDatabaseCommit().tee(teed)
+            assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(0)
             assertThat(firstEvent.isDone).isFalse()
             assertThat(teedEvent.isDone).isTrue()
@@ -138,94 +151,90 @@ class ObservablesTests {
 
         assertThat(firstEvent.get()).isEqualTo(0 to false)
         assertThat(teedEvent.get()).isEqualTo(0 to true)
-
-        toBeClosed.close()
     }
 
     @Test
     fun `new transaction open in observer when wrapped`() {
-        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+        val database = createDatabase()
 
-        val subject = PublishSubject.create<Int>()
-        val observable: Observable<Int> = subject.wrapWithDatabaseTransaction()
+        val source = PublishSubject.create<Int>()
+        val observableWithDbTx: Observable<Int> = source.wrapWithDatabaseTransaction()
 
-        val firstEvent = SettableFuture.create<Pair<Int, Boolean>>()
-        val secondEvent1 = SettableFuture.create<Pair<Int, UUID?>>()
-        val secondEvent2 = SettableFuture.create<Pair<Int, UUID?>>()
+        val undelayedEvent = SettableFuture.create<Pair<Int, Boolean>>()
+        val delayedEventFromSecondObserver = SettableFuture.create<Pair<Int, UUID?>>()
+        val delayedEventFromThirdObserver = SettableFuture.create<Pair<Int, UUID?>>()
 
-        observable.first().subscribe { firstEvent.set(it to isInDatabaseTransaction()) }
-        observable.skip(1).first().subscribe { secondEvent1.set(it to if (isInDatabaseTransaction()) StrandLocalTransactionManager.transactionId else null) }
-        observable.skip(1).first().subscribe { secondEvent2.set(it to if (isInDatabaseTransaction()) StrandLocalTransactionManager.transactionId else null) }
+        observableWithDbTx.first().subscribe { undelayedEvent.set(it to isInDatabaseTransaction()) }
+
+        fun observeSecondEvent(event: Int, future: SettableFuture<Pair<Int, UUID?>>) {
+            future.set(event to if (isInDatabaseTransaction()) StrandLocalTransactionManager.transactionId else null)
+        }
+
+        observableWithDbTx.skip(1).first().subscribe { observeSecondEvent(it, delayedEventFromSecondObserver) }
+        observableWithDbTx.skip(1).first().subscribe { observeSecondEvent(it, delayedEventFromThirdObserver) }
 
         databaseTransaction(database) {
-            val delayedSubject = subject.bufferUntilDatabaseCommit()
-            assertThat(subject).isNotEqualTo(delayedSubject)
-            delayedSubject.onNext(0)
-            subject.onNext(1)
-            assertThat(firstEvent.isDone).isTrue()
-            assertThat(secondEvent1.isDone).isFalse()
+            val commitDelayedSource = source.bufferUntilDatabaseCommit()
+            assertThat(source).isNotEqualTo(commitDelayedSource)
+            commitDelayedSource.onNext(0)
+            source.onNext(1)
+            assertThat(undelayedEvent.isDone).isTrue()
+            assertThat(undelayedEvent.get()).isEqualTo(1 to true)
+            assertThat(delayedEventFromSecondObserver.isDone).isFalse()
         }
-        assertThat(secondEvent1.isDone).isTrue()
+        assertThat(delayedEventFromSecondObserver.isDone).isTrue()
 
-        assertThat(firstEvent.get()).isEqualTo(1 to true)
-        assertThat(secondEvent1.get().first).isEqualTo(0)
-        assertThat(secondEvent1.get().second).isNotNull()
-        assertThat(secondEvent2.get().first).isEqualTo(0)
-        assertThat(secondEvent2.get().second).isNotNull()
+        assertThat(delayedEventFromSecondObserver.get().first).isEqualTo(0)
+        assertThat(delayedEventFromSecondObserver.get().second).isNotNull()
+        assertThat(delayedEventFromThirdObserver.get().first).isEqualTo(0)
+        assertThat(delayedEventFromThirdObserver.get().second).isNotNull()
 
         // Test that the two observers of the second event were notified inside the same database transaction.
-        assertThat(secondEvent1.get().second).isEqualTo(secondEvent2.get().second)
-
-        toBeClosed.close()
+        assertThat(delayedEventFromSecondObserver.get().second).isEqualTo(delayedEventFromThirdObserver.get().second)
     }
 
     @Test
     fun `check wrapping doesn't eagerly subscribe`() {
-        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+        val database = createDatabase()
 
-        val subject = PublishSubject.create<Int>()
+        val source = PublishSubject.create<Int>()
         var subscribed = false
         val event = SettableFuture.create<Int>()
 
-        val observable1: Observable<Int> = subject.bufferUntilSubscribed().doOnSubscribe { subscribed = true }
-        val observable2: Observable<Int> = observable1.wrapWithDatabaseTransaction(database)
+        val bufferedObservable: Observable<Int> = source.bufferUntilSubscribed().doOnSubscribe { subscribed = true }
+        val databaseWrappedObservable: Observable<Int> = bufferedObservable.wrapWithDatabaseTransaction(database)
 
-        subject.onNext(0)
+        source.onNext(0)
 
         assertThat(subscribed).isFalse()
         assertThat(event.isDone).isFalse()
 
-        observable2.first().subscribe { event.set(it) }
-        subject.onNext(1)
+        databaseWrappedObservable.first().subscribe { event.set(it) }
+        source.onNext(1)
 
         assertThat(event.isDone).isTrue()
         assertThat(event.get()).isEqualTo(0)
-
-        toBeClosed.close()
     }
-
 
     @Test
     fun `check wrapping unsubscribes`() {
-        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+        val database = createDatabase()
 
-        val subject = PublishSubject.create<Int>()
+        val source = PublishSubject.create<Int>()
         var unsubscribed = false
 
-        val observable1: Observable<Int> = subject.bufferUntilSubscribed().doOnUnsubscribe { unsubscribed = true }
-        val observable2: Observable<Int> = observable1.wrapWithDatabaseTransaction(database)
+        val bufferedObservable: Observable<Int> = source.bufferUntilSubscribed().doOnUnsubscribe { unsubscribed = true }
+        val databaseWrappedObservable: Observable<Int> = bufferedObservable.wrapWithDatabaseTransaction(database)
 
         assertThat(unsubscribed).isFalse()
 
-        val subscription1 = observable2.subscribe { }
-        val subscription2 = observable2.subscribe { }
+        val subscription1 = databaseWrappedObservable.subscribe { }
+        val subscription2 = databaseWrappedObservable.subscribe { }
 
         subscription1.unsubscribe()
         assertThat(unsubscribed).isFalse()
 
         subscription2.unsubscribe()
         assertThat(unsubscribed).isTrue()
-
-        toBeClosed.close()
     }
 }

--- a/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
@@ -1,6 +1,7 @@
 package net.corda.node.utilities
 
 import com.google.common.util.concurrent.SettableFuture
+import net.corda.core.bufferUntilSubscribed
 import net.corda.core.tee
 import net.corda.testing.node.makeTestDataSourceProperties
 import org.assertj.core.api.Assertions.assertThat
@@ -8,6 +9,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.junit.Test
 import rx.Observable
 import rx.subjects.PublishSubject
+import java.util.*
 
 class ObservablesTests {
 
@@ -136,6 +138,93 @@ class ObservablesTests {
 
         assertThat(firstEvent.get()).isEqualTo(0 to false)
         assertThat(teedEvent.get()).isEqualTo(0 to true)
+
+        toBeClosed.close()
+    }
+
+    @Test
+    fun `new transaction open in observer when wrapped`() {
+        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+
+        val subject = PublishSubject.create<Int>()
+        val observable: Observable<Int> = subject.wrapWithDatabaseTransaction()
+
+        val firstEvent = SettableFuture.create<Pair<Int, Boolean>>()
+        val secondEvent1 = SettableFuture.create<Pair<Int, UUID?>>()
+        val secondEvent2 = SettableFuture.create<Pair<Int, UUID?>>()
+
+        observable.first().subscribe { firstEvent.set(it to isInDatabaseTransaction()) }
+        observable.skip(1).first().subscribe { secondEvent1.set(it to if (isInDatabaseTransaction()) StrandLocalTransactionManager.transactionId else null) }
+        observable.skip(1).first().subscribe { secondEvent2.set(it to if (isInDatabaseTransaction()) StrandLocalTransactionManager.transactionId else null) }
+
+        databaseTransaction(database) {
+            val delayedSubject = subject.bufferUntilDatabaseCommit()
+            assertThat(subject).isNotEqualTo(delayedSubject)
+            delayedSubject.onNext(0)
+            subject.onNext(1)
+            assertThat(firstEvent.isDone).isTrue()
+            assertThat(secondEvent1.isDone).isFalse()
+        }
+        assertThat(secondEvent1.isDone).isTrue()
+
+        assertThat(firstEvent.get()).isEqualTo(1 to true)
+        assertThat(secondEvent1.get().first).isEqualTo(0)
+        assertThat(secondEvent1.get().second).isNotNull()
+        assertThat(secondEvent2.get().first).isEqualTo(0)
+        assertThat(secondEvent2.get().second).isNotNull()
+
+        // Test that the two observers of the second event were notified inside the same database transaction.
+        assertThat(secondEvent1.get().second).isEqualTo(secondEvent2.get().second)
+
+        toBeClosed.close()
+    }
+
+    @Test
+    fun `check wrapping doesn't eagerly subscribe`() {
+        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+
+        val subject = PublishSubject.create<Int>()
+        var subscribed = false
+        val event = SettableFuture.create<Int>()
+
+        val observable1: Observable<Int> = subject.bufferUntilSubscribed().doOnSubscribe { subscribed = true }
+        val observable2: Observable<Int> = observable1.wrapWithDatabaseTransaction(database)
+
+        subject.onNext(0)
+
+        assertThat(subscribed).isFalse()
+        assertThat(event.isDone).isFalse()
+
+        observable2.first().subscribe { event.set(it) }
+        subject.onNext(1)
+
+        assertThat(event.isDone).isTrue()
+        assertThat(event.get()).isEqualTo(0)
+
+        toBeClosed.close()
+    }
+
+
+    @Test
+    fun `check wrapping unsubscribes`() {
+        val (toBeClosed, database) = configureDatabase(makeTestDataSourceProperties())
+
+        val subject = PublishSubject.create<Int>()
+        var unsubscribed = false
+
+        val observable1: Observable<Int> = subject.bufferUntilSubscribed().doOnUnsubscribe { unsubscribed = true }
+        val observable2: Observable<Int> = observable1.wrapWithDatabaseTransaction(database)
+
+        assertThat(unsubscribed).isFalse()
+
+        val subscription1 = observable2.subscribe { }
+        val subscription2 = observable2.subscribe { }
+
+        subscription1.unsubscribe()
+        assertThat(unsubscribed).isFalse()
+
+        subscription2.unsubscribe()
+        assertThat(unsubscribed).isTrue()
 
         toBeClosed.close()
     }


### PR DESCRIPTION
Having made the observations _post database commit_ the `Observers` no longer have access to a database transaction.  This change re-introduces a database transaction for the `Observers`, so that they can interact with the database as needed, but it is distinct from that being observed.

Matthew encountered this when he updated to using the post-commit change.

Seems like this should have been easier, using more built in functionality but, alas, no.