### PR TITLE
Standardise name of Alice, Bob and Charlie nodes

### DIFF
--- a/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
+++ b/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
@@ -20,6 +20,10 @@ import net.corda.core.node.services.StateMachineTransactionMapping
 import net.corda.core.node.services.Vault
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
+import net.corda.core.utilities.CHARLIE
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.CashExitFlow
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
@@ -54,8 +58,8 @@ class NodeMonitorModelTest : DriverBasedTest() {
                 startFlowPermission<CashPaymentFlow>(),
                 startFlowPermission<CashExitFlow>())
         )
-        val aliceNodeFuture = startNode("Alice", rpcUsers = listOf(cashUser))
-        val notaryNodeFuture = startNode("Notary", advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)))
+        val aliceNodeFuture = startNode(ALICE.name, rpcUsers = listOf(cashUser))
+        val notaryNodeFuture = startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)))
         val aliceNodeHandle = aliceNodeFuture.getOrThrow()
         val notaryNodeHandle = notaryNodeFuture.getOrThrow()
         aliceNode = aliceNodeHandle.nodeInfo
@@ -77,21 +81,21 @@ class NodeMonitorModelTest : DriverBasedTest() {
 
     @Test
     fun `network map update`() {
-        newNode("Bob")
-        newNode("Charlie")
+        newNode(BOB.name)
+        newNode(CHARLIE.name)
         networkMapUpdates.filter { !it.node.advertisedServices.any { it.info.type.isNotary() } }
                 .filter { !it.node.advertisedServices.any { it.info.type == NetworkMapService.type } }
                 .expectEvents(isStrict = false) {
                     sequence(
                             // TODO : Add test for remove when driver DSL support individual node shutdown.
                             expect { output: NetworkMapCache.MapChange ->
-                                require(output.node.legalIdentity.name == "Alice") { "Expecting : Alice, Actual : ${output.node.legalIdentity.name}" }
+                                require(output.node.legalIdentity.name == ALICE.name) { "Expecting : ${ALICE.name}, Actual : ${output.node.legalIdentity.name}" }
                             },
                             expect { output: NetworkMapCache.MapChange ->
-                                require(output.node.legalIdentity.name == "Bob") { "Expecting : Bob, Actual : ${output.node.legalIdentity.name}" }
+                                require(output.node.legalIdentity.name == BOB.name) { "Expecting : ${BOB.name}, Actual : ${output.node.legalIdentity.name}" }
                             },
                             expect { output: NetworkMapCache.MapChange ->
-                                require(output.node.legalIdentity.name == "Charlie") { "Expecting : Charlie, Actual : ${output.node.legalIdentity.name}" }
+                                require(output.node.legalIdentity.name == CHARLIE.name) { "Expecting : ${CHARLIE.name}, Actual : ${output.node.legalIdentity.name}" }
                             }
                     )
                 }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.random63BitValue
 import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.utilities.ALICE
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
 import net.corda.node.internal.Node
@@ -33,7 +34,7 @@ class CordaRPCClientTest : NodeBasedTest() {
 
     @Before
     fun setUp() {
-        node = startNode("Alice", rpcUsers = listOf(rpcUser), advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type))).getOrThrow()
+        node = startNode(ALICE.name, rpcUsers = listOf(rpcUser), advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type))).getOrThrow()
         client = CordaRPCClient(node.configuration.rpcAddress!!)
     }
 

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -18,4 +18,35 @@ val DUMMY_KEY_1: KeyPair by lazy { generateKeyPair() }
 val DUMMY_KEY_2: KeyPair by lazy { generateKeyPair() }
 
 val DUMMY_NOTARY_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(20)) }
+/** Dummy notary identity for tests and simulations */
 val DUMMY_NOTARY: Party get() = Party("Notary Service", DUMMY_NOTARY_KEY.public)
+
+val DUMMY_MAP_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(30)) }
+/** Dummy network map service identity for tests and simulations */
+val DUMMY_MAP: Party get() = Party("Network Map Service", DUMMY_MAP_KEY.public)
+
+val DUMMY_BANK_A_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(40)) }
+/** Dummy bank identity for tests and simulations */
+val DUMMY_BANK_A: Party get() = Party("Bank A", DUMMY_BANK_A_KEY.public)
+
+val DUMMY_BANK_B_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(50)) }
+/** Dummy bank identity for tests and simulations */
+val DUMMY_BANK_B: Party get() = Party("Bank B", DUMMY_BANK_B_KEY.public)
+
+val DUMMY_BANK_C_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(60)) }
+/** Dummy bank identity for tests and simulations */
+val DUMMY_BANK_C: Party get() = Party("Bank C", DUMMY_BANK_C_KEY.public)
+
+
+
+val ALICE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(70)) }
+/** Dummy individual identity for tests and simulations */
+val ALICE: Party get() = Party("Alice", ALICE_KEY.public)
+
+val BOB_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(80)) }
+/** Dummy individual identity for tests and simulations */
+val BOB: Party get() = Party("Bob", BOB_KEY.public)
+
+val CHARLIE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(90)) }
+/** Dummy individual identity for tests and simulations */
+val CHARLIE: Party get() = Party("Charlie", BOB_KEY.public)

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
@@ -10,13 +10,13 @@ import net.corda.core.serialization.SerializedBytes
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
 import net.corda.core.utilities.DUMMY_KEY_1
 import net.corda.core.utilities.DUMMY_KEY_2
 import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.DUMMY_NOTARY_KEY
-import net.corda.testing.ALICE
 import net.corda.testing.ALICE_PUBKEY
-import net.corda.testing.BOB
 import org.junit.Test
 import java.security.KeyPair
 import kotlin.test.assertEquals

