### PR TITLE
Improve the flow commit API.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -2,7 +2,9 @@ package net.corda.core.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.Party
+import net.corda.core.crypto.SecureHash
 import net.corda.core.node.ServiceHub
+import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.UntrustworthyData
 import org.slf4j.Logger
@@ -169,6 +171,16 @@ abstract class FlowLogic<out T> {
         return progressTracker?.let {
             Pair(it.currentStep.toString(), it.changes.map { it.toString() })
         }
+    }
+
+    /**
+     * Suspends the flow until the transaction with the specified ID is received, successfully verified and
+     * sent to the vault for processing. Note that this call suspends until the transaction is considered
+     * valid by the local node, but that doesn't imply the vault will consider it relevant.
+     */
+    @Suspendable
+    fun waitForLedgerCommit(hash: SecureHash): SignedTransaction {
+        return stateMachine.waitForLedgerCommit(hash, this)
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/kotlin/net/corda/core/flows/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowStateMachine.kt
@@ -3,7 +3,9 @@ package net.corda.core.flows
 import co.paralleluniverse.fibers.Suspendable
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.crypto.Party
+import net.corda.core.crypto.SecureHash
 import net.corda.core.node.ServiceHub
+import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.UntrustworthyData
 import org.slf4j.Logger
 import java.util.*
@@ -34,6 +36,9 @@ interface FlowStateMachine<R> {
 
     @Suspendable
     fun send(otherParty: Party, payload: Any, sessionFlow: FlowLogic<*>)
+
+    @Suspendable
+    fun waitForLedgerCommit(hash: SecureHash, sessionFlow: FlowLogic<*>): SignedTransaction
 
     val serviceHub: ServiceHub
     val logger: Logger

--- a/core/src/main/kotlin/net/corda/core/messaging/Messaging.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/Messaging.kt
@@ -43,7 +43,8 @@ interface MessagingService {
 
     /**
      * The provided function will be invoked for each received message whose topic and session matches.  The callback
-     * will run on threads provided by the messaging service, and the callback is expected to be thread safe as a result.
+     * will run on the main server thread provided when the messaging service is constructed, and a database
+     * transaction is set up for you automatically.
      *
      * The returned object is an opaque handle that may be used to un-register handlers later with [removeMessageHandler].
      * The handle is passed to the callback as well, to avoid race conditions whereby the callback wants to unregister

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -29,11 +29,12 @@ interface ServiceHub {
     val myInfo: NodeInfo
 
     /**
-     * Given a list of [SignedTransaction]s, writes them to the local storage for validated transactions and then
-     * sends them to the vault for further processing.
+     * Given a [SignedTransaction], writes it to the local storage for validated transactions and then
+     * sends them to the vault for further processing. Expects to be run within a database transaction.
      *
      * @param txs The transactions to record.
      */
+    // TODO: Make this take a single tx.
     fun recordTransactions(txs: Iterable<SignedTransaction>)
 
     /**

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -178,10 +178,22 @@ interface VaultService {
     fun getTransactionNotes(txnId: SecureHash): Iterable<String>
 
     /**
-     *  [InsufficientBalanceException] is thrown when a Cash Spending transaction fails because
-     *  there is insufficient quantity for a given currency (and optionally set of Issuer Parties).
-     *  Note: an [Amount] of [Currency] is only fungible for a given Issuer Party within a [FungibleAsset]
-     **/
+     * Generate a transaction that moves an amount of currency to the given pubkey.
+     *
+     * Note: an [Amount] of [Currency] is only fungible for a given Issuer Party within a [FungibleAsset]
+     *
+     * @param tx A builder, which may contain inputs, outputs and commands already. The relevant components needed
+     *           to move the cash will be added on top.
+     * @param amount How much currency to send.
+     * @param to a key of the recipient.
+     * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
+     *                        of given parties. This can be useful if the party you're trying to pay has expectations
+     *                        about which type of asset claims they are willing to accept.
+     * @return A [Pair] of the same transaction builder passed in as [tx], and the list of keys that need to sign
+     *         the resulting transaction for it to be valid.
+     * @throws InsufficientBalanceException when a cash spending transaction fails because
+     *         there is insufficient quantity for a given currency (and optionally set of Issuer Parties).
+     */
     @Throws(InsufficientBalanceException::class)
     fun generateSpend(tx: TransactionBuilder,
                       amount: Amount<Currency>,

--- a/core/src/main/kotlin/net/corda/flows/BroadcastTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/BroadcastTransactionFlow.kt
@@ -3,13 +3,13 @@ package net.corda.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.Party
 import net.corda.core.flows.FlowLogic
-import net.corda.core.node.recordTransactions
 import net.corda.core.transactions.SignedTransaction
 
 
 /**
- * Notify all involved parties about a transaction, including storing a copy. Normally this would be called via
- * [FinalityFlow].
+ * Notify the specified parties about a transaction. The remote peers will download this transaction and its
+ * dependency graph, verifying them all. The flow returns when all peers have acknowledged the transactions
+ * as valid. Normally you wouldn't use this directly, it would be called via [FinalityFlow].
  *
  * @param notarisedTransaction transaction which has been notarised (if needed) and is ready to notify nodes about.
  * @param participants a list of participants involved in the transaction.
@@ -17,17 +17,14 @@ import net.corda.core.transactions.SignedTransaction
  */
 class BroadcastTransactionFlow(val notarisedTransaction: SignedTransaction,
                                val participants: Set<Party>) : FlowLogic<Unit>() {
-
     data class NotifyTxRequest(val tx: SignedTransaction)
 
     @Suspendable
     override fun call() {
-        // Record it locally
-        serviceHub.recordTransactions(notarisedTransaction)
-
         // TODO: Messaging layer should handle this broadcast for us
         val msg = NotifyTxRequest(notarisedTransaction)
         participants.filter { it != serviceHub.myInfo.legalIdentity }.forEach { participant ->
+            // This pops out the other side in DataVending.NotifyTransactionHandler.
             send(participant, msg)
         }
     }

--- a/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
@@ -1,48 +1,87 @@
 package net.corda.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.Party
 import net.corda.core.flows.FlowLogic
+import net.corda.core.node.ServiceHub
+import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 
-
 /**
- * Finalise a transaction by notarising it, then recording it locally, and then sending it to all involved parties.
+ * Verifies the given transactions, then sends them to the named notaries. If the notary agrees that the transactions
+ * are acceptable then they are from that point onwards committed to the ledger, and will be written through to the
+ * vault. Additionally they will be distributed to the parties reflected in the participants list of the states.
  *
- * @param transaction to commit.
- * @param participants a list of participants involved in the transaction.
- * @return a list of participants who were successfully notified of the transaction.
+ * The transactions will be topologically sorted before commitment to ensure that dependencies are committed before
+ * dependers, so you don't need to do this yourself.
+ *
+ * The transactions are expected to have already been resolved: if their dependencies are not available in local
+ * storage or within the given set, verification will fail. They must have signatures from all necessary parties
+ * other than the notary.
+ *
+ * If specified, the extra recipients are sent all the given transactions. The base set of parties to inform of each
+ * transaction are calculated on a per transaction basis from the contract-given set of participants.
+ *
+ * The flow returns the same transactions, in the same order, with the additional signatures.
+ *
+ * @param transactions What to commit.
+ * @param extraRecipients A list of additional participants to inform of the transaction.
  */
-class FinalityFlow(val transaction: SignedTransaction,
-                   val participants: Set<Party>,
-                   override val progressTracker: ProgressTracker) : FlowLogic<Unit>() {
-    constructor(transaction: SignedTransaction, participants: Set<Party>) : this(transaction, participants, tracker())
+class FinalityFlow(val transactions: Iterable<SignedTransaction>,
+                   val extraRecipients: Set<Party>,
+                   override val progressTracker: ProgressTracker) : FlowLogic<List<SignedTransaction>>() {
+    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(listOf(transaction), extraParticipants, tracker())
+    constructor(transaction: SignedTransaction) : this(listOf(transaction), emptySet(), tracker())
 
     companion object {
-        object NOTARISING : ProgressTracker.Step("Requesting signature by notary service")
+        object NOTARISING : ProgressTracker.Step("Requesting signature by notary service") {
+            override fun childProgressTracker() = NotaryFlow.Client.tracker()
+        }
         object BROADCASTING : ProgressTracker.Step("Broadcasting transaction to participants")
 
+        // TODO: Make all tracker() methods @JvmStatic
         fun tracker() = ProgressTracker(NOTARISING, BROADCASTING)
     }
 
     @Suspendable
     @Throws(NotaryException::class)
-    override fun call() {
-        // TODO: Resolve the tx here: it's probably already been done, but re-resolution is a no-op and it'll make the API more forgiving.
-
+    override fun call(): List<SignedTransaction> {
+        // Note: this method is carefully broken up to minimize the amount of data reachable from the stack at
+        // the point where subFlow is invoked, as that minimizes the checkpointing work to be done.
+        //
+        // Lookup the resolved transactions and use them to map each signed transaction to the list of participants.
+        // Then send to the notary if needed, record locally and distribute.
         progressTracker.currentStep = NOTARISING
-        // Notarise the transaction if needed
-        val notarisedTransaction = if (needsNotarySignature(transaction)) {
-            val notarySig = subFlow(NotaryFlow.Client(transaction))
-            transaction.withAdditionalSignature(notarySig)
-        } else {
-            transaction
-        }
+        val notarisedTxns = notariseAndRecord(lookupParties(resolveDependenciesOf(transactions)))
 
-        // Let everyone else know about the transaction
+        // Each transaction has its own set of recipients, but extra recipients get them all.
         progressTracker.currentStep = BROADCASTING
-        subFlow(BroadcastTransactionFlow(notarisedTransaction, participants))
+        val me = serviceHub.myInfo.legalIdentity
+        for ((stx, parties) in notarisedTxns) {
+            subFlow(BroadcastTransactionFlow(stx, parties + extraRecipients - me))
+        }
+        return notarisedTxns.map { it.first }
+    }
+
+    // TODO: API: Make some of these protected?
+
+    @Suspendable
+    private fun notariseAndRecord(stxnsAndParties: List<Pair<SignedTransaction, Set<Party>>>): List<Pair<SignedTransaction, Set<Party>>> {
+        return stxnsAndParties.map { pair ->
+            val stx = pair.first
+            val notarised = if (needsNotarySignature(stx)) {
+                val notarySig = subFlow(NotaryFlow.Client(stx))
+                stx + notarySig
+            } else {
+                stx
+            }
+            serviceHub.recordTransactions(listOf(notarised))
+            Pair(notarised, pair.second)
+        }
     }
 
     private fun needsNotarySignature(stx: SignedTransaction) = stx.tx.notary != null && hasNoNotarySignature(stx)
@@ -50,5 +89,39 @@ class FinalityFlow(val transaction: SignedTransaction,
         val notaryKey = stx.tx.notary?.owningKey
         val signers = stx.sigs.map { it.by }.toSet()
         return !(notaryKey?.isFulfilledBy(signers) ?: false)
+    }
+
+    private fun lookupParties(ltxns: List<Pair<SignedTransaction, LedgerTransaction>>): List<Pair<SignedTransaction, Set<Party>>> {
+        return ltxns.map { pair ->
+            val (stx, ltx) = pair
+            // Calculate who is meant to see the results based on the participants involved.
+            val keys = ltx.outputs.flatMap { it.data.participants } + ltx.inputs.flatMap { it.state.data.participants }
+            // TODO: Is it safe to drop participants we don't know how to contact? Does not knowing how to contact them count as a reason to fail?
+            val parties = keys.mapNotNull { serviceHub.identityService.partyFromKey(it) }.toSet()
+            Pair(stx, parties)
+        }
+    }
+
+    private fun resolveDependenciesOf(signedTransactions: Iterable<SignedTransaction>): List<Pair<SignedTransaction, LedgerTransaction>> {
+        // Make sure the dependencies come before the dependers.
+        val sorted = ResolveTransactionsFlow.topologicalSort(signedTransactions.toList())
+        // Build a ServiceHub that consults the argument list as well as what's in local tx storage so uncommitted
+        // transactions can depend on each other.
+        val augmentedLookup = object : ServiceHub by serviceHub {
+            val hashToTx = sorted.associateBy { it.id }
+            override fun loadState(stateRef: StateRef): TransactionState<*> {
+                val provided: TransactionState<ContractState>? = hashToTx[stateRef.txhash]?.let { it.tx.outputs[stateRef.index] }
+                return provided ?: super.loadState(stateRef)
+            }
+        }
+        // Load and verify each transaction.
+        return sorted.map { stx ->
+            val notary = stx.tx.notary
+            // The notary signature is allowed to be missing but no others.
+            val wtx = if (notary != null) stx.verifySignatures(notary.owningKey) else stx.verifySignatures()
+            val ltx = wtx.toLedgerTransaction(augmentedLookup)
+            ltx.verify()
+            stx to ltx
+        }
     }
 }

--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -16,7 +16,6 @@ import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.ProgressTracker
 
 object NotaryFlow {
-
     /**
      * A flow to be used for obtaining a signature from a [NotaryService] ascertaining the transaction
      * timestamp is correct and none of its inputs have been used in another completed transaction.

--- a/core/src/main/kotlin/net/corda/flows/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ResolveTransactionsFlow.kt
@@ -34,13 +34,16 @@ class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
     companion object {
         private fun dependencyIDs(wtx: WireTransaction) = wtx.inputs.map { it.txhash }.toSet()
 
-        private fun topologicalSort(transactions: Collection<SignedTransaction>): List<SignedTransaction> {
+        /**
+         * Topologically sorts the given transactions such that dependencies are listed before dependers. */
+        @JvmStatic
+        fun topologicalSort(transactions: Collection<SignedTransaction>): List<SignedTransaction> {
             // Construct txhash -> dependent-txs map
             val forwardGraph = HashMap<SecureHash, HashSet<SignedTransaction>>()
-            transactions.forEach { tx ->
-                tx.tx.inputs.forEach { input ->
+            transactions.forEach { stx ->
+                stx.tx.inputs.forEach { input ->
                     // Note that we use a LinkedHashSet here to make the traversal deterministic (as long as the input list is)
-                    forwardGraph.getOrPut(input.txhash) { LinkedHashSet() }.add(tx)
+                    forwardGraph.getOrPut(input.txhash) { LinkedHashSet() }.add(stx)
                 }
             }
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -174,7 +174,7 @@ class ForeignExchangeFlow(val tradeId: String,
             withNewSignature // return the almost complete transaction
         }
 
-        // Initiate the standard protocol to notarise and distribute to the involved parties
+        // Initiate the standard protocol to notarise and distribute to the involved parties.
         subFlow(FinalityFlow(allPartySignedTx, setOf(baseCurrencyBuyer, baseCurrencySeller)))
 
         return allPartySignedTx.id

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -10,6 +10,10 @@ Milestone 8
 
     * ``Party`` equality is now based on the owning key, rather than the owning key and name. This is important for
       party anonymisation to work, as each key must identify exactly one party.
+    * A new ``waitForLedgerCommit`` method is available inside flows. Given a hash it will suspend the flow until
+      a valid transaction with that hash has been received, committed and processed by the vault. This is useful
+      in multi-party flows where one side takes responsibility for sending the finished transaction to the notary,
+      and the other side wishes to wait for it.
 
 Milestone 7
 -----------

--- a/finance/src/main/kotlin/net/corda/flows/CashFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/CashFlow.kt
@@ -123,9 +123,8 @@ class CashFlow(val command: CashCommand, override val progressTracker: ProgressT
         Cash().generateIssue(builder, req.amount.issuedBy(issuer), req.recipient.owningKey, req.notary)
         val myKey = serviceHub.legalIdentityKey
         builder.signWith(myKey)
-        val tx = builder.toSignedTransaction(checkSufficientSignatures = true)
-        // Issuance transactions do not need to be notarised, so we can skip directly to broadcasting it
-        subFlow(BroadcastTransactionFlow(tx, setOf(req.recipient)))
+        val tx = builder.toSignedTransaction()
+        subFlow(FinalityFlow(tx))
         return tx
     }
 }

--- a/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
@@ -25,23 +25,17 @@ import java.util.*
  * 2. B sends to S a [SignedTransaction] that includes the state as input, B's cash as input, the state with the new
  *    owner key as output, and any change cash as output. It contains a single signature from B but isn't valid because
  *    it lacks a signature from S authorising movement of the asset.
- * 3. S signs it and hands the now finalised SignedWireTransaction back to B.
+ * 3. S signs it and commits it to the ledger, notarising it and distributing the final signed transaction back
+ *    to B.
  *
  * Assuming no malicious termination, they both end the flow being in posession of a valid, signed transaction
  * that represents an atomic asset swap.
  *
  * Note that it's the *seller* who initiates contact with the buyer, not vice-versa as you might imagine.
- *
- * To initiate the flow, use either the [runBuyer] or [runSeller] methods, depending on which side of the trade
- * your node is taking. These methods return a future which will complete once the trade is over and a fully signed
- * transaction is available: you can either block your thread waiting for the flow to complete by using
- * [ListenableFuture.get] or more usefully, register a callback that will be invoked when the time comes.
- *
- * To see an example of how to use this class, look at the unit tests.
  */
-// TODO: Common elements in multi-party transaction consensus and signing should be refactored into a superclass of this
-// and [AbstractStateReplacementFlow].
 object TwoPartyTradeFlow {
+    // TODO: Common elements in multi-party transaction consensus and signing should be refactored into a superclass of this
+    // and [AbstractStateReplacementFlow].
 
     class UnacceptablePriceException(givenPrice: Amount<Currency>) : FlowException("Unacceptable price: $givenPrice")
     class AssetMismatchException(val expectedTypeName: String, val typeName: String) : FlowException() {
@@ -70,34 +64,25 @@ object TwoPartyTradeFlow {
             object VERIFYING : ProgressTracker.Step("Verifying transaction proposal")
             object SIGNING : ProgressTracker.Step("Signing transaction")
             // DOCSTART 3
-            object NOTARY : ProgressTracker.Step("Getting notary signature") {
+            object COMMITTING : ProgressTracker.Step("Committing transaction to the ledger") {
                 override fun childProgressTracker() = FinalityFlow.tracker()
             }
             // DOCEND 3
-            object SENDING_SIGS : ProgressTracker.Step("Sending transaction signatures to buyer")
+            object SENDING_FINAL_TX : ProgressTracker.Step("Sending final transaction to buyer")
 
-            fun tracker() = ProgressTracker(AWAITING_PROPOSAL, VERIFYING, SIGNING, NOTARY, SENDING_SIGS)
+            fun tracker() = ProgressTracker(AWAITING_PROPOSAL, VERIFYING, SIGNING, COMMITTING, SENDING_FINAL_TX)
         }
 
         // DOCSTART 4
         @Suspendable
         override fun call(): SignedTransaction {
-            val partialTX: SignedTransaction = receiveAndCheckProposedTransaction()
-            val ourSignature: DigitalSignature.WithKey = calculateOurSignature(partialTX)
-            val allPartySignedTx: SignedTransaction = partialTX + ourSignature
-            val notarySignature: DigitalSignature.WithKey = getNotarySignature(allPartySignedTx)
-            val result: SignedTransaction = sendSignatures(allPartySignedTx, ourSignature, notarySignature)
-            return result
+            val partialSTX: SignedTransaction = receiveAndCheckProposedTransaction()
+            val ourSignature = calculateOurSignature(partialSTX)
+            val unnotarisedSTX: SignedTransaction = partialSTX + ourSignature
+            val finishedSTX = subFlow(FinalityFlow(unnotarisedSTX)).single()
+            return finishedSTX
         }
         // DOCEND 4
-
-        // DOCSTART 6
-        @Suspendable
-        private fun getNotarySignature(stx: SignedTransaction): DigitalSignature.WithKey {
-            progressTracker.currentStep = NOTARY
-            return subFlow(NotaryFlow.Client(stx))
-        }
-        // DOCEND 6
 
         // DOCSTART 5
         @Suspendable
@@ -107,14 +92,12 @@ object TwoPartyTradeFlow {
             val myPublicKey = myKeyPair.public.composite
             // Make the first message we'll send to kick off the flow.
             val hello = SellerTradeInfo(assetToSell, price, myPublicKey)
-
-            val maybeSTX = sendAndReceive<SignedTransaction>(otherParty, hello)
+            // What we get back from the other side is a transaction that *might* be valid and acceptable to us,
+            // but we must check it out thoroughly before we sign!
+            val untrustedSTX = sendAndReceive<SignedTransaction>(otherParty, hello)
 
             progressTracker.currentStep = VERIFYING
-
-            maybeSTX.unwrap {
-                progressTracker.nextStep()
-
+            return untrustedSTX.unwrap {
                 // Check that the tx proposed by the buyer is valid.
                 val wtx: WireTransaction = it.verifySignatures(myPublicKey, notaryNode.notaryIdentity.owningKey)
                 logger.trace { "Received partially signed transaction: ${it.id}" }
@@ -123,11 +106,10 @@ object TwoPartyTradeFlow {
                 // even though it is missing signatures.
                 subFlow(ResolveTransactionsFlow(wtx, otherParty))
 
-                if (wtx.outputs.map { it.data }.sumCashBy(myPublicKey).withoutIssuer() != price) {
+                if (wtx.outputs.map { it.data }.sumCashBy(myPublicKey).withoutIssuer() != price)
                     throw FlowException("Transaction is not sending us the right amount of cash")
-                }
 
-                return it
+                it
             }
         }
         // DOCEND 5
@@ -144,64 +126,50 @@ object TwoPartyTradeFlow {
         // but the goal of this code is not to be fully secure (yet), but rather, just to find good ways to
         // express flow state machines on top of the messaging layer.
 
-        // DOCSTART 7
         open fun calculateOurSignature(partialTX: SignedTransaction): DigitalSignature.WithKey {
             progressTracker.currentStep = SIGNING
             return myKeyPair.signWithECDSA(partialTX.id)
         }
-
-        @Suspendable
-        private fun sendSignatures(allPartySignedTx: SignedTransaction,
-                                   ourSignature: DigitalSignature.WithKey,
-                                   notarySignature: DigitalSignature.WithKey): SignedTransaction {
-            progressTracker.currentStep = SENDING_SIGS
-            val fullySigned = allPartySignedTx + notarySignature
-
-            logger.trace { "Built finished transaction, sending back to secondary!" }
-
-            send(otherParty, SignaturesFromSeller(ourSignature, notarySignature))
-            return fullySigned
-        }
-        // DOCEND 7
     }
 
-    // DOCSTART 2
     open class Buyer(val otherParty: Party,
                      val notary: Party,
                      val acceptablePrice: Amount<Currency>,
                      val typeToBuy: Class<out OwnableState>) : FlowLogic<SignedTransaction>() {
-
+        // DOCSTART 2
         object RECEIVING : ProgressTracker.Step("Waiting for seller trading info")
         object VERIFYING : ProgressTracker.Step("Verifying seller assets")
         object SIGNING : ProgressTracker.Step("Generating and signing transaction proposal")
-        object SWAPPING_SIGNATURES : ProgressTracker.Step("Swapping signatures with the seller")
+        object SENDING_SIGNATURES : ProgressTracker.Step("Sending signatures to the seller")
+        object WAITING_FOR_TX : ProgressTracker.Step("Waiting for the transaction to finalise.")
 
-        override val progressTracker = ProgressTracker(RECEIVING, VERIFYING, SIGNING, SWAPPING_SIGNATURES)
+        override val progressTracker = ProgressTracker(RECEIVING, VERIFYING, SIGNING, SENDING_SIGNATURES, WAITING_FOR_TX)
+        // DOCEND 2
 
         // DOCSTART 1
         @Suspendable
         override fun call(): SignedTransaction {
+            // Wait for a trade request to come in from the other party.
+            progressTracker.currentStep = RECEIVING
             val tradeRequest = receiveAndValidateTradeRequest()
 
+            // Put together a proposed transaction that performs the trade, and sign it.
             progressTracker.currentStep = SIGNING
             val (ptx, cashSigningPubKeys) = assembleSharedTX(tradeRequest)
             val stx = signWithOurKeys(cashSigningPubKeys, ptx)
 
-            val signatures = swapSignaturesWithSeller(stx)
+            // Send the signed transaction to the seller, who must then sign it themselves and commit
+            // it to the ledger by sending it to the notary.
+            progressTracker.currentStep = SENDING_SIGNATURES
+            send(otherParty, stx)
 
-            logger.trace { "Got signatures from seller, verifying ... " }
-
-            val fullySigned = stx + signatures.sellerSig + signatures.notarySig
-            fullySigned.verifySignatures()
-
-            logger.trace { "Signatures received are valid. Trade complete! :-)" }
-            return fullySigned
+            // Wait for the finished, notarised transaction to arrive in our transaction store.
+            progressTracker.currentStep = WAITING_FOR_TX
+            return waitForLedgerCommit(stx.id)
         }
 
         @Suspendable
         private fun receiveAndValidateTradeRequest(): SellerTradeInfo {
-            progressTracker.currentStep = RECEIVING
-            // Wait for a trade request to come in from the other side
             val maybeTradeRequest = receive<SellerTradeInfo>(otherParty)
 
             progressTracker.currentStep = VERIFYING
@@ -216,22 +184,12 @@ object TwoPartyTradeFlow {
                 if (!typeToBuy.isInstance(asset))
                     throw AssetMismatchException(typeToBuy.name, assetTypeName)
 
-                // Check the transaction that contains the state which is being resolved.
-                // We only have a hash here, so if we don't know it already, we have to ask for it.
+                // Check that the state being sold to us is in a valid chain of transactions, i.e. that the
+                // seller has a valid chain of custody proving that they own the thing they're selling.
                 subFlow(ResolveTransactionsFlow(setOf(it.assetForSale.ref.txhash), otherParty))
 
                 return it
             }
-        }
-
-        @Suspendable
-        private fun swapSignaturesWithSeller(stx: SignedTransaction): SignaturesFromSeller {
-            progressTracker.currentStep = SWAPPING_SIGNATURES
-            logger.trace { "Sending partially signed transaction to seller" }
-
-            // TODO: Protect against the seller terminating here and leaving us in the lurch without the final tx.
-
-            return sendAndReceive<SignaturesFromSeller>(otherParty, stx).unwrap { it }
         }
 
         private fun signWithOurKeys(cashSigningPubKeys: List<CompositeKey>, ptx: TransactionBuilder): SignedTransaction {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -52,9 +52,6 @@ sourceSets {
 
 dependencies {
     compile project(':finance')
-    testCompile project(':test-utils')
-    testCompile project(':client')
-
     compile "com.google.code.findbugs:jsr305:3.0.1"
 
     // Log4J: logging framework (with SLF4J bindings)
@@ -126,8 +123,11 @@ dependencies {
     // Unit testing helpers.
     testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
-
     testCompile "com.pholser:junit-quickcheck-core:$quickcheck_version"
+    testCompile "com.nhaarman:mockito-kotlin:1.1.0"
+    testCompile project(':test-utils')
+    testCompile project(':client')
+    testCompile project(':core')
 
     // For H2 database support in persistence
     compile "com.h2database:h2:1.4.193"
@@ -156,8 +156,6 @@ dependencies {
 
     // Integration test helpers
     integrationTestCompile "junit:junit:$junit_version"
-
-    testCompile "com.nhaarman:mockito-kotlin:1.1.0"
 }
 
 task integrationTest(type: Test) {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -103,6 +103,7 @@ class CordaRPCOpsImpl(
     override fun attachmentExists(id: SecureHash) = services.storageService.attachments.openAttachment(id) != null
     override fun uploadAttachment(jar: InputStream) = services.storageService.attachments.importAttachment(jar)
     override fun currentNodeTime(): Instant = Instant.now(services.clock)
+    @Suppress("OverridingDeprecatedMember", "DEPRECATION")
     override fun uploadFile(dataType: String, name: String?, file: InputStream): String {
         val acceptor = services.storageService.uploaders.firstOrNull { it.accepts(dataType) }
         return databaseTransaction(database) {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DataVendingService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DataVendingService.kt
@@ -15,7 +15,6 @@ import java.util.function.Function
 import javax.annotation.concurrent.ThreadSafe
 
 object DataVending {
-
     class Plugin : CordaPluginRegistry() {
         override val servicePlugins = listOf(Function(::Service))
     }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -195,13 +195,6 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
         }
     }
 
-    /**
-     * Generate a transaction that moves an amount of currency to the given pubkey.
-     *
-     * @param onlyFromParties if non-null, the asset states will be filtered to only include those issued by the set
-     *                        of given parties. This can be useful if the party you're trying to pay has expectations
-     *                        about which type of asset claims they are willing to accept.
-     */
     override fun generateSpend(tx: TransactionBuilder,
                                amount: Amount<Currency>,
                                to: CompositeKey,

--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -19,20 +19,21 @@ class AttachmentDemoTest {
                 startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.Companion.type)))
             ).getOrThrow()
 
-            val senderThread = CompletableFuture.runAsync {
+            val senderThread = CompletableFuture.supplyAsync {
                 nodeA.rpcClientToNode().use(demoUser[0].username, demoUser[0].password) {
                     sender(this)
                 }
-            }
-            val recipientThread = CompletableFuture.runAsync {
+            }.exceptionally { it.printStackTrace() }
+
+            val recipientThread = CompletableFuture.supplyAsync{
                 nodeB.rpcClientToNode().use(demoUser[0].username, demoUser[0].password) {
                     recipient(this)
                 }
-            }
+            }.exceptionally { it.printStackTrace() }
 
-            // Just check they don't throw any exceptions.d
-            recipientThread.get()
+            // Just check they finish and don't throw any exceptions.
             senderThread.get()
+            recipientThread.get()
         }, isDebug = true)
     }
 }

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -132,8 +132,9 @@ object FixingFlow {
      *
      * TODO: Replace [FixingSession] and [FixingSessionInitiationHandler] with generic session initiation logic once it exists.
      */
-    class FixingRoleDecider(val ref: StateRef,
-                            override val progressTracker: ProgressTracker = tracker()) : FlowLogic<Unit>() {
+    class FixingRoleDecider(val ref: StateRef, override val progressTracker: ProgressTracker) : FlowLogic<Unit>() {
+        @Suppress("unused")  // Used via reflection.
+        constructor(ref: StateRef) : this(ref, tracker())
 
         companion object {
             class LOADING() : ProgressTracker.Step("Loading state to decide fixing role")

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
@@ -55,10 +55,7 @@ class SellerFlow(val otherParty: Party,
                 amount,
                 cpOwnerKey,
                 progressTracker.getChildProgressTracker(TRADING)!!)
-        val tradeTX: SignedTransaction = subFlow(seller, shareParentSessions = true)
-        serviceHub.recordTransactions(listOf(tradeTX))
-
-        return tradeTX
+        return subFlow(seller, shareParentSessions = true)
     }
 
     @Suspendable


### PR DESCRIPTION
Make FinalityFlow do more, and be used more consistently.

Add a new waitForLedgerCommit API that is intended to be used at the end of flows, or at any other point where a flow wants to wait for a transaction to finalise (but the finalisation flow is being done by someone else).

Update the docs a bit.