### PR TITLE
Add Hong Kong to list of cities in lookup table

### DIFF
--- a/core/src/main/resources/net/corda/core/node/cities.txt
+++ b/core/src/main/resources/net/corda/core/node/cities.txt
@@ -754,3 +754,4 @@ Nuremberg	11.05	49.45
 Santa Fe	-60.69	-31.6
 Joinville	-48.84	-26.32
 Zurich	8.55	47.36
+Hong Kong 114.16 22.28

--- a/core/src/main/resources/net/corda/core/node/cities.txt
+++ b/core/src/main/resources/net/corda/core/node/cities.txt
@@ -754,4 +754,4 @@ Nuremberg	11.05	49.45
 Santa Fe	-60.69	-31.6
 Joinville	-48.84	-26.32
 Zurich	8.55	47.36
-Hong Kong 114.16 22.28
+Hong Kong	114.16	22.28


### PR DESCRIPTION
Noticed that Hong Kong was missing in the `cities.txt` lookup table.

Here's the Google Maps link for reference: https://www.google.co.uk/maps/place/22%C2%B016'48.0%22N+114%C2%B009'36.0%22E/@22.2800248,114.1582843,17.28z/data=!4m5!3m4!1s0x0:0x0!8m2!3d22.28!4d114.16