### PR TITLE
Expand details in missing signatures error

### DIFF
--- a/core/src/main/kotlin/net/corda/flows/ValidatingNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ValidatingNotaryFlow.kt
@@ -29,8 +29,8 @@ class ValidatingNotaryFlow(otherSide: Party,
             wtx.toLedgerTransaction(serviceHub).verify()
         } catch (e: Exception) {
             when (e) {
-                is TransactionVerificationException,
-                is SignatureException -> throw NotaryException(NotaryError.TransactionInvalid())
+                is TransactionVerificationException -> NotaryException(NotaryError.TransactionInvalid(e.toString()))
+                is SignatureException -> throw NotaryException(NotaryError.SignaturesInvalid(e.toString()))
                 else -> throw e
             }
         }
@@ -40,7 +40,7 @@ class ValidatingNotaryFlow(otherSide: Party,
         try {
             stx.verifySignatures(serviceHub.myInfo.notaryIdentity.owningKey)
         } catch(e: SignedTransaction.SignaturesMissingException) {
-            throw NotaryException(NotaryError.SignaturesMissing(e.missing))
+            throw NotaryException(NotaryError.SignaturesMissing(e))
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ValidatingNotaryServiceTests.kt
@@ -52,7 +52,7 @@ class ValidatingNotaryServiceTests {
         val future = runClient(stx)
 
         val ex = assertFailsWith(NotaryException::class) { future.getOrThrow() }
-        assertThat(ex.error).isInstanceOf(NotaryError.TransactionInvalid::class.java)
+        assertThat(ex.error).isInstanceOf(NotaryError.SignaturesInvalid::class.java)
     }
 
     @Test fun `should report error for missing signatures`() {
@@ -73,7 +73,7 @@ class ValidatingNotaryServiceTests {
         val notaryError = ex.error
         assertThat(notaryError).isInstanceOf(NotaryError.SignaturesMissing::class.java)
 
-        val missingKeys = (notaryError as NotaryError.SignaturesMissing).missingSigners
+        val missingKeys = (notaryError as NotaryError.SignaturesMissing).cause.missing
         assertEquals(setOf(expectedMissingKey), missingKeys)
     }
 


### PR DESCRIPTION
I'd appreciate thoughts on what the notary should be throwing, as I'm getting less convinced I'm even throwing an appropriate exception. Maybe the exception should simply wrap the cause instead of unpacking/repacking. Thoughts?
