### PR TITLE
Args are correctly passed to node runner

### DIFF
--- a/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
+++ b/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes
@@ -7,7 +7,7 @@ basedir=$( dirname "$0" )
 cd "$basedir"
 
 if which osascript >/dev/null; then
-    /usr/libexec/java_home -v 1.8 --exec java -jar runnodes.jar
+    /usr/libexec/java_home -v 1.8 --exec java -jar runnodes.jar "$@"
 else
-    java -jar runnodes.jar
+    java -jar runnodes.jar "$@"
 fi

--- a/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes.bat
+++ b/gradle-plugins/cordformation/src/main/resources/net/corda/plugins/runnodes.bat
@@ -3,6 +3,6 @@
 REM Change to the directory of this script (%~dp0)
 Pushd %~dp0
 
-java -jar runnodes.jar
+java -jar runnodes.jar %*
 
 Popd

--- a/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -80,7 +80,7 @@ private fun execJar(jarName: String, dir: File, args: List<String> = listOf(), d
     val nodeName = dir.toPath().fileName
     val separator = System.getProperty("file.separator")
     val path = System.getProperty("java.home") + separator + "bin" + separator + "java"
-    val builder = ProcessBuilder(listOf(path, "-Dname=$nodeName") + getDebugPortArg(debugPort) + listOf("-jar", jarName) + args)
+    val builder = ProcessBuilder(listOf(path, "-Dname=$nodeName") + getDebugPortArg(debugPort) + listOf("-jar", jarName, "--no-local-shell") + args)
     builder.redirectError(Paths.get("error.${dir.toPath().fileName}.log").toFile())
     builder.inheritIO()
     builder.directory(dir)


### PR DESCRIPTION
Why: Previous behaviour was buggy - correct behaviour is to pass all args to the noderunner and not start crash in the headless mode.