### PR TITLE
Replace code only used in 1 test with existing general mechanism.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -328,6 +328,7 @@ interface FileUploader {
 interface AttachmentsStorageService {
     /** Provides access to storage of arbitrary JAR files (which may contain only data, no code). */
     val attachments: AttachmentStorage
+    val attachmentsClassLoaderEnabled: Boolean
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationToken.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationToken.kt
@@ -6,6 +6,7 @@ import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.pool.KryoPool
+import net.corda.core.node.ServiceHub
 
 /**
  * The interfaces and classes in this file allow large, singleton style classes to
@@ -39,29 +40,31 @@ interface SerializationToken {
  */
 class SerializeAsTokenSerializer<T : SerializeAsToken> : Serializer<T>() {
     override fun write(kryo: Kryo, output: Output, obj: T) {
-        kryo.writeClassAndObject(output, obj.toToken(getContext(kryo) ?: throw KryoException("Attempt to write a ${SerializeAsToken::class.simpleName} instance of ${obj.javaClass.name} without initialising a context")))
+        kryo.writeClassAndObject(output, obj.toToken(kryo.serializationContext() ?: throw KryoException("Attempt to write a ${SerializeAsToken::class.simpleName} instance of ${obj.javaClass.name} without initialising a context")))
     }
 
     override fun read(kryo: Kryo, input: Input, type: Class<T>): T {
         val token = (kryo.readClassAndObject(input) as? SerializationToken) ?: throw KryoException("Non-token read for tokenized type: ${type.name}")
-        val fromToken = token.fromToken(getContext(kryo) ?: throw KryoException("Attempt to read a token for a ${SerializeAsToken::class.simpleName} instance of ${type.name} without initialising a context"))
+        val fromToken = token.fromToken(kryo.serializationContext() ?: throw KryoException("Attempt to read a token for a ${SerializeAsToken::class.simpleName} instance of ${type.name} without initialising a context"))
         if (type.isAssignableFrom(fromToken.javaClass)) {
             return type.cast(fromToken)
         } else {
             throw KryoException("Token read ($token) did not return expected tokenized type: ${type.name}")
         }
     }
+}
 
-    companion object {
-        private fun getContext(kryo: Kryo): SerializeAsTokenContext? = kryo.context.get(SerializeAsTokenContext::class.java) as? SerializeAsTokenContext
+private val serializationContextKey = SerializeAsTokenContext::class.java
 
-        fun setContext(kryo: Kryo, context: SerializeAsTokenContext) {
-            kryo.context.put(SerializeAsTokenContext::class.java, context)
-        }
+fun Kryo.serializationContext() = context.get(serializationContextKey) as? SerializeAsTokenContext
 
-        fun clearContext(kryo: Kryo) {
-            kryo.context.remove(SerializeAsTokenContext::class.java)
-        }
+fun <T> Kryo.withSerializationContext(serializationContext: SerializeAsTokenContext, block: () -> T) = run {
+    context.containsKey(serializationContextKey) && throw IllegalStateException("There is already a serialization context.")
+    context.put(serializationContextKey, serializationContext)
+    try {
+        block()
+    } finally {
+        context.remove(serializationContextKey)
     }
 }
 
@@ -74,7 +77,15 @@ class SerializeAsTokenSerializer<T : SerializeAsToken> : Serializer<T>() {
  * Then it is a case of using the companion object methods on [SerializeAsTokenSerializer] to set and clear context as necessary
  * on the Kryo instance when serializing to enable/disable tokenization.
  */
-class SerializeAsTokenContext(toBeTokenized: Any, kryoPool: KryoPool) {
+class SerializeAsTokenContext internal constructor(val serviceHub: ServiceHub, init: SerializeAsTokenContext.() -> Unit) {
+    constructor(toBeTokenized: Any, kryoPool: KryoPool, serviceHub: ServiceHub) : this(serviceHub, {
+        kryoPool.run { kryo ->
+            kryo.withSerializationContext(this) {
+                toBeTokenized.serialize(kryo)
+            }
+        }
+    })
+
     internal val tokenToTokenized = mutableMapOf<SerializationToken, SerializeAsToken>()
     internal var readOnly = false
 
@@ -88,11 +99,7 @@ class SerializeAsTokenContext(toBeTokenized: Any, kryoPool: KryoPool) {
          * accidental registrations from occuring as these could not be deserialized in a deserialization-first
          * scenario if they are not part of this iniital context construction serialization.
          */
-        kryoPool.run { kryo ->
-            SerializeAsTokenSerializer.setContext(kryo, this)
-            toBeTokenized.serialize(kryo)
-            SerializeAsTokenSerializer.clearContext(kryo)
-        }
+        init(this)
         readOnly = true
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/SerializationTokenTest.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/SerializationTokenTest.kt
@@ -3,6 +3,8 @@ package net.corda.core.serialization
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.KryoException
 import com.esotericsoftware.kryo.io.Output
+import com.nhaarman.mockito_kotlin.mock
+import net.corda.core.node.ServiceHub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -20,7 +22,6 @@ class SerializationTokenTest {
 
     @After
     fun cleanup() {
-        SerializeAsTokenSerializer.clearContext(kryo)
         storageKryo().release(kryo)
     }
 
@@ -36,15 +37,20 @@ class SerializationTokenTest {
         override fun equals(other: Any?) = other is LargeTokenizable && other.bytes.size == this.bytes.size
     }
 
+    companion object {
+        private fun serializeAsTokenContext(toBeTokenized: Any) = SerializeAsTokenContext(toBeTokenized, storageKryo(), mock<ServiceHub>())
+    }
+
     @Test
     fun `write token and read tokenizable`() {
         val tokenizableBefore = LargeTokenizable()
-        val context = SerializeAsTokenContext(tokenizableBefore, storageKryo())
-        SerializeAsTokenSerializer.setContext(kryo, context)
-        val serializedBytes = tokenizableBefore.serialize(kryo)
-        assertThat(serializedBytes.size).isLessThan(tokenizableBefore.numBytes)
-        val tokenizableAfter = serializedBytes.deserialize(kryo)
-        assertThat(tokenizableAfter).isSameAs(tokenizableBefore)
+        val context = serializeAsTokenContext(tokenizableBefore)
+        kryo.withSerializationContext(context) {
+            val serializedBytes = tokenizableBefore.serialize(kryo)
+            assertThat(serializedBytes.size).isLessThan(tokenizableBefore.numBytes)
+            val tokenizableAfter = serializedBytes.deserialize(kryo)
+            assertThat(tokenizableAfter).isSameAs(tokenizableBefore)
+        }
     }
 
     private class UnitSerializeAsToken : SingletonSerializeAsToken()
@@ -52,28 +58,31 @@ class SerializationTokenTest {
     @Test
     fun `write and read singleton`() {
         val tokenizableBefore = UnitSerializeAsToken()
-        val context = SerializeAsTokenContext(tokenizableBefore, storageKryo())
-        SerializeAsTokenSerializer.setContext(kryo, context)
-        val serializedBytes = tokenizableBefore.serialize(kryo)
-        val tokenizableAfter = serializedBytes.deserialize(kryo)
-        assertThat(tokenizableAfter).isSameAs(tokenizableBefore)
+        val context = serializeAsTokenContext(tokenizableBefore)
+        kryo.withSerializationContext(context) {
+            val serializedBytes = tokenizableBefore.serialize(kryo)
+            val tokenizableAfter = serializedBytes.deserialize(kryo)
+            assertThat(tokenizableAfter).isSameAs(tokenizableBefore)
+        }
     }
 
     @Test(expected = UnsupportedOperationException::class)
     fun `new token encountered after context init`() {
         val tokenizableBefore = UnitSerializeAsToken()
-        val context = SerializeAsTokenContext(emptyList<Any>(), storageKryo())
-        SerializeAsTokenSerializer.setContext(kryo, context)
-        tokenizableBefore.serialize(kryo)
+        val context = serializeAsTokenContext(emptyList<Any>())
+        kryo.withSerializationContext(context) {
+            tokenizableBefore.serialize(kryo)
+        }
     }
 
     @Test(expected = UnsupportedOperationException::class)
     fun `deserialize unregistered token`() {
         val tokenizableBefore = UnitSerializeAsToken()
-        val context = SerializeAsTokenContext(emptyList<Any>(), storageKryo())
-        SerializeAsTokenSerializer.setContext(kryo, context)
-        val serializedBytes = tokenizableBefore.toToken(SerializeAsTokenContext(emptyList<Any>(), storageKryo())).serialize(kryo)
-        serializedBytes.deserialize(kryo)
+        val context = serializeAsTokenContext(emptyList<Any>())
+        kryo.withSerializationContext(context) {
+            val serializedBytes = tokenizableBefore.toToken(serializeAsTokenContext(emptyList<Any>())).serialize(kryo)
+            serializedBytes.deserialize(kryo)
+        }
     }
 
     @Test(expected = KryoException::class)
@@ -85,15 +94,16 @@ class SerializationTokenTest {
     @Test(expected = KryoException::class)
     fun `deserialize non-token`() {
         val tokenizableBefore = UnitSerializeAsToken()
-        val context = SerializeAsTokenContext(tokenizableBefore, storageKryo())
-        SerializeAsTokenSerializer.setContext(kryo, context)
-        val stream = ByteArrayOutputStream()
-        Output(stream).use {
-            kryo.writeClass(it, SingletonSerializeAsToken::class.java)
-            kryo.writeObject(it, emptyList<Any>())
+        val context = serializeAsTokenContext(tokenizableBefore)
+        kryo.withSerializationContext(context) {
+            val stream = ByteArrayOutputStream()
+            Output(stream).use {
+                kryo.writeClass(it, SingletonSerializeAsToken::class.java)
+                kryo.writeObject(it, emptyList<Any>())
+            }
+            val serializedBytes = SerializedBytes<Any>(stream.toByteArray())
+            serializedBytes.deserialize(kryo)
         }
-        val serializedBytes = SerializedBytes<Any>(stream.toByteArray())
-        serializedBytes.deserialize(kryo)
     }
 
     private class WrongTypeSerializeAsToken : SerializeAsToken {
@@ -107,9 +117,10 @@ class SerializationTokenTest {
     @Test(expected = KryoException::class)
     fun `token returns unexpected type`() {
         val tokenizableBefore = WrongTypeSerializeAsToken()
-        val context = SerializeAsTokenContext(tokenizableBefore, storageKryo())
-        SerializeAsTokenSerializer.setContext(kryo, context)
-        val serializedBytes = tokenizableBefore.serialize(kryo)
-        serializedBytes.deserialize(kryo)
+        val context = serializeAsTokenContext(tokenizableBefore)
+        kryo.withSerializationContext(context) {
+            val serializedBytes = tokenizableBefore.serialize(kryo)
+            serializedBytes.deserialize(kryo)
+        }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/StorageServiceImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/StorageServiceImpl.kt
@@ -7,6 +7,8 @@ open class StorageServiceImpl(override val attachments: AttachmentStorage,
                               override val validatedTransactions: TransactionStorage,
                               override val stateMachineRecordedTransactionMapping: StateMachineRecordedTransactionMappingStorage)
     : SingletonSerializeAsToken(), TxWritableStorageService {
+    override val attachmentsClassLoaderEnabled = false
+
     lateinit override var uploaders: List<FileUploader>
 
     fun initUploaders(uploadersList: List<FileUploader>) {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -151,7 +151,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
     private val recentlyClosedSessions = ConcurrentHashMap<Long, Party>()
 
     // Context for tokenized services in checkpoints
-    private val serializationContext = SerializeAsTokenContext(tokenizableServices, quasarKryo())
+    private val serializationContext = SerializeAsTokenContext(tokenizableServices, quasarKryo(), serviceHub)
 
     /** Returns a list of all state machines executing the given flow logic at the top level (subflows do not count) */
     fun <P : FlowLogic<T>, T> findStateMachines(flowClass: Class<P>): List<Pair<P, ListenableFuture<T>>> {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -374,16 +374,18 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
     private fun serializeFiber(fiber: FlowStateMachineImpl<*>): SerializedBytes<FlowStateMachineImpl<*>> {
         return quasarKryo().run { kryo ->
             // add the map of tokens -> tokenizedServices to the kyro context
-            SerializeAsTokenSerializer.setContext(kryo, serializationContext)
-            fiber.serialize(kryo)
+            kryo.withSerializationContext(serializationContext) {
+                fiber.serialize(kryo)
+            }
         }
     }
 
     private fun deserializeFiber(checkpoint: Checkpoint): FlowStateMachineImpl<*> {
         return quasarKryo().run { kryo ->
             // put the map of token -> tokenized into the kryo context
-            SerializeAsTokenSerializer.setContext(kryo, serializationContext)
-            checkpoint.serializedFiber.deserialize(kryo).apply { fromCheckpoint = true }
+            kryo.withSerializationContext(serializationContext) {
+                checkpoint.serializedFiber.deserialize(kryo)
+            }.apply { fromCheckpoint = true }
         }
     }
 

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -173,7 +173,9 @@ class MockStorageService(override val attachments: AttachmentStorage = MockAttac
                          override val validatedTransactions: TransactionStorage = MockTransactionStorage(),
                          override val uploaders: List<FileUploader> = listOf<FileUploader>(),
                          override val stateMachineRecordedTransactionMapping: StateMachineRecordedTransactionMappingStorage = MockStateMachineRecordedTransactionMappingStorage())
-    : SingletonSerializeAsToken(), TxWritableStorageService
+    : SingletonSerializeAsToken(), TxWritableStorageService {
+    override val attachmentsClassLoaderEnabled = false
+}
 
 /**
  * Make properties appropriate for creating a DataSource for unit tests.


### PR DESCRIPTION
* The mechanism is currently under review in https://github.com/corda/corda/pull/543
* attachmentsClassLoaderEnabled is only ever true in the unit test, to preserve current behaviour
