### PR TITLE
Useful ByteArray and String {en,de}coding extension functions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -1,0 +1,88 @@
+package net.corda.core.crypto
+
+import java.util.*
+
+/**
+ * This file includes useful encoding methods and extension functions for the most common encoding/decoding operations.
+ */
+
+/**
+ * [ByteArray]
+ */
+
+// Base58.
+fun ByteArray.toBase58(): String =
+        Base58.encode(this)
+
+// Base64.
+fun ByteArray.toBase64(): String =
+        Base64.getEncoder().encodeToString(this)
+
+// Hex (or Base16).
+fun ByteArray.toHex(): String {
+    val result = StringBuffer()
+    forEach {
+        val octet = it.toInt()
+        val firstIndex = (octet and 0xF0).ushr(4)
+        val secondIndex = octet and 0x0F
+        result.append(HEX_ALPHABET[firstIndex])
+        result.append(HEX_ALPHABET[secondIndex])
+    }
+    return result.toString()
+}
+
+/**
+ * [String]
+ */
+
+// Base58-String to the actual real [String] using the UTF-8 character set.
+fun String.base58ToRealString() = String(base58ToByteArray())
+
+// Base64-String to the actual real [String] using the UTF-8 character set.
+fun String.base64ToRealString() = String(base64ToByteArray())
+
+// Hex-String to the actual real [String] using the UTF-8 character set.
+fun String.hexToRealString() = String(hexToByteArray())
+
+// Base58-String to [ByteArray].
+fun String.base58ToByteArray(): ByteArray {
+    try {
+        return Base58.decode(this)
+    } catch (afe: AddressFormatException) {
+        throw afe
+    }
+}
+
+// Base64-String to [ByteArray].
+fun String.base64ToByteArray(): ByteArray {
+    try {
+        return Base64.getDecoder().decode(this)
+    } catch (iae: IllegalArgumentException) {
+        throw iae
+    }
+}
+
+// Hex-String to [ByteArray]. Accept capital letters only.
+fun String.hexToByteArray(): ByteArray {
+    if (this.length == 0) {
+        return ByteArray(0)
+    } else if (this.matches(HEX_REGEX)) {
+        val result = ByteArray(length / 2)
+        for (i in 0 until length step 2) {
+            val firstIndex = HEX_ALPHABET.indexOf(this[i]);
+            val secondIndex = HEX_ALPHABET.indexOf(this[i + 1]);
+
+            val octet = firstIndex.shl(4).or(secondIndex)
+            result.set(i.shr(1), octet.toByte())
+        }
+        return result
+    } else
+        throw IllegalArgumentException()
+}
+
+/**
+ * Helper vars.
+ */
+
+private val HEX_REGEX = Regex("-?[0-9A-F]+") // accept capital letters only
+private val HEX_ALPHABET = "0123456789ABCDEF".toCharArray()

--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -1,88 +1,53 @@
 package net.corda.core.crypto
 
+import java.nio.charset.Charset
 import java.util.*
+import javax.xml.bind.DatatypeConverter
 
-/**
- * This file includes useful encoding methods and extension functions for the most common encoding/decoding operations.
- */
 
-/**
- * [ByteArray]
- */
+// This file includes useful encoding methods and extension functions for the most common encoding/decoding operations.
 
-// Base58.
+// [ByteArray] encoders
+
+/** Convert a byte array to a base 58 encoded string.*/
 fun ByteArray.toBase58(): String =
         Base58.encode(this)
 
-// Base64.
+/** Convert a byte array to a base 64 encoded string.*/
 fun ByteArray.toBase64(): String =
         Base64.getEncoder().encodeToString(this)
 
-// Hex (or Base16).
-fun ByteArray.toHex(): String {
-    val result = StringBuffer()
-    forEach {
-        val octet = it.toInt()
-        val firstIndex = (octet and 0xF0).ushr(4)
-        val secondIndex = octet and 0x0F
-        result.append(HEX_ALPHABET[firstIndex])
-        result.append(HEX_ALPHABET[secondIndex])
-    }
-    return result.toString()
-}
+/** Convert a byte array to a hex (base 16) capitalised encoded string.*/
+fun ByteArray.toHex(): String =
+    DatatypeConverter.printHexBinary(this)
 
-/**
- * [String]
- */
 
-// Base58-String to the actual real [String] using the UTF-8 character set.
-fun String.base58ToRealString() = String(base58ToByteArray())
+// [String] encoders and decoders
 
