### PR TITLE
Remove TransferRecipient

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
@@ -12,6 +12,7 @@ import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.getOrThrow
 import net.corda.core.map
+import net.corda.core.messaging.MessageRecipients
 import net.corda.core.random63BitValue
 import net.corda.core.rootCause
 import net.corda.core.serialization.OpaqueBytes
@@ -319,33 +320,37 @@ class StateMachineManagerTests {
                     node2.info.legalIdentity)))
             net.runNetwork()
         }
+        val endpoint = net.messagingNetwork.endpoint(notary1.net.myAddress as InMemoryMessagingNetwork.PeerHandle)!!
+        val notary1Address: MessageRecipients = endpoint.getAddressOfParty(notary1.services.networkMapCache.getPartyInfo(notary1.info.notaryIdentity)!!)
+        assert(notary1Address is InMemoryMessagingNetwork.ServiceHandle)
+        assertEquals(notary1Address, endpoint.getAddressOfParty(notary2.services.networkMapCache.getPartyInfo(notary2.info.notaryIdentity)!!))
         sessionTransfers.expectEvents(isStrict = false) {
             sequence(
                     // First Pay
                     expect(match = { it.message is SessionInit && it.message.flowName == NotaryFlow.Client::class.java.name }) {
                         it.message as SessionInit
-                        require(it.from == node1.id)
-                        require(it.to == TransferRecipient.Service(notary1.info.notaryIdentity))
+                        assertEquals(node1.id, it.from)
+                        assertEquals(notary1Address, it.to)
                     },
                     expect(match = { it.message is SessionConfirm }) {
                         it.message as SessionConfirm
-                        require(it.from == notary1.id)
+                        assertEquals(notary1.id, it.from)
                     },
                     // Second pay
                     expect(match = { it.message is SessionInit && it.message.flowName == NotaryFlow.Client::class.java.name }) {
                         it.message as SessionInit
-                        require(it.from == node1.id)
-                        require(it.to == TransferRecipient.Service(notary1.info.notaryIdentity))
+                        assertEquals(node1.id, it.from)
+                        assertEquals(notary1Address, it.to)
                     },
                     expect(match = { it.message is SessionConfirm }) {
                         it.message as SessionConfirm
-                        require(it.from == notary2.id)
+                        assertEquals(notary2.id, it.from)
                     },
                     // Third pay
                     expect(match = { it.message is SessionInit && it.message.flowName == NotaryFlow.Client::class.java.name }) {
                         it.message as SessionInit
-                        require(it.from == node1.id)
-                        require(it.to == TransferRecipient.Service(notary1.info.notaryIdentity))
+                        assertEquals(node1.id, it.from)
+                        assertEquals(notary1Address, it.to)
                     },
                     expect(match = { it.message is SessionConfirm }) {
                         it.message as SessionConfirm
@@ -398,16 +403,11 @@ class StateMachineManagerTests {
     }
 
     private fun assertSessionTransfers(node: MockNode, vararg expected: SessionTransfer) {
-        val actualForNode = sessionTransfers.filter { it.from == node.id || it.to == TransferRecipient.Peer(node.id) }
+        val actualForNode = sessionTransfers.filter { it.from == node.id || it.to == node.net.myAddress }
         assertThat(actualForNode).containsExactly(*expected)
     }
 
-    private interface TransferRecipient {
-        data class Peer(val id: Int) : TransferRecipient
-        data class Service(val identity: Party) : TransferRecipient
-    }
-
-    private data class SessionTransfer(val from: Int, val message: SessionMessage, val to: TransferRecipient) {
+    private data class SessionTransfer(val from: Int, val message: SessionMessage, val to: MessageRecipients) {
         val isPayloadTransfer: Boolean get() = message is SessionData || message is SessionInit && message.firstPayload != null
         override fun toString(): String = "$from sent $message to $to"
     }
@@ -416,13 +416,7 @@ class StateMachineManagerTests {
         return filter { it.message.topicSession == StateMachineManager.sessionTopic }.map {
             val from = it.sender.id
             val message = it.message.data.deserialize<SessionMessage>()
-            val recipients = it.recipients
-            val to = when (recipients) {
-                is InMemoryMessagingNetwork.PeerHandle -> TransferRecipient.Peer(recipients.id)
-                is InMemoryMessagingNetwork.ServiceHandle -> TransferRecipient.Service(recipients.service.identity)
-                else -> throw IllegalStateException("Unknown recipients $recipients")
-            }
-            SessionTransfer(from, sanitise(message), to)
+            SessionTransfer(from, sanitise(message), it.recipients)
         }
     }
 
@@ -437,7 +431,7 @@ class StateMachineManagerTests {
     }
 
     private infix fun MockNode.sent(message: SessionMessage): Pair<Int, SessionMessage> = Pair(id, message)
-    private infix fun Pair<Int, SessionMessage>.to(node: MockNode): SessionTransfer = SessionTransfer(first, second, TransferRecipient.Peer(node.id))
+    private infix fun Pair<Int, SessionMessage>.to(node: MockNode): SessionTransfer = SessionTransfer(first, second, node.net.myAddress)
 
 
     private class NoOpFlow(val nonTerminating: Boolean = false) : FlowLogic<Unit>() {

--- a/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -85,6 +85,7 @@ class InMemoryMessagingNetwork(
         get() = _receivedMessages
 
     val endpoints: List<InMemoryMessaging> @Synchronized get() = handleEndpointMap.values.toList()
+    fun endpoint(peer: PeerHandle): InMemoryMessaging? = handleEndpointMap.get(peer)
 
     /**
      * Creates a node and returns the new object that identifies its location on the network to senders, and the


### PR DESCRIPTION
Remove TransferRecipient from StateMachineManagerTests to get rid one of the approximately 6 different ways in which we refer to endpoints, as part of work to simplify this data model.

Signed-off-by: Ross Nicoll <ross.nicoll@r3.com>