### PR TITLE
Remove duplicate/overlapping entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,15 +14,12 @@ local.properties
 
 # General build files
 **/build/*
-!docs/build/*
-
 lib/dokka.jar
 
 **/logs/*
 
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
-
 *.iml
 
 ## Directory-based project format:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ local.properties
 
 # General build files
 **/build/*
+# Exception - Allow built documentation to remain under version control
+!docs/build/*
+
 lib/dokka.jar
 
 **/logs/*

--- a/core/src/main/resources/net/corda/core/node/cities.txt
+++ b/core/src/main/resources/net/corda/core/node/cities.txt
@@ -754,3 +754,4 @@ Nuremberg	11.05	49.45
 Santa Fe	-60.69	-31.6
 Joinville	-48.84	-26.32
 Zurich	8.55	47.36
+Hong Kong 114.16	22.28

--- a/core/src/main/resources/net/corda/core/node/cities.txt
+++ b/core/src/main/resources/net/corda/core/node/cities.txt
@@ -754,4 +754,3 @@ Nuremberg	11.05	49.45
 Santa Fe	-60.69	-31.6
 Joinville	-48.84	-26.32
 Zurich	8.55	47.36
-Hong Kong 114.16	22.28


### PR DESCRIPTION
I noticed that there were a few overlapping or duplicated entries in the .gitignore, particularly around the generation of the documentation. It might be worth cleaning these up now rather than leaving them as cruft for later.

Intellij has a useful plugin (`.ignore`) which highlights these issues rather well.

I have included the removal of the `!docs/build/*` because it appears that the intention is to generate documentation as required rather than have both the source and generated documentation under version control. Is this correct?