### PR TITLE
ProgressTracker emits exception thrown by the flow, allowing the ANSI…

### DIFF
--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -403,3 +403,9 @@ private class ObservableToFuture<T>(observable: Observable<T>) : AbstractFuture<
 
 /** Return the sum of an Iterable of [BigDecimal]s. */
 fun Iterable<BigDecimal>.sum(): BigDecimal = fold(BigDecimal.ZERO) { a, b -> a + b }
+
+fun codePointsString(vararg codePoints: Int): String {
+    val builder = StringBuilder()
+    codePoints.forEach { builder.append(Character.toChars(it)) }
+    return builder.toString()
+}

--- a/core/src/main/kotlin/net/corda/core/utilities/Emoji.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/Emoji.kt
@@ -1,5 +1,7 @@
 package net.corda.core.utilities
 
+import net.corda.core.codePointsString
+
 /**
  * A simple wrapper class that contains icons and support for printing them only when we're connected to a terminal.
  */
@@ -7,15 +9,17 @@ object Emoji {
     // Unfortunately only Apple has a terminal that can do colour emoji AND an emoji font installed by default.
     val hasEmojiTerminal by lazy { listOf("Apple_Terminal", "iTerm.app").contains(System.getenv("TERM_PROGRAM")) }
 
-    const val CODE_SANTA_CLAUS = "\ud83c\udf85"
-    const val CODE_DIAMOND = "\ud83d\udd37"
-    const val CODE_BAG_OF_CASH = "\ud83d\udcb0"
-    const val CODE_NEWSPAPER = "\ud83d\udcf0"
-    const val CODE_RIGHT_ARROW = "\u27a1\ufe0f"
-    const val CODE_LEFT_ARROW = "\u2b05\ufe0f"
-    const val CODE_GREEN_TICK = "\u2705"
-    const val CODE_PAPERCLIP = "\ud83d\udcce"
-    const val CODE_COOL_GUY = "\ud83d\ude0e"
+    @JvmStatic val CODE_SANTA_CLAUS: String = codePointsString(0x1F385)
+    @JvmStatic val CODE_DIAMOND: String = codePointsString(0x1F537)
+    @JvmStatic val CODE_BAG_OF_CASH: String = codePointsString(0x1F4B0)
+    @JvmStatic val CODE_NEWSPAPER: String = codePointsString(0x1F4F0)
+    @JvmStatic val CODE_RIGHT_ARROW: String = codePointsString(0x27A1, 0xFE0F)
+    @JvmStatic val CODE_LEFT_ARROW: String = codePointsString(0x2B05, 0xFE0F)
+    @JvmStatic val CODE_GREEN_TICK: String = codePointsString(0x2705)
+    @JvmStatic val CODE_PAPERCLIP: String = codePointsString(0x1F4CE)
+    @JvmStatic val CODE_COOL_GUY: String = codePointsString(0x1F60E)
+    @JvmStatic val CODE_NO_ENTRY: String = codePointsString(0x1F6AB)
+    @JvmStatic val SKULL_AND_CROSSBONES: String = codePointsString(0x2620)
 
     /**
      * When non-null, toString() methods are allowed to use emoji in the output as we're going to render them to a
@@ -55,4 +59,5 @@ object Emoji {
             emojiMode.set(null)
         }
     }
+
 }

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -55,7 +55,7 @@ class ProgressTracker(vararg steps: Step) {
 
     /** This class makes it easier to relabel a step on the fly, to provide transient information. */
     open inner class RelabelableStep(currentLabel: String) : Step(currentLabel) {
-        override val changes = BehaviorSubject.create<Change>()
+        override val changes: BehaviorSubject<Change> = BehaviorSubject.create()
 
         var currentLabel: String = currentLabel
             set(value) {
@@ -105,27 +105,26 @@ class ProgressTracker(vararg steps: Step) {
     var currentStep: Step
         get() = steps[stepIndex]
         set(value) {
-            if (currentStep != value) {
-                check(currentStep != DONE) { "Cannot rewind a progress tracker once it reaches the done state" }
+            check(!hasEnded) { "Cannot rewind a progress tracker once it has ended" }
+            if (currentStep == value) return
 
-                val index = steps.indexOf(value)
-                require(index != -1)
+            val index = steps.indexOf(value)
+            require(index != -1)
 
-                if (index < stepIndex) {
-                    // We are going backwards: unlink and unsubscribe from any child nodes that we're rolling back
-                    // through, in preparation for moving through them again.
-                    for (i in stepIndex downTo index) {
-                        removeChildProgressTracker(steps[i])
-                    }
+            if (index < stepIndex) {
+                // We are going backwards: unlink and unsubscribe from any child nodes that we're rolling back
+                // through, in preparation for moving through them again.
+                for (i in stepIndex downTo index) {
+                    removeChildProgressTracker(steps[i])
                 }
-
-                curChangeSubscription?.unsubscribe()
-                stepIndex = index
-                _changes.onNext(Change.Position(this, steps[index]))
-                curChangeSubscription = currentStep.changes.subscribe { _changes.onNext(it) }
-
-                if (currentStep == DONE) _changes.onCompleted()
             }
+
+            curChangeSubscription?.unsubscribe()
+            stepIndex = index
+            _changes.onNext(Change.Position(this, steps[index]))
+            curChangeSubscription = currentStep.changes.subscribe( { _changes.onNext(it) }, { _changes.onError(it) })
+
+            if (currentStep == DONE) _changes.onCompleted()
         }
 
     /** Returns the current step, descending into children to find the deepest step we are up to. */
@@ -147,6 +146,15 @@ class ProgressTracker(vararg steps: Step) {
             it.subscription?.unsubscribe()
         }
         _changes.onNext(Change.Structural(this, step))
+    }
+
+    /**
+     * Ends the progress tracker with the given error, bypassing any remaining steps. [changes] will emit the exception
+     * as an error.
+     */
+    fun endWithError(error: Throwable) {
+        check(!hasEnded) { "Progress tracker has already ended" }
+        _changes.onError(error)
     }
 
     /** The parent of this tracker: set automatically by the parent when a tracker is added as a child */
@@ -195,6 +203,9 @@ class ProgressTracker(vararg steps: Step) {
      * if a step changed its label or rendering).
      */
     val changes: Observable<Change> get() = _changes
+
+    /** Returns true if the progress tracker has ended, either by reaching the [DONE] step or prematurely with an error */
+    val hasEnded: Boolean get() = _changes.hasCompleted() || _changes.hasThrowable()
 }
 
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -24,7 +24,6 @@ import net.corda.core.messaging.send
 import net.corda.core.random63BitValue
 import net.corda.core.serialization.*
 import net.corda.core.then
-import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.trace
@@ -391,7 +390,6 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         }
         fiber.actionOnEnd = { exception, propagated ->
             try {
-                fiber.logic.progressTracker?.currentStep = ProgressTracker.DONE
                 mutex.locked {
                     stateMachines.remove(fiber)?.let { checkpointStorage.removeCheckpoint(it) }
                     notifyChangeObservers(fiber, AddOrRemove.REMOVE)

--- a/node/src/main/kotlin/net/corda/node/utilities/ANSIProgressObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ANSIProgressObserver.kt
@@ -2,7 +2,6 @@ package net.corda.node.utilities
 
 import net.corda.core.ThreadBox
 import net.corda.core.flows.FlowLogic
-import net.corda.core.utilities.ProgressTracker
 import net.corda.node.services.statemachine.StateMachineManager
 import java.util.*
 
@@ -35,13 +34,12 @@ class ANSIProgressObserver(val smm: StateMachineManager) {
                 if (currentlyRendering?.progressTracker != null) {
                     ANSIProgressRenderer.progressTracker = currentlyRendering!!.progressTracker
                 }
-            } while (currentlyRendering?.progressTracker?.currentStep == ProgressTracker.DONE)
+            } while (currentlyRendering?.progressTracker?.hasEnded ?: false)
         }
     }
 
     private fun removeFlowLogic(flowLogic: FlowLogic<*>) {
         state.locked {
-            flowLogic.progressTracker?.currentStep = ProgressTracker.DONE
             if (currentlyRendering == flowLogic) {
                 wireUpProgressRendering()
             }
@@ -51,7 +49,7 @@ class ANSIProgressObserver(val smm: StateMachineManager) {
     private fun addFlowLogic(flowLogic: FlowLogic<*>) {
         state.locked {
             pending.add(flowLogic)
-            if ((currentlyRendering?.progressTracker?.currentStep ?: ProgressTracker.DONE) == ProgressTracker.DONE) {
+            if (currentlyRendering?.progressTracker?.hasEnded ?: true) {
                 wireUpProgressRendering()
             }
         }

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -4,31 +4,34 @@ import com.google.common.util.concurrent.Futures
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.flows.IssuerFlow
-import net.corda.node.driver.driver
 import net.corda.node.services.User
+import net.corda.node.services.messaging.CordaRPCClient
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.SimpleNotaryService
+import net.corda.testing.node.NodeBasedTest
 import org.junit.Test
 
-class TraderDemoTest {
-    @Test fun `runs trader demo`() {
-        driver(isDebug = true) {
-            val permissions = setOf(
-                    startFlowPermission<IssuerFlow.IssuanceRequester>(),
-                    startFlowPermission<net.corda.traderdemo.flow.SellerFlow>())
-            val demoUser = listOf(User("demo", "demo", permissions))
-            val user = User("user1", "test", permissions = setOf(startFlowPermission<IssuerFlow.IssuanceRequester>()))
-            val (nodeA, nodeB) = Futures.allAsList(
-                    startNode("Bank A", rpcUsers = demoUser),
-                    startNode("Bank B", rpcUsers = demoUser),
-                    startNode("BankOfCorda", rpcUsers = listOf(user)),
-                    startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.type)))
-            ).getOrThrow()
-            val (nodeARpc, nodeBRpc) = listOf(nodeA, nodeB)
-                    .map { it.rpcClientToNode().start(demoUser[0].username, demoUser[0].password).proxy() }
+class TraderDemoTest : NodeBasedTest() {
+    @Test
+    fun `runs trader demo`() {
+        val permissions = setOf(
+                startFlowPermission<IssuerFlow.IssuanceRequester>(),
+                startFlowPermission<net.corda.traderdemo.flow.SellerFlow>())
+        val demoUser = listOf(User("demo", "demo", permissions))
+        val user = User("user1", "test", permissions = setOf(startFlowPermission<IssuerFlow.IssuanceRequester>()))
+        val (nodeA, nodeB) = Futures.allAsList(
+                startNode("Bank A", rpcUsers = demoUser),
+                startNode("Bank B", rpcUsers = demoUser),
+                startNode("BankOfCorda", rpcUsers = listOf(user)),
+                startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.type)))
+        ).getOrThrow()
 
-            assert(TraderDemoClientApi(nodeARpc).runBuyer())
-            assert(TraderDemoClientApi(nodeBRpc).runSeller(counterparty = nodeA.nodeInfo.legalIdentity.name))
+        val (nodeARpc, nodeBRpc) = listOf(nodeA, nodeB).map {
+            val client = CordaRPCClient(it.configuration.artemisAddress, it.configuration)
+            client.start(demoUser[0].username, demoUser[0].password).proxy()
         }
+
+        TraderDemoClientApi(nodeARpc).runBuyer()
+        TraderDemoClientApi(nodeBRpc).runSeller(counterparty = nodeA.info.legalIdentity.name)
     }
 }


### PR DESCRIPTION
… renderer to correctly stop and print the error (#189)

The `ProgressTracker.changes` observable now stops on the same error that the flow throws. This resolves issue #189 so it no longer continues printing to DONE. It now prints a 🚫 for all the steps that didn't occur due to the exception and a ☠️ at the end with the exception message.

The flow exception should now pass down to the `StateMachineInfo.progressTrackerStepAndUpdates` and `FlowHandle.progress` RPC observables.