### PR TITLE
Notarisation retry

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowStateMachine.kt
@@ -49,7 +49,8 @@ interface FlowStateMachine<R> {
     fun <T : Any> sendAndReceive(receiveType: Class<T>,
                                  otherParty: Party,
                                  payload: Any,
-                                 sessionFlow: FlowLogic<*>): UntrustworthyData<T>
+                                 sessionFlow: FlowLogic<*>,
+                                 retrySend: Boolean = false): UntrustworthyData<T>
 
     @Suspendable
     fun <T : Any> receive(receiveType: Class<T>, otherParty: Party, sessionFlow: FlowLogic<*>): UntrustworthyData<T>

--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -61,7 +61,7 @@ object NotaryFlow {
             }
 
             val response = try {
-                sendAndReceive<List<DigitalSignature.WithKey>>(notaryParty, payload)
+                sendAndReceiveWithRetry<List<DigitalSignature.WithKey>>(notaryParty, payload)
             } catch (e: NotaryException) {
                 if (e.error is NotaryError.Conflict) {
                     e.error.conflict.verified()

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -32,6 +32,7 @@ interface NodeConfiguration : SSLConfiguration {
     val certificateSigningService: URL
     val certificateChainCheckPolicies: List<CertChainPolicyConfig>
     val verifierType: VerifierType
+    val messageRedeliveryDelaySeconds: Int
 }
 
 data class FullNodeConfiguration(
@@ -51,6 +52,7 @@ data class FullNodeConfiguration(
         override val minimumPlatformVersion: Int = 1,
         override val rpcUsers: List<User>,
         override val verifierType: VerifierType,
+        override val messageRedeliveryDelaySeconds: Int = 30,
         val useHTTPS: Boolean,
         @OldConfig("artemisAddress")
         val p2pAddress: HostAndPort,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSession.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSession.kt
@@ -6,11 +6,17 @@ import net.corda.node.services.statemachine.FlowSessionState.Initiated
 import net.corda.node.services.statemachine.FlowSessionState.Initiating
 import java.util.concurrent.ConcurrentLinkedQueue
 
+/**
+ * @param retryable Indicates that the session initialisation should be retried until an expected [SessionData] response
+ * is received. Note that this requires the party on the other end to be a distributed service and run an idempotent flow
+ * that only sends back a single [SessionData] message before termination.
+ */
 class FlowSession(
         val flow: FlowLogic<*>,
         val ourSessionId: Long,
         val initiatingParty: Party?,
-        var state: FlowSessionState) {
+        var state: FlowSessionState,
+        val retryable: Boolean = false) {
     val receivedMessages = ConcurrentLinkedQueue<ReceivedSessionMessage<*>>()
     val fiber: FlowStateMachineImpl<*> get() = flow.stateMachine as FlowStateMachineImpl<*>
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -297,6 +297,15 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
         val session = openSessions[message.recipientSessionId]
         if (session != null) {
             session.fiber.logger.trace { "Received $message on $session from $sender" }
+            if (session.retryable) {
+                if (message is SessionConfirm && session.state is FlowSessionState.Initiated) {
+                    session.fiber.logger.trace { "Ignoring duplicate confirmation for session ${session.ourSessionId} – session is idempotent" }
+                    return
+                }
+                if (message !is SessionConfirm) {
+                    serviceHub.networkService.cancelRedelivery(session.ourSessionId)
+                }
+            }
             if (message is SessionEnd) {
                 openSessions.remove(message.recipientSessionId)
             }
@@ -319,7 +328,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
                     logger.trace { "Ignoring session end message for already closed session: $message" }
                 }
             } else {
-                logger.warn("Received a session message for unknown session: $message")
+                logger.warn("Received a session message for unknown session: $message, from $sender")
             }
         }
     }
@@ -523,42 +532,52 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
 
     private fun processIORequest(ioRequest: FlowIORequest) {
         executor.checkOnThread()
-        if (ioRequest is SendRequest) {
-            if (ioRequest.message is SessionInit) {
-                openSessions[ioRequest.session.ourSessionId] = ioRequest.session
+        when (ioRequest) {
+            is SendRequest -> processSendRequest(ioRequest)
+            is WaitForLedgerCommit -> processWaitForCommitRequest(ioRequest)
+        }
+    }
+
+    private fun processSendRequest(ioRequest: SendRequest) {
+        val retryId = if (ioRequest.message is SessionInit) {
+            with(ioRequest.session) {
+                openSessions[ourSessionId] = this
+                if (retryable) ourSessionId else null
             }
-            sendSessionMessage(ioRequest.session.state.sendToParty, ioRequest.message, ioRequest.session.fiber)
-            if (ioRequest !is ReceiveRequest<*>) {
-                // We sent a message, but don't expect a response, so re-enter the continuation to let it keep going.
-                resumeFiber(ioRequest.session.fiber)
-            }
-        } else if (ioRequest is WaitForLedgerCommit) {
-            // Is it already committed?
-            val stx = database.transaction {
-                serviceHub.storageService.validatedTransactions.getTransaction(ioRequest.hash)
-            }
-            if (stx != null) {
-                resumeFiber(ioRequest.fiber)
-            } else {
-                // No, then register to wait.
-                //
-                // We assume this code runs on the server thread, which is the only place transactions are committed
-                // currently. When we liberalise our threading somewhat, handing of wait requests will need to be
-                // reworked to make the wait atomic in another way. Otherwise there is a race between checking the
-                // database and updating the waiting list.
-                mutex.locked {
-                    fibersWaitingForLedgerCommit[ioRequest.hash] += ioRequest.fiber
-                }
+        } else null
+        sendSessionMessage(ioRequest.session.state.sendToParty, ioRequest.message, ioRequest.session.fiber, retryId)
+        if (ioRequest !is ReceiveRequest<*>) {
+            // We sent a message, but don't expect a response, so re-enter the continuation to let it keep going.
+            resumeFiber(ioRequest.session.fiber)
+        }
+    }
+
+    private fun processWaitForCommitRequest(ioRequest: WaitForLedgerCommit) {
+        // Is it already committed?
+        val stx = database.transaction {
+            serviceHub.storageService.validatedTransactions.getTransaction(ioRequest.hash)
+        }
+        if (stx != null) {
+            resumeFiber(ioRequest.fiber)
+        } else {
+            // No, then register to wait.
+            //
+            // We assume this code runs on the server thread, which is the only place transactions are committed
+            // currently. When we liberalise our threading somewhat, handing of wait requests will need to be
+            // reworked to make the wait atomic in another way. Otherwise there is a race between checking the
+            // database and updating the waiting list.
+            mutex.locked {
+                fibersWaitingForLedgerCommit[ioRequest.hash] += ioRequest.fiber
             }
         }
     }
 
-    private fun sendSessionMessage(party: Party, message: SessionMessage, fiber: FlowStateMachineImpl<*>? = null) {
+    private fun sendSessionMessage(party: Party, message: SessionMessage, fiber: FlowStateMachineImpl<*>? = null, retryId: Long? = null) {
         val partyInfo = serviceHub.networkMapCache.getPartyInfo(party)
                 ?: throw IllegalArgumentException("Don't know about party $party")
         val address = serviceHub.networkService.getAddressOfParty(partyInfo)
         val logger = fiber?.logger ?: logger
-        logger.trace { "Sending $message to party $party @ $address" }
-        serviceHub.networkService.send(sessionTopic, message, address)
+        logger.trace { "Sending $message to party $party @ $address" + if (retryId != null) " with retry $retryId" else "" }
+        serviceHub.networkService.send(sessionTopic, message, address, retryId = retryId)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
+++ b/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
@@ -72,7 +72,7 @@ class InteractiveShellTest {
     fun party() = check("party: \"${someCorpLegalName}\"", someCorpLegalName.toString())
 
     class DummyFSM(val logic: FlowA) : FlowStateMachine<Any?> {
-        override fun <T : Any> sendAndReceive(receiveType: Class<T>, otherParty: Party, payload: Any, sessionFlow: FlowLogic<*>): UntrustworthyData<T> {
+        override fun <T : Any> sendAndReceive(receiveType: Class<T>, otherParty: Party, payload: Any, sessionFlow: FlowLogic<*>, retrySend: Boolean): UntrustworthyData<T> {
             throw UnsupportedOperationException("not implemented")
         }
 

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -169,8 +169,8 @@ data class TestNodeConfiguration(
         override val devMode: Boolean = true,
         override val certificateSigningService: URL = URL("http://localhost"),
         override val certificateChainCheckPolicies: List<CertChainPolicyConfig> = emptyList(),
-        override val verifierType: VerifierType = VerifierType.InMemory) : NodeConfiguration {
-}
+        override val verifierType: VerifierType = VerifierType.InMemory,
+        override val messageRedeliveryDelaySeconds: Int = 5) : NodeConfiguration
 
 fun testConfiguration(baseDirectory: Path, legalName: String, basePort: Int): FullNodeConfiguration {
     return FullNodeConfiguration(

--- a/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -359,7 +359,7 @@ class InMemoryMessagingNetwork(
             state.locked { check(handlers.remove(registration as Handler)) }
         }
 
-        override fun send(message: Message, target: MessageRecipients) {
+        override fun send(message: Message, target: MessageRecipients, retryId: Long?) {
             check(running)
             msgSend(this, message, target)
             if (!sendManuallyPumped) {
@@ -375,6 +375,8 @@ class InMemoryMessagingNetwork(
             running = false
             netNodeHasShutdown(peerHandle)
         }
+
+        override fun cancelRedelivery(retryId: Long) {}
 
         /** Returns the given (topic & session, data) pair as a newly created message object. */
         override fun createMessage(topicSession: TopicSession, data: ByteArray, uuid: UUID): Message {


### PR DESCRIPTION
Add support for re-sending session messages. This is useful when talking to a distributed service, e.g. notary – if one of the nodes go down in the middle of a session, the session will be re-established with a different node (round-robin order).

I introduced a new method in `FlowLogic`: `sendAndReceiveWithRetry`, which creates a new `FlowSession` and marks it as _idempotent_. The `SessionInit` message of such session is then scheduled to be redelivered in the `NodeMessagingClient` until a `SessionData` or `SessionEnd` is received. Duplicate `SessionConfirm` responses are ignored.