### PR TITLE
[M10 Fixes] Version number parser can now handle patch versions.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/Version.kt
+++ b/core/src/main/kotlin/net/corda/core/node/Version.kt
@@ -11,18 +11,25 @@ import java.util.regex.Pattern
  * builds of the node. [NodeVersionInfo.revision] would be required to differentiate the two.
  */
 @CordaSerializable
-data class Version(val major: Int, val minor: Int, val snapshot: Boolean) {
+data class Version(val major: Int, val minor: Int, val patch: Int?, val snapshot: Boolean) {
     companion object {
-        private val pattern = Pattern.compile("""(\d+)\.(\d+)(-SNAPSHOT)?""")
+        private val pattern = Pattern.compile("""(\d+)\.(\d+)(.(\d+))?(-SNAPSHOT)?""")
 
         fun parse(string: String): Version {
             val matcher = pattern.matcher(string)
             require(matcher.matches())
-            return Version(matcher.group(1).toInt(), matcher.group(2).toInt(), matcher.group(3) != null)
+            val patch = matcher.group(4)?.toInt()
+            return Version(matcher.group(1).toInt(), matcher.group(2).toInt(), patch, matcher.group(5) != null)
         }
     }
 
-    override fun toString(): String = if (snapshot) "$major.$minor-SNAPSHOT" else "$major.$minor"
+    override fun toString(): String {
+        val sb = StringBuilder()
+        sb.append(major, ".", minor)
+        if(patch != null) sb.append(".", patch)
+        if(snapshot) sb.append("-SNAPSHOT")
+        return sb.toString()
+    }
 }
 
 data class NodeVersionInfo(val version: Version, val revision: String, val vendor: String)

--- a/core/src/test/kotlin/net/corda/core/node/VersionTest.kt
+++ b/core/src/test/kotlin/net/corda/core/node/VersionTest.kt
@@ -7,12 +7,12 @@ import org.junit.Test
 class VersionTest {
     @Test
     fun `parse valid non-SNAPSHOT string`() {
-        assertThat(Version.parse("1.2")).isEqualTo(Version(1, 2, false))
+        assertThat(Version.parse("1.2")).isEqualTo(Version(1, 2, null, false))
     }
 
     @Test
     fun `parse valid SNAPSHOT string`() {
-        assertThat(Version.parse("2.23-SNAPSHOT")).isEqualTo(Version(2, 23, true))
+        assertThat(Version.parse("2.23-SNAPSHOT")).isEqualTo(Version(2, 23, null, true))
     }
 
     @Test
@@ -27,5 +27,15 @@ class VersionTest {
         assertThatThrownBy {
             Version.parse("2.3-TEST")
         }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `parses patch version`() {
+        assertThat(Version.parse("0.1.2")).isEqualTo(Version(0, 1, 2, false))
+    }
+
+    @Test
+    fun `parses snapshot patch version`() {
+        assertThat(Version.parse("0.1.2-SNAPSHOT")).isEqualTo(Version(0, 1, 2, true))
     }
 }

--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -60,7 +60,7 @@ fun main(args: Array<String>) {
     fun manifestValue(name: String): String? = if (Manifests.exists(name)) Manifests.read(name) else null
 
     val nodeVersionInfo = NodeVersionInfo(
-            manifestValue("Corda-Version")?.let { Version.parse(it) } ?: Version(0, 0, false),
+            manifestValue("Corda-Version")?.let { Version.parse(it) } ?: Version(0, 0, 0, false),
             manifestValue("Corda-Revision") ?: "Unknown",
             manifestValue("Corda-Vendor") ?: "Unknown"
     )

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -94,7 +94,7 @@ val ALL_TEST_KEYS: List<KeyPair> get() = listOf(MEGA_CORP_KEY, MINI_CORP_KEY, AL
 
 val MOCK_IDENTITY_SERVICE: MockIdentityService get() = MockIdentityService(listOf(MEGA_CORP, MINI_CORP, DUMMY_NOTARY))
 
-val MOCK_VERSION = Version(0, 0, false)
+val MOCK_VERSION = Version(0, 0, 0, false)
 val MOCK_NODE_VERSION_INFO = NodeVersionInfo(MOCK_VERSION, "Mock revision", "Mock Vendor")
 
 fun generateStateRef() = StateRef(SecureHash.randomSHA256(), 0)


### PR DESCRIPTION
Why: We use patch versions often. 