--- a/core/src/test/kotlin/net/corda/core/flows/TxKeyFlowUtilitiesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/TxKeyFlowUtilitiesTests.kt
@@ -1,9 +1,9 @@
 package net.corda.core.flows
 
 import net.corda.core.crypto.Party
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
 import net.corda.core.utilities.DUMMY_NOTARY
-import net.corda.testing.ALICE
-import net.corda.testing.BOB
 import net.corda.testing.MOCK_IDENTITY_SERVICE
 import net.corda.testing.node.MockNetwork
 import org.junit.Before

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -9,16 +9,16 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.Vault
 import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
 import net.corda.node.driver.driver
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.ValidatingNotaryService
 import net.corda.nodeapi.User
-import net.corda.testing.expect
-import net.corda.testing.expectEvents
-import net.corda.testing.parallel
-import net.corda.testing.sequence
+import net.corda.testing.*
 import org.junit.Test
 import java.util.*
 import kotlin.concurrent.thread
@@ -36,9 +36,9 @@ class IntegrationTestingTutorial {
                     startFlowPermission<CashPaymentFlow>()
             ))
             val (alice, bob, notary) = Futures.allAsList(
-                    startNode("Alice", rpcUsers = listOf(aliceUser)),
-                    startNode("Bob", rpcUsers = listOf(bobUser)),
-                    startNode("Notary", advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type)))
+                    startNode(ALICE.name, rpcUsers = listOf(aliceUser)),
+                    startNode(BOB.name, rpcUsers = listOf(bobUser)),
+                    startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type)))
             ).getOrThrow()
             // END 1
 

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -8,10 +8,7 @@ import net.corda.core.node.services.unconsumedStates
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
-import net.corda.core.utilities.DUMMY_NOTARY
-import net.corda.core.utilities.DUMMY_PUBKEY_1
-import net.corda.core.utilities.DUMMY_PUBKEY_2
-import net.corda.core.utilities.LogHelper
+import net.corda.core.utilities.*
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.configureDatabase
 import net.corda.node.utilities.databaseTransaction

--- a/node/src/integration-test/kotlin/net/corda/node/driver/DriverTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/driver/DriverTests.kt
@@ -6,6 +6,8 @@ import net.corda.core.list
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.readLines
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.LOGS_DIRECTORY_NAME
 import net.corda.node.services.api.RegulatorService
 import net.corda.node.services.transactions.SimpleNotaryService
@@ -36,7 +38,7 @@ class DriverTests {
     @Test
     fun `simple node startup and shutdown`() {
         val (notary, regulator) = driver {
-            val notary = startNode("TestNotary", setOf(ServiceInfo(SimpleNotaryService.type)))
+            val notary = startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type)))
             val regulator = startNode("Regulator", setOf(ServiceInfo(RegulatorService.type)))
 
             nodeMustBeUp(notary.getOrThrow().nodeInfo)
