### PR TITLE
Allow escaped unsubscribed RPC Observables to be GC'd

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/messaging/CordaRPCClientImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/CordaRPCClientImpl.kt
@@ -306,7 +306,7 @@ class CordaRPCClientImpl(private val session: ClientSession,
          *
          * val observationsSubject = PublishSubject.create<Observation>()
          * originalObservable.subscribe(observationsSubject)
-         * return observationSubject
+         * return observationsSubject
          */
         private fun refCountUp() {
             if(referenceCount.andIncrement == 0) {
@@ -334,7 +334,7 @@ class CordaRPCClientImpl(private val session: ClientSession,
                  * The buffer -> dematerialize order ensures that the Observable may not unsubscribe until the caller
                  * subscribes, which must be after full deserialisation and registering of all top level Observables.
                  *
-                 * In addition, when subscribe and unsubscribe is call on the [Observable] returned here, we
+                 * In addition, when subscribe and unsubscribe is called on the [Observable] returned here, we
                  * reference count a hard reference to this [QueuedObservable] to prevent premature GC.
                  */
                 rootShared.filter { it.forHandle == handle }.map { it.what }.bufferUntilSubscribed().dematerialize<Any>().doOnSubscribe { refCountUp() }.doOnUnsubscribe { refCountDown() }.share()


### PR DESCRIPTION
We had a warning in place to remind folks to `subscribe().unsubscribe()` from `Observables` returned from RPC.  That warning could never happen though, as the RPC layer held two strong references. Once in the consumer message handler and another in the cache of `Observers`.  I made both of these weak, but then we had a failing test due to early GC.  I created a work around to that using reference counting.  Hopefully the comments explain this.

Also noticed a typo.