### PR TITLE
Prevent node from starting across upgrades (until we support it better)

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -54,6 +54,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: ['buildCertSigningRequestUtility
     applicationSource = files(project.tasks.findByName('jar'), '../build/classes/main/CordaCaplet.class', 'config/dev/log4j2.xml')
 
     capsuleManifest {
+        applicationVersion = corda_version
         appClassPath = ["jolokia-agent-war-${project.rootProject.ext.jolokia_version}.war"]
         javaAgents = ["quasar-core-${quasar_version}-jdk8.jar"]
         systemProperties['visualvm.display.name'] = 'Corda'

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -58,6 +58,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: ['buildCertSigningRequestUtility
         appClassPath = ["jolokia-agent-war-${project.rootProject.ext.jolokia_version}.war"]
         javaAgents = ["quasar-core-${quasar_version}-jdk8.jar"]
         systemProperties['visualvm.display.name'] = 'Corda'
+        systemProperties['corda.version'] = corda_version
         minJavaVersion = '1.8.0'
         // This version is known to work and avoids earlier 8u versions that have bugs.
         minUpdateVersion['1.8'] = '102'

--- a/node/src/main/java/CordaCaplet.java
+++ b/node/src/main/java/CordaCaplet.java
@@ -10,29 +10,6 @@ public class CordaCaplet extends Capsule {
 
     protected CordaCaplet(Capsule pred) {
         super(pred);
-        checkExistingVersion();
-    }
-
-    /**
-     * Aborts starting the node if an existing deployment with a different version is detected in the current directory
-     */
-    private void checkExistingVersion() {
-        String currentVersion = super.attribute(ATTR_APP_VERSION);
-        Path versionFile = Paths.get("version");
-        try {
-            if (Files.exists(versionFile)) {
-                String existingVersion = Files.readAllLines(versionFile).get(0);
-                if (!existingVersion.equals(currentVersion)) {
-                    System.err.println("ERROR: Unable to start the node, version change detected - current: " +
-                            currentVersion + ", existing: " + existingVersion + ". Node upgrades are not yet supported.");
-                    System.exit(1);
-                }
-            } else {
-                Files.write(versionFile, currentVersion.getBytes());
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/node/src/main/java/CordaCaplet.java
+++ b/node/src/main/java/CordaCaplet.java
@@ -10,6 +10,29 @@ public class CordaCaplet extends Capsule {
 
     protected CordaCaplet(Capsule pred) {
         super(pred);
+        checkExistingVersion();
+    }
+
+    /**
+     * Aborts starting the node if an existing deployment with a different version is detected in the current directory
+     */
+    private void checkExistingVersion() {
+        String currentVersion = super.attribute(ATTR_APP_VERSION);
+        Path versionFile = Paths.get("version");
+        try {
+            if (Files.exists(versionFile)) {
+                String existingVersion = Files.readAllLines(versionFile).get(0);
+                if (!existingVersion.equals(currentVersion)) {
+                    System.err.println("ERROR: Unable to start the node, version change detected - current: " +
+                            currentVersion + ", existing: " + existingVersion + ". Node upgrades are not yet supported.");
+                    System.exit(1);
+                }
+            } else {
+                Files.write(versionFile, currentVersion.getBytes());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -51,6 +51,8 @@ import java.lang.management.ManagementFactory
 import java.lang.reflect.InvocationTargetException
 import java.net.InetAddress
 import java.nio.channels.FileLock
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.time.Clock
 import java.util.*
 import javax.management.ObjectName
@@ -121,6 +123,27 @@ class Node(override val configuration: FullNodeConfiguration,
     private var shutdownThread: Thread? = null
 
     private lateinit var userService: RPCUserService
+
+    init {
+        checkVersionUnchanged()
+    }
+
+    /**
+     * Abort starting the node if an existing deployment with a different version is detected in the current directory.
+     * The current version is expected to be specified as a system property. If not provided, the check will be ignored.
+     */
+    private fun checkVersionUnchanged() {
+        val currentVersion = System.getProperty("corda.version") ?: return
+        val versionFile = Paths.get("version")
+        if (Files.exists(versionFile)) {
+            val existingVersion = Files.readAllLines(versionFile)[0]
+            check(existingVersion == currentVersion) {
+                "Version change detected - current: $currentVersion, existing: $existingVersion. Node upgrades are not yet supported."
+            }
+        } else {
+            Files.write(versionFile, currentVersion.toByteArray())
+        }
+    }
 
     override fun makeMessagingService(): MessagingServiceInternal {
         userService = RPCUserServiceImpl(configuration)
@@ -420,6 +443,7 @@ class Node(override val configuration: FullNodeConfiguration,
                 chain.doFilter(request, response)
             }
         }
+
         override fun init(filterConfig: FilterConfig?) {}
         override fun destroy() {}
     }


### PR DESCRIPTION
On first run a version file is created in the node dir, and on subsequent runs the node version is matched against it.