-// Base64-String to the actual real [String] using the UTF-8 character set.
-fun String.base64ToRealString() = String(base64ToByteArray())
+/** Base58-String to the actual real [String] */
+fun String.base58ToRealString() =
+        String(base58ToByteArray(), Charset.defaultCharset())
 
-// Hex-String to the actual real [String] using the UTF-8 character set.
-fun String.hexToRealString() = String(hexToByteArray())
+/** Base64-String to the actual real [String] */
+fun String.base64ToRealString() =
+        String(base64ToByteArray())
 
-// Base58-String to [ByteArray].
-fun String.base58ToByteArray(): ByteArray {
-    try {
-        return Base58.decode(this)
-    } catch (afe: AddressFormatException) {
-        throw afe
-    }
-}
+/** Hex-String to the actual real [String] */
+fun String.hexToRealString() =
+        String(hexToByteArray())
 
-// Base64-String to [ByteArray].
-fun String.base64ToByteArray(): ByteArray {
-    try {
-        return Base64.getDecoder().decode(this)
-    } catch (iae: IllegalArgumentException) {
-        throw iae
-    }
-}
+/** Base58-String to [ByteArray]. */
+fun String.base58ToByteArray(): ByteArray =
+        Base58.decode(this)
 
-// Hex-String to [ByteArray]. Accept capital letters only.
-fun String.hexToByteArray(): ByteArray {
-    if (this.length == 0) {
-        return ByteArray(0)
-    } else if (this.matches(HEX_REGEX)) {
-        val result = ByteArray(length / 2)
-        for (i in 0 until length step 2) {
-            val firstIndex = HEX_ALPHABET.indexOf(this[i]);
-            val secondIndex = HEX_ALPHABET.indexOf(this[i + 1]);
+/** Base64-String to [ByteArray]. */
+fun String.base64ToByteArray(): ByteArray =
+        Base64.getDecoder().decode(this)
 
-            val octet = firstIndex.shl(4).or(secondIndex)
-            result.set(i.shr(1), octet.toByte())
-        }
-        return result
-    } else
-        throw IllegalArgumentException()
-}
+/** Hex-String to [ByteArray]. Accept lowercase or capital or mixed letters. */
+fun String.hexToByteArray(): ByteArray =
+        DatatypeConverter.parseHexBinary(this);
 
-/**
- * Helper vars.
- */
 
-private val HEX_REGEX = Regex("-?[0-9A-F]+") // accept capital letters only
+// Helper vars.
 private val HEX_ALPHABET = "0123456789ABCDEF".toCharArray()

--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -9,42 +9,38 @@ import javax.xml.bind.DatatypeConverter
 
 // [ByteArray] encoders
 
-/** Convert a byte array to a base 58 encoded string.*/
 fun ByteArray.toBase58(): String =
         Base58.encode(this)
 
-/** Convert a byte array to a base 64 encoded string.*/
 fun ByteArray.toBase64(): String =
         Base64.getEncoder().encodeToString(this)
 
-/** Convert a byte array to a hex (base 16) capitalised encoded string.*/
+/** Convert a byte array to a hex (base 16) capitalized encoded string.*/
 fun ByteArray.toHex(): String =
     DatatypeConverter.printHexBinary(this)
 
 
 // [String] encoders and decoders
 
-/** Base58-String to the actual real [String] */
+/** Base58-String to the actual real [String], i.e. "JxF12TrwUP45BMd" -> "Hello World". */
 fun String.base58ToRealString() =
         String(base58ToByteArray(), Charset.defaultCharset())
 
-/** Base64-String to the actual real [String] */
+/** Base64-String to the actual real [String], i.e. "SGVsbG8gV29ybGQ=" -> "Hello World". */
 fun String.base64ToRealString() =
         String(base64ToByteArray())
 
-/** Hex-String to the actual real [String] */
+/** HEX-String to the actual real [String], i.e. "48656C6C6F20576F726C64" -> "Hello World". */
 fun String.hexToRealString() =
         String(hexToByteArray())
 
-/** Base58-String to [ByteArray]. */
 fun String.base58ToByteArray(): ByteArray =
         Base58.decode(this)
 
-/** Base64-String to [ByteArray]. */
 fun String.base64ToByteArray(): ByteArray =
         Base64.getDecoder().decode(this)
 
