### PR TITLE
End flow if waiting for ledger commit and committer flow errors

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -203,7 +203,7 @@ abstract class FlowLogic<out T> {
         val theirs = subLogic.progressTracker
         if (ours != null && theirs != null) {
             if (ours.currentStep == ProgressTracker.UNSTARTED) {
-                logger.warn("ProgressTracker has not been started for $this")
+                logger.warn("ProgressTracker has not been started")
                 ours.nextStep()
             }
             ours.setChildProgressTracker(ours.currentStep, theirs)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowIORequest.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowIORequest.kt
@@ -10,6 +10,8 @@ interface FlowIORequest {
     val stackTraceInCaseOfProblems: StackSnapshot
 }
 
+interface WaitingRequest : FlowIORequest
+
 interface SessionedFlowIORequest : FlowIORequest {
     val session: FlowSession
 }
@@ -18,7 +20,7 @@ interface SendRequest : SessionedFlowIORequest {
     val message: SessionMessage
 }
 
-interface ReceiveRequest<T : SessionMessage> : SessionedFlowIORequest {
+interface ReceiveRequest<T : SessionMessage> : SessionedFlowIORequest, WaitingRequest {
     val receiveType: Class<T>
 }
 
@@ -40,7 +42,7 @@ data class SendOnly(override val session: FlowSession, override val message: Ses
     override val stackTraceInCaseOfProblems: StackSnapshot = StackSnapshot()
 }
 
-data class WaitForLedgerCommit(val hash: SecureHash, val fiber: FlowStateMachineImpl<*>) : FlowIORequest {
+data class WaitForLedgerCommit(val hash: SecureHash, val fiber: FlowStateMachineImpl<*>) : WaitingRequest {
     @Transient
     override val stackTraceInCaseOfProblems: StackSnapshot = StackSnapshot()
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
@@ -8,7 +8,6 @@ import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.DummyState
 import net.corda.core.contracts.issuedBy
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
@@ -21,9 +20,9 @@ import net.corda.core.random63BitValue
 import net.corda.core.rootCause
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.serialization.deserialize
-import net.corda.core.utilities.unwrap
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.unwrap
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
 import net.corda.flows.FinalityFlow
@@ -36,6 +35,7 @@ import net.corda.testing.expectEvents
 import net.corda.testing.initiateSingleShotFlow
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.InMemoryMessagingNetwork.MessageTransfer
+import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
 import net.corda.testing.sequence
@@ -49,10 +49,11 @@ import rx.Observable
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class StateMachineManagerTests {
-    private val net = MockNetwork(servicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin())
+    private val net = MockNetwork(servicePeerAllocationStrategy = RoundRobin())
     private val sessionTransfers = ArrayList<SessionTransfer>()
     private lateinit var node1: MockNode
     private lateinit var node2: MockNode
@@ -102,7 +103,7 @@ class StateMachineManagerTests {
 
     @Test
     fun `exception while fiber suspended`() {
-        node2.services.registerFlowInitiator(ReceiveFlow::class) { SendFlow(2, it) }
+        node2.services.registerFlowInitiator(ReceiveFlow::class) { SendFlow("Hello", it) }
         val flow = ReceiveFlow(node2.info.legalIdentity)
         val fiber = node1.services.startFlow(flow) as FlowStateMachineImpl
         // Before the flow runs change the suspend action to throw an exception
@@ -128,8 +129,7 @@ class StateMachineManagerTests {
     @Test
     fun `flow restarted just after receiving payload`() {
         node2.services.registerFlowInitiator(SendFlow::class) { ReceiveFlow(it).nonTerminating() }
-        val payload = random63BitValue()
-        node1.services.startFlow(SendFlow(payload, node2.info.legalIdentity))
+        node1.services.startFlow(SendFlow("Hello", node2.info.legalIdentity))
 
         // We push through just enough messages to get only the payload sent
         node2.pumpReceive()
@@ -138,7 +138,7 @@ class StateMachineManagerTests {
         node2.stop()
         net.runNetwork()
         val restoredFlow = node2.restartAndGetRestoredFlow<ReceiveFlow>(node1)
-        assertThat(restoredFlow.receivedPayloads[0]).isEqualTo(payload)
+        assertThat(restoredFlow.receivedPayloads[0]).isEqualTo("Hello")
     }
 
     @Test
@@ -178,15 +178,14 @@ class StateMachineManagerTests {
 
     @Test
     fun `flow loaded from checkpoint will respond to messages from before start`() {
-        val payload = random63BitValue()
-        node1.services.registerFlowInitiator(ReceiveFlow::class) { SendFlow(payload, it) }
+        node1.services.registerFlowInitiator(ReceiveFlow::class) { SendFlow("Hello", it) }
         node2.services.startFlow(ReceiveFlow(node1.info.legalIdentity).nonTerminating()) // Prepare checkpointed receive flow
         // Make sure the add() has finished initial processing.
         node2.smm.executor.flush()
         node2.disableDBCloseOnStop()
         node2.stop() // kill receiver
         val restoredFlow = node2.restartAndGetRestoredFlow<ReceiveFlow>(node1)
-        assertThat(restoredFlow.receivedPayloads[0]).isEqualTo(payload)
+        assertThat(restoredFlow.receivedPayloads[0]).isEqualTo("Hello")
     }
 
     @Test
@@ -245,7 +244,7 @@ class StateMachineManagerTests {
         net.runNetwork()
         node2.services.registerFlowInitiator(SendFlow::class) { ReceiveFlow(it).nonTerminating() }
         node3.services.registerFlowInitiator(SendFlow::class) { ReceiveFlow(it).nonTerminating() }
-        val payload = random63BitValue()
+        val payload = "Hello World"
         node1.services.startFlow(SendFlow(payload, node2.info.legalIdentity, node3.info.legalIdentity))
         net.runNetwork()
         val node2Flow = node2.getSingleFlow<ReceiveFlow>().first
@@ -256,14 +255,14 @@ class StateMachineManagerTests {
         assertSessionTransfers(node2,
                 node1 sent sessionInit(SendFlow::class, payload) to node2,
                 node2 sent sessionConfirm to node1,
-                node1 sent sessionEnd() to node2
+                node1 sent normalEnd to node2
                 //There's no session end from the other flows as they're manually suspended
         )
 
         assertSessionTransfers(node3,
                 node1 sent sessionInit(SendFlow::class, payload) to node3,
                 node3 sent sessionConfirm to node1,
-                node1 sent sessionEnd() to node3
+                node1 sent normalEnd to node3
                 //There's no session end from the other flows as they're manually suspended
         )
 
@@ -275,8 +274,8 @@ class StateMachineManagerTests {
     fun `receiving from multiple parties`() {
         val node3 = net.createNode(node1.info.address)
         net.runNetwork()
-        val node2Payload = random63BitValue()
-        val node3Payload = random63BitValue()
+        val node2Payload = "Test 1"
+        val node3Payload = "Test 2"
         node2.services.registerFlowInitiator(ReceiveFlow::class) { SendFlow(node2Payload, it) }
         node3.services.registerFlowInitiator(ReceiveFlow::class) { SendFlow(node3Payload, it) }
         val multiReceiveFlow = ReceiveFlow(node2.info.legalIdentity, node3.info.legalIdentity).nonTerminating()
@@ -290,14 +289,14 @@ class StateMachineManagerTests {
                 node1 sent sessionInit(ReceiveFlow::class) to node2,
                 node2 sent sessionConfirm to node1,
                 node2 sent sessionData(node2Payload) to node1,
-                node2 sent sessionEnd() to node1
+                node2 sent normalEnd to node1
         )
 
         assertSessionTransfers(node3,
                 node1 sent sessionInit(ReceiveFlow::class) to node3,
                 node3 sent sessionConfirm to node1,
                 node3 sent sessionData(node3Payload) to node1,
-                node3 sent sessionEnd() to node1
+                node3 sent normalEnd to node1
         )
     }
 
@@ -313,7 +312,7 @@ class StateMachineManagerTests {
                 node2 sent sessionData(20L) to node1,
                 node1 sent sessionData(11L) to node2,
                 node2 sent sessionData(21L) to node1,
-                node1 sent sessionEnd() to node2
+                node1 sent normalEnd to node2
         )
     }
 
@@ -321,14 +320,14 @@ class StateMachineManagerTests {
     fun `different notaries are picked when addressing shared notary identity`() {
         assertEquals(notary1.info.notaryIdentity, notary2.info.notaryIdentity)
         node1.services.startFlow(CashIssueFlow(
-                DOLLARS(2000),
+                2000.DOLLARS,
                 OpaqueBytes.of(0x01),
                 node1.info.legalIdentity,
                 notary1.info.notaryIdentity))
         // We pay a couple of times, the notary picking should go round robin
         for (i in 1 .. 3) {
             node1.services.startFlow(CashPaymentFlow(
-                    DOLLARS(500).issuedBy(node1.info.legalIdentity.ref(0x01)),
+                    500.DOLLARS.issuedBy(node1.info.legalIdentity.ref(0x01)),
                     node2.info.legalIdentity))
             net.runNetwork()
         }
@@ -336,7 +335,7 @@ class StateMachineManagerTests {
         val party1Info = notary1.services.networkMapCache.getPartyInfo(notary1.info.notaryIdentity)!!
         assert(party1Info is PartyInfo.Service)
         val notary1Address: MessageRecipients = endpoint.getAddressOfParty(notary1.services.networkMapCache.getPartyInfo(notary1.info.notaryIdentity)!!)
-        assert(notary1Address is InMemoryMessagingNetwork.ServiceHandle)
+        assertThat(notary1Address).isInstanceOf(InMemoryMessagingNetwork.ServiceHandle::class.java)
         assertEquals(notary1Address, endpoint.getAddressOfParty(notary2.services.networkMapCache.getPartyInfo(notary2.info.notaryIdentity)!!))
         sessionTransfers.expectEvents(isStrict = false) {
             sequence(
@@ -368,10 +367,36 @@ class StateMachineManagerTests {
                     },
                     expect(match = { it.message is SessionConfirm }) {
                         it.message as SessionConfirm
-                        require(it.from == notary1.id)
+                        assertEquals(it.from, notary1.id)
                     }
             )
         }
+    }
+
+    @Test
+    fun `other side ends before doing expected send`() {
+        node2.services.registerFlowInitiator(ReceiveFlow::class) { NoOpFlow() }
+        val resultFuture = node1.services.startFlow(ReceiveFlow(node2.info.legalIdentity)).resultFuture
+        net.runNetwork()
+        assertThatExceptionOfType(FlowSessionException::class.java).isThrownBy {
+            resultFuture.getOrThrow()
+        }.withMessageContaining(String::class.java.name)
+    }
+
+    @Test
+    fun `non-FlowException thrown on other side`() {
+        node2.services.registerFlowInitiator(ReceiveFlow::class) { ExceptionFlow { Exception("evil bug!") } }
+        val resultFuture = node1.services.startFlow(ReceiveFlow(node2.info.legalIdentity)).resultFuture
+        net.runNetwork()
+        val exceptionResult = assertFailsWith(FlowSessionException::class) {
+            resultFuture.getOrThrow()
+        }
+        assertThat(exceptionResult.message).doesNotContain("evil bug!")
+        assertSessionTransfers(
+                node1 sent sessionInit(ReceiveFlow::class) to node2,
+                node2 sent sessionConfirm to node1,
+                node2 sent erroredEnd() to node1
+        )
     }
 
     @Test
@@ -384,7 +409,7 @@ class StateMachineManagerTests {
         assertThatExceptionOfType(MyFlowException::class.java)
                 .isThrownBy { receivingFiber.resultFuture.getOrThrow() }
                 .withMessage("Nothing useful")
-                .withStackTraceContaining("ReceiveFlow")  // Make sure the stack trace is that of the receiving flow
+                .withStackTraceContaining(ReceiveFlow::class.java.name)  // Make sure the stack trace is that of the receiving flow
         databaseTransaction(node2.database) {
             assertThat(node2.checkpointStorage.checkpoints()).isEmpty()
         }
@@ -394,10 +419,10 @@ class StateMachineManagerTests {
         assertSessionTransfers(
                 node1 sent sessionInit(ReceiveFlow::class) to node2,
                 node2 sent sessionConfirm to node1,
-                node2 sent sessionEnd(errorFlow.exceptionThrown) to node1
+                node2 sent erroredEnd(errorFlow.exceptionThrown) to node1
         )
         // Make sure the original stack trace isn't sent down the wire
-        assertThat((sessionTransfers.last().message as SessionEnd).errorResponse!!.stackTrace).isEmpty()
+        assertThat((sessionTransfers.last().message as ErrorSessionEnd).errorResponse!!.stackTrace).isEmpty()
     }
 
     @Test
@@ -450,7 +475,7 @@ class StateMachineManagerTests {
                 node1 sent sessionInit(ReceiveFlow::class) to node2,
                 node2 sent sessionConfirm to node1,
                 node2 sent sessionData("Hello") to node1,
-                node1 sent sessionEnd() to node2  // Unexpected session-end
+                node1 sent erroredEnd() to node2
         )
     }
 
@@ -496,11 +521,29 @@ class StateMachineManagerTests {
         ptx.signWith(node1.services.legalIdentityKey)
         val stx = ptx.toSignedTransaction()
 
-        val future1 = node2.services.startFlow(WaitingFlows.Waiter(stx.id)).resultFuture
-        val future2 = node1.services.startFlow(WaitingFlows.Committer(stx, node2.info.legalIdentity)).resultFuture
+        val committerFiber = node1
+                .initiateSingleShotFlow(WaitingFlows.Waiter::class) { WaitingFlows.Committer(it) }
+                .map { it.stateMachine }
+        val waiterStx = node2.services.startFlow(WaitingFlows.Waiter(stx, node1.info.legalIdentity)).resultFuture
         net.runNetwork()
-        future1.getOrThrow()
-        future2.getOrThrow()
+        assertThat(waiterStx.getOrThrow()).isEqualTo(committerFiber.getOrThrow().resultFuture.getOrThrow())
+    }
+
+    @Test
+    fun `committer throws exception before calling the finality flow`() {
+        val ptx = TransactionBuilder(notary = notary1.info.notaryIdentity)
+        ptx.addOutputState(DummyState())
+        ptx.signWith(node1.services.legalIdentityKey)
+        val stx = ptx.toSignedTransaction()
+
+        node1.services.registerFlowInitiator(WaitingFlows.Waiter::class) {
+            WaitingFlows.Committer(it) { throw Exception("Error") }
+        }
+        val waiter = node2.services.startFlow(WaitingFlows.Waiter(stx, node1.info.legalIdentity)).resultFuture
+        net.runNetwork()
+        assertThatExceptionOfType(FlowSessionException::class.java).isThrownBy {
+            waiter.getOrThrow()
+        }
     }
 
 
@@ -522,12 +565,10 @@ class StateMachineManagerTests {
     }
 
     private fun sessionInit(flowMarker: KClass<*>, payload: Any? = null) = SessionInit(0, flowMarker.java.name, payload)
-
     private val sessionConfirm = SessionConfirm(0, 0)
-
     private fun sessionData(payload: Any) = SessionData(0, payload)
-
-    private fun sessionEnd(error: FlowException? = null) = SessionEnd(0, error)
+    private val normalEnd = NormalSessionEnd(0)
+    private fun erroredEnd(errorResponse: FlowException? = null) = ErrorSessionEnd(0, errorResponse)
 
     private fun assertSessionTransfers(vararg expected: SessionTransfer) {
         assertThat(sessionTransfers).containsExactly(*expected)
@@ -557,7 +598,8 @@ class StateMachineManagerTests {
             is SessionData -> message.copy(recipientSessionId = 0)
             is SessionInit -> message.copy(initiatorSessionId = 0)
             is SessionConfirm -> message.copy(initiatorSessionId = 0, initiatedSessionId = 0)
-            is SessionEnd -> message.copy(recipientSessionId = 0)
+            is NormalSessionEnd -> message.copy(recipientSessionId = 0)
+            is ErrorSessionEnd -> message.copy(recipientSessionId = 0)
             else -> message
         }
     }
@@ -578,7 +620,7 @@ class StateMachineManagerTests {
     }
 
 
-    private class SendFlow(val payload: Any, vararg val otherParties: Party) : FlowLogic<Unit>() {
+    private class SendFlow(val payload: String, vararg val otherParties: Party) : FlowLogic<Unit>() {
         init {
             require(otherParties.isNotEmpty())
         }
@@ -595,11 +637,11 @@ class StateMachineManagerTests {
             require(otherParties.isNotEmpty())
         }
 
-        @Transient var receivedPayloads: List<Any> = emptyList()
+        @Transient var receivedPayloads: List<String> = emptyList()
 
         @Suspendable
         override fun call() {
-            receivedPayloads = otherParties.map { receive<Any>(it).unwrap { it } }
+            receivedPayloads = otherParties.map { receive<String>(it).unwrap { it } }
             if (nonTerminating) {
                 Fiber.park()
             }
@@ -630,23 +672,26 @@ class StateMachineManagerTests {
         }
     }
 
-    private class MyFlowException(message: String) : FlowException(message) {
+    private class MyFlowException(override val message: String) : FlowException() {
         override fun equals(other: Any?): Boolean = other is MyFlowException && other.message == this.message
-        override fun hashCode(): Int = message?.hashCode() ?: 31
+        override fun hashCode(): Int = message.hashCode()
     }
 
     private object WaitingFlows {
-        class Waiter(private val hash: SecureHash) : FlowLogic<Unit>() {
+        class Waiter(val stx: SignedTransaction, val otherParty: Party) : FlowLogic<SignedTransaction>() {
             @Suspendable
-            override fun call() {
-                waitForLedgerCommit(hash)
+            override fun call(): SignedTransaction {
+                send(otherParty, stx)
+                return waitForLedgerCommit(stx.id)
             }
         }
 
-        class Committer(private val stx: SignedTransaction, private val otherParty: Party) : FlowLogic<Unit>() {
+        class Committer(val otherParty: Party, val throwException: (() -> Exception)? = null) : FlowLogic<SignedTransaction>() {
             @Suspendable
-            override fun call() {
-                subFlow(FinalityFlow(stx, setOf(otherParty)))
+            override fun call(): SignedTransaction {
+                val stx = receive<SignedTransaction>(otherParty).unwrap { it }
+                if (throwException != null) throw throwException.invoke()
+                return subFlow(FinalityFlow(stx, setOf(otherParty))).single()
             }
         }
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -282,6 +282,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
      * parameter set to -1 (the default) which simply runs as many rounds as necessary to result in network
      * stability (no nodes sent any messages in the last round).
      */
+    @JvmOverloads
     fun runNetwork(rounds: Int = -1) {
         check(!networkSendManuallyPumped)
         fun pumpAll() = messagingNetwork.endpoints.map { it.pumpReceive(false) }
@@ -324,6 +325,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
      * Sets up a network with the requested number of nodes (defaulting to two), with one or more service nodes that
      * run a notary, network map, any oracles etc. Can't be combined with [createTwoNodes].
      */
+    @JvmOverloads
     fun createSomeNodes(numPartyNodes: Int = 2, nodeFactory: Factory = defaultFactory, notaryKeyPair: KeyPair? = DUMMY_NOTARY_KEY): BasketOfNodes {
         require(nodes.isEmpty())
         val notaryServiceInfo = ServiceInfo(SimpleNotaryService.type)


### PR DESCRIPTION
The new `waitForLedgerCommit` would wait forever if the other side (the committer) threw an exception before it did the FinalityFlow call.