### PR TITLE
[WIP] Make InMemoryUniquenessProvider idempotent

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryUniquenessProvider.kt
@@ -20,13 +20,22 @@ class InMemoryUniquenessProvider() : UniquenessProvider {
             val conflictingStates = LinkedHashMap<StateRef, UniquenessProvider.ConsumingTx>()
             for (inputState in states) {
                 val consumingTx = get(inputState)
-                if (consumingTx != null) conflictingStates[inputState] = consumingTx
+                // If one or more inputs have been used as input for a transaction with a different ID we have a conflict.
+                // The ID is a SecureHash over the transaction, it can be seen as the "output". Identical states can not
+                // be used as input for multiple transactions (e.g. double spending is not allowed).
+                // TODO:
+                // - Only allow the same callerIdentity to re-commit the inputs?
+                // - Only allow re-commit for identical parameters?
+                // - Add a time limit to re-committing or restrict the number of attempts to re-commit the input states?
+                if (consumingTx != null && consumingTx.id != txId)
+                    conflictingStates[inputState] = consumingTx
             }
             if (conflictingStates.isNotEmpty()) {
                 val conflict = UniquenessProvider.Conflict(conflictingStates)
                 throw UniquenessException(conflict)
             } else {
                 states.forEachIndexed { i, stateRef ->
+                    // TODO: Put is a noop in the re-commit case.
                     put(stateRef, UniquenessProvider.ConsumingTx(txId, i, callerIdentity))
                 }
             }


### PR DESCRIPTION
The goal is to make the notary flows idempotent. This could be done by
patching the NotaryFlow implementation, but I've decided to change the
underlying uniqueness providers.

TODO: Update the perisistent and raft uniqueness providers.