### PR TITLE
Add composite signature engine

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt
@@ -1,0 +1,79 @@
+package net.corda.core.crypto
+
+import net.corda.core.serialization.deserialize
+import java.io.ByteArrayOutputStream
+import java.security.*
+import java.security.spec.AlgorithmParameterSpec
+
+/**
+ * Dedicated class for storing a set of signatures that comprise [CompositeKey].
+ */
+class CompositeSignature : Signature(ALGORITHM) {
+    companion object {
+        val ALGORITHM = "X-Corda-CompositeSig"
+    }
+
+    private var buffer: ByteArrayOutputStream = ByteArrayOutputStream(1024)
+    private var verifyKey: CompositeKey? = null
+
+    private fun assertInitialised() {
+        if (verifyKey == null)
+            throw SignatureException("Engine has not been initialised with a signing key")
+    }
+
+    @Throws(InvalidAlgorithmParameterException::class)
+    override fun engineGetParameter(param: String?): Any {
+        throw InvalidAlgorithmParameterException("Composite signatures do not support any parameters")
+    }
+
+    @Throws(InvalidKeyException::class)
+    override fun engineInitSign(privateKey: PrivateKey?) {
+        throw InvalidKeyException("Composite signatures must be assembled independently from signatures provided by the component private keys")
+    }
+
+    @Throws(InvalidKeyException::class)
+    override fun engineInitVerify(publicKey: PublicKey?) {
+        if (publicKey is CompositeKey) {
+            buffer = ByteArrayOutputStream(1024)
+            verifyKey = publicKey
+        } else {
+            throw InvalidKeyException("Key to verify must be a composite key")
+        }
+    }
+
+    @Throws(InvalidAlgorithmParameterException::class)
+    override fun engineSetParameter(param: String?, value: Any?) {
+        throw InvalidAlgorithmParameterException("Composite signatures do not support any parameters")
+    }
+
+    @Throws(InvalidAlgorithmParameterException::class)
+    override fun engineSetParameter(params: AlgorithmParameterSpec) {
+        throw InvalidAlgorithmParameterException("Composite signatures do not support any parameters")
+    }
+
+    @Throws(SignatureException::class)
+    override fun engineSign(): ByteArray {
+        throw SignatureException("Composite signatures must be assembled independently from signatures provided by the component private keys")
+    }
+
+    override fun engineUpdate(b: Byte) {
+        assertInitialised()
+        buffer.write(b.toInt())
+    }
+
+    override fun engineUpdate(b: ByteArray, off: Int, len: Int) {
+        assertInitialised()
+        buffer.write(b, off, len)
+    }
+
+    @Throws(SignatureException::class)
+    override fun engineVerify(sigBytes: ByteArray): Boolean {
+        val sig = sigBytes.deserialize<CompositeSignaturesWithKeys>()
+        return if (verifyKey != null && verifyKey!!.isFulfilledBy(sig.sigs.map { it.by })) {
+            val clearData = buffer.toByteArray()
+            sig.sigs.all { it.verifyWithECDSABool(clearData) }
+        } else {
+            false
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeSignature.kt
@@ -75,7 +75,7 @@ class CompositeSignature : Signature(ALGORITHM) {
             val sig = sigBytes.deserialize<CompositeSignaturesWithKeys>()
             return if (verifyKey.isFulfilledBy(sig.sigs.map { it.by })) {
                 val clearData = buffer.toByteArray()
-                sig.sigs.all { it.verifyWithECDSABool(clearData) }
+                sig.sigs.all { it.isValidForECDSA(clearData) }
             } else {
                 false
             }

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeSignaturesWithKeys.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeSignaturesWithKeys.kt
@@ -1,0 +1,14 @@
+package net.corda.core.crypto
+
+import net.corda.core.serialization.CordaSerializable
+
+/**
+ * Custom class for holding signature data. This exists for later extension work to provide a standardised cross-platform
+ * serialization format (i.e. not Kryo).
+ */
+@CordaSerializable
+data class CompositeSignaturesWithKeys(val sigs: List<DigitalSignature.WithKey>) {
+    companion object {
+        val EMPTY = CompositeSignaturesWithKeys(emptyList())
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
@@ -58,7 +58,7 @@ open class DigitalSignature(bits: ByteArray) : OpaqueBytes(bits) {
          * @return whether the signature is correct for this key.
          */
         @Throws(InvalidKeyException::class, SignatureException::class)
-        fun verifyWithECDSABool(content: ByteArray) = by.verifyWithECDSABool(content, this)
+        fun isValidForECDSA(content: ByteArray) = by.isValidForECDSA(content, this)
     }
 
     // TODO: consider removing this as whoever needs to identify the signer should be able to derive it from the public key
@@ -140,7 +140,7 @@ fun KeyPair.signWithECDSA(bytesToSign: ByteArray, party: Party): DigitalSignatur
 // not match.
 @Throws(IllegalStateException::class, SignatureException::class)
 fun PublicKey.verifyWithECDSA(content: ByteArray, signature: DigitalSignature) {
-    if (!verifyWithECDSABool(content, signature))
+    if (!isValidForECDSA(content, signature))
         throw SignatureException("Signature did not match")
 }
 
@@ -156,7 +156,7 @@ fun PublicKey.verifyWithECDSA(content: ByteArray, signature: DigitalSignature) {
  * @return whether the signature is correct for this key.
  */
 @Throws(IllegalStateException::class, SignatureException::class)
-fun PublicKey.verifyWithECDSABool(content: ByteArray, signature: DigitalSignature) : Boolean {
+fun PublicKey.isValidForECDSA(content: ByteArray, signature: DigitalSignature) : Boolean {
     val pubKey = when (this) {
         is CompositeKey -> throw IllegalStateException("Verification of CompositeKey signatures currently not supported.") // TODO CompositeSignature verification.
         else -> this

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
@@ -21,13 +21,44 @@ import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.SignatureException
 
+// TODO: Is there a use-case for bare [DigitalSignature], or is everything a [DigitalSignature.WithKey]? If there's no
+//       actual use-case, we should merge the with key version into the parent class. In that case [CompositeSignatureWithKeys]
+//       should be renamed to match.
 /** A wrapper around a digital signature. */
 @CordaSerializable
 open class DigitalSignature(bits: ByteArray) : OpaqueBytes(bits) {
     /** A digital signature that identifies who the public key is owned by. */
     open class WithKey(val by: PublicKey, bits: ByteArray) : DigitalSignature(bits) {
+        /**
+         * Utility to simplify the act of verifying a signature.
+         *
+         * @throws InvalidKeyException if the key to verify the signature with is not valid (i.e. wrong key type for the
+         * signature).
+         * @throws SignatureException if the signature is invalid (i.e. damaged), or does not match the key (incorrect).
+         */
+        @Throws(InvalidKeyException::class, SignatureException::class)
         fun verifyWithECDSA(content: ByteArray) = by.verifyWithECDSA(content, this)
+        /**
+         * Utility to simplify the act of verifying a signature.
+         *
+         * @throws InvalidKeyException if the key to verify the signature with is not valid (i.e. wrong key type for the
+         * signature).
+         * @throws SignatureException if the signature is invalid (i.e. damaged), or does not match the key (incorrect).
+         */
+        @Throws(InvalidKeyException::class, SignatureException::class)
         fun verifyWithECDSA(content: OpaqueBytes) = by.verifyWithECDSA(content.bytes, this)
+        /**
+         * Utility to simplify the act of verifying a signature. In comparison to [verifyWithECDSA] doesn't throw an
+         * exception, making it more suitable where a boolean is required, but normally you should use the function
+         * which throws, as it avoids the risk of failing to test the result.
+         *
+         * @throws InvalidKeyException if the key to verify the signature with is not valid (i.e. wrong key type for the
+         * signature).
+         * @throws SignatureException if the signature is invalid (i.e. damaged).
+         * @return whether the signature is correct for this key.
+         */
+        @Throws(InvalidKeyException::class, SignatureException::class)
+        fun verifyWithECDSABool(content: ByteArray) = by.verifyWithECDSABool(content, this)
     }
 
     // TODO: consider removing this as whoever needs to identify the signer should be able to derive it from the public key
@@ -97,9 +128,35 @@ fun KeyPair.signWithECDSA(bytesToSign: ByteArray, party: Party): DigitalSignatur
     return DigitalSignature.LegallyIdentifiable(party, sig.bytes)
 }
 
-/** Utility to simplify the act of verifying a signature */
-@Throws(SignatureException::class, IllegalStateException::class)
+/**
+ * Utility to simplify the act of verifying a signature.
+ *
+ * @throws InvalidKeyException if the key to verify the signature with is not valid (i.e. wrong key type for the
+ * signature).
+ * @throws SignatureException if the signature is invalid (i.e. damaged), or does not match the key (incorrect).
+ */
+// TODO: SignatureException should be used only for a damaged signature, as per `java.security.Signature.verify()`,
+// we should use another exception (perhaps IllegalArgumentException) for indicating the signature is valid but does
+// not match.
+@Throws(IllegalStateException::class, SignatureException::class)
 fun PublicKey.verifyWithECDSA(content: ByteArray, signature: DigitalSignature) {
+    if (!verifyWithECDSABool(content, signature))
+        throw SignatureException("Signature did not match")
+}
+
+/**
+ * Utility to simplify the act of verifying a signature. In comparison to [verifyWithECDSA] if the key and signature
+ * do not match it returns false rather than throwing an exception. Normally you should use the function which throws,
+ * as it avoids the risk of failing to test the result, but this is for uses such as [java.security.Signature.verify]
+ * implementations.
+ *
+ * @throws InvalidKeyException if the key to verify the signature with is not valid (i.e. wrong key type for the
+ * signature).
+ * @throws SignatureException if the signature is invalid (i.e. damaged).
+ * @return whether the signature is correct for this key.
+ */
+@Throws(IllegalStateException::class, SignatureException::class)
+fun PublicKey.verifyWithECDSABool(content: ByteArray, signature: DigitalSignature) : Boolean {
     val pubKey = when (this) {
         is CompositeKey -> throw IllegalStateException("Verification of CompositeKey signatures currently not supported.") // TODO CompositeSignature verification.
         else -> this
@@ -107,8 +164,7 @@ fun PublicKey.verifyWithECDSA(content: ByteArray, signature: DigitalSignature) {
     val verifier = EdDSAEngine()
     verifier.initVerify(pubKey)
     verifier.update(content)
-    if (!verifier.verify(signature.bytes))
-        throw SignatureException("Signature did not match")
+    return verifier.verify(signature.bytes)
 }
 
 /** Render a public key to a string, using a short form if it's an elliptic curve public key */

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -23,6 +23,10 @@ import java.util.*
  * map to the same key (and they could be different in important ways, like validity!). The signatures on a
  * SignedTransaction might be invalid or missing: the type does not imply validity.
  * A transaction ID should be the hash of the [WireTransaction] Merkle tree root. Thus adding or removing a signature does not change it.
+ *
+ * @param sigs a list of signatures from individual (non-composite) public keys. This is passed as a list of signatures
+ * when verifying composite key signatures, but may be used as individual signatures where a single key is expected to
+ * sign.
  */
 data class SignedTransaction(val txBits: SerializedBytes<WireTransaction>,
                              val sigs: List<DigitalSignature.WithKey>

--- a/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
@@ -47,10 +47,11 @@ class CompositeKeyTests {
     }
 
     @Test
-    fun `(Alice and Bob) not fulfilled by neither signature alone`() {
+    fun `(Alice and Bob) requires both signatures to fulfil`() {
         val aliceAndBob = CompositeKey.Builder().addKeys(alicePublicKey, bobPublicKey).build()
         assertFalse { aliceAndBob.isFulfilledBy(listOf(aliceSignature).byKeys()) }
         assertFalse { aliceAndBob.isFulfilledBy(listOf(bobSignature).byKeys()) }
+        assertTrue { aliceAndBob.isFulfilledBy(listOf(aliceSignature, bobSignature).byKeys()) }
     }
 
     @Test

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -56,6 +56,9 @@ Special thank you to `Qian Hong <https://github.com/fracting>`_, `Marek Skocovsk
 
     * The basic Amount API has been upgraded to have support for advanced financial use cases and to better integrate with currency reference data.
 
+* Added ``CompositeSignature`` and ``CompositeSignatureData`` as part of enabling ``java.security`` classes to work with
+  composite keys and signatures.
+
 * Configuration:
     * Replace ``artemisPort`` with ``p2pPort`` in Gradle configuration.
     * Replace ``artemisAddress`` with ``p2pAddress`` in node configuration.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,9 @@ UNRELEASED
 * API changes:
     * Added extension function ``Database.transaction`` to replace ``databaseTransaction``, which is now deprecated.
 
+    * Added ``CompositeSignature`` and ``CompositeSignatureData`` as part of enabling ``java.security`` classes to work with
+      composite keys and signatures.
+
 Milestone 10.0
 --------------
 
@@ -55,9 +58,6 @@ Special thank you to `Qian Hong <https://github.com/fracting>`_, `Marek Skocovsk
         * We also have a new ``:node-api`` module (package ``net.corda.nodeapi``) which contains the shared code between ``node`` and ``client``.
 
     * The basic Amount API has been upgraded to have support for advanced financial use cases and to better integrate with currency reference data.
-
-* Added ``CompositeSignature`` and ``CompositeSignatureData`` as part of enabling ``java.security`` classes to work with
-  composite keys and signatures.
 
 * Configuration:
     * Replace ``artemisPort`` with ``p2pPort`` in Gradle configuration.

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -29,6 +29,11 @@ Soft locks are automatically applied to coin selection (eg. cash spending) to en
 
 The basic Amount API has been upgraded to have support for advanced financial use cases and to better integrate with currency reference data.
 
+Work has contined on confidential identities, introducing code to enable the Java standard libraries to work with
+composite key signatures. This will form the underlying basis of future work to standardise the public key and signature
+formats to enable interoperability with other systems, as well as enabling the use of composite signatures on X.509
+certificates to prove association between transaction keys and identity keys.
+
 We have added optional out-of-process transaction verification. Any number of external verifier processes may be attached to the node which can handle loadbalanced verification requests.
 
 We have also delivered the long waited Kotlin 1.1 upgrade in M10! The new features in Kotlin allow us to write even more clean and easy to manage code, which greatly increases our productivity.

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -4,6 +4,14 @@ Release notes
 Here are release notes for each snapshot release from M9 onwards. This includes guidance on how to upgrade code from
 the previous milestone release.
 
+Unreleased
+----------
+
+Work has continued on confidential identities, introducing code to enable the Java standard libraries to work with
+composite key signatures. This will form the underlying basis of future work to standardise the public key and signature
+formats to enable interoperability with other systems, as well as enabling the use of composite signatures on X.509
+certificates to prove association between transaction keys and identity keys.
+
 Milestone 10
 ------------
 
@@ -28,11 +36,6 @@ Such transactions would result in naturally wasted effort when the notary reject
 Soft locks are automatically applied to coin selection (eg. cash spending) to ensure that no two transactions attempt to spend the same fungible states.
 
 The basic Amount API has been upgraded to have support for advanced financial use cases and to better integrate with currency reference data.
-
-Work has contined on confidential identities, introducing code to enable the Java standard libraries to work with
-composite key signatures. This will form the underlying basis of future work to standardise the public key and signature
-formats to enable interoperability with other systems, as well as enabling the use of composite signatures on X.509
-certificates to prove association between transaction keys and identity keys.
 
 We have added optional out-of-process transaction verification. Any number of external verifier processes may be attached to the node which can handle loadbalanced verification requests.
 

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -156,20 +156,20 @@ class CordaRPCOpsImplTest {
         transactions.expectEvents {
             sequence(
                     // ISSUE
-                    expect { tx ->
-                        require(tx.tx.inputs.isEmpty())
-                        require(tx.tx.outputs.size == 1)
-                        val signaturePubKeys = tx.sigs.map { it.by }.toSet()
+                    expect { stx ->
+                        require(stx.tx.inputs.isEmpty())
+                        require(stx.tx.outputs.size == 1)
+                        val signaturePubKeys = stx.sigs.map { it.by }.toSet()
                         // Only Alice signed
                         val aliceKey = aliceNode.info.legalIdentity.owningKey
                         require(signaturePubKeys.size <= aliceKey.keys.size)
                         require(aliceKey.isFulfilledBy(signaturePubKeys))
                     },
                     // MOVE
-                    expect { tx ->
-                        require(tx.tx.inputs.size == 1)
-                        require(tx.tx.outputs.size == 1)
-                        val signaturePubKeys = tx.sigs.map { it.by }.toSet()
+                    expect { stx ->
+                        require(stx.tx.inputs.size == 1)
+                        require(stx.tx.outputs.size == 1)
+                        val signaturePubKeys = stx.sigs.map { it.by }.toSet()
                         // Alice and Notary signed
                         require(aliceNode.info.legalIdentity.owningKey.isFulfilledBy(signaturePubKeys))
                         require(notaryNode.info.notaryIdentity.owningKey.isFulfilledBy(signaturePubKeys))


### PR DESCRIPTION
Add `CompositeSignature` engine and `CompositeSignatureData` type as part of next steps towards integrating composite signatures with the Java standard crypto libraries.

This doesn't add this to the signature types recognised by Corda yet, that work requires further extensions (such as a key generator).
