### PR TITLE
Add note for enabling verifyInstrumentation in IntelliJ

### DIFF
--- a/docs/source/tutorial-building-transactions.rst
+++ b/docs/source/tutorial-building-transactions.rst
@@ -100,11 +100,16 @@ reject each other's trade proposals which is implemented in
 examples using the IntelliJ IDE one can run/step the respective unit 
 tests in ``FxTransactionBuildTutorialTest.kt`` and 
 ``WorkflowTransactionBuildTutorialTest.kt``, which drive the flows as 
-part of a simulated in-memory network of nodes. Before creating the IntelliJ 
-run configurations for these unit tests go to Run -> Edit Configurations -> 
-Defaults -> JUnit, add ``-javaagent:lib/quasar.jar`` to the VM options, and 
-set Working directory to ``$PROJECT_DIR$`` so that the ``Quasar`` 
-instrumentation is correctly configured. 
+part of a simulated in-memory network of nodes.
+
+.. |nbsp| unicode:: 0xA0
+    :trim:
+
+.. note:: Before creating the IntelliJ run configurations for these unit tests
+    go to Run -> Edit |nbsp| Configurations -> Defaults -> JUnit, add
+    ``-javaagent:lib/quasar.jar -Dco.paralleluniverse.fibers.verifyInstrumentation``
+    to the VM options, and set Working directory to ``$PROJECT_DIR$``
+    so that the ``Quasar`` instrumentation is correctly configured.
 
 For the Cash transaction let’s assume the cash resources are using the 
 standard ``CashState`` in the ``:financial`` Gradle module. The Cash 


### PR DESCRIPTION
so that errors due to missing @Suspendable are less cryptic.
* Previously it was possible for a test to succeed in the IDE but fail in the Gradle build, as the Gradle build enables verifyInstrumentation and it's a little too strict
* IntelliJ only looks at the default config when creating a new test config, so users are free to remove verifyInstrumentation from individual test configs for performance
