### PR TITLE
Remove use of names from contracts

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -203,8 +203,7 @@ interface VaultService {
 
 inline fun <reified T : LinearState> VaultService.linearHeadsOfType() = linearHeadsOfType_(T::class.java)
 inline fun <reified T : DealState> VaultService.dealsWith(party: Party) = linearHeadsOfType<T>().values.filter {
-    // TODO: Replace name comparison with full party comparison (keys are currenty not equal)
-    it.state.data.parties.any { it.name == party.name }
+    it.state.data.parties.any { it == party }
 }
 
 /**

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
@@ -190,7 +190,7 @@ class Obligation<P> : Contract {
                     "amount in settle command ${command.value.amount} matches settled total $totalAmountSettled" by (command.value.amount == totalAmountSettled)
                     "signatures are present from all obligors" by command.signers.containsAll(requiredSigners)
                     "there are no zero sized inputs" by inputs.none { it.amount.quantity == 0L }
-                    "at obligor ${obligor.name} the obligations after settlement balance" by
+                    "at obligor ${obligor} the obligations after settlement balance" by
                             (inputAmount == outputAmount + Amount(totalPenniesSettled, groupingKey))
                 }
                 return setOf(command.value)

--- a/finance/src/main/kotlin/net/corda/contracts/clause/AbstractConserveAmount.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/clause/AbstractConserveAmount.kt
@@ -99,7 +99,7 @@ abstract class AbstractConserveAmount<S : FungibleAsset<T>, C : CommandData, T :
 
         requireThat {
             "there are no zero sized inputs" by inputs.none { it.amount.quantity == 0L }
-            "for reference ${deposit.reference} at issuer ${deposit.party.name} the amounts balance: ${inputAmount.quantity} - ${amountExitingLedger.quantity} != ${outputAmount.quantity}" by
+            "for reference ${deposit.reference} at issuer ${deposit.party} the amounts balance: ${inputAmount.quantity} - ${amountExitingLedger.quantity} != ${outputAmount.quantity}" by
                     (inputAmount == outputAmount + amountExitingLedger)
         }
 

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -191,7 +191,7 @@ class CashTests {
             // Move fails: not allowed to summon money.
             tweak {
                 command(DUMMY_PUBKEY_1) { Cash.Commands.Move() }
-                this `fails with` "at issuer MegaCorp the amounts balance"
+                this `fails with` "the amounts balance"
             }
 
             // Issue works.
@@ -305,14 +305,14 @@ class CashTests {
         transaction {
             input { inState }
             output { outState `issued by` MINI_CORP }
-            this `fails with` "at issuer MegaCorp the amounts balance"
+            this `fails with` "the amounts balance"
         }
         // Can't change deposit reference when splitting.
         transaction {
             input { inState }
             output { outState.copy(amount = inState.amount / 2).editDepositRef(0) }
             output { outState.copy(amount = inState.amount / 2).editDepositRef(1) }
-            this `fails with` "for reference [01] at issuer MegaCorp the amounts balance"
+            this `fails with` "the amounts balance"
         }
         // Can't mix currencies.
         transaction {
@@ -338,7 +338,7 @@ class CashTests {
             input { inState `issued by` MINI_CORP }
             output { outState }
             command(DUMMY_PUBKEY_1) { Cash.Commands.Move() }
-            this `fails with` "at issuer MiniCorp the amounts balance"
+            this `fails with` "the amounts balance"
         }
         // Can't combine two different deposits at the same issuer.
         transaction {
@@ -386,10 +386,10 @@ class CashTests {
 
             command(MEGA_CORP_PUBKEY, MINI_CORP_PUBKEY) { Cash.Commands.Move() }
 
-            this `fails with` "at issuer MegaCorp the amounts balance"
+            this `fails with` "the amounts balance"
 
             command(MEGA_CORP_PUBKEY) { Cash.Commands.Exit(200.DOLLARS `issued by` defaultIssuer) }
-            this `fails with` "at issuer MiniCorp the amounts balance"
+            this `fails with` "the amounts balance"
 
             command(MINI_CORP_PUBKEY) { Cash.Commands.Exit(200.DOLLARS `issued by` MINI_CORP.ref(defaultRef)) }
             this.verifies()
@@ -404,7 +404,7 @@ class CashTests {
             output { outState.copy(amount = inState.amount - (200.DOLLARS `issued by` defaultIssuer)) }
             command(MEGA_CORP_PUBKEY) { Cash.Commands.Exit(200.DOLLARS `issued by` defaultIssuer) }
             command(DUMMY_PUBKEY_1) { Cash.Commands.Move() }
-            this `fails with` "at issuer MegaCorp the amounts balance"
+            this `fails with` "the amounts balance"
         }
     }
 
@@ -418,13 +418,13 @@ class CashTests {
             // Can't merge them together.
             tweak {
                 output { inState.copy(owner = DUMMY_PUBKEY_2, amount = 2000.DOLLARS `issued by` defaultIssuer) }
-                this `fails with` "at issuer MegaCorp the amounts balance"
+                this `fails with` "the amounts balance"
             }
             // Missing MiniCorp deposit
             tweak {
                 output { inState.copy(owner = DUMMY_PUBKEY_2) }
                 output { inState.copy(owner = DUMMY_PUBKEY_2) }
-                this `fails with` "at issuer MegaCorp the amounts balance"
+                this `fails with` "the amounts balance"
             }
 
             // This works.

--- a/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
@@ -143,7 +143,7 @@ class ObligationTests {
             // Move fails: not allowed to summon money.
             tweak {
                 command(DUMMY_PUBKEY_1) { Obligation.Commands.Move() }
-                this `fails with` "for reference [00] at issuer MegaCorp the amounts balance"
+                this `fails with` "the amounts balance"
             }
 
             // Issue works.
@@ -609,7 +609,7 @@ class ObligationTests {
         transaction {
             input { inState }
             output { outState `issued by` MINI_CORP }
-            this `fails with` "for reference [00] at issuer MegaCorp the amounts balance"
+            this `fails with` "the amounts balance"
         }
         // Can't mix currencies.
         transaction {
@@ -636,7 +636,7 @@ class ObligationTests {
             input { inState `issued by` MINI_CORP }
             output { outState }
             command(DUMMY_PUBKEY_1) { Obligation.Commands.Move() }
-            this `fails with` "for reference [00] at issuer MiniCorp the amounts balance"
+            this `fails with` "the amounts balance"
         }
     }
 
@@ -678,10 +678,10 @@ class ObligationTests {
 
             command(DUMMY_PUBKEY_1) { Obligation.Commands.Move() }
 
-            this `fails with` "for reference [00] at issuer MegaCorp the amounts balance"
+            this `fails with` "the amounts balance"
 
             command(DUMMY_PUBKEY_1) { Obligation.Commands.Exit(Amount(200.DOLLARS.quantity, inState.amount.token.copy(product = megaCorpDollarSettlement))) }
-            this `fails with` "for reference [00] at issuer MegaCorp the amounts balance"
+            this `fails with` "the amounts balance"
 
             command(DUMMY_PUBKEY_1) { Obligation.Commands.Exit(Amount(200.POUNDS.quantity, inState.amount.token.copy(product = megaCorpPoundSettlement))) }
             this.verifies()
@@ -698,13 +698,13 @@ class ObligationTests {
             // Can't merge them together.
             tweak {
                 output { inState.copy(beneficiary = DUMMY_PUBKEY_2, quantity = 200000L) }
-                this `fails with` "for reference [00] at issuer MegaCorp the amounts balance"
+                this `fails with` "the amounts balance"
             }
             // Missing MiniCorp deposit
             tweak {
                 output { inState.copy(beneficiary = DUMMY_PUBKEY_2) }
                 output { inState.copy(beneficiary = DUMMY_PUBKEY_2) }
-                this `fails with` "for reference [00] at issuer MegaCorp the amounts balance"
+                this `fails with` "the amounts balance"
             }
 
             // This works.


### PR DESCRIPTION
Remove dependency on name data that cash/obligation state objects will not have access to party details (such as name) once privacy is correctly enforced.