### PR TITLE
ANSIProgressObserver memory leak

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/ANSIProgressObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ANSIProgressObserver.kt
@@ -40,6 +40,7 @@ class ANSIProgressObserver(val smm: StateMachineManager) {
 
     private fun removeFlowLogic(flowLogic: FlowLogic<*>) {
         state.locked {
+            pending.remove(flowLogic)
             if (currentlyRendering == flowLogic) {
                 wireUpProgressRendering()
             }


### PR DESCRIPTION
ArrayDeque FlowLogic references were not being removed on flow termination
Identified this memory leak in YourKitProfiler upon load testing soft locking.