### PR TITLE
Add Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+dist: trusty
+
+language: java
+
+script:
+  - ./gradlew build
+  - ./gradlew install


### PR DESCRIPTION
Hi folks,

I'd like to propose using Travis CI as a continuous integration platform for corda, here is a demo build:
https://travis-ci.org/fracting/corda/builds

[![Build Status](https://travis-ci.org/fracting/corda.svg?branch=ci-20161228)](https://travis-ci.org/fracting/corda)

If this patch is accepted, I'm going to setup another build configuration for corda on Windows platform using Appveyor [1]. Both Travis CI and Appveyor are free for open source projects.

If you need assistant to connect Travis CI with corda github account please let me know.

Please share me what you think or what I can help further. Cheers.

[1] https://www.appveyor.com/
