### PR TITLE
Several tests were corrupting Kryo which was then returned to the common pool.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -93,11 +93,9 @@ class CordaClassResolver(val whitelist: ClassWhitelist) : DefaultClassResolver()
                 || (type.superclass != null && hasAnnotationOnInterface(type.superclass))
     }
 
-    // Always reset, even if references are off (see superclass).
+    // Need to clear out class names from attachments.
     override fun reset() {
-        if (classToNameId != null) classToNameId.clear()
-        if (nameIdToClass != null) nameIdToClass.clear()
-        nextNameId = 0
+        super.reset()
         // Kryo creates a cache of class name to Class<*> which does not work so well with multiple class loaders.
         // TODO: come up with a more efficient way.  e.g. segregate the name space by class loader.
         if(nameToClass != null) {

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -527,11 +527,18 @@ object ReferencesAwareJavaSerializer : JavaSerializer() {
 
 val ATTACHMENT_STORAGE = "ATTACHMENT_STORAGE"
 
-var Kryo.attachmentStorage: AttachmentStorage?
+val Kryo.attachmentStorage: AttachmentStorage?
     get() = this.context.get(ATTACHMENT_STORAGE, null) as AttachmentStorage?
-    set(value) {
-        this.context.put(ATTACHMENT_STORAGE, value)
+
+fun <T> Kryo.withAttachmentStorage(attachmentStorage: AttachmentStorage?, block: () -> T): T {
+    val priorAttachmentStorage = this.attachmentStorage
+    this.context.put(ATTACHMENT_STORAGE, attachmentStorage)
+    try {
+        return block()
+    } finally {
+        this.context.put(ATTACHMENT_STORAGE, priorAttachmentStorage)
     }
+}
 
 object OrderedSerializer : Serializer<HashMap<Any, Any>>() {
     override fun write(kryo: Kryo, output: Output, obj: HashMap<Any, Any>) {

--- a/core/src/test/kotlin/net/corda/core/node/AttachmentClassLoaderTests.kt
+++ b/core/src/test/kotlin/net/corda/core/node/AttachmentClassLoaderTests.kt
@@ -83,14 +83,9 @@ class AttachmentClassLoaderTests {
 
     @Before
     fun setup() {
+        // Do not release these back to the pool, since we do some unorthodox modifications to them below.
         kryo = p2PKryo().borrow()
         kryo2 = p2PKryo().borrow()
-    }
-
-    @After
-    fun teardown() {
-        p2PKryo().release(kryo)
-        p2PKryo().release(kryo2)
     }
 
     @Test

--- a/core/src/test/kotlin/net/corda/core/node/AttachmentClassLoaderTests.kt
+++ b/core/src/test/kotlin/net/corda/core/node/AttachmentClassLoaderTests.kt
@@ -253,7 +253,18 @@ class AttachmentClassLoaderTests {
         val state2 = bytes.deserialize(kryo)
         assertEquals(cl, state2.contract.javaClass.classLoader)
         assertNotNull(state2)
+
+        // We should be able to load same class from a different class loader and have them be distinct.
+        val cl2 = AttachmentsClassLoader(arrayOf(att0, att1, att2).map { storage.openAttachment(it)!! }, FilteringClassLoader)
+
+        kryo.classLoader = cl2
+        kryo.addToWhitelist(Class.forName("net.corda.contracts.isolated.AnotherDummyContract", true, cl2))
+
+        val state3 = bytes.deserialize(kryo)
+        assertEquals(cl2, state3.contract.javaClass.classLoader)
+        assertNotNull(state3)
     }
+
 
     @Test
     fun `test serialization of WireTransaction with statically loaded contract`() {

--- a/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
@@ -10,6 +10,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.slf4j.LoggerFactory
 import java.io.InputStream
@@ -25,12 +26,8 @@ class KryoTests {
 
     @Before
     fun setup() {
+        // We deliberately do not return this, since we do some unorthodox registering below and do not want to pollute the pool.
         kryo = p2PKryo().borrow()
-    }
-
-    @After
-    fun teardown() {
-        p2PKryo().release(kryo)
     }
 
     @Test

--- a/node/src/main/kotlin/net/corda/node/serialization/DefaultWhitelist.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/DefaultWhitelist.kt
@@ -6,6 +6,7 @@ import net.corda.core.node.CordaPluginRegistry
 import net.corda.core.serialization.SerializationCustomization
 import org.apache.activemq.artemis.api.core.SimpleString
 import rx.Notification
+import rx.exceptions.OnErrorNotImplementedException
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.Period
@@ -49,6 +50,7 @@ class DefaultWhitelist : CordaPluginRegistry() {
             addToWhitelist(LocalDate::class.java)
             addToWhitelist(Period::class.java)
             addToWhitelist(BitSet::class.java)
+            addToWhitelist(OnErrorNotImplementedException::class.java)
         }
         return true
     }


### PR DESCRIPTION
1. Stop returning meddled with Kryo's to the common pool in two sets of tests.
1. Kryo has a cache of class names to class instances that is incompatible with attachments.  Created a workaround and associated unit test.
1. Do not allow an attachment storage instance to be associated with a Kryo beyond the necessary scope.
1. Whilst investigating, found a class that needed to be on the serialisation whitelist.