### PR TITLE
Interim patch introducing X500Names

### DIFF
--- a/config/dev/generalnodea.conf
+++ b/config/dev/generalnodea.conf
@@ -8,6 +8,6 @@ webAddress : "localhost:10004"
 extraAdvertisedServiceIds : [ "corda.interest_rates" ]
 networkMapService : {
   address : "localhost:10000"
-  legalName : "Network Map Service"
+  legalName : "CN=Network Map Service,O=R3,OU=corda,L=London,C=UK"
 }
 useHTTPS : false

--- a/config/dev/generalnodeb.conf
+++ b/config/dev/generalnodeb.conf
@@ -1,4 +1,4 @@
-myLegalName : "Bank B"
+myLegalName : "CN=Bank B,O=Bank A,L=London,C=UK"
 nearestCity : "London"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
@@ -8,6 +8,6 @@ webAddress : "localhost:10007"
 extraAdvertisedServiceIds : [ "corda.interest_rates" ]
 networkMapService : {
   address : "localhost:10000"
-  legalName : "Network Map Service"
+  legalName : "CN=Network Map Service,O=R3,OU=corda,L=London,C=UK"
 }
 useHTTPS : false

--- a/core/src/main/kotlin/net/corda/core/crypto/Party.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Party.kt
@@ -2,6 +2,7 @@ package net.corda.core.crypto
 
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.serialization.OpaqueBytes
+import org.bouncycastle.asn1.x500.X500Name
 import java.security.PublicKey
 
 /**
@@ -23,6 +24,7 @@ import java.security.PublicKey
  * @see CompositeKey
  */
 class Party(val name: String, owningKey: PublicKey) : AbstractParty(owningKey) {
+    constructor(name: X500Name, owningKey: PublicKey) : this(name.toString(), owningKey)
     override fun toAnonymous(): AnonymousParty = AnonymousParty(owningKey)
     override fun toString() = "${owningKey.toBase58String()} ($name)"
     override fun nameOrNull(): String? = name

--- a/core/src/main/kotlin/net/corda/core/node/services/ServiceInfo.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/ServiceInfo.kt
@@ -1,6 +1,7 @@
 package net.corda.core.node.services
 
 import net.corda.core.serialization.CordaSerializable
+import org.bouncycastle.asn1.x500.X500Name
 
 /**
  * A container for additional information for an advertised service.
@@ -11,6 +12,7 @@ import net.corda.core.serialization.CordaSerializable
  */
 @CordaSerializable
 data class ServiceInfo(val type: ServiceType, val name: String? = null) {
+    constructor(type: ServiceType, name: X500Name?) : this(type, name?.toString())
     companion object {
         fun parse(encoded: String): ServiceInfo {
             val parts = encoded.split("|")

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -20,34 +20,32 @@ val DUMMY_KEY_2: KeyPair by lazy { generateKeyPair() }
 
 val DUMMY_NOTARY_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(20)) }
 /** Dummy notary identity for tests and simulations */
-val DUMMY_NOTARY: Party get() = Party("CN=Notary Service,O=R3,OU=corda,L=London,C=UK", DUMMY_NOTARY_KEY.public)
+val DUMMY_NOTARY: Party get() = Party(X500Name("CN=Notary Service,O=R3,OU=corda,L=London,C=UK"), DUMMY_NOTARY_KEY.public)
 
 val DUMMY_MAP_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(30)) }
 /** Dummy network map service identity for tests and simulations */
-val DUMMY_MAP: Party get() = Party("CN=Network Map Service,O=R3,OU=corda,L=London,C=UK", DUMMY_MAP_KEY.public)
+val DUMMY_MAP: Party get() = Party(X500Name("CN=Network Map Service,O=R3,OU=corda,L=London,C=UK"), DUMMY_MAP_KEY.public)
 
 val DUMMY_BANK_A_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(40)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_A: Party get() = Party("CN=Bank A,O=Bank A,L=London,C=UK", DUMMY_BANK_A_KEY.public)
