### PR TITLE
Remove unwanted dependencies.

### DIFF
--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -2,13 +2,7 @@ apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.publish-utils'
 
-description 'Corda core'
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
+description 'Corda verifier'
 
 repositories {
     mavenLocal()
@@ -54,7 +48,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlinx:kotlinx-support-jdk8:0.3"
-    compile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
 
     // Log4J: logging framework (with SLF4J bindings)
@@ -68,6 +62,12 @@ dependencies {
     integrationTestCompile "junit:junit:$junit_version"
 
     integrationTestCompile "org.apache.activemq:artemis-server:${artemis_version}"
+}
+
+configurations.compile {
+    // We want to use SLF4J's version of these bindings: jcl-over-slf4j
+    // Remove any transitive dependency on Apache's version.
+    exclude group: 'commons-logging', module: 'commons-logging'
 }
 
 task standaloneJar(type: Jar) {


### PR DESCRIPTION
- `kotlin-test` is the testing framework, and should not be at compile scope.
- We must exclude the Apache version of the `commons-logging` APIs in favour of SLF4J.
