### PR TITLE
Tactical fix for Explorer crash issue under Kotlin 1.1.1

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/ObservableUtilities.kt
@@ -111,8 +111,14 @@ fun <A> ObservableList<out A>.filter(predicate: ObservableValue<(A) -> Boolean>)
  * val owners: ObservableList<Person> = dogs.map(Dog::owner).filterNotNull()
  */
 fun <A> ObservableList<out A?>.filterNotNull(): ObservableList<A> {
+    //TODO This is a tactical work round for an issue with SAM conversion (https://youtrack.jetbrains.com/issue/ALL-1552) so that the M10 explorer works.
     @Suppress("UNCHECKED_CAST")
-    return filtered { it != null } as ObservableList<A>
+    return (this as ObservableList<A?>).filtered(object : Predicate<A?> {
+        override fun test(t: A?): Boolean {
+            return t != null
+
+        }
+    }) as ObservableList<A>
 }
 
 /**


### PR DESCRIPTION
Original code compiles, but then throws a typecast expression at runtime when trying to process the lambdas. This means that the explorer will crash out as soon as there are cash states to load from the vault.

Hopefully, we can revert once there is a compiler fix, but for M10 we may have to live with this.