### PR TITLE
Minor: Fix isValidatingNotary check

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -111,7 +111,11 @@ interface NetworkMapCache {
 
     /** Checks whether a given party is an advertised validating notary identity */
     fun isValidatingNotary(party: Party): Boolean {
-        return notaryNodes.any { it.notaryIdentity == party && it.advertisedServices.any { it.info.type.isValidatingNotary() }}
+        val notary = notaryNodes.firstOrNull { it.notaryIdentity == party }
+                ?: throw IllegalArgumentException("No notary found with identity $party. This is most likely caused " +
+                "by using the notary node's legal identity instead of its advertised notary identity. " +
+                "Your options are: ${notaryNodes.map { "\"${it.notaryIdentity.name}\"" }.joinToString()}.")
+        return notary.advertisedServices.any { it.info.type.isValidatingNotary() }
     }
 
     /**


### PR DESCRIPTION
Fix isValidatingNotary check: throw exception if the provided party is not a notary

This will result in the client failing before sending an incorrect type of tx to the notary which leads to a more obscure error.