### PR TITLE
Utilising a PublicKeyCache on key deserialisation

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/PublicKeyCache.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/PublicKeyCache.kt
@@ -1,0 +1,31 @@
+package net.corda.core.crypto
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import java.security.*
+
+/**
+ * A cache for [PublicKey]s required to reduce memory footprint and avoid creating/referencing new [PublicKey] objects
+ * during deserialization. This is very helpful in cases where we usually transact with certain clients and for load testing.
+ * Current implementation uses Guava's [CacheBuilder] which is thread-safe, and can be safely accessed
+ * by multiple concurrent threads. Values are automatically loaded by the cache, and are stored in the cache
+ * until evicted. Currently, a reference-based eviction policy is utilised in which softly-referenced objects (values)
+ * will be garbage-collected in a <i>globally</i> least-recently-used manner, in response to memory
+ * demand. Use of soft-values will result to comparisons using identity (==) equality instead of equals().
+ */
+object PublicKeyCache {
+    private val cache = CacheBuilder.newBuilder()
+            .maximumSize(128) // This is a guessed value.
+            .softValues()
+            .build(object : CacheLoader<PublicKey, PublicKey>() { // TODO: consider using key-hash as cache.key
+                override fun load(key: PublicKey): PublicKey {
+                    return key
+                }
+            })
+
+    /**
+     * Returns the value associated with {@code key} in this cache, first loading that value if
+     * necessary. No observable state associated with this cache is modified until loading completes.
+     */
+    fun get(key: PublicKey) = cache.getUnchecked(key)
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -363,7 +363,7 @@ object Ed25519PublicKeySerializer : Serializer<EdDSAPublicKey>() {
 
     override fun read(kryo: Kryo, input: Input, type: Class<EdDSAPublicKey>): EdDSAPublicKey {
         val A = input.readBytesWithLength()
-        return EdDSAPublicKey(EdDSAPublicKeySpec(A, ed25519Curve))
+        return PublicKeyCache.get(EdDSAPublicKey(EdDSAPublicKeySpec(A, ed25519Curve))) as EdDSAPublicKey
     }
 }
 


### PR DESCRIPTION
A cache for PublicKeys required to reduce memory footprint and avoid creating/referencing new PublicKey objects during deserialisation. This is very helpful in cases where we usually transact with certain clients and for load testing. Current implementation uses Guava's CacheBuilder which is thread-safe and we apply reference-based eviction on cache.values.
Note that in the future and when we decide to do so, we could use the key-sha256 as cache.key.