### PR TITLE
docs: Create users separately for different parties with minimum requ…

### DIFF
--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -29,25 +29,26 @@ class IntegrationTestingTutorial {
     fun `alice bob cash exchange example`() {
         // START 1
         driver {
-            val testUser = User("testUser", "testPassword", permissions = setOf(
-                    startFlowPermission<CashIssueFlow>(),
+            val aliceUser = User("aliceUser", "testPassword1", permissions = setOf(
+                    startFlowPermission<CashIssueFlow>()
+            ))
+            val bobUser = User("bobUser", "testPassword2", permissions = setOf(
                     startFlowPermission<CashPaymentFlow>()
             ))
             val (alice, bob, notary) = Futures.allAsList(
-                    startNode("Alice", rpcUsers = listOf(testUser)),
-                    startNode("Bob", rpcUsers = listOf(testUser)),
+                    startNode("Alice", rpcUsers = listOf(aliceUser)),
+                    startNode("Bob", rpcUsers = listOf(bobUser)),
                     startNode("Notary", advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type)))
             ).getOrThrow()
             // END 1
 
             // START 2
             val aliceClient = alice.rpcClientToNode()
-
-            aliceClient.start("testUser", "testPassword")
+            aliceClient.start("aliceUser", "testPassword1")
             val aliceProxy = aliceClient.proxy()
-            val bobClient = bob.rpcClientToNode()
 
-            bobClient.start("testUser", "testPassword")
+            val bobClient = bob.rpcClientToNode()
+            bobClient.start("bobUser", "testPassword2")
             val bobProxy = bobClient.proxy()
             // END 2
 


### PR DESCRIPTION
…ired permission.

When I was reading the doc, initially it was confusing why two users from two nodes share the same username and password, are they representing the same person or different persons from the view of business? By creating users separately, it makes the doc clearer. Additionally, we split CashFlow to multiple flows since 9055c9d9b06235645c196de84c5bd32b751edf48, creating users separately could take the advantage of minimum permissions requirement according to specific flows. I hope that's an improvement :)