### PR TITLE
Update notary change flow to support encumbrances

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -114,25 +114,6 @@ interface ContractState {
      * list should just contain the owner.
      */
     val participants: List<CompositeKey>
-
-    /**
-     * All contract states may be _encumbered_ by up to one other state.
-     *
-     * The encumbrance state, if present, forces additional controls over the encumbered state, since the platform checks
-     * that the encumbrance state is present as an input in the same transaction that consumes the encumbered state, and
-     * the contract code and rules of the encumbrance state will also be verified during the execution of the transaction.
-     * For example, a cash contract state could be encumbered with a time-lock contract state; the cash state is then only
-     * processable in a transaction that verifies that the time specified in the encumbrance time-lock has passed.
-     *
-     * The encumbered state refers to another by index, and the referred encumbrance state
-     * is an output state in a particular position on the same transaction that created the encumbered state. An alternative
-     * implementation would be encumber by reference to a StateRef., which would allow the specification of encumbrance
-     * by a state created in a prior transaction.
-     *
-     * Note that an encumbered state that is being consumed must have its encumbrance consumed in the same transaction,
-     * otherwise the transaction is not valid.
-     */
-    val encumbrance: Int? get() = null
 }
 
 /**
@@ -143,13 +124,31 @@ data class TransactionState<out T : ContractState>(
         /** The custom contract state */
         val data: T,
         /** Identity of the notary that ensures the state is not used as an input to a transaction more than once */
-        val notary: Party) {
+        val notary: Party,
+        /**
+         * All contract states may be _encumbered_ by up to one other state.
+         *
+         * The encumbrance state, if present, forces additional controls over the encumbered state, since the platform checks
+         * that the encumbrance state is present as an input in the same transaction that consumes the encumbered state, and
+         * the contract code and rules of the encumbrance state will also be verified during the execution of the transaction.
+         * For example, a cash contract state could be encumbered with a time-lock contract state; the cash state is then only
+         * processable in a transaction that verifies that the time specified in the encumbrance time-lock has passed.
+         *
+         * The encumbered state refers to another by index, and the referred encumbrance state
+         * is an output state in a particular position on the same transaction that created the encumbered state. An alternative
+         * implementation would be encumber by reference to a StateRef., which would allow the specification of encumbrance
+         * by a state created in a prior transaction.
+         *
+         * Note that an encumbered state that is being consumed must have its encumbrance consumed in the same transaction,
+         * otherwise the transaction is not valid.
+         */
+        val encumbrance: Int? = null) {
 
     /**
      * Copies the underlying state, replacing the notary field with the new value.
      * To replace the notary, we need an approval (signature) from _all_ participants of the [ContractState].
      */
-    fun withNotary(newNotary: Party) = TransactionState(this.data, newNotary)
+    fun withNotary(newNotary: Party) = TransactionState(this.data, newNotary, encumbrance)
 }
 
 /** Wraps the [ContractState] in a [TransactionState] object */

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionTypes.kt
@@ -74,14 +74,14 @@ sealed class TransactionType {
 
         private fun verifyEncumbrances(tx: LedgerTransaction) {
             // Validate that all encumbrances exist within the set of input states.
-            val encumberedInputs = tx.inputs.filter { it.state.data.encumbrance != null }
+            val encumberedInputs = tx.inputs.filter { it.state.encumbrance != null }
             encumberedInputs.forEach { encumberedInput ->
                 val encumbranceStateExists = tx.inputs.any {
-                    it.ref.txhash == encumberedInput.ref.txhash && it.ref.index == encumberedInput.state.data.encumbrance
+                    it.ref.txhash == encumberedInput.ref.txhash && it.ref.index == encumberedInput.state.encumbrance
                 }
                 if (!encumbranceStateExists) {
                     throw TransactionVerificationException.TransactionMissingEncumbranceException(
-                            tx, encumberedInput.state.data.encumbrance!!,
+                            tx, encumberedInput.state.encumbrance!!,
                             TransactionVerificationException.Direction.INPUT
                     )
                 }
@@ -90,11 +90,23 @@ sealed class TransactionType {
             // Check that, in the outputs, an encumbered state does not refer to itself as the encumbrance,
             // and that the number of outputs can contain the encumbrance.
             for ((i, output) in tx.outputs.withIndex()) {
-                val encumbranceIndex = output.data.encumbrance ?: continue
+                val encumbranceIndex = output.encumbrance ?: continue
                 if (encumbranceIndex == i || encumbranceIndex >= tx.outputs.size) {
                     throw TransactionVerificationException.TransactionMissingEncumbranceException(
                             tx, encumbranceIndex,
                             TransactionVerificationException.Direction.OUTPUT)
+                }
+            }
+            // Verify encumbrance contracts
+            val encumbranceStates = tx.inputs.mapNotNull { it.state.encumbrance }.map { tx.inputs[it].state } +
+                    tx.outputs.mapNotNull { it.encumbrance }.map { tx.outputs[it] }
+            val contracts = encumbranceStates.map { it.data.contract }
+            val ctx = tx.toTransactionForContract()
+            for (contract in contracts.toSet()) {
+                try {
+                    contract.verify(ctx)
+                } catch(e: Throwable) {
+                    throw TransactionVerificationException.ContractRejection(tx, contract, e)
                 }
             }
         }

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionTypes.kt
@@ -97,18 +97,6 @@ sealed class TransactionType {
                             TransactionVerificationException.Direction.OUTPUT)
                 }
             }
-            // Verify encumbrance contracts
-            val encumbranceStates = tx.inputs.mapNotNull { it.state.encumbrance }.map { tx.inputs[it].state } +
-                    tx.outputs.mapNotNull { it.encumbrance }.map { tx.outputs[it] }
-            val contracts = encumbranceStates.map { it.data.contract }
-            val ctx = tx.toTransactionForContract()
-            for (contract in contracts.toSet()) {
-                try {
-                    contract.verify(ctx)
-                } catch(e: Throwable) {
-                    throw TransactionVerificationException.ContractRejection(tx, contract, e)
-                }
-            }
         }
 
         /**

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -159,6 +159,7 @@ open class TransactionBuilder(
         return outputs.size - 1
     }
 
+    @JvmOverloads
     fun addOutputState(state: ContractState, notary: Party, encumbrance: Int? = null) = addOutputState(TransactionState(state, notary, encumbrance))
 
     /** A default notary must be specified during builder construction to use this method */

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -159,7 +159,7 @@ open class TransactionBuilder(
         return outputs.size - 1
     }
 
