### PR TITLE
Restore :client:rpc unit tests to their correct location.

### DIFF
--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractClientRPC.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractClientRPC.kt
@@ -4,10 +4,10 @@ import net.corda.core.messaging.RPCOps
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.utilities.LogHelper
 import net.corda.node.services.RPCUserService
-import net.corda.node.services.User
-import net.corda.node.services.messaging.ArtemisMessagingComponent
 import net.corda.node.services.messaging.RPCDispatcher
 import net.corda.node.utilities.AffinityExecutor
+import net.corda.nodeapi.ArtemisMessagingComponent
+import net.corda.nodeapi.User
 import org.apache.activemq.artemis.api.core.Message
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.TransportConfiguration

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
@@ -7,9 +7,9 @@ import net.corda.core.getOrThrow
 import net.corda.core.messaging.RPCOps
 import net.corda.core.messaging.RPCReturnsObservables
 import net.corda.core.success
-import net.corda.node.services.User
-import net.corda.node.services.messaging.CURRENT_RPC_USER
-import net.corda.node.services.messaging.RPCSinceVersion
+import net.corda.nodeapi.CURRENT_RPC_USER
+import net.corda.nodeapi.RPCSinceVersion
+import net.corda.nodeapi.User
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTest.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTest.kt
@@ -1,8 +1,9 @@
 package net.corda.client.rpc
 
 import net.corda.core.messaging.RPCOps
-import net.corda.node.services.User
 import net.corda.node.services.messaging.*
+import net.corda.nodeapi.PermissionException
+import net.corda.nodeapi.User
 import org.junit.After
 import org.junit.Test
 import kotlin.test.*


### PR DESCRIPTION
These tests were misplaced when `client:rpc` module was created.