### PR TITLE
Kryo: Remove unnecessary keypair generation

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -410,7 +410,6 @@ fun createKryo(k: Kryo = Kryo()): Kryo {
             }
         })
 
-        // Some things where the JRE provides an efficient custom serialisation.
         register(EdDSAPublicKey::class.java, Ed25519PublicKeySerializer)
         register(EdDSAPrivateKey::class.java, Ed25519PrivateKeySerializer)
         register(Instant::class.java, ReferencesAwareJavaSerializer)

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -411,9 +411,8 @@ fun createKryo(k: Kryo = Kryo()): Kryo {
         })
 
         // Some things where the JRE provides an efficient custom serialisation.
-        val keyPair = generateKeyPair()
-        register(keyPair.public.javaClass, Ed25519PublicKeySerializer)
-        register(keyPair.private.javaClass, Ed25519PrivateKeySerializer)
+        register(EdDSAPublicKey::class.java, Ed25519PublicKeySerializer)
+        register(EdDSAPrivateKey::class.java, Ed25519PrivateKeySerializer)
         register(Instant::class.java, ReferencesAwareJavaSerializer)
 
         // Using a custom serializer for compactness


### PR DESCRIPTION
This key pair generation takes up about 17% node thread CPU time