### PR TITLE
Generated files in node-schemas are now correctly identified by IntelliJ

### DIFF
--- a/node-schemas/build.gradle
+++ b/node-schemas/build.gradle
@@ -1,8 +1,13 @@
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'idea'
 apply plugin: 'net.corda.plugins.publish-utils'
 
 description 'Corda node database schemas'
+
+buildscript {
+    ext.generatedSourcesDir = "${projectDir}/generated/source/kapt/main"
+}
 
 repositories {
     mavenLocal()
@@ -26,7 +31,7 @@ sourceSets {
     }
     generated {
         java {
-            srcDir "${projectDir}/generated/source/kapt/main/"
+            srcDir generatedSourcesDir
             compileClasspath += sourceSets.main.compileClasspath + sourceSets.main.output
         }
     }
@@ -75,4 +80,10 @@ project.afterEvaluate {
 
 jar {
     from sourceSets.generated.output
+}
+
+idea {
+    module {
+        sourceDirs += project.sourceSets.generated.allSource
+    }
 }


### PR DESCRIPTION
Reason: This fixes the compile issues with IntelliJ.