### PR TITLE
Move generateSpend() into AbstractConserveAmount

### DIFF
--- a/finance/src/main/kotlin/net/corda/contracts/clause/AbstractConserveAmount.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/clause/AbstractConserveAmount.kt
@@ -1,7 +1,9 @@
 package net.corda.contracts.clause
 
+import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.*
 import net.corda.core.contracts.clauses.Clause
+import net.corda.core.crypto.AbstractParty
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.transactions.TransactionBuilder
 import java.util.*
@@ -12,28 +14,116 @@ import java.util.*
  * errors on no-match, ends on match.
  */
 abstract class AbstractConserveAmount<S : FungibleAsset<T>, C : CommandData, T : Any> : Clause<S, C, Issued<T>>() {
-    /**
-     * Gather assets from the given list of states, sufficient to match or exceed the given amount.
-     *
-     * @param acceptableCoins list of states to use as inputs.
-     * @param amount the amount to gather states up to.
-     * @throws InsufficientBalanceException if there isn't enough value in the states to cover the requested amount.
-     */
-    @Throws(InsufficientBalanceException::class)
-    private fun gatherCoins(acceptableCoins: Collection<StateAndRef<S>>,
-                            amount: Amount<T>): Pair<ArrayList<StateAndRef<S>>, Amount<T>> {
-        val gathered = arrayListOf<StateAndRef<S>>()
-        var gatheredAmount = Amount(0, amount.token)
-        for (c in acceptableCoins) {
-            if (gatheredAmount >= amount) break
-            gathered.add(c)
-            gatheredAmount += Amount(c.state.data.amount.quantity, amount.token)
+    companion object {
+        fun <S : FungibleAsset<T>, T: Any> generateSpend(tx: TransactionBuilder,
+                          amount: Amount<T>,
+                          to: CompositeKey,
+                          assetsStates: List<StateAndRef<S>>,
+                          deriveState: (TransactionState<S>, Amount<Issued<T>>, CompositeKey) -> TransactionState<S>,
+                          onlyFromParties: Set<AbstractParty>?): Pair<TransactionBuilder, List<CompositeKey>> {
+            // Discussion
+            //
+            // This code is analogous to the Wallet.send() set of methods in bitcoinj, and has the same general outline.
+            //
+            // First we must select a set of asset states (which for convenience we will call 'coins' here, as in bitcoinj).
+            // The input states can be considered our "vault", and may consist of different products, and with different
+            // issuers and deposits.
+            //
+            // Coin selection is a complex problem all by itself and many different approaches can be used. It is easily
+            // possible for different actors to use different algorithms and approaches that, for example, compete on
+            // privacy vs efficiency (number of states created). Some spends may be artificial just for the purposes of
+            // obfuscation and so on.
+            //
+            // Having selected input states of the correct asset, we must craft output states for the amount we're sending and
+            // the "change", which goes back to us. The change is required to make the amounts balance. We may need more
+            // than one change output in order to avoid merging assets from different deposits. The point of this design
+            // is to ensure that ledger entries are immutable and globally identifiable.
+            //
+            // Finally, we add the states to the provided partial transaction.
+
+            val currency = amount.token
+            var acceptableCoins = run {
+                val ofCurrency = assetsStates.filter { it.state.data.amount.token.product == currency }
+                if (onlyFromParties != null)
+                    ofCurrency.filter { it.state.data.amount.token.issuer.party in onlyFromParties }
+                else
+                    ofCurrency
+            }
+            tx.notary = acceptableCoins.firstOrNull()?.state?.notary
+            // TODO: We should be prepared to produce multiple transactions spending inputs from
+            // different notaries, or at least group states by notary and take the set with the
+            // highest total value
+            acceptableCoins = acceptableCoins.filter { it.state.notary == tx.notary }
+
+            val (gathered, gatheredAmount) = gatherCoins(acceptableCoins, amount)
+            val takeChangeFrom = gathered.firstOrNull()
+            val change = if (takeChangeFrom != null && gatheredAmount > amount) {
+                Amount(gatheredAmount.quantity - amount.quantity, takeChangeFrom.state.data.amount.token)
+            } else {
+                null
+            }
+            val keysUsed = gathered.map { it.state.data.owner }.toSet()
+
+            val states = gathered.groupBy { it.state.data.amount.token.issuer }.map {
+                val coins = it.value
+                val totalAmount = coins.map { it.state.data.amount }.sumOrThrow()
+                deriveState(coins.first().state, totalAmount, to)
+            }.sortedBy { it.data.amount.quantity }
+
+            val outputs = if (change != null) {
+                // Just copy a key across as the change key. In real life of course, this works but leaks private data.
+                // In bitcoinj we derive a fresh key here and then shuffle the outputs to ensure it's hard to follow
+                // value flows through the transaction graph.
+                val existingOwner = gathered.first().state.data.owner
+                // Add a change output and adjust the last output downwards.
+                states.subList(0, states.lastIndex) +
+                        states.last().let {
+                            val spent = it.data.amount.withoutIssuer() - change.withoutIssuer()
+                            deriveState(it, Amount(spent.quantity, it.data.amount.token), it.data.owner)
+                        } +
+                        states.last().let {
+                            deriveState(it, Amount(change.quantity, it.data.amount.token), existingOwner)
+                        }
+            } else states
+
+            for (state in gathered) tx.addInputState(state)
+            for (state in outputs) tx.addOutputState(state)
+
+            // What if we already have a move command with the right keys? Filter it out here or in platform code?
+            val keysList = keysUsed.toList()
+            tx.addCommand(Cash().generateMoveCommand(), keysList)
+
+            // update Vault
+            //        notify(tx.toWireTransaction())
+            // Vault update must be completed AFTER transaction is recorded to ledger storage!!!
+            // (this is accomplished within the recordTransaction function)
+
+            return Pair(tx, keysList)
         }
 
-        if (gatheredAmount < amount)
-            throw InsufficientBalanceException(amount - gatheredAmount)
+        /**
+         * Gather assets from the given list of states, sufficient to match or exceed the given amount.
+         *
+         * @param acceptableCoins list of states to use as inputs.
+         * @param amount the amount to gather states up to.
+         * @throws InsufficientBalanceException if there isn't enough value in the states to cover the requested amount.
+         */
+        @Throws(InsufficientBalanceException::class)
+        fun <S : FungibleAsset<T>, T: Any> gatherCoins(acceptableCoins: Collection<StateAndRef<S>>,
+                                amount: Amount<T>): Pair<ArrayList<StateAndRef<S>>, Amount<T>> {
+            val gathered = arrayListOf<StateAndRef<S>>()
+            var gatheredAmount = Amount(0, amount.token)
+            for (c in acceptableCoins) {
+                if (gatheredAmount >= amount) break
+                gathered.add(c)
+                gatheredAmount += Amount(c.state.data.amount.quantity, amount.token)
+            }
 
-        return Pair(gathered, gatheredAmount)
+            if (gatheredAmount < amount)
+                throw InsufficientBalanceException(amount - gatheredAmount)
+
+            return Pair(gathered, gatheredAmount)
+        }
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -4,6 +4,7 @@ import io.requery.TransactionIsolation
 import io.requery.kotlin.`in`
 import io.requery.kotlin.eq
 import net.corda.contracts.asset.Cash
+import net.corda.contracts.clause.AbstractConserveAmount
 import net.corda.core.ThreadBox
 import net.corda.core.bufferUntilSubscribed
 import net.corda.core.contracts.*
@@ -224,114 +225,12 @@ class NodeVaultService(private val services: ServiceHub, dataSourceProperties: P
                                amount: Amount<Currency>,
                                to: CompositeKey,
                                onlyFromParties: Set<AbstractParty>?): Pair<TransactionBuilder, List<CompositeKey>> {
-        // Discussion
-        //
-        // This code is analogous to the Wallet.send() set of methods in bitcoinj, and has the same general outline.
-        //
-        // First we must select a set of asset states (which for convenience we will call 'coins' here, as in bitcoinj).
-        // The input states can be considered our "vault", and may consist of different products, and with different
-        // issuers and deposits.
-        //
-        // Coin selection is a complex problem all by itself and many different approaches can be used. It is easily
-        // possible for different actors to use different algorithms and approaches that, for example, compete on
-        // privacy vs efficiency (number of states created). Some spends may be artificial just for the purposes of
-        // obfuscation and so on.
-        //
-        // Having selected input states of the correct asset, we must craft output states for the amount we're sending and
-        // the "change", which goes back to us. The change is required to make the amounts balance. We may need more
-        // than one change output in order to avoid merging assets from different deposits. The point of this design
-        // is to ensure that ledger entries are immutable and globally identifiable.
-        //
-        // Finally, we add the states to the provided partial transaction.
-
-        val assetsStates = unconsumedStates<Cash.State>()
-
-        val currency = amount.token
-        var acceptableCoins = run {
-            val ofCurrency = assetsStates.filter { it.state.data.amount.token.product == currency }
-            if (onlyFromParties != null)
-                ofCurrency.filter { it.state.data.amount.token.issuer.party in onlyFromParties }
-            else
-                ofCurrency
-        }
-        tx.notary = acceptableCoins.firstOrNull()?.state?.notary
-        // TODO: We should be prepared to produce multiple transactions spending inputs from
-        // different notaries, or at least group states by notary and take the set with the
-        // highest total value
-        acceptableCoins = acceptableCoins.filter { it.state.notary == tx.notary }
-
-        val (gathered, gatheredAmount) = gatherCoins(acceptableCoins, amount)
-        val takeChangeFrom = gathered.firstOrNull()
-        val change = if (takeChangeFrom != null && gatheredAmount > amount) {
-            Amount(gatheredAmount.quantity - amount.quantity, takeChangeFrom.state.data.amount.token)
-        } else {
-            null
-        }
-        val keysUsed = gathered.map { it.state.data.owner }.toSet()
-
-        val states = gathered.groupBy { it.state.data.amount.token.issuer }.map {
-            val coins = it.value
-            val totalAmount = coins.map { it.state.data.amount }.sumOrThrow()
-            deriveState(coins.first().state, totalAmount, to)
-        }.sortedBy { it.data.amount.quantity }
-
-        val outputs = if (change != null) {
-            // Just copy a key across as the change key. In real life of course, this works but leaks private data.
-            // In bitcoinj we derive a fresh key here and then shuffle the outputs to ensure it's hard to follow
-            // value flows through the transaction graph.
-            val existingOwner = gathered.first().state.data.owner
-            // Add a change output and adjust the last output downwards.
-            states.subList(0, states.lastIndex) +
-                    states.last().let {
-                        val spent = it.data.amount.withoutIssuer() - change.withoutIssuer()
-                        deriveState(it, Amount(spent.quantity, it.data.amount.token), it.data.owner)
-                    } +
-                    states.last().let {
-                        deriveState(it, Amount(change.quantity, it.data.amount.token), existingOwner)
-                    }
-        } else states
-
-        for (state in gathered) tx.addInputState(state)
-        for (state in outputs) tx.addOutputState(state)
-
-        // What if we already have a move command with the right keys? Filter it out here or in platform code?
-        val keysList = keysUsed.toList()
-        tx.addCommand(Cash().generateMoveCommand(), keysList)
-
-        // update Vault
-        //        notify(tx.toWireTransaction())
-        // Vault update must be completed AFTER transaction is recorded to ledger storage!!!
-        // (this is accomplished within the recordTransaction function)
-
-        return Pair(tx, keysList)
+        return AbstractConserveAmount.generateSpend(tx, amount, to, unconsumedStates<Cash.State>(),
+                { state, amount, owner -> deriveState(state, amount, owner) }, onlyFromParties)
     }
 
     private fun deriveState(txState: TransactionState<Cash.State>, amount: Amount<Issued<Currency>>, owner: CompositeKey)
             = txState.copy(data = txState.data.copy(amount = amount, owner = owner))
-
-    /**
-     * Gather assets from the given list of states, sufficient to match or exceed the given amount.
-     *
-     * @param acceptableCoins list of states to use as inputs.
-     * @param amount the amount to gather states up to.
-     * @throws InsufficientBalanceException if there isn't enough value in the states to cover the requested amount.
-     */
-    @Throws(InsufficientBalanceException::class)
-    private fun gatherCoins(acceptableCoins: Collection<StateAndRef<Cash.State>>,
-                            amount: Amount<Currency>): Pair<ArrayList<StateAndRef<Cash.State>>, Amount<Currency>> {
-        val gathered = arrayListOf<StateAndRef<Cash.State>>()
-        var gatheredAmount = Amount(0, amount.token)
-        for (c in acceptableCoins) {
-            if (gatheredAmount >= amount) break
-            gathered.add(c)
-            gatheredAmount += Amount(c.state.data.amount.quantity, amount.token)
-        }
-
-        if (gatheredAmount < amount)
-            throw InsufficientBalanceException(amount - gatheredAmount)
-
-        return Pair(gathered, gatheredAmount)
-    }
 
     private fun makeUpdate(tx: WireTransaction, ourKeys: Set<PublicKey>): Vault.Update {
         val ourNewStates = tx.outputs.


### PR DESCRIPTION
Move generateSpend() into AbstractConserveAmount and make it generic enough to use for other
similar contracts to cash, rather than just cash. Also removes duplicated logic in gathering
coins.