### PR TITLE
Windows runnodes.bat now works from any working directory

### DIFF
--- a/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes.bat
+++ b/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes.bat
@@ -1,5 +1,8 @@
 @echo off
 
+REM Change to the directory of this script
+cd /d %~dp0
+
 FOR /R ".\" %%G in (.) DO (
  Pushd %%G
  start java -jar corda.jar

--- a/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes.bat
+++ b/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes.bat
@@ -1,10 +1,12 @@
 @echo off
 
-REM Change to the directory of this script
-cd /d %~dp0
+REM Change to the directory of this script (%~dp0)
+Pushd %~dp0
 
 FOR /R ".\" %%G in (.) DO (
  Pushd %%G
  start java -jar corda.jar
  Popd
 )
+
+Popd

--- a/publish.properties
+++ b/publish.properties
@@ -1,1 +1,1 @@
-gradlePluginsVersion=0.6.3
+gradlePluginsVersion=0.6.4


### PR DESCRIPTION
Before it would go into an infinite loop and crash the machine, or fail to start any nodes.