### PR TITLE
Exclude old version of Javassist in favour of Hibernate's version from Node.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:${assertj_version}"
 
+    // TODO: Upgrade to junit-quickcheck 0.8, once it is released,
+    //       because it depends on org.javassist:javassist instead
+    //       of javassist:javassist.
     compile "com.pholser:junit-quickcheck-core:$quickcheck_version"
     compile "com.pholser:junit-quickcheck-generators:$quickcheck_version"
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -52,8 +52,12 @@ sourceSets {
 
 dependencies {
 
-    compile project(':finance')
-    compile project(':node-schemas')
+    compile (project(':finance')) {
+        exclude group: 'javassist', module: 'javassist'
+    }
+    compile (project(':node-schemas')) {
+        exclude group: 'javassist', module: 'javassist'
+    }
 
     compile "com.google.code.findbugs:jsr305:3.0.1"
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -52,6 +52,10 @@ sourceSets {
 
 dependencies {
 
+    // Excluding javassist:javassist (which is a transitive dependency of core)
+    // because it clashes with Hibernate's transitive org.javassist:javassist
+    // dependency.
+    // TODO: Remove both of these exclusions once junit-quickcheck 0.8 is released.
     compile (project(':finance')) {
         exclude group: 'javassist', module: 'javassist'
     }


### PR DESCRIPTION
The Maven `groupId` coordinate for Javassist has changed from `javassist` to `org.javassist` between v3.11.0.GA and v3.20.0-GA. This means that Gradle considers them to be distinct artifacts and so includes _both_ Javassist versions. We only want the latest version to be included.

The `core` project includes `javassist:javassist:3.11.0.GA` as a transitive dependency. The `node` project include `org.javassist:javassist:3.20.0-GA` via Hibernate. So we need to exclude `javassist:javassist` from any project that has `core` as a transitive dependency.