### PR TITLE
Rog webserver index

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     compile "org.glassfish.jersey.containers:jersey-container-jetty-http:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"
 
+    // For rendering the index page.
+    compile "org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.3"
+
     testCompile "junit:junit:$junit_version"
 }
 

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt
@@ -1,0 +1,90 @@
+package net.corda.webserver.servlets
+
+import kotlinx.html.*
+import kotlinx.html.stream.appendHTML
+import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.node.CordaPluginRegistry
+import org.glassfish.jersey.server.model.Resource
+import org.glassfish.jersey.server.model.ResourceMethod
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Dumps some data about the installed CorDapps.
+ * TODO: Add registered flow initiators.
+ */
+class CorDappInfoServlet(val plugins: List<CordaPluginRegistry>, val rpc: CordaRPCOps): HttpServlet() {
+
+    override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
+        resp.writer.appendHTML().html {
+            head {
+                title { +"Installed CorDapps" }
+            }
+            body {
+                h2 { +"Installed CorDapps" }
+                plugins.forEach { plugin ->
+                    h3 { +plugin::class.java.name }
+                    if (plugin.requiredFlows.isNotEmpty()) {
+                        div {
+                            p { +"Whitelisted flows:" }
+                            ul {
+                                plugin.requiredFlows.map { it.key }.forEach { li { +it } }
+                            }
+                        }
+                    }
+                    if (plugin.webApis.isNotEmpty()) {
+                        div {
+                            plugin.webApis.forEach { api ->
+                                val resource = Resource.from(api.apply(rpc)::class.java)
+                                p { +"${resource.name}:" }
+                                val endpoints = processEndpoints("", resource, mutableListOf<Endpoint>())
+                                ul {
+                                    endpoints.forEach {
+                                        li { a(it.uri) { +"${it.method}\t${it.text}" } }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (plugin.staticServeDirs.isNotEmpty()) {
+                        div {
+                            p { +"Static web content:" }
+                            ul {
+                                plugin.staticServeDirs.map { it.key }.forEach {
+                                    li { a("web/$it") { +it } }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    data class Endpoint(val method: String, val uri: String, val text: String)
+
+    /**
+     * Recursively enumerate and record all of the end-points listed in the API implementations.
+     */
+    private fun processEndpoints(uriPrefix: String, resource: Resource, endpoints: MutableList<Endpoint>): List<Endpoint> {
+        val resources = arrayListOf<Resource>()
+        val path = if (resource.path != null) "$uriPrefix/${resource.path}" else uriPrefix
+
+        resources.addAll(resource.childResources)
+
+        for (method in resource.allMethods) {
+            if (method.type == ResourceMethod.JaxrsType.SUB_RESOURCE_LOCATOR) {
+                resources.add( Resource.from(resource.resourceLocator.invocable.definitionMethod.returnType))
+            } else {
+                endpoints.add(Endpoint(method.httpMethod, "api$path", resource.path))
+            }
+        }
+
+        resources.forEach {
+            processEndpoints(path, it, endpoints)
+        }
+
+        return endpoints
+    }
+}


### PR DESCRIPTION
First stab at a rough and ready index page for the web server which displays the api end-points available as well as any static content served and all whitelisted flows. Useful for when you can't remember the paths to your api end-points.

TODO: Enumerate all flow initiators as well.