### PR TITLE
Upgraded Kotlin version to 1.1.1 to fix issues with Cordapp building.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     // Dependency versions. Can run 'gradle dependencyUpdates' to find new versions of things.
     //
     // TODO: Sort this alphabetically.
-    ext.kotlin_version = '1.0.7'
+    ext.kotlin_version = '1.1.1'
     ext.quasar_version = '0.7.6'    // TODO: Upgrade to 0.7.7+ when Quasar bug 238 is resolved.
     ext.asm_version = '0.5.3'
     ext.artemis_version = '1.5.3'

--- a/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -222,7 +222,7 @@ class InMemoryMessagingNetwork(
             override fun <A> pickNext(service: ServiceHandle, pickFrom: List<A>): A {
                 val nextIndex = previousPicks.compute(service) { _key, previous ->
                     (previous?.plus(1) ?: 0) % pickFrom.size
-                }
+                }!!
                 return pickFrom[nextIndex]
             }
         }


### PR DESCRIPTION
Why: It seems Kotlin 1.0.7 has a bug with building the template that 1.1.1 doesn't have. Since we're aiming to upgrade to 1.1.x and the IntelliJ error has been fixed by https://github.com/corda/corda/pull/434 we can now proceed with this upgrade too. 

Once this is merged the template and tutorial will be fixed.