### PR TITLE
Fix IRS demo after Party changes.

### DIFF
--- a/docs/source/running-the-demos.rst
+++ b/docs/source/running-the-demos.rst
@@ -104,7 +104,7 @@ To run from IntelliJ:
    The date change rolls the clock forwards and causes the nodes to agree on the fixings over a period.
 
 This demo also has a web app. To use this, run nodes and upload rates, then navigate to
-http://localhost:10005/web/irsdemo and http://localhost:10007/web/irsdemo to see each node's view of the ledger.
+http://localhost:10007/web/irsdemo and http://localhost:10010/web/irsdemo to see each node's view of the ledger.
 
 To use the web app, click the "Create Deal" button, fill in the form, then click the "Submit" button. You can then
 use the time controls at the top left of the home page to run the fixings. Click any individual trade in the blotter to view it.

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -71,7 +71,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
         nearestCity "London"
         advertisedServices = ["corda.notary.validating", "corda.interest_rates"]
         artemisPort 10002
-        webPort 10003
+        webPort 10004
         cordapps = []
         useTestClock true
     }
@@ -79,8 +79,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
         name "Bank A"
         nearestCity "London"
         advertisedServices = []
-        artemisPort 10004
-        webPort 10005
+        artemisPort 10005
+        webPort 10007
         cordapps = []
         useTestClock true
     }
@@ -89,7 +89,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['build']) {
         nearestCity "New York"
         advertisedServices = []
         artemisPort 10006
-        webPort 10007
+        webPort 10010
         cordapps = []
         useTestClock true
     }

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/IRSDemo.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/IRSDemo.kt
@@ -30,8 +30,8 @@ fun main(args: Array<String>) {
     val role = options.valueOf(roleArg)!!
     val value = options.valueOf(valueArg)
     when (role) {
-        Role.UploadRates -> IRSDemoClientApi(HostAndPort.fromString("localhost:10003")).runUploadRates()
-        Role.Trade -> IRSDemoClientApi(HostAndPort.fromString("localhost:10005")).runTrade(value)
+        Role.UploadRates -> IRSDemoClientApi(HostAndPort.fromString("localhost:10004")).runUploadRates()
+        Role.Trade -> IRSDemoClientApi(HostAndPort.fromString("localhost:10007")).runTrade(value)
         Role.Date -> IRSDemoClientApi(HostAndPort.fromString("localhost:10007")).runDateChange(value)
     }
 }

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/InterestRateSwapAPI.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/InterestRateSwapAPI.kt
@@ -63,6 +63,16 @@ class InterestRateSwapAPI(val rpc: CordaRPCOps) {
     @Produces(MediaType.APPLICATION_JSON)
     fun fetchDeals(): Array<InterestRateSwap.State> = getAllDeals()
 
+    // Function needed to substitute party keys in JSON file example-irs-trade.json
+    @GET
+    @Path("partykeys")
+    @Produces(MediaType.APPLICATION_JSON)
+    fun partyFromName(): Response {
+        val keyA = rpc.partyFromName("Bank A")?.owningKey
+        val keyB = rpc.partyFromName("Bank B")?.owningKey
+        return Response.ok().entity(Pair(keyA, keyB)).build()
+    }
+
     @POST
     @Path("deals")
     @Consumes(MediaType.APPLICATION_JSON)

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/IrsDemoClientApi.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/IrsDemoClientApi.kt
@@ -14,7 +14,8 @@ class IRSDemoClientApi(private val hostAndPort: HostAndPort) {
 
     fun runTrade(tradeId: String): Boolean {
         val fileContents = IOUtils.toString(javaClass.classLoader.getResourceAsStream("example-irs-trade.json"))
-        val tradeFile = fileContents.replace("tradeXXX", tradeId)
+        val (keyA, keyB) = api.getJson<Pair<String, String>>("partykeys")
+        val tradeFile = fileContents.replace("tradeXXX", tradeId).replace("fixedRatePayerKey", keyA).replace("floatingRatePayerKey", keyB)
         return api.postJson("deals", tradeFile)
     }
 


### PR DESCRIPTION
Override party keys from example-irs-trade.json file, so demos run correctly. Add api call to query for
Bank A and Bank B keys. Change port numbers, which are hardcoded in 2 places and were different when run through IntelliJ and through CLI.