### PR TITLE
Cordformation now correctly includes and excludes cordapps.

### DIFF
--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
@@ -191,11 +191,10 @@ class Node {
      */
     private void installDependencies() {
         def cordaJar = verifyAndGetCordaJar()
-        def cordappDeps = getCordappList()
         def depsDir = new File(nodeDir, "dependencies")
         def coreDeps = project.zipTree(cordaJar).getFiles().collect { it.getName() }
         def appDeps = project.configurations.runtime.filter {
-            it != cordaJar && !cordappDeps.contains(it) && !coreDeps.contains(it.getName())
+            it != cordaJar && !project.configurations.cordapp.contains(it) && !coreDeps.contains(it.getName())
         }
         project.copy {
             from appDeps
@@ -250,7 +249,7 @@ class Node {
      */
     private Collection<File> getCordappList() {
         return project.configurations.cordapp.files {
-            cordapps.contains("${it.group}:${it.name}:${it.version}")
+            cordapps.contains(it.group + ":" + it.name + ":" + it.version)
         }
     }
 }

--- a/publish.properties
+++ b/publish.properties
@@ -1,1 +1,1 @@
-gradlePluginsVersion=0.7.1
+gradlePluginsVersion=0.8


### PR DESCRIPTION
Before they would all be in the dependencies directory. 