### PR TITLE
Java code can now extend core FlowLogics which don't return anything …

### DIFF
--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -85,15 +85,17 @@ object NotaryFlow {
      *
      * Additional transaction validation logic can be added when implementing [receiveAndVerifyTx].
      */
+    // See AbstractStateReplacementFlow.Acceptor for why it's Void?
     abstract class Service(val otherSide: Party,
                            val timestampChecker: TimestampChecker,
-                           val uniquenessProvider: UniquenessProvider) : FlowLogic<Unit>() {
+                           val uniquenessProvider: UniquenessProvider) : FlowLogic<Void?>() {
         @Suspendable
-        override fun call() {
+        override fun call(): Void? {
             val (id, inputs, timestamp) = receiveAndVerifyTx()
             validateTimestamp(timestamp)
             commitInputStates(inputs, id)
             signAndSendResponse(id)
+            return null
         }
 
         /**

--- a/finance/src/test/java/net/corda/flows/AbstractStateReplacementFlowTest.java
+++ b/finance/src/test/java/net/corda/flows/AbstractStateReplacementFlowTest.java
@@ -1,0 +1,18 @@
+package net.corda.flows;
+
+import net.corda.core.crypto.Party;
+import net.corda.core.utilities.ProgressTracker;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class AbstractStateReplacementFlowTest {
+
+    // Acceptor used to have a type parameter of Unit which prevented Java code from subclassing it (https://youtrack.jetbrains.com/issue/KT-15964).
+    private static class TestAcceptorCanBeInheritedInJava extends AbstractStateReplacementFlow.Acceptor {
+        public TestAcceptorCanBeInheritedInJava(@NotNull Party otherSide, @NotNull ProgressTracker progressTracker) {
+            super(otherSide, progressTracker);
+        }
+        @Override
+        protected void verifyProposal(@NotNull AbstractStateReplacementFlow.Proposal proposal) {}
+    }
+}


### PR DESCRIPTION
…(by using Void? instead of Unit)

This is a fix for #179 