### PR TITLE
Convert databaseTransaction to extension function Database.transaction

### DIFF
--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -14,7 +14,7 @@ import net.corda.flows.ContractUpgradeFlow
 import net.corda.flows.FinalityFlow
 import net.corda.node.internal.CordaRPCOpsImpl
 import net.corda.node.services.startFlowPermission
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.nodeapi.CURRENT_RPC_USER
 import net.corda.nodeapi.User
 import net.corda.testing.node.MockNetwork
@@ -60,8 +60,8 @@ class ContractUpgradeFlowTest {
         a.services.startFlow(FinalityFlow(stx, setOf(a.info.legalIdentity, b.info.legalIdentity)))
         mockNet.runNetwork()
 
-        val atx = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(stx.id) }
-        val btx = databaseTransaction(b.database) { b.services.storageService.validatedTransactions.getTransaction(stx.id) }
+        val atx = a.database.transaction { a.services.storageService.validatedTransactions.getTransaction(stx.id) }
+        val btx = b.database.transaction { b.services.storageService.validatedTransactions.getTransaction(stx.id) }
         requireNotNull(atx)
         requireNotNull(btx)
 
@@ -80,13 +80,13 @@ class ContractUpgradeFlowTest {
         val result = resultFuture.get()
 
         fun check(node: MockNetwork.MockNode) {
-            val nodeStx = databaseTransaction(node.database) {
+            val nodeStx = node.database.transaction {
                 node.services.storageService.validatedTransactions.getTransaction(result.ref.txhash)
             }
             requireNotNull(nodeStx)
 
             // Verify inputs.
-            val input = databaseTransaction(node.database) {
+            val input = node.database.transaction {
                 node.services.storageService.validatedTransactions.getTransaction(nodeStx!!.tx.inputs.single().txhash)
             }
             requireNotNull(input)
@@ -110,8 +110,8 @@ class ContractUpgradeFlowTest {
         a.services.startFlow(FinalityFlow(stx, setOf(a.info.legalIdentity, b.info.legalIdentity)))
         mockNet.runNetwork()
 
-        val atx = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(stx.id) }
-        val btx = databaseTransaction(b.database) { b.services.storageService.validatedTransactions.getTransaction(stx.id) }
+        val atx = a.database.transaction { a.services.storageService.validatedTransactions.getTransaction(stx.id) }
+        val btx = b.database.transaction { b.services.storageService.validatedTransactions.getTransaction(stx.id) }
         requireNotNull(atx)
         requireNotNull(btx)
 
@@ -143,11 +143,11 @@ class ContractUpgradeFlowTest {
         val result = resultFuture.get()
         // Check results.
         listOf(a, b).forEach {
-            val signedTX = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(result.ref.txhash) }
+            val signedTX = a.database.transaction { a.services.storageService.validatedTransactions.getTransaction(result.ref.txhash) }
             requireNotNull(signedTX)
 
             // Verify inputs.
-            val input = databaseTransaction(a.database) { a.services.storageService.validatedTransactions.getTransaction(signedTX!!.tx.inputs.single().txhash) }
+            val input = a.database.transaction { a.services.storageService.validatedTransactions.getTransaction(signedTX!!.tx.inputs.single().txhash) }
             requireNotNull(input)
             assertTrue(input!!.tx.outputs.single().data is DummyContract.State)
 
@@ -166,7 +166,7 @@ class ContractUpgradeFlowTest {
         a.services.startFlow(ContractUpgradeFlow.Instigator(stateAndRef, CashV2::class.java))
         mockNet.runNetwork()
         // Get contract state from the vault.
-        val firstState = databaseTransaction(a.database) { a.vault.unconsumedStates<ContractState>().single() }
+        val firstState = a.database.transaction { a.vault.unconsumedStates<ContractState>().single() }
         assertTrue(firstState.state.data is CashV2.State, "Contract state is upgraded to the new version.")
         assertEquals(Amount(1000000, USD).`issued by`(a.info.legalIdentity.ref(1)), (firstState.state.data as CashV2.State).amount, "Upgraded cash contain the correct amount.")
         assertEquals(listOf(a.info.legalIdentity.owningKey), (firstState.state.data as CashV2.State).owners, "Upgraded cash belongs to the right owner.")

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,12 @@ Changelog
 
 Here are brief summaries of what's changed between each snapshot release.
 
+UNRELEASED
+----------
+
+* API changes:
+    * Added extension function ``Database.transaction`` to replace ``databaseTransaction``, which is now deprecated.
+
 Milestone 10.0
 --------------
 

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
@@ -11,7 +11,7 @@ import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.ValidatingNotaryService
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -80,11 +80,11 @@ class FxTransactionBuildTutorialTest {
         doIt.resultFuture.getOrThrow()
         // Get the balances when the vault updates
         nodeAVaultUpdate.get()
-        val balancesA = databaseTransaction(nodeA.database) {
+        val balancesA = nodeA.database.transaction {
             nodeA.services.vaultService.cashBalances
         }
         nodeBVaultUpdate.get()
-        val balancesB = databaseTransaction(nodeB.database) {
+        val balancesB = nodeB.database.transaction {
             nodeB.services.vaultService.cashBalances
         }
         println("BalanceA\n" + balancesA)
@@ -98,10 +98,10 @@ class FxTransactionBuildTutorialTest {
 
     private fun printBalances() {
         // Print out the balances
-        databaseTransaction(nodeA.database) {
+        nodeA.database.transaction {
             println("BalanceA\n" + nodeA.services.vaultService.cashBalances)
         }
-        databaseTransaction(nodeB.database) {
+        nodeB.database.transaction {
             println("BalanceB\n" + nodeB.services.vaultService.cashBalances)
         }
     }

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
@@ -13,7 +13,7 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.DUMMY_NOTARY_KEY
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.ValidatingNotaryService
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -66,10 +66,10 @@ class WorkflowTransactionBuildTutorialTest {
         // Wait for NodeB to include it's copy in the vault
         nodeBVaultUpdate.get()
         // Fetch the latest copy of the state from both nodes
-        val latestFromA = databaseTransaction(nodeA.database) {
+        val latestFromA = nodeA.database.transaction {
             nodeA.services.latest<TradeApprovalContract.State>(proposalRef.ref)
         }
-        val latestFromB = databaseTransaction(nodeB.database) {
+        val latestFromB = nodeB.database.transaction {
             nodeB.services.latest<TradeApprovalContract.State>(proposalRef.ref)
         }
         // Confirm the state as as expected
@@ -90,10 +90,10 @@ class WorkflowTransactionBuildTutorialTest {
         nodeAVaultUpdate.get()
         secondNodeBVaultUpdate.get()
         // Fetch the latest copies from the vault
-        val finalFromA = databaseTransaction(nodeA.database) {
+        val finalFromA = nodeA.database.transaction {
             nodeA.services.latest<TradeApprovalContract.State>(proposalRef.ref)
         }
-        val finalFromB = databaseTransaction(nodeB.database) {
+        val finalFromB = nodeB.database.transaction {
             nodeB.services.latest<TradeApprovalContract.State>(proposalRef.ref)
         }
         // Confirm the state is as expected

--- a/docs/source/flow-testing.rst
+++ b/docs/source/flow-testing.rst
@@ -76,7 +76,7 @@ It doesn't do anything else. This code simply creates a transaction that issues 
 converts the builder to the final ``SignedTransaction``. It then does so again, but this time instead of issuing
 it re-assigns ownership instead. The chain of two transactions is finally committed to node A by sending them
 directly to the ``a.services.recordTransaction`` method (note that this method doesn't check the transactions are
-valid) inside a ``databaseTransaction``.  All node flows run within a database transaction in the nodes themselves,
+valid) inside a ``database.transaction``.  All node flows run within a database transaction in the nodes themselves,
 but any time we need to use the database directly from a unit test, you need to provide a database transaction as shown
 here.
 

--- a/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
@@ -15,7 +15,7 @@ import net.corda.core.utilities.DUMMY_NOTARY_KEY
 import net.corda.core.utilities.DUMMY_PUBKEY_1
 import net.corda.core.utilities.TEST_TX_TIME
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.*
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.makeTestDataSourceProperties
@@ -216,7 +216,7 @@ class CommercialPaperTestsGeneric {
         val dataSourcePropsAlice = makeTestDataSourceProperties()
         val dataSourceAndDatabaseAlice = configureDatabase(dataSourcePropsAlice)
         val databaseAlice = dataSourceAndDatabaseAlice.second
-        databaseTransaction(databaseAlice) {
+        databaseAlice.transaction {
 
             aliceServices = object : MockServices() {
                 override val vaultService: VaultService = makeVaultService(dataSourcePropsAlice)
@@ -236,7 +236,7 @@ class CommercialPaperTestsGeneric {
         val dataSourcePropsBigCorp = makeTestDataSourceProperties()
         val dataSourceAndDatabaseBigCorp = configureDatabase(dataSourcePropsBigCorp)
         val databaseBigCorp = dataSourceAndDatabaseBigCorp.second
-        databaseTransaction(databaseBigCorp) {
+        databaseBigCorp.transaction {
 
             bigCorpServices = object : MockServices() {
                 override val vaultService: VaultService = makeVaultService(dataSourcePropsBigCorp)
@@ -267,7 +267,7 @@ class CommercialPaperTestsGeneric {
                     signWith(DUMMY_NOTARY_KEY)
                 }.toSignedTransaction()
 
-        databaseTransaction(databaseAlice) {
+        databaseAlice.transaction {
             // Alice pays $9000 to BigCorp to own some of their debt.
             moveTX = run {
                 val ptx = TransactionType.General.Builder(DUMMY_NOTARY)
@@ -280,7 +280,7 @@ class CommercialPaperTestsGeneric {
             }
         }
 
-        databaseTransaction(databaseBigCorp) {
+        databaseBigCorp.transaction {
             // Verify the txns are valid and insert into both sides.
             listOf(issueTX, moveTX).forEach {
                 it.toLedgerTransaction(aliceServices).verify()
@@ -289,7 +289,7 @@ class CommercialPaperTestsGeneric {
             }
         }
 
-        databaseTransaction(databaseBigCorp) {
+        databaseBigCorp.transaction {
             fun makeRedeemTX(time: Instant): Pair<SignedTransaction, UUID> {
                 val ptx = TransactionType.General.Builder(DUMMY_NOTARY)
                 ptx.setTime(time, 30.seconds)

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -11,7 +11,7 @@ import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.*
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.*
 import net.corda.testing.node.MockKeyManagementService
 import net.corda.testing.node.MockServices
@@ -53,7 +53,7 @@ class CashTests {
         val dataSourceAndDatabase = configureDatabase(dataSourceProps)
         dataSource = dataSourceAndDatabase.first
         database = dataSourceAndDatabase.second
-        databaseTransaction(database) {
+        database.transaction {
             services = object : MockServices() {
                 override val keyManagementService: MockKeyManagementService = MockKeyManagementService(MINI_CORP_KEY, MEGA_CORP_KEY, OUR_KEY)
                 override val vaultService: VaultService = makeVaultService(dataSourceProps)
@@ -484,7 +484,7 @@ class CashTests {
 
     fun makeSpend(amount: Amount<Currency>, dest: PublicKey): WireTransaction {
         val tx = TransactionType.General.Builder(DUMMY_NOTARY)
-        databaseTransaction(database) {
+        database.transaction {
             vault.generateSpend(tx, amount, dest)
         }
         return tx.toWireTransaction()
@@ -562,7 +562,7 @@ class CashTests {
     @Test
     fun generateSimpleDirectSpend() {
 
-        databaseTransaction(database) {
+        database.transaction {
 
             val wtx = makeSpend(100.DOLLARS, THEIR_PUBKEY_1)
 
@@ -577,7 +577,7 @@ class CashTests {
     @Test
     fun generateSimpleSpendWithParties() {
 
-        databaseTransaction(database) {
+        database.transaction {
 
             val tx = TransactionType.General.Builder(DUMMY_NOTARY)
             vault.generateSpend(tx, 80.DOLLARS, ALICE_PUBKEY, setOf(MINI_CORP.toAnonymous()))
@@ -589,7 +589,7 @@ class CashTests {
     @Test
     fun generateSimpleSpendWithChange() {
 
-        databaseTransaction(database) {
+        database.transaction {
 
             val wtx = makeSpend(10.DOLLARS, THEIR_PUBKEY_1)
 
@@ -605,7 +605,7 @@ class CashTests {
     @Test
     fun generateSpendWithTwoInputs() {
 
-        databaseTransaction(database) {
+        database.transaction {
             val wtx = makeSpend(500.DOLLARS, THEIR_PUBKEY_1)
 
             @Suppress("UNCHECKED_CAST")
@@ -621,7 +621,7 @@ class CashTests {
     @Test
     fun generateSpendMixedDeposits() {
 
-        databaseTransaction(database) {
+        database.transaction {
             val wtx = makeSpend(580.DOLLARS, THEIR_PUBKEY_1)
             assertEquals(3, wtx.inputs.size)
 
@@ -642,7 +642,7 @@ class CashTests {
     @Test
     fun generateSpendInsufficientBalance() {
 
-        databaseTransaction(database) {
+        database.transaction {
 
             val e: InsufficientBalanceException = assertFailsWith("balance") {
                 makeSpend(1000.DOLLARS, THEIR_PUBKEY_1)

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/JDBCHashMapTestSuite.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/JDBCHashMapTestSuite.kt
@@ -246,17 +246,17 @@ class JDBCHashMapTestSuite {
 
         @Test
         fun `fill map and check content after reconstruction`() {
-            databaseTransaction(database) {
+            database.transaction {
                 val persistentMap = JDBCHashMap<String, String>("the_table")
                 // Populate map the first time.
                 applyOpsToMap(persistentMap)
                 assertThat(persistentMap.entries).containsExactly(*transientMapForComparison.entries.toTypedArray())
             }
-            databaseTransaction(database) {
+            database.transaction {
                 val persistentMap = JDBCHashMap<String, String>("the_table", loadOnInit = false)
                 assertThat(persistentMap.entries).containsExactly(*transientMapForComparison.entries.toTypedArray())
             }
-            databaseTransaction(database) {
+            database.transaction {
                 val persistentMap = JDBCHashMap<String, String>("the_table", loadOnInit = true)
                 assertThat(persistentMap.entries).containsExactly(*transientMapForComparison.entries.toTypedArray())
             }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -49,7 +49,7 @@ import net.corda.node.services.vault.VaultSoftLockManager
 import net.corda.node.utilities.AddOrRemove.ADD
 import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import org.apache.activemq.artemis.utils.ReusableLatch
 import org.jetbrains.exposed.sql.Database
 import org.slf4j.Logger
@@ -141,7 +141,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         }
 
         override fun recordTransactions(txs: Iterable<SignedTransaction>) {
-            databaseTransaction(database) {
+            database.transaction {
                 recordTransactionsInternal(storage, txs)
             }
         }
@@ -339,7 +339,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
             log.info("Connected to ${database.vendor} database.")
             dbCloser = Runnable { toClose.close() }
             runOnStop += dbCloser!!
-            databaseTransaction(database) {
+            database.transaction {
                 insideTransaction()
             }
         } else {

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
@@ -338,7 +338,7 @@ class NodeMessagingClient(override val config: NodeConfiguration,
             // Note that handlers may re-enter this class. We aren't holding any locks and methods like
             // start/run/stop have re-entrancy assertions at the top, so it is OK.
             nodeExecutor.fetchFrom {
-                databaseTransaction(database) {
+                database.transaction {
                     if (msg.uniqueMessageId in processedMessages) {
                         log.trace { "Discard duplicate message ${msg.uniqueMessageId} for ${msg.topicSession}" }
                     } else {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -21,7 +21,7 @@ import net.corda.core.utilities.debug
 import net.corda.core.utilities.trace
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.utilities.StrandLocalTransactionManager
-import net.corda.node.utilities.createDatabaseTransaction
+import net.corda.node.utilities.createTransaction
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.transactions.TransactionManager
@@ -133,7 +133,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
 
     private fun createTransaction() {
         // Make sure we have a database transaction
-        createDatabaseTransaction(database)
+        database.createTransaction()
         logger.trace { "Starting database transaction ${TransactionManager.currentOrNull()} on ${Strand.currentStrand()}" }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -243,7 +243,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         val waitingForResponse = fiber.waitingForResponse
         if (waitingForResponse != null) {
             if (waitingForResponse is WaitForLedgerCommit) {
-                val stx = databaseTransaction(database) {
+                val stx = database.transaction {
                     serviceHub.storageService.validatedTransactions.getTransaction(waitingForResponse.hash)
                 }
                 if (stx != null) {
@@ -457,7 +457,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         // on the flow completion future inside that context. The problem is that any progress checkpoints are
         // unable to acquire the table lock and move forward till the calling transaction finishes.
         // Committing in line here on a fresh context ensure we can progress.
-        val fiber = isolatedTransaction(database) {
+        val fiber = database.isolatedTransaction {
             val fiber = createFiber(logic)
             updateCheckpoint(fiber)
             fiber
@@ -508,7 +508,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
             }
         } else if (ioRequest is WaitForLedgerCommit) {
             // Is it already committed?
-            val stx = databaseTransaction(database) {
+            val stx = database.transaction {
                 serviceHub.storageService.validatedTransactions.getTransaction(ioRequest.hash)
             }
             if (stx != null) {

--- a/node/src/main/kotlin/net/corda/node/services/vault/CashBalanceAsMetricsObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/CashBalanceAsMetricsObserver.kt
@@ -3,7 +3,7 @@ package net.corda.node.services.vault
 import com.codahale.metrics.Gauge
 import net.corda.core.node.services.VaultService
 import net.corda.node.services.api.ServiceHubInternal
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import org.jetbrains.exposed.sql.Database
 import java.util.*
 
@@ -31,7 +31,7 @@ class CashBalanceAsMetricsObserver(val serviceHubInternal: ServiceHubInternal, v
         //
         // Note: exported as pennies.
         val m = serviceHubInternal.monitoringService.metrics
-        databaseTransaction(database) {
+        database.transaction {
             for ((key, value) in vault.cashBalances) {
                 val metric = balanceMetrics.getOrPut(key) {
                     val newMetric = BalanceMetric()

--- a/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JDBCHashMap.kt
@@ -189,7 +189,7 @@ abstract class AbstractJDBCHashSet<K : Any, out T : JDBCHashedTable>(protected v
  * number of hash "buckets", where one bucket represents all entries with the same hash code.  There is a default value
  * for maximum buckets.
  *
- * All operations require a [databaseTransaction] to be started.
+ * All operations require a [transaction] to be started.
  *
  * The keys/values/entries collections are really designed just for iterating and other uses might turn out to be
  * costly in terms of performance.  Beware when loadOnInit=true, the iterator first sorts the entries which could be

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -18,7 +18,7 @@ import net.corda.node.internal.CordaRPCOpsImpl
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.SimpleNotaryService
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.nodeapi.CURRENT_RPC_USER
 import net.corda.nodeapi.PermissionException
 import net.corda.nodeapi.User
@@ -63,7 +63,7 @@ class CordaRPCOpsImplTest {
                 startFlowPermission<CashPaymentFlow>()
         )))
 
-        databaseTransaction(aliceNode.database) {
+        aliceNode.database.transaction {
             stateMachineUpdates = rpc.stateMachinesAndUpdates().second
             transactions = rpc.verifiedTransactions().second
             vaultUpdates = rpc.vaultAndUpdates().second
@@ -76,7 +76,7 @@ class CordaRPCOpsImplTest {
         val ref = OpaqueBytes(ByteArray(1) { 1 })
 
         // Check the monitoring service wallet is empty
-        databaseTransaction(aliceNode.database) {
+        aliceNode.database.transaction {
             assertFalse(aliceNode.services.vaultService.unconsumedStates<ContractState>().iterator().hasNext())
         }
 

--- a/node/src/test/kotlin/net/corda/node/messaging/AttachmentTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/AttachmentTests.kt
@@ -14,8 +14,8 @@ import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.node.services.persistence.schemas.AttachmentEntity
 import net.corda.node.services.transactions.SimpleNotaryService
-import net.corda.node.utilities.databaseTransaction
 import net.corda.testing.node.MockNetwork
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.makeTestDataSourceProperties
 import org.jetbrains.exposed.sql.Database
 import org.junit.Before
@@ -60,7 +60,7 @@ class AttachmentTests {
         val (n0, n1) = network.createTwoNodes()
 
         // Insert an attachment into node zero's store directly.
-        val id = databaseTransaction(n0.database) {
+        val id = n0.database.transaction {
             n0.storage.attachments.importAttachment(ByteArrayInputStream(fakeAttachment()))
         }
 
@@ -71,7 +71,7 @@ class AttachmentTests {
         assertEquals(0, f1.resultFuture.getOrThrow().fromDisk.size)
 
         // Verify it was inserted into node one's store.
-        val attachment = databaseTransaction(n1.database) {
+        val attachment = n1.database.transaction {
             n1.storage.attachments.openAttachment(id)!!
         }
 
@@ -118,7 +118,7 @@ class AttachmentTests {
 
         val attachment = fakeAttachment()
         // Insert an attachment into node zero's store directly.
-        val id = databaseTransaction(n0.database) {
+        val id = n0.database.transaction {
             n0.storage.attachments.importAttachment(ByteArrayInputStream(attachment))
         }
 
@@ -129,7 +129,7 @@ class AttachmentTests {
         val corruptAttachment = AttachmentEntity()
         corruptAttachment.attId = id
         corruptAttachment.content = attachment
-        databaseTransaction(n0.database) {
+        n0.database.transaction {
             (n0.storage.attachments as NodeAttachmentService).session.update(corruptAttachment)
         }
 

--- a/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/HibernateObserverTests.kt
@@ -14,7 +14,7 @@ import net.corda.core.utilities.LogHelper
 import net.corda.node.services.api.SchemaService
 import net.corda.node.services.schema.HibernateObserver
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.node.makeTestDataSourceProperties
 import org.hibernate.annotations.Cascade
@@ -110,7 +110,7 @@ class HibernateObserverTests {
 
         @Suppress("UNUSED_VARIABLE")
         val observer = HibernateObserver(rawUpdatesPublisher, schemaService)
-        databaseTransaction(database) {
+        database.transaction {
             rawUpdatesPublisher.onNext(Vault.Update(emptySet(), setOf(StateAndRef(TransactionState(TestState(), MEGA_CORP), StateRef(SecureHash.sha256("dummy"), 0)))))
             val parentRowCountResult = TransactionManager.current().connection.prepareStatement("select count(*) from contract_Parents").executeQuery()
             parentRowCountResult.next()

--- a/node/src/test/kotlin/net/corda/node/services/InMemoryNetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/InMemoryNetworkMapCacheTest.kt
@@ -3,7 +3,7 @@ package net.corda.node.services
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.node.services.network.NetworkMapService
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.MockNetwork
 import org.junit.Test
 import java.math.BigInteger
@@ -30,7 +30,7 @@ class InMemoryNetworkMapCacheTest {
         // Node A currently knows only about itself, so this returns node A
         assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeA.info)
 
-        databaseTransaction(nodeA.database) {
+        nodeA.database.transaction {
             nodeA.netMapCache.addNode(nodeB.info)
         }
         // The details of node B write over those for node A

--- a/node/src/test/kotlin/net/corda/node/services/PersistentNetworkMapServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/PersistentNetworkMapServiceTest.kt
@@ -6,7 +6,7 @@ import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.network.PersistentNetworkMapService
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
 import java.math.BigInteger
@@ -24,7 +24,7 @@ class PersistentNetworkMapServiceTest : AbstractNetworkMapServiceTest<Persistent
         get() = (mapServiceNode.inNodeNetworkMapService as SwizzleNetworkMapService).delegate
 
     override fun swizzle() {
-        databaseTransaction(mapServiceNode.database) {
+        mapServiceNode.database.transaction {
             (mapServiceNode.inNodeNetworkMapService as SwizzleNetworkMapService).swizzle()
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/PersistentUniquenessProviderTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/PersistentUniquenessProviderTests.kt
@@ -5,7 +5,7 @@ import net.corda.core.node.services.UniquenessException
 import net.corda.core.utilities.LogHelper
 import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.generateStateRef
 import net.corda.testing.node.makeTestDataSourceProperties
@@ -39,7 +39,7 @@ class PersistentUniquenessProviderTests {
     }
 
     @Test fun `should commit a transaction with unused inputs without exception`() {
-        databaseTransaction(database) {
+        database.transaction {
             val provider = PersistentUniquenessProvider()
             val inputState = generateStateRef()
 
@@ -48,7 +48,7 @@ class PersistentUniquenessProviderTests {
     }
 
     @Test fun `should report a conflict for a transaction with previously used inputs`() {
-        databaseTransaction(database) {
+        database.transaction {
             val provider = PersistentUniquenessProvider()
             val inputState = generateStateRef()
 

--- a/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ScheduledFlowTests.kt
@@ -14,7 +14,7 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.FinalityFlow
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.ValidatingNotaryService
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -115,10 +115,10 @@ class ScheduledFlowTests {
     fun `create and run scheduled flow then wait for result`() {
         nodeA.services.startFlow(InsertInitialStateFlow(nodeB.info.legalIdentity))
         net.waitQuiescent()
-        val stateFromA = databaseTransaction(nodeA.database) {
+        val stateFromA = nodeA.database.transaction {
             nodeA.services.vaultService.linearHeadsOfType<ScheduledState>().values.first()
         }
-        val stateFromB = databaseTransaction(nodeB.database) {
+        val stateFromB = nodeB.database.transaction {
             nodeB.services.vaultService.linearHeadsOfType<ScheduledState>().values.first()
         }
         assertEquals(stateFromA, stateFromB, "Must be same copy on both nodes")
@@ -133,10 +133,10 @@ class ScheduledFlowTests {
             nodeB.services.startFlow(InsertInitialStateFlow(nodeA.info.legalIdentity))
         }
         net.waitQuiescent()
-        val statesFromA = databaseTransaction(nodeA.database) {
+        val statesFromA = nodeA.database.transaction {
             nodeA.services.vaultService.linearHeadsOfType<ScheduledState>()
         }
-        val statesFromB = databaseTransaction(nodeB.database) {
+        val statesFromB = nodeB.database.transaction {
             nodeB.services.vaultService.linearHeadsOfType<ScheduledState>()
         }
         assertEquals(2 * N, statesFromA.count(), "Expect all states to be present")

--- a/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
@@ -23,7 +23,7 @@ import net.corda.node.services.vault.schemas.VaultCashBalancesEntity
 import net.corda.node.services.vault.schemas.VaultSchema
 import net.corda.node.services.vault.schemas.VaultStatesEntity
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.makeTestDataSourceProperties
 import org.assertj.core.api.Assertions
 import org.jetbrains.exposed.sql.Database
@@ -61,14 +61,14 @@ class RequeryConfigurationTest {
     fun `transaction inserts in same DB transaction scope across two persistence engines`() {
         val txn = newTransaction()
 
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(txn)
             requerySession.withTransaction {
                 insert(createVaultStateEntity(txn))
             }
         }
 
-        databaseTransaction(database) {
+        database.transaction {
             Assertions.assertThat(transactionStorage.transactions).containsOnly(txn)
             requerySession.withTransaction {
                 val result = select(VaultSchema.VaultStates::class) where (VaultSchema.VaultStates::txId eq txn.tx.inputs[0].txhash.toString())
@@ -81,7 +81,7 @@ class RequeryConfigurationTest {
     fun `transaction operations in same DB transaction scope across two persistence engines`() {
         val txn = newTransaction()
 
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(txn)
             requerySession.withTransaction {
                 upsert(createCashBalance())
@@ -90,7 +90,7 @@ class RequeryConfigurationTest {
             }
         }
 
-        databaseTransaction(database) {
+        database.transaction {
             Assertions.assertThat(transactionStorage.transactions).containsOnly(txn)
             requerySession.withTransaction {
                 val cashQuery = select(VaultSchema.VaultCashBalances::class) where (VaultSchema.VaultCashBalances::currency eq "GBP")
@@ -105,7 +105,7 @@ class RequeryConfigurationTest {
     fun `transaction rollback in same DB transaction scope across two persistence engines`() {
         val txn = newTransaction()
 
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(txn)
             requerySession.withTransaction {
                 insert(createVaultStateEntity(txn))
@@ -113,7 +113,7 @@ class RequeryConfigurationTest {
             rollback()
         }
 
-        databaseTransaction(database) {
+        database.transaction {
             Assertions.assertThat(transactionStorage.transactions).isEmpty()
             requerySession.withTransaction {
                 val result = select(VaultSchema.VaultStates::class) where (VaultSchema.VaultStates::txId eq txn.tx.inputs[0].txhash.toString())
@@ -145,13 +145,13 @@ class RequeryConfigurationTest {
     }
 
     private fun newTransactionStorage() {
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage = DBTransactionStorage()
         }
     }
 
     private fun newRequeryStorage(dataSourceProperties: Properties) {
-        databaseTransaction(database) {
+        database.transaction {
             val configuration = RequeryConfiguration(dataSourceProperties, true)
             requerySession = configuration.sessionForModel(Models.VAULT)
         }

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -22,7 +22,7 @@ import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.node.utilities.AffinityExecutor.ServiceAffinityExecutor
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.MOCK_NODE_VERSION_INFO
 import net.corda.testing.TestNodeConfiguration
 import net.corda.testing.freeLocalHostAndPort
@@ -220,7 +220,7 @@ class ArtemisMessagingTests {
     }
 
     private fun createMessagingClient(server: HostAndPort = hostAndPort): NodeMessagingClient {
-        return databaseTransaction(database) {
+        return database.transaction {
             NodeMessagingClient(
                     config,
                     MOCK_NODE_VERSION_INFO,

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -12,7 +12,7 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.core.utilities.LogHelper
 import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.node.makeTestDataSourceProperties
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.exposed.sql.Database
@@ -45,14 +45,14 @@ class DBTransactionStorageTests {
 
     @Test
     fun `empty store`() {
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.getTransaction(newTransaction().id)).isNull()
         }
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.transactions).isEmpty()
         }
         newTransactionStorage()
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.transactions).isEmpty()
         }
     }
@@ -60,16 +60,16 @@ class DBTransactionStorageTests {
     @Test
     fun `one transaction`() {
         val transaction = newTransaction()
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(transaction)
         }
         assertTransactionIsRetrievable(transaction)
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.transactions).containsExactly(transaction)
         }
         newTransactionStorage()
         assertTransactionIsRetrievable(transaction)
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.transactions).containsExactly(transaction)
         }
     }
@@ -78,16 +78,16 @@ class DBTransactionStorageTests {
     fun `two transactions across restart`() {
         val firstTransaction = newTransaction()
         val secondTransaction = newTransaction()
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(firstTransaction)
         }
         newTransactionStorage()
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(secondTransaction)
         }
         assertTransactionIsRetrievable(firstTransaction)
         assertTransactionIsRetrievable(secondTransaction)
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.transactions).containsOnly(firstTransaction, secondTransaction)
         }
     }
@@ -96,13 +96,13 @@ class DBTransactionStorageTests {
     fun `two transactions with rollback`() {
         val firstTransaction = newTransaction()
         val secondTransaction = newTransaction()
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(firstTransaction)
             transactionStorage.addTransaction(secondTransaction)
             rollback()
         }
 
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.transactions).isEmpty()
         }
     }
@@ -111,13 +111,13 @@ class DBTransactionStorageTests {
     fun `two transactions in same DB transaction scope`() {
         val firstTransaction = newTransaction()
         val secondTransaction = newTransaction()
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(firstTransaction)
             transactionStorage.addTransaction(secondTransaction)
         }
         assertTransactionIsRetrievable(firstTransaction)
         assertTransactionIsRetrievable(secondTransaction)
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.transactions).containsOnly(firstTransaction, secondTransaction)
         }
     }
@@ -126,7 +126,7 @@ class DBTransactionStorageTests {
     fun `updates are fired`() {
         val future = transactionStorage.updates.toFuture()
         val expected = newTransaction()
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage.addTransaction(expected)
         }
         val actual = future.get(1, TimeUnit.SECONDS)
@@ -134,13 +134,13 @@ class DBTransactionStorageTests {
     }
 
     private fun newTransactionStorage() {
-        databaseTransaction(database) {
+        database.transaction {
             transactionStorage = DBTransactionStorage()
         }
     }
 
     private fun assertTransactionIsRetrievable(transaction: SignedTransaction) {
-        databaseTransaction(database) {
+        database.transaction {
             assertThat(transactionStorage.getTransaction(transaction.id)).isEqualTo(transaction)
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
@@ -13,7 +13,7 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.BroadcastTransactionFlow.NotifyTxRequest
 import net.corda.node.services.persistence.DataVending.Service.NotifyTransactionHandler
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
@@ -48,7 +48,7 @@ class DataVendingServiceTests {
         val registerKey = registerNode.services.legalIdentityKey
         ptx.signWith(registerKey)
         val tx = ptx.toSignedTransaction()
-        databaseTransaction(vaultServiceNode.database) {
+        vaultServiceNode.database.transaction {
             assertThat(vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>()).isEmpty()
 
             registerNode.sendNotifyTx(tx, vaultServiceNode)
@@ -78,7 +78,7 @@ class DataVendingServiceTests {
         val registerKey = registerNode.services.legalIdentityKey
         ptx.signWith(registerKey)
         val tx = ptx.toSignedTransaction(false)
-        databaseTransaction(vaultServiceNode.database) {
+        vaultServiceNode.database.transaction {
             assertThat(vaultServiceNode.services.vaultService.unconsumedStates<Cash.State>()).isEmpty()
 
             registerNode.sendNotifyTx(tx, vaultServiceNode)

--- a/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
@@ -45,7 +45,7 @@ class ObservablesTests {
         observable.first().subscribe { firstEvent.set(it to isInDatabaseTransaction()) }
         observable.skip(1).first().subscribe { secondEvent.set(it to isInDatabaseTransaction()) }
 
-        databaseTransaction(database) {
+        database.transaction {
             val delayedSubject = source.bufferUntilDatabaseCommit()
             assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(0)
@@ -72,7 +72,7 @@ class ObservablesTests {
         observable.first().subscribe { firstEvent.set(it to isInDatabaseTransaction()) }
         observable.skip(1).first().subscribe { secondEvent.set(it to isInDatabaseTransaction()) }
 
-        databaseTransaction(database) {
+        database.transaction {
             val delayedSubject = source.bufferUntilDatabaseCommit()
             assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(0)
@@ -83,7 +83,7 @@ class ObservablesTests {
         assertThat(firstEvent.get()).isEqualTo(0 to false)
         assertThat(secondEvent.isDone).isFalse()
 
-        databaseTransaction(database) {
+        database.transaction {
             val delayedSubject = source.bufferUntilDatabaseCommit()
             assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(1)
@@ -140,7 +140,7 @@ class ObservablesTests {
 
         teed.first().subscribe { teedEvent.set(it to isInDatabaseTransaction()) }
 
-        databaseTransaction(database) {
+        database.transaction {
             val delayedSubject = source.bufferUntilDatabaseCommit().tee(teed)
             assertThat(source).isNotEqualTo(delayedSubject)
             delayedSubject.onNext(0)
@@ -173,7 +173,7 @@ class ObservablesTests {
         observableWithDbTx.skip(1).first().subscribe { observeSecondEvent(it, delayedEventFromSecondObserver) }
         observableWithDbTx.skip(1).first().subscribe { observeSecondEvent(it, delayedEventFromThirdObserver) }
 
-        databaseTransaction(database) {
+        database.transaction {
             val commitDelayedSource = source.bufferUntilDatabaseCommit()
             assertThat(source).isNotEqualTo(commitDelayedSource)
             commitDelayedSource.onNext(0)

--- a/samples/irs-demo/src/main/kotlin/net/corda/simulation/IRSSimulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/simulation/IRSSimulation.kt
@@ -20,7 +20,7 @@ import net.corda.flows.TwoPartyDealFlow.AutoOffer
 import net.corda.flows.TwoPartyDealFlow.Instigator
 import net.corda.irs.contract.InterestRateSwap
 import net.corda.jackson.JacksonSupport
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.initiateSingleShotFlow
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.MockIdentityService
@@ -75,7 +75,7 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
     }
 
     private fun loadLinearHeads(node: SimulatedNode): Map<UniqueIdentifier, StateAndRef<InterestRateSwap.State<AnonymousParty>>> {
-        return databaseTransaction(node.database) {
+        return node.database.transaction {
             node.services.vaultService.linearHeadsOfType<InterestRateSwap.State<AnonymousParty>>()
         }
     }

--- a/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
@@ -18,7 +18,7 @@ import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.node.utilities.AddOrRemove
-import net.corda.node.utilities.databaseTransaction
+import net.corda.node.utilities.transaction
 import net.corda.testing.TestNodeConfiguration
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.MockNetwork
@@ -128,7 +128,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
                 override fun start(): MockNetwork.MockNode {
                     super.start()
                     javaClass.classLoader.getResourceAsStream("example.rates.txt").use {
-                        databaseTransaction(database) {
+                        database.transaction {
                             findService<NodeInterestRates.Service>().upload(it)
                         }
                     }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
@@ -13,8 +13,8 @@ import net.corda.node.services.messaging.NodeMessagingClient
 import net.corda.node.services.network.InMemoryNetworkMapCache
 import net.corda.node.utilities.AffinityExecutor.ServiceAffinityExecutor
 import net.corda.node.utilities.configureDatabase
-import net.corda.node.utilities.databaseTransaction
 import net.corda.testing.MOCK_NODE_VERSION_INFO
+import net.corda.node.utilities.transaction
 import net.corda.testing.freeLocalHostAndPort
 import org.jetbrains.exposed.sql.Database
 import java.io.Closeable
@@ -35,7 +35,7 @@ class SimpleNode(val config: NodeConfiguration, val address: HostAndPort = freeL
     val executor = ServiceAffinityExecutor(config.myLegalName, 1)
     val broker = ArtemisMessagingServer(config, address, rpcAddress, InMemoryNetworkMapCache(), userService)
     val networkMapRegistrationFuture: SettableFuture<Unit> = SettableFuture.create<Unit>()
-    val net = databaseTransaction(database) {
+    val net = database.transaction {
         NodeMessagingClient(
                 config,
                 MOCK_NODE_VERSION_INFO,


### PR DESCRIPTION
Pros:
* database.transaction is more concise than databaseTransaction(database) and may be more readable
* "transaction" shows up in IDE suggestions for "database."
* Easier to see opportunities for using Kotlin's "with" function

Cons:
* Users may confuse "transaction" with the other kind(s) of transaction
