### PR TITLE
Correct network map cache tests 

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -72,12 +72,7 @@ interface NetworkMapCache {
      */
 
     /** Look up the node info for a specific peer key. */
-    fun getNodeByLegalIdentityKey(compositeKey: CompositeKey): NodeInfo? {
-        // Although we should never have more than one match, it is theoretically possible. Report an error if it happens.
-        val candidates = partyNodes.filter { it.legalIdentity.owningKey == compositeKey }
-        check(candidates.size <= 1) { "Found more than one match for key $compositeKey" }
-        return candidates.singleOrNull()
-    }
+    fun getNodeByLegalIdentityKey(compositeKey: CompositeKey): NodeInfo?
     /** Look up all nodes advertising the service owned by [compositeKey] */
     fun getNodesByAdvertisedServiceIdentityKey(compositeKey: CompositeKey): List<NodeInfo> {
         return partyNodes.filter { it.advertisedServices.any { it.identity.owningKey == compositeKey } }

--- a/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import net.corda.core.bufferUntilSubscribed
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
 import net.corda.core.map
 import net.corda.core.messaging.MessagingService
@@ -69,6 +70,8 @@ open class InMemoryNetworkMapCache : SingletonSerializeAsToken(), NetworkMapCach
         }
         return null
     }
+
+    override fun getNodeByLegalIdentityKey(compositeKey: CompositeKey): NodeInfo? = registeredNodes[Party("", compositeKey)]
 
     override fun track(): Pair<List<NodeInfo>, Observable<MapChange>> {
         synchronized(_changed) {

--- a/node/src/test/kotlin/net/corda/node/services/InMemoryNetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/InMemoryNetworkMapCacheTest.kt
@@ -4,7 +4,6 @@ import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.utilities.databaseTransaction
-import net.corda.testing.expect
 import net.corda.testing.node.MockNetwork
 import org.junit.Test
 import java.math.BigInteger
@@ -34,12 +33,7 @@ class InMemoryNetworkMapCacheTest {
         databaseTransaction(nodeA.database) {
             nodeA.netMapCache.addNode(nodeB.info)
         }
-        // Now both nodes match, so it throws an error
-        expect<IllegalStateException> {
-            nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey)
-        }
-        expect<IllegalStateException> {
-            nodeA.netMapCache.getNodeByLegalIdentityKey(nodeB.info.legalIdentity.owningKey)
-        }
+        // The details of node B write over those for node A
+        assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeB.info)
     }
 }


### PR DESCRIPTION
InMemoryNetworkMapCacheTest was not actually asserting that an expected exception was thrown, which meant when earlier changes to the service changed the operation it wasn't caught. The service now overwrites previous node if a new matching node is added, and this updates the test to follow that design.