### PR TITLE
Integrate sandbox properly with top-level build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     ext.jersey_version = '2.25'
     ext.jolokia_version = '2.0.0-M3'
     ext.assertj_version = '3.6.1'
-    ext.slf4j_version = '1.7.24'
+    ext.slf4j_version = '1.7.25'
     ext.log4j_version = '2.7'
     ext.bouncycastle_version = '1.56'
     ext.guava_version = constants.getProperty("guavaVersion")

--- a/experimental/sandbox/build.gradle
+++ b/experimental/sandbox/build.gradle
@@ -1,13 +1,9 @@
-group 'net.corda'
-version '0.6-SNAPSHOT'
-
 apply plugin: 'java'
 apply plugin: 'kotlin'
 
-sourceCompatibility = 1.8
-
 buildscript {
     ext.asm_version = '5.1'
+    ext.logback_version = '1.2.3'
 }
 
 dependencies {
@@ -21,7 +17,20 @@ dependencies {
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
 
     // Simple Logging Facade: makes the code independent of the chosen logging framework.
-    compile "org.slf4j:slf4j-api:1.7.21"
+    compile "org.slf4j:slf4j-api:$slf4j_version"
+    compile "ch.qos.logback:logback-classic:$logback_version"
 
     testCompile "junit:junit:$junit_version"
+}
+
+task standaloneJar(type: Jar) {
+    // Create a fat jar by packing all deps into the output
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    with jar
+    manifest {
+        attributes 'Main-Class': 'net.corda.sandbox.tools.SandboxCreator'
+    }
+    archiveName "corda-sandbox-creator-${version}.jar"
 }

--- a/experimental/sandbox/src/main/java/net/corda/sandbox/Utils.java
+++ b/experimental/sandbox/src/main/java/net/corda/sandbox/Utils.java
@@ -1,11 +1,7 @@
 package net.corda.sandbox;
 
-import net.corda.sandbox.visitors.CostInstrumentingMethodVisitor;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.objectweb.asm.*;
-import org.objectweb.asm.commons.ClassRemapper;
 
 /**
  *

--- a/experimental/sandbox/src/main/java/net/corda/sandbox/tools/SandboxCreator.java
+++ b/experimental/sandbox/src/main/java/net/corda/sandbox/tools/SandboxCreator.java
@@ -9,7 +9,6 @@ import java.nio.file.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import net.corda.sandbox.visitors.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import joptsimple.OptionParser;

--- a/experimental/sandbox/src/main/java/net/corda/sandbox/visitors/WhitelistCheckingClassVisitor.java
+++ b/experimental/sandbox/src/main/java/net/corda/sandbox/visitors/WhitelistCheckingClassVisitor.java
@@ -9,13 +9,11 @@ import net.corda.sandbox.Utils;
 import java.util.HashSet;
 import java.util.Set;
 
-import net.corda.sandbox.*;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static net.corda.sandbox.CandidateMethod.State.*;
 import static org.objectweb.asm.Opcodes.*;
 
 /**

--- a/experimental/sandbox/src/main/java/net/corda/sandbox/visitors/WhitelistCheckingMethodVisitor.java
+++ b/experimental/sandbox/src/main/java/net/corda/sandbox/visitors/WhitelistCheckingMethodVisitor.java
@@ -2,13 +2,11 @@ package net.corda.sandbox.visitors;
 
 import net.corda.sandbox.CandidacyStatus;
 import net.corda.sandbox.CandidateMethod;
-import net.corda.sandbox.*;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static net.corda.sandbox.CandidateMethod.State.*;
 import net.corda.sandbox.Utils;
 import org.objectweb.asm.Label;
 

--- a/experimental/sandbox/src/test/java/net/corda/sandbox/CandidateMethodTest.java
+++ b/experimental/sandbox/src/test/java/net/corda/sandbox/CandidateMethodTest.java
@@ -1,6 +1,5 @@
 package net.corda.sandbox;
 
-import net.corda.sandbox.CandidateMethod;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
- Upgrade to SLF4J 1.7.25 (as required by Logback)
- Inherit properties from top-level build file.
- Create executable fat jar.
- Remove unused imports.