### PR TITLE
ANSIProgressRenderer - using the first console appender Vs single

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/ANSIProgressRenderer.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ANSIProgressRenderer.kt
@@ -62,7 +62,7 @@ object ANSIProgressRenderer {
             // than doing things the official way with a dedicated plugin, etc, as it avoids mucking around with all
             // the config XML and lifecycle goop.
             val manager = LogManager.getContext(false) as LoggerContext
-            val consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().single()
+            val consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().first()
             val scrollingAppender = object : AbstractOutputStreamAppender<OutputStreamManager>(
                     consoleAppender.name, consoleAppender.layout, consoleAppender.filter,
                     consoleAppender.ignoreExceptions(), true, consoleAppender.manager) {


### PR DESCRIPTION
A small fix to ANSIProgressRenderer required due to the existence of multiple console appenders, causing `filterIsInstance<ConsoleAppender>().single()` to fail when running from console Vs IntelliJ.