### PR TITLE
FlowException serialised over RPC (subtypes are flattened), and chang…

### DIFF
--- a/client/src/integration-test/kotlin/net/corda/client/CordaRPCClientTest.kt
+++ b/client/src/integration-test/kotlin/net/corda/client/CordaRPCClientTest.kt
@@ -1,6 +1,8 @@
 package net.corda.client
 
 import net.corda.core.contracts.DOLLARS
+import net.corda.core.contracts.issuedBy
+import net.corda.core.flows.FlowException
 import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
@@ -8,26 +10,27 @@ import net.corda.core.random63BitValue
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.flows.CashCommand
 import net.corda.flows.CashFlow
-import net.corda.node.driver.DriverBasedTest
-import net.corda.node.driver.NodeHandle
-import net.corda.node.driver.driver
+import net.corda.node.internal.Node
 import net.corda.node.services.User
+import net.corda.node.services.config.configureTestSSL
 import net.corda.node.services.messaging.CordaRPCClient
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.ValidatingNotaryService
+import net.corda.testing.node.NodeBasedTest
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Before
 import org.junit.Test
 
-class CordaRPCClientTest : DriverBasedTest() {
+class CordaRPCClientTest : NodeBasedTest() {
     private val rpcUser = User("user1", "test", permissions = setOf(startFlowPermission<CashFlow>()))
-    private lateinit var node: NodeHandle
+    private lateinit var node: Node
     private lateinit var client: CordaRPCClient
 
-    override fun setup() = driver(isDebug = true) {
-        node = startNode(rpcUsers = listOf(rpcUser), advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type))).getOrThrow()
-        client = node.rpcClientToNode()
-        runTest()
+    @Before
+    fun setUp() {
+        node = startNode("Alice", rpcUsers = listOf(rpcUser), advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type))).getOrThrow()
+        client = CordaRPCClient(node.configuration.artemisAddress, configureTestSSL())
     }
 
     @Test
@@ -50,7 +53,7 @@ class CordaRPCClientTest : DriverBasedTest() {
     }
 
     @Test
-    fun `indefinite block bug`() {
+    fun `close-send deadlock and premature shutdown on empty observable`() {
         println("Starting client")
         client.start(rpcUser.username, rpcUser.password)
         println("Creating proxy")
@@ -58,11 +61,25 @@ class CordaRPCClientTest : DriverBasedTest() {
         println("Starting flow")
         val flowHandle = proxy.startFlow(
                 ::CashFlow,
-                CashCommand.IssueCash(20.DOLLARS, OpaqueBytes.of(0), node.nodeInfo.legalIdentity, node.nodeInfo.legalIdentity))
+                CashCommand.IssueCash(20.DOLLARS, OpaqueBytes.of(0), node.info.legalIdentity, node.info.legalIdentity))
         println("Started flow, waiting on result")
         flowHandle.progress.subscribe {
             println("PROGRESS $it")
         }
-        println("Result: ${flowHandle.returnValue.toBlocking().first()}")
+        println("Result: ${flowHandle.returnValue.getOrThrow()}")
+    }
+
+    @Test
+    fun `FlowException thrown by flow`() {
+        client.start(rpcUser.username, rpcUser.password)
+        val proxy = client.proxy()
+        val handle = proxy.startFlow(::CashFlow, CashCommand.PayCash(
+                amount = 100.DOLLARS.issuedBy(node.info.legalIdentity.ref(1)),
+                recipient = node.info.legalIdentity
+        ))
+        // TODO Restrict this to CashException once RPC serialisation has been fixed
+        assertThatExceptionOfType(FlowException::class.java).isThrownBy {
+            handle.returnValue.getOrThrow()
+        }
     }
 }

