### PR TITLE
DEFAULT_MAX_BUCKETS based on max heap size

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
@@ -26,7 +26,7 @@ import kotlin.system.measureTimeMillis
  * TODO: make this value configurable
  * TODO: tune this value, as it's currently mostly a guess
  */
-val DEFAULT_MAX_BUCKETS = (256 * (1 + Math.max(0, Runtime.getRuntime().maxMemory() - 128) / 64)).toInt()
+val DEFAULT_MAX_BUCKETS = (256 * (1 + Math.max(0, (Runtime.getRuntime().maxMemory() - 128) / 64))).toInt()
 
 /**
  * A convenient JDBC table backed hash map with iteration order based on insertion order.

--- a/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
@@ -26,7 +26,7 @@ import kotlin.system.measureTimeMillis
  * TODO: make this value configurable
  * TODO: tune this value, as it's currently mostly a guess
  */
-val DEFAULT_MAX_BUCKETS = (256 * (1 + Math.max(0, (Runtime.getRuntime().maxMemory() - 128) / 64))).toInt()
+val DEFAULT_MAX_BUCKETS = (256 * (1 + Math.max(0, (Runtime.getRuntime().maxMemory()/1000000 - 128) / 64))).toInt()
 
 /**
  * A convenient JDBC table backed hash map with iteration order based on insertion order.

--- a/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
@@ -21,11 +21,12 @@ import kotlin.system.measureTimeMillis
 
 /**
  * The default maximum size of the LRU cache.
+ * Current computation is linear to max heap size, ensuring a minimum of 256 buckets.
  *
  * TODO: make this value configurable
  * TODO: tune this value, as it's currently mostly a guess
  */
-val DEFAULT_MAX_BUCKETS = 4096
+val DEFAULT_MAX_BUCKETS = (256 * (1 + Math.max(0, Runtime.getRuntime().maxMemory() - 128) / 64)).toInt()
 
 /**
  * A convenient JDBC table backed hash map with iteration order based on insertion order.


### PR DESCRIPTION
formula used: `DEFAULT_MAX_BUCKETS = 256 * ( 1 + MAX(0, (maxHeapSize - 128) / 64))`

Two slightly different approaches have also been tested, here is the comparison chart:
![defaultmaxbuckets_vs_maxheapsize](https://cloud.githubusercontent.com/assets/25659162/24000269/b3e04a68-0a52-11e7-85e1-b5093047ac29.jpg)
