### PR TITLE
Simple normalisation of CompositeKeys

### DIFF
--- a/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
+++ b/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
@@ -6,7 +6,7 @@ import net.corda.core.bufferUntilSubscribed
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.USD
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.crypto.keys
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.getOrThrow
@@ -160,7 +160,7 @@ class NodeMonitorModelTest : DriverBasedTest() {
                         // Only Alice signed
                         val aliceKey = aliceNode.legalIdentity.owningKey
                         require(signaturePubKeys.size <= aliceKey.keys.size)
-                        require(aliceKey.composite.isFulfilledBy(signaturePubKeys))
+                        require(aliceKey.isFulfilledBy(signaturePubKeys))
                         issueTx = stx
                     },
                     // MOVE
@@ -169,8 +169,8 @@ class NodeMonitorModelTest : DriverBasedTest() {
                         require(stx.tx.outputs.size == 1)
                         val signaturePubKeys = stx.sigs.map { it.by }.toSet()
                         // Alice and Notary signed
-                        require(aliceNode.legalIdentity.owningKey.composite.isFulfilledBy(signaturePubKeys))
-                        require(notaryNode.notaryIdentity.owningKey.composite.isFulfilledBy(signaturePubKeys))
+                        require(aliceNode.legalIdentity.owningKey.isFulfilledBy(signaturePubKeys))
+                        require(notaryNode.notaryIdentity.owningKey.isFulfilledBy(signaturePubKeys))
                         moveTx = stx
                     }
             )

--- a/core/src/main/kotlin/net/corda/core/contracts/DummyContractV2.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/DummyContractV2.kt
@@ -11,6 +11,7 @@ val DUMMY_V2_PROGRAM_ID = DummyContractV2()
 /**
  * Dummy contract state for testing of the upgrade process.
  */
