### PR TITLE
Upgrade Dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ buildscript {
     ext.jopt_simple_version = '5.0.2'
     ext.jansi_version = '1.14'
     ext.hibernate_version = '5.2.6.Final'
+    ext.dokka_version = '0.9.13'
 
     repositories {
         mavenLocal()
@@ -46,6 +47,7 @@ buildscript {
         classpath "net.corda.plugins:quasar-utils:$gradle_plugins_version"
         classpath "net.corda.plugins:cordformation:$gradle_plugins_version"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
     }
 }
 
@@ -61,6 +63,7 @@ apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordformation'
+apply plugin: 'org.jetbrains.dokka'
 
 // We need the following three lines even though they're inside an allprojects {} block below because otherwise
 // IntelliJ gets confused when importing the project and ends up erasing and recreating the .idea directory, along
@@ -185,3 +188,22 @@ bintrayConfig {
         email = 'dev@corda.net'
     }
 }
+
+// API docs
+
+dokka {
+    moduleName = 'corda'
+    outputDirectory = 'docs/build/html/api/kotlin'
+    processConfigurations = ['compile']
+    sourceDirs = files('core/src/main/kotlin', 'client/src/main/kotlin', 'node/src/main/kotlin', 'finance/src/main/kotlin')
+}
+
+task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+    moduleName = 'corda'
+    outputFormat = "javadoc"
+    outputDirectory = 'docs/build/html/api/javadoc'
+    processConfigurations = ['compile']
+    sourceDirs = files('core/src/main/kotlin', 'client/src/main/kotlin', 'node/src/main/kotlin', 'finance/src/main/kotlin')
+}
+
+task apidocs(dependsOn: ['dokka', 'dokkaJavadoc'])

--- a/docs/generate-docsite.sh
+++ b/docs/generate-docsite.sh
@@ -7,12 +7,6 @@ if [ ! -e ./gradlew ]; then
     exit 1
 fi
 
-if [ ! -e lib/dokka.jar ]; then
-    echo "Downloading Dokka tool ... "
-    echo
-    curl -L -o lib/dokka.jar https://github.com/Kotlin/dokka/releases/download/0.9.8/dokka-fatjar.jar
-fi
-
 (
     cd docs
 
@@ -43,13 +37,13 @@ fi
     echo "Generating docsite ..."
     echo
 
-    make html
+    make clean html
 )
 
 echo
 echo "Generating API docs ..."
 echo
-java -jar lib/dokka.jar -output docs/build/html/api core/src/main/kotlin finance/src/main/kotlin node/src/main/kotlin client/src/main/kotlin  | grep -v "No documentation for"
+./gradlew apidocs
 
 echo
 echo "Writing robots.txt"

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -6,7 +6,7 @@
 {% block sidebartitle %}
 {{ super() }}
 <br>
-<a href="api/index.html">API reference</a>
+API reference: <a href="api/kotlin/corda/index.html">Kotlin</a>/ <a href="api/javadoc/index.html">JavaDoc</a>
 <br>
 <a href="https://discourse.corda.net">Discourse Forums</a>
 <br>


### PR DESCRIPTION
Docs: upgrade Dokka, start building a javadoc version of the API docs alongside the Kotlin API docs. Switch to using gradle to download/invoke it.

https://r3-cev.atlassian.net/browse/CORDA-153

There is more we can do here: the docs don't API link to the Java SDK or the javadoc sites of any of our libraries. Dokka and the gradle plugin *do* support this, but the syntax is confusing to me and the feature isn't well documented. I've filed CORDA-154 to track setting that up, but this is still an improvement.

I'll push a docsite regen after this is merged.