### PR TITLE
Make the corda.jar executable on UNIX.

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -73,6 +73,11 @@ task buildCordaJAR(type: FatCapsule) {
         jvmArgs = ['-Xmx200m', '-XX:+UseG1GC']
     }
 
+    // Make the resulting JAR file directly executable on UNIX by prepending a shell script to it.
+    // This lets you run the file like so: ./corda.jar
+    // Other than being slightly less typing, this has one big advantage: Ctrl-C works properly in the terminal.
+    reallyExecutable { trampolining() }
+
     manifest {
         attributes('Corda-Version': corda_version)
     }


### PR DESCRIPTION
When run in this way, it eliminates the overhead of a second JVM.

runnodes changes coming in another PR.