### PR TITLE
Use tmux instead of xterm in runnodes, if available

### DIFF
--- a/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
+++ b/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
@@ -52,9 +52,17 @@ else
     for dir in `ls`; do
         if [ -d $dir ]; then
             pushd $dir >/dev/null
-            xterm -T "`basename $dir`" -e './NODEJAR_NAME' &
+            if [ -n "$TMUX" ]; then
+                tmux new-window 'java -jar NODEJAR_NAME'
+            else
+                xterm -T "`basename $dir`" -e 'java -jar NODEJAR_NAME' &
+            fi
             if [[ "${NO_WEB_SERVER:-}" == "" ]]; then
-                xterm -T "`basename $dir` Web Server" -e 'java -jar WEBJAR_NAME' &
+                if [ -n "$TMUX" ]; then
+                    tmux new-window 'java -jar WEBJAR_NAME'
+                else
+                    xterm -T "`basename $dir` Web Server" -e 'java -jar WEBJAR_NAME' &
+                fi
             fi
             popd >/dev/null
         fi


### PR DESCRIPTION
Hello, this is a small proposed improvement to the `runnodes` script. When running the CLI demos on a remote Linux VM (e.g. via ssh), the `xterm` command is often not available. This change will check if the script is running within a tmux session and use a `tmux new-window` command if that is the case. 

Tested using the Trader demo.