+// DOCSTART 1
 class DummyContractV2 : UpgradedContract<DummyContract.State, DummyContractV2.State> {
     override val legacyContract = DummyContract::class.java
 
@@ -35,7 +36,7 @@ class DummyContractV2 : UpgradedContract<DummyContract.State, DummyContractV2.St
 
     // The "empty contract"
     override val legalContractReference: SecureHash = SecureHash.sha256("")
-
+    // DOCEND 1
     /**
      * Generate an upgrade transaction from [DummyContract].
      *

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -4,17 +4,6 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.serialize
 import java.security.PublicKey
 
-// Holds node - weight pairs for a CompositeKey. Ordered first by weight, then by node's hashCode.
-@CordaSerializable
-data class NodeWeight(val node: PublicKey, val weight: Int): Comparable<NodeWeight> {
-    override fun compareTo(other: NodeWeight): Int {
-        if(weight == other.weight) {
-            return node.hashCode().compareTo(other.node.hashCode())
-        }
-        else return weight.compareTo(other.weight)
-    }
-}
-
 /**
  * A tree data structure that enables the representation of composite public keys.
  * Notice that with that implementation CompositeKey extends PublicKey. Leaves are represented by single public keys.
@@ -33,13 +22,24 @@ data class NodeWeight(val node: PublicKey, val weight: Int): Comparable<NodeWeig
  * signatures required) to satisfy the sub-tree rooted at this node.
  */
 @CordaSerializable
-class CompositeKey(val threshold: Int,
+class CompositeKey private constructor (val threshold: Int,
                    children: List<NodeWeight>) : PublicKey {
     val children = children.sorted()
     init {
         require (children.size == children.toSet().size) { "Trying to construct CompositeKey with duplicated child nodes." }
         // If we want PublicKey we only keep one key, otherwise it will lead to semantically equivalent trees but having different structures.
         require(children.size > 1) { "Cannot construct CompositeKey with only one child node." }
+    }
+
+    // Holds node - weight pairs for a CompositeKey. Ordered first by weight, then by node's hashCode.
+    @CordaSerializable
+    data class NodeWeight(val node: PublicKey, val weight: Int): Comparable<NodeWeight> {
+        override fun compareTo(other: NodeWeight): Int {
+            if(weight == other.weight) {
+                return node.hashCode().compareTo(other.node.hashCode())
+            }
+            else return weight.compareTo(other.weight)
+        }
     }
 
     companion object {

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -1,10 +1,19 @@
 package net.corda.core.crypto
 
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
-import java.security.InvalidKeyException
 import java.security.PublicKey
+
+// Holds node - weight pairs for a CompositeKey. Ordered first by weight, then by node's hashCode.
+@CordaSerializable
+data class NodeWeight(val node: PublicKey, val weight: Int): Comparable<NodeWeight> {
+    override fun compareTo(other: NodeWeight): Int {
+        if(weight == other.weight) {
+            return node.hashCode().compareTo(other.node.hashCode())
+        }
+        else return weight.compareTo(other.weight)
+    }
+}
 
 /**
  * A tree data structure that enables the representation of composite public keys.
@@ -18,16 +27,21 @@ import java.security.PublicKey
  * Using these constructs we can express e.g. 1 of N (OR) or N of N (AND) signature requirements. By nesting we can
  * create multi-level requirements such as *"either the CEO or 3 of 5 of his assistants need to sign"*.
  *
- * [CompositeKey] maintains a list of child nodes – sub-trees, and associated
- * [weights] carried by child node signatures.
+ * [CompositeKey] maintains a list of [NodeWeigh] which holds child subtree with associated weight carried by child node signatures.
  *
  * The [threshold] specifies the minimum total weight required (in the simple case – the minimum number of child
  * signatures required) to satisfy the sub-tree rooted at this node.
  */
 @CordaSerializable
 class CompositeKey(val threshold: Int,
-                   val children: List<PublicKey>, // Can also be CompositeKey subtree.
-                   val weights: List<Int>) : PublicKey {
+                   children: List<NodeWeight>) : PublicKey {
+    val children = children.sorted()
+    init {
+        require (children.size == children.toSet().size) { "Trying to construct CompositeKey with duplicated child nodes." }
+        // If we want PublicKey we only keep one key, otherwise it will lead to semantically equivalent trees but having different structures.
+        require(children.size > 1) { "Cannot construct CompositeKey with only one child node." }
+    }
+
     companion object {
         // TODO: Get the design standardised and from there define a recognised name
         val ALGORITHM = "X-Corda-CompositeKey"
@@ -37,24 +51,21 @@ class CompositeKey(val threshold: Int,
 
     fun isFulfilledBy(key: PublicKey) = isFulfilledBy(setOf(key))
 
-    /** Checks whether any of the given [keys] matches a leaf on the tree */
-    fun containsAny(otherKeys: Iterable<PublicKey>) = keys.intersect(otherKeys).isNotEmpty()
-
     override fun getAlgorithm() = ALGORITHM
     override fun getEncoded(): ByteArray = this.serialize().bytes
     override fun getFormat() = FORMAT
 
     // TODO Can CompositeKey be fulfilled by other composite keys? With composite signature it makes some sense.
     fun isFulfilledBy(keys: Iterable<PublicKey>): Boolean {
-        val totalWeight = children.mapIndexed { i, childNode ->
-            if (childNode is CompositeKey) {
-                if (childNode.isFulfilledBy(keys))
-                    weights[i]
+        val totalWeight = children.map { it ->
+            if (it.node is CompositeKey) {
+                if (it.node.isFulfilledBy(keys))
+                    it.weight
                 else
                     0
             } else {
-                if (keys.contains(childNode))
-                    weights[i]
+                if (keys.contains(it.node))
+                    it.weight
                 else
                     0
             }
@@ -63,18 +74,13 @@ class CompositeKey(val threshold: Int,
     }
 
     val keys: Set<PublicKey>
-        get() = children.flatMap { it.keys }.toSet() // Uses PublicKey.keys extension.
+        get() = children.flatMap { it.node.keys }.toSet() // Uses PublicKey.keys extension.
 
-    // TODO We need equivalence of CompositeKeys or normalisation when builder is called.
-    //  Otherwise we can end up with semantically equivalent trees but different structure. It already can be problematic
-    //  when having single PublicKey and PublicKey wrapped in CompositeKey, but that's not the only case.
     // Auto-generated. TODO: remove once data class inheritance is enabled
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is CompositeKey) return false
-
         if (threshold != other.threshold) return false
-        if (weights != other.weights) return false
         if (children != other.children) return false
 
         return true
@@ -82,7 +88,6 @@ class CompositeKey(val threshold: Int,
 
     override fun hashCode(): Int {
         var result = threshold
-        result = 31 * result + weights.hashCode()
         result = 31 * result + children.hashCode()
         return result
     }
@@ -90,14 +95,12 @@ class CompositeKey(val threshold: Int,
     override fun toString() = "(${children.joinToString()})"
 
     /** A helper class for building a [CompositeKey]. */
-    class Builder() {
-        private val children: MutableList<PublicKey> = mutableListOf()
-        private val weights: MutableList<Int> = mutableListOf()
+    class Builder {
+        private val children: MutableList<NodeWeight> = mutableListOf()
 
         /** Adds a child [CompositeKey] node. Specifying a [weight] for the child is optional and will default to 1. */
         fun addKey(key: PublicKey, weight: Int = 1): Builder {
-            children.add(key)
-            weights.add(weight)
+            children.add(NodeWeight(key, weight))
             return this
         }
 
@@ -109,22 +112,23 @@ class CompositeKey(val threshold: Int,
         fun addKeys(keys: List<PublicKey>): Builder = addKeys(*keys.toTypedArray())
 
         /**
-         * Builds the [CompositeKey.Node]. If [threshold] is not specified, it will default to
+         * Builds the [CompositeKey]. If [threshold] is not specified, it will default to
          * the size of the children, effectively generating an "N of N" requirement.
+         * During process removes single keys wrapped in [CompositeKey] and enforces ordering on child nodes.
          */
-        fun build(threshold: Int? = null): CompositeKey {
-            return CompositeKey(threshold ?: children.size, children.toList(), weights.toList())
+        @Throws(IllegalArgumentException::class)
+        fun build(threshold: Int? = null): PublicKey {
+            val n = children.size
+            if (n > 1)
+                return CompositeKey(threshold ?: n, children)
+            else if (n == 1) {
+                if (threshold != null && threshold != children[0].weight)
+                    throw IllegalArgumentException("Trying to build invalid CompositeKey, threshold value different than weight of single child node.")
+                return children[0].node // We can assume that this node is a correct CompositeKey.
+            }
+            else throw IllegalArgumentException("Trying to build CompositeKey without child nodes.")
         }
     }
-
-    /**
-     * Returns the enclosed [PublicKey] for a [CompositeKey] with a single leaf node
-     *
-     * @throws InvalidKeyException if the [CompositeKey] contains more than one node
-     */
-    val singleKey: PublicKey
-        @Throws(InvalidKeyException::class)
-        get() = keys.singleOrNull() ?: throw InvalidKeyException("The key is composed of more than one PublicKey primitive")
 }
 
 /** Returns the set of all [PublicKey]s contained within the PublicKey. These may be also [CompositeKey]s */

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtilities.kt
@@ -118,14 +118,17 @@ val PublicKey.keys: Set<PublicKey> get() {
     else setOf(this)
 }
 
-fun PublicKey.isFulfilledBy(key: PublicKey): Boolean  = isFulfilledBy(setOf(key))
-fun PublicKey.isFulfilledBy(keys: Iterable<PublicKey>): Boolean {
-    return if (this is CompositeKey) this.isFulfilledBy(keys)
-    else this in keys
+fun PublicKey.isFulfilledBy(otherKey: PublicKey): Boolean  = isFulfilledBy(setOf(otherKey))
+fun PublicKey.isFulfilledBy(otherKeys: Iterable<PublicKey>): Boolean {
+    return if (this is CompositeKey) this.isFulfilledBy(otherKeys)
+    else this in otherKeys
 }
 
 /** Checks whether any of the given [keys] matches a leaf on the CompositeKey tree or a single PublicKey */
-fun PublicKey.containsAny(otherKeys: Iterable<PublicKey>) = keys.intersect(otherKeys).isNotEmpty()
+fun PublicKey.containsAny(otherKeys: Iterable<PublicKey>): Boolean {
+    return if (this is CompositeKey) keys.intersect(otherKeys).isNotEmpty()
+    else this in otherKeys
+}
 
 /** Returns the set of all [PublicKey]s of the signatures */
 fun Iterable<DigitalSignature.WithKey>.byKeys() = map { it.by }.toSet()

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -379,7 +379,7 @@ object CompositeKeySerializer : Serializer<CompositeKey>() {
 
     override fun read(kryo: Kryo, input: Input, type: Class<CompositeKey>): CompositeKey {
         val threshold = input.readInt()
-        val children = readListOfLength<CompositeKey.NodeWeight>(kryo, input, minLen = 2)
+        val children = readListOfLength<CompositeKey.NodeAndWeight>(kryo, input, minLen = 2)
         val builder = CompositeKey.Builder()
         children.forEach { builder.addKey(it.node, it.weight)  }
         return builder.build(threshold) as CompositeKey

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -6,7 +6,7 @@ import net.corda.core.contracts.TransactionResolutionException
 import net.corda.core.node.ServiceHub
 import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.crypto.signWithECDSA
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
@@ -69,7 +69,7 @@ data class SignedTransaction(val txBits: SerializedBytes<WireTransaction>,
 
         val missing = getMissingSignatures()
         if (missing.isNotEmpty()) {
-            val allowed = allowedToBeMissing.map { it.composite }.toSet()
+            val allowed = allowedToBeMissing.toSet()
             val needed = missing - allowed
             if (needed.isNotEmpty())
                 throw SignaturesMissingException(needed, getMissingKeyDescriptions(needed), id)
@@ -97,7 +97,7 @@ data class SignedTransaction(val txBits: SerializedBytes<WireTransaction>,
         val sigKeys = sigs.map { it.by }.toSet()
         // TODO Problem is that we can get single PublicKey wrapped as CompositeKey in allowedToBeMissing/mustSign
         //  equals on CompositeKey won't catch this case (do we want to single PublicKey be equal to the same key wrapped in CompositeKey with threshold 1?)
-        val missing = tx.mustSign.filter { !it.composite.isFulfilledBy(sigKeys) }.map { it.composite }.toSet()
+        val missing = tx.mustSign.filter { !it.isFulfilledBy(sigKeys) }.toSet()
         return missing
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -136,7 +136,7 @@ open class TransactionBuilder(
     fun toSignedTransaction(checkSufficientSignatures: Boolean = true): SignedTransaction {
         if (checkSufficientSignatures) {
             val gotKeys = currentSigs.map { it.by }.toSet()
-            val missing: Set<PublicKey> = signers.filter { !it.composite.isFulfilledBy(gotKeys) }.toSet()
+            val missing: Set<PublicKey> = signers.filter { !it.isFulfilledBy(gotKeys) }.toSet()
             if (missing.isNotEmpty())
                 throw IllegalStateException("Missing signatures on the transaction for the public keys: ${missing.joinToString()}")
         }

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -5,13 +5,14 @@ package net.corda.core.utilities
 import net.corda.core.crypto.*
 import java.math.BigInteger
 import java.security.KeyPair
+import java.security.PublicKey
 import java.time.Instant
 
 // A dummy time at which we will be pretending test transactions are created.
 val TEST_TX_TIME: Instant get() = Instant.parse("2015-04-17T12:00:00.00Z")
 
-val DUMMY_PUBKEY_1: CompositeKey get() = DummyPublicKey("x1").composite
-val DUMMY_PUBKEY_2: CompositeKey get() = DummyPublicKey("x2").composite
+val DUMMY_PUBKEY_1: PublicKey get() = DummyPublicKey("x1")
+val DUMMY_PUBKEY_2: PublicKey get() = DummyPublicKey("x2")
 
 val DUMMY_KEY_1: KeyPair by lazy { generateKeyPair() }
 val DUMMY_KEY_2: KeyPair by lazy { generateKeyPair() }

--- a/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
@@ -97,7 +97,7 @@ abstract class AbstractStateReplacementFlow {
             val proposal = Proposal(originalState.ref, modification, stx)
             val response = sendAndReceive<DigitalSignature.WithKey>(party, proposal)
             return response.unwrap {
-                check(party.owningKey.composite.isFulfilledBy(it.by)) { "Not signed by the required participant" }
+                check(party.owningKey.isFulfilledBy(it.by)) { "Not signed by the required participant" }
                 it.verifyWithECDSA(stx.id)
                 it
             }

--- a/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FinalityFlow.kt
@@ -5,7 +5,7 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.flows.FlowLogic
 import net.corda.core.node.ServiceHub
 import net.corda.core.transactions.LedgerTransaction
@@ -94,7 +94,7 @@ class FinalityFlow(val transactions: Iterable<SignedTransaction>,
     private fun hasNoNotarySignature(stx: SignedTransaction): Boolean {
         val notaryKey = stx.tx.notary?.owningKey
         val signers = stx.sigs.map { it.by }.toSet()
-        return !(notaryKey?.composite?.isFulfilledBy(signers) ?: false)
+        return !(notaryKey?.isFulfilledBy(signers) ?: false)
     }
 
     private fun lookupParties(ltxns: List<Pair<SignedTransaction, LedgerTransaction>>): List<Pair<SignedTransaction, Set<Party>>> {

--- a/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
@@ -93,7 +93,7 @@ object TwoPartyDealFlow {
             progressTracker.currentStep = AWAITING_PROPOSAL
 
             // Make the first message we'll send to kick off the flow.
-            val hello = Handshake(payload, myKeyPair.public.composite)
+            val hello = Handshake(payload, myKeyPair.public)
             val maybeSTX = sendAndReceive<SignedTransaction>(otherParty, hello)
 
             return maybeSTX

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionGraphSearchTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionGraphSearchTests.kt
@@ -1,6 +1,5 @@
 package net.corda.core.contracts
 
-import net.corda.core.crypto.composite
 import net.corda.core.crypto.newSecureRandom
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
@@ -32,7 +31,7 @@ class TransactionGraphSearchTests {
     fun buildTransactions(command: CommandData, signer: KeyPair): GraphTransactionStorage {
         val originTx = TransactionType.General.Builder(DUMMY_NOTARY).apply {
             addOutputState(DummyState(random31BitValue()))
-            addCommand(command, signer.public.composite)
+            addCommand(command, signer.public)
             signWith(signer)
             signWith(DUMMY_NOTARY_KEY)
         }.toSignedTransaction(false)

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
@@ -1,9 +1,10 @@
 package net.corda.core.contracts
 
 import net.corda.contracts.asset.DUMMY_CASH_ISSUER_KEY
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.generateKeyPair
 import net.corda.core.crypto.signWithECDSA
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.transactions.LedgerTransaction
@@ -22,6 +23,48 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class TransactionTests {
+
+    private fun makeSigned(wtx: WireTransaction, vararg keys: KeyPair): SignedTransaction {
+        val bytes: SerializedBytes<WireTransaction> = wtx.serialized
+        return SignedTransaction(bytes, keys.map { it.signWithECDSA(wtx.id.bytes) })
+    }
+
+    @Test
+    fun `signed transaction missing signatures - CompositeKey`() {
+        val ak = generateKeyPair()
+        val bk = generateKeyPair()
+        val ck = generateKeyPair()
+        val apub = ak.public
+        val bpub = bk.public
+        val cpub = ck.public
+        val c1 = CompositeKey.Builder().addKeys(apub, bpub).build(2)
+        val compKey = CompositeKey.Builder().addKeys(c1, cpub).build(1)
+        val wtx = WireTransaction(
+                inputs = listOf(StateRef(SecureHash.randomSHA256(), 0)),
+                attachments = emptyList(),
+                outputs = emptyList(),
+                commands = emptyList(),
+                notary = DUMMY_NOTARY,
+                signers = listOf(compKey, DUMMY_KEY_1.public, DUMMY_KEY_2.public),
+                type = TransactionType.General(),
+                timestamp = null
+        )
+        assertEquals(
+                setOf(compKey, DUMMY_KEY_2.public),
+                assertFailsWith<SignedTransaction.SignaturesMissingException> { makeSigned(wtx, DUMMY_KEY_1).verifySignatures() }.missing
+        )
+
+        assertEquals(
+                setOf(compKey, DUMMY_KEY_2.public),
+                assertFailsWith<SignedTransaction.SignaturesMissingException> { makeSigned(wtx, DUMMY_KEY_1, ak).verifySignatures() }.missing
+        )
+        makeSigned(wtx, DUMMY_KEY_1, DUMMY_KEY_2, ak, bk).verifySignatures()
+        makeSigned(wtx, DUMMY_KEY_1, DUMMY_KEY_2, ck).verifySignatures()
+        makeSigned(wtx, DUMMY_KEY_1, DUMMY_KEY_2, ak, bk, ck).verifySignatures()
+        makeSigned(wtx, DUMMY_KEY_1, DUMMY_KEY_2, ak).verifySignatures(compKey)
+        makeSigned(wtx, DUMMY_KEY_1, ak).verifySignatures(compKey, DUMMY_KEY_2.public) // Mixed allowed to be missing.
+    }
+
     @Test
     fun `signed transaction missing signatures`() {
         val wtx = WireTransaction(
@@ -30,31 +73,29 @@ class TransactionTests {
                 outputs = emptyList(),
                 commands = emptyList(),
                 notary = DUMMY_NOTARY,
-                signers = listOf(DUMMY_KEY_1.public.composite, DUMMY_KEY_2.public.composite),
+                signers = listOf(DUMMY_KEY_1.public, DUMMY_KEY_2.public),
                 type = TransactionType.General(),
                 timestamp = null
         )
-        val bytes: SerializedBytes<WireTransaction> = wtx.serialized
-        fun make(vararg keys: KeyPair) = SignedTransaction(bytes, keys.map { it.signWithECDSA(wtx.id.bytes) })
-        assertFailsWith<IllegalArgumentException> { make().verifySignatures() }
+        assertFailsWith<IllegalArgumentException> { makeSigned(wtx).verifySignatures() }
 
         assertEquals(
-                setOf(DUMMY_KEY_1.public.composite),
-                assertFailsWith<SignedTransaction.SignaturesMissingException> { make(DUMMY_KEY_2).verifySignatures() }.missing
+                setOf(DUMMY_KEY_1.public),
+                assertFailsWith<SignedTransaction.SignaturesMissingException> { makeSigned(wtx, DUMMY_KEY_2).verifySignatures() }.missing
         )
         assertEquals(
-                setOf(DUMMY_KEY_2.public.composite),
-                assertFailsWith<SignedTransaction.SignaturesMissingException> { make(DUMMY_KEY_1).verifySignatures() }.missing
+                setOf(DUMMY_KEY_2.public),
+                assertFailsWith<SignedTransaction.SignaturesMissingException> { makeSigned(wtx, DUMMY_KEY_1).verifySignatures() }.missing
         )
         assertEquals(
-                setOf(DUMMY_KEY_2.public.composite),
-                assertFailsWith<SignedTransaction.SignaturesMissingException> { make(DUMMY_CASH_ISSUER_KEY).verifySignatures(DUMMY_KEY_1.public.composite) }.missing
+                setOf(DUMMY_KEY_2.public),
+                assertFailsWith<SignedTransaction.SignaturesMissingException> { makeSigned(wtx, DUMMY_CASH_ISSUER_KEY).verifySignatures(DUMMY_KEY_1.public) }.missing
         )
 
-        make(DUMMY_KEY_1).verifySignatures(DUMMY_KEY_2.public.composite)
-        make(DUMMY_KEY_2).verifySignatures(DUMMY_KEY_1.public.composite)
+        makeSigned(wtx, DUMMY_KEY_1).verifySignatures(DUMMY_KEY_2.public)
+        makeSigned(wtx, DUMMY_KEY_2).verifySignatures(DUMMY_KEY_1.public)
 
-        make(DUMMY_KEY_1, DUMMY_KEY_2).verifySignatures()
+        makeSigned(wtx, DUMMY_KEY_1, DUMMY_KEY_2).verifySignatures()
     }
 
     @Test
@@ -65,7 +106,7 @@ class TransactionTests {
         val commands = emptyList<AuthenticatedObject<CommandData>>()
         val attachments = emptyList<Attachment>()
         val id = SecureHash.randomSHA256()
-        val signers = listOf(DUMMY_NOTARY_KEY.public.composite)
+        val signers = listOf(DUMMY_NOTARY_KEY.public)
         val timestamp: Timestamp? = null
         val transaction: LedgerTransaction = LedgerTransaction(
                 inputs,
@@ -92,7 +133,7 @@ class TransactionTests {
         val commands = emptyList<AuthenticatedObject<CommandData>>()
         val attachments = emptyList<Attachment>()
         val id = SecureHash.randomSHA256()
-        val signers = listOf(DUMMY_NOTARY_KEY.public.composite)
+        val signers = listOf(DUMMY_NOTARY_KEY.public)
         val timestamp: Timestamp? = null
         val transaction: LedgerTransaction = LedgerTransaction(
                 inputs,

--- a/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
@@ -63,7 +63,6 @@ class CompositeKeyTests {
 
     @Test
     fun `tree canonical form`() {
-        assertFailsWith<IllegalArgumentException> { CompositeKey(1, listOf(NodeWeight(alicePublicKey, 1))) }
         assertEquals(CompositeKey.Builder().addKeys(alicePublicKey).build(), alicePublicKey)
         val node1 = CompositeKey.Builder().addKeys(alicePublicKey, bobPublicKey).build(1) // threshold = 1
         val node2 = CompositeKey.Builder().addKeys(alicePublicKey, bobPublicKey).build(2) // threshold = 2
@@ -86,7 +85,6 @@ class CompositeKeyTests {
         assertEquals(tree5, tree6)
 
         // Chain of single nodes should throw.
-        assertFailsWith<IllegalArgumentException> { CompositeKey(1, listOf(NodeWeight(tree1, 1))) }
         assertEquals(CompositeKey.Builder().addKeys(tree1).build(), tree1)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/crypto/PartyTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartyTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.assertNotEquals
 class PartyTest {
     @Test
     fun `equality`() {
-        val key = entropyToKeyPair(BigInteger.valueOf(20170207L)).public.composite
-        val differentKey = entropyToKeyPair(BigInteger.valueOf(7201702L)).public.composite
+        val key = entropyToKeyPair(BigInteger.valueOf(20170207L)).public
+        val differentKey = entropyToKeyPair(BigInteger.valueOf(7201702L)).public
         val anonymousParty = AnonymousParty(key)
         val party = Party("test key", key)
         assertEquals<AbstractParty>(party, anonymousParty)

--- a/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
@@ -2,7 +2,6 @@ package net.corda.core.serialization
 
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.composite
 import net.corda.core.seconds
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.*
@@ -47,7 +46,7 @@ class TransactionSerializationTests {
     val fakeStateRef = generateStateRef()
     val inputState = StateAndRef(TransactionState(TestCash.State(depositRef, 100.POUNDS, DUMMY_PUBKEY_1), DUMMY_NOTARY), fakeStateRef)
     val outputState = TransactionState(TestCash.State(depositRef, 600.POUNDS, DUMMY_PUBKEY_1), DUMMY_NOTARY)
-    val changeState = TransactionState(TestCash.State(depositRef, 400.POUNDS, DUMMY_KEY_1.public.composite), DUMMY_NOTARY)
+    val changeState = TransactionState(TestCash.State(depositRef, 400.POUNDS, DUMMY_KEY_1.public), DUMMY_NOTARY)
 
 
     lateinit var tx: TransactionBuilder
@@ -55,7 +54,7 @@ class TransactionSerializationTests {
     @Before
     fun setup() {
         tx = TransactionType.General.Builder(DUMMY_NOTARY).withItems(
-                inputState, outputState, changeState, Command(TestCash.Commands.Move(), arrayListOf(DUMMY_KEY_1.public.composite))
+                inputState, outputState, changeState, Command(TestCash.Commands.Move(), arrayListOf(DUMMY_KEY_1.public))
         )
     }
 
@@ -94,7 +93,7 @@ class TransactionSerializationTests {
         // If the signature was replaced in transit, we don't like it.
         assertFailsWith(SignatureException::class) {
             val tx2 = TransactionType.General.Builder(DUMMY_NOTARY).withItems(inputState, outputState, changeState,
-                    Command(TestCash.Commands.Move(), DUMMY_KEY_2.public.composite))
+                    Command(TestCash.Commands.Move(), DUMMY_KEY_2.public))
             tx2.signWith(DUMMY_NOTARY_KEY)
             tx2.signWith(DUMMY_KEY_2)
 

--- a/core/src/test/kotlin/net/corda/core/testing/Generators.kt
+++ b/core/src/test/kotlin/net/corda/core/testing/Generators.kt
@@ -33,27 +33,22 @@ class PrivateKeyGenerator : Generator<PrivateKey>(PrivateKey::class.java) {
     }
 }
 
+// TODO add CompositeKeyGenerator that actually does something useful.
 class PublicKeyGenerator : Generator<PublicKey>(PublicKey::class.java) {
     override fun generate(random: SourceOfRandomness, status: GenerationStatus): PublicKey {
         return entropyToKeyPair(random.nextBigInteger(32)).public
     }
 }
 
-class CompositeKeyGenerator : Generator<CompositeKey>(CompositeKey::class.java) {
-    override fun generate(random: SourceOfRandomness, status: GenerationStatus): CompositeKey {
-        return entropyToKeyPair(random.nextBigInteger(32)).public.composite
-    }
-}
-
 class AnonymousPartyGenerator : Generator<AnonymousParty>(AnonymousParty::class.java) {
     override fun generate(random: SourceOfRandomness, status: GenerationStatus): AnonymousParty {
-        return AnonymousParty(CompositeKeyGenerator().generate(random, status))
+        return AnonymousParty(PublicKeyGenerator().generate(random, status))
     }
 }
 
 class PartyGenerator : Generator<Party>(Party::class.java) {
     override fun generate(random: SourceOfRandomness, status: GenerationStatus): Party {
-        return Party(StringGenerator().generate(random, status), CompositeKeyGenerator().generate(random, status))
+        return Party(StringGenerator().generate(random, status), PublicKeyGenerator().generate(random, status))
     }
 }
 

--- a/docs/source/contract-upgrade.rst
+++ b/docs/source/contract-upgrade.rst
@@ -86,35 +86,10 @@ Bank A and Bank B decided to upgrade the contract to ``DummyContractV2``
 
 1. Developer will create a new contract extending the ``UpgradedContract`` class, and a new state object ``DummyContractV2.State`` referencing the new contract.
 
-.. container:: codeset
-
-   .. sourcecode:: kotlin
-   
-      class DummyContractV2 : UpgradedContract<DummyContract.State, DummyContractV2.State> {
-          override val legacyContract = DummyContract::class.java
-      
-          data class State(val magicNumber: Int = 0, val owners: List<CompositeKey>) : ContractState {
-              override val contract = DUMMY_V2_PROGRAM_ID
-              override val participants: List<CompositeKey> = owners
-          }
-      
-          interface Commands : CommandData {
-              class Create : TypeOnlyCommandData(), Commands
-              class Move : TypeOnlyCommandData(), Commands
-          }
-      
-          override fun upgrade(state: DummyContract.State): DummyContractV2.State {
-              return DummyContractV2.State(state.magicNumber, state.participants)
-          }
-      
-          override fun verify(tx: TransactionForContract) {
-              if (tx.commands.any { it.value is UpgradeCommand }) ContractUpgradeFlow.verify(tx)
-              // Other verifications.
-          }
-      
-          // The "empty contract"
-          override val legalContractReference: SecureHash = SecureHash.sha256("")
-      }
+.. literalinclude:: /../../core/src/main/kotlin/net/corda/core/contracts/DummyContractV2.kt
+    :language: kotlin
+    :start-after: DOCSTART 1
+    :end-before: DOCEND 1
 
 2. Bank A will instruct its node to accept the contract upgrade to ``DummyContractV2`` for the contract state.
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
@@ -65,7 +65,7 @@ data class TradeApprovalContract(override val legalContractReference: SecureHash
         override val participants: List<PublicKey> get() = parties.map { it.owningKey }
 
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return participants.any { (it is CompositeKey && it.containsAny(ourKeys)) || it in ourKeys }
+            return participants.any { it.containsAny(ourKeys) }
         }
     }
 

--- a/docs/source/flow-state-machines.rst
+++ b/docs/source/flow-state-machines.rst
@@ -121,7 +121,7 @@ each side.
           data class SellerTradeInfo(
                   val assetForSale: StateAndRef<OwnableState>,
                   val price: Amount<Currency>,
-                  val sellerOwnerKey: CompositeKey
+                  val sellerOwnerKey: PublicKey
           )
 
           data class SignaturesFromSeller(val sellerSig: DigitalSignature.WithKey,

--- a/docs/source/key-concepts-core-types.rst
+++ b/docs/source/key-concepts-core-types.rst
@@ -19,7 +19,7 @@ A number of interfaces then extend ``ContractState``, representing standardised 
 of state such as:
 
       ``OwnableState``
-      A state which has an owner (represented as a ``CompositeKey``, discussed later). Exposes the owner and a function
+      A state which has an owner (represented as a ``PublicKey`` which can be a ``CompositeKey``, discussed later). Exposes the owner and a function
       for replacing the owner e.g. when an asset is sold.
 
       ``SchedulableState``
@@ -90,7 +90,7 @@ keys under their control.
 Parties can be represented either in full (including name) or pseudonymously, using the ``Party`` or ``AnonymousParty``
 classes respectively. For example, in a transaction sent to your node as part of a chain of custody it is important you
 can convince yourself of the transaction's validity, but equally important that you don't learn anything about who was
-involved in that transaction. In these cases ``AnonymousParty`` should be used, which contains a composite public key
+involved in that transaction. In these cases ``AnonymousParty`` should be used, which contains a public key (may be a composite key)
 without any identifying information about who owns it. In contrast, for internal processing where extended details of
 a party are required, the ``Party`` class should be used. The identity service provides functionality for resolving
 anonymous parties to full parties.

--- a/experimental/src/test/kotlin/net/corda/contracts/universal/ContractDefinition.kt
+++ b/experimental/src/test/kotlin/net/corda/contracts/universal/ContractDefinition.kt
@@ -1,7 +1,6 @@
 package net.corda.contracts.universal
 
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.composite
 import net.corda.core.crypto.generateKeyPair
 import org.junit.Test
 import java.util.*
@@ -11,7 +10,7 @@ val acmeCorp = Party("ACME Corporation", generateKeyPair().public)
 val highStreetBank = Party("High Street Bank", generateKeyPair().public)
 val momAndPop = Party("Mom and Pop", generateKeyPair().public)
 
-val acmeCorporationHasDefaulted = TerminalEvent(acmeCorp, generateKeyPair().public.composite)
+val acmeCorporationHasDefaulted = TerminalEvent(acmeCorp, generateKeyPair().public)
 
 
 // Currencies

--- a/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
+++ b/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
@@ -11,6 +11,7 @@ import net.corda.core.contracts.clauses.Clause;
 import net.corda.core.contracts.clauses.ClauseVerifier;
 import net.corda.core.contracts.clauses.GroupClauseVerifier;
 import net.corda.core.crypto.CryptoUtilities;
+import net.corda.core.crypto.NullPublicKey;
 import net.corda.core.crypto.Party;
 import net.corda.core.crypto.SecureHash;
 import net.corda.core.node.services.VaultService;
@@ -126,7 +127,7 @@ public class JavaCommercialPaper implements Contract {
         }
 
         public State withoutOwner() {
-            return new State(issuance, CryptoUtilities.getNullCompositeKey(), faceValue, maturityDate);
+            return new State(issuance, NullPublicKey.INSTANCE, faceValue, maturityDate);
         }
 
         @NotNull

--- a/finance/src/main/kotlin/net/corda/contracts/CommercialPaperLegacy.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/CommercialPaperLegacy.kt
@@ -2,7 +2,7 @@ package net.corda.contracts
 
 import net.corda.contracts.asset.sumCashBy
 import net.corda.core.contracts.*
-import net.corda.core.crypto.NullCompositeKey
+import net.corda.core.crypto.NullPublicKey
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
 import net.corda.core.node.services.VaultService
@@ -33,7 +33,7 @@ class CommercialPaperLegacy : Contract {
         override val contract = CP_LEGACY_PROGRAM_ID
         override val participants = listOf(owner)
 
-        fun withoutOwner() = copy(owner = NullCompositeKey)
+        fun withoutOwner() = copy(owner = NullPublicKey)
         override fun withNewOwner(newOwner: PublicKey) = Pair(Commands.Move(), copy(owner = newOwner))
         override fun toString() = "${Emoji.newspaper}CommercialPaper(of $faceValue redeemable on $maturityDate by '$issuance', owned by $owner)"
 

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
@@ -209,8 +209,8 @@ infix fun Cash.State.`with deposit`(deposit: PartyAndReference): Cash.State = wi
 /** A randomly generated key. */
 val DUMMY_CASH_ISSUER_KEY by lazy { entropyToKeyPair(BigInteger.valueOf(10)) }
 /** A dummy, randomly generated issuer party by the name of "Snake Oil Issuer" */
-val DUMMY_CASH_ISSUER by lazy { Party("Snake Oil Issuer", DUMMY_CASH_ISSUER_KEY.public.composite).ref(1) }
+val DUMMY_CASH_ISSUER by lazy { Party("Snake Oil Issuer", DUMMY_CASH_ISSUER_KEY.public).ref(1) }
 /** An extension property that lets you write 100.DOLLARS.CASH */
-val Amount<Currency>.CASH: Cash.State get() = Cash.State(Amount(quantity, Issued(DUMMY_CASH_ISSUER, token)), NullCompositeKey)
+val Amount<Currency>.CASH: Cash.State get() = Cash.State(Amount(quantity, Issued(DUMMY_CASH_ISSUER, token)), NullPublicKey)
 /** An extension property that lets you get a cash state from an issued token, under the [NullPublicKey] */
-val Amount<Issued<Currency>>.STATE: Cash.State get() = Cash.State(this, NullCompositeKey)
+val Amount<Issued<Currency>>.STATE: Cash.State get() = Cash.State(this, NullPublicKey)

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
@@ -723,9 +723,9 @@ infix fun <T: Any> Obligation.State<T>.`issued by`(party: AbstractParty) = copy(
 /** A randomly generated key. */
 val DUMMY_OBLIGATION_ISSUER_KEY by lazy { entropyToKeyPair(BigInteger.valueOf(10)) }
 /** A dummy, randomly generated issuer party by the name of "Snake Oil Issuer" */
-val DUMMY_OBLIGATION_ISSUER by lazy { Party("Snake Oil Issuer", DUMMY_OBLIGATION_ISSUER_KEY.public.composite) }
+val DUMMY_OBLIGATION_ISSUER by lazy { Party("Snake Oil Issuer", DUMMY_OBLIGATION_ISSUER_KEY.public) }
 
 val Issued<Currency>.OBLIGATION_DEF: Obligation.Terms<Currency>
     get() = Obligation.Terms(nonEmptySetOf(Cash().legalContractReference), nonEmptySetOf(this), TEST_TX_TIME)
 val Amount<Issued<Currency>>.OBLIGATION: Obligation.State<Currency>
-    get() = Obligation.State(Obligation.Lifecycle.NORMAL, DUMMY_OBLIGATION_ISSUER.toAnonymous(), token.OBLIGATION_DEF, quantity, NullCompositeKey)
+    get() = Obligation.State(Obligation.Lifecycle.NORMAL, DUMMY_OBLIGATION_ISSUER.toAnonymous(), token.OBLIGATION_DEF, quantity, NullPublicKey)

--- a/finance/src/main/kotlin/net/corda/contracts/testing/DummyDealContract.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/testing/DummyDealContract.kt
@@ -20,7 +20,7 @@ class DummyDealContract : Contract {
             override val ref: String,
             override val parties: List<AnonymousParty> = listOf()) : DealState {
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return participants.any { (it is CompositeKey && it.containsAny(ourKeys)) || it in ourKeys }
+            return participants.any { it.containsAny(ourKeys) }
         }
 
         override fun generateAgreement(notary: Party): TransactionBuilder {

--- a/finance/src/main/kotlin/net/corda/contracts/testing/DummyLinearContract.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/testing/DummyLinearContract.kt
@@ -6,7 +6,7 @@ import net.corda.core.contracts.clauses.FilterOn
 import net.corda.core.contracts.clauses.verifyClause
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.containsAny
 import java.security.PublicKey
 
 class DummyLinearContract: Contract {
@@ -24,7 +24,7 @@ class DummyLinearContract: Contract {
             val nonce: SecureHash = SecureHash.randomSHA256()) : LinearState {
 
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return participants.any { (it is CompositeKey && it.containsAny(ourKeys)) || it in ourKeys }
+            return participants.any { it.containsAny(ourKeys) }
         }
     }
 }

--- a/finance/src/main/kotlin/net/corda/contracts/testing/VaultFiller.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/testing/VaultFiller.kt
@@ -10,7 +10,6 @@ import net.corda.core.contracts.Issued
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.TransactionType
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.composite
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.Vault
 import net.corda.core.serialization.OpaqueBytes
@@ -26,7 +25,7 @@ fun ServiceHub.fillWithSomeTestDeals(dealIds: List<String>) {
     val transactions: List<SignedTransaction> = dealIds.map {
         // Issue a deal state
         val dummyIssue = TransactionType.General.Builder(notary = DUMMY_NOTARY).apply {
-            addOutputState(DummyDealContract.State(ref = it, participants = listOf(freshKey.public.composite)))
+            addOutputState(DummyDealContract.State(ref = it, participants = listOf(freshKey.public)))
             signWith(freshKey)
             signWith(DUMMY_NOTARY_KEY)
         }
@@ -41,7 +40,7 @@ fun ServiceHub.fillWithSomeTestLinearStates(numberToCreate: Int) {
     for (i in 1..numberToCreate) {
         // Issue a deal state
         val dummyIssue = TransactionType.General.Builder(notary = DUMMY_NOTARY).apply {
-            addOutputState(DummyLinearContract.State(participants = listOf(freshKey.public.composite)))
+            addOutputState(DummyLinearContract.State(participants = listOf(freshKey.public)))
             signWith(freshKey)
             signWith(DUMMY_NOTARY_KEY)
         }

--- a/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
@@ -95,7 +95,7 @@ object TwoPartyTradeFlow {
         private fun receiveAndCheckProposedTransaction(): SignedTransaction {
             progressTracker.currentStep = AWAITING_PROPOSAL
 
-            val myPublicKey = myKeyPair.public.composite
+            val myPublicKey = myKeyPair.public
             // Make the first message we'll send to kick off the flow.
             val hello = SellerTradeInfo(assetToSell, price, myPublicKey)
             // What we get back from the other side is a transaction that *might* be valid and acceptable to us,
@@ -222,7 +222,7 @@ object TwoPartyTradeFlow {
             // reveal who the owner actually is. The key management service is expected to derive a unique key from some
             // initial seed in order to provide privacy protection.
             val freshKey = serviceHub.keyManagementService.freshKey()
-            val (command, state) = tradeRequest.assetForSale.state.data.withNewOwner(freshKey.public.composite)
+            val (command, state) = tradeRequest.assetForSale.state.data.withNewOwner(freshKey.public)
             tx.addOutputState(state, tradeRequest.assetForSale.state.notary)
             tx.addCommand(command, tradeRequest.assetForSale.state.data.owner)
 

--- a/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
@@ -5,7 +5,6 @@ import net.corda.contracts.testing.fillWithSomeTestCash
 import net.corda.core.contracts.*
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.composite
 import net.corda.core.days
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultService
@@ -278,8 +277,8 @@ class CommercialPaperTestsGeneric {
             // Alice pays $9000 to BigCorp to own some of their debt.
             moveTX = run {
                 val ptx = TransactionType.General.Builder(DUMMY_NOTARY)
-                aliceVaultService.generateSpend(ptx, 9000.DOLLARS, bigCorpServices.key.public.composite)
-                CommercialPaper().generateMove(ptx, issueTX.tx.outRef(0), aliceServices.key.public.composite)
+                aliceVaultService.generateSpend(ptx, 9000.DOLLARS, bigCorpServices.key.public)
+                CommercialPaper().generateMove(ptx, issueTX.tx.outRef(0), aliceServices.key.public)
                 ptx.signWith(bigCorpServices.key)
                 ptx.signWith(aliceServices.key)
                 ptx.signWith(DUMMY_NOTARY_KEY)

--- a/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
@@ -2,7 +2,7 @@ package net.corda.contracts.asset
 
 import net.corda.contracts.asset.Obligation.Lifecycle
 import net.corda.core.contracts.*
-import net.corda.core.crypto.NullCompositeKey
+import net.corda.core.crypto.NullPublicKey
 import net.corda.core.crypto.SecureHash
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.utilities.*
@@ -506,7 +506,7 @@ class ObligationTests {
         val oneUnitFcoj = Amount(1, defaultFcoj)
         val obligationDef = Obligation.Terms(nonEmptySetOf(CommodityContract().legalContractReference), nonEmptySetOf(defaultFcoj), TEST_TX_TIME)
         val oneUnitFcojObligation = Obligation.State(Obligation.Lifecycle.NORMAL, ALICE,
-                obligationDef, oneUnitFcoj.quantity, NullCompositeKey)
+                obligationDef, oneUnitFcoj.quantity, NullPublicKey)
         // Try settling a simple commodity obligation
         ledger {
             unverifiedTransaction {

--- a/finance/src/test/kotlin/net/corda/contracts/testing/Generators.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/testing/Generators.kt
@@ -25,7 +25,7 @@ class ContractStateGenerator : Generator<ContractState>(ContractState::class.jav
     override fun generate(random: SourceOfRandomness, status: GenerationStatus): ContractState {
         return Cash.State(
                 amount = AmountGenerator(IssuedGenerator(CurrencyGenerator())).generate(random, status),
-                owner = CompositeKeyGenerator().generate(random, status)
+                owner = PublicKeyGenerator().generate(random, status)
         )
     }
 }
@@ -58,8 +58,8 @@ class CommandDataGenerator : Generator<CommandData>(CommandData::class.java) {
 class CommandGenerator : Generator<Command>(Command::class.java) {
     override fun generate(random: SourceOfRandomness, status: GenerationStatus): Command {
         val signersGenerator = ArrayListGenerator()
-        signersGenerator.addComponentGenerators(listOf(CompositeKeyGenerator()))
-        return Command(CommandDataGenerator().generate(random, status), CompositeKeyGenerator().generate(random, status))
+        signersGenerator.addComponentGenerators(listOf(PublicKeyGenerator()))
+        return Command(CommandDataGenerator().generate(random, status), PublicKeyGenerator().generate(random, status))
     }
 }
 

--- a/node-schemas/src/test/kotlin/net/corda/node/services/vault/schemas/VaultSchemaTest.kt
+++ b/node-schemas/src/test/kotlin/net/corda/node/services/vault/schemas/VaultSchemaTest.kt
@@ -630,7 +630,7 @@ class VaultSchemaTest {
 
     @Test
     fun insertWithBigCompositeKey() {
-        val keys = (1..314).map { generateKeyPair().public.composite }
+        val keys = (1..314).map { generateKeyPair().public }
         val bigNotaryKey = CompositeKey.Builder().addKeys(keys).build()
         val vaultStEntity = VaultStatesEntity().apply {
             txId = SecureHash.randomSHA256().toString()

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -4,7 +4,6 @@ import co.paralleluniverse.fibers.Suspendable
 import com.google.common.net.HostAndPort
 import net.corda.client.rpc.CordaRPCClientImpl
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.composite
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.crypto.toBase58String
 import net.corda.core.flows.FlowLogic

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
@@ -323,7 +323,7 @@ data class NodeRegistration(val node: NodeInfo, val serial: Long, val type: AddO
 class WireNodeRegistration(raw: SerializedBytes<NodeRegistration>, sig: DigitalSignature.WithKey) : SignedData<NodeRegistration>(raw, sig) {
     @Throws(IllegalArgumentException::class)
     override fun verifyData(data: NodeRegistration) {
-        require(data.node.legalIdentity.owningKey.composite.isFulfilledBy(sig.by))
+        require(data.node.legalIdentity.owningKey.isFulfilledBy(sig.by))
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -14,9 +14,10 @@ import net.corda.core.ThreadBox
 import net.corda.core.bufferUntilSubscribed
 import net.corda.core.contracts.*
 import net.corda.core.crypto.AbstractParty
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.containsAny
 import net.corda.core.crypto.toBase58String
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.StatesNotAvailableException
@@ -600,7 +601,7 @@ class NodeVaultService(private val services: ServiceHub, dataSourceProperties: P
     }
 
     private fun isRelevant(state: ContractState, ourKeys: Set<PublicKey>) = when (state) {
-        is OwnableState -> state.owner.composite.containsAny(ourKeys)
+        is OwnableState -> state.owner.containsAny(ourKeys)
     // It's potentially of interest to the vault
         is LinearState -> state.isRelevant(ourKeys)
         else -> false

--- a/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
@@ -2,7 +2,6 @@ package net.corda.node.utilities
 
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.composite
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.loggerFor

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -2,7 +2,7 @@ package net.corda.node
 
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.*
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.crypto.keys
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.messaging.StateMachineUpdate
@@ -163,7 +163,7 @@ class CordaRPCOpsImplTest {
                         // Only Alice signed
                         val aliceKey = aliceNode.info.legalIdentity.owningKey
                         require(signaturePubKeys.size <= aliceKey.keys.size)
-                        require(aliceKey.composite.isFulfilledBy(signaturePubKeys))
+                        require(aliceKey.isFulfilledBy(signaturePubKeys))
                     },
                     // MOVE
                     expect { tx ->
@@ -171,8 +171,8 @@ class CordaRPCOpsImplTest {
                         require(tx.tx.outputs.size == 1)
                         val signaturePubKeys = tx.sigs.map { it.by }.toSet()
                         // Alice and Notary signed
-                        require(aliceNode.info.legalIdentity.owningKey.composite.isFulfilledBy(signaturePubKeys))
-                        require(notaryNode.info.notaryIdentity.owningKey.composite.isFulfilledBy(signaturePubKeys))
+                        require(aliceNode.info.legalIdentity.owningKey.isFulfilledBy(signaturePubKeys))
+                        require(notaryNode.info.notaryIdentity.owningKey.isFulfilledBy(signaturePubKeys))
                     }
             )
         }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -258,7 +258,7 @@ class TwoPartyTradeFlowTests {
             }
 
             val extraKey = bobNode.keyManagement.freshKey()
-            val bobsFakeCash = fillUpForBuyer(false, extraKey.public.composite,
+            val bobsFakeCash = fillUpForBuyer(false, extraKey.public,
                     DUMMY_CASH_ISSUER.party,
                     notaryNode.info.notaryIdentity).second
             val bobsSignedTxns = insertFakeTransactions(bobsFakeCash, bobNode, notaryNode, bobNode.services.legalIdentityKey, extraKey)
@@ -459,7 +459,7 @@ class TwoPartyTradeFlowTests {
         val bobKey = bobNode.services.legalIdentityKey
         val issuer = MEGA_CORP.ref(1, 2, 3)
 
-        val bobsBadCash = fillUpForBuyer(bobError, bobKey.public.composite, DUMMY_CASH_ISSUER.party,
+        val bobsBadCash = fillUpForBuyer(bobError, bobKey.public, DUMMY_CASH_ISSUER.party,
                 notaryNode.info.notaryIdentity).second
         val alicesFakePaper = databaseTransaction(aliceNode.database) {
             fillUpForSeller(aliceError, aliceNode.info.legalIdentity.owningKey,

--- a/node/src/test/kotlin/net/corda/node/services/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/InMemoryIdentityServiceTests.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services
 
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.composite
 import net.corda.core.crypto.generateKeyPair
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.testing.*
@@ -48,7 +47,7 @@ class InMemoryIdentityServiceTests {
     @Test
     fun `get identity by name`() {
         val service = InMemoryIdentityService()
-        val identities = listOf("Node A", "Node B", "Node C").map { Party(it, generateKeyPair().public.composite) }
+        val identities = listOf("Node A", "Node B", "Node C").map { Party(it, generateKeyPair().public) }
         assertNull(service.partyFromName(identities.first().name))
         identities.forEach { service.registerIdentity(it) }
         identities.forEach { assertEquals(it, service.partyFromName(it.name)) }

--- a/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services
 
 import net.corda.core.contracts.*
-import net.corda.core.crypto.composite
 import net.corda.core.days
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRef
@@ -271,7 +270,7 @@ class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
                 val state = TestState(factory.create(TestFlowLogic::class.java, increment), instant)
                 val usefulTX = TransactionType.General.Builder(null).apply {
                     addOutputState(state, DUMMY_NOTARY)
-                    addCommand(Command(), freshKey.public.composite)
+                    addCommand(Command(), freshKey.public)
                     signWith(freshKey)
                 }.toSignedTransaction()
                 val txHash = usefulTX.id

--- a/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
@@ -2,8 +2,9 @@ package net.corda.node.services
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Party
-import net.corda.core.crypto.composite
+import net.corda.core.crypto.containsAny
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRefFactory
 import net.corda.core.node.CordaPluginRegistry
@@ -47,7 +48,7 @@ class ScheduledFlowTests {
         override val participants: List<PublicKey> = listOf(source.owningKey, destination.owningKey)
 
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return participants.any { it.composite.containsAny(ourKeys) }
+            return participants.any { it.containsAny(ourKeys) }
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ValidatingNotaryServiceTests.kt
@@ -3,13 +3,11 @@ package net.corda.node.services
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.contracts.*
 import net.corda.core.crypto.DigitalSignature
-import net.corda.core.crypto.composite
 import net.corda.core.crypto.keys
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_NOTARY
-import net.corda.core.utilities.DUMMY_NOTARY_KEY
 import net.corda.flows.NotaryError
 import net.corda.flows.NotaryException
 import net.corda.flows.NotaryFlow
@@ -17,7 +15,6 @@ import net.corda.node.internal.AbstractNode
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.ValidatingNotaryService
 import net.corda.testing.MEGA_CORP_KEY
-import net.corda.testing.MINI_CORP_KEY
 import net.corda.testing.node.MockNetwork
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -57,7 +54,7 @@ class ValidatingNotaryServiceTests {
     }
 
     @Test fun `should report error for missing signatures`() {
-        val expectedMissingKey = MEGA_CORP_KEY.public.composite
+        val expectedMissingKey = MEGA_CORP_KEY.public
         val stx = run {
             val inputState = issueState(clientNode)
 

--- a/node/src/test/kotlin/net/corda/node/services/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/VaultWithCashTest.kt
@@ -6,7 +6,6 @@ import net.corda.contracts.testing.fillWithSomeTestCash
 import net.corda.contracts.testing.fillWithSomeTestDeals
 import net.corda.contracts.testing.fillWithSomeTestLinearStates
 import net.corda.core.contracts.*
-import net.corda.core.crypto.composite
 import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.consumedStates
 import net.corda.core.node.services.unconsumedStates
@@ -14,9 +13,6 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.DUMMY_NOTARY_KEY
 import net.corda.core.utilities.LogHelper
-import net.corda.node.services.schema.HibernateObserver
-import net.corda.node.services.schema.NodeSchemaService
-import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.configureDatabase
 import net.corda.node.utilities.databaseTransaction
 import net.corda.testing.BOB_KEY
@@ -85,7 +81,7 @@ class VaultWithCashTest {
 
             val state = w[0].state.data
             assertEquals(30.45.DOLLARS `issued by` DUMMY_CASH_ISSUER, state.amount)
-            assertEquals(services.key.public.composite, state.owner)
+            assertEquals(services.key.public, state.owner)
 
             assertEquals(34.70.DOLLARS `issued by` DUMMY_CASH_ISSUER, (w[2].state.data).amount)
             assertEquals(34.85.DOLLARS `issued by` DUMMY_CASH_ISSUER, (w[1].state.data).amount)
@@ -98,7 +94,7 @@ class VaultWithCashTest {
             // A tx that sends us money.
             val freshKey = services.keyManagementService.freshKey()
             val usefulTX = TransactionType.General.Builder(null).apply {
-                Cash().generateIssue(this, 100.DOLLARS `issued by` MEGA_CORP.ref(1), freshKey.public.composite, DUMMY_NOTARY)
+                Cash().generateIssue(this, 100.DOLLARS `issued by` MEGA_CORP.ref(1), freshKey.public, DUMMY_NOTARY)
                 signWith(MEGA_CORP_KEY)
             }.toSignedTransaction()
 
@@ -116,7 +112,7 @@ class VaultWithCashTest {
 
             // A tx that doesn't send us anything.
             val irrelevantTX = TransactionType.General.Builder(DUMMY_NOTARY).apply {
-                Cash().generateIssue(this, 100.DOLLARS `issued by` MEGA_CORP.ref(1), BOB_KEY.public.composite, DUMMY_NOTARY)
+                Cash().generateIssue(this, 100.DOLLARS `issued by` MEGA_CORP.ref(1), BOB_KEY.public, DUMMY_NOTARY)
                 signWith(MEGA_CORP_KEY)
                 signWith(DUMMY_NOTARY_KEY)
             }.toSignedTransaction()
@@ -140,7 +136,7 @@ class VaultWithCashTest {
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 10, 10, Random(0L),
                                             issuedBy = MEGA_CORP.ref(1),
                                             issuerKey = MEGA_CORP_KEY,
-                                            ownedBy = freshKey.public.composite)
+                                            ownedBy = freshKey.public)
             println("Cash balance: ${vault.cashBalances[USD]}")
 
             assertThat(vault.unconsumedStates<Cash.State>()).hasSize(10)
@@ -231,8 +227,8 @@ class VaultWithCashTest {
 
             // Issue a linear state
             val dummyIssue = TransactionType.General.Builder(notary = DUMMY_NOTARY).apply {
-                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public.composite)))
-                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public.composite)))
+                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public)))
+                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public)))
                 signWith(freshKey)
                 signWith(DUMMY_NOTARY_KEY)
             }.toSignedTransaction()
@@ -252,7 +248,7 @@ class VaultWithCashTest {
 
             // Issue a linear state
             val dummyIssue = TransactionType.General.Builder(notary = DUMMY_NOTARY).apply {
-                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public.composite)))
+                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public)))
                 signWith(freshKey)
                 signWith(DUMMY_NOTARY_KEY)
             }.toSignedTransaction()
@@ -264,7 +260,7 @@ class VaultWithCashTest {
 
             // Move the same state
             val dummyMove = TransactionType.General.Builder(notary = DUMMY_NOTARY).apply {
-                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public.composite)))
+                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(linearId = linearId, participants = listOf(freshKey.public)))
                 addInputState(dummyIssue.tx.outRef<LinearState>(0))
                 signWith(DUMMY_NOTARY_KEY)
             }.toSignedTransaction()
@@ -281,7 +277,7 @@ class VaultWithCashTest {
 
         val freshKey = services.keyManagementService.freshKey()
         databaseTransaction(database) {
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L), ownedBy = freshKey.public.composite)
+            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L), ownedBy = freshKey.public)
             services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 2, 2, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
             val cash = vault.unconsumedStates<Cash.State>()
@@ -325,8 +321,8 @@ class VaultWithCashTest {
 
             // Create a txn consuming different contract types
             val dummyMove = TransactionType.General.Builder(notary = DUMMY_NOTARY).apply {
-                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(participants = listOf(freshKey.public.composite)))
-                addOutputState(net.corda.contracts.testing.DummyDealContract.State(ref = "999", participants = listOf(freshKey.public.composite)))
+                addOutputState(net.corda.contracts.testing.DummyLinearContract.State(participants = listOf(freshKey.public)))
+                addOutputState(net.corda.contracts.testing.DummyDealContract.State(ref = "999", participants = listOf(freshKey.public)))
                 addInputState(linearStates.first())
                 addInputState(deals.first())
                 signWith(DUMMY_NOTARY_KEY)

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -6,7 +6,6 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import com.typesafe.config.ConfigFactory.empty
-import net.corda.core.crypto.composite
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.messaging.Message
 import net.corda.core.messaging.RPCOps

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -3,7 +3,6 @@ package net.corda.node.services.vault
 import net.corda.contracts.asset.Cash
 import net.corda.contracts.testing.fillWithSomeTestCash
 import net.corda.core.contracts.*
-import net.corda.core.crypto.composite
 import net.corda.core.node.services.StatesNotAvailableException
 import net.corda.core.node.services.TxWritableStorageService
 import net.corda.core.node.services.VaultService
@@ -365,7 +364,7 @@ class NodeVaultServiceTest {
 
             // Issue a txn to Send us some Money
             val usefulTX = TransactionType.General.Builder(null).apply {
-                Cash().generateIssue(this, 100.DOLLARS `issued by` MEGA_CORP.ref(1), freshKey.public.composite, DUMMY_NOTARY)
+                Cash().generateIssue(this, 100.DOLLARS `issued by` MEGA_CORP.ref(1), freshKey.public, DUMMY_NOTARY)
                 signWith(MEGA_CORP_KEY)
             }.toSignedTransaction()
 
@@ -378,7 +377,7 @@ class NodeVaultServiceTest {
 
             // Issue more Money (GBP)
             val anotherTX = TransactionType.General.Builder(null).apply {
-                Cash().generateIssue(this, 200.POUNDS `issued by` MEGA_CORP.ref(1), freshKey.public.composite, DUMMY_NOTARY)
+                Cash().generateIssue(this, 200.POUNDS `issued by` MEGA_CORP.ref(1), freshKey.public, DUMMY_NOTARY)
                 signWith(MEGA_CORP_KEY)
             }.toSignedTransaction()
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
@@ -685,7 +685,7 @@ class InterestRateSwap() : Contract {
             get() = parties.map { it.owningKey }
 
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return fixedLeg.fixedRatePayer.owningKey.composite.containsAny(ourKeys) || floatingLeg.floatingRatePayer.owningKey.composite.containsAny(ourKeys)
+            return fixedLeg.fixedRatePayer.owningKey.containsAny(ourKeys) || floatingLeg.floatingRatePayer.owningKey.containsAny(ourKeys)
         }
 
         override val parties: List<AnonymousParty>

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
@@ -43,7 +43,7 @@ class SellerFlow(val otherParty: Party,
 
         val notary: NodeInfo = serviceHub.networkMapCache.notaryNodes[0]
         val cpOwnerKey = serviceHub.legalIdentityKey
-        val commercialPaper = selfIssueSomeCommercialPaper(cpOwnerKey.public.composite, notary)
+        val commercialPaper = selfIssueSomeCommercialPaper(cpOwnerKey.public, notary)
 
         progressTracker.currentStep = TRADING
 

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -34,6 +34,7 @@ import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyPair
+import java.security.PublicKey
 import java.util.*
 import kotlin.reflect.KClass
 
@@ -57,36 +58,36 @@ import kotlin.reflect.KClass
 
 // A few dummy values for testing.
 val MEGA_CORP_KEY: KeyPair by lazy { generateKeyPair() }
-val MEGA_CORP_PUBKEY: CompositeKey get() = MEGA_CORP_KEY.public.composite
+val MEGA_CORP_PUBKEY: PublicKey get() = MEGA_CORP_KEY.public
 
 val MINI_CORP_KEY: KeyPair by lazy { generateKeyPair() }
-val MINI_CORP_PUBKEY: CompositeKey get() = MINI_CORP_KEY.public.composite
+val MINI_CORP_PUBKEY: PublicKey get() = MINI_CORP_KEY.public
 
 val ORACLE_KEY: KeyPair by lazy { generateKeyPair() }
-val ORACLE_PUBKEY: CompositeKey get() = ORACLE_KEY.public.composite
+val ORACLE_PUBKEY: PublicKey get() = ORACLE_KEY.public
 
 val ALICE_KEY: KeyPair by lazy { generateKeyPair() }
-val ALICE_PUBKEY: CompositeKey get() = ALICE_KEY.public.composite
+val ALICE_PUBKEY: PublicKey get() = ALICE_KEY.public
 val ALICE: Party get() = Party("Alice", ALICE_PUBKEY)
 
 val BOB_KEY: KeyPair by lazy { generateKeyPair() }
-val BOB_PUBKEY: CompositeKey get() = BOB_KEY.public.composite
+val BOB_PUBKEY: PublicKey get() = BOB_KEY.public
 val BOB: Party get() = Party("Bob", BOB_PUBKEY)
 
 val CHARLIE_KEY: KeyPair by lazy { generateKeyPair() }
-val CHARLIE_PUBKEY: CompositeKey get() = CHARLIE_KEY.public.composite
+val CHARLIE_PUBKEY: PublicKey get() = CHARLIE_KEY.public
 val CHARLIE: Party get() = Party("Charlie", CHARLIE_PUBKEY)
 
 val MEGA_CORP: Party get() = Party("MegaCorp", MEGA_CORP_PUBKEY)
 val MINI_CORP: Party get() = Party("MiniCorp", MINI_CORP_PUBKEY)
 
 val BOC_KEY: KeyPair by lazy { generateKeyPair() }
-val BOC_PUBKEY: CompositeKey get() = BOC_KEY.public.composite
+val BOC_PUBKEY: PublicKey get() = BOC_KEY.public
 val BOC: Party get() = Party("BankOfCorda", BOC_PUBKEY)
 val BOC_PARTY_REF = BOC.ref(OpaqueBytes.of(1)).reference
 
 val BIG_CORP_KEY: KeyPair by lazy { generateKeyPair() }
-val BIG_CORP_PUBKEY: CompositeKey get() = BIG_CORP_KEY.public.composite
+val BIG_CORP_PUBKEY: PublicKey get() = BIG_CORP_KEY.public
 val BIG_CORP: Party get() = Party("BigCorporation", BIG_CORP_PUBKEY)
 val BIG_CORP_PARTY_REF = BIG_CORP.ref(OpaqueBytes.of(1)).reference
 

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -68,7 +68,7 @@ open class MockServices(val key: KeyPair = generateKeyPair()) : ServiceHub {
     override val networkMapCache: NetworkMapCache get() = throw UnsupportedOperationException()
     override val clock: Clock get() = Clock.systemUTC()
     override val schedulerService: SchedulerService get() = throw UnsupportedOperationException()
-    override val myInfo: NodeInfo get() = NodeInfo(object : SingleMessageRecipient {}, Party("MegaCorp", key.public.composite), MOCK_VERSION)
+    override val myInfo: NodeInfo get() = NodeInfo(object : SingleMessageRecipient {}, Party("MegaCorp", key.public), MOCK_VERSION)
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
 
     fun makeVaultService(dataSourceProps: Properties): VaultService {

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/GeneratedLedger.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/GeneratedLedger.kt
@@ -201,7 +201,7 @@ class GeneratedCommandData(
 ) : CommandData
 
 val keyPairGenerator = Generator.long().map { entropyToKeyPair(BigInteger.valueOf(it)) }
-val publicKeyGenerator = keyPairGenerator.map { it.public.composite }
+val publicKeyGenerator = keyPairGenerator.map { it.public }
 val stateGenerator: Generator<ContractState> =
         Generator.replicatePoisson(2.0, publicKeyGenerator).combine(Generator.long()) { participants, nonce ->
             GeneratedState(nonce, participants)


### PR DESCRIPTION
There was an issue with semantically equivalent trees but different structure, which causes equality and hashCode bugs. Added simple invariants to CompositeKey constructor to forbid the most obvious cases of such behaviour. Adjusted builder to emit simplified keys - if CompositeKey holds only single node, that node is moved up, so we won't end up with chains of wrapped keys. Added ordering of nodes on given tree level. It's not full normalisation of trees, but I think that it's sufficient (we don't have a use case for logical transformation of trees to the canonical form).