### PR TITLE
Add public host discovery to Node startup

### DIFF
--- a/core/src/main/kotlin/net/corda/core/messaging/Messaging.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/Messaging.kt
@@ -190,6 +190,8 @@ interface Message {
 interface ReceivedMessage : Message {
     /** The authenticated sender. */
     val peer: X500Name
+    /** The remote host name of the sender. */
+    val originHost: String?
 }
 
 /** A singleton that's useful for validating topic strings */

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingComponent.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingComponent.kt
@@ -42,6 +42,7 @@ abstract class ArtemisMessagingComponent() : SingletonSerializeAsToken() {
         const val RPC_QUEUE_REMOVALS_QUEUE = "rpc.qremovals"
         const val NOTIFICATIONS_ADDRESS = "${INTERNAL_PREFIX}activemq.notifications"
         const val NETWORK_MAP_QUEUE = "${INTERNAL_PREFIX}networkmap"
+        const val UNREGISTERED_PEERS_PREFIX = "${INTERNAL_PREFIX}peers.unregistered."
 
         const val VERIFY_PEER_COMMON_NAME = "corda.verifyPeerCommonName"
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingComponent.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingComponent.kt
@@ -42,7 +42,7 @@ abstract class ArtemisMessagingComponent() : SingletonSerializeAsToken() {
         const val RPC_QUEUE_REMOVALS_QUEUE = "rpc.qremovals"
         const val NOTIFICATIONS_ADDRESS = "${INTERNAL_PREFIX}activemq.notifications"
         const val NETWORK_MAP_QUEUE = "${INTERNAL_PREFIX}networkmap"
-        const val UNREGISTERED_PEERS_PREFIX = "${INTERNAL_PREFIX}peers.unregistered."
+        const val UNREGISTERED_PEERS_PREFIX = "${INTERNAL_PREFIX}unregistered."
 
         const val VERIFY_PEER_COMMON_NAME = "corda.verifyPeerCommonName"
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/HostDiscoveryInterceptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/HostDiscoveryInterceptor.kt
@@ -1,0 +1,26 @@
+package net.corda.node.services.messaging
+
+import net.corda.node.services.network.NetworkMapService
+import org.apache.activemq.artemis.api.core.Interceptor
+import org.apache.activemq.artemis.api.core.Message
+import org.apache.activemq.artemis.core.protocol.core.Packet
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionSendMessage
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
+
+/**
+ * Intercepts session messages containing the public address discovery topic and
+ * and adds a property specifying the origin host.
+ */
+class HostDiscoveryInterceptor : Interceptor {
+    override fun intercept(packet: Packet, connection: RemotingConnection): Boolean {
+        if (packet is SessionSendMessage && isHostDiscovery(packet.message)) {
+            val remoteHost = extractHost(connection.remoteAddress)
+            packet.message.putStringProperty("originHost", remoteHost)
+        }
+        return true
+    }
+
+    private fun isHostDiscovery(message: Message) = message.getStringProperty(NodeMessagingClient.TOPIC_PROPERTY) == NetworkMapService.DISCOVER_HOST_TOPIC
+    // TODO: handle IP6
+    private fun extractHost(address: String) = address.split("/", ":")[1]
+}

--- a/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -276,7 +276,7 @@ class InMemoryMessagingNetwork(
     }
 
     @CordaSerializable
-    private data class InMemoryReceivedMessage(override val topicSession: TopicSession, override val data: ByteArray, override val uniqueMessageId: UUID, override val debugTimestamp: Instant, override val peer: X500Name) : ReceivedMessage
+    private data class InMemoryReceivedMessage(override val topicSession: TopicSession, override val data: ByteArray, override val uniqueMessageId: UUID, override val debugTimestamp: Instant, override val peer: X500Name, override val originHost: String) : ReceivedMessage
 
     /**
      * An [InMemoryMessaging] provides a [MessagingService] that isn't backed by any kind of network or disk storage
@@ -452,6 +452,6 @@ class InMemoryMessagingNetwork(
         private fun MessageTransfer.toReceivedMessage(): ReceivedMessage = InMemoryReceivedMessage(
                 message.topicSession,
                 message.data.copyOf(), // Kryo messes with the buffer so give each client a unique copy
-                message.uniqueMessageId, message.debugTimestamp, X509Utilities.getDevX509Name(sender.description))
+                message.uniqueMessageId, message.debugTimestamp, X509Utilities.getDevX509Name(sender.description), "localhost")
     }
 }


### PR DESCRIPTION
If no public host is specified for the message broker, the node requests it from the network map service, updates its NodeInfo accordingly, and proceeds with network map registration.

On the network map service side, the public host detection is done by intercepting Artemis message packets that contain the relevant topic and appending a string property with the remote host.

The reason we need two roundtrips is that the network map service distributes NodeInfos signed by the respective nodes, and it cannot just swap out a node's advertised address with the real public one.

This approach involves a couple of "tricks" that might be slightly controversial, but the only other option I could come up with is having the network map service run a dedicated ip detection web server, which I think would introduce too much extra maintenance..

Some more testing & polishing is still needed, but I want to get some feedback before proceeding.
