### PR TITLE
Some support for Deterministic Key Derivation

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
@@ -125,9 +125,8 @@ fun generateKeyPair(): KeyPair = KeyPairGenerator().generateKeyPair()
  * @param entropy the seed in form of BigInteger.
  * @return the generated EdDSA keypair.
  */
-fun entropyToKeyPair(entropy: BigInteger): KeyPair {
-    return deterministicKeyPair(entropy.toByteArray())
-}
+fun entropyToKeyPair(entropy: BigInteger): KeyPair =
+        deterministicKeyPair(entropy.toByteArray())
 
 /**
  * Returns a deterministically generated key pair from a given private key and an index (similarly to BIP32 hardened keys).
@@ -138,9 +137,8 @@ fun entropyToKeyPair(entropy: BigInteger): KeyPair {
  * @param index a number input that will be concatenated to the  parent key to form the final seed.
  * @return the generated EdDSA keypair.
  */
-fun privKeyToNewKeyPair(parentPrivateKey: EdDSAPrivateKey, index: Int): KeyPair {
-    return deterministicKeyPair(parentPrivateKey.abyte.plus(index.bytes()))
-}
+fun privKeyToNewKeyPair(parentPrivateKey: EdDSAPrivateKey, index: Int): KeyPair =
+        deterministicKeyPair(parentPrivateKey.abyte.plus(index.bytes()))
 
 /**
  * Returns a deterministically generated key pair from a provided seed. This is useful for deterministic
@@ -161,11 +159,11 @@ fun deterministicKeyPair(bytes: ByteArray): KeyPair {
  * Extension function to return the ByteArray representation of an Int.
  * TODO: check which of the bytes() and bytesV2() performs better
  */
-fun Int.bytes()  =
+fun Int.bytes() =
         byteArrayOf(this.ushr(24).toByte(), this.ushr(16).toByte(), this.ushr(8).toByte(), this.toByte())
 
 /*
  * Extension function to return the ByteArray representation of an Int.
  */
-fun Int.bytesV2()  =
+fun Int.bytesV2() =
         ByteBuffer.allocate(4).putInt(this).array()

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
@@ -11,6 +11,7 @@ import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import java.math.BigInteger
+import java.nio.ByteBuffer
 import java.security.*
 
 fun newSecureRandom(): SecureRandom {
@@ -119,14 +120,52 @@ operator fun KeyPair.component2() = this.public
 fun generateKeyPair(): KeyPair = KeyPairGenerator().generateKeyPair()
 
 /**
- * Returns a key pair derived from the given private key entropy. This is useful for unit tests and other cases where
- * you want hard-coded private keys.
+ * Returns a key pair derived from the given entropy.
+ *
+ * @param entropy the seed in form of BigInteger.
+ * @return the generated EdDSA keypair.
  */
 fun entropyToKeyPair(entropy: BigInteger): KeyPair {
+    return deterministicKeyPair(entropy.toByteArray())
+}
+
+/**
+ * Returns a deterministically generated key pair from a given private key and an index (similarly to BIP32 hardened keys).
+ * This is useful, as no backup of private keys is required and they can be re-generated from their parent key.
+ * TODO: check with Mike if we need full implementation of the BIP32 protocol as we still do not support PublicParent -> PublicChild
+ *
+ * @param parentPrivateKey the parent private key from which we will generate a new keypair.
+ * @param index a number input that will be concatenated to the  parent key to form the final seed.
+ * @return the generated EdDSA keypair.
+ */
+fun privKeyToNewKeyPair(parentPrivateKey: EdDSAPrivateKey, index: Int): KeyPair {
+    return deterministicKeyPair(parentPrivateKey.abyte.plus(index.bytes()))
+}
+
+/**
+ * Returns a deterministically generated key pair from a provided seed. This is useful for deterministic
+ * or hierarchical deterministic key derivation, unit tests and other cases where you want hard-coded private keys.
+ *
+ * @param bytes the seed for deterministic key generation.
+ * @return the generated EdDSA keypair.
+ */
+fun deterministicKeyPair(bytes: ByteArray): KeyPair {
     val params = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.CURVE_ED25519_SHA512)
-    val bytes = entropy.toByteArray().copyOf(params.curve.field.getb() / 8)
     val priv = EdDSAPrivateKeySpec(bytes, params)
     val pub = EdDSAPublicKeySpec(priv.a, params)
     val key = KeyPair(EdDSAPublicKey(pub), EdDSAPrivateKey(priv))
     return key
 }
+
+/*
+ * Extension function to return the ByteArray representation of an Int.
+ * TODO: check which of the bytes() and bytesV2() performs better
+ */
+fun Int.bytes()  =
+        byteArrayOf(this.ushr(24).toByte(), this.ushr(16).toByte(), this.ushr(8).toByte(), this.toByte())
+
+/*
+ * Extension function to return the ByteArray representation of an Int.
+ */
+fun Int.bytesV2()  =
+        ByteBuffer.allocate(4).putInt(this).array()


### PR DESCRIPTION
Some minor changes to the `entropyToKeyPair` to support **private key || index** as entropy to generate a new Keypair (similarly to BIP32 deterministic hardened key derivation, but by utilising SHA512 vs HMAC). _We still do not support PublicParent -> PublicChild key derivation._