### PR TITLE
Refactor use of SLF4J's dependencies in Gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
     ext.jersey_version = '2.25'
     ext.jolokia_version = '2.0.0-M3'
     ext.assertj_version = '3.6.1'
+    ext.slf4j_version = '1.7.22'
     ext.log4j_version = '2.7'
     ext.bouncycastle_version = '1.56'
     ext.guava_version = '19.0'

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -47,10 +47,6 @@ dependencies {
     compile project(":core")
     compile project(':node')
 
-    // Log4J: logging framework (with SLF4J bindings)
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
-    compile "org.apache.logging.log4j:log4j-core:${log4j_version}"
-
     compile "com.google.guava:guava:$guava_version"
 
     // ReactFX: Functional reactive UI programming.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,9 +50,11 @@ dependencies {
     // Thread safety annotations
     compile "com.google.code.findbugs:jsr305:3.0.1"
 
-    // Log4J: logging framework (with SLF4J bindings)
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
+    // Log4J: logging framework (ONLY explicitly referenced by net.corda.core.utilities.Logging.kt)
     compile "org.apache.logging.log4j:log4j-core:${log4j_version}"
+
+    // SLF4J: commons-logging bindings for a SLF4J back end
+    compile "org.slf4j:jcl-over-slf4j:$slf4j_version"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:${assertj_version}"
@@ -92,4 +94,10 @@ dependencies {
 
     // Requery: SQL based query & persistence for Kotlin
     compile "io.requery:requery-kotlin:$requery_version"
+}
+
+configurations.compile {
+    // We want to use SLF4J's version of these binding: jcl-over-slf4j
+    // Remove any transitive dependency on Apache's version.
+    exclude group: 'commons-logging', module: 'commons-logging'
 }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -59,7 +59,6 @@ dependencies {
 
     // Log4J: logging framework (with SLF4J bindings)
     compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
-    compile "org.apache.logging.log4j:log4j-core:${log4j_version}"
     compile "org.apache.logging.log4j:log4j-web:${log4j_version}"
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -92,8 +91,6 @@ dependencies {
     // TODO: Remove this dependency and the code that requires it
     compile "commons-fileupload:commons-fileupload:1.3.2"
 
-    // Force commons logging to version 1.2 to override Artemis, which pulls in 1.1.3 (ARTEMIS-424)
-    compile "commons-logging:commons-logging:1.2"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
 
     // Coda Hale's Metrics: for monitoring of key statistics
@@ -145,6 +142,12 @@ dependencies {
 
     // Integration test helpers
     integrationTestCompile "junit:junit:$junit_version"
+}
+
+configurations.compile {
+    // We want to use SLF4J's version of these binding: jcl-over-slf4j
+    // Remove any transitive dependency on Apache's version.
+    exclude group: 'commons-logging', module: 'commons-logging'
 }
 
 task integrationTest(type: Test) {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -28,18 +28,11 @@ dependencies {
     compile project(':node')
     compile project(':node:webserver')
 
-    // Log4J: logging framework (with SLF4J bindings)
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
-    compile "org.apache.logging.log4j:log4j-core:${log4j_version}"
-
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
     compile "com.google.guava:guava:$guava_version"
-
-    // Force commons logging to version 1.2 to override Artemis, which pulls in 1.1.3 (ARTEMIS-424)
-    compile "commons-logging:commons-logging:1.2"
 
     // Unit testing helpers.
     compile "junit:junit:$junit_version"
@@ -49,4 +42,10 @@ dependencies {
 
     // OkHTTP: Simple HTTP library.
     compile "com.squareup.okhttp3:okhttp:$okhttp_version"
+}
+
+configurations.compile {
+    // We want to use SLF4J's version of these bindings: jcl-over-slf4j
+    // Remove any transitive dependency on Apache's version.
+    exclude group: 'commons-logging', module: 'commons-logging'
 }


### PR DESCRIPTION
Corda uses the SLF4J logging API with Log4j2 as the sole SLF4J back-end. We therefore need to exclude Apache's `commons-logging:commons-logging` module in favour of SL4J's own `jcl-over-slf4j` module so that JARs using the `common-logging` API will integrate with SLF4J correctly.

As a rule, only Corda application modules (e.g. Node) should include an explicit dependency on Log4j2. The library modules should only require SLF4J.