### PR TITLE
Move CordaRPCClientTest into :client:rpc module.

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -1,6 +1,5 @@
-package net.corda.client.jfx
+package net.corda.client.rpc
 
-import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.flows.FlowException
 import net.corda.core.getOrThrow


### PR DESCRIPTION
This integration test was accidentally left in the wrong module.