### PR TITLE
Fixed TransactionSerializationTests.signWireTX by ensuring the signed…

### DIFF
--- a/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
@@ -69,7 +69,7 @@ class TransactionSerializationTests {
         signedTX.verifySignatures()
 
         // Corrupt the data and ensure the signature catches the problem.
-        signedTX.id.bytes[5] = 0
+        signedTX.id.bytes[5] = signedTX.id.bytes[5].inc()
         assertFailsWith(SignatureException::class) {
             signedTX.verifySignatures()
         }


### PR DESCRIPTION
… transaction corruption always corrupts the signature.

Fixes issue #134 