### PR TITLE
Attachment InputStream (de)serializers

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -34,6 +34,9 @@ import javax.annotation.concurrent.ThreadSafe
 class CordaRPCClient(val host: HostAndPort, override val config: SSLConfiguration? = null, val serviceConfigurationOverride: (ServerLocator.() -> Unit)? = null) : Closeable, ArtemisMessagingComponent() {
     private companion object {
         val log = loggerFor<CordaRPCClient>()
+        /** 10 MiB maximum allowed file size for attachments, including message headers. TODO: acquire this value from Network Map when supported. */
+        @JvmStatic val MAX_FILE_SIZE = 10485760
+
     }
 
     // TODO: Certificate handling for clients needs more work.
@@ -63,6 +66,7 @@ class CordaRPCClient(val host: HostAndPort, override val config: SSLConfiguratio
                     retryInterval = 5.seconds.toMillis()
                     retryIntervalMultiplier = 1.5  // Exponential backoff
                     maxRetryInterval = 3.minutes.toMillis()
+                    minLargeMessageSize = MAX_FILE_SIZE
                     serviceConfigurationOverride?.invoke(this)
                 }
                 sessionFactory = serverLocator.createSessionFactory()

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -55,10 +55,13 @@ object DefaultKryoCustomizer {
             ImmutableMapSerializer.registerSerializers(this)
             ImmutableMultimapSerializer.registerSerializers(this)
 
-            // InputStream subclasses whitelisting
+            // InputStream subclasses whitelisting, required for attachments.
             register(BufferedInputStream::class.java, InputStreamSerializer)
             register(FileInputStream::class.java, InputStreamSerializer)
-            addDefaultSerializer(InputStream::class.java, InputStreamSerializer) // used for HashCheckingStream
+
+            // Required for HashCheckingStream (de)serialization.
+            // Note that return type should be specifically set to InputStream, otherwise it may not work, i.e. val aStream : InputStream = HashCheckingStream(...).
+            addDefaultSerializer(InputStream::class.java, InputStreamSerializer)
             register(Class.forName("sun.net.www.protocol.jar.JarURLConnection\$JarURLInputStream"), InputStreamSerializer)
 
             noReferencesWithin<WireTransaction>()

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -19,6 +19,8 @@ import net.i2p.crypto.eddsa.EdDSAPublicKey
 import org.objenesis.strategy.StdInstantiatorStrategy
 import org.slf4j.Logger
 import java.io.BufferedInputStream
+import java.io.FileInputStream
+import java.io.InputStream
 import java.util.*
 
 object DefaultKryoCustomizer {
@@ -53,7 +55,10 @@ object DefaultKryoCustomizer {
             ImmutableMapSerializer.registerSerializers(this)
             ImmutableMultimapSerializer.registerSerializers(this)
 
+            // InputStream subclasses whitelisting
             register(BufferedInputStream::class.java, InputStreamSerializer)
+            register(FileInputStream::class.java, InputStreamSerializer)
+            addDefaultSerializer(InputStream::class.java, InputStreamSerializer) // used for HashCheckingStream
             register(Class.forName("sun.net.www.protocol.jar.JarURLConnection\$JarURLInputStream"), InputStreamSerializer)
 
             noReferencesWithin<WireTransaction>()

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -89,6 +89,8 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
                              val userService: RPCUserService) : ArtemisMessagingComponent() {
     companion object {
         private val log = loggerFor<ArtemisMessagingServer>()
+        /** 10 MiB maximum allowed file size for attachments, including message headers. TODO: acquire this value from Network Map when supported. */
+        @JvmStatic val MAX_FILE_SIZE = 10485760
     }
 
     private class InnerState {
@@ -166,6 +168,9 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
         idCacheSize = 2000 // Artemis Default duplicate cache size i.e. a guess
         isPersistIDCache = true
         isPopulateValidatedUser = true
+        journalBufferSize_NIO = MAX_FILE_SIZE // Artemis default is 490KiB - required to address IllegalArgumentException (when Artemis uses Java NIO): Record is too large to store.
+        journalBufferSize_AIO = MAX_FILE_SIZE // Required to address IllegalArgumentException (when Artemis uses Linux Async IO): Record is too large to store.
+        journalFileSize = MAX_FILE_SIZE // The size of each journal file in bytes. Artemis default is 10MiB.
         managementNotificationAddress = SimpleString(NOTIFICATIONS_ADDRESS)
         // Artemis allows multiple servers to be grouped together into a cluster for load balancing purposes. The cluster
         // user is used for connecting the nodes together. It has super-user privileges and so it's imperative that its

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
@@ -152,6 +152,7 @@ class NodeMessagingClient(override val config: NodeConfiguration,
             // TODO Add broker CN to config for host verification in case the embedded broker isn't used
             val tcpTransport = ArtemisTcpTransport.tcpTransport(ConnectionDirection.Outbound(), serverHostPort, config)
             val locator = ActiveMQClient.createServerLocatorWithoutHA(tcpTransport)
+            locator.setMinLargeMessageSize(ArtemisMessagingServer.MAX_FILE_SIZE)
             clientFactory = locator.createSessionFactory()
 
             // Login using the node username. The broker will authentiate us as its node (as opposed to another peer)

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -65,6 +65,7 @@ class NodeAttachmentService(override var storePath: Path, dataSourceProperties: 
      * inside it, we haven't read the whole file, so we can't check the hash. But when copying it over the network
      * this will provide an additional safety check against user error.
      */
+    @CordaSerializable
     private class HashCheckingStream(val expected: SecureHash.SHA256,
                                      val expectedSize: Int,
                                      input: InputStream,

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -65,8 +65,8 @@ class NodeAttachmentService(override var storePath: Path, dataSourceProperties: 
      * inside it, we haven't read the whole file, so we can't check the hash. But when copying it over the network
      * this will provide an additional safety check against user error.
      */
-    @CordaSerializable
-    private class HashCheckingStream(val expected: SecureHash.SHA256,
+    @VisibleForTesting @CordaSerializable
+    class HashCheckingStream(val expected: SecureHash.SHA256,
                                      val expectedSize: Int,
                                      input: InputStream,
                                      private val counter: CountingInputStream = CountingInputStream(input),

--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 import java.util.concurrent.CompletableFuture
 
 class AttachmentDemoTest {
+    /** Tested successfully with an attachment of 10,404,514 bytes. */
     @Test fun `runs attachment demo`() {
         driver(dsl = {
             val demoUser = listOf(User("demo", "demo", setOf("StartFlow.net.corda.flows.FinalityFlow")))


### PR DESCRIPTION
A solution for [#347](https://github.com/corda/corda/issues/347), where HashCheckingStream could not be  (de)serialized. I've also registered FileInputSteam as it may be required in attachments.