-    fun addOutputState(state: ContractState, notary: Party) = addOutputState(TransactionState(state, notary))
+    fun addOutputState(state: ContractState, notary: Party, encumbrance: Int? = null) = addOutputState(TransactionState(state, notary, encumbrance))
 
     /** A default notary must be specified during builder construction to use this method */
     fun addOutputState(state: ContractState): Int {

--- a/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
@@ -67,10 +67,10 @@ abstract class AbstractStateReplacementFlow<T> {
         }
 
         abstract protected fun assembleProposal(stateRef: StateRef, modification: T, stx: SignedTransaction): Proposal<T>
-        abstract protected fun assembleTx(): Pair<SignedTransaction, List<CompositeKey>>
+        abstract protected fun assembleTx(): Pair<SignedTransaction, Iterable<CompositeKey>>
 
         @Suspendable
-        private fun collectSignatures(participants: List<CompositeKey>, stx: SignedTransaction): List<DigitalSignature.WithKey> {
+        private fun collectSignatures(participants: Iterable<CompositeKey>, stx: SignedTransaction): List<DigitalSignature.WithKey> {
             val parties = participants.map {
                 val participantNode = serviceHub.networkMapCache.getNodeByLegalIdentityKey(it) ?:
                         throw IllegalStateException("Participant $it to state $originalState not found on the network")

--- a/core/src/main/kotlin/net/corda/flows/NotaryChangeFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryChangeFlow.kt
@@ -1,13 +1,11 @@
 package net.corda.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.ContractState
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.TransactionType
+import net.corda.core.contracts.*
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.UntrustworthyData
 import net.corda.flows.NotaryChangeFlow.Acceptor
@@ -36,17 +34,66 @@ object NotaryChangeFlow : AbstractStateReplacementFlow<Party>() {
         override fun assembleProposal(stateRef: StateRef, modification: Party, stx: SignedTransaction): AbstractStateReplacementFlow.Proposal<Party>
                 = Proposal(stateRef, modification, stx)
 
-        override fun assembleTx(): Pair<SignedTransaction, List<CompositeKey>> {
+        override fun assembleTx(): Pair<SignedTransaction, Iterable<CompositeKey>> {
             val state = originalState.state
-            val newState = state.withNotary(modification)
-            val participants = state.data.participants
-            val tx = TransactionType.NotaryChange.Builder(originalState.state.notary).withItems(originalState, newState)
+            val tx = TransactionType.NotaryChange.Builder(originalState.state.notary)
+
+            val participants: Iterable<CompositeKey>
+
+            if (state.encumbrance == null) {
+                val modifiedState = TransactionState(state.data, modification)
+                tx.addInputState(originalState)
+                tx.addOutputState(modifiedState)
+                participants = state.data.participants
+            } else {
+                participants = resolveEncumbrances(tx)
+            }
+
             val myKey = serviceHub.legalIdentityKey
             tx.signWith(myKey)
 
             val stx = tx.toSignedTransaction(false)
+
             return Pair(stx, participants)
         }
+
+        /**
+         * Adds the notary change state transitions to the [tx] builder for the [originalState] and its encumbrance
+         * state chain (encumbrance states migh be themselves encumbered by other states).
+         *
+         * @return union of all added states' participants
+         */
+        private fun resolveEncumbrances(tx: TransactionBuilder): Iterable<CompositeKey> {
+            val stateRef = originalState.ref
+            val txId = stateRef.txhash
+            val issuingTx = serviceHub.storageService.validatedTransactions.getTransaction(txId)
+            val outputs = issuingTx!!.tx.outputs
+
+            val participants = mutableSetOf<CompositeKey>()
+
+            var nextStateIndex = stateRef.index
+            var newOutputPosition = 0
+            while (nextStateIndex != -1) {
+                val nextState = outputs[nextStateIndex]
+                tx.addInputState(StateAndRef(nextState, StateRef(txId, nextStateIndex)))
+                participants.addAll(nextState.data.participants)
+
+                if (nextState.encumbrance == null) {
+                    val modifiedState = TransactionState(nextState.data, modification)
+                    tx.addOutputState(modifiedState)
+                    nextStateIndex = -1
+                } else {
+                    val modifiedState = TransactionState(nextState.data, modification, newOutputPosition + 1)
+                    tx.addOutputState(modifiedState)
+                    nextStateIndex = nextState.encumbrance
+                }
+
+                newOutputPosition++
+            }
+
+            return participants
+        }
+
     }
 
     class Acceptor(otherSide: Party,

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -84,12 +84,12 @@ private fun prepareOurInputsAndOutputs(serviceHub: ServiceHub, request: FxReques
     val (inputs, residual) = gatherOurInputs(serviceHub, sellAmount, request.notary)
 
     // Build and an output state for the counterparty
-    val transferedFundsOutput = Cash.State(sellAmount, request.counterparty.owningKey, null)
+    val transferedFundsOutput = Cash.State(sellAmount, request.counterparty.owningKey)
 
     if (residual > 0L) {
         // Build an output state for the residual change back to us
         val residualAmount = Amount(residual, sellAmount.token)
-        val residualOutput = Cash.State(residualAmount, serviceHub.myInfo.legalIdentity.owningKey, null)
+        val residualOutput = Cash.State(residualAmount, serviceHub.myInfo.legalIdentity.owningKey)
         return FxResponse(inputs, listOf(transferedFundsOutput, residualOutput))
     } else {
         return FxResponse(inputs, listOf(transferedFundsOutput))

--- a/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
+++ b/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
@@ -123,12 +123,6 @@ public class JavaCommercialPaper implements Contract {
         public List<CompositeKey> getParticipants() {
             return ImmutableList.of(this.owner);
         }
-
-        @Nullable
-        @Override
-        public Integer getEncumbrance() {
-            return null;
-        }
     }
 
     public interface Clauses {
@@ -303,10 +297,14 @@ public class JavaCommercialPaper implements Contract {
         return SecureHash.sha256("https://en.wikipedia.org/wiki/Commercial_paper");
     }
 
-    public TransactionBuilder generateIssue(@NotNull PartyAndReference issuance, @NotNull Amount<Issued<Currency>> faceValue, @Nullable Instant maturityDate, @NotNull Party notary) {
+    public TransactionBuilder generateIssue(@NotNull PartyAndReference issuance, @NotNull Amount<Issued<Currency>> faceValue, @Nullable Instant maturityDate, @NotNull Party notary, Integer encumbrance) {
         State state = new State(issuance, issuance.getParty().getOwningKey(), faceValue, maturityDate);
-        TransactionState output = new TransactionState<>(state, notary);
+        TransactionState output = new TransactionState<>(state, notary, encumbrance);
         return new TransactionType.General.Builder(notary).withItems(output, new Command(new Commands.Issue(), issuance.getParty().getOwningKey()));
+    }
+
+    public TransactionBuilder generateIssue(@NotNull PartyAndReference issuance, @NotNull Amount<Issued<Currency>> faceValue, @Nullable Instant maturityDate, @NotNull Party notary) {
+        return generateIssue(issuance, faceValue, maturityDate, notary, null);
     }
 
     public void generateRedeem(TransactionBuilder tx, StateAndRef<State> paper, VaultService vault) throws InsufficientBalanceException {
@@ -317,7 +315,7 @@ public class JavaCommercialPaper implements Contract {
 
     public void generateMove(TransactionBuilder tx, StateAndRef<State> paper, CompositeKey newOwner) {
         tx.addInputState(paper);
-        tx.addOutputState(new TransactionState<>(new State(paper.getState().getData().getIssuance(), newOwner, paper.getState().getData().getFaceValue(), paper.getState().getData().getMaturityDate()), paper.getState().getNotary()));
+        tx.addOutputState(new TransactionState<>(new State(paper.getState().getData().getIssuance(), newOwner, paper.getState().getData().getFaceValue(), paper.getState().getData().getMaturityDate()), paper.getState().getNotary(), paper.getState().getEncumbrance()));
         tx.addCommand(new Command(new Commands.Move(), paper.getState().getData().getOwner()));
     }
 }

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
@@ -82,8 +82,7 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
             override val amount: Amount<Issued<Currency>>,
 
             /** There must be a MoveCommand signed by this key to claim the amount. */
-            override val owner: CompositeKey,
-            override val encumbrance: Int? = null
+            override val owner: CompositeKey
     ) : FungibleAsset<Currency>, QueryableState {
         constructor(deposit: PartyAndReference, amount: Amount<Currency>, owner: CompositeKey)
                 : this(Amount(amount.quantity, Issued(deposit, amount.token)), owner)
@@ -103,7 +102,6 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
         override fun generateMappedObject(schema: MappedSchema): PersistentState {
             return when (schema) {
                 is CashSchemaV1 -> CashSchemaV1.PersistentCashState(
-                        encumbrance = this.encumbrance,
                         owner = this.owner.toBase58String(),
                         pennies = this.amount.quantity,
                         currency = this.amount.token.product.currencyCode,

--- a/finance/src/main/kotlin/net/corda/schemas/CashSchemaV1.kt
+++ b/finance/src/main/kotlin/net/corda/schemas/CashSchemaV1.kt
@@ -19,9 +19,6 @@ object CashSchemaV1 : MappedSchema(schemaFamily = CashSchema.javaClass, version 
     @Entity
     @Table(name = "cash_states")
     class PersistentCashState(
-            @Column(name = "encumbrance")
-            var encumbrance: Int?,
-
             @Column(name = "owner_key")
             var owner: String,
 

--- a/finance/src/test/java/net/corda/contracts/asset/CashTestsJava.java
+++ b/finance/src/test/java/net/corda/contracts/asset/CashTestsJava.java
@@ -15,8 +15,8 @@ import static net.corda.testing.CoreTestUtils.*;
 public class CashTestsJava {
     private final OpaqueBytes defaultRef = new OpaqueBytes(new byte[]{1});
     private final PartyAndReference defaultIssuer = getMEGA_CORP().ref(defaultRef);
-    private final Cash.State inState = new Cash.State(issuedBy(DOLLARS(1000), defaultIssuer), getDUMMY_PUBKEY_1(), null);
-    private final Cash.State outState = new Cash.State(inState.getAmount(), getDUMMY_PUBKEY_2(), null);
+    private final Cash.State inState = new Cash.State(issuedBy(DOLLARS(1000), defaultIssuer), getDUMMY_PUBKEY_1());
+    private final Cash.State outState = new Cash.State(inState.getAmount(), getDUMMY_PUBKEY_2());
 
     @Test
     public void trivial() {
@@ -26,7 +26,7 @@ public class CashTestsJava {
                 tx.failsWith("the amounts balance");
 
                 tx.tweak(tw -> {
-                    tw.output(new Cash.State(issuedBy(DOLLARS(2000), defaultIssuer), getDUMMY_PUBKEY_2(), null));
+                    tw.output(new Cash.State(issuedBy(DOLLARS(2000), defaultIssuer), getDUMMY_PUBKEY_2()));
                     return tw.failsWith("the amounts balance");
                 });
 

--- a/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
@@ -115,8 +115,8 @@ data class TestTransactionDSLInterpreter private constructor(
         transactionBuilder.addInputState(StateAndRef(state, stateRef))
     }
 
-    override fun _output(label: String?, notary: Party, contractState: ContractState) {
-        val outputIndex = transactionBuilder.addOutputState(contractState, notary)
+    override fun _output(label: String?, notary: Party, encumbrance: Int?, contractState: ContractState) {
+        val outputIndex = transactionBuilder.addOutputState(contractState, notary, encumbrance)
         if (label != null) {
             if (label in labelToIndexMap) {
                 throw DuplicateOutputLabel(label)

--- a/test-utils/src/main/kotlin/net/corda/testing/TransactionDSLInterpreter.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TransactionDSLInterpreter.kt
@@ -31,9 +31,10 @@ interface TransactionDSLInterpreter : Verifies, OutputStateLookup {
      * Adds an output to the transaction.
      * @param label An optional label that may be later used to retrieve the output probably in other transactions.
      * @param notary The associated notary.
+     * @param encumbrance The position of the encumbrance state.
      * @param contractState The state itself.
      */
-    fun _output(label: String?, notary: Party, contractState: ContractState)
+    fun _output(label: String?, notary: Party, encumbrance: Int?, contractState: ContractState)
 
     /**
      * Adds an [Attachment] reference to the transaction.
@@ -85,16 +86,16 @@ class TransactionDSL<out T : TransactionDSLInterpreter>(val interpreter: T) : Tr
      * @see TransactionDSLInterpreter._output
      */
     @JvmOverloads
-    fun output(label: String? = null, notary: Party = DUMMY_NOTARY, contractStateClosure: () -> ContractState) =
-            _output(label, notary,  contractStateClosure())
+    fun output(label: String? = null, notary: Party = DUMMY_NOTARY, encumbrance: Int? = null, contractStateClosure: () -> ContractState) =
+            _output(label, notary, encumbrance, contractStateClosure())
     /**
      * @see TransactionDSLInterpreter._output
      */
     fun output(label: String, contractState: ContractState) =
-            _output(label, DUMMY_NOTARY, contractState)
+            _output(label, DUMMY_NOTARY, null, contractState)
 
     fun output(contractState: ContractState) =
-            _output(null, DUMMY_NOTARY, contractState)
+            _output(null, DUMMY_NOTARY, null, contractState)
 
     /**
      * @see TransactionDSLInterpreter._command


### PR DESCRIPTION
Also moved the encumbrance pointer from ContractState to TransactionState - during the notary change tx we sometimes need to modify the encumbrance pointer to reflect the new output indexes.

Continuing from the discussion in Discourse, this is the minimal fix that makes encumbrances usable, without introducing a new type of state.

Will clean up & add tests later, just want to get some feedback first.
