### PR TITLE
Add 'finance' module to Corda WebServer, for plugins to use.

### DIFF
--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -220,6 +220,8 @@ class NodeConfigTest {
 
         assertEquals(localPort(20001), webConfig.webAddress)
         assertEquals(localPort(10001), webConfig.p2pAddress)
+        assertEquals("trustpass", webConfig.trustStorePassword)
+        assertEquals("cordacadevpass", webConfig.keyStorePassword)
     }
 
     @Test

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -31,6 +31,7 @@ sourceSets {
 
 dependencies {
     compile project(':core')
+    compile project(':finance')
     compile project(':client:rpc')
     compile project(':client:jackson')
     testCompile project(':node')

--- a/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
@@ -163,7 +163,8 @@ class NodeWebServer(val config: WebServerConfig) {
                 Thread.sleep(retryDelay)
             } catch (e: Throwable) {
                 // E.g. a plugin cannot be instantiated?
-                log.error("Cannot launch WebServer: {}", e)
+                // Note that we do want the exception stacktrace.
+                log.error("Cannot start WebServer", e)
                 throw e
             }
         }

--- a/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
@@ -161,6 +161,10 @@ class NodeWebServer(val config: WebServerConfig) {
             } catch (e: java.nio.file.NoSuchFileException) {
                 log.debug("Tried to open a file that doesn't yet exist, retrying", e)
                 Thread.sleep(retryDelay)
+            } catch (e: Throwable) {
+                // E.g. a plugin cannot be instantiated?
+                log.error("Cannot launch WebServer: {}", e)
+                throw e
             }
         }
     }


### PR DESCRIPTION
Removing `finance` from the WebServer means that the `BankOfCorda` plugin can no longer be instantiated. This generates a `NoClassDefFoundError` as the WebServer tries to boot:
```
Caused by: java.lang.NoClassDefFoundError: net/corda/flows/IssuerFlow$IssuanceRequester
        at net.corda.bank.plugin.BankOfCordaPlugin.<init>(BankOfCordaPlugin.kt:16) ~[bank-of-corda.jar:?]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_121]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:1.8.0_121]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_121]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_121]
        at java.lang.Class.newInstance(Class.java:442) ~[?:1.8.0_121]
        at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:380) ~[?:1.8.0_121]
        ... 29 more
```
Restore `finance` to WebServer on the basis that a lot of CorDapps will probably want to use it.

Also test for `keyStorePassword` and `trustStorePassword` in the WebServer configuration because it won't boot without these either.