### PR TITLE
Updated docs to refer to the latest M9.2 release.

### DIFF
--- a/docs/source/getting-set-up.rst
+++ b/docs/source/getting-set-up.rst
@@ -80,7 +80,7 @@ And a simple example CorDapp for you to explore basic concepts is available here
 You can clone these repos to your local machine by running the command ``git clone [repo URL]``.
 
 By default, these repos will be on the ``master`` branch. However, this is an unstable development branch. You should check 
-out the latest release tag instead by running ``git checkout release-M9.0``.
+out the latest release tag instead by running ``git checkout release-M9.2``.
 
 Opening Corda/CorDapps in IDEA
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ Welcome to the Corda documentation!
 ===================================
 
 .. warning:: This build of the docs is from the "|version|" branch, not a milestone release. It may not reflect the
-   current state of the code. `Read the docs for milestone release M9.0 <https://docs.corda.net/releases/release-M9.0/>`_.
+   current state of the code. `Read the docs for milestone release M9.2 <https://docs.corda.net/releases/release-M9.2/>`_.
 
 `Corda <https://www.corda.net/>`_ is an open-source distributed ledger platform. The latest *milestone* (i.e. stable)
 release is M9.2. The codebase is on `GitHub <https://github.com/corda>`_, and our community can be found on


### PR DESCRIPTION
Reason: Because otherwise the main docsite refers to an out of date release.