### PR TITLE
Additional thread affinity for the StateMachineManager.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -58,6 +58,7 @@ interface ServiceHub {
 
     /**
      * Will check [logicType] and [args] against a whitelist and if acceptable then construct and initiate the flow.
+     * Note that you must be on the server thread to call this method.
      *
      * @throws IllegalFlowLogicException or IllegalArgumentException if there are problems with the [logicType] or [args].
      */

--- a/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
+++ b/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
@@ -1,9 +1,6 @@
 package net.corda.flows
 
 import com.google.common.util.concurrent.ListenableFuture
-import net.corda.testing.BOC
-import net.corda.testing.BOC_KEY
-import net.corda.flows.IssuerFlow.IssuanceRequester
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.PartyAndReference
@@ -14,10 +11,8 @@ import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.DUMMY_NOTARY_KEY
-import net.corda.testing.MEGA_CORP
-import net.corda.testing.MEGA_CORP_KEY
-import net.corda.testing.initiateSingleShotFlow
-import net.corda.testing.ledger
+import net.corda.flows.IssuerFlow.IssuanceRequester
+import net.corda.testing.*
 import net.corda.testing.node.MockNetwork
 import org.junit.Test
 import java.util.*
@@ -62,7 +57,7 @@ class IssuerFlowTest {
         }.map { it.fsm }
 
         val issueRequest = IssuanceRequester(amount, issueToPartyAndRef.party, issueToPartyAndRef.reference, bankOfCordaNode.info.legalIdentity)
-        val issueRequestResultFuture = bankClientNode.smm.add(issueRequest).resultFuture
+        val issueRequestResultFuture = bankClientNode.services.startFlow(issueRequest).resultFuture
 
         return IssuerFlowTest.RunResult(issuerFuture, issueRequestResultFuture)
     }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -6,7 +6,6 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.SettableFuture
 import net.corda.core.*
-import net.corda.core.contracts.Amount
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.X509Utilities
 import net.corda.core.flows.FlowLogic
@@ -17,12 +16,14 @@ import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.*
 import net.corda.core.node.services.*
 import net.corda.core.node.services.NetworkMapCache.MapChange
-import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
-import net.corda.flows.*
+import net.corda.flows.CashCommand
+import net.corda.flows.CashFlow
+import net.corda.flows.FinalityFlow
+import net.corda.flows.sendRequest
 import net.corda.node.api.APIServer
 import net.corda.node.services.api.*
 import net.corda.node.services.config.NodeConfiguration
@@ -123,7 +124,9 @@ abstract class AbstractNode(open val configuration: NodeConfiguration, val netwo
         override val monitoringService: MonitoringService = MonitoringService(MetricRegistry())
         override val flowLogicRefFactory: FlowLogicRefFactory get() = flowLogicFactory
 
-        override fun <T> startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = smm.add(logic)
+        override fun <T> startFlow(logic: FlowLogic<T>): FlowStateMachine<T> {
+            return serverThread.fetchFrom { smm.add(logic) }
+        }
 
         override fun registerFlowInitiator(markerClass: KClass<*>, flowFactory: (Party) -> FlowLogic<*>) {
             require(markerClass !in flowFactories) { "${markerClass.java.name} has already been used to register a flow" }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -64,9 +64,7 @@ abstract class ServiceHubInternal : PluginServiceHub {
     }
 
     /**
-     * TODO: borrowing this method from service manager work in another branch.  It's required to avoid circular dependency
-     *       between SMM and the scheduler.  That particular problem should also be resolved by the service manager work
-     *       itself, at which point this method would not be needed (by the scheduler).
+     * Starts an already constructed flow. Note that you must be on the server thread to call this method.
      */
     abstract fun <T> startFlow(logic: FlowLogic<T>): FlowStateMachine<T>
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -381,8 +381,11 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
      * Kicks off a brand new state machine of the given class.
      * The state machine will be persisted when it suspends, with automated restart if the StateMachineManager is
      * restarted with checkpointed state machines in the storage service.
+     *
+     * Note that you must be on the [executor] thread.
      */
     fun <T> add(logic: FlowLogic<T>): FlowStateMachine<T> {
+        executor.checkOnThread()
         // We swap out the parent transaction context as using this frequently leads to a deadlock as we wait
         // on the flow completion future inside that context. The problem is that any progress checkpoints are
         // unable to acquire the table lock and move forward till the calling transaction finishes.

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeProtocolTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeProtocolTests.kt
@@ -59,7 +59,6 @@ import kotlin.test.assertTrue
  * We assume that Alice and Bob already found each other via some market, and have agreed the details already.
  */
 class TwoPartyTradeFlowTests {
-
     lateinit var net: MockNetwork
     lateinit var notaryNode: MockNetwork.MockNode
     lateinit var aliceNode: MockNetwork.MockNode
@@ -418,7 +417,7 @@ class TwoPartyTradeFlowTests {
             Buyer(otherParty, notaryNode.info.notaryIdentity, 1000.DOLLARS, CommercialPaper.State::class.java)
         }.map { it.fsm }
         val seller = Seller(bobNode.info.legalIdentity, notaryNode.info, assetToSell, 1000.DOLLARS, ALICE_KEY)
-        val sellerResultFuture = aliceNode.smm.add(seller).resultFuture
+        val sellerResultFuture = aliceNode.services.startFlow(seller).resultFuture
         return RunResult(buyerFuture, sellerResultFuture, seller.fsm.id)
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
@@ -79,7 +79,9 @@ open class MockServiceHubInternal(
 
     override fun recordTransactions(txs: Iterable<SignedTransaction>) = recordTransactionsInternal(txStorageService, txs)
 
-    override fun <T> startFlow(logic: FlowLogic<T>): FlowStateMachine<T> = smm.add(logic)
+    override fun <T> startFlow(logic: FlowLogic<T>): FlowStateMachine<T> {
+        return smm.executor.fetchFrom { smm.add(logic) }
+    }
 
     override fun registerFlowInitiator(markerClass: KClass<*>, flowFactory: (Party) -> FlowLogic<*>) {
         flowFactories[markerClass.java] = flowFactory

--- a/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.assertTrue
 
 class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
-
     val realClock: Clock = Clock.systemUTC()
     val stoppedClock = Clock.fixed(realClock.instant(), realClock.zone)
     val testClock = TestClock(stoppedClock)


### PR DESCRIPTION
Check that the SMM.add method is being called on the SMM thread and throw if not. Make ServiceHubInternal.startFlow() do a blocking call onto the server thread. Update unit tests.

This resolves an issue whereby the scheduler was starting flows outside of the server thread, which isn't intended.