### PR TITLE
In checkpoints, serialize hash of attachment instead of its data

### DIFF
--- a/core/src/main/kotlin/net/corda/flows/FetchAttachmentsFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FetchAttachmentsFlow.kt
@@ -4,6 +4,9 @@ import net.corda.core.contracts.Attachment
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
+import net.corda.core.serialization.SerializationToken
+import net.corda.core.serialization.SerializeAsToken
+import net.corda.core.serialization.SerializeAsTokenContext
 import java.io.InputStream
 
 /**
@@ -23,11 +26,18 @@ class FetchAttachmentsFlow(requests: Set<SecureHash>,
         }
     }
 
-    private class ByteArrayAttachment(private val wire: ByteArray) : Attachment {
+    private class ByteArrayAttachment(private val wire: ByteArray) : Attachment, SerializeAsToken {
         override val id: SecureHash by lazy { wire.sha256() }
         override fun open(): InputStream = wire.inputStream()
         override fun equals(other: Any?) = other === this || other is Attachment && other.id == this.id
         override fun hashCode(): Int = id.hashCode()
         override fun toString(): String = "${javaClass.simpleName}(id=$id)"
+
+        private class Token(private val id: SecureHash) : SerializationToken {
+            override fun fromToken(context: SerializeAsTokenContext) = ByteArrayAttachment(context.attachmentReloader.reloadAttachment(id))
+        }
+
+        override fun toToken(context: SerializeAsTokenContext) = Token(id)
+
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
@@ -1,0 +1,191 @@
+package net.corda.core.serialization
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.Attachment
+import net.corda.core.crypto.Party
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowLogic
+import net.corda.core.getOrThrow
+import net.corda.core.messaging.RPCOps
+import net.corda.core.messaging.SingleMessageRecipient
+import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.unwrap
+import net.corda.flows.FetchAttachmentsFlow
+import net.corda.node.services.config.NodeConfiguration
+import net.corda.node.services.network.NetworkMapService
+import net.corda.node.services.persistence.NodeAttachmentService
+import net.corda.node.services.persistence.schemas.AttachmentEntity
+import net.corda.node.utilities.transaction
+import net.corda.testing.node.MockNetwork
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets.UTF_8
+import java.security.KeyPair
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.assertEquals
+
+private fun createAttachmentData(content: String) = ByteArrayOutputStream().apply {
+    ZipOutputStream(this).use {
+        with(it) {
+            putNextEntry(ZipEntry("content"))
+            write(content.toByteArray(UTF_8))
+        }
+    }
+}.toByteArray()
+
+private fun Attachment.extractContent() = ByteArrayOutputStream().apply { extractFile("content", this) }.toString(UTF_8.name())
+
+private fun MockNetwork.MockNode.attachments() = services.storageService.attachments as NodeAttachmentService
+private fun MockNetwork.MockNode.saveAttachment(content: String) = database.transaction { attachments().importAttachment(createAttachmentData(content).inputStream()) }
+private fun MockNetwork.MockNode.hackAttachment(attachmentId: SecureHash, content: String) = database.transaction { attachments().updateAttachment(attachmentId, createAttachmentData(content)) }
+
+/**
+ * @see NodeAttachmentService.importAttachment
+ */
+private fun NodeAttachmentService.updateAttachment(attachmentId: SecureHash, data: ByteArray) {
+    with(session) {
+        withTransaction {
+            update(AttachmentEntity().apply {
+                attId = attachmentId
+                content = data
+            })
+        }
+    }
+}
+
+class AttachmentSerializationTest {
+
+    private lateinit var network: MockNetwork
+    private lateinit var server: MockNetwork.MockNode
+    private lateinit var client: MockNetwork.MockNode
+
+    @Before
+    fun setUp() {
+        network = MockNetwork()
+        server = network.createNode(advertisedServices = ServiceInfo(NetworkMapService.type))
+        client = network.createNode(server.info.address)
+        client.disableDBCloseOnStop() // Otherwise the in-memory database may disappear (taking the checkpoint with it) while we reboot the client.
+        network.runNetwork()
+    }
+
+    @After
+    fun tearDown() {
+        network.stopNodes()
+    }
+
+    private class ServerLogic(private val client: Party) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            receive<String>(client).unwrap { assertEquals("ping one", it) }
+            sendAndReceive<String>(client, "pong").unwrap { assertEquals("ping two", it) }
+        }
+    }
+
+    private class ClientResult(internal val attachmentContent: String)
+
+    private abstract class ClientLogic(server: MockNetwork.MockNode) : FlowLogic<ClientResult>() {
+
+        internal val server = server.info.legalIdentity
+
+        @Suspendable
+        internal fun communicate() {
+            sendAndReceive<String>(server, "ping one").unwrap { assertEquals("pong", it) }
+            send(server, "ping two")
+        }
+
+        @Suspendable
+        override fun call() = ClientResult(getAttachmentContent())
+
+        internal abstract fun getAttachmentContent(): String
+
+    }
+
+    private class CustomAttachment(override val id: SecureHash, internal val customContent: String) : Attachment {
+        override fun open() = throw UnsupportedOperationException("Not implemented.")
+    }
+
+    private class CustomAttachmentLogic(server: MockNetwork.MockNode, private val attachmentId: SecureHash, private val customContent: String) : ClientLogic(server) {
+        @Suspendable
+        override fun getAttachmentContent(): String {
+            val customAttachment = CustomAttachment(attachmentId, customContent)
+            communicate()
+            return customAttachment.customContent
+        }
+    }
+
+    private class OpenAttachmentLogic(server: MockNetwork.MockNode, private val attachmentId: SecureHash) : ClientLogic(server) {
+        @Suspendable
+        override fun getAttachmentContent(): String {
+            val localAttachment = serviceHub.storageService.attachments.openAttachment(attachmentId)!!
+            communicate()
+            return localAttachment.extractContent()
+        }
+    }
+
+    private class FetchAttachmentLogic(server: MockNetwork.MockNode, private val attachmentId: SecureHash) : ClientLogic(server) {
+        @Suspendable
+        override fun getAttachmentContent(): String {
+            val (downloadedAttachment) = subFlow(FetchAttachmentsFlow(setOf(attachmentId), server)).downloaded
+            communicate()
+            return downloadedAttachment.extractContent()
+        }
+    }
+
+    private fun launchFlow(clientLogic: ClientLogic, rounds: Int) {
+        server.services.registerFlowInitiator(clientLogic.javaClass, ::ServerLogic)
+        client.services.startFlow(clientLogic)
+        network.runNetwork(rounds)
+    }
+
+    private fun rebootClientAndGetAttachmentContent(checkAttachmentsOnLoad: Boolean = true): String {
+        client.stop()
+        client = network.createNode(server.info.address, client.id, object : MockNetwork.Factory {
+            override fun create(config: NodeConfiguration, network: MockNetwork, networkMapAddr: SingleMessageRecipient?, advertisedServices: Set<ServiceInfo>, id: Int, overrideServices: Map<ServiceInfo, KeyPair>?, entropyRoot: BigInteger): MockNetwork.MockNode {
+                return object : MockNetwork.MockNode(config, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot) {
+                    override fun startMessagingService(rpcOps: RPCOps) {
+                        attachments().checkAttachmentsOnLoad = checkAttachmentsOnLoad
+                        super.startMessagingService(rpcOps)
+                    }
+                }
+            }
+        })
+        return (client.smm.allStateMachines[0].stateMachine.resultFuture.apply { network.runNetwork() }.getOrThrow() as ClientResult).attachmentContent
+    }
+
+    @Test
+    fun `custom (and non-persisted) attachment should be saved in checkpoint`() {
+        val attachmentId = SecureHash.sha256("any old data")
+        launchFlow(CustomAttachmentLogic(server, attachmentId, "custom"), 1)
+        assertEquals("custom", rebootClientAndGetAttachmentContent())
+    }
+
+    @Test
+    fun `custom attachment should be saved in checkpoint even if its data was persisted`() {
+        val attachmentId = client.saveAttachment("genuine")
+        launchFlow(CustomAttachmentLogic(server, attachmentId, "custom"), 1)
+        client.hackAttachment(attachmentId, "hacked") // Should not be reloaded, checkAttachmentsOnLoad may cause next line to blow up if client attempts it.
+        assertEquals("custom", rebootClientAndGetAttachmentContent())
+    }
+
+    @Test
+    fun `only the hash of a regular attachment should be saved in checkpoint`() {
+        val attachmentId = client.saveAttachment("genuine")
+        client.attachments().checkAttachmentsOnLoad = false // Cached by AttachmentImpl.
+        launchFlow(OpenAttachmentLogic(server, attachmentId), 1)
+        client.hackAttachment(attachmentId, "hacked")
+        assertEquals("hacked", rebootClientAndGetAttachmentContent(false)) // Pass in false to allow non-genuine data to be loaded.
+    }
+
+    @Test
+    fun `only the hash of a FetchAttachmentsFlow attachment should be saved in checkpoint`() {
+        val attachmentId = server.saveAttachment("genuine")
+        launchFlow(FetchAttachmentLogic(server, attachmentId), 2)
+        client.hackAttachment(attachmentId, "hacked")
+        assertEquals("hacked", rebootClientAndGetAttachmentContent(false))
+    }
+
+}


### PR DESCRIPTION
This PR implements https://r3-cev.atlassian.net/browse/CORDA-300