@@ -50,7 +52,7 @@ class DriverTests {
     @Test
     fun `starting node with no services`() {
         val noService = driver {
-            val noService = startNode("NoService")
+            val noService = startNode(DUMMY_BANK_A.name)
             nodeMustBeUp(noService.getOrThrow().nodeInfo)
             noService.getOrThrow()
         }
@@ -60,7 +62,7 @@ class DriverTests {
     @Test
     fun `random free port allocation`() {
         val nodeHandle = driver(portAllocation = PortAllocation.RandomFree) {
-            val nodeInfo = startNode("NoService")
+            val nodeInfo = startNode(DUMMY_BANK_A.name)
             nodeMustBeUp(nodeInfo.getOrThrow().nodeInfo)
             nodeInfo.getOrThrow()
         }
@@ -73,7 +75,7 @@ class DriverTests {
         val logConfigFile = Paths.get("..", "config", "dev", "log4j2.xml").toAbsolutePath()
         assertThat(logConfigFile).isRegularFile()
         driver(isDebug = true, systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())) {
-            val baseDirectory = startNode("Alice").getOrThrow().configuration.baseDirectory
+            val baseDirectory = startNode(DUMMY_BANK_A.name).getOrThrow().configuration.baseDirectory
             val logFile = (baseDirectory / LOGS_DIRECTORY_NAME).list { it.sorted().findFirst().get() }
             val debugLinesPresent = logFile.readLines { lines -> lines.anyMatch { line -> line.startsWith("[DEBUG]") } }
             assertThat(debugLinesPresent).isTrue()

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -9,6 +9,7 @@ import net.corda.core.div
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.ServiceType
+import net.corda.core.utilities.ALICE
 import net.corda.flows.NotaryError
 import net.corda.flows.NotaryException
 import net.corda.flows.NotaryFlow
@@ -30,7 +31,7 @@ class BFTNotaryServiceTests : NodeBasedTest() {
     @Test
     fun `detect double spend`() {
         val masterNode = startBFTNotaryCluster(notaryName, 4, BFTNonValidatingNotaryService.type).first()
-        val alice = startNode("Alice").getOrThrow()
+        val alice = startNode(ALICE.name).getOrThrow()
 
         val notaryParty = alice.netMapCache.getNotary(notaryName)!!
         val notaryNodeKeyPair = databaseTransaction(masterNode.database) { masterNode.services.notaryIdentityKey }

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -10,6 +10,8 @@ import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
 import net.corda.node.driver.NodeHandle
@@ -39,9 +41,9 @@ class DistributedServiceTests : DriverBasedTest() {
                 startFlowPermission<CashIssueFlow>(),
                 startFlowPermission<CashPaymentFlow>())
         )
-        val aliceFuture = startNode("Alice", rpcUsers = listOf(testUser))
+        val aliceFuture = startNode(ALICE.name, rpcUsers = listOf(testUser))
         val notariesFuture = startNotaryCluster(
-                "Notary",
+                DUMMY_NOTARY.name,
                 rpcUsers = listOf(testUser),
                 clusterSize = clusterSize,
                 type = RaftValidatingNotaryService.type

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -8,6 +8,7 @@ import net.corda.core.contracts.TransactionType
 import net.corda.core.crypto.Party
 import net.corda.core.getOrThrow
 import net.corda.core.map
+import net.corda.core.utilities.DUMMY_BANK_A
 import net.corda.flows.NotaryError
 import net.corda.flows.NotaryException
 import net.corda.flows.NotaryFlow
@@ -27,7 +28,7 @@ class RaftNotaryServiceTests : NodeBasedTest() {
     fun `detect double spend`() {
         val (masterNode, alice) = Futures.allAsList(
                 startNotaryCluster(notaryName, 3).map { it.first() },
-                startNode("Alice")
+                startNode(DUMMY_BANK_A.name)
         ).getOrThrow()
 
         val notaryParty = alice.netMapCache.getNotary(notaryName)!!

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -11,6 +11,8 @@ import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.random63BitValue
 import net.corda.core.seconds
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
 import net.corda.core.utilities.unwrap
 import net.corda.node.internal.Node
 import net.corda.nodeapi.ArtemisMessagingComponent.Companion.CLIENTS_PREFIX
@@ -49,7 +51,7 @@ abstract class MQSecurityTest : NodeBasedTest() {
 
     @Before
     fun start() {
-        alice = startNode("Alice", rpcUsers = extraRPCUsers + rpcUser).getOrThrow()
+        alice = startNode(ALICE.name, rpcUsers = extraRPCUsers + rpcUser).getOrThrow()
         attacker = createAttacker()
         startAttacker(attacker)
     }
@@ -84,7 +86,7 @@ abstract class MQSecurityTest : NodeBasedTest() {
 
     @Test
     fun `create queue for peer which has not been communicated with`() {
-        val bob = startNode("Bob").getOrThrow()
+        val bob = startNode(BOB.name).getOrThrow()
         assertAllQueueCreationAttacksFail("$PEERS_PREFIX${bob.info.legalIdentity.owningKey.toBase58String()}")
     }
 
@@ -227,7 +229,7 @@ abstract class MQSecurityTest : NodeBasedTest() {
     }
 
     private fun startBobAndCommunicateWithAlice(): Party {
-        val bob = startNode("Bob").getOrThrow()
+        val bob = startNode(BOB.name).getOrThrow()
         bob.services.registerFlowInitiator(SendFlow::class.java, ::ReceiveFlow)
         val bobParty = bob.info.legalIdentity
         // Perform a protocol exchange to force the peer queue to be created

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.getOrThrow
 import net.corda.core.node.NodeInfo
 import net.corda.core.random63BitValue
 import net.corda.core.seconds
+import net.corda.core.utilities.BOB
 import net.corda.flows.sendRequest
 import net.corda.node.internal.NetworkMapInfo
 import net.corda.node.services.config.configureWithDevSSLCertificate
@@ -29,7 +30,7 @@ class P2PSecurityTest : NodeBasedTest() {
     @Test
     fun `incorrect legal name for the network map service config`() {
         val incorrectNetworkMapName = random63BitValue().toString()
-        val node = startNode("Bob", configOverrides = mapOf(
+        val node = startNode(BOB.name, configOverrides = mapOf(
                 "networkMapService" to mapOf(
                         "address" to networkMapNode.configuration.p2pAddress.toString(),
                         "legalName" to incorrectNetworkMapName

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -16,8 +16,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.ServiceType
-import net.corda.core.utilities.ProcessUtilities
-import net.corda.core.utilities.loggerFor
+import net.corda.core.utilities.*
 import net.corda.node.LOGS_DIRECTORY_NAME
 import net.corda.node.services.config.ConfigHelper
 import net.corda.node.services.config.FullNodeConfiguration
@@ -145,8 +144,8 @@ sealed class PortAllocation {
 /**
  * [driver] allows one to start up nodes like this:
  *   driver {
- *     val noService = startNode("NoService")
- *     val notary = startNode("Notary")
+ *     val noService = startNode(DUMMY_BANK_A.name)
+ *     val notary = startNode(DUMMY_NOTARY.name)
  *
  *     (...)
  *   }
@@ -344,7 +343,7 @@ class DriverDSL(
         val isDebug: Boolean,
         val automaticallyStartNetworkMap: Boolean
 ) : DriverDSLInternalInterface {
-    private val networkMapLegalName = "NetworkMapService"
+    private val networkMapLegalName = DUMMY_MAP.name
     private val networkMapAddress = portAllocation.nextHostAndPort()
     val executorService: ListeningScheduledExecutorService = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(2))
     val shutdownManager = ShutdownManager(executorService)
@@ -458,7 +457,7 @@ class DriverDSL(
             verifierType: VerifierType,
             rpcUsers: List<User>
     ): ListenableFuture<Pair<Party, List<NodeHandle>>> {
-        val nodeNames = (1..clusterSize).map { "Notary Node $it" }
+        val nodeNames = (1..clusterSize).map { "${DUMMY_NOTARY.name} $it" }
         val paths = nodeNames.map { driverDirectory / it }
         ServiceIdentityGenerator.generateToDisk(paths, type.id, notaryName)
 
@@ -539,9 +538,9 @@ class DriverDSL(
 
     companion object {
         val name = arrayOf(
-                "Alice",
-                "Bob",
-                "Bank"
+                ALICE.name,
+                BOB.name,
+                DUMMY_BANK_A.name
         )
 
         fun <A> pickA(array: Array<A>): A = array[Math.abs(Random().nextInt()) % array.size]

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -16,6 +16,8 @@ import net.corda.core.rootCause
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
 import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.LogHelper
 import net.corda.core.utilities.TEST_TX_TIME

--- a/node/src/test/kotlin/net/corda/node/services/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/InMemoryIdentityServiceTests.kt
@@ -3,9 +3,9 @@ package net.corda.node.services
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.generateKeyPair
 import net.corda.node.services.identity.InMemoryIdentityService
-import net.corda.testing.ALICE
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
 import net.corda.testing.ALICE_PUBKEY
-import net.corda.testing.BOB
 import net.corda.testing.BOB_PUBKEY
 import org.junit.Test
 import kotlin.test.assertEquals

--- a/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NodeSchedulerServiceTest.kt
@@ -13,11 +13,11 @@ import net.corda.node.services.events.NodeSchedulerService
 import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.node.services.vault.NodeVaultService
+import net.corda.core.utilities.ALICE_KEY
 import net.corda.node.utilities.AddOrRemove
 import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.configureDatabase
 import net.corda.node.utilities.databaseTransaction
-import net.corda.testing.ALICE_KEY
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.MockKeyManagementService
 import net.corda.testing.node.TestClock

--- a/node/src/test/kotlin/net/corda/node/services/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/VaultWithCashTest.kt
@@ -10,12 +10,12 @@ import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.consumedStates
 import net.corda.core.node.services.unconsumedStates
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.BOB_KEY
 import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.DUMMY_NOTARY_KEY
 import net.corda.core.utilities.LogHelper
 import net.corda.node.utilities.configureDatabase
 import net.corda.node.utilities.databaseTransaction
-import net.corda.testing.BOB_KEY
 import net.corda.testing.BOB_PUBKEY
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.MEGA_CORP_KEY

--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -3,6 +3,9 @@ package net.corda.attachmentdemo
 import com.google.common.util.concurrent.Futures
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
@@ -25,9 +28,9 @@ class AttachmentDemoTest {
         driver(dsl = {
             val demoUser = listOf(User("demo", "demo", setOf("StartFlow.net.corda.flows.FinalityFlow")))
             val (nodeA, nodeB) = Futures.allAsList(
-                    startNode("Bank A", rpcUsers = demoUser),
-                    startNode("Bank B", rpcUsers = demoUser),
-                    startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.Companion.type)))
+                    startNode(DUMMY_BANK_A.name, rpcUsers = demoUser),
+                    startNode(DUMMY_BANK_B.name, rpcUsers = demoUser),
+                    startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.Companion.type)))
             ).getOrThrow()
 
             val senderThread = CompletableFuture.supplyAsync {

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -11,10 +11,10 @@ import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.sizedInputStreamAndHash
+import net.corda.core.utilities.ALICE_KEY
 import net.corda.core.utilities.Emoji
 import net.corda.flows.FinalityFlow
 import net.corda.nodeapi.config.SSLConfiguration
-import net.corda.testing.ALICE_KEY
 import java.io.InputStream
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
@@ -2,6 +2,9 @@ package net.corda.attachmentdemo
 
 import net.corda.core.div
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
@@ -14,9 +17,9 @@ import java.nio.file.Paths
 fun main(args: Array<String>) {
     val demoUser = listOf(User("demo", "demo", setOf("StartFlow.net.corda.flows.FinalityFlow")))
     driver(isDebug = true, driverDirectory = Paths.get("build") / "attachment-demo-nodes") {
-        startNode("Controller", setOf(ServiceInfo(SimpleNotaryService.Companion.type)))
-        startNode("Bank A", rpcUsers = demoUser)
-        startNode("Bank B", rpcUsers = demoUser)
+        startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.Companion.type)))
+        startNode(DUMMY_BANK_A.name, rpcUsers = demoUser)
+        startNode(DUMMY_BANK_B.name, rpcUsers = demoUser)
         waitForAllNodesToFinish()
     }
 }

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
@@ -7,6 +7,7 @@ import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
+import net.corda.testing.BOC
 import org.junit.Test
 
 class BankOfCordaHttpAPITest {
@@ -14,11 +15,11 @@ class BankOfCordaHttpAPITest {
     fun `issuer flow via Http`() {
         driver(dsl = {
             val (nodeBankOfCorda) = Futures.allAsList(
-                    startNode("BankOfCorda", setOf(ServiceInfo(SimpleNotaryService.type))),
+                    startNode(BOC.name, setOf(ServiceInfo(SimpleNotaryService.type))),
                     startNode("BigCorporation")
             ).getOrThrow()
             val nodeBankOfCordaApiAddr = startWebserver(nodeBankOfCorda).getOrThrow()
-            assert(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", "BigCorporation", "1", "BankOfCorda")))
+            assert(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", "BigCorporation", "1", BOC.name)))
         }, isDebug = true)
     }
 }

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -10,10 +10,7 @@ import net.corda.node.driver.driver
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
-import net.corda.testing.BIG_CORP_PARTY_REF
-import net.corda.testing.expect
-import net.corda.testing.expectEvents
-import net.corda.testing.sequence
+import net.corda.testing.*
 import org.junit.Test
 
 class BankOfCordaRPCClientTest {
@@ -23,7 +20,7 @@ class BankOfCordaRPCClientTest {
             val bocManager = User("bocManager", "password1", permissions = setOf(startFlowPermission<IssuanceRequester>()))
             val bigCorpCFO = User("bigCorpCFO", "password2", permissions = emptySet())
             val (nodeBankOfCorda, nodeBigCorporation) = Futures.allAsList(
-                    startNode("BankOfCorda", setOf(ServiceInfo(SimpleNotaryService.type)), listOf(bocManager)),
+                    startNode(BOC.name, setOf(ServiceInfo(SimpleNotaryService.type)), listOf(bocManager)),
                     startNode("BigCorporation", rpcUsers = listOf(bigCorpCFO))
             ).getOrThrow()
 

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
@@ -7,12 +7,14 @@ import net.corda.bank.api.BankOfCordaWebApi.IssueRequestParams
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.ServiceType
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.CashPaymentFlow
 import net.corda.flows.IssuerFlow
 import net.corda.node.driver.driver
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
+import net.corda.testing.BOC
 import kotlin.system.exitProcess
 
 /**
@@ -53,8 +55,8 @@ private class BankOfCordaDriver {
             driver(dsl = {
                 val bankUser = User(BANK_USERNAME, "test", permissions = setOf(startFlowPermission<CashPaymentFlow>(), startFlowPermission<IssuerFlow.IssuanceRequester>()))
                 val bigCorpUser = User(BIGCORP_USERNAME, "test", permissions = setOf(startFlowPermission<CashPaymentFlow>()))
-                startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.type)))
-                val bankOfCorda = startNode("BankOfCorda", rpcUsers = listOf(bankUser), advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.USD"))))
+                startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type)))
+                val bankOfCorda = startNode(BOC.name, rpcUsers = listOf(bankUser), advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.USD"))))
                 startNode("BigCorporation", rpcUsers = listOf(bigCorpUser))
                 startWebserver(bankOfCorda.get())
                 waitForAllNodesToFinish()

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -6,6 +6,9 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.crypto.toBase58String
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.irs.api.NodeInterestRates
 import net.corda.irs.contract.InterestRateSwap
 import net.corda.irs.utilities.postJson
@@ -31,9 +34,9 @@ class IRSDemoTest : IntegrationTestCategory {
     fun `runs IRS demo`() {
         driver(useTestClock = true, isDebug = true) {
             val (controller, nodeA, nodeB) = Futures.allAsList(
-                    startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.type), ServiceInfo(NodeInterestRates.type))),
-                    startNode("Bank A", rpcUsers = listOf(rpcUser)),
-                    startNode("Bank B")
+                    startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type), ServiceInfo(NodeInterestRates.type))),
+                    startNode(DUMMY_BANK_A.name, rpcUsers = listOf(rpcUser)),
+                    startNode(DUMMY_BANK_B.name)
             ).getOrThrow()
 
             val (controllerAddr, nodeAAddr, nodeBAddr) = Futures.allAsList(

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/Main.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/Main.kt
@@ -3,6 +3,9 @@ package net.corda.irs
 import com.google.common.util.concurrent.Futures
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.irs.api.NodeInterestRates
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
@@ -14,9 +17,9 @@ import net.corda.node.services.transactions.SimpleNotaryService
 fun main(args: Array<String>) {
     driver(dsl = {
         val (controller, nodeA, nodeB) = Futures.allAsList(
-                startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.type), ServiceInfo(NodeInterestRates.type))),
-                startNode("Bank A"),
-                startNode("Bank B")
+                startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type), ServiceInfo(NodeInterestRates.type))),
+                startNode(DUMMY_BANK_A.name),
+                startNode(DUMMY_BANK_B.name)
         ).getOrThrow()
 
         startWebserver(controller)

--- a/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
@@ -10,6 +10,8 @@ import net.corda.core.node.PhysicalLocation
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.containsType
 import net.corda.core.then
+import net.corda.core.utilities.DUMMY_MAP
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.ProgressTracker
 import net.corda.irs.api.NodeInterestRates
 import net.corda.node.services.config.NodeConfiguration
@@ -91,7 +93,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             require(advertisedServices.containsType(NetworkMapService.type))
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
-                    myLegalName = "Network coordination center",
+                    myLegalName = DUMMY_MAP.name,
                     nearestCity = "Amsterdam",
                     networkMapService = null)
             return object : SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot) {}
@@ -105,7 +107,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             require(advertisedServices.containsType(SimpleNotaryService.type))
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
-                    myLegalName = "Notary Service",
+                    myLegalName = DUMMY_NOTARY.name,
                     nearestCity = "Zurich",
                     networkMapService = null)
             return SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot)

--- a/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/Main.kt
+++ b/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/Main.kt
@@ -1,6 +1,9 @@
 package net.corda.notarydemo
 
 import net.corda.core.div
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.RaftValidatingNotaryService
 import net.corda.nodeapi.User
@@ -10,9 +13,9 @@ import java.nio.file.Paths
 fun main(args: Array<String>) {
     val demoUser = listOf(User("demo", "demo", setOf("StartFlow.net.corda.notarydemo.flows.DummyIssueAndMove", "StartFlow.net.corda.flows.NotaryFlow\$Client")))
     driver(isDebug = true, driverDirectory = Paths.get("build") / "notary-demo-nodes") {
-        startNode("Party", rpcUsers = demoUser)
-        startNode("Counterparty")
-        startNotaryCluster("Raft notary", clusterSize = 3, type = RaftValidatingNotaryService.type)
+        startNode(ALICE.name, rpcUsers = demoUser)
+        startNode(BOB.name)
+        startNotaryCluster(DUMMY_NOTARY.name, clusterSize = 3, type = RaftValidatingNotaryService.type)
         waitForAllNodesToFinish()
     }
 }

--- a/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/NotaryDemo.kt
+++ b/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/NotaryDemo.kt
@@ -10,6 +10,7 @@ import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.BOB
 import net.corda.flows.NotaryFlow
 import net.corda.nodeapi.config.SSLConfiguration
 import net.corda.notarydemo.flows.DummyIssueAndMove
@@ -33,7 +34,7 @@ private class NotaryDemoClientApi(val rpc: CordaRPCOps) {
     }
 
     private val counterpartyNode by lazy {
-        rpc.networkMapUpdates().first.first { it.legalIdentity.name == "Counterparty" }
+        rpc.networkMapUpdates().first.first { it.legalIdentity.name == BOB.name }
     }
 
     private companion object {

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -4,6 +4,9 @@ import com.google.common.util.concurrent.Futures
 import com.opengamma.strata.product.common.BuySell
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.testing.IntegrationTestCategory
@@ -20,14 +23,14 @@ class SimmValuationTest : IntegrationTestCategory {
     private companion object {
         // SIMM demo can only currently handle one valuation date due to a lack of market data or a market data source.
         val valuationDate = LocalDate.parse("2016-06-06")
-        val nodeALegalName = "Bank A"
-        val nodeBLegalName = "Bank B"
+        val nodeALegalName = DUMMY_BANK_A.name
+        val nodeBLegalName = DUMMY_BANK_B.name
         val testTradeId = "trade1"
     }
 
     @Test fun `runs SIMM valuation demo`() {
         driver(isDebug = true) {
-            startNode("Controller", setOf(ServiceInfo(SimpleNotaryService.type))).getOrThrow()
+            startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type))).getOrThrow()
             val (nodeA, nodeB) = Futures.allAsList(startNode(nodeALegalName), startNode(nodeBLegalName)).getOrThrow()
             val (nodeAApi, nodeBApi) = Futures.allAsList(startWebserver(nodeA), startWebserver(nodeB))
                     .getOrThrow()

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/Main.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/Main.kt
@@ -3,6 +3,9 @@ package net.corda.vega
 import com.google.common.util.concurrent.Futures
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_BANK_C
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
 
@@ -15,9 +18,9 @@ fun main(args: Array<String>) {
     driver(dsl = {
         startNode("Controller", setOf(ServiceInfo(SimpleNotaryService.type)))
         val (nodeA, nodeB, nodeC) = Futures.allAsList(
-                startNode("Bank A"),
-                startNode("Bank B"),
-                startNode("Bank C")
+                startNode(DUMMY_BANK_A.name),
+                startNode(DUMMY_BANK_B.name),
+                startNode(DUMMY_BANK_C.name)
         ).getOrThrow()
 
         startWebserver(nodeA)

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt
@@ -8,6 +8,8 @@ import net.corda.core.crypto.*
 import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.DUMMY_MAP
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.vega.analytics.InitialMarginTriple
 import net.corda.vega.contracts.IRSState
 import net.corda.vega.contracts.PortfolioState
@@ -246,7 +248,9 @@ class PortfolioApi(val rpc: CordaRPCOps) {
     @Produces(MediaType.APPLICATION_JSON)
     fun getWhoAmI(): AvailableParties {
         val counterParties = rpc.networkMapUpdates().first.filter {
-            it.legalIdentity.name != "NetworkMapService" && it.legalIdentity.name != "Notary" && it.legalIdentity.name != ownParty.name
+            it.legalIdentity.name != DUMMY_MAP.name
+                    && it.legalIdentity.name != DUMMY_NOTARY.name
+                    && it.legalIdentity.name != ownParty.name
         }
 
         return AvailableParties(

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -4,10 +4,14 @@ import com.google.common.util.concurrent.Futures
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.IssuerFlow
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
+import net.corda.testing.BOC
 import net.corda.testing.node.NodeBasedTest
 import org.junit.Test
 
@@ -20,10 +24,10 @@ class TraderDemoTest : NodeBasedTest() {
         val demoUser = listOf(User("demo", "demo", permissions))
         val user = User("user1", "test", permissions = setOf(startFlowPermission<IssuerFlow.IssuanceRequester>()))
         val (nodeA, nodeB) = Futures.allAsList(
-                startNode("Bank A", rpcUsers = demoUser),
-                startNode("Bank B", rpcUsers = demoUser),
-                startNode("BankOfCorda", rpcUsers = listOf(user)),
-                startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.type)))
+                startNode(DUMMY_BANK_A.name, rpcUsers = demoUser),
+                startNode(DUMMY_BANK_B.name, rpcUsers = demoUser),
+                startNode(BOC.name, rpcUsers = listOf(user)),
+                startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type)))
         ).getOrThrow()
 
         val (nodeARpc, nodeBRpc) = listOf(nodeA, nodeB).map {

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/Main.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/Main.kt
@@ -2,6 +2,7 @@ package net.corda.traderdemo
 
 import net.corda.core.div
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.IssuerFlow
 import net.corda.node.driver.driver
 import net.corda.node.services.startFlowPermission
@@ -9,6 +10,9 @@ import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
 import net.corda.testing.BOC
 import java.nio.file.Paths
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
+import net.corda.core.utilities.DUMMY_NOTARY
 
 /**
  * This file is exclusively for being able to run your nodes through an IDE (as opposed to running deployNodes)
@@ -21,9 +25,9 @@ fun main(args: Array<String>) {
     val demoUser = listOf(User("demo", "demo", permissions))
     driver(driverDirectory = Paths.get("build") / "trader-demo-nodes", isDebug = true) {
         val user = User("user1", "test", permissions = setOf(startFlowPermission<IssuerFlow.IssuanceRequester>()))
-        startNode("Notary", setOf(ServiceInfo(SimpleNotaryService.type)))
-        startNode("Bank A", rpcUsers = demoUser)
-        startNode("Bank B", rpcUsers = demoUser)
+        startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type)))
+        startNode(DUMMY_BANK_A.name, rpcUsers = demoUser)
+        startNode(DUMMY_BANK_B.name, rpcUsers = demoUser)
         startNode(BOC.name, rpcUsers = listOf(user))
         waitForAllNodesToFinish()
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -14,8 +14,7 @@ import net.corda.core.node.Version
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.toFuture
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.utilities.DUMMY_NOTARY
-import net.corda.core.utilities.DUMMY_NOTARY_KEY
+import net.corda.core.utilities.*
 import net.corda.node.internal.AbstractNode
 import net.corda.node.internal.NetworkMapInfo
 import net.corda.node.services.config.*
@@ -63,17 +62,9 @@ val MINI_CORP_PUBKEY: PublicKey get() = MINI_CORP_KEY.public
 val ORACLE_KEY: KeyPair by lazy { generateKeyPair() }
 val ORACLE_PUBKEY: PublicKey get() = ORACLE_KEY.public
 
-val ALICE_KEY: KeyPair by lazy { generateKeyPair() }
 val ALICE_PUBKEY: PublicKey get() = ALICE_KEY.public
-val ALICE: Party get() = Party("Alice", ALICE_PUBKEY)
-
-val BOB_KEY: KeyPair by lazy { generateKeyPair() }
 val BOB_PUBKEY: PublicKey get() = BOB_KEY.public
-val BOB: Party get() = Party("Bob", BOB_PUBKEY)
-
-val CHARLIE_KEY: KeyPair by lazy { generateKeyPair() }
 val CHARLIE_PUBKEY: PublicKey get() = CHARLIE_KEY.public
-val CHARLIE: Party get() = Party("Charlie", CHARLIE_PUBKEY)
 
 val MEGA_CORP: Party get() = Party("MegaCorp", MEGA_CORP_PUBKEY)
 val MINI_CORP: Party get() = Party("MiniCorp", MINI_CORP_PUBKEY)

--- a/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -8,6 +8,7 @@ import net.corda.core.flatMap
 import net.corda.core.map
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.ServiceType
+import net.corda.core.utilities.DUMMY_MAP
 import net.corda.node.internal.Node
 import net.corda.node.services.config.ConfigHelper
 import net.corda.node.services.config.FullNodeConfiguration
@@ -53,7 +54,7 @@ abstract class NodeBasedTest {
      * You can use this method to start the network map node in a more customised manner. Otherwise it
      * will automatically be started with the default parameters.
      */
-    fun startNetworkMapNode(legalName: String = "Network Map",
+    fun startNetworkMapNode(legalName: String = DUMMY_MAP.name,
                             advertisedServices: Set<ServiceInfo> = emptySet(),
                             rpcUsers: List<User> = emptyList(),
                             configOverrides: Map<String, Any> = emptyMap()): Node {

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -6,6 +6,7 @@ import javafx.scene.input.KeyCode
 import javafx.scene.layout.Pane
 import javafx.stage.FileChooser
 import javafx.util.converter.NumberStringConverter
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.demobench.model.*
 import net.corda.demobench.ui.CloseableTab
 import tornadofx.*
@@ -115,7 +116,7 @@ class NodeTabView : Fragment() {
         root.add(nodeConfigView)
         root.add(nodeTerminalView)
 
-        model.legalName.value = if (nodeController.hasNetworkMap()) "" else "Notary"
+        model.legalName.value = if (nodeController.hasNetworkMap()) "" else DUMMY_NOTARY.name
         model.p2pPort.value = nodeController.nextPort
         model.rpcPort.value = nodeController.nextPort
         model.webPort.value = nodeController.nextPort

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -4,6 +4,7 @@ import com.google.common.net.HostAndPort
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import net.corda.core.div
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.internal.NetworkMapInfo
 import net.corda.node.services.config.FullNodeConfiguration
 import net.corda.nodeapi.User
@@ -152,14 +153,14 @@ class NodeConfigTest {
                 services = listOf("my.service"),
                 users = listOf(user("jenny"))
         )
-        config.networkMap = NetworkMapConfig("Notary", 12345)
+        config.networkMap = NetworkMapConfig(DUMMY_NOTARY.name, 12345)
 
         assertEquals("{"
                 + "\"extraAdvertisedServiceIds\":[\"my.service\"],"
                 + "\"h2port\":30001,"
                 + "\"myLegalName\":\"MyName\","
                 + "\"nearestCity\":\"Stockholm\","
-                + "\"networkMapService\":{\"address\":\"localhost:12345\",\"legalName\":\"Notary\"},"
+                + "\"networkMapService\":{\"address\":\"localhost:12345\",\"legalName\":\"NotaryService\"},"
                 + "\"p2pAddress\":\"localhost:10001\","
                 + "\"rpcAddress\":\"localhost:40002\","
                 + "\"rpcUsers\":["
@@ -182,7 +183,7 @@ class NodeConfigTest {
                 services = listOf("my.service"),
                 users = listOf(user("jenny"))
         )
-        config.networkMap = NetworkMapConfig("Notary", 12345)
+        config.networkMap = NetworkMapConfig(DUMMY_NOTARY.name, 12345)
 
         val nodeConfig = config.toFileConfig()
                 .withValue("basedir", ConfigValueFactory.fromAnyRef(baseDir.toString()))
@@ -196,7 +197,7 @@ class NodeConfigTest {
         assertEquals(localPort(10001), fullConfig.p2pAddress)
         assertEquals(listOf("my.service"), fullConfig.extraAdvertisedServiceIds)
         assertEquals(listOf(user("jenny")), fullConfig.rpcUsers)
-        assertEquals(NetworkMapInfo(localPort(12345), "Notary"), fullConfig.networkMapService)
+        assertEquals(NetworkMapInfo(localPort(12345), DUMMY_NOTARY.name), fullConfig.networkMapService)
         assertTrue((fullConfig.dataSourceProperties["dataSource.url"] as String).contains("AUTO_SERVER_PORT=30001"))
         assertTrue(fullConfig.useTestClock)
     }
@@ -213,7 +214,7 @@ class NodeConfigTest {
                 services = listOf("my.service"),
                 users = listOf(user("jenny"))
         )
-        config.networkMap = NetworkMapConfig("Notary", 12345)
+        config.networkMap = NetworkMapConfig(DUMMY_NOTARY.name, 12345)
 
         val nodeConfig = config.toFileConfig()
                 .withValue("basedir", ConfigValueFactory.fromAnyRef(baseDir.toString()))

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.demobench.model
 
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.nodeapi.User
 import org.junit.Test
 import java.nio.file.Path
@@ -96,7 +97,7 @@ class NodeControllerTest {
     @Test
     fun `test register non-network-map node`() {
         val config = createConfig(legalName = "Node is not Network Map")
-        config.networkMap = NetworkMapConfig("Notary", 10000)
+        config.networkMap = NetworkMapConfig(DUMMY_NOTARY.name, 10000)
         assertFalse(config.isNetworkMap())
 
         assertFalse(controller.hasNetworkMap())

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
@@ -26,6 +26,9 @@ import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.success
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.loggerFor
 import net.corda.explorer.model.CordaViewModel
 import net.corda.explorer.model.SettingsModel
@@ -162,12 +165,12 @@ fun main(args: Array<String>) {
                 startFlowPermission<IssuanceRequester>())
         )
         // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
-        val notary = startNode("Notary", advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)),
+        val notary = startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)),
                 customOverrides = mapOf("nearestCity" to "Zurich"))
-        val alice = startNode("Alice", rpcUsers = arrayListOf(user),
+        val alice = startNode(ALICE.name, rpcUsers = arrayListOf(user),
                 advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("cash"))),
                 customOverrides = mapOf("nearestCity" to "Milan"))
-        val bob = startNode("Bob", rpcUsers = arrayListOf(user),
+        val bob = startNode(BOB.name, rpcUsers = arrayListOf(user),
                 advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("cash"))),
                 customOverrides = mapOf("nearestCity" to "Madrid"))
         val issuerGBP = startNode("UK Bank Plc", rpcUsers = arrayListOf(manager),

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
@@ -9,6 +9,8 @@ import net.corda.core.node.services.ServiceInfo
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
 import net.corda.node.services.config.VerifierType
@@ -33,7 +35,7 @@ class VerifierTests {
     @Test
     fun `single verifier works with requestor`() {
         verifierDriver(automaticallyStartNetworkMap = false) {
-            val aliceFuture = startVerificationRequestor("Alice")
+            val aliceFuture = startVerificationRequestor(ALICE.name)
             val transactions = generateTransactions(100)
             val alice = aliceFuture.get()
             startVerifier(alice)
@@ -50,7 +52,7 @@ class VerifierTests {
     @Test
     fun `multiple verifiers work with requestor`() {
         verifierDriver(automaticallyStartNetworkMap = false) {
-            val aliceFuture = startVerificationRequestor("Alice")
+            val aliceFuture = startVerificationRequestor(ALICE.name)
             val transactions = generateTransactions(100)
             val alice = aliceFuture.get()
             val numberOfVerifiers = 4
@@ -70,7 +72,7 @@ class VerifierTests {
     @Test
     fun `verification redistributes on verifier death`() {
         verifierDriver(automaticallyStartNetworkMap = false) {
-            val aliceFuture = startVerificationRequestor("Alice")
+            val aliceFuture = startVerificationRequestor(ALICE.name)
             val numberOfTransactions = 100
             val transactions = generateTransactions(numberOfTransactions)
             val alice = aliceFuture.get()
@@ -98,7 +100,7 @@ class VerifierTests {
     @Test
     fun `verification request waits until verifier comes online`() {
         verifierDriver(automaticallyStartNetworkMap = false) {
-            val aliceFuture = startVerificationRequestor("Alice")
+            val aliceFuture = startVerificationRequestor(ALICE.name)
             val transactions = generateTransactions(100)
             val alice = aliceFuture.get()
             val futures = transactions.map { alice.verifyTransaction(it) }
@@ -110,8 +112,8 @@ class VerifierTests {
     @Test
     fun `single verifier works with a node`() {
         verifierDriver {
-            val aliceFuture = startNode("Alice")
-            val notaryFuture = startNode("Notary", advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type)), verifierType = VerifierType.OutOfProcess)
+            val aliceFuture = startNode(ALICE.name)
+            val notaryFuture = startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(ValidatingNotaryService.type)), verifierType = VerifierType.OutOfProcess)
             val alice = aliceFuture.get()
             val notary = notaryFuture.get()
             startVerifier(notary)

--- a/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt
+++ b/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt
@@ -2,6 +2,7 @@ package net.corda.webserver
 
 import com.google.common.net.HostAndPort
 import net.corda.core.getOrThrow
+import net.corda.core.utilities.DUMMY_BANK_A
 import net.corda.node.driver.addressMustBeBound
 import net.corda.node.driver.addressMustNotBeBound
 import net.corda.node.driver.driver
@@ -24,7 +25,7 @@ class DriverTests {
     @Test
     fun `starting a node and independent web server works`() {
         val addr = driver {
-            val node = startNode("test").getOrThrow()
+            val node = startNode(DUMMY_BANK_A.name).getOrThrow()
             val webserverAddr = startWebserver(node).getOrThrow()
             webserverMustBeUp(webserverAddr)
             webserverAddr


### PR DESCRIPTION
Start replacing strings used as node names with the standard party name, to reduce churn when introducing proper X500 legal names.
