### PR TITLE
Fix DemoBench shutdown, even when failing to unsubscribe from an Observable.

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
@@ -211,7 +211,10 @@ class NodeTerminalView : Fragment() {
 
     fun destroy() {
         if (!isDestroyed) {
-            subscriptions.forEach { it.unsubscribe() }
+            subscriptions.forEach {
+                // Don't allow any exceptions here to halt tab destruction.
+                try { it.unsubscribe() } catch (e: Exception) {}
+            }
             webServer.close()
             explorer.close()
             viewer.close()


### PR DESCRIPTION
Ignore exceptions when unsubscribing from Observables because they prevent DemoBench shutting down properly.