### PR TITLE
Make NotaryFlow idempotent

### DIFF
--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -101,6 +101,7 @@ object NotaryFlow {
 
             val result = try {
                 validateTimestamp(wtx)
+                detectDuplicateInputs(wtx)
                 beforeCommit(stx)
                 commitInputStates(wtx)
                 val sig = sign(stx.id.bytes)
@@ -145,11 +146,10 @@ object NotaryFlow {
             }
         }
 
-        /** A NotaryException is thrown if any of the states have been consumed by a different transaction or input
-         * states are present multiple times within this transaction.
+        /** A NotaryException is thrown if any of the states have been consumed by a different transaction. Note that
+         * this method does not throw an exception when input states are present multiple times within the transaction.
          */
         private fun commitInputStates(tx: WireTransaction) {
-            detectDuplicateInputs(tx)
             try {
                 uniquenessProvider.commit(tx.inputs, tx.id, otherSide)
             } catch (e: UniquenessException) {

--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -146,7 +146,8 @@ object NotaryFlow {
             }
         }
 
-        /** A NotaryException is thrown if any of the states have been consumed by a different transaction. Note that
+        /**
+         * A NotaryException is thrown if any of the states have been consumed by a different transaction. Note that
          * this method does not throw an exception when input states are present multiple times within the transaction.
          */
         private fun commitInputStates(tx: WireTransaction) {

--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -101,6 +101,7 @@ object NotaryFlow {
 
             val result = try {
                 validateTimestamp(wtx)
+                // TODO:  Move the duplicate input detection to `TransactionType.verify()`.
                 detectDuplicateInputs(wtx)
                 beforeCommit(stx)
                 commitInputStates(wtx)

--- a/node/src/test/kotlin/net/corda/node/services/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryServiceTests.kt
@@ -95,15 +95,34 @@ class NotaryServiceTests {
 
         val firstAttempt = NotaryFlow.Client(stx)
         val secondAttempt = NotaryFlow.Client(stx)
-        clientNode.services.startFlow(firstAttempt)
-        val future = clientNode.services.startFlow(secondAttempt)
+        val f1 = clientNode.services.startFlow(firstAttempt)
+        val f2 = clientNode.services.startFlow(secondAttempt)
 
         net.runNetwork()
 
-        future.resultFuture.getOrThrow()
+        assertEquals(f1.resultFuture.getOrThrow(), f2.resultFuture.getOrThrow())
     }
 
-    @Test fun `should report conflict when inputs are reused accross transactions`() {
+    @Test fun `should report conflict when inputs are reused within a single transactions`() {
+        val stx = run {
+            val inputState = issueState(clientNode)
+            // Use inputState twice as input of a single transaction.
+            val tx = TransactionType.General.Builder(notaryNode.info.notaryIdentity).withItems(inputState, inputState)
+            tx.signWith(clientNode.keyPair!!)
+            tx.toSignedTransaction(false)
+        }
+
+        val future = clientNode.services.startFlow(NotaryFlow.Client(stx))
+
+        net.runNetwork()
+
+        val ex = assertFailsWith(NotaryException::class) { future.resultFuture.getOrThrow() }
+        val notaryError = ex.error as NotaryError.Conflict
+        assertEquals(notaryError.tx, stx.tx)
+        notaryError.conflict.verified()
+    }
+
+    @Test fun `should report conflict when inputs are reused across transactions`() {
         val inputState = issueState(clientNode)
         val stx = run {
             val tx = TransactionType.General.Builder(notaryNode.info.notaryIdentity).withItems(inputState)


### PR DESCRIPTION
Alternatively, we could make the underlying UniquenessProviders idempotent.