### PR TITLE
Fix intermittent BindException test failures.

### DIFF
--- a/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -15,7 +15,6 @@ import net.corda.node.services.config.FullNodeConfiguration
 import net.corda.node.services.transactions.RaftValidatingNotaryService
 import net.corda.node.utilities.ServiceIdentityGenerator
 import net.corda.testing.MOCK_NODE_VERSION_INFO
-import net.corda.testing.freeLocalHostAndPort
 import net.corda.testing.getFreeLocalPorts
 import org.junit.After
 import org.junit.Rule
@@ -116,13 +115,14 @@ abstract class NodeBasedTest {
                                   rpcUsers: List<User>,
                                   configOverrides: Map<String, Any>): Node {
         val baseDirectory = (tempFolder.root.toPath() / legalName).createDirectories()
+        val localPort = getFreeLocalPorts("localhost", 2)
         val config = ConfigHelper.loadConfig(
                 baseDirectory = baseDirectory,
                 allowMissingConfig = true,
                 configOverrides = mapOf(
                         "myLegalName" to legalName,
-                        "p2pAddress" to freeLocalHostAndPort().toString(),
-                        "rpcAddress" to freeLocalHostAndPort().toString(),
+                        "p2pAddress" to localPort[0].toString(),
+                        "rpcAddress" to localPort[1].toString(),
                         "extraAdvertisedServiceIds" to advertisedServices.map { it.toString() },
                         "rpcUsers" to rpcUsers.map {
                             mapOf(


### PR DESCRIPTION
Ever since the RPC port split, the `CordaRPCClientTest` has experienced intermittent failures:

```
java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method)
```

Stop allocating multiple local ports using `freeLocalHostAndPort()` method, because this is unsafe. Use `getFreeLocalPorts()` instead.