### PR TITLE
Use curl instead of wget

### DIFF
--- a/docs/generate-docsite.sh
+++ b/docs/generate-docsite.sh
@@ -10,7 +10,7 @@ fi
 if [ ! -e lib/dokka.jar ]; then
     echo "Downloading Dokka tool ... "
     echo
-    wget -O lib/dokka.jar https://github.com/Kotlin/dokka/releases/download/0.9.8/dokka-fatjar.jar
+    curl -L -o lib/dokka.jar https://github.com/Kotlin/dokka/releases/download/0.9.8/dokka-fatjar.jar
 fi
 
 (


### PR DESCRIPTION
Use curl instead of wget, for compatibility with OS X.