### PR TITLE
Fix to prevent node dropping and re-creating Requery tables on startup

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/database/RequeryConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/database/RequeryConfiguration.kt
@@ -38,7 +38,7 @@ class RequeryConfiguration(val properties: Properties, val useDefaultLogging: Bo
     fun makeSessionFactoryForModel(model: EntityModel): KotlinEntityDataStore<Persistable> {
         val configuration = KotlinConfigurationTransactionWrapper(model, dataSource, useDefaultLogging = this.useDefaultLogging)
         val tables = SchemaModifier(configuration)
-        val mode = TableCreationMode.DROP_CREATE
+        val mode = TableCreationMode.CREATE_NOT_EXISTS
         tables.createTables(mode)
         return KotlinEntityDataStore(configuration)
     }


### PR DESCRIPTION
RequeryConfiguration setting for table creation is now CREATE_NOT_EXISTS (was DROP_CREATE)