### PR TITLE
FlowException thrown by a flow is propagated to all counterparties

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt
@@ -1,8 +1,9 @@
 package net.corda.core.contracts
 
 import net.corda.core.crypto.CompositeKey
+import net.corda.core.flows.FlowException
 
-class InsufficientBalanceException(val amountMissing: Amount<*>) : Exception() {
+class InsufficientBalanceException(val amountMissing: Amount<*>) : FlowException() {
     override fun toString() = "Insufficient balance, missing $amountMissing"
 }
 

--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -1,0 +1,13 @@
+package net.corda.core.flows
+
+/**
+ * Exception which can be thrown by a [FlowLogic] at any point in its logic to unexpectedly bring it to a permanent end.
+ * The exception will propagate to all counterparty flows and will be thrown on their end the next time they wait on a
+ * [FlowLogic.receive] or [FlowLogic.sendAndReceive]. Any flow which no longer needs to do a receive, or has already ended,
+ * will not receive the exception (if this is required then have them wait for a confirmation message).
+ *
+ * [FlowException] (or a subclass) can be a valid expected response from a flow, particularly ones which act as a service.
+ * It is recommended a [FlowLogic] document the [FlowException] types it can throw.
+ */
+open class FlowException @JvmOverloads constructor(message: String? = null, cause: Throwable? = null)
+    : Exception(message, cause)

--- a/core/src/main/kotlin/net/corda/core/flows/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowStateMachine.kt
@@ -40,5 +40,3 @@ interface FlowStateMachine<R> {
     val id: StateMachineRunId
     val resultFuture: ListenableFuture<R>
 }
-
-class FlowException(message: String) : RuntimeException(message)

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -11,6 +11,7 @@ import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.serializers.JavaSerializer
 import com.esotericsoftware.kryo.serializers.MapSerializer
 import de.javakaffee.kryoserializers.ArraysAsListSerializer
+import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer
 import de.javakaffee.kryoserializers.guava.*
 import net.corda.core.contracts.*
 import net.corda.core.crypto.*
@@ -402,12 +403,10 @@ fun createKryo(k: Kryo = Kryo()): Kryo {
         // serialise the Kryo object itself when suspending a fiber. That's dumb, useless AND can cause crashes, so
         // we avoid it here.
         register(Kryo::class.java, object : Serializer<Kryo>() {
-            override fun write(kryo: Kryo, output: Output, obj: Kryo) {
-            }
-
             override fun read(kryo: Kryo, input: Input, type: Class<Kryo>): Kryo {
                 return createKryo((Fiber.getFiberSerializer() as KryoSerializer).kryo)
             }
+            override fun write(kryo: Kryo, output: Output, obj: Kryo) {}
         })
 
         register(EdDSAPublicKey::class.java, Ed25519PublicKeySerializer)
@@ -441,6 +440,7 @@ fun createKryo(k: Kryo = Kryo()): Kryo {
 
         addDefaultSerializer(BufferedInputStream::class.java, InputStreamSerializer)
 
+        UnmodifiableCollectionsSerializer.registerSerializers(k)
         ImmutableListSerializer.registerSerializers(k)
         ImmutableSetSerializer.registerSerializers(k)
         ImmutableSortedSetSerializer.registerSerializers(k)

--- a/core/src/main/kotlin/net/corda/core/utilities/UntrustworthyData.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/UntrustworthyData.kt
@@ -1,5 +1,7 @@
 package net.corda.core.utilities
 
+import net.corda.core.flows.FlowException
+
 /**
  * A small utility to approximate taint tracking: if a method gives you back one of these, it means the data came from
  * a remote source that may be incentivised to pass us junk that violates basic assumptions and thus must be checked
@@ -17,6 +19,7 @@ class UntrustworthyData<out T>(private val fromUntrustedWorld: T) {
         get() = fromUntrustedWorld
 
     @Suppress("DEPRECATION")
+    @Throws(FlowException::class)
     inline fun <R> unwrap(validator: (T) -> R) = validator(data)
 
     @Suppress("DEPRECATION")

--- a/core/src/main/kotlin/net/corda/flows/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FetchDataFlow.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.NamedByHash
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.utilities.UntrustworthyData
 import net.corda.flows.FetchDataFlow.DownloadedVsRequestedDataMismatch
@@ -30,14 +31,15 @@ abstract class FetchDataFlow<T : NamedByHash, in W : Any>(
         protected val requests: Set<SecureHash>,
         protected val otherSide: Party) : FlowLogic<FetchDataFlow.Result<T>>() {
 
-    open class BadAnswer : Exception()
-    class HashNotFound(val requested: SecureHash) : BadAnswer()
-    class DownloadedVsRequestedDataMismatch(val requested: SecureHash, val got: SecureHash) : BadAnswer()
+    class DownloadedVsRequestedDataMismatch(val requested: SecureHash, val got: SecureHash) : IllegalArgumentException()
+    class DownloadedVsRequestedSizeMismatch(val requested: Int, val got: Int) : IllegalArgumentException()
+    class HashNotFound(val requested: SecureHash) : FlowException()
 
     data class Request(val hashes: List<SecureHash>)
     data class Result<out T : NamedByHash>(val fromDisk: List<T>, val downloaded: List<T>)
 
     @Suspendable
+    @Throws(HashNotFound::class)
     override fun call(): Result<T> {
         // Load the items we have from disk and figure out which we're missing.
         val (fromDisk, toFetch) = loadWhatWeHave()
@@ -48,7 +50,7 @@ abstract class FetchDataFlow<T : NamedByHash, in W : Any>(
             logger.trace("Requesting ${toFetch.size} dependency(s) for verification")
 
             // TODO: Support "large message" response streaming so response sizes are not limited by RAM.
-            val maybeItems = sendAndReceive<ArrayList<W?>>(otherSide, Request(toFetch))
+            val maybeItems = sendAndReceive<ArrayList<W>>(otherSide, Request(toFetch))
             // Check for a buggy/malicious peer answering with something that we didn't ask for.
             val downloaded = validateFetchResponse(maybeItems, toFetch)
             maybeWriteToDisk(downloaded)
@@ -78,22 +80,19 @@ abstract class FetchDataFlow<T : NamedByHash, in W : Any>(
     @Suppress("UNCHECKED_CAST")
     protected open fun convert(wire: W): T = wire as T
 
-    private fun validateFetchResponse(maybeItems: UntrustworthyData<ArrayList<W?>>,
-                                      requests: List<SecureHash>): List<T> =
-            maybeItems.unwrap { response ->
-                if (response.size != requests.size)
-                    throw BadAnswer()
-                for ((index, resp) in response.withIndex()) {
-                    if (resp == null) throw HashNotFound(requests[index])
-                }
-                val answers = response.requireNoNulls().map { convert(it) }
-                // Check transactions actually hash to what we requested, if this fails the remote node
-                // is a malicious flow violator or buggy.
-                for ((index, item) in answers.withIndex())
-                    if (item.id != requests[index])
-                        throw DownloadedVsRequestedDataMismatch(requests[index], item.id)
-
-                answers
+    private fun validateFetchResponse(maybeItems: UntrustworthyData<ArrayList<W>>,
+                                      requests: List<SecureHash>): List<T> {
+        return maybeItems.unwrap { response ->
+            if (response.size != requests.size)
+                throw DownloadedVsRequestedSizeMismatch(requests.size, response.size)
+            val answers = response.map { convert(it) }
+            // Check transactions actually hash to what we requested, if this fails the remote node
+            // is a malicious flow violator or buggy.
+            for ((index, item) in answers.withIndex()) {
+                if (item.id != requests[index])
+                    throw DownloadedVsRequestedDataMismatch(requests[index], item.id)
             }
-
+            answers
+        }
+    }
 }

--- a/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
@@ -27,6 +27,7 @@ class FinalityFlow(val transaction: SignedTransaction,
     }
 
     @Suspendable
+    @Throws(NotaryException::class)
     override fun call() {
         // TODO: Resolve the tx here: it's probably already been done, but re-resolution is a no-op and it'll make the API more forgiving.
 

--- a/core/src/main/kotlin/net/corda/flows/NotaryChangeFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryChangeFlow.kt
@@ -1,13 +1,11 @@
 package net.corda.flows
 
-import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
-import net.corda.core.utilities.UntrustworthyData
 import net.corda.flows.NotaryChangeFlow.Acceptor
 import net.corda.flows.NotaryChangeFlow.Instigator
 
@@ -20,19 +18,12 @@ import net.corda.flows.NotaryChangeFlow.Instigator
  * Finally, [Instigator] sends the transaction containing all signatures back to each participant so they can record it and
  * use the new updated state for future transactions.
  */
-object NotaryChangeFlow : AbstractStateReplacementFlow<Party>() {
+object NotaryChangeFlow : AbstractStateReplacementFlow() {
 
-    data class Proposal(override val stateRef: StateRef,
-                        override val modification: Party,
-                        override val stx: SignedTransaction) : AbstractStateReplacementFlow.Proposal<Party>
-
-    class Instigator<T : ContractState>(originalState: StateAndRef<T>,
-                                        newNotary: Party,
-                                        progressTracker: ProgressTracker = tracker())
-        : AbstractStateReplacementFlow.Instigator<T, Party>(originalState, newNotary, progressTracker) {
-
-        override fun assembleProposal(stateRef: StateRef, modification: Party, stx: SignedTransaction): AbstractStateReplacementFlow.Proposal<Party>
-                = Proposal(stateRef, modification, stx)
+    class Instigator<out T : ContractState>(
+            originalState: StateAndRef<T>,
+            newNotary: Party,
+            progressTracker: ProgressTracker = tracker()) : AbstractStateReplacementFlow.Instigator<T, Party>(originalState, newNotary, progressTracker) {
 
         override fun assembleTx(): Pair<SignedTransaction, Iterable<CompositeKey>> {
             val state = originalState.state
@@ -66,7 +57,8 @@ object NotaryChangeFlow : AbstractStateReplacementFlow<Party>() {
         private fun resolveEncumbrances(tx: TransactionBuilder): Iterable<CompositeKey> {
             val stateRef = originalState.ref
             val txId = stateRef.txhash
-            val issuingTx = serviceHub.storageService.validatedTransactions.getTransaction(txId) ?: throw IllegalStateException("Transaction $txId not found")
+            val issuingTx = serviceHub.storageService.validatedTransactions.getTransaction(txId)
+                    ?: throw StateReplacementException("Transaction $txId not found")
             val outputs = issuingTx.tx.outputs
 
             val participants = mutableSetOf<CompositeKey>()
@@ -97,8 +89,7 @@ object NotaryChangeFlow : AbstractStateReplacementFlow<Party>() {
     }
 
     class Acceptor(otherSide: Party,
-                   override val progressTracker: ProgressTracker = tracker())
-        : AbstractStateReplacementFlow.Acceptor<Party>(otherSide) {
+                   override val progressTracker: ProgressTracker = tracker()) : AbstractStateReplacementFlow.Acceptor<Party>(otherSide) {
 
         /**
          * Check the notary change proposal.
@@ -107,26 +98,28 @@ object NotaryChangeFlow : AbstractStateReplacementFlow<Party>() {
          * and is also in a geographically convenient location we can just automatically approve the change.
          * TODO: In more difficult cases this should call for human attention to manually verify and approve the proposal
          */
-        @Suspendable
-        override fun verifyProposal(maybeProposal: UntrustworthyData<AbstractStateReplacementFlow.Proposal<Party>>): AbstractStateReplacementFlow.Proposal<Party> {
-            return maybeProposal.unwrap { proposal ->
-                val newNotary = proposal.modification
-                val isNotary = serviceHub.networkMapCache.notaryNodes.any { it.notaryIdentity == newNotary }
-                require(isNotary) { "The proposed node $newNotary does not run a Notary service " }
+        override fun verifyProposal(proposal: AbstractStateReplacementFlow.Proposal<Party>): Unit {
+            val state = proposal.stateRef
+            val proposedTx = proposal.stx.tx
 
-                val state = proposal.stateRef
-                val proposedTx = proposal.stx.tx
-                require(state in proposedTx.inputs) { "The proposed state $state is not in the proposed transaction inputs" }
-                require(proposedTx.type.javaClass == TransactionType.NotaryChange::class.java) {
-                    "The proposed transaction is not a notary change transaction."
-                }
-
-                // An example requirement
-                val blacklist = listOf("Evil Notary")
-                require(!blacklist.contains(newNotary.name)) { "The proposed new notary $newNotary is not trusted by the party" }
-
-                proposal
+            if (proposedTx.type !is TransactionType.NotaryChange) {
+                throw StateReplacementException("The proposed transaction is not a notary change transaction.")
             }
+
+            val newNotary = proposal.modification
+            val isNotary = serviceHub.networkMapCache.notaryNodes.any { it.notaryIdentity == newNotary }
+            if (!isNotary) {
+                throw StateReplacementException("The proposed node $newNotary does not run a Notary service")
+            }
+            if (state !in proposedTx.inputs) {
+                throw StateReplacementException("The proposed state $state is not in the proposed transaction inputs")
+            }
+
+//            // An example requirement
+//            val blacklist = listOf("Evil Notary")
+//            checkProposal(newNotary.name !in blacklist) {
+//                "The proposed new notary $newNotary is not trusted by the party"
+//            }
         }
     }
 }

--- a/core/src/main/kotlin/net/corda/flows/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ResolveTransactionsFlow.kt
@@ -50,16 +50,12 @@ class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
             fun visit(transaction: SignedTransaction) {
                 if (transaction.id !in visited) {
                     visited.add(transaction.id)
-                    forwardGraph[transaction.id]?.forEach {
-                        visit(it)
-                    }
+                    forwardGraph[transaction.id]?.forEach(::visit)
                     result.add(transaction)
                 }
             }
 
-            transactions.forEach {
-                visit(it)
-            }
+            transactions.forEach(::visit)
 
             result.reverse()
             require(result.size == transactions.size)
@@ -93,6 +89,7 @@ class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
     }
 
     @Suspendable
+    @Throws(FetchDataFlow.HashNotFound::class)
     override fun call(): List<LedgerTransaction> {
         val newTxns: Iterable<SignedTransaction> = topologicalSort(downloadDependencies(txHashes))
 

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -9,9 +9,9 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.Vault
 import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.toFuture
 import net.corda.flows.CashCommand
 import net.corda.flows.CashFlow
-import net.corda.flows.CashFlowResult
 import net.corda.node.driver.driver
 import net.corda.node.services.User
 import net.corda.node.services.startFlowPermission
@@ -87,7 +87,7 @@ class IntegrationTestingTutorial {
                         amount = i.DOLLARS.issuedBy(alice.nodeInfo.legalIdentity.ref(issueRef)),
                         recipient = alice.nodeInfo.legalIdentity
                 ))
-                assert(flowHandle.returnValue.toBlocking().first() is CashFlowResult.Success)
+                flowHandle.returnValue.toFuture().getOrThrow()
             }
 
             aliceVaultUpdates.expectEvents {

--- a/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
@@ -38,13 +38,18 @@ abstract class OnLedgerAsset<T : Any, C : CommandData, S : FungibleAsset<T>> : C
      * the responsibility of the caller to check that they do not exit funds held by others.
      * @return the public key of the assets issuer, who must sign the transaction for it to be valid.
      */
+    @Throws(InsufficientBalanceException::class)
     fun generateExit(tx: TransactionBuilder, amountIssued: Amount<Issued<T>>,
-                     assetStates: List<StateAndRef<S>>): CompositeKey
-            = conserveClause.generateExit(tx, amountIssued, assetStates,
-            deriveState = { state, amount, owner -> deriveState(state, amount, owner) },
-            generateMoveCommand = { -> generateMoveCommand() },
-            generateExitCommand = { amount -> generateExitCommand(amount) }
-    )
+                     assetStates: List<StateAndRef<S>>): CompositeKey {
+        return conserveClause.generateExit(
+                tx,
+                amountIssued,
+                assetStates,
+                deriveState = { state, amount, owner -> deriveState(state, amount, owner) },
+                generateMoveCommand = { -> generateMoveCommand() },
+                generateExitCommand = { amount -> generateExitCommand(amount) }
+        )
+    }
 
     abstract fun generateExitCommand(amount: Amount<Issued<T>>): FungibleAsset.Commands.Exit<T>
     abstract fun generateIssueCommand(): FungibleAsset.Commands.Issue

--- a/finance/src/main/kotlin/net/corda/contracts/clause/AbstractConserveAmount.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/clause/AbstractConserveAmount.kt
@@ -45,6 +45,7 @@ abstract class AbstractConserveAmount<S : FungibleAsset<T>, C : CommandData, T :
      * the responsibility of the caller to check that they do not attempt to exit funds held by others.
      * @return the public key of the assets issuer, who must sign the transaction for it to be valid.
      */
+    @Throws(InsufficientBalanceException::class)
     fun generateExit(tx: TransactionBuilder, amountIssued: Amount<Issued<T>>,
                      assetStates: List<StateAndRef<S>>,
                      deriveState: (TransactionState<S>, Amount<Issued<T>>, CompositeKey) -> TransactionState<S>,

--- a/finance/src/main/kotlin/net/corda/flows/IssuerFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/IssuerFlow.kt
@@ -1,19 +1,14 @@
 package net.corda.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.ThreadBox
 import net.corda.core.contracts.*
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
-import net.corda.core.node.NodeInfo
 import net.corda.core.node.PluginServiceHub
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
-import net.corda.flows.CashCommand
-import net.corda.flows.CashFlow
-import net.corda.flows.CashFlowResult
 import java.util.*
 
 /**
@@ -27,22 +22,16 @@ object IssuerFlow {
     data class IssuanceRequestState(val amount: Amount<Currency>, val issueToParty: Party, val issuerPartyRef: OpaqueBytes)
 
     /**
-     * IssuanceRequester should be used by a client to ask a remote note to issue some [FungibleAsset] with the given details.
+     * IssuanceRequester should be used by a client to ask a remote node to issue some [FungibleAsset] with the given details.
      * Returns the transaction created by the Issuer to move the cash to the Requester.
      */
     class IssuanceRequester(val amount: Amount<Currency>, val issueToParty: Party, val issueToPartyRef: OpaqueBytes,
                             val issuerBankParty: Party): FlowLogic<SignedTransaction>() {
         @Suspendable
+        @Throws(CashException::class)
         override fun call(): SignedTransaction {
             val issueRequest = IssuanceRequestState(amount, issueToParty, issueToPartyRef)
-            try {
-                return sendAndReceive<SignedTransaction>(issuerBankParty, issueRequest).unwrap { it }
-            // catch and report exception before throwing back to caller
-            } catch (e: Exception) {
-                logger.error("IssuanceRequesterException: request failed: [${issueRequest}]")
-                // TODO: awaiting exception handling strategy (what action should be taken here?)
-                throw e
-            }
+            return sendAndReceive<SignedTransaction>(issuerBankParty, issueRequest).unwrap { it }
         }
     }
 
@@ -51,22 +40,25 @@ object IssuerFlow {
      * Returns the generated transaction representing the transfer of the [Issued] [FungibleAsset] to the issue requester.
      */
     class Issuer(val otherParty: Party): FlowLogic<SignedTransaction>() {
-        override val progressTracker: ProgressTracker = tracker()
         companion object {
             object AWAITING_REQUEST : ProgressTracker.Step("Awaiting issuance request")
             object ISSUING : ProgressTracker.Step("Self issuing asset")
             object TRANSFERRING : ProgressTracker.Step("Transferring asset to issuance requester")
             object SENDING_CONFIRM : ProgressTracker.Step("Confirming asset issuance to requester")
             fun tracker() = ProgressTracker(AWAITING_REQUEST, ISSUING, TRANSFERRING, SENDING_CONFIRM)
+            private val VALID_CURRENCIES = listOf(USD, GBP, EUR, CHF)
         }
 
+        override val progressTracker: ProgressTracker = tracker()
+
         @Suspendable
+        @Throws(CashException::class)
         override fun call(): SignedTransaction {
             progressTracker.currentStep = AWAITING_REQUEST
-            val issueRequest = receive<IssuanceRequestState>(otherParty).unwrap { it }
-            // validate request inputs (for example, lets restrict the types of currency that can be issued)
-            require(listOf<Currency>(USD, GBP, EUR, CHF).contains(issueRequest.amount.token)) {
-                logger.error("Currency must be one of USD, GBP, EUR, CHF")
+            val issueRequest = receive<IssuanceRequestState>(otherParty).unwrap {
+                // validate request inputs (for example, lets restrict the types of currency that can be issued)
+                if (it.amount.token !in VALID_CURRENCIES) throw FlowException("Currency must be one of $VALID_CURRENCIES")
+                it
             }
             // TODO: parse request to determine Asset to issue
             val txn = issueCashTo(issueRequest.amount, issueRequest.issueToParty, issueRequest.issuerPartyRef)
@@ -79,52 +71,30 @@ object IssuerFlow {
         //       state references (thus causing Notarisation double spend exceptions).
         @Suspendable
         private fun issueCashTo(amount: Amount<Currency>,
-                                issueTo: Party, issuerPartyRef: OpaqueBytes): SignedTransaction {
+                                issueTo: Party,
+                                issuerPartyRef: OpaqueBytes): SignedTransaction {
             // TODO: pass notary in as request parameter
             val notaryParty = serviceHub.networkMapCache.notaryNodes[0].notaryIdentity
             // invoke Cash subflow to issue Asset
             progressTracker.currentStep = ISSUING
             val bankOfCordaParty = serviceHub.myInfo.legalIdentity
-            try {
-                val issueCashFlow = CashFlow(CashCommand.IssueCash(amount, issuerPartyRef, bankOfCordaParty, notaryParty))
-                val resultIssue = subFlow(issueCashFlow)
-                // NOTE: issueCashFlow performs a Broadcast (which stores a local copy of the txn to the ledger)
-                if (resultIssue is CashFlowResult.Failed) {
-                    logger.error("Problem issuing cash: ${resultIssue.message}")
-                    throw Exception(resultIssue.message)
-                }
-                // short-circuit when issuing to self
-                if (issueTo.equals(serviceHub.myInfo.legalIdentity))
-                    return (resultIssue as CashFlowResult.Success).transaction!!
-                // now invoke Cash subflow to Move issued assetType to issue requester
-                progressTracker.currentStep = TRANSFERRING
-                val moveCashFlow = CashFlow(CashCommand.PayCash(amount.issuedBy(bankOfCordaParty.ref(issuerPartyRef)), issueTo))
-                val resultMove = subFlow(moveCashFlow)
-                // NOTE: CashFlow PayCash calls FinalityFlow which performs a Broadcast (which stores a local copy of the txn to the ledger)
-                if (resultMove is CashFlowResult.Failed) {
-                    logger.error("Problem transferring cash: ${resultMove.message}")
-                    throw Exception(resultMove.message)
-                }
-                val txn = (resultMove as CashFlowResult.Success).transaction
-                txn?.let {
-                    return txn
-                }
-                // NOTE: CashFlowResult.Success should always return a signedTransaction
-                throw Exception("Missing CashFlow transaction [${(resultMove)}]")
-            }
-            // catch and report exception before throwing back to caller flow
-            catch (e: Exception) {
-                logger.error("Issuer Exception: failed for amount ${amount} issuedTo ${issueTo} with issuerPartyRef ${issuerPartyRef}")
-                // TODO: awaiting exception handling strategy (what action should be taken here?)
-                throw e
-            }
+            val issueCashFlow = CashFlow(CashCommand.IssueCash(amount, issuerPartyRef, bankOfCordaParty, notaryParty))
+            val issueTx = subFlow(issueCashFlow)
+            // NOTE: issueCashFlow performs a Broadcast (which stores a local copy of the txn to the ledger)
+            // short-circuit when issuing to self
+            if (issueTo == serviceHub.myInfo.legalIdentity)
+                return issueTx
+            // now invoke Cash subflow to Move issued assetType to issue requester
+            progressTracker.currentStep = TRANSFERRING
+            val moveCashFlow = CashFlow(CashCommand.PayCash(amount.issuedBy(bankOfCordaParty.ref(issuerPartyRef)), issueTo))
+            val moveTx = subFlow(moveCashFlow)
+            // NOTE: CashFlow PayCash calls FinalityFlow which performs a Broadcast (which stores a local copy of the txn to the ledger)
+            return moveTx
         }
 
         class Service(services: PluginServiceHub) {
             init {
-                services.registerFlowInitiator(IssuanceRequester::class) {
-                    Issuer(it)
-                }
+                services.registerFlowInitiator(IssuanceRequester::class, ::Issuer)
             }
         }
     }

--- a/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
+++ b/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
@@ -5,7 +5,9 @@ import net.corda.core.contracts.Amount
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.currency
+import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowStateMachine
+import net.corda.core.getOrThrow
 import net.corda.core.map
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
@@ -39,8 +41,8 @@ class IssuerFlowTest {
             assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
 
             // try to issue an amount of a restricted currency
-            assertFailsWith<Exception> {
-                runIssuerAndIssueRequester(Amount(100000L, currency("BRL")), issueToPartyAndRef).issueRequestResult.get()
+            assertFailsWith<FlowException> {
+                runIssuerAndIssueRequester(Amount(100000L, currency("BRL")), issueToPartyAndRef).issueRequestResult.getOrThrow()
             }
 
             bankOfCordaNode.stop()

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -5,14 +5,15 @@ import net.corda.core.contracts.Amount
 import net.corda.core.contracts.POUNDS
 import net.corda.core.contracts.issuedBy
 import net.corda.core.crypto.Party
+import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.toFuture
 import net.corda.flows.CashCommand
 import net.corda.flows.CashFlow
-import net.corda.flows.CashFlowResult
 import net.corda.node.driver.DriverBasedTest
 import net.corda.node.driver.NodeHandle
 import net.corda.node.driver.driver
@@ -137,13 +138,13 @@ class DistributedServiceTests : DriverBasedTest() {
         val issueHandle = aliceProxy.startFlow(
                 ::CashFlow,
                 CashCommand.IssueCash(amount, OpaqueBytes.of(0), alice.nodeInfo.legalIdentity, raftNotaryIdentity))
-        require(issueHandle.returnValue.toBlocking().first() is CashFlowResult.Success)
+        issueHandle.returnValue.toFuture().getOrThrow()
     }
 
     private fun paySelf(amount: Amount<Currency>) {
         val payHandle = aliceProxy.startFlow(
                 ::CashFlow,
                 CashCommand.PayCash(amount.issuedBy(alice.nodeInfo.legalIdentity.ref(0)), alice.nodeInfo.legalIdentity))
-        require(payHandle.returnValue.toBlocking().first() is CashFlowResult.Success)
+        payHandle.returnValue.toFuture().getOrThrow()
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RPCStructures.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RPCStructures.kt
@@ -28,7 +28,6 @@ import net.corda.core.node.services.*
 import net.corda.core.serialization.*
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
-import net.corda.flows.CashFlowResult
 import net.corda.node.internal.AbstractNode
 import net.corda.node.services.User
 import net.corda.node.services.messaging.ArtemisMessagingComponent.Companion.NODE_USER
@@ -190,8 +189,6 @@ private class RPCKryo(observableSerializer: Serializer<Observable<Any>>? = null)
         register(Cash.Clauses.ConserveAmount::class.java)
         register(listOf(Unit).javaClass) // SingletonList
         register(setOf(Unit).javaClass) // SingletonSet
-        register(CashFlowResult.Success::class.java)
-        register(CashFlowResult.Failed::class.java)
         register(ServiceEntry::class.java)
         register(NodeInfo::class.java)
         register(PhysicalLocation::class.java)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt
@@ -29,7 +29,7 @@ data class SessionData(override val recipientSessionId: Long, val payload: Any) 
     }
 }
 
-data class SessionEnd(override val recipientSessionId: Long) : ExistingSessionMessage
+data class SessionEnd(override val recipientSessionId: Long, val errorResponse: FlowException?) : ExistingSessionMessage
 
 data class ReceivedSessionMessage<out M : ExistingSessionMessage>(val sender: Party, val message: M)
 
@@ -37,7 +37,9 @@ fun <T> ReceivedSessionMessage<SessionData>.checkPayloadIs(type: Class<T>): Untr
     if (type.isInstance(message.payload)) {
         return UntrustworthyData(type.cast(message.payload))
     } else {
-        throw FlowException("We were expecting a ${type.name} from $sender but we instead got a " +
+        throw FlowSessionException("We were expecting a ${type.name} from $sender but we instead got a " +
                 "${message.payload.javaClass.name} (${message.payload})")
     }
 }
+
+class FlowSessionException(message: String) : RuntimeException(message)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -12,6 +12,7 @@ import net.corda.core.ThreadBox
 import net.corda.core.bufferUntilSubscribed
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.commonName
+import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowStateMachine
 import net.corda.core.flows.StateMachineRunId
@@ -194,7 +195,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
             checkpointStorage.forEach {
                 // If a flow is added before start() then don't attempt to restore it
                 if (!stateMachines.containsValue(it)) {
-                    val fiber = deserializeFiber(it.serializedFiber)
+                    val fiber = deserializeFiber(it)
                     initFiber(fiber)
                     stateMachines[fiber] = it
                 }
@@ -256,7 +257,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
             if (peerParty != null) {
                 if (message is SessionConfirm) {
                     logger.debug { "Received session confirmation but associated fiber has already terminated, so sending session end" }
-                    sendSessionMessage(peerParty, SessionEnd(message.initiatedSessionId))
+                    sendSessionMessage(peerParty, SessionEnd(message.initiatedSessionId, null))
                 } else {
                     logger.trace { "Ignoring session end message for already closed session: $message" }
                 }
@@ -269,30 +270,44 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
     private fun onSessionInit(sessionInit: SessionInit, sender: Party) {
         logger.trace { "Received $sessionInit $sender" }
         val otherPartySessionId = sessionInit.initiatorSessionId
-        try {
-            val markerClass = Class.forName(sessionInit.flowName)
-            val flowFactory = serviceHub.getFlowFactory(markerClass)
-            if (flowFactory != null) {
-                val flow = flowFactory(sender)
-                val fiber = createFiber(flow)
-                val session = FlowSession(flow, random63BitValue(), FlowSessionState.Initiated(sender, otherPartySessionId))
-                if (sessionInit.firstPayload != null) {
-                    session.receivedMessages += ReceivedSessionMessage(sender, SessionData(session.ourSessionId, sessionInit.firstPayload))
-                }
-                openSessions[session.ourSessionId] = session
-                fiber.openSessions[Pair(flow, sender)] = session
-                updateCheckpoint(fiber)
-                sendSessionMessage(sender, SessionConfirm(otherPartySessionId, session.ourSessionId), fiber)
-                fiber.logger.debug { "Initiated from $sessionInit on $session" }
-                startFiber(fiber)
-            } else {
-                logger.warn("Unknown flow marker class in $sessionInit")
-                sendSessionMessage(sender, SessionReject(otherPartySessionId, "Don't know ${markerClass.name}"))
-            }
+
+        fun sendSessionReject(message: String) = sendSessionMessage(sender, SessionReject(otherPartySessionId, message))
+
+        val markerClass = try {
+            Class.forName(sessionInit.flowName)
         } catch (e: Exception) {
             logger.warn("Received invalid $sessionInit", e)
-            sendSessionMessage(sender, SessionReject(otherPartySessionId, "Unable to establish session"))
+            sendSessionReject("Don't know ${sessionInit.flowName}")
+            return
         }
+
+        val flowFactory = serviceHub.getFlowFactory(markerClass)
+        if (flowFactory == null) {
+            logger.warn("Unknown flow marker class in $sessionInit")
+            sendSessionReject("Don't know ${markerClass.name}")
+            return
+        }
+
+        val session = try {
+            val flow = flowFactory(sender)
+            val fiber = createFiber(flow)
+            val session = FlowSession(flow, random63BitValue(), FlowSessionState.Initiated(sender, otherPartySessionId))
+            if (sessionInit.firstPayload != null) {
+                session.receivedMessages += ReceivedSessionMessage(sender, SessionData(session.ourSessionId, sessionInit.firstPayload))
+            }
+            openSessions[session.ourSessionId] = session
+            fiber.openSessions[Pair(flow, sender)] = session
+            updateCheckpoint(fiber)
+            session
+        } catch (e: Exception) {
+            logger.warn("Couldn't start session for $sessionInit", e)
+            sendSessionReject("Unable to establish session")
+            return
+        }
+
+        sendSessionMessage(sender, SessionConfirm(otherPartySessionId, session.ourSessionId), session.fiber)
+        session.fiber.logger.debug { "Initiated from $sessionInit on $session" }
+        startFiber(session.fiber)
     }
 
     private fun serializeFiber(fiber: FlowStateMachineImpl<*>): SerializedBytes<FlowStateMachineImpl<*>> {
@@ -302,11 +317,11 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         return fiber.serialize(kryo)
     }
 
-    private fun deserializeFiber(serialisedFiber: SerializedBytes<FlowStateMachineImpl<*>>): FlowStateMachineImpl<*> {
+    private fun deserializeFiber(checkpoint: Checkpoint): FlowStateMachineImpl<*> {
         val kryo = quasarKryo()
         // put the map of token -> tokenized into the kryo context
         SerializeAsTokenSerializer.setContext(kryo, serializationContext)
-        return serialisedFiber.deserialize(kryo).apply { fromCheckpoint = true }
+        return checkpoint.serializedFiber.deserialize(kryo).apply { fromCheckpoint = true }
     }
 
     private fun quasarKryo(): Kryo {
@@ -330,14 +345,14 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
             processIORequest(ioRequest)
             decrementLiveFibers()
         }
-        fiber.actionOnEnd = {
+        fiber.actionOnEnd = { errorResponse: FlowException? ->
             try {
                 fiber.logic.progressTracker?.currentStep = ProgressTracker.DONE
                 mutex.locked {
                     stateMachines.remove(fiber)?.let { checkpointStorage.removeCheckpoint(it) }
                     notifyChangeObservers(fiber, AddOrRemove.REMOVE)
                 }
-                endAllFiberSessions(fiber)
+                endAllFiberSessions(fiber, errorResponse)
             } finally {
                 fiber.commitTransaction()
                 decrementLiveFibers()
@@ -352,18 +367,27 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         }
     }
 
-    private fun endAllFiberSessions(fiber: FlowStateMachineImpl<*>) {
+    private fun endAllFiberSessions(fiber: FlowStateMachineImpl<*>, errorResponse: FlowException?) {
+        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+        (errorResponse as java.lang.Throwable?)?.stackTrace = emptyArray()
         openSessions.values.removeIf { session ->
             if (session.fiber == fiber) {
-                val initiatedState = session.state as? FlowSessionState.Initiated
-                if (initiatedState != null) {
-                    sendSessionMessage(initiatedState.peerParty, SessionEnd(initiatedState.peerSessionId), fiber)
-                    recentlyClosedSessions[session.ourSessionId] = initiatedState.peerParty
-                }
+                session.endSession(errorResponse)
                 true
             } else {
                 false
             }
+        }
+    }
+
+    private fun FlowSession.endSession(errorResponse: FlowException?) {
+        val initiatedState = state as? Initiated
+        if (initiatedState != null) {
+            sendSessionMessage(
+                    initiatedState.peerParty,
+                    SessionEnd(initiatedState.peerSessionId, errorResponse),
+                    fiber)
+            recentlyClosedSessions[ourSessionId] = initiatedState.peerParty
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -11,18 +11,16 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.DUMMY_NOTARY_KEY
 import net.corda.flows.NotaryChangeFlow.Instigator
 import net.corda.flows.StateReplacementException
-import net.corda.flows.StateReplacementRefused
 import net.corda.node.internal.AbstractNode
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.testing.node.MockNetwork
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Before
 import org.junit.Test
 import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class NotaryChangeTests {
@@ -83,8 +81,9 @@ class NotaryChangeTests {
 
         net.runNetwork()
 
-        val ex = assertFailsWith(StateReplacementException::class) { future.resultFuture.getOrThrow() }
-        assertThat(ex.error).isInstanceOf(StateReplacementRefused::class.java)
+        assertThatExceptionOfType(StateReplacementException::class.java).isThrownBy {
+            future.resultFuture.getOrThrow()
+        }
     }
 
     @Test

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
@@ -7,11 +7,13 @@ import net.corda.core.contracts.Issued
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.USD
 import net.corda.core.crypto.Party
+import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.toFuture
 import net.corda.flows.CashCommand
+import net.corda.flows.CashException
 import net.corda.flows.CashFlow
-import net.corda.flows.CashFlowResult
 import net.corda.loadtest.LoadTest
 import net.corda.loadtest.NodeHandle
 import org.slf4j.LoggerFactory
@@ -205,14 +207,11 @@ val crossCashTest = LoadTest<CrossCashCommand, CrossCashState>(
         },
 
         execute = { command ->
-            val result = command.node.connection.proxy.startFlow(::CashFlow, command.command).returnValue.toBlocking().first()
-            when (result) {
-                is CashFlowResult.Success -> {
-                    log.info(result.message)
-                }
-                is CashFlowResult.Failed -> {
-                    log.error(result.message)
-                }
+            try {
+                val result = command.node.connection.proxy.startFlow(::CashFlow, command.command).returnValue.toFuture().getOrThrow()
+                log.info("Success: $result")
+            } catch (e: CashException) {
+                log.error("Failure", e)
             }
         },
 


### PR DESCRIPTION
Introducing `FlowException` which if thrown by any flow will be propagated to all its counterparties. The next time the counterparty does a receive it will throw that exception. The throwing flow will terminate prematurely and so will the receiving flows if they doesn't catch the exception. You can surround the receive call (or `subFlow`) with a try-catch if exception handling is required.

This system works well with service-like flows like the notary. I've modified it (and other similar flows) to throw a NotaryException (which is now a FlowException) rather than sending a bad/error result object.

I've also introduced a `checkData` method to `FlowLogic` which throws a `IllegalDataException` back to the sender of data that something's wrong with it - it becomes the sender's problem if they send incorrect data. I've updated one or two places where the standard `check` method is used to use this instead. I'm sure there's other places it can be used.

If any other exception is thrown then the framework does what it already used to do for all exceptions - terminate the flow with lots of exception noise and end the sessions with its counterparties which also then terminate with lots of noise. Having more control on what to do with these "unexpected" exceptions will be part 2.