### PR TITLE
Deprecated FlowLogic.getCounterpartyMarker as it's complicated and probably not used

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -42,11 +42,9 @@ abstract class FlowLogic<out T> {
      */
     val serviceHub: ServiceHub get() = stateMachine.serviceHub
 
-    /**
-     * Return the marker [Class] which [party] has used to register the counterparty flow that is to execute on the
-     * other side. The default implementation returns the class object of this FlowLogic, but any [Class] instance
-     * will do as long as the other side registers with it.
-     */
+    @Deprecated("This is no longer used and will be removed in a future release. If you are using this to communicate " +
+            "with the same party but for two different message streams, then the correct way of doing that is to use sub-flows",
+            level = DeprecationLevel.ERROR)
     open fun getCounterpartyMarker(party: Party): Class<*> = javaClass
 
     /**
@@ -190,9 +188,10 @@ abstract class FlowLogic<out T> {
 
     private var _stateMachine: FlowStateMachine<*>? = null
     /**
-     * Internal only. Reference to the [Fiber] instance that is the top level controller for the entire flow. When
-     * inside a flow this is equivalent to [Strand.currentStrand]. This is public only because it must be accessed
-     * across module boundaries.
+     * @suppress
+     * Internal only. Reference to the [co.paralleluniverse.fibers.Fiber] instance that is the top level controller for
+     * the entire flow. When inside a flow this is equivalent to [co.paralleluniverse.strands.Strand.currentStrand]. This
+     * is public only because it must be accessed across module boundaries.
      */
     var stateMachine: FlowStateMachine<*>
         get() = _stateMachine ?: throw IllegalStateException("This can only be done after the flow has been started.")

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -82,6 +82,7 @@ object DefaultKryoCustomizer {
 
             register(MetaData::class.java, MetaDataSerializer)
             register(BitSet::class.java, BitSetSerializer())
+            register(Class::class.java, ClassSerializer)
 
             addDefaultSerializer(Logger::class.java, LoggerSerializer)
 

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -565,6 +565,17 @@ object LoggerSerializer : Serializer<Logger>() {
     }
 }
 
+object ClassSerializer : Serializer<Class<*>>() {
+    override fun read(kryo: Kryo, input: Input, type: Class<Class<*>>): Class<*> {
+        val className = input.readString()
+        return Class.forName(className)
+    }
+
+    override fun write(kryo: Kryo, output: Output, clazz: Class<*>) {
+        output.writeString(clazz.name)
+    }
+}
+
 /**
  * For serialising an [X500Name] without touching Sun internal classes.
  */

--- a/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
+++ b/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
@@ -30,7 +30,7 @@ public class FlowsInJavaTest {
 
     @Test
     public void suspendableActionInsideUnwrap() throws Exception {
-        node2.getServices().registerFlowInitiator(SendInUnwrapFlow.class, (otherParty) -> new OtherFlow(otherParty, "Hello"));
+        node2.getServices().registerServiceFlow(SendInUnwrapFlow.class, (otherParty) -> new OtherFlow(otherParty, "Hello"));
         Future<String> result = node1.getServices().startFlow(new SendInUnwrapFlow(node2.getInfo().getLegalIdentity())).getResultFuture();
         net.runNetwork();
         assertThat(result.get()).isEqualTo("Hello");

--- a/core/src/test/kotlin/net/corda/core/flows/TxKeyFlow.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/TxKeyFlow.kt
@@ -15,7 +15,7 @@ import java.security.cert.Certificate
  */
 object TxKeyFlow {
     fun registerFlowInitiator(services: PluginServiceHub) {
-        services.registerFlowInitiator(Requester::class.java, ::Provider)
+        services.registerServiceFlow(Requester::class.java, ::Provider)
     }
 
     class Requester(val otherSide: Party,

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -24,7 +24,7 @@ import java.util.*
 object FxTransactionDemoTutorial {
     // Would normally be called by custom service init in a CorDapp
     fun registerFxProtocols(pluginHub: PluginServiceHub) {
-        pluginHub.registerFlowInitiator(ForeignExchangeFlow::class.java, ::ForeignExchangeRemoteFlow)
+        pluginHub.registerServiceFlow(ForeignExchangeFlow::class.java, ::ForeignExchangeRemoteFlow)
     }
 }
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
@@ -17,7 +17,7 @@ import java.time.Duration
 object WorkflowTransactionBuildTutorial {
     // Would normally be called by custom service init in a CorDapp
     fun registerWorkflowProtocols(pluginHub: PluginServiceHub) {
-        pluginHub.registerFlowInitiator(SubmitCompletionFlow::class.java, ::RecordCompletionFlow)
+        pluginHub.registerServiceFlow(SubmitCompletionFlow::class.java, ::RecordCompletionFlow)
     }
 }
 

--- a/finance/src/main/kotlin/net/corda/flows/IssuerFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/IssuerFlow.kt
@@ -96,7 +96,7 @@ object IssuerFlow {
 
         class Service(services: PluginServiceHub) {
             init {
-                services.registerFlowInitiator(IssuanceRequester::class.java, ::Issuer)
+                services.registerServiceFlow(IssuanceRequester::class.java, ::Issuer)
             }
         }
     }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/RPCStructures.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/RPCStructures.kt
@@ -2,11 +2,8 @@
 
 package net.corda.nodeapi
 
-import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Registration
 import com.esotericsoftware.kryo.Serializer
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.flows.FlowException
 import net.corda.core.serialization.*
@@ -71,17 +68,6 @@ open class RPCException(msg: String, cause: Throwable?) : RuntimeException(msg, 
     class DeadlineExceeded(rpcName: String) : RPCException("Deadline exceeded on call to $rpcName")
 }
 
-object ClassSerializer : Serializer<Class<*>>() {
-    override fun read(kryo: Kryo, input: Input, type: Class<Class<*>>): Class<*> {
-        val className = input.readString()
-        return Class.forName(className)
-    }
-
-    override fun write(kryo: Kryo, output: Output, clazz: Class<*>) {
-        output.writeString(clazz.name)
-    }
-}
-
 @CordaSerializable
 class PermissionException(msg: String) : RuntimeException(msg)
 
@@ -99,7 +85,6 @@ class RPCKryo(observableSerializer: Serializer<Observable<Any>>) : CordaKryo(mak
         DefaultKryoCustomizer.customize(this)
 
         // RPC specific classes
-        register(Class::class.java, ClassSerializer)
         register(MultipartStream.ItemInputStream::class.java, InputStreamSerializer)
         register(MarshalledObservation::class.java, ImmutableClassSerializer(MarshalledObservation::class))
         register(Observable::class.java, observableSerializer)

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -230,7 +230,7 @@ abstract class MQSecurityTest : NodeBasedTest() {
 
     private fun startBobAndCommunicateWithAlice(): Party {
         val bob = startNode(BOB.name).getOrThrow()
-        bob.services.registerFlowInitiator(SendFlow::class.java, ::ReceiveFlow)
+        bob.services.registerServiceFlow(SendFlow::class.java, ::ReceiveFlow)
         val bobParty = bob.info.legalIdentity
         // Perform a protocol exchange to force the peer queue to be created
         alice.services.startFlow(SendFlow(bobParty, 0)).resultFuture.getOrThrow()

--- a/node/src/main/kotlin/net/corda/node/services/NotaryChangeService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/NotaryChangeService.kt
@@ -17,7 +17,7 @@ object NotaryChange {
      */
     class Service(services: PluginServiceHub) : SingletonSerializeAsToken() {
         init {
-            services.registerFlowInitiator(NotaryChangeFlow.Instigator::class.java) { NotaryChangeFlow.Acceptor(it) }
+            services.registerServiceFlow(NotaryChangeFlow.Instigator::class.java) { NotaryChangeFlow.Acceptor(it) }
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.api
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.ListenableFuture
+import net.corda.core.crypto.Party
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRefFactory
@@ -85,7 +86,8 @@ abstract class ServiceHubInternal : PluginServiceHub {
      * Note that you must be on the server thread to call this method. [flowInitiator] points how flow was started,
      * See: [FlowInitiator].
      *
-     * @throws IllegalFlowLogicException or IllegalArgumentException if there are problems with the [logicType] or [args].
+     * @throws net.corda.core.flows.IllegalFlowLogicException or IllegalArgumentException if there are problems with the
+     * [logicType] or [args].
      */
     fun <T : Any> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
@@ -96,4 +98,6 @@ abstract class ServiceHubInternal : PluginServiceHub {
         val logic = flowLogicRefFactory.toFlowLogic(logicRef) as FlowLogic<T>
         return startFlow(logic, flowInitiator)
     }
+
+    abstract fun getServiceFlowFactory(clientFlowClass: Class<out FlowLogic<*>>): ((Party) -> FlowLogic<*>)?
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/DataVendingService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DataVendingService.kt
@@ -34,9 +34,9 @@ object DataVending {
     @ThreadSafe
     class Service(services: PluginServiceHub) : SingletonSerializeAsToken() {
         init {
-            services.registerFlowInitiator(FetchTransactionsFlow::class.java, ::FetchTransactionsHandler)
-            services.registerFlowInitiator(FetchAttachmentsFlow::class.java, ::FetchAttachmentsHandler)
-            services.registerFlowInitiator(BroadcastTransactionFlow::class.java, ::NotifyTransactionHandler)
+            services.registerServiceFlow(FetchTransactionsFlow::class.java, ::FetchTransactionsHandler)
+            services.registerServiceFlow(FetchAttachmentsFlow::class.java, ::FetchAttachmentsHandler)
+            services.registerServiceFlow(BroadcastTransactionFlow::class.java, ::NotifyTransactionHandler)
         }
 
         private class FetchTransactionsHandler(otherParty: Party) : FetchDataHandler<SignedTransaction>(otherParty) {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.statemachine
 
 import net.corda.core.crypto.Party
 import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.UntrustworthyData
 
@@ -12,7 +13,9 @@ import net.corda.core.utilities.UntrustworthyData
 @CordaSerializable
 interface SessionMessage
 
-data class SessionInit(val initiatorSessionId: Long, val flowName: String, val firstPayload: Any?) : SessionMessage
+data class SessionInit(val initiatorSessionId: Long,
+                       val clientFlowClass: Class<out FlowLogic<*>>,
+                       val firstPayload: Any?) : SessionMessage
 
 interface ExistingSessionMessage : SessionMessage {
     val recipientSessionId: Long

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NotaryService.kt
@@ -18,7 +18,7 @@ import net.corda.node.services.api.ServiceHubInternal
 abstract class NotaryService(services: ServiceHubInternal) : SingletonSerializeAsToken() {
 
     init {
-        services.registerFlowInitiator(NotaryFlow.Client::class.java) { createFlow(it) }
+        services.registerServiceFlow(NotaryFlow.Client::class.java) { createFlow(it) }
     }
 
     /** Implement a factory that specifies the transaction commit flow for the notary service to use */

--- a/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
@@ -22,7 +22,6 @@ import net.corda.testing.MOCK_IDENTITY_SERVICE
 import net.corda.testing.node.MockNetworkMapCache
 import net.corda.testing.node.MockStorageService
 import java.time.Clock
-import java.util.concurrent.ConcurrentHashMap
 
 open class MockServiceHubInternal(
         val customVault: VaultService? = null,
@@ -68,8 +67,6 @@ open class MockServiceHubInternal(
     private val txStorageService: TxWritableStorageService
         get() = storage ?: throw UnsupportedOperationException()
 
-    private val flowFactories = ConcurrentHashMap<Class<*>, (Party) -> FlowLogic<*>>()
-
     lateinit var smm: StateMachineManager
 
     init {
@@ -86,11 +83,7 @@ open class MockServiceHubInternal(
         return smm.executor.fetchFrom { smm.add(logic, flowInitiator) }
     }
 
-    override fun registerFlowInitiator(markerClass: Class<*>, flowFactory: (Party) -> FlowLogic<*>) {
-        flowFactories[markerClass] = flowFactory
-    }
+    override fun registerServiceFlow(clientFlowClass: Class<out FlowLogic<*>>, serviceFlowFactory: (Party) -> FlowLogic<*>) = Unit
 
-    override fun getFlowFactory(markerClass: Class<*>): ((Party) -> FlowLogic<*>)? {
-        return flowFactories[markerClass]
-    }
+    override fun getServiceFlowFactory(clientFlowClass: Class<out FlowLogic<*>>): ((Party) -> FlowLogic<*>)? = null
 }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
@@ -89,7 +89,7 @@ class DataVendingServiceTests {
     }
 
     private fun MockNode.sendNotifyTx(tx: SignedTransaction, walletServiceNode: MockNode) {
-        walletServiceNode.services.registerFlowInitiator(NotifyTxFlow::class.java, ::NotifyTransactionHandler)
+        walletServiceNode.services.registerServiceFlow(NotifyTxFlow::class.java, ::NotifyTransactionHandler)
         services.startFlow(NotifyTxFlow(walletServiceNode.info.legalIdentity, tx))
         network.runNetwork()
     }

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
@@ -75,8 +75,8 @@ object NodeInterestRates {
             // Note: access to the singleton oracle property is via the registered SingletonSerializeAsToken Service.
             // Otherwise the Kryo serialisation of the call stack in the Quasar Fiber extends to include
             // the framework Oracle and the flow will crash.
-            services.registerFlowInitiator(RatesFixFlow.FixSignFlow::class.java) { FixSignHandler(it, this) }
-            services.registerFlowInitiator(RatesFixFlow.FixQueryFlow::class.java) { FixQueryHandler(it, this) }
+            services.registerServiceFlow(RatesFixFlow.FixSignFlow::class.java) { FixSignHandler(it, this) }
+            services.registerServiceFlow(RatesFixFlow.FixQueryFlow::class.java) { FixQueryHandler(it, this) }
         }
 
         private class FixSignHandler(val otherParty: Party, val service: Service) : FlowLogic<Unit>() {

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
@@ -31,7 +31,7 @@ object AutoOfferFlow {
 
     class Service(services: PluginServiceHub) : SingletonSerializeAsToken() {
         init {
-            services.registerFlowInitiator(Instigator::class.java) { Acceptor(it) }
+            services.registerServiceFlow(Instigator::class.java) { Acceptor(it) }
         }
     }
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -24,7 +24,7 @@ object FixingFlow {
 
     class Service(services: PluginServiceHub) {
         init {
-            services.registerFlowInitiator(Floater::class.java) { Fixer(it) }
+            services.registerServiceFlow(Floater::class.java) { Fixer(it) }
         }
     }
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt
@@ -30,7 +30,7 @@ object UpdateBusinessDayFlow {
 
     class Service(services: PluginServiceHub) {
         init {
-            services.registerFlowInitiator(Broadcast::class.java, ::UpdateBusinessDayHandler)
+            services.registerServiceFlow(Broadcast::class.java, ::UpdateBusinessDayHandler)
         }
     }
 

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt
@@ -44,7 +44,7 @@ object IRSTradeFlow {
 
     class Service(services: PluginServiceHub) {
         init {
-            services.registerFlowInitiator(Requester::class.java, ::Receiver)
+            services.registerServiceFlow(Requester::class.java, ::Receiver)
         }
     }
 

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
@@ -184,7 +184,7 @@ object SimmFlow {
      */
     class Service(services: PluginServiceHub) {
         init {
-            services.registerFlowInitiator(Requester::class.java, ::Receiver)
+            services.registerServiceFlow(Requester::class.java, ::Receiver)
         }
     }
 

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
@@ -31,7 +31,7 @@ class BuyerFlow(val otherParty: Party,
                 it.automaticallyExtractAttachments = true
                 it.storePath
             }
-            services.registerFlowInitiator(SellerFlow::class.java) { BuyerFlow(it, attachmentsPath.toString()) }
+            services.registerServiceFlow(SellerFlow::class.java) { BuyerFlow(it, attachmentsPath.toString()) }
         }
     }
 

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -140,14 +140,14 @@ fun getFreeLocalPorts(hostName: String, numberToAlloc: Int): List<HostAndPort> {
 
 /**
  * The given flow factory will be used to initiate just one instance of a flow of type [P] when a counterparty
- * flow requests for it using [markerClass].
+ * flow requests for it using [clientFlowClass].
  * @return Returns a [ListenableFuture] holding the single [FlowStateMachineImpl] created by the request.
  */
 inline fun <reified P : FlowLogic<*>> AbstractNode.initiateSingleShotFlow(
-        markerClass: KClass<out FlowLogic<*>>,
+        clientFlowClass: KClass<out FlowLogic<*>>,
         noinline flowFactory: (Party) -> P): ListenableFuture<P> {
     val future = smm.changes.filter { it is StateMachineManager.Change.Add && it.logic is P }.map { it.logic as P }.toFuture()
-    services.registerFlowInitiator(markerClass.java, flowFactory)
+    services.registerServiceFlow(clientFlowClass.java, flowFactory)
     return future
 }
 


### PR DESCRIPTION
The replacement for it is to use sub-flows.

Also made flow registration require the client flow class rather than any old class.