### PR TITLE
Strip commas from node paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     ext.assertj_version = '3.6.1'
     ext.slf4j_version = '1.7.25'
     ext.log4j_version = '2.7'
-    ext.bouncycastle_version = '1.56'
+    ext.bouncycastle_version = constants.getProperty("bouncycastleVersion")
     ext.guava_version = constants.getProperty("guavaVersion")
     ext.quickcheck_version = '0.7'
     ext.okhttp_version = '3.5.0'

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,5 @@
-gradlePluginsVersion=0.11.1
+gradlePluginsVersion=0.11.2
 kotlinVersion=1.1.1
 guavaVersion=21.0
+bouncycastleVersion=1.56
 typesafeConfigVersion=1.3.1

--- a/gradle-plugins/cordformation/build.gradle
+++ b/gradle-plugins/cordformation/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     file("$projectDir/../../constants.properties").withInputStream { constants.load(it) }
 
     ext.kotlin_version = constants.getProperty("kotlinVersion")
+    ext.bouncycastle_version = constants.getProperty("bouncycastleVersion")
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
 
     repositories {
@@ -47,6 +48,9 @@ dependencies {
 
     // TypeSafe Config: for simple and human friendly config files.
     compile "com.typesafe:config:$typesafe_config_version"
+
+    // Bouncy Castle: for X.500 distinguished name manipulation
+    compile "org.bouncycastle:bcprov-jdk15on:${bouncycastle_version}"
 }
 
 task createNodeRunner(type: Jar, dependsOn: [classes]) {

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
@@ -1,6 +1,8 @@
 package net.corda.plugins
 
 import com.typesafe.config.*
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x500.style.BCStyle
 import org.gradle.api.Project
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -154,7 +156,15 @@ class Node {
     }
 
     void build(File rootDir) {
-        nodeDir = new File(rootDir, name.replaceAll("\\s",""))
+        def dirName
+        try {
+            X500Name x500Name = new X500Name(name)
+            dirName = x500Name.getRDNs(BCStyle.CN).getAt(0).getFirst().getValue().toString()
+        } catch(IllegalArgumentException ex) {
+            // Can't parse as an X500 name, use the full string
+            dirName = name
+        }
+        nodeDir = new File(rootDir, dirName.replaceAll("\\s",""))
         configureRpcUsers()
         installCordaJar()
         installWebserverJar()


### PR DESCRIPTION
Strip commas from node legal name before assembling path, to work around Windows treating the comma as a separator and then complaining the extension is too long.