### PR TITLE
Fix intermittent failure in ScheduledFlowTests 

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -221,7 +221,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
             keyManagement = makeKeyManagementService()
             api = APIServerImpl(this@AbstractNode)
             flowLogicFactory = initialiseFlowLogicFactory()
-            scheduler = NodeSchedulerService(database, services, flowLogicFactory, unfinishedSchedulesLatch = busyNodeLatch)
+            scheduler = NodeSchedulerService(database, services, flowLogicFactory, unfinishedSchedules = busyNodeLatch)
 
             val tokenizableServices = mutableListOf(storage, net, vault, keyManagement, identity, platformClock, scheduler)
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -335,13 +335,14 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
                 fiber.logic.progressTracker?.currentStep = ProgressTracker.DONE
                 mutex.locked {
                     stateMachines.remove(fiber)?.let { checkpointStorage.removeCheckpoint(it) }
-                    totalFinishedFlows.inc()
-                    unfinishedFibers.countDown()
                     notifyChangeObservers(fiber, AddOrRemove.REMOVE)
                 }
                 endAllFiberSessions(fiber)
             } finally {
+                fiber.commitTransaction()
                 decrementLiveFibers()
+                totalFinishedFlows.inc()
+                unfinishedFibers.countDown()
             }
         }
         mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -6,7 +6,6 @@ import co.paralleluniverse.io.serialization.kryo.KryoSerializer
 import co.paralleluniverse.strands.Strand
 import com.codahale.metrics.Gauge
 import com.esotericsoftware.kryo.Kryo
-import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.support.jdk8.collections.removeIf
 import net.corda.core.ThreadBox
@@ -70,7 +69,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
                           val checkpointStorage: CheckpointStorage,
                           val executor: AffinityExecutor,
                           val database: Database,
