### PR TITLE
Fix race in IntegrationTestingTutorial.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -275,11 +275,7 @@ class TransientProperty<out T>(private val initializer: () -> T) {
     @Transient private var v: T? = null
 
     @Synchronized
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        if (v == null)
-            v = initializer()
-        return v!!
-    }
+    operator fun getValue(thisRef: Any?, property: KProperty<*>) = v ?: initializer().also { v = it }
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/utilities/Logging.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/Logging.kt
@@ -65,7 +65,7 @@ object LogHelper {
     /**
      * May fail to restore the original level due to unavoidable race if called by multiple threads.
      */
-    inline fun <T> withLevel(logName: String, levelName: String, block: () -> T) = let {
+    inline fun <T> withLevel(logName: String, levelName: String, block: () -> T) = run {
         val level = Level.valueOf(levelName)
         val oldLevel = LogManager.getLogger(logName).level
         Configurator.setLevel(logName, level)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -87,13 +87,8 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
 
     @Transient private var _resultFuture: SettableFuture<R>? = SettableFuture.create<R>()
     /** This future will complete when the call method returns. */
-    override val resultFuture: ListenableFuture<R> get() {
-        return _resultFuture ?: run {
-            val f = SettableFuture.create<R>()
-            _resultFuture = f
-            return f
-        }
-    }
+    override val resultFuture: ListenableFuture<R>
+        get() = _resultFuture ?: SettableFuture.create<R>().also { _resultFuture = it }
 
     // This state IS serialised, as we need it to know what the fiber is waiting for.
     internal val openSessions = HashMap<Pair<FlowLogic<*>, Party>, FlowSession>()
@@ -456,7 +451,7 @@ private data class FlowHandleImpl<A>(
 }
 
 @CordaSerializable
-private data class FlowProgressHandleImpl<A> (
+private data class FlowProgressHandleImpl<A>(
         override val id: StateMachineRunId,
         override val returnValue: ListenableFuture<A>,
         override val progress: Observable<String>) : FlowProgressHandle<A> {


### PR DESCRIPTION
* Previously the futures stack was likely to be empty, so failure in startFlow was not caught and would result in the test hanging
* Minor unrelated improvements
