### PR TITLE
Clean up BFTNotaryServiceTests

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -26,7 +26,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class BFTNotaryServiceTests : NodeBasedTest() {
-    private val notaryName = "BFT Notary Server"
+    private companion object {
+        val notaryName = "BFT Notary Server"
+    }
 
     @Test
     fun `detect double spend`() {
@@ -74,6 +76,7 @@ class BFTNotaryServiceTests : NodeBasedTest() {
     private fun startBFTNotaryCluster(notaryName: String,
                                       clusterSize: Int,
                                       serviceType: ServiceType): List<Node> {
+        require(clusterSize > 0)
         val quorum = (2 * clusterSize + 1) / 3
         ServiceIdentityGenerator.generateToDisk(
                 (0 until clusterSize).map { tempFolder.root.toPath() / "$notaryName-$it" },
@@ -82,13 +85,7 @@ class BFTNotaryServiceTests : NodeBasedTest() {
                 quorum)
 
         val serviceInfo = ServiceInfo(serviceType, notaryName)
-        val masterNode = startNode(
-                "$notaryName-0",
-                advertisedServices = setOf(serviceInfo),
-                configOverrides = mapOf("notaryNodeId" to 0)
-        ).getOrThrow()
-
-        val remainingNodes = (1 until clusterSize).map {
+        val nodes = (0 until clusterSize).map {
             startNode(
                     "$notaryName-$it",
                     advertisedServices = setOf(serviceInfo),
@@ -96,6 +93,6 @@ class BFTNotaryServiceTests : NodeBasedTest() {
             ).getOrThrow()
         }
 
-        return remainingNodes + masterNode
+        return nodes
     }
 }


### PR DESCRIPTION
BFTNotaryServiceTests generates a master node independently of the cluster nodes, so it can put it
at the end of the list of nodes. The calling function however treats the first node in the list as
the master, not the last node. This simplifies the code while maintaining the same behaviour.