### PR TITLE
Example code for contract upgrade using RPC.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/DummyContractV2.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/DummyContractV2.kt
@@ -12,7 +12,7 @@ val DUMMY_V2_PROGRAM_ID = DummyContractV2()
  * Dummy contract state for testing of the upgrade process.
  */
 class DummyContractV2 : UpgradedContract<DummyContract.State, DummyContractV2.State> {
-    override val legacyContract = DUMMY_PROGRAM_ID
+    override val legacyContract = DummyContract::class.java
 
     data class State(val magicNumber: Int = 0, val owners: List<CompositeKey>) : ContractState {
         override val contract = DUMMY_V2_PROGRAM_ID

--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -398,7 +398,7 @@ interface NetCommand : CommandData {
 }
 
 /** Indicates that this transaction replaces the inputs contract state to another contract state */
-data class UpgradeCommand(val upgradedContractClass: Class<UpgradedContract<*, *>>) : CommandData
+data class UpgradeCommand(val upgradedContractClass: Class<out UpgradedContract<*, *>>) : CommandData
 
 /** Wraps an object that was signed by a public key, which may be a well known/recognised institutional key. */
 data class AuthenticatedObject<out T : Any>(
@@ -456,7 +456,7 @@ interface Contract {
  * @param NewState the upgraded contract state.
  */
 interface UpgradedContract<in OldState : ContractState, out NewState : ContractState> : Contract {
-    val legacyContract: Contract
+    val legacyContract: Class<out Contract>
     /**
      * Upgrade contract's state object to a new state object.
      *

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -114,7 +114,7 @@ interface CordaRPCOps : RPCOps {
      * Invoking this method indicate the node is willing to upgrade the [state] using the [upgradedContractClass].
      * This method will NOT initiate the upgrade process. To start the upgrade process, see [ContractUpgradeFlow.Instigator].
      */
-    fun authoriseContractUpgrade(state: StateAndRef<*>, upgradedContractClass: Class<UpgradedContract<*, *>>)
+    fun authoriseContractUpgrade(state: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>)
 
     /**
      * Authorise a contract state upgrade.

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -165,7 +165,7 @@ interface VaultService {
 
     /** Get contracts we would be willing to upgrade the suggested contract to. */
     // TODO: We need a better place to put business logic functions
-    fun getAuthorisedContractUpgrade(ref: StateRef): Class<UpgradedContract<*, *>>?
+    fun getAuthorisedContractUpgrade(ref: StateRef): Class<out UpgradedContract<*, *>>?
 
     /**
      * Authorise a contract state upgrade.
@@ -173,7 +173,7 @@ interface VaultService {
      * Invoking this method indicate the node is willing to upgrade the [state] using the [upgradedContractClass].
      * This method will NOT initiate the upgrade process. To start the upgrade process, see [ContractUpgradeFlow.Instigator].
      */
-    fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<UpgradedContract<*, *>>)
+    fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>)
 
     /**
      * Authorise a contract state upgrade.

--- a/core/src/main/kotlin/net/corda/flows/ContractUpgradeFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ContractUpgradeFlow.kt
@@ -33,7 +33,7 @@ object ContractUpgradeFlow {
         val upgradedContract = command.upgradedContractClass.newInstance() as UpgradedContract<ContractState, *>
         requireThat {
             "The signing keys include all participant keys" by keysThatSigned.containsAll(participants)
-            "Inputs state reference the legacy contract" by (input.contract.javaClass == upgradedContract.legacyContract.javaClass)
+            "Inputs state reference the legacy contract" by (input.contract.javaClass == upgradedContract.legacyContract)
             "Outputs state reference the upgraded contract" by (output.contract.javaClass == command.upgradedContractClass)
             "Output state must be an upgraded version of the input state" by (output == upgradedContract.upgrade(input))
         }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,6 +87,7 @@ Documentation Contents:
    tutorial-contract
    tutorial-contract-clauses
    tutorial-test-dsl
+   contract-upgrade
    tutorial-integration-testing
    tutorial-clientrpc-api
    tutorial-building-transactions
@@ -105,7 +106,6 @@ Documentation Contents:
    network-simulator
    clauses
    merkle-trees
-   contract-upgrade
 
 .. toctree::
    :maxdepth: 2

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -84,7 +84,8 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
                 CashExitFlow::class.java to setOf(Amount::class.java, PartyAndReference::class.java),
                 CashIssueFlow::class.java to setOf(Amount::class.java, OpaqueBytes::class.java, Party::class.java),
                 CashPaymentFlow::class.java to setOf(Amount::class.java, Party::class.java),
-                FinalityFlow::class.java to emptySet()
+                FinalityFlow::class.java to emptySet(),
+                ContractUpgradeFlow.Instigator::class.java to emptySet()
         )
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -103,7 +103,7 @@ class CordaRPCOpsImpl(
 
     override fun attachmentExists(id: SecureHash) = services.storageService.attachments.openAttachment(id) != null
     override fun uploadAttachment(jar: InputStream) = services.storageService.attachments.importAttachment(jar)
-    override fun authoriseContractUpgrade(state: StateAndRef<*>, upgradedContractClass: Class<UpgradedContract<*, *>>) = services.vaultService.authoriseContractUpgrade(state, upgradedContractClass)
+    override fun authoriseContractUpgrade(state: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>) = services.vaultService.authoriseContractUpgrade(state, upgradedContractClass)
     override fun deauthoriseContractUpgrade(state: StateAndRef<*>) = services.vaultService.deauthoriseContractUpgrade(state)
     override fun currentNodeTime(): Instant = Instant.now(services.clock)
     @Suppress("OverridingDeprecatedMember", "DEPRECATION")

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -344,7 +344,7 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
 
     override fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>) {
         val upgrade = upgradedContractClass.newInstance()
-        if (upgrade.legacyContract.javaClass != stateAndRef.state.data.contract.javaClass) {
+        if (upgrade.legacyContract != stateAndRef.state.data.contract.javaClass) {
             throw IllegalArgumentException("The contract state cannot be upgraded using provided UpgradedContract.")
         }
         authorisedUpgrade.put(stateAndRef.ref, upgradedContractClass)

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -338,11 +338,11 @@ class NodeVaultService(private val services: ServiceHub) : SingletonSerializeAsT
     }
 
     // TODO : Persists this in DB.
-    private val authorisedUpgrade = mutableMapOf<StateRef, Class<UpgradedContract<*, *>>>()
+    private val authorisedUpgrade = mutableMapOf<StateRef, Class<out UpgradedContract<*, *>>>()
 
     override fun getAuthorisedContractUpgrade(ref: StateRef) = authorisedUpgrade[ref]
 
-    override fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<UpgradedContract<*, *>>) {
+    override fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>) {
         val upgrade = upgradedContractClass.newInstance()
         if (upgrade.legacyContract.javaClass != stateAndRef.state.data.contract.javaClass) {
             throw IllegalArgumentException("The contract state cannot be upgraded using provided UpgradedContract.")


### PR DESCRIPTION
* Added missing out modifier to UpgradedContract class
* Added ContractUpgradeFlow.Instigator to whitelist in AbstractNode
* Added test for contract upgrade using RPC 