### PR TITLE
Fixed broken NodeRunner on MacOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     ext.quickcheck_version = '0.7'
     ext.okhttp_version = '3.5.0'
     ext.netty_version = '4.1.5.Final'
-    ext.typesafe_config_version = '1.3.1'
+    ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.2'
     ext.junit_version = '4.12'
     ext.mockito_version = '1.10.19'

--- a/constants.properties
+++ b/constants.properties
@@ -1,3 +1,4 @@
-gradlePluginsVersion=0.10.5
+gradlePluginsVersion=0.11.0
 kotlinVersion=1.1.1
 guavaVersion=21.0
+typesafeConfigVersion=1.3.1

--- a/gradle-plugins/cordformation/build.gradle
+++ b/gradle-plugins/cordformation/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     file("$projectDir/../../constants.properties").withInputStream { constants.load(it) }
 
     ext.kotlin_version = constants.getProperty("kotlinVersion")
+    ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
 
     repositories {
         mavenCentral()
@@ -45,8 +46,7 @@ dependencies {
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 
     // TypeSafe Config: for simple and human friendly config files.
-    // TODO: Add a common versions file between Corda and gradle plugins to de-duplicate this version number
-    compile "com.typesafe:config:1.3.1"
+    compile "com.typesafe:config:$typesafe_config_version"
 }
 
 task createNodeRunner(type: Jar, dependsOn: [classes]) {

--- a/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -28,7 +28,7 @@ val debugPortAlloc: IncrementalPortAllocator = IncrementalPortAllocator()
 
 fun main(args: Array<String>) {
     val startedProcesses = mutableListOf<Process>()
-    val headless = (GraphicsEnvironment.isHeadless() || (!args.isEmpty() && (args[0] == HEADLESS_FLAG)))
+    val headless = GraphicsEnvironment.isHeadless() || (args.isNotEmpty() && args[0] == HEADLESS_FLAG)
     val workingDir = Paths.get(System.getProperty("user.dir")).toFile()
     val javaArgs = args.filter { it != HEADLESS_FLAG }
     println("Starting nodes in $workingDir")
@@ -69,7 +69,7 @@ private fun isWebserver(maybeWebserverDir: File) = maybeWebserverDir.isDirectory
 private fun hasWebserverPort(nodeConfDir: File) = Files.readAllLines(File(nodeConfDir, nodeConfName).toPath()).joinToString { it }.contains("webAddress")
 
 private fun getDebugPortArg(debugPort: Int?) = if (debugPort != null) {
-    listOf("""-Dcapsule.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$debugPort"""")
+    listOf("-Dcapsule.jvm.args=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$debugPort")
 } else {
     emptyList()
 }


### PR DESCRIPTION
The use of double-quotes for the debug port argument string breaks the MacOS start script. Using single fixes it. I need you both to test on your respective machines that runnodes is still working.