### PR TITLE
Add functions for converting Amount to/from decimal

### DIFF
--- a/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
@@ -1,0 +1,26 @@
+package net.corda.core.contracts
+
+import org.junit.Test
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+
+/**
+ * Tests of the [Amount] class.
+ */
+class AmountTests {
+    @Test
+    fun basicCurrency() {
+        val expected = 1000L
+        val amount = Amount(expected, GBP)
+        assertEquals(expected, amount.quantity)
+    }
+
+    @Test
+    fun decimalConversion() {
+        val quantity = 1234L
+        val amount = Amount(quantity, GBP)
+        val expected = BigDecimal("12.34")
+        assertEquals(expected, amount.toDecimal())
+        assertEquals(amount, Amount.fromDecimal(amount.toDecimal(), amount.token))
+    }
+}


### PR DESCRIPTION
Add new functions for converting amounts to/from decimal representation. Also adds clarification that the constructor which takes in a BigDecimal drops any fractional part.

Signed-off-by: Ross Nicoll <ross.nicoll@r3.com>