### PR TITLE
Use loggerFor() function from Core.

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/DemoBench.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/DemoBench.kt
@@ -2,8 +2,6 @@ package net.corda.demobench
 
 import javafx.scene.image.Image
 import net.corda.demobench.views.DemoBenchView
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import tornadofx.App
 import tornadofx.addStageIcon
 
@@ -51,8 +49,3 @@ class DemoBench : App(DemoBenchView::class) {
         addStageIcon(Image("cordalogo.png"))
     }
 }
-
-/*
- * Trivial utility function to create SLF4J Logger.
- */
-inline fun <reified T: Any> loggerFor(): Logger = LoggerFactory.getLogger(T::class.java)

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt
@@ -1,8 +1,8 @@
 package net.corda.demobench.explorer
 
+import net.corda.core.utilities.loggerFor
 import java.io.IOException
 import java.util.concurrent.Executors
-import net.corda.demobench.loggerFor
 import net.corda.demobench.model.NodeConfig
 import net.corda.demobench.model.forceDirectory
 

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
@@ -4,7 +4,7 @@ import com.jediterm.terminal.TtyConnector
 import com.jediterm.terminal.ui.*
 import com.jediterm.terminal.ui.settings.SettingsProvider
 import com.pty4j.PtyProcess
-import net.corda.demobench.loggerFor
+import net.corda.core.utilities.loggerFor
 
 import java.awt.*
 import java.io.IOException

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
@@ -5,7 +5,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit.SECONDS
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.messaging.CordaRPCOps
-import net.corda.demobench.loggerFor
+import net.corda.core.utilities.loggerFor
 import net.corda.demobench.model.NodeConfig
 
 class NodeRPC(config: NodeConfig, start: () -> Unit, invoke: (CordaRPCOps) -> Unit): AutoCloseable {

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/web/DBViewer.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/web/DBViewer.kt
@@ -1,9 +1,9 @@
 package net.corda.demobench.web
 
+import net.corda.core.utilities.loggerFor
 import java.sql.SQLException
 import java.util.concurrent.Executors
 import kotlin.reflect.jvm.jvmName
-import net.corda.demobench.loggerFor
 import org.h2.Driver
 import org.h2.server.web.LocalWebServer
 import org.h2.tools.Server

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt
@@ -1,8 +1,8 @@
 package net.corda.demobench.web
 
+import net.corda.core.utilities.loggerFor
 import java.io.IOException
 import java.util.concurrent.Executors
-import net.corda.demobench.loggerFor
 import net.corda.demobench.model.NodeConfig
 
 class WebServer internal constructor(private val webServerController: WebServerController) : AutoCloseable {


### PR DESCRIPTION
We've removed as much of Node as we can from DemoBench, so use this function from Core rather than reimplementing it.