### PR TITLE
Kryo register FileInputStream and addDefaultSerializer for InputStream

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -19,6 +19,8 @@ import net.i2p.crypto.eddsa.EdDSAPublicKey
 import org.objenesis.strategy.StdInstantiatorStrategy
 import org.slf4j.Logger
 import java.io.BufferedInputStream
+import java.io.FileInputStream
+import java.io.InputStream
 import java.util.*
 
 object DefaultKryoCustomizer {
@@ -53,7 +55,13 @@ object DefaultKryoCustomizer {
             ImmutableMapSerializer.registerSerializers(this)
             ImmutableMultimapSerializer.registerSerializers(this)
 
+            // InputStream subclasses whitelisting, required for attachments.
             register(BufferedInputStream::class.java, InputStreamSerializer)
+            register(FileInputStream::class.java, InputStreamSerializer)
+            // Required for HashCheckingStream (de)serialization.
+            // Note that return type should be specifically set to InputStream, otherwise it may not work, i.e. val aStream : InputStream = HashCheckingStream(...).
+            addDefaultSerializer(InputStream::class.java, InputStreamSerializer)
+
             register(Class.forName("sun.net.www.protocol.jar.JarURLConnection\$JarURLInputStream"), InputStreamSerializer)
 
             noReferencesWithin<WireTransaction>()

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -58,11 +58,10 @@ object DefaultKryoCustomizer {
             // InputStream subclasses whitelisting, required for attachments.
             register(BufferedInputStream::class.java, InputStreamSerializer)
             register(FileInputStream::class.java, InputStreamSerializer)
+            register(Class.forName("sun.net.www.protocol.jar.JarURLConnection\$JarURLInputStream"), InputStreamSerializer)
             // Required for HashCheckingStream (de)serialization.
             // Note that return type should be specifically set to InputStream, otherwise it may not work, i.e. val aStream : InputStream = HashCheckingStream(...).
             addDefaultSerializer(InputStream::class.java, InputStreamSerializer)
-
-            register(Class.forName("sun.net.www.protocol.jar.JarURLConnection\$JarURLInputStream"), InputStreamSerializer)
 
             noReferencesWithin<WireTransaction>()
 

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -57,11 +57,7 @@ object DefaultKryoCustomizer {
 
             // InputStream subclasses whitelisting, required for attachments.
             register(BufferedInputStream::class.java, InputStreamSerializer)
-            register(FileInputStream::class.java, InputStreamSerializer)
             register(Class.forName("sun.net.www.protocol.jar.JarURLConnection\$JarURLInputStream"), InputStreamSerializer)
-            // Required for HashCheckingStream (de)serialization.
-            // Note that return type should be specifically set to InputStream, otherwise it may not work, i.e. val aStream : InputStream = HashCheckingStream(...).
-            addDefaultSerializer(InputStream::class.java, InputStreamSerializer)
 
             noReferencesWithin<WireTransaction>()
 
@@ -87,6 +83,11 @@ object DefaultKryoCustomizer {
             register(BitSet::class.java, ReferencesAwareJavaSerializer)
 
             addDefaultSerializer(Logger::class.java, LoggerSerializer)
+
+            register(FileInputStream::class.java, InputStreamSerializer)
+            // Required for HashCheckingStream (de)serialization.
+            // Note that return type should be specifically set to InputStream, otherwise it may not work, i.e. val aStream : InputStream = HashCheckingStream(...).
+            addDefaultSerializer(InputStream::class.java, InputStreamSerializer)
 
             val customization = KryoSerializationCustomization(this)
             pluginRegistries.forEach { it.customizeSerialization(customization) }

--- a/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
@@ -8,9 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
-import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.slf4j.LoggerFactory
 import java.io.InputStream
@@ -19,6 +17,8 @@ import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import net.corda.node.services.persistence.NodeAttachmentService
+import java.io.ByteArrayInputStream
 
 class KryoTests {
 
@@ -130,6 +130,15 @@ class KryoTests {
         val logger2 = logger.serialize(storageKryo()).deserialize(storageKryo())
         assertEquals(logger.name, logger2.name)
         assertTrue(logger === logger2)
+    }
+    @Test
+    fun `HashCheckingStream (de)serialize`() {
+        val rubbish = ByteArray(12345, { (it * it * 0.12345).toByte() })
+        val readRubbishStream : InputStream = NodeAttachmentService.HashCheckingStream(SecureHash.sha256(rubbish), rubbish.size, ByteArrayInputStream(rubbish)).serialize(kryo).deserialize(kryo)
+        for (i in 0 .. 12344) {
+            assertEquals(rubbish[i], readRubbishStream.read().toByte())
+        }
+        assertEquals(-1, readRubbishStream.read())
     }
 
     @CordaSerializable

--- a/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
@@ -131,6 +131,7 @@ class KryoTests {
         assertEquals(logger.name, logger2.name)
         assertTrue(logger === logger2)
     }
+
     @Test
     fun `HashCheckingStream (de)serialize`() {
         val rubbish = ByteArray(12345, { (it * it * 0.12345).toByte() })

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -65,8 +65,9 @@ class NodeAttachmentService(override var storePath: Path, dataSourceProperties: 
      * inside it, we haven't read the whole file, so we can't check the hash. But when copying it over the network
      * this will provide an additional safety check against user error.
      */
-    private class HashCheckingStream(val expected: SecureHash.SHA256,
-                                     val expectedSize: Int,
+    @VisibleForTesting @CordaSerializable
+    class HashCheckingStream(val expected: SecureHash.SHA256,
+                             val expectedSize: Int,
                                      input: InputStream,
                                      private val counter: CountingInputStream = CountingInputStream(input),
                                      private val stream: HashingInputStream = HashingInputStream(Hashing.sha256(), counter)) : FilterInputStream(stream) {

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -68,9 +68,9 @@ class NodeAttachmentService(override var storePath: Path, dataSourceProperties: 
     @VisibleForTesting @CordaSerializable
     class HashCheckingStream(val expected: SecureHash.SHA256,
                              val expectedSize: Int,
-                                     input: InputStream,
-                                     private val counter: CountingInputStream = CountingInputStream(input),
-                                     private val stream: HashingInputStream = HashingInputStream(Hashing.sha256(), counter)) : FilterInputStream(stream) {
+                             input: InputStream,
+                             private val counter: CountingInputStream = CountingInputStream(input),
+                             private val stream: HashingInputStream = HashingInputStream(Hashing.sha256(), counter)) : FilterInputStream(stream) {
         override fun close() {
             super.close()
 
@@ -87,7 +87,7 @@ class NodeAttachmentService(override var storePath: Path, dataSourceProperties: 
                                  private val checkOnLoad: Boolean) : Attachment {
         override fun open(): InputStream {
 
-            var stream = ByteArrayInputStream(attachment)
+            val stream = ByteArrayInputStream(attachment)
 
             // This is just an optional safety check. If it slows things down too much it can be disabled.
             if (id is SecureHash.SHA256 && checkOnLoad)


### PR DESCRIPTION
A solution for [#347](https://github.com/corda/corda/issues/347) and [#447](https://github.com/corda/corda/issues/447) where HashCheckingStream could not be (de)serialised. I've also registered FileInputStream as it may be required in attachments.