### PR TITLE
 Lazy NodeVaultService.states

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -203,15 +203,15 @@ interface VaultService {
                       onlyFromParties: Set<AbstractParty>? = null): Pair<TransactionBuilder, List<CompositeKey>>
 
     /**
-     * Return [ContractState]s of a given [Contract] type and list of [Vault.StateStatus]
+     * Return [ContractState]s of a given [Contract] type an [Iterable] of [Vault.StateStatus]
      */
-    fun <T : ContractState> states(clazzes: Set<Class<T>>, statuses: EnumSet<Vault.StateStatus>): List<StateAndRef<T>>
+    fun <T : ContractState> states(clazzes: Set<Class<T>>, statuses: EnumSet<Vault.StateStatus>): Iterable<StateAndRef<T>>
 }
 
-inline fun <reified T: ContractState> VaultService.unconsumedStates(): List<StateAndRef<T>> =
+inline fun <reified T: ContractState> VaultService.unconsumedStates(): Iterable<StateAndRef<T>> =
         states(setOf(T::class.java), EnumSet.of(Vault.StateStatus.UNCONSUMED))
 
-inline fun <reified T: ContractState> VaultService.consumedStates(): List<StateAndRef<T>> =
+inline fun <reified T: ContractState> VaultService.consumedStates(): Iterable<StateAndRef<T>> =
         states(setOf(T::class.java), EnumSet.of(Vault.StateStatus.CONSUMED))
 
 /** Returns the [linearState] heads only when the type of the state would be considered an 'instanceof' the given type. */

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -203,7 +203,7 @@ interface VaultService {
                       onlyFromParties: Set<AbstractParty>? = null): Pair<TransactionBuilder, List<CompositeKey>>
 
     /**
-     * Return [ContractState]s of a given [Contract] type an [Iterable] of [Vault.StateStatus]
+     * Return [ContractState]s of a given [Contract] type and [Iterable] of [Vault.StateStatus].
      */
     fun <T : ContractState> states(clazzes: Set<Class<T>>, statuses: EnumSet<Vault.StateStatus>): Iterable<StateAndRef<T>>
 }

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -165,11 +165,11 @@ class ContractUpgradeFlowTest {
         // Starts contract upgrade flow.
         a.services.startFlow(ContractUpgradeFlow.Instigator(stateAndRef, CashV2::class.java))
         mockNet.runNetwork()
-        // Get contract state form the vault.
-        val state = databaseTransaction(a.database) { a.vault.unconsumedStates<ContractState>() }
-        assertTrue(state.single().state.data is CashV2.State, "Contract state is upgraded to the new version.")
-        assertEquals(Amount(1000000, USD).`issued by`(a.info.legalIdentity.ref(1)), (state.first().state.data as CashV2.State).amount, "Upgraded cash contain the correct amount.")
-        assertEquals(listOf(a.info.legalIdentity.owningKey), (state.first().state.data as CashV2.State).owners, "Upgraded cash belongs to the right owner.")
+        // Get contract state from the vault.
+        val states = databaseTransaction(a.database) { a.vault.unconsumedStates<ContractState>().toList() }
+            assertTrue(states.single().state.data is CashV2.State, "Contract state is upgraded to the new version.")
+            assertEquals(Amount(1000000, USD).`issued by`(a.info.legalIdentity.ref(1)), (states.first().state.data as CashV2.State).amount, "Upgraded cash contain the correct amount.")
+            assertEquals(listOf(a.info.legalIdentity.owningKey), (states.first().state.data as CashV2.State).owners, "Upgraded cash belongs to the right owner.")
     }
 
     class CashV2 : UpgradedContract<Cash.State, CashV2.State> {

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -166,10 +166,10 @@ class ContractUpgradeFlowTest {
         a.services.startFlow(ContractUpgradeFlow.Instigator(stateAndRef, CashV2::class.java))
         mockNet.runNetwork()
         // Get contract state from the vault.
-        val states = databaseTransaction(a.database) { a.vault.unconsumedStates<ContractState>().toList() }
-            assertTrue(states.single().state.data is CashV2.State, "Contract state is upgraded to the new version.")
-            assertEquals(Amount(1000000, USD).`issued by`(a.info.legalIdentity.ref(1)), (states.first().state.data as CashV2.State).amount, "Upgraded cash contain the correct amount.")
-            assertEquals(listOf(a.info.legalIdentity.owningKey), (states.first().state.data as CashV2.State).owners, "Upgraded cash belongs to the right owner.")
+        val firstState = databaseTransaction(a.database) { a.vault.unconsumedStates<ContractState>().single() }
+        assertTrue(firstState.state.data is CashV2.State, "Contract state is upgraded to the new version.")
+        assertEquals(Amount(1000000, USD).`issued by`(a.info.legalIdentity.ref(1)), (firstState.state.data as CashV2.State).amount, "Upgraded cash contain the correct amount.")
+        assertEquals(listOf(a.info.legalIdentity.owningKey), (firstState.state.data as CashV2.State).owners, "Upgraded cash belongs to the right owner.")
     }
 
     class CashV2 : UpgradedContract<Cash.State, CashV2.State> {

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -78,7 +78,7 @@ class CashTests {
             services.fillWithSomeTestCash(howMuch = 80.SWISS_FRANCS, atLeastThisManyStates = 1, atMostThisManyStates = 1,
                     issuedBy = MINI_CORP.ref(1), issuerKey = MINI_CORP_KEY, ownedBy = OUR_PUBKEY_1)
 
-            vaultStatesUnconsumed = services.vaultService.unconsumedStates<Cash.State>()
+            vaultStatesUnconsumed = services.vaultService.unconsumedStates<Cash.State>().toList()
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -165,7 +165,7 @@ class NodeVaultService(private val services: ServiceHub, dataSourceProperties: P
                 Sequence{iterator}
                         .map { it ->
                             val stateRef = StateRef(SecureHash.parse(it.txId), it.index)
-                            // TODO: revisit Kryo bug when using THREAD_LOCAL_KYRO
+                            // TODO: revisit Kryo bug when using THREAD_LOCAL_KRYO
                             val state = it.contractState.deserialize<TransactionState<T>>(createKryo())
                             StateAndRef(state, stateRef)
                         }

--- a/node/src/test/kotlin/net/corda/node/services/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NodeVaultServiceTest.kt
@@ -102,7 +102,7 @@ class NodeVaultServiceTest {
             }
             services1.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
 
-            val w1 = services1.vaultService.unconsumedStates<Cash.State>()
+            val w1 = services1.vaultService.unconsumedStates<Cash.State>().toList()
             assertThat(w1).hasSize(3)
 
             val stateRefs = listOf(w1[1].ref, w1[2].ref)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
@@ -56,7 +56,6 @@ class DataVendingServiceTests {
             // Check the transaction is in the receiving node
             val actual = vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>().singleOrNull()
             val expected = tx.tx.outRef<Cash.State>(0)
-
             assertEquals(expected, actual)
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
@@ -17,6 +17,7 @@ import net.corda.node.utilities.databaseTransaction
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -48,7 +49,7 @@ class DataVendingServiceTests {
         ptx.signWith(registerKey)
         val tx = ptx.toSignedTransaction()
         databaseTransaction(vaultServiceNode.database) {
-            assertEquals(0, vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>().size)
+            assertThat(vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>()).isEmpty()
 
             registerNode.sendNotifyTx(tx, vaultServiceNode)
 
@@ -79,12 +80,12 @@ class DataVendingServiceTests {
         ptx.signWith(registerKey)
         val tx = ptx.toSignedTransaction(false)
         databaseTransaction(vaultServiceNode.database) {
-            assertEquals(0, vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>().size)
+            assertThat(vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>()).isEmpty()
 
             registerNode.sendNotifyTx(tx, vaultServiceNode)
 
             // Check the transaction is not in the receiving node
-            assertEquals(0, vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>().size)
+            assertThat(vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>()).isEmpty()
         }
     }
 


### PR DESCRIPTION
Change return type to `Iterable` that is actually backed by a `Sequence` to achieve lazy state loading from Vault's DB. Both `VaultService.unconsumedStates()` and `VaultService.consumedStates()` have been affected. Unit-tests are aligned to reflect this change. No changes seem to be required on corda-tutorial and corda-template, respectively.