### PR TITLE
Remove TERM_PROGRAM from Corda environment.

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
@@ -47,6 +47,9 @@ class R3Pty(val name: String, settings: SettingsProvider, dimension: Dimension, 
         val environment = HashMap<String, String>(envs)
         if (!UIUtil.isWindows) {
             environment["TERM"] = "xterm"
+
+            // This environment variable is specific to MacOSX.
+            environment.remove("TERM_PROGRAM")
         }
 
         val connector = createTtyConnector(args, environment, workingDir)


### PR DESCRIPTION
DemoBench launches Corda with a copy of its environment, which means that Corda inherits the following environment variables on MacOSX;
```
TERM=xterm-256color
TERM_PROGRAM=iTerm.app
```
However, when Corda sees the `TERM_PROGRAM` environment variable, it assumes that the terminal supports emojis. But DemoBench uses JediTerm, which does  _not_ support emojis.