### PR TITLE
Improve robustness of integration tests that commonly have false positives

### DIFF
--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -37,6 +37,7 @@ configurations {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
+    testCompile "org.assertj:assertj-core:${assertj_version}"
 
     // Corda integration dependencies
     runtime project(path: ":node:capsule", configuration: 'runtimeArtifacts')

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -38,6 +38,7 @@ configurations {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
+    testCompile "org.assertj:assertj-core:${assertj_version}"
 
     // Corda integration dependencies
     runtime project(path: ":node:capsule", configuration: 'runtimeArtifacts')

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -34,6 +34,7 @@ configurations {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
+    testCompile "org.assertj:assertj-core:${assertj_version}"
 
     // Corda integration dependencies
     runtime project(path: ":node:capsule", configuration: 'runtimeArtifacts')

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
@@ -1,9 +1,13 @@
 package net.corda.traderdemo
 
 import com.google.common.util.concurrent.Futures
+import net.corda.contracts.CommercialPaper
+import net.corda.contracts.asset.Cash
 import net.corda.contracts.testing.calculateRandomlySizedAmounts
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.DOLLARS
+import net.corda.core.contracts.USD
+import net.corda.core.contracts.filterStatesOfType
 import net.corda.core.getOrThrow
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
@@ -23,6 +27,12 @@ class TraderDemoClientApi(val rpc: CordaRPCOps) {
     private companion object {
         val logger = loggerFor<TraderDemoClientApi>()
     }
+
+    val cashCount: Int get() = rpc.vaultAndUpdates().first.filterStatesOfType<Cash.State>().size
+
+    val dollarCashBalance: Amount<Currency> get() = rpc.getCashBalances()[USD]!!
+
+    val commercialPaperCount: Int get() = rpc.vaultAndUpdates().first.filterStatesOfType<CommercialPaper.State>().size
 
     fun runBuyer(amount: Amount<Currency> = 30000.DOLLARS) {
         val bankOfCordaParty = rpc.partyFromName(BOC.name)

--- a/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -18,6 +18,7 @@ import net.corda.nodeapi.User
 import net.corda.nodeapi.config.parseAs
 import net.corda.testing.MOCK_NODE_VERSION_INFO
 import net.corda.testing.getFreeLocalPorts
+import org.apache.logging.log4j.Level
 import org.junit.After
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -38,6 +39,10 @@ abstract class NodeBasedTest {
     private var _networkMapNode: Node? = null
 
     val networkMapNode: Node get() = _networkMapNode ?: startNetworkMapNode()
+
+    init {
+        System.setProperty("consoleLogLevel", Level.DEBUG.name().toLowerCase())
+    }
 
     /**
      * Stops the network map node and all the nodes started by [startNode]. This is called automatically after each test


### PR DESCRIPTION
Why: The tests below are a hotbed for false positives due to a lack of assertions about the final state.

What: Each of the tests now have checks to verify various quantities to ensure the final output is what we're expecting. To avoid making the tests more brittle I have avoided testing details that would be too specific.