### PR TITLE
Size of notary key in vault schema fix.

### DIFF
--- a/node-schemas/generated/source/kapt/main/net/corda/node/services/vault/schemas/VaultStatesEntity.java
+++ b/node-schemas/generated/source/kapt/main/net/corda/node/services/vault/schemas/VaultStatesEntity.java
@@ -82,7 +82,7 @@ public class VaultStatesEntity implements VaultSchema.VaultStates, Persistable {
     .setLazy(false)
     .setNullable(true)
     .setUnique(false)
-    .setDefinition("TEXT")
+    .setLength(65535)
     .build());
 
     public static final AttributeDelegate<VaultStatesEntity, String> CONTRACT_STATE_CLASS_NAME = new AttributeDelegate(

--- a/node-schemas/generated/source/kapt/main/net/corda/node/services/vault/schemas/VaultStatesEntity.java
+++ b/node-schemas/generated/source/kapt/main/net/corda/node/services/vault/schemas/VaultStatesEntity.java
@@ -82,6 +82,7 @@ public class VaultStatesEntity implements VaultSchema.VaultStates, Persistable {
     .setLazy(false)
     .setNullable(true)
     .setUnique(false)
+    .setDefinition("TEXT")
     .build());
 
     public static final AttributeDelegate<VaultStatesEntity, String> CONTRACT_STATE_CLASS_NAME = new AttributeDelegate(

--- a/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/VaultSchema.kt
+++ b/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/VaultSchema.kt
@@ -40,7 +40,7 @@ object VaultSchema {
         @get:Column(name = "notary_name")
         var notaryName: String
 
-        @get:Column(name = "notary_key", definition = "TEXT") // TODO What is the upper limit on size of CompositeKey?
+        @get:Column(name = "notary_key", length = 65535) // TODO What is the upper limit on size of CompositeKey?
         var notaryKey: String
 
         /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */

--- a/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/VaultSchema.kt
+++ b/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/VaultSchema.kt
@@ -40,7 +40,7 @@ object VaultSchema {
         @get:Column(name = "notary_name")
         var notaryName: String
 
-        @get:Column(name = "notary_key")
+        @get:Column(name = "notary_key", definition = "TEXT")
         var notaryKey: String
 
         /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */

--- a/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/VaultSchema.kt
+++ b/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/VaultSchema.kt
@@ -40,7 +40,7 @@ object VaultSchema {
         @get:Column(name = "notary_name")
         var notaryName: String
 
-        @get:Column(name = "notary_key", definition = "TEXT")
+        @get:Column(name = "notary_key", definition = "TEXT") // TODO What is the upper limit on size of CompositeKey?
         var notaryKey: String
 
         /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */


### PR DESCRIPTION
Fix in vault schema so notary_key can have more key entries in CompositeKey, as it's kept as Base58 string. Change default varchar field with size 255 to text.