### PR TITLE
Ensure Node uses only a single version of Netty.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
     ext.guava_version = '19.0'
     ext.quickcheck_version = '0.7'
     ext.okhttp_version = '3.5.0'
+    ext.netty_version = '4.1.5.Final'
     ext.typesafe_config_version = '1.3.1'
     ext.junit_version = '4.12'
     ext.jopt_simple_version = '5.0.2'

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -151,7 +151,7 @@ dependencies {
     compile 'io.atomix.catalyst:catalyst-netty:1.1.2'
 
     // Netty: All of it.
-    compile group: 'io.netty', name: 'netty-all', version: netty_version
+    compile "io.netty:netty-all:$netty_version"
 
     // OkHTTP: Simple HTTP library.
     compile "com.squareup.okhttp3:okhttp:$okhttp_version"

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -23,6 +23,12 @@ configurations {
     // we don't want isolated.jar in classPath, since we want to test jar being dynamically loaded as an attachment
     runtime.exclude module: 'isolated'
 
+    compile {
+        // We don't need these because we already include netty-all.
+        exclude group: 'io.netty', module: 'netty-transport'
+        exclude group: 'io.netty', module: 'netty-handler'
+    }
+
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
 }
@@ -142,7 +148,10 @@ dependencies {
     // Java Atomix: RAFT library
     compile 'io.atomix.copycat:copycat-client:1.1.4'
     compile 'io.atomix.copycat:copycat-server:1.1.4'
-    compile 'io.atomix.catalyst:catalyst-netty:1.1.1'
+    compile 'io.atomix.catalyst:catalyst-netty:1.1.2'
+
+    // Netty: All of it.
+    compile group: 'io.netty', name: 'netty-all', version: netty_version
 
     // OkHTTP: Simple HTTP library.
     compile "com.squareup.okhttp3:okhttp:$okhttp_version"


### PR DESCRIPTION
See issue #342 
Upgrade to Catalyst 1.1.2, which also depends on Netty 4.1.5.Final.
Once both Catalyst and Artemis depend on the same version of Netty, we can remove the individual netty modules in favour of `netty-all` (as requested by Artemis).