### PR TITLE
Fix typo in docs for FixOf where Duration should be Tenor

### DIFF
--- a/docs/build/html/_sources/oracles.txt
+++ b/docs/build/html/_sources/oracles.txt
@@ -104,7 +104,7 @@ Here is an extract from the ``NodeInterestRates.Oracle`` class and supporting ty
 .. sourcecode:: kotlin
 
    /** A [FixOf] identifies the question side of a fix: what day, tenor and type of fix ("LIBOR", "EURIBOR" etc) */
-   data class FixOf(val name: String, val forDay: LocalDate, val ofTenor: Duration)
+   data class FixOf(val name: String, val forDay: LocalDate, val ofTenor: Tenor)
 
    /** A [Fix] represents a named interest rate, on a given day, for a given duration. It can be embedded in a tx. */
    data class Fix(val of: FixOf, val value: BigDecimal) : CommandData

--- a/docs/source/oracles.rst
+++ b/docs/source/oracles.rst
@@ -104,7 +104,7 @@ Here is an extract from the ``NodeInterestRates.Oracle`` class and supporting ty
 .. sourcecode:: kotlin
 
    /** A [FixOf] identifies the question side of a fix: what day, tenor and type of fix ("LIBOR", "EURIBOR" etc) */
-   data class FixOf(val name: String, val forDay: LocalDate, val ofTenor: Duration)
+   data class FixOf(val name: String, val forDay: LocalDate, val ofTenor: Tenor)
 
    /** A [Fix] represents a named interest rate, on a given day, for a given duration. It can be embedded in a tx. */
    data class Fix(val of: FixOf, val value: BigDecimal) : CommandData


### PR DESCRIPTION
Constructor for `FixOf` was updated in this commit https://github.com/corda/corda/commit/6c0e6961078cb5816c83f4cbfc1f02571af288c9#diff-e738b0f300324e8641cf05106b1e3d89L82 but documentation was not yet updated