### PR TITLE
Upgrade reactivex.rxjava version to latest 1.x

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     compile "com.google.guava:guava:$guava_version"
 
     // RxJava: observable streams of events.
-    // TODO: We can't upgrade past 1.1.6 due to a behaviour change in RxJava breaking our code. See PR #99 for discussion. Resolve.
     compile "io.reactivex:rxjava:1.2.4"
 
     // Kryo: object graph serialization.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     // RxJava: observable streams of events.
     // TODO: We can't upgrade past 1.1.6 due to a behaviour change in RxJava breaking our code. See PR #99 for discussion. Resolve.
-    compile "io.reactivex:rxjava:1.1.6"
+    compile "io.reactivex:rxjava:1.2.4"
 
     // Kryo: object graph serialization.
     compile "com.esotericsoftware:kryo:4.0.0"

--- a/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
@@ -14,6 +14,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import rx.Observable
 import rx.Subscriber
 import rx.subjects.PublishSubject
+import rx.subjects.Subject
 import rx.subjects.UnicastSubject
 import java.io.Closeable
 import java.security.PublicKey
@@ -109,13 +110,13 @@ class StrandLocalTransactionManager(initWithDatabase: Database) : TransactionMan
 
         val manager: StrandLocalTransactionManager get() = databaseToInstance[database]!!
 
-        val transactionBoundaries: PublishSubject<Boundary> get() = manager._transactionBoundaries
+        val transactionBoundaries: Subject<Boundary, Boundary> get() = manager._transactionBoundaries
     }
 
 
     data class Boundary(val txId: UUID)
 
-    private val _transactionBoundaries = PublishSubject.create<Boundary>()
+    private val _transactionBoundaries = PublishSubject.create<Boundary>().toSerialized()
 
     init {
         // Found a unit test that was forgetting to close the database transactions.  When you close() on the top level
@@ -140,7 +141,7 @@ class StrandLocalTransactionManager(initWithDatabase: Database) : TransactionMan
     override fun currentOrNull(): Transaction? = threadLocalTx.get()
 
     // Direct copy of [ThreadLocalTransaction].
-    private class StrandLocalTransaction(override val db: Database, isolation: Int, val threadLocal: ThreadLocal<Transaction>, val transactionBoundaries: PublishSubject<Boundary>) : TransactionInterface {
+    private class StrandLocalTransaction(override val db: Database, isolation: Int, val threadLocal: ThreadLocal<Transaction>, val transactionBoundaries: Subject<Boundary, Boundary>) : TransactionInterface {
         val id = UUID.randomUUID()
 
         override val connection: Connection by lazy(LazyThreadSafetyMode.NONE) {
@@ -184,12 +185,11 @@ class StrandLocalTransactionManager(initWithDatabase: Database) : TransactionMan
 fun <T : Any> rx.Observer<T>.bufferUntilDatabaseCommit(): rx.Observer<T> {
     val currentTxId = StrandLocalTransactionManager.transactionId
     val databaseTxBoundary: Observable<StrandLocalTransactionManager.Boundary> = StrandLocalTransactionManager.transactionBoundaries.filter { it.txId == currentTxId }.first()
-    val subject = UnicastSubject.create<T>()
+    val subject = UnicastSubject.create<T>().toSerialized()
     subject.delaySubscription(databaseTxBoundary).subscribe(this)
     databaseTxBoundary.doOnCompleted { subject.onCompleted() }
     return subject
 }
-
 
 // A subscriber that delegates to multiple others, wrapping a database transaction around the combination.
 private class DatabaseTransactionWrappingSubscriber<U>(val db: Database?) : Subscriber<U>() {

--- a/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
@@ -185,7 +185,7 @@ class StrandLocalTransactionManager(initWithDatabase: Database) : TransactionMan
 fun <T : Any> rx.Observer<T>.bufferUntilDatabaseCommit(): rx.Observer<T> {
     val currentTxId = StrandLocalTransactionManager.transactionId
     val databaseTxBoundary: Observable<StrandLocalTransactionManager.Boundary> = StrandLocalTransactionManager.transactionBoundaries.filter { it.txId == currentTxId }.first()
-    val subject = UnicastSubject.create<T>().toSerialized()
+    val subject = UnicastSubject.create<T>()
     subject.delaySubscription(databaseTxBoundary).subscribe(this)
     databaseTxBoundary.doOnCompleted { subject.onCompleted() }
     return subject

--- a/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
@@ -116,7 +116,7 @@ class StrandLocalTransactionManager(initWithDatabase: Database) : TransactionMan
 
     data class Boundary(val txId: UUID)
 
-    private val _transactionBoundaries = PublishSubject.create<Boundary>().toSerialized()
+    private val _transactionBoundaries = PublishSubject.create<Boundary>()//.toSerialized()
 
     init {
         // Found a unit test that was forgetting to close the database transactions.  When you close() on the top level

--- a/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
@@ -116,7 +116,7 @@ class StrandLocalTransactionManager(initWithDatabase: Database) : TransactionMan
 
     data class Boundary(val txId: UUID)
 
-    private val _transactionBoundaries = PublishSubject.create<Boundary>()//.toSerialized()
+    private val _transactionBoundaries = PublishSubject.create<Boundary>().toSerialized()
 
     init {
         // Found a unit test that was forgetting to close the database transactions.  When you close() on the top level


### PR DESCRIPTION
(please excuse somewhat bogus branch title)

When upgrading previously we encountered some failing tests.  These could not be reproduced locally and so we suspected some kind of thread safety issue.  On further inspection it seems the database boundary related subject is obviously useable from multiple threads yet isn't _serialized_.  Converting this to the thread safe form using `toSerialized()` seems to resolve the issue after numerous runs of the branch in CI.  The run in CI after upgrading the library but before any other changes failed.
