### PR TITLE
Fix duplicate content root problems in IntelliJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,16 @@ allprojects {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
+    // Use manual resource copying of log4j2.xml rather than source sets.
+    // This prevents problems in IntelliJ with regard to duplicate source roots.
+    processResources {
+        from file("$rootDir/config/dev/log4j2.xml")
+    }
+
+    processTestResources {
+        from file("$rootDir/config/test/log4j2.xml")
+    }
+
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-Xlint:-options"
     }

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -21,11 +21,6 @@ sourceSets {
             srcDir file('src/integration-test/kotlin')
         }
     }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
 }
 
 // To find potential version conflicts, run "gradle htmlDependencyReport" and then look in

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -10,14 +10,6 @@ configurations {
     runtime.exclude module: 'isolated'
 }
 
-sourceSets {
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
-}
-
 // To find potential version conflicts, run "gradle htmlDependencyReport" and then look in
 // build/reports/project/dependencies/index.html for green highlighted parts of the tree.
 

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -21,11 +21,6 @@ sourceSets {
             srcDir file('src/integration-test/kotlin')
         }
     }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
 }
 
 // To find potential version conflicts, run "gradle htmlDependencyReport" and then look in

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,14 +10,6 @@ buildscript {
     }
 }
 
-sourceSets {
-    test {
-        resources {
-            srcDir "../config/test"
-        }
-    }
-}
-
 dependencies {
 
     testCompile "junit:junit:$junit_version"

--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -21,12 +21,6 @@ configurations {
 }
 
 sourceSets {
-    main {
-        resources {
-            srcDir "../../../config/dev"
-        }
-    }
-
     integrationTest {
         kotlin {
             compileClasspath += main.output + test.output

--- a/finance/build.gradle
+++ b/finance/build.gradle
@@ -22,14 +22,6 @@ dependencies {
     testCompile "com.pholser:junit-quickcheck-generators:$quickcheck_version"
 }
 
-sourceSets {
-    test {
-        resources {
-            srcDir "../config/test"
-        }
-    }
-}
-
 configurations.testCompile {
     // Excluding javassist:javassist because it clashes with Hibernate's
     // transitive org.javassist:javassist dependency.

--- a/finance/isolated/build.gradle
+++ b/finance/isolated/build.gradle
@@ -4,11 +4,3 @@ apply plugin: CanonicalizerPlugin
 dependencies {
     compile project(':core')
 }
-
-sourceSets {
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
-}

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -10,19 +10,6 @@ buildscript {
     }
 }
 
-sourceSets {
-    test {
-        resources {
-            srcDir "../config/test"
-        }
-    }
-    main {
-        resources {
-            srcDir "../config/dev"
-        }
-    }
-}
-
 dependencies {
     compile project(":core")
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -38,16 +38,6 @@ sourceSets {
             srcDir file('src/integration-test/resources')
         }
     }
-    test {
-        resources {
-            srcDir "../config/test"
-        }
-    }
-    main {
-        resources {
-            srcDir "../config/dev"
-        }
-    }
 }
 
 // To find potential version conflicts, run "gradle htmlDependencyReport" and then look in

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -19,19 +19,6 @@ configurations {
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-sourceSets {
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-}
-
 dependencies {
     compile project(':node')
 }

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -7,16 +7,6 @@ apply plugin: 'net.corda.plugins.cordformation'
 apply plugin: 'maven-publish'
 
 sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
     integrationTest {
         kotlin {
             compileClasspath += main.output + test.output

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -7,16 +7,6 @@ apply plugin: 'net.corda.plugins.cordformation'
 apply plugin: 'maven-publish'
 
 sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
     integrationTest {
         kotlin {
             compileClasspath += main.output + test.output

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -10,16 +10,6 @@ apply plugin: 'application'
 mainClassName = 'net.corda.irs.IRSDemo'
 
 sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
     integrationTest {
         kotlin {
             compileClasspath += main.output + test.output

--- a/samples/raft-notary-demo/build.gradle
+++ b/samples/raft-notary-demo/build.gradle
@@ -13,19 +13,6 @@ ext {
     advertisedNotary = "$notaryType|$notaryName"
 }
 
-sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
-}
-
 configurations {
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -11,16 +11,6 @@ apply plugin: 'net.corda.plugins.cordformation'
 apply plugin: 'maven-publish'
 
 sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
     integrationTest {
         kotlin {
             compileClasspath += main.output + test.output

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -7,16 +7,6 @@ apply plugin: 'net.corda.plugins.cordformation'
 apply plugin: 'maven-publish'
 
 sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
     integrationTest {
         kotlin {
             compileClasspath += main.output + test.output

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -12,19 +12,6 @@ apply plugin: 'application'
 sourceCompatibility = 1.8
 mainClassName = 'net.corda.explorer.Main'
 
-sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-    test {
-        resources {
-            srcDir "../../config/test"
-        }
-    }
-}
-
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/tools/loadtest/build.gradle
+++ b/tools/loadtest/build.gradle
@@ -1,14 +1,6 @@
 apply plugin: 'kotlin'
 apply plugin: 'application'
 
-sourceSets {
-    main {
-        resources {
-            srcDir "../../config/dev"
-        }
-    }
-}
-
 mainClassName = 'net.corda.loadtest.MainKt'
 
 dependencies {

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -18,16 +18,6 @@ sourceSets {
             srcDir file('src/integration-test/kotlin')
         }
     }
-    test {
-        resources {
-            srcDir "../config/test"
-        }
-    }
-    main {
-        resources {
-            srcDir "../config/dev"
-        }
-    }
 }
 
 dependencies {

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -17,16 +17,14 @@ sourceSets {
             srcDir file('src/integration-test/kotlin')
         }
     }
-    test {
-        resources {
-            srcDir "$rootDir/config/test"
-        }
-    }
-    main {
-        resources {
-            srcDir "$rootDir/config/dev"
-        }
-    }
+}
+
+processResources {
+    from file("$rootDir/config/dev/jolokia-access.xml")
+}
+
+processTestResources {
+    from file("$rootDir/config/test/jolokia-access.xml")
 }
 
 dependencies {

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -19,19 +19,6 @@ configurations {
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-sourceSets {
-    test {
-        resources {
-            srcDir "$rootDir/config/test"
-        }
-    }
-    main {
-        resources {
-            srcDir "$rootDir/config/dev"
-        }
-    }
-}
-
 dependencies {
     compile project(':webserver')
 }


### PR DESCRIPTION
Copy the log4j2.xml files manually during the resource processing steps in gradle. This avoids the problem where IntelliJ identifies the config folders as being used in multiple projects.

This should address the following issues:
https://github.com/corda/corda/issues/525
https://github.com/corda/corda/issues/553
https://github.com/corda/corda/issues/325