### PR TITLE
Some support for deterministic key-pair derivation

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
@@ -11,6 +11,7 @@ import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import java.math.BigInteger
+import java.nio.ByteBuffer
 import java.security.*
 
 fun newSecureRandom(): SecureRandom {
@@ -119,14 +120,50 @@ operator fun KeyPair.component2() = this.public
 fun generateKeyPair(): KeyPair = KeyPairGenerator().generateKeyPair()
 
 /**
- * Returns a key pair derived from the given private key entropy. This is useful for unit tests and other cases where
- * you want hard-coded private keys.
+ * Returns a key pair derived from the given entropy.
+ *
+ * @param entropy the seed in form of BigInteger.
+ * @return the generated EdDSA keypair.
  */
-fun entropyToKeyPair(entropy: BigInteger): KeyPair {
+fun entropyToKeyPair(entropy: BigInteger): KeyPair =
+        deterministicKeyPair(entropy.toByteArray())
+
+/**
+ * Returns a deterministically generated key pair from a given private key and an index (similarly to BIP32 hardened keys).
+ * This is useful, as no backup of private keys is required and they can be re-generated from their parent key.
+ * TODO: check with Mike if we need full implementation of the BIP32 protocol as we still do not support PublicParent -> PublicChild
+ *
+ * @param parentPrivateKey the parent private key from which we will generate a new keypair.
+ * @param index a number input that will be concatenated to the  parent key to form the final seed.
+ * @return the generated EdDSA keypair.
+ */
+fun privKeyToNewKeyPair(parentPrivateKey: EdDSAPrivateKey, index: Int): KeyPair =
+        deterministicKeyPair(parentPrivateKey.geta().plus(index.bytes()))
+
+/**
+ * Returns a deterministically generated key pair from a provided seed. This is useful for deterministic
+ * or hierarchical deterministic key derivation, unit tests and other cases where you want hard-coded private keys.
+ *
+ * @param bytes the seed for deterministic key generation.
+ * @return the generated EdDSA keypair.
+ */
+fun deterministicKeyPair(bytes: ByteArray): KeyPair {
     val params = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.CURVE_ED25519_SHA512)
-    val bytes = entropy.toByteArray().copyOf(params.curve.field.getb() / 8)
     val priv = EdDSAPrivateKeySpec(bytes, params)
     val pub = EdDSAPublicKeySpec(priv.a, params)
     val key = KeyPair(EdDSAPublicKey(pub), EdDSAPrivateKey(priv))
     return key
 }
+
+/*
+ * Extension function to return the ByteArray representation of an Int.
+ * TODO: check which of the bytes() and bytesV2() performs better
+ */
+fun Int.bytes() =
+        byteArrayOf(this.ushr(24).toByte(), this.ushr(16).toByte(), this.ushr(8).toByte(), this.toByte())
+
+/*
+ * Extension function to return the ByteArray representation of an Int.
+ */
+fun Int.bytesV2() =
+        ByteBuffer.allocate(4).putInt(this).array()


### PR DESCRIPTION
Deterministic Key Derivation for our current EdDSA implementation. Key pair is generated from a parent private key and an index, similarly to BIP32 hardened key generation, but using SHA512 VS HMAC.

Note1: Unlike BIP32, this version does not support PublicParent -> PublicChild.

Note2: From my understanding, we still don't utilise any encryption stuff, just signatures. So why do we need  non hardened keys in the first place? Moreover, do we want to use Ed25519 for both signing and decrypting? 
See here: [ed25519 for encryption](http://crypto.stackexchange.com/questions/37896/using-a-single-ed25519-key-for-encryption-and-signature)
and here: [curve25519 Vs ed25519](http://crypto.stackexchange.com/questions/27866/why-curve25519-for-encryption-but-ed25519-for-signatures)

Note3: Although in [EdDSA - wikipedia](https://en.wikipedia.org/wiki/EdDSA) both k (named `seed` in our code) and s (named `a` in our code) could be considered as the PrivateKey input in our HD generation, I pick `a`, because in case of a key-compromise it is slightly better to achieve forward secrecy on past signatures. Anyway, we can choose one or the other.