+val DUMMY_BANK_A: Party get() = Party(X500Name("CN=Bank A,O=Bank A,L=London,C=UK"), DUMMY_BANK_A_KEY.public)
 
 val DUMMY_BANK_B_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(50)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_B: Party get() = Party("CN=Bank B,O=Bank B,L=New York,C=USA", DUMMY_BANK_B_KEY.public)
+val DUMMY_BANK_B: Party get() = Party(X500Name("CN=Bank B,O=Bank B,L=New York,C=USA"), DUMMY_BANK_B_KEY.public)
 
 val DUMMY_BANK_C_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(60)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_C: Party get() = Party("CN=Bank C,O=Bank C,L=Tokyo,C=Japan", DUMMY_BANK_C_KEY.public)
-
-
+val DUMMY_BANK_C: Party get() = Party(X500Name("CN=Bank C,O=Bank C,L=Tokyo,C=Japan"), DUMMY_BANK_C_KEY.public)
 
 val ALICE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(70)) }
 /** Dummy individual identity for tests and simulations */
-val ALICE: Party get() = Party("CN=Alice Corp,O=Alice Corp,L=London,C=UK", ALICE_KEY.public)
+val ALICE: Party get() = Party(X500Name("CN=Alice Corp,O=Alice Corp,L=London,C=UK"), ALICE_KEY.public)
 
 val BOB_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(80)) }
 /** Dummy individual identity for tests and simulations */
-val BOB: Party get() = Party("CN=Bob Plc,O=Bob Plc,L=London,C=UK", BOB_KEY.public)
+val BOB: Party get() = Party(X500Name("CN=Bob Plc,O=Bob Plc,L=London,C=UK"), BOB_KEY.public)
 
 val CHARLIE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(90)) }
 /** Dummy individual identity for tests and simulations */
-val CHARLIE: Party get() = Party("CN=Charlie Ltd,O=Charlie Ltd,L=London,C=UK", CHARLIE_KEY.public)
+val CHARLIE: Party get() = Party(X500Name("CN=Charlie Ltd,O=Charlie Ltd,L=London,C=UK"), CHARLIE_KEY.public)

