### PR TITLE
Add public IP detection (from network interfaces), node outputs a war…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt
@@ -1,0 +1,25 @@
+package net.corda.node.utilities
+
+import java.net.InetAddress
+import java.net.NetworkInterface
+
+object AddressUtils {
+    /** Returns the first public IP address found on any of the network interfaces, or `null` if none found. */
+    fun tryDetectPublicIP(): InetAddress? {
+        for (int in NetworkInterface.getNetworkInterfaces()) {
+            for (address in int.inetAddresses) {
+                if (isPublic(address)) return address
+            }
+        }
+        return null
+    }
+
+    /** Returns `true` if the provided `address` is a public IP address or hostname. */
+    fun isPublic(address: InetAddress): Boolean {
+        return !(address.isSiteLocalAddress || address.isAnyLocalAddress ||
+                address.isLinkLocalAddress || address.isLoopbackAddress ||
+                address.isMulticastAddress)
+    }
+
+    fun isPublic(hostText: String) = isPublic(InetAddress.getByName(hostText))
+}

--- a/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/AddressUtilsTests.kt
@@ -1,0 +1,31 @@
+package net.corda.node.utilities
+
+import org.junit.Test
+import java.net.InetAddress
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddressUtilsTests {
+    @Test
+    fun `correctly determines if the provided address is public`() {
+        val hostName = InetAddress.getLocalHost()
+        assertFalse { AddressUtils.isPublic(hostName) }
+        assertFalse { AddressUtils.isPublic("localhost") }
+        assertFalse { AddressUtils.isPublic("127.0.0.1") }
+        assertFalse { AddressUtils.isPublic("::1") }
+        assertFalse { AddressUtils.isPublic("0.0.0.0") }
+        assertFalse { AddressUtils.isPublic("::") }
+        assertFalse { AddressUtils.isPublic("10.0.0.0") }
+        assertFalse { AddressUtils.isPublic("10.255.255.255") }
+        assertFalse { AddressUtils.isPublic("192.168.0.10") }
+        assertFalse { AddressUtils.isPublic("192.168.255.255") }
+        assertFalse { AddressUtils.isPublic("172.16.0.0") }
+        assertFalse { AddressUtils.isPublic("172.31.255.255") }
+
+        assertTrue { AddressUtils.isPublic("172.32.0.0") }
+        assertTrue { AddressUtils.isPublic("192.169.0.0") }
+        assertTrue { AddressUtils.isPublic("11.0.0.0") }
+        assertTrue { AddressUtils.isPublic("corda.net") }
+        assertTrue { AddressUtils.isPublic("2607:f298:5:110f::eef:8729") }
+    }
+}


### PR DESCRIPTION
…ning if no public IP detected or specified in the config.

The warning is being outputted to both the logfile and stdout:
```
   ______               __
  / ____/     _________/ /___ _
 / /     __  / ___/ __  / __ `/         "It's OK computer, I go to sleep after
/ /___  /_/ / /  / /_/ / /_/ /          twenty minutes of inactivity too!"
\____/     /_/   \__,_/\__,_/

--- MILESTONE 9 -------------------------------------------------------------------

Logs can be found in                    : /.../logs
Database connection url is              : jdbc:h2:tcp://x.x.x.x:50497/node
WARNING: The specified messaging host "localhost" is private, this node will not be reachable by any other nodes outside the private network.
Node listening on address               : localhost:10002
Loaded plugins                          : net.corda.attachmentdemo.plugin.AttachmentDemoPlugin
Node started up and registered in 23.23 sec
```