### PR TITLE
Explicit dependency on SLF4J API, to help IntelliJ.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
     // SLF4J: commons-logging bindings for a SLF4J back end
     compile "org.slf4j:jcl-over-slf4j:$slf4j_version"
+    compile "org.slf4j:slf4j-api:$slf4j_version"
 
     // AssertJ: for fluent assertions for testing
     testCompile "org.assertj:assertj-core:${assertj_version}"


### PR DESCRIPTION
Stop relying on `jcl-over-slf4j`'s transitive dependency on `slf4j-api` because this can confuse IntelliJ.