### PR TITLE
Two runnodes fixes for MacOS X

### DIFF
--- a/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
+++ b/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
@@ -16,10 +16,11 @@ if which osascript >/dev/null; then
     rootdir=`pwd`
     for dir in `ls`; do
         if [ -d $dir ]; then
+            cmd="bash -c 'cd $rootdir/$dir; /usr/libexec/java_home -v 1.8 --exec java -jar JAR_NAME && exit'"
             script="$script
     tell application \"System Events\" to tell process \"Terminal\" to keystroke \"t\" using command down
     delay 0.5
-    do script \"cd $rootdir/$dir; java -jar JAR_NAME && exit\" in window 1"
+    do script \"$cmd\" in window 1"
             first=false
         fi
     done


### PR DESCRIPTION
1) Support users who run non-bash shells
2) Use /usr/bin/libexec to pick the right Java version, as currently Corda does not start on Java 9