### PR TITLE
NodeRunner: fix OSX script. Add a delay before starting the next node.

### DIFF
--- a/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -10,6 +10,15 @@ private val nodeJarName = "corda.jar"
 private val webJarName = "corda-webserver.jar"
 private val nodeConfName = "node.conf"
 
+private val os: OS by lazy {
+    val osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
+    if ((osName.indexOf("mac") >= 0) || (osName.indexOf("darwin") >= 0)) OS.MACOS
+    else if (osName.indexOf("win") >= 0) OS.WINDOWS
+    else OS.LINUX
+}
+
+private enum class OS { MACOS, WINDOWS, LINUX }
+
 fun main(args: Array<String>) {
     val startedProcesses = mutableListOf<Process>()
     val headless = (GraphicsEnvironment.isHeadless() || (!args.isEmpty() && (args[0] == "--headless")))
@@ -22,13 +31,13 @@ fun main(args: Array<String>) {
         if (isNode(it)) {
             println("Starting node in $it")
             startedProcesses.add(runJar(nodeJarName, it, javaArgs))
-            Thread.sleep(1000)
+            if (os == OS.MACOS) Thread.sleep(1000)
         }
 
         if (isWebserver(it)) {
             println("Starting webserver in $it")
             startedProcesses.add(runJar(webJarName, it, javaArgs))
-            Thread.sleep(1000)
+            if (os == OS.MACOS) Thread.sleep(1000)
         }
     }
 
@@ -63,8 +72,8 @@ private fun execJarInTerminalWindow(jarName: String, dir: File, args: List<Strin
     val javaCmd = "java -jar $jarName " + args.joinToString(" ") { it }
     val nodeName = "${dir.toPath().fileName} $jarName"
     val osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
-    val builder = if ((osName.indexOf("mac") >= 0) || (osName.indexOf("darwin") >= 0)) {
-        ProcessBuilder(
+    val builder = when (os) {
+        OS.MACOS -> ProcessBuilder(
                 "osascript", "-e",
                 """tell app "Terminal"
     activate
@@ -73,21 +82,21 @@ private fun execJarInTerminalWindow(jarName: String, dir: File, args: List<Strin
     do script "bash -c 'cd $dir; /usr/libexec/java_home -v 1.8 --exec $javaCmd && exit'" in selected tab of the front window
 end tell"""
         )
-    } else if (osName.indexOf("win") >= 0) {
-        ProcessBuilder(
-                "cmd", "/C", "start $javaCmd"
+        OS.WINDOWS -> ProcessBuilder(
+                "cmd"
+                , "/C", "start $javaCmd"
         )
-    } else {
-        // Assume Linux
-        val isTmux = System.getenv("TMUX")?.isNotEmpty() ?: false
-        if (isTmux) {
-            ProcessBuilder(
-                    "tmux", "new-window", "-n", nodeName, javaCmd
-            )
-        } else {
-            ProcessBuilder(
-                    "xterm", "-T", nodeName, "-e", javaCmd
-            )
+        OS.LINUX -> {
+            val isTmux = System.getenv("TMUX")?.isNotEmpty() ?: false
+            if (isTmux) {
+                ProcessBuilder(
+                        "tmux", "new-window", "-n", nodeName, javaCmd
+                )
+            } else {
+                ProcessBuilder(
+                        "xterm", "-T", nodeName, "-e", javaCmd
+                )
+            }
         }
     }
     return builder.directory(dir).start()

--- a/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -22,11 +22,13 @@ fun main(args: Array<String>) {
         if (isNode(it)) {
             println("Starting node in $it")
             startedProcesses.add(runJar(nodeJarName, it, javaArgs))
+            Thread.sleep(1000)
         }
 
         if (isWebserver(it)) {
             println("Starting webserver in $it")
             startedProcesses.add(runJar(webJarName, it, javaArgs))
+            Thread.sleep(1000)
         }
     }
 
@@ -64,11 +66,12 @@ private fun execJarInTerminalWindow(jarName: String, dir: File, args: List<Strin
     val builder = if ((osName.indexOf("mac") >= 0) || (osName.indexOf("darwin") >= 0)) {
         ProcessBuilder(
                 "osascript", "-e",
-                """tell app "Terminal
-activate
-tell application \"System Events\" to tell process \"Terminal\" to keystroke \"t\" using command down
-delay 0.5
-do script "bash -c 'cd $dir; /usr/libexec/java_home -v 1.8 --exec $javaCmd && exit'" in window 1"""
+                """tell app "Terminal"
+    activate
+    tell app "System Events" to tell process "Terminal" to keystroke "t" using command down
+    delay 0.5
+    do script "bash -c 'cd $dir; /usr/libexec/java_home -v 1.8 --exec $javaCmd && exit'" in selected tab of the front window
+end tell"""
         )
     } else if (osName.indexOf("win") >= 0) {
         ProcessBuilder(


### PR DESCRIPTION
The sleep is needed so that Terminal opens every process in a new tab properly. Starting all nodes at the same time just leads to a single new tab being open..
I also think it's useful to start the nodes in order, e.g. with Raft or BFT notaries the first node has to fully initialize before all others do. 