### PR TITLE
Fix incorrect port numbers in documentation for node explorer

### DIFF
--- a/docs/build/html/_sources/node-explorer.txt
+++ b/docs/build/html/_sources/node-explorer.txt
@@ -63,11 +63,11 @@ The Demo Nodes can be started in one of two modes:
 
 .. note:: 5 Corda nodes will be created on the following port on localhost by default.
 
-   * Notary -> 20002
-   * Alice -> 20004
-   * Bob -> 20006
+   * Notary -> 20001
+   * Alice -> 20003
+   * Bob -> 20005
    * UK Bank Plc -> 20008       (*Issuer node*)
-   * USA Bank Corp -> 20010     (*Issuer node*)
+   * USA Bank Corp -> 20009     (*Issuer node*)
 
 Explorer login credentials to the Issuer nodes are defaulted to ``manager`` and ``test``.
 Explorer login credentials to the Participants nodes are defaulted to ``user1`` and ``test``.

--- a/docs/build/html/node-explorer.html
+++ b/docs/build/html/node-explorer.html
@@ -288,11 +288,11 @@ Participant nodes will randomly generate spends (eg. move cash to other nodes, i
 <p class="first admonition-title">Note</p>
 <p>5 Corda nodes will be created on the following port on localhost by default.</p>
 <ul class="last simple">
-<li>Notary -&gt; 20002</li>
-<li>Alice -&gt; 20004</li>
-<li>Bob -&gt; 20006</li>
-<li>UK Bank Plc -&gt; 20008       (<em>Issuer node</em>)</li>
-<li>USA Bank Corp -&gt; 20010     (<em>Issuer node</em>)</li>
+<li>Notary -&gt; 20001</li>
+<li>Alice -&gt; 20003</li>
+<li>Bob -&gt; 20005</li>
+<li>UK Bank Plc -&gt; 20007       (<em>Issuer node</em>)</li>
+<li>USA Bank Corp -&gt; 20009     (<em>Issuer node</em>)</li>
 </ul>
 </div>
 <p>Explorer login credentials to the Issuer nodes are defaulted to <code class="docutils literal"><span class="pre">manager</span></code> and <code class="docutils literal"><span class="pre">test</span></code>.

--- a/docs/source/node-explorer.rst
+++ b/docs/source/node-explorer.rst
@@ -63,11 +63,11 @@ The Demo Nodes can be started in one of two modes:
 
 .. note:: 5 Corda nodes will be created on the following port on localhost by default.
 
-   * Notary -> 20002
-   * Alice -> 20004
-   * Bob -> 20006
+   * Notary -> 20001
+   * Alice -> 20003
+   * Bob -> 20005
    * UK Bank Plc -> 20008       (*Issuer node*)
-   * USA Bank Corp -> 20010     (*Issuer node*)
+   * USA Bank Corp -> 20009     (*Issuer node*)
 
 Explorer login credentials to the Issuer nodes are defaulted to ``manager`` and ``test``.
 Explorer login credentials to the Participants nodes are defaulted to ``user1`` and ``test``.

--- a/tools/explorer/README.md
+++ b/tools/explorer/README.md
@@ -34,11 +34,11 @@ The Participant nodes are only able to spend cash (eg. move cash).
 
 **These Corda nodes will be created on the following port on localhost.**
 
-    Notary -> 20002
-    Alice -> 20004
-    Bob -> 20006
-    UK Bank Plc -> 20008
-    USA Bank Corp -> 20010
+   * Notary -> 20001
+   * Alice -> 20003
+   * Bob -> 20005
+   * UK Bank Plc -> 20008       (*Issuer node*)
+   * USA Bank Corp -> 20009     (*Issuer node*)
 
 Explorer login credentials to the Issuer nodes are 'manager'/'test'.
 Explorer login credentials to the Participants nodes are 'user1'/'test'.


### PR DESCRIPTION
The current documentation incorrectly identifies the port numbers when running up the node explorer. This can lead to confusion as developers use the documentation over the log messages and fail to connect to the nodes.