### PR TITLE
Fixes for deprecated warnings

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/jackson/StringToMethodCallParser.kt
+++ b/client/jackson/src/main/kotlin/net/corda/jackson/StringToMethodCallParser.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.Callable
 import javax.annotation.concurrent.ThreadSafe
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
-import kotlin.reflect.KotlinReflectionInternalError
+import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.kotlinFunction
 
 /**

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogicRef.kt
@@ -9,9 +9,9 @@ import java.lang.reflect.Type
 import java.util.*
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
+import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaConstructor
 import kotlin.reflect.jvm.javaType
-import kotlin.reflect.primaryConstructor
 
 /**
  * A class for conversion to and from [FlowLogic] and [FlowLogicRef] instances.

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -112,11 +112,3 @@ interface ServiceHub : ServicesForResolution {
      */
     val notaryIdentityKey: KeyPair get() = this.keyManagementService.toKeyPair(this.myInfo.notaryIdentity.owningKey.keys)
 }
-
-/**
- * Given some [SignedTransaction]s, writes them to the local storage for validated transactions and then
- * sends them to the vault for further processing.
- *
- * @param txs The transactions to record.
- */
-fun ServiceHub.recordTransactions(vararg txs: SignedTransaction) = recordTransactions(txs.toList())

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -27,7 +27,11 @@ import java.security.spec.InvalidKeySpecException
 import java.time.Instant
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
-import kotlin.reflect.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaType
 
 /**
@@ -64,6 +68,7 @@ import kotlin.reflect.jvm.javaType
 
 // A convenient instance of Kryo pre-configured with some useful things. Used as a default by various functions.
 fun p2PKryo(): KryoPool = kryoPool
+
 // Same again, but this has whitelisting turned off for internal storage use only.
 fun storageKryo(): KryoPool = internalKryoPool
 
@@ -392,7 +397,7 @@ object CompositeKeyNodeSerializer : Serializer<CompositeKey.Node>() {
         val weights = input.readInts(childCount)
 
         val builder = CompositeKey.Builder()
-        weights.zip(children).forEach { builder.addKey(it.second, it.first)  }
+        weights.zip(children).forEach { builder.addKey(it.second, it.first) }
         return builder.build(threshold)
     }
 }

--- a/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
@@ -10,7 +10,6 @@ import net.corda.core.crypto.Party
 import net.corda.core.crypto.signWithECDSA
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
-import net.corda.core.node.recordTransactions
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction

--- a/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
@@ -7,7 +7,6 @@ import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.*
 import net.corda.core.flows.FlowLogic
 import net.corda.core.node.NodeInfo
-import net.corda.core.node.recordTransactions
 import net.corda.core.node.services.ServiceType
 import net.corda.core.seconds
 import net.corda.core.serialization.CordaSerializable

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -143,16 +143,16 @@ class ContractUpgradeFlowTest {
         val result = resultFuture.get()
         // Check results.
         listOf(a, b).forEach {
-            val stx = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(result.ref.txhash) }
-            requireNotNull(stx)
+            val signedTX = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(result.ref.txhash) }
+            requireNotNull(signedTX)
 
             // Verify inputs.
-            val input = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(stx!!.tx.inputs.single().txhash) }
+            val input = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(signedTX!!.tx.inputs.single().txhash) }
             requireNotNull(input)
             assertTrue(input!!.tx.outputs.single().data is DummyContract.State)
 
             // Verify outputs.
-            assertTrue(stx!!.tx.outputs.single().data is DummyContractV2.State)
+            assertTrue(signedTX!!.tx.outputs.single().data is DummyContractV2.State)
         }
     }
 

--- a/core/src/test/kotlin/net/corda/core/flows/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ResolveTransactionsFlowTest.kt
@@ -5,7 +5,6 @@ import net.corda.core.crypto.NullSignature
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
 import net.corda.core.getOrThrow
-import net.corda.core.node.recordTransactions
 import net.corda.core.serialization.opaque
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_NOTARY_KEY

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/ExampleConfigTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/ExampleConfigTest.kt
@@ -6,7 +6,7 @@ import net.corda.verifier.Verifier
 import org.junit.Test
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.reflect.declaredMemberProperties
+import kotlin.reflect.full.declaredMemberProperties
 
 class ExampleConfigTest {
 

--- a/finance/src/main/kotlin/net/corda/contracts/testing/VaultFiller.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/testing/VaultFiller.kt
@@ -13,7 +13,6 @@ import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.composite
 import net.corda.core.node.ServiceHub
-import net.corda.core.node.recordTransactions
 import net.corda.core.node.services.Vault
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction

--- a/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
@@ -7,7 +7,6 @@ import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.composite
 import net.corda.core.days
-import net.corda.core.node.recordTransactions
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultService
 import net.corda.core.seconds
@@ -17,9 +16,6 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.DUMMY_NOTARY_KEY
 import net.corda.core.utilities.DUMMY_PUBKEY_1
 import net.corda.core.utilities.TEST_TX_TIME
-import net.corda.node.services.schema.HibernateObserver
-import net.corda.node.services.schema.NodeSchemaService
-import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.configureDatabase
 import net.corda.node.utilities.databaseTransaction
 import net.corda.testing.*

--- a/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
@@ -41,7 +41,7 @@ class ArtemisTcpTransport {
         ): TransportConfiguration {
             val options = mutableMapOf<String, Any?>(
                     // Basic TCP target details
-                    TransportConstants.HOST_PROP_NAME to hostAndPort.hostText,
+                    TransportConstants.HOST_PROP_NAME to hostAndPort.host,
                     TransportConstants.PORT_PROP_NAME to hostAndPort.port,
 
                     // Turn on AMQP support, which needs the protocol jar on the classpath.

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -232,7 +232,7 @@ fun getTimestampAsDirectoryName(): String {
 fun addressMustBeBound(executorService: ScheduledExecutorService, hostAndPort: HostAndPort): ListenableFuture<Unit> {
     return poll(executorService, "address $hostAndPort to bind") {
         try {
-            Socket(hostAndPort.hostText, hostAndPort.port).close()
+            Socket(hostAndPort.host, hostAndPort.port).close()
             Unit
         } catch (_exception: SocketException) {
             null
@@ -243,7 +243,7 @@ fun addressMustBeBound(executorService: ScheduledExecutorService, hostAndPort: H
 fun addressMustNotBeBound(executorService: ScheduledExecutorService, hostAndPort: HostAndPort): ListenableFuture<Unit> {
     return poll(executorService, "address $hostAndPort to unbind") {
         try {
-            Socket(hostAndPort.hostText, hostAndPort.port).close()
+            Socket(hostAndPort.host, hostAndPort.port).close()
             null
         } catch (_exception: SocketException) {
             Unit

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -143,7 +143,7 @@ class Node(override val configuration: FullNodeConfiguration,
 
     private fun makeLocalMessageBroker(): HostAndPort {
         with(configuration) {
-            val useHost = tryDetectIfNotPublicHost(p2pAddress.hostText)
+            val useHost = tryDetectIfNotPublicHost(p2pAddress.host)
             val useAddress = useHost?.let { HostAndPort.fromParts(it, p2pAddress.port) } ?: p2pAddress
             messageBroker = ArtemisMessagingServer(this, useAddress, rpcAddress, services.networkMapCache, userService)
             return useAddress

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -355,7 +355,7 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
                 connectorFactoryClassName = VerifyingNettyConnectorFactory::class.java.name,
                 expectedCommonName = legalName
         )
-        val tcpTransport = createTcpTransport(connectionDirection, target.hostText, target.port)
+        val tcpTransport = createTcpTransport(connectionDirection, target.host, target.port)
         tcpTransport.params[ArtemisMessagingServer::class.java.name] = this
         // We intentionally overwrite any previous connector config in case the peer legal name changed
         activeMQServer.configuration.addConnectorConfiguration(target.toString(), tcpTransport)

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt
@@ -60,7 +60,7 @@ class RaftUniquenessProvider(storagePath: Path, myAddress: HostAndPort, clusterA
     init {
         log.info("Creating Copycat server, log stored in: ${storagePath.toFile()}")
         val stateMachineFactory = { DistributedImmutableMap<String, ByteArray>(db, DB_TABLE_NAME) }
-        val address = Address(myAddress.hostText, myAddress.port)
+        val address = Address(myAddress.host, myAddress.port)
         val storage = buildStorage(storagePath)
         val transport = buildTransport(config)
         val serializer = Serializer()
@@ -74,7 +74,7 @@ class RaftUniquenessProvider(storagePath: Path, myAddress: HostAndPort, clusterA
 
         val serverFuture = if (clusterAddresses.isNotEmpty()) {
             log.info("Joining an existing Copycat cluster at $clusterAddresses")
-            val cluster = clusterAddresses.map { Address(it.hostText, it.port) }
+            val cluster = clusterAddresses.map { Address(it.host, it.port) }
             server.join(cluster)
         } else {
             log.info("Bootstrapping a Copycat cluster at $address")

--- a/node/src/test/kotlin/net/corda/node/services/DistributedImmutableMapTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/DistributedImmutableMapTests.kt
@@ -90,7 +90,7 @@ class DistributedImmutableMapTests {
 
     private fun createReplica(myAddress: HostAndPort, clusterAddress: HostAndPort? = null): CompletableFuture<Member> {
         val storage = Storage.builder().withStorageLevel(StorageLevel.MEMORY).build()
-        val address = Address(myAddress.hostText, myAddress.port)
+        val address = Address(myAddress.host, myAddress.port)
 
         val stateMachineFactory = { DistributedImmutableMap<String, ByteArray>(database, "commited_states_${myAddress.port}") }
 
@@ -100,7 +100,7 @@ class DistributedImmutableMapTests {
                 .build()
 
         val serverInitFuture = if (clusterAddress != null) {
-            val cluster = Address(clusterAddress.hostText, clusterAddress.port)
+            val cluster = Address(clusterAddress.host, clusterAddress.port)
             server.join(cluster)
         } else {
             server.bootstrap()

--- a/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
@@ -8,7 +8,6 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRef
 import net.corda.core.flows.FlowLogicRefFactory
 import net.corda.core.node.ServiceHub
-import net.corda.core.node.recordTransactions
 import net.corda.core.node.services.VaultService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.DUMMY_NOTARY

--- a/node/src/test/kotlin/net/corda/node/visualiser/GroupToGraphConversion.kt
+++ b/node/src/test/kotlin/net/corda/node/visualiser/GroupToGraphConversion.kt
@@ -9,7 +9,7 @@ import net.corda.testing.TestTransactionDSLInterpreter
 import org.graphstream.graph.Edge
 import org.graphstream.graph.Node
 import org.graphstream.graph.implementations.SingleGraph
-import kotlin.reflect.memberProperties
+import kotlin.reflect.full.memberProperties
 
 @Suppress("unused") // TODO: Re-evaluate by EOY2016 if this code is still useful and if not, delete.
 class GraphVisualiser(val dsl: LedgerDSL<TestTransactionDSLInterpreter, TestLedgerDSLInterpreter>) {

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
@@ -470,7 +470,7 @@ class InterestRateSwap() : Contract {
         }
     }
 
-    override fun verify(tx: TransactionForContract) = verifyClause(tx, AllComposition(Clauses.Timestamped(), Clauses.Group()), tx.commands.select<Commands>())
+    override fun verify(tx: TransactionForContract) = verifyClause(tx, AllOf(Clauses.Timestamped(), Clauses.Group()), tx.commands.select<Commands>())
 
     interface Clauses {
         /**
@@ -519,7 +519,7 @@ class InterestRateSwap() : Contract {
             }
         }
 
-        class Group : GroupClauseVerifier<State<*>, Commands, UniqueIdentifier>(AnyComposition(Agree(), Fix(), Pay(), Mature())) {
+        class Group : GroupClauseVerifier<State<*>, Commands, UniqueIdentifier>(AnyOf(Agree(), Fix(), Pay(), Mature())) {
             // Group by Trade ID for in / out states
             override fun groupStates(tx: TransactionForContract): List<TransactionForContract.InOutGroup<State<*>, UniqueIdentifier>> {
                 return tx.groupStates() { state -> state.linearId }

--- a/samples/irs-demo/src/main/kotlin/net/corda/simulation/TradeSimulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/simulation/TradeSimulation.kt
@@ -11,7 +11,6 @@ import net.corda.core.contracts.`issued by`
 import net.corda.core.days
 import net.corda.core.flatMap
 import net.corda.core.flows.FlowStateMachine
-import net.corda.core.node.recordTransactions
 import net.corda.core.seconds
 import net.corda.core.transactions.SignedTransaction
 import net.corda.flows.TwoPartyTradeFlow.Buyer

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt
@@ -78,7 +78,7 @@ class ConnectionManager(private val username: String, private val jSch: JSch) {
         log.info("Connected to $nodeHost!")
 
         log.info("Creating tunnel from $nodeHost:$remoteMessagingPort to $localTunnelAddress...")
-        session.setPortForwardingL(localTunnelAddress.port, localTunnelAddress.hostText, remoteMessagingPort)
+        session.setPortForwardingL(localTunnelAddress.port, localTunnelAddress.host, remoteMessagingPort)
         log.info("Tunnel created!")
 
         val connection = NodeConnection(nodeHost, session, localTunnelAddress, rpcUsername, rpcPassword)


### PR DESCRIPTION
* Changed deprecated kotlin.reflect.primaryConstructor to kotlin.reflect.full.primaryConstructor
* Changed deprecated kotlin.reflect.memberProperties to kotlin.reflect.full.memberProperties
* Changed deprecated kotlin.reflect.declaredMemberProperties to kotlin.reflect.full.declaredMemberProperties
* Changed deprecated AllComposition to AllOf
* Changed deprecated AnyComposition to AnyOf
* Changed deprecated kotlin.reflect.KotlinReflectionInternalError to kotlin.reflect.jvm.internal.KotlinReflectionInternalError
* Changed deprecated HostAndPort.hostText to HostAndPort.host
* Removed duplicated method net.corda.core.node.recordTransactions