### PR TITLE
Fix up HibernateObserver to allow cascading persistence after bug report

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -287,7 +287,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         VaultSoftLockManager(vault, smm)
         CashBalanceAsMetricsObserver(services, database)
         ScheduledActivityObserver(services)
-        HibernateObserver(vault, schemas)
+        HibernateObserver(vault.rawUpdates, schemas)
     }
 
     private fun makeInfo(): NodeInfo {

--- a/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
@@ -50,7 +50,7 @@ class HibernateObserver(vaultService: VaultService, val schemaService: SchemaSer
     private fun makeSessionFactoryForSchema(schema: MappedSchema): SessionFactory {
         logger.info("Creating session factory for schema $schema")
         val serviceRegistry = BootstrapServiceRegistryBuilder().build()
-        val metadataSources = MetadataSources(serviceRegistry);
+        val metadataSources = MetadataSources(serviceRegistry)
         // We set a connection provider as the auto schema generation requires it.  The auto schema generation will not
         // necessarily remain and would likely be replaced by something like Liquibase.  For now it is very convenient though.
         // TODO: replace auto schema generation as it isn't intended for production use, according to Hibernate docs.

--- a/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
@@ -65,6 +65,7 @@ class HibernateObserverTests {
         var children: MutableSet<Child> = mutableSetOf()
     }
 
+    @Suppress("unused")
     @Entity
     @Table(name = "Children")
     class Child {
@@ -79,71 +80,72 @@ class HibernateObserverTests {
     }
 
     @Test
-    fun `test`() {
+    fun `test child objects are persisted`() {
         val testSchema = object : MappedSchema(SchemaFamily::class.java, 1, setOf(Parent::class.java, Child::class.java)) {}
         val rawUpdatesPublisher = PublishSubject.create<Vault.Update>()
         val vaultService = object : VaultService {
             override val rawUpdates: Observable<Vault.Update> = rawUpdatesPublisher
 
             override val updates: Observable<Vault.Update>
-                get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+                get() = throw UnsupportedOperationException()
+
             override val cashBalances: Map<Currency, Amount<Currency>>
-                get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+                get() = throw UnsupportedOperationException()
 
             override fun track(): Pair<Vault<ContractState>, Observable<Vault.Update>> {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun statesForRefs(refs: List<StateRef>): Map<StateRef, TransactionState<*>?> {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun notifyAll(txns: Iterable<WireTransaction>) {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun getAuthorisedContractUpgrade(ref: StateRef): Class<out UpgradedContract<*, *>>? {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>) {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun deauthoriseContractUpgrade(stateAndRef: StateAndRef<*>) {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun addNoteToTransaction(txnId: SecureHash, noteText: String) {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun getTransactionNotes(txnId: SecureHash): Iterable<String> {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun generateSpend(tx: TransactionBuilder, amount: Amount<Currency>, to: CompositeKey, onlyFromParties: Set<AbstractParty>?): Pair<TransactionBuilder, List<CompositeKey>> {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun <T : ContractState> states(clazzes: Set<Class<T>>, statuses: EnumSet<Vault.StateStatus>, includeSoftLockedStates: Boolean): Iterable<StateAndRef<T>> {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun softLockReserve(lockId: UUID, stateRefs: Set<StateRef>) {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun softLockRelease(lockId: UUID, stateRefs: Set<StateRef>?) {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun <T : ContractState> softLockedStates(lockId: UUID?): List<StateAndRef<T>> {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
 
             override fun <T : ContractState> unconsumedStatesForSpending(amount: Amount<Currency>, onlyFromIssuerParties: Set<AbstractParty>?, notary: Party?, lockId: UUID, withIssuerRefs: Set<OpaqueBytes>?): List<StateAndRef<T>> {
-                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                throw UnsupportedOperationException()
             }
         }
         val schemaService = object : SchemaService {
@@ -159,6 +161,7 @@ class HibernateObserverTests {
             }
 
         }
+        @Suppress("UNUSED_VARIABLE")
         val observer = HibernateObserver(vaultService, schemaService)
         databaseTransaction(database) {
             rawUpdatesPublisher.onNext(Vault.Update(emptySet(), setOf(StateAndRef(TransactionState(object : QueryableState {
@@ -167,13 +170,15 @@ class HibernateObserverTests {
                 }
 
                 override fun generateMappedObject(schema: MappedSchema): PersistentState {
-                    TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                    throw UnsupportedOperationException()
                 }
 
                 override val contract: Contract
-                    get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+                    get() = throw UnsupportedOperationException()
+
                 override val participants: List<CompositeKey>
-                    get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+                    get() = throw UnsupportedOperationException()
+
             }, MEGA_CORP), StateRef(SecureHash.sha256("dummy"), 0)))))
 
             val parentRowCountResult = TransactionManager.current().connection.prepareStatement("select count(*) from contract_Parents").executeQuery()

--- a/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
@@ -79,8 +79,9 @@ class HibernateObserverTests {
         var parent: Parent? = null
     }
 
+    // This method does not use back quotes for a nice name since it seems to kill the kotlin compiler.
     @Test
-    fun `test child objects are persisted`() {
+    fun testChildObjectsArePersisted() {
         val testSchema = object : MappedSchema(SchemaFamily::class.java, 1, setOf(Parent::class.java, Child::class.java)) {}
         val rawUpdatesPublisher = PublishSubject.create<Vault.Update>()
         val vaultService = object : VaultService {

--- a/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
@@ -1,0 +1,191 @@
+package net.corda.node.services
+
+import net.corda.core.contracts.*
+import net.corda.core.crypto.AbstractParty
+import net.corda.core.crypto.CompositeKey
+import net.corda.core.crypto.Party
+import net.corda.core.crypto.SecureHash
+import net.corda.core.node.services.Vault
+import net.corda.core.node.services.VaultService
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import net.corda.core.schemas.QueryableState
+import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.LogHelper
+import net.corda.node.services.api.SchemaService
+import net.corda.node.services.schema.HibernateObserver
+import net.corda.node.utilities.configureDatabase
+import net.corda.node.utilities.databaseTransaction
+import net.corda.testing.MEGA_CORP
+import net.corda.testing.node.makeTestDataSourceProperties
+import org.hibernate.annotations.Cascade
+import org.hibernate.annotations.CascadeType
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import rx.Observable
+import rx.subjects.PublishSubject
+import java.io.Closeable
+import java.util.*
+import javax.persistence.*
+import kotlin.test.assertEquals
+
+
+class HibernateObserverTests {
+    lateinit var dataSource: Closeable
+    lateinit var database: Database
+
+    @Before
+    fun setUp() {
+        LogHelper.setLevel(HibernateObserver::class)
+        val dataSourceAndDatabase = configureDatabase(makeTestDataSourceProperties())
+        dataSource = dataSourceAndDatabase.first
+        database = dataSourceAndDatabase.second
+    }
+
+    @After
+    fun cleanUp() {
+        dataSource.close()
+        LogHelper.reset(HibernateObserver::class)
+    }
+
+    class SchemaFamily
+
+    @Entity
+    @Table(name = "Parents")
+    class Parent : PersistentState() {
+        @OneToMany(fetch = FetchType.LAZY)
+        @JoinColumns(JoinColumn(name = "transaction_id"), JoinColumn(name = "output_index"))
+        @OrderColumn
+        @Cascade(CascadeType.PERSIST)
+        var children: MutableSet<Child> = mutableSetOf()
+    }
+
+    @Entity
+    @Table(name = "Children")
+    class Child {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "child_id", unique = true, nullable = false)
+        var childId: Int? = null
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumns(JoinColumn(name = "transaction_id"), JoinColumn(name = "output_index"))
+        var parent: Parent? = null
+    }
+
+    @Test
+    fun `test`() {
+        val testSchema = object : MappedSchema(SchemaFamily::class.java, 1, setOf(Parent::class.java, Child::class.java)) {}
+        val rawUpdatesPublisher = PublishSubject.create<Vault.Update>()
+        val vaultService = object : VaultService {
+            override val rawUpdates: Observable<Vault.Update> = rawUpdatesPublisher
+
+            override val updates: Observable<Vault.Update>
+                get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+            override val cashBalances: Map<Currency, Amount<Currency>>
+                get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+
+            override fun track(): Pair<Vault<ContractState>, Observable<Vault.Update>> {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun statesForRefs(refs: List<StateRef>): Map<StateRef, TransactionState<*>?> {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun notifyAll(txns: Iterable<WireTransaction>) {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun getAuthorisedContractUpgrade(ref: StateRef): Class<out UpgradedContract<*, *>>? {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>) {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun deauthoriseContractUpgrade(stateAndRef: StateAndRef<*>) {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun addNoteToTransaction(txnId: SecureHash, noteText: String) {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun getTransactionNotes(txnId: SecureHash): Iterable<String> {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun generateSpend(tx: TransactionBuilder, amount: Amount<Currency>, to: CompositeKey, onlyFromParties: Set<AbstractParty>?): Pair<TransactionBuilder, List<CompositeKey>> {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun <T : ContractState> states(clazzes: Set<Class<T>>, statuses: EnumSet<Vault.StateStatus>, includeSoftLockedStates: Boolean): Iterable<StateAndRef<T>> {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun softLockReserve(lockId: UUID, stateRefs: Set<StateRef>) {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun softLockRelease(lockId: UUID, stateRefs: Set<StateRef>?) {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun <T : ContractState> softLockedStates(lockId: UUID?): List<StateAndRef<T>> {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+
+            override fun <T : ContractState> unconsumedStatesForSpending(amount: Amount<Currency>, onlyFromIssuerParties: Set<AbstractParty>?, notary: Party?, lockId: UUID, withIssuerRefs: Set<OpaqueBytes>?): List<StateAndRef<T>> {
+                TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            }
+        }
+        val schemaService = object : SchemaService {
+            override val schemaOptions: Map<MappedSchema, SchemaService.SchemaOptions> = emptyMap()
+
+            override fun selectSchemas(state: QueryableState): Iterable<MappedSchema> = setOf(testSchema)
+
+            override fun generateMappedObject(state: QueryableState, schema: MappedSchema): PersistentState {
+                val parent = Parent()
+                parent.children.add(Child())
+                parent.children.add(Child())
+                return parent
+            }
+
+        }
+        val observer = HibernateObserver(vaultService, schemaService)
+        databaseTransaction(database) {
+            rawUpdatesPublisher.onNext(Vault.Update(emptySet(), setOf(StateAndRef(TransactionState(object : QueryableState {
+                override fun supportedSchemas(): Iterable<MappedSchema> {
+                    return setOf(testSchema)
+                }
+
+                override fun generateMappedObject(schema: MappedSchema): PersistentState {
+                    TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+                }
+
+                override val contract: Contract
+                    get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+                override val participants: List<CompositeKey>
+                    get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+            }, MEGA_CORP), StateRef(SecureHash.sha256("dummy"), 0)))))
+
+            val parentRowCountResult = TransactionManager.current().connection.prepareStatement("select count(*) from contract_Parents").executeQuery()
+            parentRowCountResult.next()
+            val parentRows = parentRowCountResult.getInt(1)
+            parentRowCountResult.close()
+            val childrenRowCountResult = TransactionManager.current().connection.prepareStatement("select count(*) from contract_Children").executeQuery()
+            childrenRowCountResult.next()
+            val childrenRows = childrenRowCountResult.getInt(1)
+            childrenRowCountResult.close()
+            assertEquals(1, parentRows, "Expected one parent")
+            assertEquals(2, childrenRows, "Expected two children")
+        }
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
@@ -1,18 +1,15 @@
 package net.corda.node.services
 
-import net.corda.core.contracts.*
-import net.corda.core.crypto.AbstractParty
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.CompositeKey
-import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
 import net.corda.core.node.services.Vault
-import net.corda.core.node.services.VaultService
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.QueryableState
-import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.LogHelper
 import net.corda.node.services.api.SchemaService
 import net.corda.node.services.schema.HibernateObserver
@@ -27,10 +24,8 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import rx.Observable
 import rx.subjects.PublishSubject
 import java.io.Closeable
-import java.util.*
 import javax.persistence.*
 import kotlin.test.assertEquals
 
@@ -100,71 +95,6 @@ class HibernateObserverTests {
     fun testChildObjectsArePersisted() {
         val testSchema = object : MappedSchema(SchemaFamily::class.java, 1, setOf(Parent::class.java, Child::class.java)) {}
         val rawUpdatesPublisher = PublishSubject.create<Vault.Update>()
-        val vaultService = object : VaultService {
-            override val rawUpdates: Observable<Vault.Update> = rawUpdatesPublisher
-
-            override val updates: Observable<Vault.Update>
-                get() = throw UnsupportedOperationException()
-
-            override val cashBalances: Map<Currency, Amount<Currency>>
-                get() = throw UnsupportedOperationException()
-
-            override fun track(): Pair<Vault<ContractState>, Observable<Vault.Update>> {
-                throw UnsupportedOperationException()
-            }
-
-            override fun statesForRefs(refs: List<StateRef>): Map<StateRef, TransactionState<*>?> {
-                throw UnsupportedOperationException()
-            }
-
-            override fun notifyAll(txns: Iterable<WireTransaction>) {
-                throw UnsupportedOperationException()
-            }
-
-            override fun getAuthorisedContractUpgrade(ref: StateRef): Class<out UpgradedContract<*, *>>? {
-                throw UnsupportedOperationException()
-            }
-
-            override fun authoriseContractUpgrade(stateAndRef: StateAndRef<*>, upgradedContractClass: Class<out UpgradedContract<*, *>>) {
-                throw UnsupportedOperationException()
-            }
-
-            override fun deauthoriseContractUpgrade(stateAndRef: StateAndRef<*>) {
-                throw UnsupportedOperationException()
-            }
-
-            override fun addNoteToTransaction(txnId: SecureHash, noteText: String) {
-                throw UnsupportedOperationException()
-            }
-
-            override fun getTransactionNotes(txnId: SecureHash): Iterable<String> {
-                throw UnsupportedOperationException()
-            }
-
-            override fun generateSpend(tx: TransactionBuilder, amount: Amount<Currency>, to: CompositeKey, onlyFromParties: Set<AbstractParty>?): Pair<TransactionBuilder, List<CompositeKey>> {
-                throw UnsupportedOperationException()
-            }
-
-            override fun <T : ContractState> states(clazzes: Set<Class<T>>, statuses: EnumSet<Vault.StateStatus>, includeSoftLockedStates: Boolean): Iterable<StateAndRef<T>> {
-                throw UnsupportedOperationException()
-            }
-
-            override fun softLockReserve(lockId: UUID, stateRefs: Set<StateRef>) {
-                throw UnsupportedOperationException()
-            }
-
-            override fun softLockRelease(lockId: UUID, stateRefs: Set<StateRef>?) {
-                throw UnsupportedOperationException()
-            }
-
-            override fun <T : ContractState> softLockedStates(lockId: UUID?): List<StateAndRef<T>> {
-                throw UnsupportedOperationException()
-            }
-
-            override fun <T : ContractState> unconsumedStatesForSpending(amount: Amount<Currency>, onlyFromIssuerParties: Set<AbstractParty>?, notary: Party?, lockId: UUID, withIssuerRefs: Set<OpaqueBytes>?): List<StateAndRef<T>> {
-                throw UnsupportedOperationException()
-            }
-        }
         val schemaService = object : SchemaService {
             override val schemaOptions: Map<MappedSchema, SchemaService.SchemaOptions> = emptyMap()
 
@@ -179,7 +109,7 @@ class HibernateObserverTests {
         }
 
         @Suppress("UNUSED_VARIABLE")
-        val observer = HibernateObserver(vaultService, schemaService)
+        val observer = HibernateObserver(rawUpdatesPublisher, schemaService)
         databaseTransaction(database) {
             rawUpdatesPublisher.onNext(Vault.Update(emptySet(), setOf(StateAndRef(TransactionState(TestState(), MEGA_CORP), StateRef(SecureHash.sha256("dummy"), 0)))))
             val parentRowCountResult = TransactionManager.current().connection.prepareStatement("select count(*) from contract_Parents").executeQuery()

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -17,8 +17,8 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.services.persistence.InMemoryStateMachineRecordedTransactionMappingStorage
 import net.corda.node.services.schema.HibernateObserver
 import net.corda.node.services.schema.NodeSchemaService
-import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.services.transactions.InMemoryTransactionVerifierService
+import net.corda.node.services.vault.NodeVaultService
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.MINI_CORP
 import net.corda.testing.MOCK_VERSION
@@ -28,7 +28,6 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.KeyPair
 import java.security.PrivateKey
@@ -74,7 +73,7 @@ open class MockServices(val key: KeyPair = generateKeyPair()) : ServiceHub {
     fun makeVaultService(dataSourceProps: Properties): VaultService {
         val vaultService = NodeVaultService(this, dataSourceProps)
         // Vault cash spending requires access to contract_cash_states and their updates
-        HibernateObserver(vaultService, NodeSchemaService())
+        HibernateObserver(vaultService.rawUpdates, NodeSchemaService())
         return vaultService
     }
 }


### PR DESCRIPTION
Fixes https://github.com/corda/corda/issues/514

Switch from `StatelessSession` to normal `Session` since stateless version will not cascade persistence, and adds unit test to ensure persistence cascades.

Have run the Explorer demo in simulation mode (which repeatedly persists cash) connected to YourKit and it shows no memory leaks involving Hibernate so I think I have successfully disabled any caching and any other state retention (which is the original motivation for using `StatelessSession` since we are write-only).