-                          @VisibleForTesting val unfinishedFibers: ReusableLatch = ReusableLatch()) {
+                          private val unfinishedFibers: ReusableLatch = ReusableLatch()) {
 
     inner class FiberScheduler : FiberExecutorScheduler("Same thread scheduler", executor)
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -69,7 +69,8 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
                           tokenizableServices: List<Any>,
                           val checkpointStorage: CheckpointStorage,
                           val executor: AffinityExecutor,
-                          val database: Database) {
+                          val database: Database,
+                          @VisibleForTesting val unfinishedFibers: ReusableLatch = ReusableLatch()) {
 
     inner class FiberScheduler : FiberExecutorScheduler("Same thread scheduler", executor)
 
@@ -102,8 +103,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
     @Volatile private var stopping = false
     // How many Fibers are running and not suspended.  If zero and stopping is true, then we are halted.
     private val liveFibers = ReusableLatch()
-    @VisibleForTesting
-    val unfinishedFibers = ReusableLatch()
+
 
     // Monitoring support.
     private val metrics = serviceHub.monitoringService.metrics

--- a/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
@@ -4,7 +4,6 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRefFactory
 import net.corda.core.node.CordaPluginRegistry
@@ -97,7 +96,7 @@ class ScheduledFlowTests {
 
     @Before
     fun setup() {
-        net = MockNetwork(threadPerNode = true)
+        net = MockNetwork(threadPerNode = false)
         notaryNode = net.createNode(
                 legalName = DUMMY_NOTARY.name,
                 keyPair = DUMMY_NOTARY_KEY,
@@ -107,6 +106,7 @@ class ScheduledFlowTests {
         nodeA.testPluginRegistries.add(ScheduledFlowTestPlugin())
         nodeB.testPluginRegistries.add(ScheduledFlowTestPlugin())
         net.startNodes()
+        net.runNetworkAsyncUntilNodesStopped()
     }
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
@@ -96,7 +96,7 @@ class ScheduledFlowTests {
 
     @Before
     fun setup() {
-        net = MockNetwork(threadPerNode = false)
+        net = MockNetwork(threadPerNode = true)
         notaryNode = net.createNode(
                 legalName = DUMMY_NOTARY.name,
                 keyPair = DUMMY_NOTARY_KEY,
@@ -106,7 +106,6 @@ class ScheduledFlowTests {
         nodeA.testPluginRegistries.add(ScheduledFlowTestPlugin())
         nodeB.testPluginRegistries.add(ScheduledFlowTestPlugin())
         net.startNodes()
-        net.runNetworkAsyncUntilNodesStopped()
     }
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
@@ -19,7 +19,6 @@ import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import java.security.PublicKey
 import java.time.Instant
@@ -127,10 +126,7 @@ class ScheduledFlowTests {
         assertTrue("Must be processed", stateFromB.state.data.processed)
     }
 
-    @Ignore
     @Test
-    // TODO I need to investigate why we get very very occasional SessionInit failures
-    // during notarisation.
     fun `Run a whole batch of scheduled flows`() {
         val N = 100
         for (i in 0..N - 1) {

--- a/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -44,7 +44,8 @@ import kotlin.concurrent.thread
 @ThreadSafe
 class InMemoryMessagingNetwork(
         val sendManuallyPumped: Boolean,
-        val servicePeerAllocationStrategy: ServicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.Random()
+        val servicePeerAllocationStrategy: ServicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.Random(),
+        val messagesInFlight: ReusableLatch = ReusableLatch()
 ) : SingletonSerializeAsToken() {
     companion object {
         val MESSAGES_LOG_NAME = "messages"
@@ -77,8 +78,6 @@ class InMemoryMessagingNetwork(
 
     // Holds the mapping from services to peers advertising the service.
     private val serviceToPeersMapping = HashMap<ServiceHandle, LinkedHashSet<PeerHandle>>()
-
-    val messagesInFlight = ReusableLatch()
 
     @Suppress("unused") // Used by the visualiser tool.
     /** A stream of (sender, message, recipients) triples */

--- a/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -45,7 +45,7 @@ import kotlin.concurrent.thread
 class InMemoryMessagingNetwork(
         val sendManuallyPumped: Boolean,
         val servicePeerAllocationStrategy: ServicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.Random(),
-        val messagesInFlight: ReusableLatch = ReusableLatch()
+        private val messagesInFlight: ReusableLatch = ReusableLatch()
 ) : SingletonSerializeAsToken() {
     companion object {
         val MESSAGES_LOG_NAME = "messages"

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -54,8 +54,8 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
                   private val defaultFactory: Factory = MockNetwork.DefaultFactory) {
     private var nextNodeId = 0
     val filesystem: FileSystem = Jimfs.newFileSystem(unix())
-    private val busyNetworkLatch: ReusableLatch = ReusableLatch()
-    val messagingNetwork = InMemoryMessagingNetwork(networkSendManuallyPumped, servicePeerAllocationStrategy, busyNetworkLatch)
+    private val busyLatch: ReusableLatch = ReusableLatch()
+    val messagingNetwork = InMemoryMessagingNetwork(networkSendManuallyPumped, servicePeerAllocationStrategy, busyLatch)
 
     // A unique identifier for this network to segregate databases with the same nodeID but different networks.
     private val networkId = random63BitValue()
@@ -113,7 +113,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
                         override val networkMapAddress: SingleMessageRecipient?,
                         advertisedServices: Set<ServiceInfo>,
                         val id: Int,
-                        val keyPair: KeyPair?) : AbstractNode(config, advertisedServices, TestClock(), mockNet.busyNetworkLatch) {
+                        val keyPair: KeyPair?) : AbstractNode(config, advertisedServices, TestClock(), mockNet.busyLatch) {
         override val log: Logger = loggerFor<MockNode>()
         override val serverThread: AffinityExecutor =
                 if (mockNet.threadPerNode)
@@ -294,6 +294,6 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
     // Test method to block until all scheduled activity, active flows
     // and network activity has ceased.
     fun waitQuiescent() {
-        busyNetworkLatch.await()
+        busyLatch.await()
     }
 }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -163,7 +163,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
 
         override fun stop() {
             synchronized(this) {
-                check(!stopped)
+                if (stopped) return
                 stopped = true
             }
             super.stop()


### PR DESCRIPTION
Solve race condition across testing various counters by moving to single threaded network and testing counters on that single thread.