### PR TITLE
Extend identity service tests

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -6,6 +6,8 @@ import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
 import net.corda.core.node.services.IdentityService
 import net.corda.core.serialization.SingletonSerializeAsToken
+import net.corda.core.utilities.loggerFor
+import net.corda.core.utilities.trace
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.annotation.concurrent.ThreadSafe
@@ -15,10 +17,15 @@ import javax.annotation.concurrent.ThreadSafe
  */
 @ThreadSafe
 class InMemoryIdentityService() : SingletonSerializeAsToken(), IdentityService {
+    companion object {
+        private val log = loggerFor<InMemoryIdentityService>()
+    }
+
     private val keyToParties = ConcurrentHashMap<CompositeKey, Party>()
     private val nameToParties = ConcurrentHashMap<String, Party>()
 
     override fun registerIdentity(party: Party) {
+        log.trace { "Registering identity ${party}" }
         keyToParties[party.owningKey] = party
         nameToParties[party.name] = party
     }

--- a/node/src/test/kotlin/net/corda/node/services/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/InMemoryIdentityServiceTests.kt
@@ -1,10 +1,10 @@
 package net.corda.node.services
 
+import net.corda.core.crypto.Party
+import net.corda.core.crypto.composite
+import net.corda.core.crypto.generateKeyPair
 import net.corda.node.services.identity.InMemoryIdentityService
-import net.corda.testing.ALICE
-import net.corda.testing.ALICE_PUBKEY
-import net.corda.testing.BOB
-import net.corda.testing.BOB_PUBKEY
+import net.corda.testing.*
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -40,11 +40,17 @@ class InMemoryIdentityServiceTests {
     }
 
     @Test
-    fun `get identity by name`() {
+    fun `get identity by name with no registered identities`() {
         val service = InMemoryIdentityService()
         assertNull(service.partyFromName(ALICE.name))
-        service.registerIdentity(ALICE)
-        assertEquals(ALICE, service.partyFromName(ALICE.name))
-        assertNull(service.partyFromName(BOB.name))
+    }
+
+    @Test
+    fun `get identity by name`() {
+        val service = InMemoryIdentityService()
+        val identities = listOf("Node A", "Node B", "Node C").map { Party(it, generateKeyPair().public.composite) }
+        assertNull(service.partyFromName(identities.first().name))
+        identities.forEach { service.registerIdentity(it) }
+        identities.forEach { assertEquals(it, service.partyFromName(it.name)) }
     }
 }


### PR DESCRIPTION
RBS report problems with multiple nodes being able to find each other in the identity service. This extends the name lookup test case to try three nodes, to check all of the stored values, and to use random keys rather than static.