--- a/core/src/test/kotlin/net/corda/core/node/ServiceInfoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/node/ServiceInfoTests.kt
@@ -3,13 +3,14 @@ package net.corda.core.node
 import net.corda.core.crypto.X509Utilities
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.ServiceType
+import org.bouncycastle.asn1.x500.X500Name
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class ServiceInfoTests {
     val serviceType = ServiceType.getServiceType("test", "service").getSubType("subservice")
-    val name = "CN=service.name,O=R3,OU=corda,L=London,C=UK"
+    val name = X500Name("CN=service.name,O=R3,OU=corda,L=London,C=UK")
 
     @Test
     fun `type and name encodes correctly`() {

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
@@ -16,6 +16,7 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.Emoji
 import net.corda.schemas.CashSchemaV1
+import org.bouncycastle.asn1.x500.X500Name
 import java.math.BigInteger
 import java.security.PublicKey
 import java.util.*
@@ -203,7 +204,7 @@ infix fun Cash.State.`with deposit`(deposit: PartyAndReference): Cash.State = wi
 /** A randomly generated key. */
 val DUMMY_CASH_ISSUER_KEY by lazy { entropyToKeyPair(BigInteger.valueOf(10)) }
 /** A dummy, randomly generated issuer party by the name of "Snake Oil Issuer" */
-val DUMMY_CASH_ISSUER by lazy { Party("CN=Snake Oil Issuer,O=R3,OU=corda,L=London,C=UK", DUMMY_CASH_ISSUER_KEY.public).ref(1) }
+val DUMMY_CASH_ISSUER by lazy { Party(X500Name("CN=Snake Oil Issuer,O=R3,OU=corda,L=London,C=UK"), DUMMY_CASH_ISSUER_KEY.public).ref(1) }
 /** An extension property that lets you write 100.DOLLARS.CASH */
 val Amount<Currency>.CASH: Cash.State get() = Cash.State(Amount(quantity, Issued(DUMMY_CASH_ISSUER, token)), NullPublicKey)
 /** An extension property that lets you get a cash state from an issued token, under the [NullPublicKey] */

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
@@ -13,6 +13,7 @@ import net.corda.core.utilities.Emoji
 import net.corda.core.utilities.NonEmptySet
 import net.corda.core.utilities.TEST_TX_TIME
 import net.corda.core.utilities.nonEmptySetOf
+import org.bouncycastle.asn1.x500.X500Name
 import java.math.BigInteger
 import java.security.PublicKey
 import java.time.Duration
@@ -719,7 +720,7 @@ infix fun <T : Any> Obligation.State<T>.`issued by`(party: AbstractParty) = copy
 /** A randomly generated key. */
 val DUMMY_OBLIGATION_ISSUER_KEY by lazy { entropyToKeyPair(BigInteger.valueOf(10)) }
 /** A dummy, randomly generated issuer party by the name of "Snake Oil Issuer" */
-val DUMMY_OBLIGATION_ISSUER by lazy { Party("CN=Snake Oil Issuer,O=R3,OU=corda,L=London,C=UK", DUMMY_OBLIGATION_ISSUER_KEY.public) }
+val DUMMY_OBLIGATION_ISSUER by lazy { Party(X500Name("CN=Snake Oil Issuer,O=R3,OU=corda,L=London,C=UK"), DUMMY_OBLIGATION_ISSUER_KEY.public) }
 
 val Issued<Currency>.OBLIGATION_DEF: Obligation.Terms<Currency>
     get() = Obligation.Terms(nonEmptySetOf(Cash().legalContractReference), nonEmptySetOf(this), TEST_TX_TIME)

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -27,15 +27,15 @@ import kotlin.test.assertFailsWith
 
 class BFTNotaryServiceTests : NodeBasedTest() {
     private companion object {
-        val notaryName = "BFT Notary Server"
+        val notaryCommonName = "BFT Notary Server"
     }
 
     @Test
     fun `detect double spend`() {
-        val masterNode = startBFTNotaryCluster(notaryName, 4, BFTNonValidatingNotaryService.type).first()
+        val masterNode = startBFTNotaryCluster(notaryCommonName, 4, BFTNonValidatingNotaryService.type).first()
         val alice = startNode(ALICE.name).getOrThrow()
 
-        val notaryParty = alice.netMapCache.getNotary(notaryName)!!
+        val notaryParty = alice.netMapCache.getNotary(notaryCommonName)!!
         val notaryNodeKeyPair = with(masterNode) { database.transaction { services.notaryIdentityKey } }
         val aliceKey = with(alice) { database.transaction { services.legalIdentityKey } }
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -9,6 +9,7 @@ import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.loggerFor
 import net.corda.node.utilities.*
+import org.bouncycastle.asn1.x500.X500Name
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.statements.InsertStatement
 import java.util.*
@@ -38,7 +39,7 @@ class PersistentUniquenessProvider : UniquenessProvider, SingletonSerializeAsTok
         override fun valueFromRow(row: ResultRow): UniquenessProvider.ConsumingTx = UniquenessProvider.ConsumingTx(
                 row[table.consumingTxHash],
                 row[table.consumingIndex],
-                Party(row[table.requestingParty.name], row[table.requestingParty.owningKey])
+                Party(X500Name(row[table.requestingParty.name]), row[table.requestingParty.owningKey])
         )
 
         override fun addKeyToInsert(insert: InsertStatement,

--- a/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
+++ b/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
@@ -69,7 +69,7 @@ class InteractiveShellTest {
     fun flowTooManyParams() = check("b: 12, c: Yo, d: Bar", "")
 
     @Test
-    fun party() = check("party: \"${someCorpLegalName}\"", someCorpLegalName)
+    fun party() = check("party: \"${someCorpLegalName}\"", someCorpLegalName.toString())
 
     class DummyFSM(val logic: FlowA) : FlowStateMachine<Any?> {
         override fun <T : Any> sendAndReceive(receiveType: Class<T>, otherParty: Party, payload: Any, sessionFlow: FlowLogic<*>): UntrustworthyData<T> {

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -31,6 +31,7 @@ import net.corda.testing.*
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.MockNetwork
 import org.assertj.core.api.Assertions.assertThat
+import org.bouncycastle.asn1.x500.X500Name
 import org.jetbrains.exposed.sql.Database
 import org.junit.After
 import org.junit.Before

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -16,6 +16,7 @@ import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.testing.node.MockNetwork
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.bouncycastle.asn1.x500.X500Name
 import org.junit.Before
 import org.junit.Test
 import java.time.Instant
@@ -75,7 +76,7 @@ class NotaryChangeTests {
     @Test
     fun `should throw when a participant refuses to change Notary`() {
         val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode)
-        val newEvilNotary = Party("CN=Evil Notary,O=Evil R3,OU=corda,L=London,C=UK", generateKeyPair().public)
+        val newEvilNotary = Party(X500Name("CN=Evil Notary,O=Evil R3,OU=corda,L=London,C=UK"), generateKeyPair().public)
         val flow = Instigator(state, newEvilNotary)
         val future = clientNodeA.services.startFlow(flow)
 

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
@@ -8,6 +8,7 @@ import net.corda.core.utilities.ALICE
 import net.corda.core.utilities.BOB
 import net.corda.testing.ALICE_PUBKEY
 import net.corda.testing.BOB_PUBKEY
+import org.bouncycastle.asn1.x500.X500Name
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -52,7 +53,7 @@ class InMemoryIdentityServiceTests {
     fun `get identity by name`() {
         val service = InMemoryIdentityService()
         val identities = listOf("Node A", "Node B", "Node C")
-                .map { Party("CN=$it,O=R3,OU=corda,L=London,C=UK", generateKeyPair().public) }
+                .map { Party(X500Name("CN=$it,O=R3,OU=corda,L=London,C=UK"), generateKeyPair().public) }
         assertNull(service.partyFromName(identities.first().name))
         identities.forEach { service.registerIdentity(it) }
         identities.forEach { assertEquals(it, service.partyFromName(it.name)) }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/StateMachineManagerTests.kt
@@ -43,6 +43,7 @@ import net.corda.testing.sequence
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType
+import org.bouncycastle.asn1.x500.X500Name
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
@@ -8,6 +8,7 @@ import net.corda.core.crypto.X509Utilities
 import net.corda.core.exists
 import net.corda.core.utilities.ALICE
 import net.corda.testing.TestNodeConfiguration
+import org.bouncycastle.asn1.x500.X500Name
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -24,9 +25,12 @@ class NetworkRegistrationHelperTest {
     fun buildKeyStore() {
         val id = SecureHash.randomSHA256().toString()
 
-        val certs = arrayOf(X509Utilities.createSelfSignedCACert("CORDA_CLIENT_CA").certificate,
-                X509Utilities.createSelfSignedCACert("CORDA_INTERMEDIATE_CA").certificate,
-                X509Utilities.createSelfSignedCACert("CORDA_ROOT_CA").certificate)
+        val identities = listOf("CORDA_CLIENT_CA",
+                "CORDA_INTERMEDIATE_CA",
+                "CORDA_ROOT_CA")
+                .map { X500Name("CN=${it},O=R3,OU=corda,L=London,C=UK") }
+        val certs = identities.map { X509Utilities.createSelfSignedCACert(it).certificate }
+                .toTypedArray()
 
         val certService: NetworkRegistrationService = mock {
             on { submitRequest(any()) }.then { id }

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
@@ -8,6 +8,7 @@ import net.corda.core.node.services.ServiceInfo
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.testing.BOC
+import org.bouncycastle.asn1.x500.X500Name
 import org.junit.Test
 
 class BankOfCordaHttpAPITest {
@@ -19,7 +20,7 @@ class BankOfCordaHttpAPITest {
                     startNode(BIGCORP_LEGAL_NAME)
             ).getOrThrow()
             val nodeBankOfCordaApiAddr = startWebserver(nodeBankOfCorda).getOrThrow().listenAddress
-            assert(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name)))
+            assert(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", X500Name(BOC.name))))
         }, isDebug = true)
     }
 }

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
@@ -16,6 +16,7 @@ import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
 import net.corda.testing.BOC
+import org.bouncycastle.asn1.x500.X500Name
 import kotlin.system.exitProcess
 
 /**
@@ -28,7 +29,7 @@ fun main(args: Array<String>) {
 val BANK_USERNAME = "bankUser"
 val BIGCORP_USERNAME = "bigCorpUser"
 
-val BIGCORP_LEGAL_NAME = "CN=BigCorporation,O=R3,OU=corda,L=London,C=UK"
+val BIGCORP_LEGAL_NAME = X500Name("CN=BigCorporation,O=R3,OU=corda,L=London,C=UK")
 
 private class BankOfCordaDriver {
     enum class Role {
@@ -66,7 +67,7 @@ private class BankOfCordaDriver {
             }, isDebug = true)
         } else {
             try {
-                val requestParams = IssueRequestParams(options.valueOf(quantity), options.valueOf(currency), BIGCORP_LEGAL_NAME, "1", BOC.name)
+                val requestParams = IssueRequestParams(options.valueOf(quantity), options.valueOf(currency), BIGCORP_LEGAL_NAME, "1", X500Name(BOC.name))
                 when (role) {
                     Role.ISSUE_CASH_RPC -> {
                         println("Requesting Cash via RPC ...")

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
@@ -9,6 +9,7 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.utilities.loggerFor
 import net.corda.flows.IssuerFlow.IssuanceRequester
+import org.bouncycastle.asn1.x500.X500Name
 import java.time.LocalDateTime
 import javax.ws.rs.*
 import javax.ws.rs.core.MediaType
@@ -19,7 +20,13 @@ import javax.ws.rs.core.Response
 class BankOfCordaWebApi(val rpc: CordaRPCOps) {
     data class IssueRequestParams(val amount: Long, val currency: String,
                                   val issueToPartyName: String, val issueToPartyRefAsString: String,
-                                  val issuerBankName: String)
+                                  val issuerBankName: String) {
+        constructor(amount: Long, currency: String,
+                    issueToPartyName: X500Name, issueToPartyRefAsString: String,
+                    issuerBankName: X500Name) : this(amount, currency,
+                issueToPartyName.toString(), issueToPartyRefAsString,
+                issuerBankName.toString())
+    }
 
     private companion object {
         val logger = loggerFor<BankOfCordaWebApi>()

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/testing/NodeInterestRatesTest.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/testing/NodeInterestRatesTest.kt
@@ -25,6 +25,7 @@ import net.corda.testing.MEGA_CORP
 import net.corda.testing.MEGA_CORP_KEY
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.makeTestDataSourceProperties
+import org.bouncycastle.asn1.x500.X500Name
 import org.jetbrains.exposed.sql.Database
 import org.junit.After
 import org.junit.Assert
@@ -48,7 +49,7 @@ class NodeInterestRatesTest {
         """.trimIndent())
 
     val DUMMY_CASH_ISSUER_KEY = generateKeyPair()
-    val DUMMY_CASH_ISSUER = Party("CN=Cash issuer,O=R3,OU=corda,L=London,C=UK", DUMMY_CASH_ISSUER_KEY.public)
+    val DUMMY_CASH_ISSUER = Party(X500Name("CN=Cash issuer,O=R3,OU=corda,L=London,C=UK"), DUMMY_CASH_ISSUER_KEY.public)
 
     val clock = Clock.systemUTC()
     lateinit var oracle: NodeInterestRates.Oracle

--- a/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/Main.kt
+++ b/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/Main.kt
@@ -7,6 +7,7 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.node.driver.driver
 import net.corda.node.services.transactions.RaftValidatingNotaryService
 import net.corda.nodeapi.User
+import org.bouncycastle.asn1.x500.X500Name
 import java.nio.file.Paths
 
 /** Creates and starts all nodes required for the demo. */

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/Main.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/Main.kt
@@ -1,6 +1,7 @@
 package net.corda.vega
 
 import com.google.common.util.concurrent.Futures
+import net.corda.core.crypto.X509Utilities
 import net.corda.core.getOrThrow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.DUMMY_BANK_A
@@ -16,7 +17,7 @@ import net.corda.node.services.transactions.SimpleNotaryService
  */
 fun main(args: Array<String>) {
     driver(dsl = {
-        startNode("Controller", setOf(ServiceInfo(SimpleNotaryService.type)))
+        startNode(X509Utilities.getDevX509Name("Controller"), setOf(ServiceInfo(SimpleNotaryService.type)))
         val (nodeA, nodeB, nodeC) = Futures.allAsList(
                 startNode(DUMMY_BANK_A.name),
                 startNode(DUMMY_BANK_B.name),

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/Main.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/Main.kt
@@ -2,6 +2,8 @@ package net.corda.traderdemo
 
 import net.corda.core.div
 import net.corda.core.node.services.ServiceInfo
+import net.corda.core.utilities.DUMMY_BANK_A
+import net.corda.core.utilities.DUMMY_BANK_B
 import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.IssuerFlow
 import net.corda.node.driver.driver
@@ -10,9 +12,6 @@ import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
 import net.corda.testing.BOC
 import java.nio.file.Paths
-import net.corda.core.utilities.DUMMY_BANK_A
-import net.corda.core.utilities.DUMMY_BANK_B
-import net.corda.core.utilities.DUMMY_NOTARY
 
 /**
  * This file is exclusively for being able to run your nodes through an IDE (as opposed to running deployNodes)

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt
@@ -4,7 +4,10 @@ import com.google.common.net.HostAndPort
 import joptsimple.OptionParser
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.DOLLARS
+import net.corda.core.crypto.X509Utilities
+import net.corda.core.utilities.DUMMY_BANK_A
 import net.corda.core.utilities.loggerFor
+import org.bouncycastle.asn1.x500.X500Name
 import org.slf4j.Logger
 import kotlin.system.exitProcess
 
@@ -48,7 +51,7 @@ private class TraderDemo {
         } else {
             val host = HostAndPort.fromString("localhost:10009")
             CordaRPCClient(host).use("demo", "demo") {
-                TraderDemoClientApi(this).runSeller(1000.DOLLARS, "CN=Bank A,O=Bank A,L=London,C=UK")
+                TraderDemoClientApi(this).runSeller(1000.DOLLARS, DUMMY_BANK_A.name)
             }
         }
     }

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
@@ -16,6 +16,7 @@ import net.corda.core.utilities.DUMMY_BANK_C
 import net.corda.core.utilities.ProgressTracker
 import net.corda.flows.NotaryFlow
 import net.corda.flows.TwoPartyTradeFlow
+import net.corda.testing.BOC
 import java.security.PublicKey
 import java.time.Instant
 import java.util.*
@@ -66,7 +67,7 @@ class SellerFlow(val otherParty: Party,
     fun selfIssueSomeCommercialPaper(ownedBy: PublicKey, notaryNode: NodeInfo): StateAndRef<CommercialPaper.State> {
         // Make a fake company that's issued its own paper.
         val keyPair = generateKeyPair()
-        val party = Party(DUMMY_BANK_C.name, keyPair.public)
+        val party = Party(BOC.name, keyPair.public)
 
         val issuance: SignedTransaction = run {
             val tx = CommercialPaper().generateIssue(party.ref(1, 2, 3), 1100.DOLLARS `issued by` DUMMY_CASH_ISSUER,

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -8,6 +8,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.X509Utilities
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.flows.FlowLogic
 import net.corda.core.node.ServiceHub
@@ -26,6 +27,7 @@ import net.corda.nodeapi.config.SSLConfiguration
 import net.corda.testing.node.MockIdentityService
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.makeTestDataSourceProperties
+import org.bouncycastle.asn1.x500.X500Name
 import java.net.ServerSocket
 import java.net.URL
 import java.nio.file.Files
@@ -67,17 +69,17 @@ val ALICE_PUBKEY: PublicKey get() = ALICE_KEY.public
 val BOB_PUBKEY: PublicKey get() = BOB_KEY.public
 val CHARLIE_PUBKEY: PublicKey get() = CHARLIE_KEY.public
 
-val MEGA_CORP: Party get() = Party("MegaCorp", MEGA_CORP_PUBKEY)
-val MINI_CORP: Party get() = Party("MiniCorp", MINI_CORP_PUBKEY)
+val MEGA_CORP: Party get() = Party(X509Utilities.getDevX509Name("MegaCorp"), MEGA_CORP_PUBKEY)
+val MINI_CORP: Party get() = Party(X509Utilities.getDevX509Name("MiniCorp"), MINI_CORP_PUBKEY)
 
 val BOC_KEY: KeyPair by lazy { generateKeyPair() }
 val BOC_PUBKEY: PublicKey get() = BOC_KEY.public
-val BOC: Party get() = Party("CN=BankOfCorda,O=R3,OU=corda,L=New York,C=USA", BOC_PUBKEY)
+val BOC: Party get() = Party(X500Name("CN=BankOfCorda,O=R3,OU=corda,L=New York,C=USA"), BOC_PUBKEY)
 val BOC_PARTY_REF = BOC.ref(OpaqueBytes.of(1)).reference
 
 val BIG_CORP_KEY: KeyPair by lazy { generateKeyPair() }
 val BIG_CORP_PUBKEY: PublicKey get() = BIG_CORP_KEY.public
-val BIG_CORP: Party get() = Party("BigCorporation", BIG_CORP_PUBKEY)
+val BIG_CORP: Party get() = Party(X509Utilities.getDevX509Name("BigCorporation"), BIG_CORP_PUBKEY)
 val BIG_CORP_PARTY_REF = BIG_CORP.ref(OpaqueBytes.of(1)).reference
 
 val ALL_TEST_KEYS: List<KeyPair> get() = listOf(MEGA_CORP_KEY, MINI_CORP_KEY, ALICE_KEY, BOB_KEY, DUMMY_NOTARY_KEY)

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
@@ -3,11 +3,13 @@ package net.corda.testing.node
 import co.paralleluniverse.common.util.VisibleForTesting
 import net.corda.core.crypto.DummyPublicKey
 import net.corda.core.crypto.Party
+import net.corda.core.crypto.X509Utilities
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.node.services.network.InMemoryNetworkMapCache
 import net.corda.testing.MOCK_VERSION_INFO
+import org.bouncycastle.asn1.x500.X500Name
 import rx.Observable
 import rx.subjects.PublishSubject
 
@@ -15,13 +17,18 @@ import rx.subjects.PublishSubject
  * Network map cache with no backing map service.
  */
 class MockNetworkMapCache : InMemoryNetworkMapCache() {
+    private companion object {
+        val BANK_C = Party(X500Name("CN=Bank C,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"), DummyPublicKey("Bank C"))
+        val BANK_D = Party(X500Name("CN=Bank D,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"), DummyPublicKey("Bank D"))
+    }
+
     override val changed: Observable<NetworkMapCache.MapChange> = PublishSubject.create<NetworkMapCache.MapChange>()
 
     data class MockAddress(val id: String) : SingleMessageRecipient
 
     init {
-        val mockNodeA = NodeInfo(MockAddress("bankC:8080"), Party("Bank C", DummyPublicKey("Bank C")), MOCK_VERSION_INFO.platformVersion)
-        val mockNodeB = NodeInfo(MockAddress("bankD:8080"), Party("Bank D", DummyPublicKey("Bank D")), MOCK_VERSION_INFO.platformVersion)
+        val mockNodeA = NodeInfo(MockAddress("bankC:8080"), BANK_C, MOCK_VERSION_INFO.platformVersion)
+        val mockNodeB = NodeInfo(MockAddress("bankD:8080"), BANK_D, MOCK_VERSION_INFO.platformVersion)
         registeredNodes[mockNodeA.legalIdentity.owningKey] = mockNodeA
         registeredNodes[mockNodeB.legalIdentity.owningKey] = mockNodeB
         runWithoutMapService()

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -3,9 +3,6 @@ package net.corda.testing.node
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.crypto.*
-import net.corda.core.flows.FlowInitiator
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowStateMachine
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.messaging.MessagingService
 import net.corda.core.messaging.SingleMessageRecipient
@@ -65,7 +62,7 @@ open class MockServices(val key: KeyPair = generateKeyPair()) : ServiceHub {
     override val networkMapCache: NetworkMapCache get() = throw UnsupportedOperationException()
     override val clock: Clock get() = Clock.systemUTC()
     override val schedulerService: SchedulerService get() = throw UnsupportedOperationException()
-    override val myInfo: NodeInfo get() = NodeInfo(object : SingleMessageRecipient {}, Party("MegaCorp", key.public), MOCK_VERSION_INFO.platformVersion)
+    override val myInfo: NodeInfo get() = NodeInfo(object : SingleMessageRecipient {}, Party(MEGA_CORP.name, key.public), MOCK_VERSION_INFO.platformVersion)
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
 
     fun makeVaultService(dataSourceProps: Properties): VaultService {

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
@@ -18,6 +18,7 @@ import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.GBP
 import net.corda.core.contracts.USD
+import net.corda.core.crypto.X509Utilities
 import net.corda.core.failure
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.node.services.ServiceInfo
@@ -44,6 +45,7 @@ import net.corda.node.services.startFlowPermission
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
 import org.apache.commons.lang.SystemUtils
+import org.bouncycastle.asn1.x500.X500Name
 import org.controlsfx.dialog.ExceptionDialog
 import tornadofx.*
 import java.time.Instant
@@ -172,10 +174,10 @@ fun main(args: Array<String>) {
         val bob = startNode(BOB.name, rpcUsers = arrayListOf(user),
                 advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("cash"))),
                 customOverrides = mapOf("nearestCity" to "Madrid"))
-        val issuerGBP = startNode("UK Bank Plc", rpcUsers = arrayListOf(manager),
+        val issuerGBP = startNode(X500Name("CN=UK Bank Plc,O=UK Bank Plc,L=London,C=UK"), rpcUsers = arrayListOf(manager),
                 advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.GBP"))),
                 customOverrides = mapOf("nearestCity" to "London"))
-        val issuerUSD = startNode("USA Bank Corp", rpcUsers = arrayListOf(manager),
+        val issuerUSD = startNode(X500Name("CN=USA Bank Corp,O=USA Bank Corp,L=New York,C=USA"), rpcUsers = arrayListOf(manager),
                 advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.USD"))),
                 customOverrides = mapOf("nearestCity" to "New York"))
 


### PR DESCRIPTION
This is an intermediary step to introducing X500Names in all Party instances, which adds:

* Party constructor which accepts X500Name and then converts it to string.
* startNode() function which takes in X500Name instead of String
* Numerous legal name fixes to use full distinguished names