### PR TITLE
Add logging to node startup when it attempt to connect to the map server 

### DIFF
--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import java.lang.management.ManagementFactory
 import java.net.InetAddress
 import java.nio.file.Paths
+import kotlin.concurrent.thread
 import kotlin.system.exitProcess
 
 private var renderBasicInfoToConsole = true
@@ -84,6 +85,14 @@ fun main(args: Array<String>) {
         val node = conf.createNode()
         node.start()
         printPluginsAndServices(node)
+
+        thread {
+            Thread.sleep(30.seconds.toMillis())
+            while (!node.networkMapRegistrationFuture.isDone) {
+                printBasicNodeInfo("Waiting for response from network map ...")
+                Thread.sleep(30.seconds.toMillis())
+            }
+        }
 
         node.networkMapRegistrationFuture.success {
             val elapsed = (System.currentTimeMillis() - startTime) / 10 / 100.0

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -25,6 +25,7 @@ import net.corda.flows.CashFlow
 import net.corda.flows.FinalityFlow
 import net.corda.flows.sendRequest
 import net.corda.node.api.APIServer
+import net.corda.node.printBasicNodeInfo
 import net.corda.node.services.api.*
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.configureWithDevSSLCertificate
@@ -389,6 +390,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
             noNetworkMapConfigured()  // TODO This method isn't needed as runWithoutMapService sets the Future in the cache
 
         } else {
+            printBasicNodeInfo("Registering with network map ...")
             registerWithNetworkMap()
         }
     }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -25,7 +25,6 @@ import net.corda.flows.CashFlow
 import net.corda.flows.FinalityFlow
 import net.corda.flows.sendRequest
 import net.corda.node.api.APIServer
-import net.corda.node.printBasicNodeInfo
 import net.corda.node.services.api.*
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.configureWithDevSSLCertificate
@@ -390,7 +389,6 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
             noNetworkMapConfigured()  // TODO This method isn't needed as runWithoutMapService sets the Future in the cache
 
         } else {
-            printBasicNodeInfo("Registering with network map ...")
             registerWithNetworkMap()
         }
     }


### PR DESCRIPTION
Add logging to avoid node startup "hang" when it attempt to connects to the network map, also can use as a hint telling user Network map might be down or unreachable.

Fix for https://github.com/corda/corda/issues/97