### PR TITLE
Use the project's version of Kotlin to build Explorer.

### DIFF
--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.0.3'
-
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 repositories {
     mavenCentral()
     maven {


### PR DESCRIPTION
Node Explorer does not need to use Kotlin 1.0.3, and can use 1.0.6 like the rest of Corda.