### PR TITLE
Use platform version of Guava for DemoBench.

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     ext.tornadofx_version = '1.6.2'
     ext.jna_version = '4.1.0'
     ext.purejavacomm_version = '0.0.17'
-    ext.guava_version = '14.0.1'
     ext.controlsfx_version = '8.40.12'
 
     ext.java_home = System.properties.'java.home'


### PR DESCRIPTION
The platform version of Guava is 19.0, which exceeds DemoBench's own requirement. So use the platform version instead.