### PR TITLE
CashExitFlow now uses soft locked states

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -247,6 +247,13 @@ interface VaultService {
     fun <T : ContractState> softLockedStates(lockId: UUID? = null): List<StateAndRef<T>>
 
     // DOCEND SoftLockAPI
+
+    /**
+     * TODO: this function should be private to the vault, but currently Cash Exit functionality
+     * is implemented in a separate module (finance) and requires access to it.
+     */
+    @Suspendable
+    fun <T : ContractState> unconsumedStatesForSpending(amount: Amount<Currency>, onlyFromIssuerParties: Set<AbstractParty>? = null, notary: Party? = null, lockId: UUID): List<StateAndRef<T>>
 }
 
 inline fun <reified T: ContractState> VaultService.unconsumedStates(includeSoftLockedStates: Boolean = true): Iterable<StateAndRef<T>> =

--- a/finance/src/main/kotlin/net/corda/flows/CashExitFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/CashExitFlow.kt
@@ -7,8 +7,6 @@ import net.corda.core.contracts.InsufficientBalanceException
 import net.corda.core.contracts.TransactionType
 import net.corda.core.contracts.issuedBy
 import net.corda.core.crypto.Party
-import net.corda.core.node.services.Vault
-import net.corda.core.node.services.unconsumedStates
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -35,11 +33,12 @@ class CashExitFlow(val amount: Amount<Currency>, val issueRef: OpaqueBytes, prog
         progressTracker.currentStep = GENERATING_TX
         val builder: TransactionBuilder = TransactionType.General.Builder(null)
         val issuer = serviceHub.myInfo.legalIdentity.ref(issueRef)
+        val exitStates = serviceHub.vaultService.unconsumedStatesForSpending<Cash.State>(amount, setOf(issuer.party), builder.notary, builder.lockId)
         try {
             Cash().generateExit(
                     builder,
                     amount.issuedBy(issuer),
-                    serviceHub.vaultService.unconsumedStates<Cash.State>().filter { it.state.data.owner == issuer.party.owningKey })
+                    exitStates)
         } catch (e: InsufficientBalanceException) {
             throw CashException("Exiting more cash than exists", e)
         }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -326,7 +326,7 @@ class NodeVaultService(private val services: ServiceHub, dataSourceProperties: P
     val spendLock: ReentrantLock = ReentrantLock()
 
     @Suspendable
-    internal fun <T : ContractState> unconsumedStatesForSpending(amount: Amount<Currency>, onlyFromIssuerParties: Set<AbstractParty>? = null, notary: Party? = null, lockId: UUID): List<StateAndRef<T>> {
+    override fun <T : ContractState> unconsumedStatesForSpending(amount: Amount<Currency>, onlyFromIssuerParties: Set<AbstractParty>?, notary: Party?, lockId: UUID): List<StateAndRef<T>> {
 
         val issuerKeysStr = onlyFromIssuerParties?.fold("") { left, right -> left + "('${right.owningKey.toBase58String()}')," }?.dropLast(1)
         var stateAndRefs = mutableListOf<StateAndRef<T>>()


### PR DESCRIPTION
This PR fixes a NotaryException (double spend) scenario whereby an Exit and Spend are executed concurrently, but the Exit flow was NOT soft locking any states in its coin selection.