### PR TITLE
Change encoding between base58, base64, hex

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -45,5 +45,31 @@ fun String.hexToByteArray(): ByteArray =
         DatatypeConverter.parseHexBinary(this);
 
 
+// Encoding changers
+
+/** Encoding changer. Base58-[String] to Base64-[String], i.e. "SGVsbG8gV29ybGQ=" -> JxF12TrwUP45BMd" */
+fun String.base58toBase64(): String =
+        base58ToByteArray().toBase64()
+
+/** Encoding changer. Base58-[String] to Hex-[String], i.e. "SGVsbG8gV29ybGQ=" -> "48656C6C6F20576F726C64" */
+fun String.base58toHex(): String =
+        base58ToByteArray().toHex()
+
+/** Encoding changer. Base64-[String] to Base58-[String], i.e. "SGVsbG8gV29ybGQ=" -> JxF12TrwUP45BMd" */
+fun String.base64toBase58(): String =
+        base64ToByteArray().toBase58()
+
+/** Encoding changer. Base64-[String] to Hex-[String], i.e. "SGVsbG8gV29ybGQ=" -> "48656C6C6F20576F726C64" */
+fun String.base64toHex(): String =
+        base64ToByteArray().toHex()
+
+/** Encoding changer. Hex-[String] to Base58-[String], i.e. "48656C6C6F20576F726C64" -> "JxF12TrwUP45BMd" */
+fun String.hexToBase58(): String =
+        hexToByteArray().toBase58()
+
+/** Encoding changer. Hex-[String] to Base64-[String], i.e. "48656C6C6F20576F726C64" -> "SGVsbG8gV29ybGQ=" */
+fun String.hexToBase64(): String =
+        hexToByteArray().toBase64()
+
 // Helper vars.
 private val HEX_ALPHABET = "0123456789ABCDEF".toCharArray()

--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -9,67 +9,52 @@ import javax.xml.bind.DatatypeConverter
 
 // [ByteArray] encoders
 
-fun ByteArray.toBase58(): String =
-        Base58.encode(this)
+fun ByteArray.toBase58(): String = Base58.encode(this)
 
-fun ByteArray.toBase64(): String =
-        Base64.getEncoder().encodeToString(this)
+fun ByteArray.toBase64(): String = Base64.getEncoder().encodeToString(this)
 
 /** Convert a byte array to a hex (base 16) capitalized encoded string.*/
-fun ByteArray.toHex(): String =
-    DatatypeConverter.printHexBinary(this)
+fun ByteArray.toHex(): String = DatatypeConverter.printHexBinary(this)
 
 
 // [String] encoders and decoders
 
 /** Base58-String to the actual real [String], i.e. "JxF12TrwUP45BMd" -> "Hello World". */
-fun String.base58ToRealString() =
-        String(base58ToByteArray(), Charset.defaultCharset())
+fun String.base58ToRealString() = String(base58ToByteArray(), Charset.defaultCharset())
 
 /** Base64-String to the actual real [String], i.e. "SGVsbG8gV29ybGQ=" -> "Hello World". */
-fun String.base64ToRealString() =
-        String(base64ToByteArray())
+fun String.base64ToRealString() = String(base64ToByteArray())
 
 /** HEX-String to the actual real [String], i.e. "48656C6C6F20576F726C64" -> "Hello World". */
-fun String.hexToRealString() =
-        String(hexToByteArray())
+fun String.hexToRealString() = String(hexToByteArray())
 
-fun String.base58ToByteArray(): ByteArray =
-        Base58.decode(this)
+fun String.base58ToByteArray(): ByteArray = Base58.decode(this)
 
-fun String.base64ToByteArray(): ByteArray =
-        Base64.getDecoder().decode(this)
+fun String.base64ToByteArray(): ByteArray = Base64.getDecoder().decode(this)
 
 /** Hex-String to [ByteArray]. Accept any hex form (capitalized, lowercase, mixed). */
-fun String.hexToByteArray(): ByteArray =
-        DatatypeConverter.parseHexBinary(this);
+fun String.hexToByteArray(): ByteArray = DatatypeConverter.parseHexBinary(this);
 
 
 // Encoding changers
 
 /** Encoding changer. Base58-[String] to Base64-[String], i.e. "SGVsbG8gV29ybGQ=" -> JxF12TrwUP45BMd" */
-fun String.base58toBase64(): String =
-        base58ToByteArray().toBase64()
+fun String.base58toBase64(): String = base58ToByteArray().toBase64()
 
 /** Encoding changer. Base58-[String] to Hex-[String], i.e. "SGVsbG8gV29ybGQ=" -> "48656C6C6F20576F726C64" */
-fun String.base58toHex(): String =
-        base58ToByteArray().toHex()
+fun String.base58toHex(): String = base58ToByteArray().toHex()
 
 /** Encoding changer. Base64-[String] to Base58-[String], i.e. "SGVsbG8gV29ybGQ=" -> JxF12TrwUP45BMd" */
-fun String.base64toBase58(): String =
-        base64ToByteArray().toBase58()
+fun String.base64toBase58(): String = base64ToByteArray().toBase58()
 
 /** Encoding changer. Base64-[String] to Hex-[String], i.e. "SGVsbG8gV29ybGQ=" -> "48656C6C6F20576F726C64" */
-fun String.base64toHex(): String =
-        base64ToByteArray().toHex()
+fun String.base64toHex(): String = base64ToByteArray().toHex()
 
 /** Encoding changer. Hex-[String] to Base58-[String], i.e. "48656C6C6F20576F726C64" -> "JxF12TrwUP45BMd" */
-fun String.hexToBase58(): String =
-        hexToByteArray().toBase58()
+fun String.hexToBase58(): String = hexToByteArray().toBase58()
 
 /** Encoding changer. Hex-[String] to Base64-[String], i.e. "48656C6C6F20576F726C64" -> "SGVsbG8gV29ybGQ=" */
-fun String.hexToBase64(): String =
-        hexToByteArray().toBase64()
+fun String.hexToBase64(): String = hexToByteArray().toBase64()
 
 // Helper vars.
 private val HEX_ALPHABET = "0123456789ABCDEF".toCharArray()

--- a/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/EncodingUtilsTest.kt
@@ -86,4 +86,21 @@ class EncodingUtilsTest {
             // expected.
         }
     }
+
+    //Encoding changers tests
+    @Test
+    fun `change encoding between base58, base64, hex`() {
+        // base58 to base64
+        assertEquals(testBase64String, testBase58String.base58toBase64())
+        // base58 to hex
+        assertEquals(testHexString, testBase58String.base58toHex())
+        // base64 to base58
+        assertEquals(testBase58String, testBase64String.base64toBase58())
+        // base64 to hex
+        assertEquals(testHexString, testBase64String.base64toHex())
+        // hex to base58
+        assertEquals(testBase58String, testHexString.hexToBase58())
+        // hex to base64
+        assertEquals(testBase64String, testHexString.hexToBase64())
+    }
 }


### PR DESCRIPTION
Some extra utilities to convert between base58, base64 and hex `String ` formats. This is useful for flexibility purposes + it will be required to convert crypto-keys and other data from and to CERTs.