### PR TITLE
Replace kotlinx-support-jdk8 with kotlin-stdlib-jre8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     // For sharing constants between builds
     Properties constants = new Properties()
-    file("constants.properties").withInputStream { constants.load(it) }
+    file("$projectDir/constants.properties").withInputStream { constants.load(it) }
 
     // Our version: bump this on release.
     ext.corda_version = "0.10-SNAPSHOT"
@@ -10,7 +10,7 @@ buildscript {
     // Dependency versions. Can run 'gradle dependencyUpdates' to find new versions of things.
     //
     // TODO: Sort this alphabetically.
-    ext.kotlin_version = '1.1.1'
+    ext.kotlin_version = constants.getProperty("kotlinVersion")
     ext.quasar_version = '0.7.6'    // TODO: Upgrade to 0.7.7+ when Quasar bug 238 is resolved.
     ext.asm_version = '0.5.3'
     ext.artemis_version = '1.5.3'

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'net.corda.plugins.publish-utils'
 
 dependencies {
     compile project(':core')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
     // Jackson and its plugins: parsing to/from JSON and other textual formats.

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ContractStateModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ContractStateModel.kt
@@ -2,7 +2,6 @@ package net.corda.client.jfx.model
 
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
-import kotlinx.support.jdk8.collections.removeIf
 import net.corda.client.jfx.utils.fold
 import net.corda.client.jfx.utils.map
 import net.corda.contracts.asset.Cash

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NetworkIdentityModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NetworkIdentityModel.kt
@@ -3,7 +3,6 @@ package net.corda.client.jfx.model
 import javafx.beans.value.ObservableValue
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
-import kotlinx.support.jdk8.collections.removeIf
 import net.corda.client.jfx.utils.firstOrDefault
 import net.corda.client.jfx.utils.firstOrNullObservable
 import net.corda.client.jfx.utils.fold

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
@@ -3,7 +3,6 @@ package net.corda.client.jfx.utils
 import javafx.beans.binding.Bindings
 import javafx.beans.value.ObservableValue
 import javafx.collections.ObservableList
-import kotlinx.support.jdk8.collections.stream
 import net.corda.client.jfx.model.ExchangeRate
 import net.corda.core.contracts.Amount
 import org.fxmisc.easybind.EasyBind

--- a/constants.properties
+++ b/constants.properties
@@ -1,2 +1,3 @@
 gradlePluginsVersion=0.10.2
+kotlinVersion=1.1.1
 guavaVersion=21.0

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,9 +30,8 @@ dependencies {
     testCompile project(":node")
     testCompile project(":test-utils")
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlinx:kotlinx-support-jdk8:0.3"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
     // Thread safety annotations

--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -7,7 +7,6 @@ import com.google.common.base.Function
 import com.google.common.base.Throwables
 import com.google.common.io.ByteStreams
 import com.google.common.util.concurrent.*
-import kotlinx.support.jdk7.use
 import net.corda.core.crypto.newSecureRandom
 import net.corda.core.serialization.CordaSerializable
 import org.slf4j.Logger

--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -4,7 +4,7 @@
 buildscript {
     // For sharing constants between builds
     Properties constants = new Properties()
-    file("../constants.properties").withInputStream { constants.load(it) }
+    file("$projectDir/../constants.properties").withInputStream { constants.load(it) }
 
     // If you bump this version you must re-bootstrap the codebase. See the README for more information.
     ext.gradle_plugins_version = constants.getProperty("gradlePluginsVersion")

--- a/gradle-plugins/cordformation/build.gradle
+++ b/gradle-plugins/cordformation/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     // TODO: Unify with the one in the main project
-    ext.kotlin_version = '1.0.5-2'
+    ext.kotlin_version = '1.1.1'
 
     repositories {
         mavenCentral()
@@ -39,7 +39,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    noderunner "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    noderunner "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 
     // TypeSafe Config: for simple and human friendly config files.
     // TODO: Add a common versions file between Corda and gradle plugins to de-duplicate this version number

--- a/gradle-plugins/cordformation/build.gradle
+++ b/gradle-plugins/cordformation/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
-    // TODO: Unify with the one in the main project
-    ext.kotlin_version = '1.1.1'
+    // For sharing constants between builds
+    Properties constants = new Properties()
+    file("$projectDir/../../constants.properties").withInputStream { constants.load(it) }
+
+    ext.kotlin_version = constants.getProperty("kotlinVersion")
 
     repositories {
         mavenCentral()

--- a/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -71,7 +71,6 @@ private fun execJar(jarName: String, dir: File, args: List<String> = listOf()): 
 private fun execJarInTerminalWindow(jarName: String, dir: File, args: List<String> = listOf()): Process {
     val javaCmd = "java -jar $jarName " + args.joinToString(" ") { it }
     val nodeName = "${dir.toPath().fileName} $jarName"
-    val osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
     val builder = when (os) {
         OS.MACOS -> ProcessBuilder(
                 "osascript", "-e",

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -26,9 +26,8 @@ sourceSets {
 dependencies {
     compile project(":core")
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlinx:kotlinx-support-jdk8:0.3"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
     compile "org.apache.activemq:artemis-commons:${artemis_version}"

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
     compile "org.apache.logging.log4j:log4j-web:${log4j_version}"
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
@@ -1,7 +1,6 @@
 package net.corda.services.messaging
 
 import com.google.common.util.concurrent.ListenableFuture
-import kotlinx.support.jdk7.use
 import net.corda.core.crypto.Party
 import net.corda.core.div
 import net.corda.core.getOrThrow

--- a/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
@@ -1,6 +1,5 @@
 package net.corda.node.services.schema
 
-import kotlinx.support.jdk7.use
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -9,7 +9,6 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.pool.KryoPool
 import com.google.common.collect.HashMultimap
 import com.google.common.util.concurrent.ListenableFuture
-import kotlinx.support.jdk8.collections.removeIf
 import net.corda.core.ThreadBox
 import net.corda.core.bufferUntilSubscribed
 import net.corda.core.crypto.Party

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -32,7 +32,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -32,7 +32,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/network-visualiser/build.gradle
+++ b/samples/network-visualiser/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'us.kirchmeier.capsule'
 dependencies {
     compile project(':samples:irs-demo')
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/raft-notary-demo/build.gradle
+++ b/samples/raft-notary-demo/build.gradle
@@ -32,7 +32,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -36,7 +36,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/SwapExample.kt
+++ b/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/SwapExample.kt
@@ -29,7 +29,6 @@ import com.opengamma.strata.product.common.BuySell
 import com.opengamma.strata.product.swap.ResolvedSwapTrade
 import com.opengamma.strata.product.swap.SwapTrade
 import com.opengamma.strata.product.swap.type.FixedIborSwapConventions
-import kotlinx.support.jdk8.collections.stream
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.vega.analytics.BimmAnalysisUtils

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -32,7 +32,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile project(':node:webserver')
     compile project(':verifier')
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt
@@ -13,7 +13,6 @@ import java.util.logging.Level
 import java.util.stream.StreamSupport
 import javafx.stage.FileChooser
 import javafx.stage.FileChooser.ExtensionFilter
-import kotlinx.support.jdk8.collections.spliterator
 import net.corda.demobench.model.*
 import net.corda.demobench.plugin.PluginController
 import net.corda.demobench.plugin.inPluginsDir

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -26,7 +26,7 @@ sourceSets {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/ConnectionManager.kt
@@ -5,8 +5,7 @@ import com.jcraft.jsch.*
 import com.jcraft.jsch.agentproxy.AgentProxy
 import com.jcraft.jsch.agentproxy.connector.SSHAgentConnector
 import com.jcraft.jsch.agentproxy.usocket.JNAUSocketFactory
-import kotlinx.support.jdk8.collections.parallelStream
-import kotlinx.support.jdk8.streams.toList
+import kotlin.streams.toList
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.node.driver.PortAllocation

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt
@@ -1,6 +1,5 @@
 package net.corda.loadtest
 
-import kotlinx.support.jdk8.collections.parallelStream
 import net.corda.client.mock.Generator
 import net.corda.core.div
 import net.corda.node.driver.PortAllocation

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -33,9 +33,8 @@ sourceSets {
 dependencies {
     compile project(":node-api")
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlinx:kotlinx-support-jdk8:0.3"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
 


### PR DESCRIPTION
We no longer need `kotlinx-support-jdk8` as of Kotlin 1.1.