-/** Hex-String to [ByteArray]. Accept lowercase or capital or mixed letters. */
+/** Hex-String to [ByteArray]. Accept any hex form (capitalized, lowercase, mixed). */
 fun String.hexToByteArray(): ByteArray =
         DatatypeConverter.parseHexBinary(this);
 

--- a/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
@@ -8,52 +8,63 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class EncodingUtilsTest {
-    @Test
-    fun testEncode() {
-        // Test Hello World.
-        val testbytes = "Hello World".toByteArray()
-        assertEquals("JxF12TrwUP45BMd", testbytes.toBase58())
-        assertEquals("SGVsbG8gV29ybGQ=", testbytes.toBase64())
-        assertEquals("48656C6C6F20576F726C64", testbytes.toHex())
 
-        // Test empty encode.
+    val testString = "Hello World"
+    val testBytes = testString.toByteArray()
+    val testBase58String = "JxF12TrwUP45BMd" // Base58 format for Hello World.
+    val testBase64String = "SGVsbG8gV29ybGQ=" // Base64 format for Hello World.
+    val testHexString = "48656C6C6F20576F726C64" // HEX format for Hello World.
+
+    // Encoding tests
+    @Test
+    fun `encoding Hello World`() {
+        assertEquals(testBase58String, testBytes.toBase58())
+        assertEquals(testBase64String, testBytes.toBase64())
+        assertEquals(testHexString, testBytes.toHex())
+    }
+
+    @Test
+    fun `empty encoding`() {
         val emptyByteArray = ByteArray(0)
         assertEquals("", emptyByteArray.toBase58())
         assertEquals("", emptyByteArray.toBase64())
         assertEquals("", emptyByteArray.toHex())
-
-        // Test 7 zero bytes.
+    }
+    @Test
+    fun `encoding 7 zero bytes`() {
         val sevenZeroByteArray = ByteArray(7)
         assertEquals("1111111", sevenZeroByteArray.toBase58())
         assertEquals("AAAAAAAAAA==", sevenZeroByteArray.toBase64())
         assertEquals("00000000000000", sevenZeroByteArray.toHex())
     }
 
+    //Decoding tests
     @Test
-    fun testDecode() {
-        val testString = "Hello World"
-        val testBase58String = "JxF12TrwUP45BMd"
-        val testBase64String = "SGVsbG8gV29ybGQ="
-        val testHexString = "48656C6C6F20576F726C64"
-
+    fun `decoding to real String`() {
         assertEquals(testString, testBase58String.base58ToRealString())
         assertEquals(testString, testBase64String.base64ToRealString())
         assertEquals(testString, testHexString.hexToRealString())
+    }
 
-        // Test empty Strings.
+    @Test
+    fun `decoding empty Strings`() {
         assertEquals("", "".base58ToRealString())
         assertEquals("", "".base64ToRealString())
         assertEquals("", "".hexToRealString())
+    }
 
-        // Test for Hex lowercase.
+    @Test
+    fun `decoding lowercase and mixed HEX`() {
         val testHexStringLowercase = testHexString.toLowerCase()
         assertEquals(testHexString.hexToRealString(), testHexStringLowercase.hexToRealString())
 
-        // Test for Hex mixed.
-        val testHexStringMixed = testHexString.replace('C','c')
+        val testHexStringMixed = testHexString.replace('C', 'c')
         assertEquals(testHexString.hexToRealString(), testHexStringMixed.hexToRealString())
+    }
 
-        // Test for wrong format.
+    @Test
+    fun `decoding on wrong format`() {
+        // the String "Hello World" is not a valid Base58 or Base64 or HEX format
         try {
             testString.base58ToRealString()
             fail()
@@ -74,7 +85,5 @@ class EncodingUtilsTest {
         } catch (e: IllegalArgumentException) {
             // expected.
         }
-
     }
-
 }

--- a/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
@@ -10,19 +10,19 @@ import kotlin.test.fail
 class EncodingUtilsTest {
     @Test
     fun testEncode() {
-        // Test Hello World
+        // Test Hello World.
         val testbytes = "Hello World".toByteArray()
         assertEquals("JxF12TrwUP45BMd", testbytes.toBase58())
         assertEquals("SGVsbG8gV29ybGQ=", testbytes.toBase64())
         assertEquals("48656C6C6F20576F726C64", testbytes.toHex())
 
-        // Test empty encode
+        // Test empty encode.
         val emptyByteArray = ByteArray(0)
         assertEquals("", emptyByteArray.toBase58())
         assertEquals("", emptyByteArray.toBase64())
         assertEquals("", emptyByteArray.toHex())
 
-        // Test 7 zero bytes
+        // Test 7 zero bytes.
         val sevenZeroByteArray = ByteArray(7)
         assertEquals("1111111", sevenZeroByteArray.toBase58())
         assertEquals("AAAAAAAAAA==", sevenZeroByteArray.toBase64())
@@ -40,38 +40,39 @@ class EncodingUtilsTest {
         assertEquals(testString, testBase64String.base64ToRealString())
         assertEquals(testString, testHexString.hexToRealString())
 
-        // Test empty Strings
+        // Test empty Strings.
         assertEquals("", "".base58ToRealString())
         assertEquals("", "".base64ToRealString())
         assertEquals("", "".hexToRealString())
 
+        // Test for Hex lowercase.
+        val testHexStringLowercase = testHexString.toLowerCase()
+        assertEquals(testHexString.hexToRealString(), testHexStringLowercase.hexToRealString())
+
+        // Test for Hex mixed.
+        val testHexStringMixed = testHexString.replace('C','c')
+        assertEquals(testHexString.hexToRealString(), testHexStringMixed.hexToRealString())
+
+        // Test for wrong format.
         try {
             testString.base58ToRealString()
             fail()
         } catch (e: AddressFormatException) {
-            // expected
+            // expected.
         }
 
         try {
             testString.base64ToRealString()
             fail()
         } catch (e: IllegalArgumentException) {
-            // expected
+            // expected.
         }
 
         try {
             testString.hexToRealString()
             fail()
         } catch (e: IllegalArgumentException) {
-            // expected
-        }
-
-        // not allow lowercase
-        try {
-            testString.toLowerCase().hexToRealString()
-            fail()
-        } catch (e: IllegalArgumentException) {
-            // expected
+            // expected.
         }
 
     }

--- a/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
@@ -1,0 +1,79 @@
+package net.corda.core.crypto
+
+import org.junit.Test
+import java.math.BigInteger
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class EncodingUtilsTest {
+    @Test
+    fun testEncode() {
+        // Test Hello World
+        val testbytes = "Hello World".toByteArray()
+        assertEquals("JxF12TrwUP45BMd", testbytes.toBase58())
+        assertEquals("SGVsbG8gV29ybGQ=", testbytes.toBase64())
+        assertEquals("48656C6C6F20576F726C64", testbytes.toHex())
+
+        // Test empty encode
+        val emptyByteArray = ByteArray(0)
+        assertEquals("", emptyByteArray.toBase58())
+        assertEquals("", emptyByteArray.toBase64())
+        assertEquals("", emptyByteArray.toHex())
+
+        // Test 7 zero bytes
+        val sevenZeroByteArray = ByteArray(7)
+        assertEquals("1111111", sevenZeroByteArray.toBase58())
+        assertEquals("AAAAAAAAAA==", sevenZeroByteArray.toBase64())
+        assertEquals("00000000000000", sevenZeroByteArray.toHex())
+    }
+
+    @Test
+    fun testDecode() {
+        val testString = "Hello World"
+        val testBase58String = "JxF12TrwUP45BMd"
+        val testBase64String = "SGVsbG8gV29ybGQ="
+        val testHexString = "48656C6C6F20576F726C64"
+
+        assertEquals(testString, testBase58String.base58ToRealString())
+        assertEquals(testString, testBase64String.base64ToRealString())
+        assertEquals(testString, testHexString.hexToRealString())
+
+        // Test empty Strings
+        assertEquals("", "".base58ToRealString())
+        assertEquals("", "".base64ToRealString())
+        assertEquals("", "".hexToRealString())
+
+        try {
+            testString.base58ToRealString()
+            fail()
+        } catch (e: AddressFormatException) {
+            // expected
+        }
+
+        try {
+            testString.base64ToRealString()
+            fail()
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+
+        try {
+            testString.hexToRealString()
+            fail()
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+
+        // not allow lowercase
+        try {
+            testString.toLowerCase().hexToRealString()
+            fail()
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+
+    }
+
+}


### PR DESCRIPTION
As basic `ByteArray` and `String` encoding/decoding operations are (and will be) required from multiple classes, especially inside the crypto-package, I created a utilities file (and it's corresponding unit-tests) to enlist some of the most common functions used for encoding (hex, base58, base64).
We can always add here new extension {en,de}coding functions, so we hopefully reuse code whenever required.