--- a/client/src/integration-test/kotlin/net/corda/client/NodeMonitorModelTest.kt
+++ b/client/src/integration-test/kotlin/net/corda/client/NodeMonitorModelTest.kt
@@ -124,7 +124,7 @@ class NodeMonitorModelTest : DriverBasedTest() {
                 issueRef = OpaqueBytes(ByteArray(1, { 1 })),
                 recipient = aliceNode.legalIdentity,
                 notary = notaryNode.notaryIdentity
-        )).returnValue.toBlocking().first()
+        )).returnValue.getOrThrow()
 
         rpc.startFlow(::CashFlow, CashCommand.PayCash(
                 amount = Amount(100, Issued(PartyAndReference(aliceNode.legalIdentity, OpaqueBytes(ByteArray(1, { 1 }))), USD)),

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -1,5 +1,6 @@
 package net.corda.core.messaging
 
+import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.crypto.CompositeKey
@@ -107,15 +108,16 @@ interface CordaRPCOps : RPCOps {
     fun uploadFile(dataType: String, name: String?, file: InputStream): String
 
     /**
-     * Returns the node-local current time.
+     * Returns the node's current time.
      */
     fun currentNodeTime(): Instant
 
     /**
-     * Returns an Observable emitting a single Unit once the node is registered with the network map.
+     * Returns a [ListenableFuture] which completes when the node has registered wih the network map service. It can also
+     * complete with an exception if it is unable to.
      */
     @RPCReturnsObservables
-    fun waitUntilRegisteredWithNetworkMap(): Observable<Unit>
+    fun waitUntilRegisteredWithNetworkMap(): ListenableFuture<Unit>
 
     // TODO These need rethinking. Instead of these direct calls we should have a way of replicating a subset of
     // the node's state locally and query that directly.
@@ -179,13 +181,10 @@ inline fun <T : Any, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startFlow
  *
  * @param id The started state machine's ID.
  * @param progress The stream of progress tracker events.
- * @param returnValue An Observable emitting a single event containing the flow's return value.
- *     To block on this value:
- *       val returnValue = rpc.startFlow(::MyFlow).returnValue.toBlocking().first()
+ * @param returnValue A [ListenableFuture] of the flow's return value.
  */
 data class FlowHandle<A>(
         val id: StateMachineRunId,
         val progress: Observable<String>,
-        // TODO This should be ListenableFuture<A>
-        val returnValue: Observable<A>
+        val returnValue: ListenableFuture<A>
 )

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -5,6 +5,7 @@ import co.paralleluniverse.io.serialization.kryo.KryoSerializer
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Kryo.DefaultInstantiatorStrategy
 import com.esotericsoftware.kryo.KryoException
+import com.esotericsoftware.kryo.Registration
 import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
@@ -66,7 +67,7 @@ import kotlin.reflect.jvm.javaType
  */
 
 // A convenient instance of Kryo pre-configured with some useful things. Used as a default by various functions.
-val THREAD_LOCAL_KRYO = ThreadLocal.withInitial { createKryo() }
+val THREAD_LOCAL_KRYO: ThreadLocal<Kryo> = ThreadLocal.withInitial { createKryo() }
 
 /**
  * A type safe wrapper around a byte array that contains a serialised object. You can call [SerializedBytes.deserialize]
@@ -76,7 +77,7 @@ class SerializedBytes<T : Any>(bytes: ByteArray) : OpaqueBytes(bytes) {
     // It's OK to use lazy here because SerializedBytes is configured to use the ImmutableClassSerializer.
     val hash: SecureHash by lazy { bytes.sha256() }
 
-    fun writeToFile(path: Path) = Files.write(path, bytes)
+    fun writeToFile(path: Path): Path = Files.write(path, bytes)
 }
 
 // Some extension functions that make deserialisation convenient and provide auto-casting of the result.
@@ -385,8 +386,7 @@ object KotlinObjectSerializer : Serializer<DeserializeAsKotlinObjectDef>() {
         return type.getField("INSTANCE").get(null) as DeserializeAsKotlinObjectDef
     }
 
-    override fun write(kryo: Kryo, output: Output, obj: DeserializeAsKotlinObjectDef) {
-    }
+    override fun write(kryo: Kryo, output: Output, obj: DeserializeAsKotlinObjectDef) {}
 }
 
 fun createKryo(k: Kryo = Kryo()): Kryo {
@@ -402,12 +402,10 @@ fun createKryo(k: Kryo = Kryo()): Kryo {
         // Because we like to stick a Kryo object in a ThreadLocal to speed things up a bit, we can end up trying to
         // serialise the Kryo object itself when suspending a fiber. That's dumb, useless AND can cause crashes, so
         // we avoid it here.
-        register(Kryo::class.java, object : Serializer<Kryo>() {
-            override fun read(kryo: Kryo, input: Input, type: Class<Kryo>): Kryo {
-                return createKryo((Fiber.getFiberSerializer() as KryoSerializer).kryo)
-            }
-            override fun write(kryo: Kryo, output: Output, obj: Kryo) {}
-        })
+        register(Kryo::class,
+                read = { kryo, input -> createKryo((Fiber.getFiberSerializer() as KryoSerializer).kryo) },
+                write = { kryo, output, obj -> }
+        )
 
         register(EdDSAPublicKey::class.java, Ed25519PublicKeySerializer)
         register(EdDSAPrivateKey::class.java, Ed25519PrivateKeySerializer)
@@ -435,6 +433,8 @@ fun createKryo(k: Kryo = Kryo()): Kryo {
         // This ensures a NonEmptySetSerializer is constructed with an initial value.
         register(NonEmptySet::class.java, NonEmptySetSerializer)
 
+        register(Array<StackTraceElement>::class, read = { kryo, input -> emptyArray() }, write = { kryo, output, o -> })
+
         /** This ensures any kotlin objects that implement [DeserializeAsKotlinObjectDef] are read back in as singletons. */
         addDefaultSerializer(DeserializeAsKotlinObjectDef::class.java, KotlinObjectSerializer)
 
@@ -449,6 +449,19 @@ fun createKryo(k: Kryo = Kryo()): Kryo {
 
         noReferencesWithin<WireTransaction>()
     }
+}
+
+inline fun <T : Any> Kryo.register(
+        type: KClass<T>,
+        crossinline read: (Kryo, Input) -> T,
+        crossinline write: (Kryo, Output, T) -> Unit): Registration {
+    return register(
+            type.java,
+            object : Serializer<T>() {
+                override fun read(kryo: Kryo, input: Input, type: Class<T>): T = read(kryo, input)
+                override fun write(kryo: Kryo, output: Output, obj: T) = write(kryo, output, obj)
+            }
+    )
 }
 
 /**
@@ -517,7 +530,7 @@ var Kryo.attachmentStorage: AttachmentStorage?
 //Used in Merkle tree calculation. It doesn't cover all the cases of unstable serialization format.
 fun extendKryoHash(kryo: Kryo): Kryo {
     return kryo.apply {
-        setReferences(false)
+        references = false
         register(LinkedHashMap::class.java, MapSerializer())
         register(HashMap::class.java, OrderedSerializer)
     }

--- a/core/src/test/kotlin/net/corda/core/UtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/UtilsTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.*
 import org.junit.Test
 import rx.subjects.PublishSubject
 import java.util.*
+import java.util.concurrent.CancellationException
 
 class UtilsTest {
     @Test
@@ -43,5 +44,17 @@ class UtilsTest {
         assertThatThrownBy {
             future.getOrThrow()
         }.isSameAs(exception)
+    }
+
+    @Test
+    fun `toFuture - cancel`() {
+        val subject = PublishSubject.create<String>()
+        val future = subject.toFuture()
+        future.cancel(false)
+        assertThat(subject.hasObservers()).isFalse()
+        subject.onNext("Hello")
+        assertThatExceptionOfType(CancellationException::class.java).isThrownBy {
+            future.get()
+        }
     }
 }

--- a/docs/source/clientrpc.rst
+++ b/docs/source/clientrpc.rst
@@ -46,6 +46,14 @@ through to the server where the corresponding server-side observables are also u
    a warning printed to the logs and the proxy will be closed for you. But don't rely on this, as garbage
    collection is non-deterministic.
 
+Futures
+-------
+
+A method can also return a ``ListenableFuture`` in its object graph and it will be treated in a similar manner to
+observables, including needing to mark the RPC with the ``@RPCReturnsObservables`` annotation. Unlike for an observable,
+once the single value (or an exception) has been received all server-side resources will be released automatically. Calling
+the ``cancel`` method on the future will unsubscribe it from any future value and release any resources.
+
 Versioning
 ----------
 

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -9,7 +9,6 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.Vault
 import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.toFuture
 import net.corda.flows.CashCommand
 import net.corda.flows.CashFlow
 import net.corda.node.driver.driver
@@ -87,7 +86,7 @@ class IntegrationTestingTutorial {
                         amount = i.DOLLARS.issuedBy(alice.nodeInfo.legalIdentity.ref(issueRef)),
                         recipient = alice.nodeInfo.legalIdentity
                 ))
-                flowHandle.returnValue.toFuture().getOrThrow()
+                flowHandle.returnValue.getOrThrow()
             }
 
             aliceVaultUpdates.expectEvents {

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -11,7 +11,6 @@ import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.toFuture
 import net.corda.flows.CashCommand
 import net.corda.flows.CashFlow
 import net.corda.node.driver.DriverBasedTest
@@ -138,13 +137,13 @@ class DistributedServiceTests : DriverBasedTest() {
         val issueHandle = aliceProxy.startFlow(
                 ::CashFlow,
                 CashCommand.IssueCash(amount, OpaqueBytes.of(0), alice.nodeInfo.legalIdentity, raftNotaryIdentity))
-        issueHandle.returnValue.toFuture().getOrThrow()
+        issueHandle.returnValue.getOrThrow()
     }
 
     private fun paySelf(amount: Amount<Currency>) {
         val payHandle = aliceProxy.startFlow(
                 ::CashFlow,
                 CashCommand.PayCash(amount.issuedBy(alice.nodeInfo.legalIdentity.ref(0)), alice.nodeInfo.legalIdentity))
-        payHandle.returnValue.toFuture().getOrThrow()
+        payHandle.returnValue.getOrThrow()
     }
 }

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -380,7 +380,7 @@ open class DriverDSL(
         registerProcess(processFuture)
         return processFuture.flatMap { process ->
             establishRpc(messagingAddress, configuration).flatMap { rpc ->
-                rpc.waitUntilRegisteredWithNetworkMap().toFuture().map {
+                rpc.waitUntilRegisteredWithNetworkMap().map {
                     NodeHandle(rpc.nodeIdentity(), rpc, configuration, process)
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -15,7 +15,6 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.StateMachineTransactionMapping
 import net.corda.core.node.services.Vault
-import net.corda.core.toObservable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.node.services.messaging.requirePermission
 import net.corda.node.services.startFlowPermission
@@ -97,7 +96,7 @@ class CordaRPCOpsImpl(
         return FlowHandle(
                 id = stateMachine.id,
                 progress = stateMachine.logic.track()?.second ?: Observable.empty(),
-                returnValue = stateMachine.resultFuture.toObservable()
+                returnValue = stateMachine.resultFuture
         )
     }
 
@@ -111,7 +110,7 @@ class CordaRPCOpsImpl(
         }
     }
 
-    override fun waitUntilRegisteredWithNetworkMap() = services.networkMapCache.mapServiceRegistered.toObservable()
+    override fun waitUntilRegisteredWithNetworkMap() = services.networkMapCache.mapServiceRegistered
     override fun partyFromKey(key: CompositeKey) = services.identityService.partyFromKey(key)
     override fun partyFromName(name: String) = services.identityService.partyFromName(name)
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -368,9 +368,6 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
     }
 
     private fun endAllFiberSessions(fiber: FlowStateMachineImpl<*>, errorResponse: Pair<FlowException, Boolean>?) {
-        // TODO Blanking the stack trace prevents the receiving flow from filling in its own stack trace
-//        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-//        (errorResponse?.first as java.lang.Throwable?)?.stackTrace = emptyArray()
         openSessions.values.removeIf { session ->
             if (session.fiber == fiber) {
                 session.endSession(errorResponse)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
@@ -390,9 +390,8 @@ class StateMachineManagerTests {
                 node2 sent sessionConfirm to node1,
                 node2 sent sessionEnd(errorFlow.exceptionThrown) to node1
         )
-        // TODO see StateMachineManager.endAllFiberSessions
-//        // Make sure the original stack trace isn't sent down the wire
-//        assertThat((sessionTransfers.last().message as SessionEnd).errorResponse!!.stackTrace).isEmpty()
+        // Make sure the original stack trace isn't sent down the wire
+        assertThat((sessionTransfers.last().message as SessionEnd).errorResponse!!.stackTrace).isEmpty()
     }
 
     @Test

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -6,6 +6,7 @@ import net.corda.core.contracts.TransactionType
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
 import net.corda.core.div
+import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.Emoji
@@ -83,9 +84,9 @@ fun sender(rpc: CordaRPCOps) {
     // Send the transaction to the other recipient
     val stx = ptx.toSignedTransaction()
     println("Sending ${stx.id}")
-    val protocolHandle = rpc.startFlow(::FinalityFlow, stx, setOf(otherSide))
-    protocolHandle.progress.subscribe(::println)
-    protocolHandle.returnValue.toBlocking().first()
+    val flowHandle = rpc.startFlow(::FinalityFlow, stx, setOf(otherSide))
+    flowHandle.progress.subscribe(::println)
+    flowHandle.returnValue.getOrThrow()
 }
 
 fun recipient(rpc: CordaRPCOps) {

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -5,7 +5,6 @@ import net.corda.core.contracts.DOLLARS
 import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
-import net.corda.core.transactions.SignedTransaction
 import net.corda.flows.IssuerFlow.IssuanceRequester
 import net.corda.node.driver.driver
 import net.corda.node.services.User
@@ -16,7 +15,6 @@ import net.corda.testing.expect
 import net.corda.testing.expectEvents
 import net.corda.testing.sequence
 import org.junit.Test
-import kotlin.test.assertTrue
 
 class BankOfCordaRPCClientTest {
     @Test
@@ -45,13 +43,12 @@ class BankOfCordaRPCClientTest {
             val vaultUpdatesBigCorp = bigCorpProxy.vaultAndUpdates().second
 
             // Kick-off actual Issuer Flow
-            val result = bocProxy.startFlow(
+            bocProxy.startFlow(
                     ::IssuanceRequester,
                     1000.DOLLARS,
                     nodeBigCorporation.nodeInfo.legalIdentity,
                     BOC_PARTY_REF,
-                    nodeBankOfCorda.nodeInfo.legalIdentity).returnValue.toBlocking().first()
-            assertTrue { result is SignedTransaction }
+                    nodeBankOfCorda.nodeInfo.legalIdentity).returnValue.getOrThrow()
 
             // Check Bank of Corda Vault Updates
             vaultUpdatesBoc.expectEvents {

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt
@@ -2,14 +2,15 @@ package net.corda.bank.api
 
 import com.google.common.net.HostAndPort
 import net.corda.bank.api.BankOfCordaWebApi.IssueRequestParams
-import net.corda.flows.IssuerFlow.IssuanceRequester
-import net.corda.node.services.messaging.CordaRPCClient
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.currency
+import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
+import net.corda.flows.IssuerFlow.IssuanceRequester
 import net.corda.node.services.config.configureTestSSL
+import net.corda.node.services.messaging.CordaRPCClient
 import net.corda.testing.http.HttpApi
 
 /**
@@ -43,6 +44,6 @@ class BankOfCordaClientApi(val hostAndPort: HostAndPort) {
         val amount = Amount(params.amount, currency(params.currency))
         val issuerToPartyRef = OpaqueBytes.of(params.issueToPartyRefAsString.toByte())
 
-        return proxy.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty).returnValue.toBlocking().first()
+        return proxy.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty).returnValue.getOrThrow()
     }
 }

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
@@ -1,19 +1,17 @@
 package net.corda.traderdemo
 
-import com.google.common.net.HostAndPort
+import com.google.common.util.concurrent.Futures
 import net.corda.contracts.testing.calculateRandomlySizedAmounts
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.DOLLARS
+import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.Emoji
 import net.corda.core.utilities.loggerFor
 import net.corda.flows.IssuerFlow.IssuanceRequester
-import net.corda.node.services.messaging.CordaRPCClient
 import net.corda.testing.BOC
-import net.corda.testing.http.HttpApi
 import net.corda.traderdemo.flow.SellerFlow
 import java.util.*
 import kotlin.test.assertEquals
@@ -26,20 +24,17 @@ class TraderDemoClientApi(val rpc: CordaRPCOps) {
         val logger = loggerFor<TraderDemoClientApi>()
     }
 
-    fun runBuyer(amount: Amount<Currency> = 30000.0.DOLLARS, notary: String = "Notary"): Boolean {
+    fun runBuyer(amount: Amount<Currency> = 30000.0.DOLLARS): Boolean {
         val bankOfCordaParty = rpc.partyFromName(BOC.name)
                 ?: throw Exception("Unable to locate ${BOC.name} in Network Map Service")
         val me = rpc.nodeIdentity()
         // TODO: revert back to multiple issue request amounts (3,10) when soft locking implemented
         val amounts = calculateRandomlySizedAmounts(amount, 1, 1, Random())
-        val handles = amounts.map {
-            rpc.startFlow(::IssuanceRequester, amount, me.legalIdentity, OpaqueBytes.of(1), bankOfCordaParty)
+        val resultFutures = amounts.map {
+            rpc.startFlow(::IssuanceRequester, amount, me.legalIdentity, OpaqueBytes.of(1), bankOfCordaParty).returnValue
         }
 
-        handles.forEach {
-            require(it.returnValue.toBlocking().first() is SignedTransaction)
-        }
-
+        Futures.allAsList(resultFutures).getOrThrow()
         return true
     }
 
@@ -60,7 +55,7 @@ class TraderDemoClientApi(val rpc: CordaRPCOps) {
             }
 
             // The line below blocks and waits for the future to resolve.
-            val stx = rpc.startFlow(::SellerFlow, otherParty, amount).returnValue.toBlocking().first()
+            val stx = rpc.startFlow(::SellerFlow, otherParty, amount).returnValue.getOrThrow()
             logger.info("Sale completed - we have a happy customer!\n\nFinal transaction is:\n\n${Emoji.renderIfSupported(stx.tx)}")
             return true
         } else {

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/NewTransaction.kt
@@ -21,7 +21,6 @@ import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.toFuture
 import net.corda.core.transactions.SignedTransaction
 import net.corda.explorer.model.CashTransaction
 import net.corda.explorer.model.IssuerModel
@@ -101,7 +100,7 @@ class NewTransaction : Fragment() {
                     rpcProxy.value!!.startFlow(::CashFlow, it)
                 }
                 val response = try {
-                    handle?.returnValue?.toFuture()?.getOrThrow()
+                    handle?.returnValue?.getOrThrow()
                 } catch (e: FlowException) {
                     e
                 }

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
@@ -7,12 +7,11 @@ import net.corda.core.contracts.Issued
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.USD
 import net.corda.core.crypto.Party
+import net.corda.core.flows.FlowException
 import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.toFuture
 import net.corda.flows.CashCommand
-import net.corda.flows.CashException
 import net.corda.flows.CashFlow
 import net.corda.loadtest.LoadTest
 import net.corda.loadtest.NodeHandle
@@ -208,9 +207,9 @@ val crossCashTest = LoadTest<CrossCashCommand, CrossCashState>(
 
         execute = { command ->
             try {
-                val result = command.node.connection.proxy.startFlow(::CashFlow, command.command).returnValue.toFuture().getOrThrow()
+                val result = command.node.connection.proxy.startFlow(::CashFlow, command.command).returnValue.getOrThrow()
                 log.info("Success: $result")
-            } catch (e: CashException) {
+            } catch (e: FlowException) {
                 log.error("Failure", e)
             }
         },

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt
@@ -7,11 +7,10 @@ import net.corda.client.mock.replicatePoisson
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.USD
 import net.corda.core.crypto.Party
+import net.corda.core.flows.FlowException
 import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
-import net.corda.core.toFuture
 import net.corda.flows.CashCommand
-import net.corda.flows.CashException
 import net.corda.flows.CashFlow
 import net.corda.loadtest.LoadTest
 import net.corda.loadtest.NodeHandle
@@ -63,9 +62,9 @@ val selfIssueTest = LoadTest<SelfIssueCommand, SelfIssueState>(
 
         execute = { command ->
             try {
-                val result = command.node.connection.proxy.startFlow(::CashFlow, command.command).returnValue.toFuture().getOrThrow()
+                val result = command.node.connection.proxy.startFlow(::CashFlow, command.command).returnValue.getOrThrow()
                 log.info("Success: $result")
-            } catch (e: CashException) {
+            } catch (e: FlowException) {
                 log.error("Failure", e)
             }
         },


### PR DESCRIPTION
…e to startFlow RPC for correct exception handling

`FlowException` thrown by a flow wasn't being serialised via RPC. Further, to deal with the various subtypes a temporary solution (until a better serialisation scheme) is to flatten any subtype and serialise as FlowException. This also lead me to change `FlowHandle.returnValue` to return a ListenableFuture as BlockingObservable doesn't do exceptions well.