### PR TITLE
Make non-validating notary use FilteredTransactions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -5,11 +5,9 @@ import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.contracts.Contract
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
-import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.MessagingService
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo
-import net.corda.core.node.ServiceEntry
 import net.corda.core.randomOrNull
 import rx.Observable
 
@@ -73,6 +71,7 @@ interface NetworkMapCache {
 
     /** Look up the node info for a specific peer key. */
     fun getNodeByLegalIdentityKey(compositeKey: CompositeKey): NodeInfo?
+
     /** Look up all nodes advertising the service owned by [compositeKey] */
     fun getNodesByAdvertisedServiceIdentityKey(compositeKey: CompositeKey): List<NodeInfo> {
         return partyNodes.filter { it.advertisedServices.any { it.identity.owningKey == compositeKey } }
@@ -107,6 +106,11 @@ interface NetworkMapCache {
 
     /** Checks whether a given party is an advertised notary identity */
     fun isNotary(party: Party): Boolean = notaryNodes.any { it.notaryIdentity == party }
+
+    /** Checks whether a given party is an advertised validating notary identity */
+    fun isValidatingNotary(party: Party): Boolean {
+        return notaryNodes.any { it.notaryIdentity == party && it.advertisedServices.any { it.info.type.isValidatingNotary() }}
+    }
 
     /**
      * Add a network map service; fetches a copy of the latest map from the service and subscribes to any further

--- a/core/src/main/kotlin/net/corda/core/node/services/ServiceType.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/ServiceType.kt
@@ -43,6 +43,7 @@ sealed class ServiceType(val id: String) {
 
     fun isSubTypeOf(superType: ServiceType) = (id == superType.id) || id.startsWith(superType.id + ".")
     fun isNotary() = isSubTypeOf(notary)
+    fun isValidatingNotary() = isNotary() && id.contains(".validating")
 
     override fun hashCode(): Int = id.hashCode()
     override fun toString(): String = id.toString()

--- a/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
@@ -84,7 +84,12 @@ class FinalityFlow(val transactions: Iterable<SignedTransaction>,
         }
     }
 
-    private fun needsNotarySignature(stx: SignedTransaction) = stx.tx.notary != null && hasNoNotarySignature(stx)
+    private fun needsNotarySignature(stx: SignedTransaction): Boolean {
+        val wtx = stx.tx
+        val needsNotarisation = wtx.inputs.isNotEmpty() || wtx.timestamp != null
+        return needsNotarisation && hasNoNotarySignature(stx)
+
+    }
     private fun hasNoNotarySignature(stx: SignedTransaction): Boolean {
         val notaryKey = stx.tx.notary?.owningKey
         val signers = stx.sigs.map { it.by }.toSet()

--- a/core/src/main/kotlin/net/corda/flows/NonValidatingNotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NonValidatingNotaryFlow.kt
@@ -1,0 +1,29 @@
+package net.corda.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.Party
+import net.corda.core.node.services.TimestampChecker
+import net.corda.core.node.services.UniquenessProvider
+import net.corda.core.transactions.FilteredTransaction
+import net.corda.core.utilities.unwrap
+
+class NonValidatingNotaryFlow(otherSide: Party,
+                              timestampChecker: TimestampChecker,
+                              uniquenessProvider: UniquenessProvider) : NotaryFlow.Service(otherSide, timestampChecker, uniquenessProvider) {
+    /**
+     * The received transaction is not checked for contract-validity, as that would require fully
+     * resolving it into a [TransactionForVerification], for which the caller would have to reveal the whole transaction
+     * history chain.
+     * As a result, the Notary _will commit invalid transactions_ as well, but as it also records the identity of
+     * the caller, it is possible to raise a dispute and verify the validity of the transaction and subsequently
+     * undo the commit of the input states (the exact mechanism still needs to be worked out).
+     */
+    @Suspendable
+    override fun receiveAndVerifyTx(): NotaryFlow.Service.TransactionParts {
+        val ftx = receive<FilteredTransaction>(otherSide).unwrap {
+            it.verify()
+            it
+        }
+        return TransactionParts(ftx.rootHash, ftx.filteredLeaves.inputs, ftx.filteredLeaves.timestamp)
+    }
+}

--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -1,10 +1,9 @@
 package net.corda.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.crypto.DigitalSignature
-import net.corda.core.crypto.Party
-import net.corda.core.crypto.SignedData
-import net.corda.core.crypto.signWithECDSA
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.Timestamp
+import net.corda.core.crypto.*
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.node.services.TimestampChecker
@@ -12,13 +11,12 @@ import net.corda.core.node.services.UniquenessException
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
-import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
 
 object NotaryFlow {
     /**
-     * A flow to be used for obtaining a signature from a [NotaryService] ascertaining the transaction
+     * A flow to be used by a party for obtaining a signature from a [NotaryService] ascertaining the transaction
      * timestamp is correct and none of its inputs have been used in another completed transaction.
      *
      * @throws NotaryException in case the any of the inputs to the transaction have been consumed
@@ -52,8 +50,14 @@ object NotaryFlow {
                 throw NotaryException(NotaryError.SignaturesMissing(ex))
             }
 
+            val payload: Any = if (serviceHub.networkMapCache.isValidatingNotary(notaryParty)) {
+                stx
+            } else {
+                wtx.buildFilteredTransaction { it is StateRef || it is Timestamp }
+            }
+
             val response = try {
-                sendAndReceive<DigitalSignature.WithKey>(notaryParty, SignRequest(stx))
+                sendAndReceive<DigitalSignature.WithKey>(notaryParty, payload)
             } catch (e: NotaryException) {
                 if (e.error is NotaryError.Conflict) {
                     e.error.conflict.verified()
@@ -73,64 +77,64 @@ object NotaryFlow {
         }
     }
 
-
     /**
-     * Checks that the timestamp command is valid (if present) and commits the input state, or returns a conflict
+     * A flow run by a notary service that handles notarisation requests.
+     *
+     * It checks that the timestamp command is valid (if present) and commits the input state, or returns a conflict
      * if any of the input states have been previously committed.
      *
-     * Extend this class, overriding _beforeCommit_ to add custom transaction processing/validation logic.
-     *
-     * TODO: the notary service should only be able to see timestamp commands and inputs
+     * Additional transaction validation logic can be added when implementing [receiveAndVerifyTx].
      */
-    open class Service(val otherSide: Party,
-                       val timestampChecker: TimestampChecker,
-                       val uniquenessProvider: UniquenessProvider) : FlowLogic<Unit>() {
-
+    abstract class Service(val otherSide: Party,
+                           val timestampChecker: TimestampChecker,
+                           val uniquenessProvider: UniquenessProvider) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
-            val stx = receive<SignRequest>(otherSide).unwrap { it.tx }
-            val wtx = stx.tx
-
-            validateTimestamp(wtx)
-            beforeCommit(stx)
-            commitInputStates(wtx)
-            val sig = sign(stx.id.bytes)
-            send(otherSide, sig)
-        }
-
-        private fun validateTimestamp(tx: WireTransaction) {
-            if (tx.timestamp != null
-                    && !timestampChecker.isValid(tx.timestamp))
-                throw NotaryException(NotaryError.TimestampInvalid())
+            val (id, inputs, timestamp) = receiveAndVerifyTx()
+            validateTimestamp(timestamp)
+            commitInputStates(inputs, id)
+            signAndSendResponse(id)
         }
 
         /**
-         * No pre-commit processing is done. Transaction is not checked for contract-validity, as that would require fully
-         * resolving it into a [TransactionForVerification], for which the caller would have to reveal the whole transaction
-         * history chain.
-         * As a result, the Notary _will commit invalid transactions_ as well, but as it also records the identity of
-         * the caller, it is possible to raise a dispute and verify the validity of the transaction and subsequently
-         * undo the commit of the input states (the exact mechanism still needs to be worked out).
+         * Implement custom logic to receive the transaction to notarise, and perform verification based on validity and
+         * privacy requirements.
          */
         @Suspendable
-        open fun beforeCommit(stx: SignedTransaction) {
+        abstract fun receiveAndVerifyTx(): TransactionParts
+
+        /**
+         * The minimum amount of information needed to notarise a transaction. Note that this does not include
+         * any sensitive transaction details.
+         */
+        data class TransactionParts(val id: SecureHash, val inputs: List<StateRef>, val timestamp: Timestamp?)
+
+        @Suspendable
+        private fun signAndSendResponse(txId: SecureHash) {
+            val sig = sign(txId.bytes)
+            send(otherSide, sig)
+        }
+
+        private fun validateTimestamp(t: Timestamp?) {
+            if (t != null && !timestampChecker.isValid(t))
+                throw NotaryException(NotaryError.TimestampInvalid())
         }
 
         /**
          * A NotaryException is thrown if any of the states have been consumed by a different transaction. Note that
          * this method does not throw an exception when input states are present multiple times within the transaction.
          */
-        private fun commitInputStates(tx: WireTransaction) {
+        private fun commitInputStates(inputs: List<StateRef>, txId: SecureHash) {
             try {
-                uniquenessProvider.commit(tx.inputs, tx.id, otherSide)
+                uniquenessProvider.commit(inputs, txId, otherSide)
             } catch (e: UniquenessException) {
-                val conflicts = tx.inputs.filterIndexed { i, stateRef ->
+                val conflicts = inputs.filterIndexed { i, stateRef ->
                     val consumingTx = e.error.stateHistory[stateRef]
-                    consumingTx != null && consumingTx != UniquenessProvider.ConsumingTx(tx.id, i, otherSide)
+                    consumingTx != null && consumingTx != UniquenessProvider.ConsumingTx(txId, i, otherSide)
                 }
                 if (conflicts.isNotEmpty()) {
                     // TODO: Create a new UniquenessException that only contains the conflicts filtered above.
-                    throw notaryException(tx, e)
+                    throw notaryException(txId, e)
                 }
             }
         }
@@ -140,14 +144,12 @@ object NotaryFlow {
             return mySigningKey.signWithECDSA(bits)
         }
 
-        private fun notaryException(tx: WireTransaction, e: UniquenessException): NotaryException {
+        private fun notaryException(txId: SecureHash, e: UniquenessException): NotaryException {
             val conflictData = e.error.serialize()
             val signedConflict = SignedData(conflictData, sign(conflictData.bytes))
-            return NotaryException(NotaryError.Conflict(tx, signedConflict))
+            return NotaryException(NotaryError.Conflict(txId, signedConflict))
         }
     }
-
-    data class SignRequest(val tx: SignedTransaction)
 }
 
 class NotaryException(val error: NotaryError) : FlowException() {
@@ -155,15 +157,15 @@ class NotaryException(val error: NotaryError) : FlowException() {
 }
 
 sealed class NotaryError {
-    class Conflict(val tx: WireTransaction, val conflict: SignedData<UniquenessProvider.Conflict>) : NotaryError() {
-        override fun toString() = "One or more input states for transaction ${tx.id} have been used in another transaction"
+    class Conflict(val txId: SecureHash, val conflict: SignedData<UniquenessProvider.Conflict>) : NotaryError() {
+        override fun toString() = "One or more input states for transaction $txId have been used in another transaction"
     }
 
     /** Thrown if the time specified in the timestamp command is outside the allowed tolerance */
     class TimestampInvalid : NotaryError()
 
     class TransactionInvalid(val msg: String) : NotaryError()
-    class SignaturesInvalid(val msg: String): NotaryError()
+    class SignaturesInvalid(val msg: String) : NotaryError()
 
     class SignaturesMissing(val cause: SignedTransaction.SignaturesMissingException) : NotaryError() {
         override fun toString() = cause.toString()

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -53,7 +53,7 @@ class RaftNotaryServiceTests : NodeBasedTest() {
 
         val ex = assertFailsWith(NotaryException::class) { secondSpend.resultFuture.getOrThrow() }
         val error = ex.error as NotaryError.Conflict
-        assertEquals(error.tx, secondSpendTx.tx)
+        assertEquals(error.txId, secondSpendTx.id)
     }
 
     private fun issueState(node: AbstractNode, notary: Party, notaryKey: KeyPair): StateAndRef<*> {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
@@ -4,6 +4,7 @@ import net.corda.core.crypto.Party
 import net.corda.core.node.services.ServiceType
 import net.corda.core.node.services.TimestampChecker
 import net.corda.core.node.services.UniquenessProvider
+import net.corda.flows.NonValidatingNotaryFlow
 import net.corda.flows.NotaryFlow
 import net.corda.node.services.api.ServiceHubInternal
 
@@ -16,6 +17,6 @@ class SimpleNotaryService(services: ServiceHubInternal,
     }
 
     override fun createFlow(otherParty: Party): NotaryFlow.Service {
-        return NotaryFlow.Service(otherParty, timestampChecker, uniquenessProvider)
+        return NonValidatingNotaryFlow(otherParty, timestampChecker, uniquenessProvider)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryServiceTests.kt
@@ -128,7 +128,7 @@ class NotaryServiceTests {
 
         val ex = assertFailsWith(NotaryException::class) { future.resultFuture.getOrThrow() }
         val notaryError = ex.error as NotaryError.Conflict
-        assertEquals(notaryError.tx, stx2.tx)
+        assertEquals(notaryError.txId, stx2.id)
         notaryError.conflict.verified()
     }
 


### PR DESCRIPTION
Pass a FilteredTransaction instead of a Signed transaction to a non-validating notary flow to preserve privacy.

This also means that the non-validating notary can service requests on the network without loading any custom plugins, as it does not need to deserialize any commands/output states or run contract verification logic.