### PR TITLE
Correct message when checking signing keys

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
@@ -119,7 +119,7 @@ inline fun <reified T : MoveCommand> verifyMoveCommand(inputs: List<OwnableState
     val command = commands.requireSingleCommand<T>()
     val keysThatSigned = command.signers.toSet()
     requireThat {
-        "the owning keys are the same as the signing keys" by keysThatSigned.containsAll(owningPubKeys)
+        "the owning keys are a subset of the signing keys" by keysThatSigned.containsAll(owningPubKeys)
     }
     return command.value
 }

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
@@ -405,7 +405,7 @@ class Obligation<P> : Contract {
         val owningPubKeys = inputs.filter { it is State<P> }.map { (it as State<P>).beneficiary }.toSet()
         val keysThatSigned = setLifecycleCommand.signers.toSet()
         requireThat {
-            "the owning keys are the same as the signing keys" by keysThatSigned.containsAll(owningPubKeys)
+            "the owning keys are a subset of the signing keys" by keysThatSigned.containsAll(owningPubKeys)
         }
     }
 

--- a/finance/src/test/java/net/corda/contracts/asset/CashTestsJava.java
+++ b/finance/src/test/java/net/corda/contracts/asset/CashTestsJava.java
@@ -38,7 +38,7 @@ public class CashTestsJava {
                 tx.tweak(tw -> {
                     tw.output(outState);
                     tw.command(getDUMMY_PUBKEY_2(), new Cash.Commands.Move());
-                    return tw.failsWith("the owning keys are the same as the signing keys");
+                    return tw.failsWith("the owning keys are a subset of the signing keys");
                 });
                 tx.tweak(tw -> {
                     tw.output(outState);

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -99,7 +99,7 @@ class CashTests {
             tweak {
                 output { outState }
                 command(DUMMY_PUBKEY_2) { Cash.Commands.Move() }
-                this `fails with` "the owning keys are the same as the signing keys"
+                this `fails with` "the owning keys are a subset of the signing keys"
             }
             tweak {
                 output { outState }

--- a/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
@@ -66,7 +66,7 @@ class ObligationTests {
             tweak {
                 output { outState }
                 command(DUMMY_PUBKEY_2) { Obligation.Commands.Move() }
-                this `fails with` "the owning keys are the same as the signing keys"
+                this `fails with` "the owning keys are a subset of the signing keys"
             }
             tweak {
                 output { outState }


### PR DESCRIPTION
The keys used to sign a command are tested for being a superset of the keys which own the states, not for being an exact match (as the text previously suggested). This corrects the message used if this requirement isn't met.