### PR TITLE
Create testArtifacts configuration for 'core' module.

### DIFF
--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     // This adds support for java.time types.
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
 
-    testCompile project(':core').sourceSets.test.output
+    testCompile project(path: ':core', configuration: 'testArtifacts')
     testCompile "junit:junit:$junit_version"
 
     // TODO: Upgrade to junit-quickcheck 0.8, once it is released,

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,8 +100,21 @@ dependencies {
     compile "io.requery:requery-kotlin:$requery_version"
 }
 
-configurations.compile {
-    // We want to use SLF4J's version of these binding: jcl-over-slf4j
-    // Remove any transitive dependency on Apache's version.
-    exclude group: 'commons-logging', module: 'commons-logging'
+configurations {
+    compile {
+        // We want to use SLF4J's version of these binding: jcl-over-slf4j
+        // Remove any transitive dependency on Apache's version.
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
+
+    testArtifacts.extendsFrom testRuntime
+}
+
+task testJar(type: Jar) {
+    classifier "tests"
+    from sourceSets.test.output
+}
+
+artifacts {
+    testArtifacts testJar
 }

--- a/finance/build.gradle
+++ b/finance/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile project(':core')
 
     testCompile project(':test-utils')
-    testCompile project(':core').sourceSets.test.output
+    testCompile project(path: ':core', configuration: 'testArtifacts')
     testCompile "junit:junit:$junit_version"
 
     // TODO: Upgrade to junit-quickcheck 0.8, once it is released,


### PR DESCRIPTION
Create a jar containing the `:core` project's test classes, and assign it classifier "tests" (which is the same classifier that Maven assigns to test artifacts).
Reference this test artifact in the `:client:jackson` and `:finance` modules.