### PR TITLE
Amount: add support for basic parsing from text.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
@@ -27,7 +27,9 @@ fun commodity(code: String) = Commodity.getInstance(code)!!
 @JvmField val GBP = currency("GBP")
 @JvmField val EUR = currency("EUR")
 @JvmField val CHF = currency("CHF")
-@JvmField val FCOJ = commodity("FCOJ")
+@JvmField val JPY = currency("JPY")
+@JvmField val RUB = currency("RUB")
+@JvmField val FCOJ = commodity("FCOJ")   // Frozen concentrated orange juice, yum!
 
 fun DOLLARS(amount: Int): Amount<Currency> = Amount(amount.toLong() * 100, USD)
 fun DOLLARS(amount: Double): Amount<Currency> = Amount((amount * 100).toLong(), USD)

--- a/core/src/main/kotlin/net/corda/core/contracts/FinanceTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/FinanceTypes.kt
@@ -39,7 +39,7 @@ import java.util.*
 data class Amount<T>(val quantity: Long, val token: T) : Comparable<Amount<T>> {
     companion object {
         /**
-         * Build an amount from a decimal representation. For example, with an input of "12.34" GBP,
+         * Build a currency amount from a decimal representation. For example, with an input of "12.34" GBP,
          * returns an amount with a quantity of "1234".
          *
          * @see Amount<Currency>.toDecimal
@@ -52,7 +52,9 @@ data class Amount<T>(val quantity: Long, val token: T) : Comparable<Amount<T>> {
         private val currencySymbols: Map<String, Currency> = mapOf(
                 "$" to USD,
                 "£" to GBP,
-                "€" to EUR
+                "€" to EUR,
+                "¥" to JPY,
+                "₽" to RUB
         )
         private val currencyCodes: Map<String, Currency> by lazy { Currency.getAvailableCurrencies().map { it.currencyCode to it }.toMap() }
 
@@ -68,10 +70,16 @@ data class Amount<T>(val quantity: Long, val token: T) : Comparable<Amount<T>> {
          * - €5000
          *
          * Note this method does NOT respect internationalisation rules: it ignores commas and uses . as the
-         * decimal point separator, always. It also ignores the users locale: $ is special cased to be USD,
-         * £ is special cased to GBP and € is special cased to Euro. Thus an input of $12 expecting some other
-         * countries dollar will not work. Do your own parsing if you need correct handling of currency amounts
-         * with locale-sensitive handling.
+         * decimal point separator, always. It also ignores the users locale:
+         *
+         * - $ is always USD,
+         * - £ is always GBP
+         * - € is always the Euro
+         * - ¥ is always Japanese Yen.
+         * - ₽ is always the Russian ruble.
+         *
+         * Thus an input of $12 expecting some other countries dollar will not work. Do your own parsing if
+         * you need correct handling of currency amounts with locale-sensitive handling.
          *
          * @throws IllegalArgumentException if the input string was not understood.
          */
@@ -117,17 +125,17 @@ data class Amount<T>(val quantity: Long, val token: T) : Comparable<Amount<T>> {
     constructor(quantity: BigInteger, token: T) : this(quantity.toLong(), token)
 
     operator fun plus(other: Amount<T>): Amount<T> {
-        checkCurrency(other)
+        checkToken(other)
         return Amount(Math.addExact(quantity, other.quantity), token)
     }
 
     operator fun minus(other: Amount<T>): Amount<T> {
-        checkCurrency(other)
+        checkToken(other)
         return Amount(Math.subtractExact(quantity, other.quantity), token)
     }
 
-    private fun checkCurrency(other: Amount<T>) {
-        require(other.token == token) { "Currency mismatch: ${other.token} vs $token" }
+    private fun checkToken(other: Amount<T>) {
+        require(other.token == token) { "Token mismatch: ${other.token} vs $token" }
     }
 
     operator fun div(other: Long): Amount<T> = Amount(quantity / other, token)
@@ -135,10 +143,16 @@ data class Amount<T>(val quantity: Long, val token: T) : Comparable<Amount<T>> {
     operator fun div(other: Int): Amount<T> = Amount(quantity / other, token)
     operator fun times(other: Int): Amount<T> = Amount(Math.multiplyExact(quantity, other.toLong()), token)
 
-    override fun toString(): String = (BigDecimal(quantity).divide(BigDecimal(100))).setScale(2).toPlainString() + " " + token
+    override fun toString(): String {
+        val bd = if (token is Currency)
+            BigDecimal(quantity).movePointLeft(token.defaultFractionDigits)
+        else
+            BigDecimal(quantity)
+        return bd.toPlainString() + " " + token
+    }
 
     override fun compareTo(other: Amount<T>): Int {
-        checkCurrency(other)
+        checkToken(other)
         return quantity.compareTo(other.quantity)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/FinanceTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/FinanceTypes.kt
@@ -48,6 +48,58 @@ data class Amount<T>(val quantity: Long, val token: T) : Comparable<Amount<T>> {
             val longQuantity = quantity.movePointRight(currency.defaultFractionDigits).toLong()
             return Amount(longQuantity, currency)
         }
+
+        private val currencySymbols: Map<String, Currency> = mapOf(
+                "$" to USD,
+                "£" to GBP,
+                "€" to EUR
+        )
+        private val currencyCodes: Map<String, Currency> by lazy { Currency.getAvailableCurrencies().map { it.currencyCode to it }.toMap() }
+
+        /**
+         * Returns an amount that is equal to the given currency amount in text. Examples of what is supported:
+         *
+         * - 12 USD
+         * - 14.50 USD
+         * - 10 USD
+         * - 30 CHF
+         * - $10.24
+         * - £13
+         * - €5000
+         *
+         * Note this method does NOT respect internationalisation rules: it ignores commas and uses . as the
+         * decimal point separator, always. It also ignores the users locale: $ is special cased to be USD,
+         * £ is special cased to GBP and € is special cased to Euro. Thus an input of $12 expecting some other
+         * countries dollar will not work. Do your own parsing if you need correct handling of currency amounts
+         * with locale-sensitive handling.
+         *
+         * @throws IllegalArgumentException if the input string was not understood.
+         */
+        fun parseCurrency(input: String): Amount<Currency> {
+            val i = input.filter { it != ',' }
+            try {
+                // First check the symbols at the front.
+                for ((symbol, currency) in currencySymbols) {
+                    if (i.startsWith(symbol)) {
+                        val rest = i.substring(symbol.length)
+                        return fromDecimal(BigDecimal(rest), currency)
+                    }
+                }
+                // Now check the codes at the end.
+                val split = i.split(' ')
+                if (split.size == 2) {
+                    val (rest, code) = split
+                    for ((cc, currency) in currencyCodes) {
+                        if (cc == code) {
+                            return fromDecimal(BigDecimal(rest), currency)
+                        }
+                    }
+                }
+            } catch(e: Exception) {
+                throw IllegalArgumentException("Could not parse $input as a currency", e)
+            }
+            throw IllegalArgumentException("Did not recognise the currency in $input or could not parse")
+        }
     }
 
     init {

--- a/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
@@ -23,4 +23,12 @@ class AmountTests {
         assertEquals(expected, amount.toDecimal())
         assertEquals(amount, Amount.fromDecimal(amount.toDecimal(), amount.token))
     }
+
+    @Test
+    fun parsing() {
+        assertEquals(Amount(1234L, GBP), Amount.parseCurrency("£12.34"))
+        assertEquals(Amount(1200L, GBP), Amount.parseCurrency("£12"))
+        assertEquals(Amount(1000L, USD), Amount.parseCurrency("$10"))
+        assertEquals(Amount(1500000000L, CHF), Amount.parseCurrency("15,000,000 CHF"))
+    }
 }

--- a/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
@@ -29,6 +29,14 @@ class AmountTests {
         assertEquals(Amount(1234L, GBP), Amount.parseCurrency("£12.34"))
         assertEquals(Amount(1200L, GBP), Amount.parseCurrency("£12"))
         assertEquals(Amount(1000L, USD), Amount.parseCurrency("$10"))
+        assertEquals(Amount(5000L, JPY), Amount.parseCurrency("¥5000"))
+        assertEquals(Amount(500000L, RUB), Amount.parseCurrency("₽5000"))
         assertEquals(Amount(1500000000L, CHF), Amount.parseCurrency("15,000,000 CHF"))
+    }
+
+    @Test
+    fun rendering() {
+        assertEquals("5000 JPY", Amount.parseCurrency("¥5000").toString())
+        assertEquals("50.12 USD", Amount.parseCurrency("$50.12").toString())
     }
 }


### PR DESCRIPTION
The symbols are just conveniences (they are ambiguous so would not normally be used in pro-level apps).