### PR TITLE
Clean up X500 names in Corda simulation

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
@@ -659,6 +659,7 @@ object X509Utilities {
 }
 
 val X500Name.commonName: String get() = getRDNs(BCStyle.CN).first().first.value.toString()
+val X500Name.location: String get() = getRDNs(BCStyle.L).first().first.value.toString()
 
 class CertificateStream(val input: InputStream) {
     private val certificateFactory = CertificateFactory.getInstance("X.509")

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -20,11 +20,11 @@ val DUMMY_KEY_2: KeyPair by lazy { generateKeyPair() }
 
 val DUMMY_NOTARY_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(20)) }
 /** Dummy notary identity for tests and simulations */
-val DUMMY_NOTARY: Party get() = Party(X500Name("CN=Notary Service,O=R3,OU=corda,L=London,C=UK"), DUMMY_NOTARY_KEY.public)
+val DUMMY_NOTARY: Party get() = Party(X500Name("CN=Notary Service,O=R3,OU=corda,L=Zurich,C=CH"), DUMMY_NOTARY_KEY.public)
 
 val DUMMY_MAP_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(30)) }
 /** Dummy network map service identity for tests and simulations */
-val DUMMY_MAP: Party get() = Party(X500Name("CN=Network Map Service,O=R3,OU=corda,L=London,C=UK"), DUMMY_MAP_KEY.public)
+val DUMMY_MAP: Party get() = Party(X500Name("CN=Network Map Service,O=R3,OU=corda,L=Amsterdam,C=NL"), DUMMY_MAP_KEY.public)
 
 val DUMMY_BANK_A_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(40)) }
 /** Dummy bank identity for tests and simulations */
@@ -32,11 +32,11 @@ val DUMMY_BANK_A: Party get() = Party(X500Name("CN=Bank A,O=Bank A,L=London,C=UK
 
 val DUMMY_BANK_B_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(50)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_B: Party get() = Party(X500Name("CN=Bank B,O=Bank B,L=New York,C=USA"), DUMMY_BANK_B_KEY.public)
+val DUMMY_BANK_B: Party get() = Party(X500Name("CN=Bank B,O=Bank B,L=New York,C=US"), DUMMY_BANK_B_KEY.public)
 
 val DUMMY_BANK_C_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(60)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_C: Party get() = Party(X500Name("CN=Bank C,O=Bank C,L=Tokyo,C=Japan"), DUMMY_BANK_C_KEY.public)
+val DUMMY_BANK_C: Party get() = Party(X500Name("CN=Bank C,O=Bank C,L=Tokyo,C=JP"), DUMMY_BANK_C_KEY.public)
 
 val ALICE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(70)) }
 /** Dummy individual identity for tests and simulations */
@@ -49,3 +49,7 @@ val BOB: Party get() = Party(X500Name("CN=Bob Plc,O=Bob Plc,L=London,C=UK"), BOB
 val CHARLIE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(90)) }
 /** Dummy individual identity for tests and simulations */
 val CHARLIE: Party get() = Party(X500Name("CN=Charlie Ltd,O=Charlie Ltd,L=London,C=UK"), CHARLIE_KEY.public)
+
+val DUMMY_REGULATOR_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(100)) }
+/** Dummy regulator for tests and simulations */
+val DUMMY_REGULATOR: Party get() = Party(X500Name("CN=Regulator A,OU=Corda,O=AMF,L=Paris,C=FR"), DUMMY_REGULATOR_KEY.public)

--- a/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
@@ -1,6 +1,7 @@
 package net.corda.core.crypto
 
 import net.corda.core.div
+import net.corda.testing.MEGA_CORP
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.GeneralName
 import org.junit.Rule
@@ -30,7 +31,7 @@ class X509UtilitiesTest {
 
     @Test
     fun `create valid self-signed CA certificate`() {
-        val caCertAndKey = X509Utilities.createSelfSignedCACert("Test Cert")
+        val caCertAndKey = X509Utilities.createSelfSignedCACert(X500Name("CN=Test Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"))
         assertTrue { caCertAndKey.certificate.subjectDN.name.contains("CN=Test Cert") } // using our subject common name
         assertEquals(caCertAndKey.certificate.issuerDN, caCertAndKey.certificate.subjectDN) //self-signed
         caCertAndKey.certificate.checkValidity(Date()) // throws on verification problems
@@ -42,7 +43,7 @@ class X509UtilitiesTest {
     @Test
     fun `load and save a PEM file certificate`() {
         val tmpCertificateFile = tempFile("cacert.pem")
-        val caCertAndKey = X509Utilities.createSelfSignedCACert("Test Cert")
+        val caCertAndKey = X509Utilities.createSelfSignedCACert(X500Name("CN=Test Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"))
         X509Utilities.saveCertificateAsPEMFile(caCertAndKey.certificate, tmpCertificateFile)
         val readCertificate = X509Utilities.loadCertificateFromPEMFile(tmpCertificateFile)
         assertEquals(caCertAndKey.certificate, readCertificate)
@@ -50,8 +51,8 @@ class X509UtilitiesTest {
 
     @Test
     fun `create valid server certificate chain`() {
-        val caCertAndKey = X509Utilities.createSelfSignedCACert("Test CA Cert")
-        val subjectDN = X509Utilities.getDevX509Name("Server Cert")
+        val caCertAndKey = X509Utilities.createSelfSignedCACert(X500Name("CN=Test CA Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"))
+        val subjectDN = X500Name("CN=Server Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US")
         val keyPair = X509Utilities.generateECDSAKeyPairForSSL()
         val serverCert = X509Utilities.createServerCert(subjectDN, keyPair.public, caCertAndKey, listOf("alias name"), listOf("10.0.0.54"))
         assertTrue { serverCert.subjectDN.name.contains("CN=Server Cert") } // using our subject common name
@@ -138,7 +139,7 @@ class X509UtilitiesTest {
         val caCertAndKey = X509Utilities.loadCertificateAndKey(caKeyStore, "cakeypass", X509Utilities.CORDA_INTERMEDIATE_CA_PRIVATE_KEY)
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverkeypass", caKeyStore, "cakeypass", "Mega Corp.")
+        X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverkeypass", caKeyStore, "cakeypass", X500Name(MEGA_CORP.name))
 
         // Load back server certificate
         val serverKeyStore = X509Utilities.loadKeyStore(tmpServerKeyStore, "serverstorepass")
@@ -147,7 +148,7 @@ class X509UtilitiesTest {
         serverCertAndKey.certificate.checkValidity(Date())
         serverCertAndKey.certificate.verify(caCertAndKey.certificate.publicKey)
 
-        assertTrue { serverCertAndKey.certificate.subjectDN.name.contains("CN=Mega Corp.") }
+        assertTrue { serverCertAndKey.certificate.subjectDN.name.contains(X500Name(MEGA_CORP.name).commonName) }
 
         // Now sign something with private key and verify against certificate public key
         val testData = "123456".toByteArray()
@@ -175,7 +176,7 @@ class X509UtilitiesTest {
                 "trustpass")
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        val keyStore = X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverstorepass", caKeyStore, "cakeypass", "Mega Corp.")
+        val keyStore = X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverstorepass", caKeyStore, "cakeypass", X500Name(MEGA_CORP.name))
         val trustStore = X509Utilities.loadKeyStore(tmpTrustStore, "trustpass")
 
         val context = SSLContext.getInstance("TLS")
@@ -248,7 +249,7 @@ class X509UtilitiesTest {
         val peerChain = clientSocket.session.peerCertificates
         val peerX500Principal = (peerChain[0] as X509Certificate).subjectX500Principal
         val x500name = X500Name(peerX500Principal.name)
-        assertEquals("Mega Corp.", x500name.commonName)
+        assertEquals(X500Name(MEGA_CORP.name), x500name)
 
 
         val output = DataOutputStream(clientSocket.outputStream)

--- a/docs/source/creating-a-cordapp.rst
+++ b/docs/source/creating-a-cordapp.rst
@@ -216,7 +216,7 @@ is a three node example;
             cordapps []
         }
         node {
-            name "CN=NodeB,O=R3,OU=corda,L=New York,C=USA"
+            name "CN=NodeB,O=R3,OU=corda,L=New York,C=US"
             nearestCity "New York"
             advertisedServices = []
             p2pPort 10008

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -65,7 +65,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = ext.rpcUsers
     }
     node {
-        name "CN=Bank B,O=Bank B,L=New York,C=USA"
+        name "CN=Bank B,O=Bank B,L=New York,C=US"
         nearestCity "New York"
         advertisedServices = []
         p2pPort 10008

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -52,7 +52,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = []
     }
     node {
-        name "CN=BankOfCorda,O=R3,OU=corda,L=New York,C=USA"
+        name "CN=BankOfCorda,O=R3,OU=corda,L=New York,C=US"
         nearestCity "New York"
         advertisedServices = ["corda.issuer.USD"]
         p2pPort 10005

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -69,7 +69,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         useTestClock true
     }
     node {
-        name "CN=Bank B,O=Bank B,L=New York,C=USA"
+        name "CN=Bank B,O=Bank B,L=New York,C=US"
         nearestCity "New York"
         advertisedServices = []
         p2pPort 10008

--- a/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
@@ -2,6 +2,7 @@ package net.corda.simulation
 
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import net.corda.core.crypto.location
 import net.corda.core.flatMap
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.SingleMessageRecipient
@@ -12,6 +13,7 @@ import net.corda.core.node.services.containsType
 import net.corda.core.then
 import net.corda.core.utilities.DUMMY_MAP
 import net.corda.core.utilities.DUMMY_NOTARY
+import net.corda.core.utilities.DUMMY_REGULATOR
 import net.corda.core.utilities.ProgressTracker
 import net.corda.irs.api.NodeInterestRates
 import net.corda.node.services.config.NodeConfiguration
@@ -24,6 +26,7 @@ import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.TestClock
 import net.corda.testing.node.setTo
+import org.bouncycastle.asn1.x500.X500Name
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.math.BigInteger
@@ -47,7 +50,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             throw IllegalArgumentException("The latency injector is only useful when using manual pumping.")
     }
 
-    val bankLocations = listOf("London", "Frankfurt", "Rome")
+    val bankLocations = listOf(Pair("London", "UK"), Pair("Frankfurt", "DE"), Pair("Rome", "IT"))
 
     // This puts together a mock network of SimulatedNodes.
 
@@ -65,12 +68,11 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
                             advertisedServices: Set<ServiceInfo>, id: Int, overrideServices: Map<ServiceInfo, KeyPair>?,
                             entropyRoot: BigInteger): MockNetwork.MockNode {
             val letter = 'A' + counter
-            val city = bankLocations[counter++ % bankLocations.size]
+            val (city, country) = bankLocations[counter++ % bankLocations.size]
 
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
-                    // TODO: Set this back to "Bank of $city" after video day.
-                    myLegalName = "CN=Bank $letter,O=Bank $letter,L=city",
+                    myLegalName = "CN=Bank $letter,O=Bank $letter,L=$city,C=$country",
                     nearestCity = city,
                     networkMapService = null)
             return SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot)
@@ -94,7 +96,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
                     myLegalName = DUMMY_MAP.name,
-                    nearestCity = "Amsterdam",
+                    nearestCity = X500Name(DUMMY_MAP.name).location,
                     networkMapService = null)
             return object : SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot) {}
         }
@@ -108,22 +110,24 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
                     myLegalName = DUMMY_NOTARY.name,
-                    nearestCity = "Zurich",
+                    nearestCity = X500Name(DUMMY_NOTARY.name).location,
                     networkMapService = null)
             return SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot)
         }
     }
 
     object RatesOracleFactory : MockNetwork.Factory {
+        // TODO: Make a more realistic legal name
+        val RATES_SERVICE_NAME = "CN=Rates Service Provider,O=R3,OU=corda,L=Madrid,C=ES"
+
         override fun create(config: NodeConfiguration, network: MockNetwork, networkMapAddr: SingleMessageRecipient?,
                             advertisedServices: Set<ServiceInfo>, id: Int, overrideServices: Map<ServiceInfo, KeyPair>?,
                             entropyRoot: BigInteger): MockNetwork.MockNode {
             require(advertisedServices.containsType(NodeInterestRates.type))
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
-                    // TODO: Make a more realistic legal name
-                    myLegalName = "CN=Rates Service Provider,O=R3,OU=corda,L=Madrid,C=ES",
-                    nearestCity = "Madrid",
+                    myLegalName = RATES_SERVICE_NAME,
+                    nearestCity = X500Name(RATES_SERVICE_NAME).location,
                     networkMapService = null)
             return object : SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot) {
                 override fun start(): MockNetwork.MockNode {
@@ -145,9 +149,8 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
                             entropyRoot: BigInteger): MockNetwork.MockNode {
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
-                    // TODO: Make a more realistic legal name
-                    myLegalName = "CN=Regulator A,O=R3,OU=corda,L=Paris,C=FR",
-                    nearestCity = "Paris",
+                    myLegalName = DUMMY_REGULATOR.name,
+                    nearestCity = X500Name(DUMMY_REGULATOR.name).location,
                     networkMapService = null)
             return object : SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot) {
                 // TODO: Regulatory nodes don't actually exist properly, this is a last minute demo request.

--- a/samples/irs-demo/src/main/resources/example-irs-trade.json
+++ b/samples/irs-demo/src/main/resources/example-irs-trade.json
@@ -22,7 +22,7 @@
     "interestPeriodAdjustment": "Adjusted"
   },
   "floatingLeg": {
-    "floatingRatePayer": "CN=Bank B,O=Bank B,L=New York,C=USA",
+    "floatingRatePayer": "CN=Bank B,O=Bank B,L=New York,C=US",
     "notional": "€25000000",
     "paymentFrequency": "Quarterly",
     "effectiveDate": "2016-03-11",

--- a/samples/irs-demo/src/main/resources/irsweb/js/viewmodel/FloatingLeg.js
+++ b/samples/irs-demo/src/main/resources/irsweb/js/viewmodel/FloatingLeg.js
@@ -2,7 +2,7 @@
 
 define(['utils/dayCountBasisLookup'], (dayCountBasisLookup) => {
     return {
-        floatingRatePayer: "CN=Bank B,O=Bank B,L=New York,C=USA",
+        floatingRatePayer: "CN=Bank B,O=Bank B,L=New York,C=US",
         notional: {
            quantity: 2500000000
         },

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -75,7 +75,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = []
     }
     node {
-        name "CN=Bank B,O=Bank B,L=New York,C=USA"
+        name "CN=Bank B,O=Bank B,L=New York,C=US"
         nearestCity "New York"
         advertisedServices = []
         p2pPort 10006

--- a/samples/simm-valuation-demo/src/main/resources/simmvaluationweb/app/viewmodel/FloatingLegViewModel.js
+++ b/samples/simm-valuation-demo/src/main/resources/simmvaluationweb/app/viewmodel/FloatingLegViewModel.js
@@ -1,7 +1,7 @@
 "use strict";
 var FloatingLegViewModel = (function () {
     function FloatingLegViewModel() {
-        this.floatingRatePayer = "CN=Bank B,O=Bank B,L=New York,C=USA";
+        this.floatingRatePayer = "CN=Bank B,O=Bank B,L=New York,C=US";
         this.notional = {
             quantity: 2500000000
         };

--- a/samples/simm-valuation-demo/src/main/web/src/app/viewmodel/FloatingLegViewModel.ts
+++ b/samples/simm-valuation-demo/src/main/web/src/app/viewmodel/FloatingLegViewModel.ts
@@ -1,7 +1,7 @@
 export class FloatingLegViewModel {
   constructor() { }
 
-  floatingRatePayer = "CN=Bank B,O=Bank B,L=New York,C=USA";
+  floatingRatePayer = "CN=Bank B,O=Bank B,L=New York,C=US";
   notional: Object = {
      quantity: 2500000000
   };

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -76,7 +76,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = ext.rpcUsers
     }
     node {
-        name "CN=Bank B,O=Bank B,L=New York,C=USA"
+        name "CN=Bank B,O=Bank B,L=New York,C=US"
         nearestCity "New York"
         advertisedServices = []
         p2pPort 10008
@@ -85,7 +85,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = ext.rpcUsers
     }
     node {
-        name "CN=BankOfCorda,O=R3,OU=corda,L=New York,C=USA"
+        name "CN=BankOfCorda,O=R3,OU=corda,L=New York,C=US"
         nearestCity "London"
         advertisedServices = []
         p2pPort 10011

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -74,7 +74,7 @@ val MINI_CORP: Party get() = Party(X509Utilities.getDevX509Name("MiniCorp"), MIN
 
 val BOC_KEY: KeyPair by lazy { generateKeyPair() }
 val BOC_PUBKEY: PublicKey get() = BOC_KEY.public
-val BOC: Party get() = Party(X500Name("CN=BankOfCorda,O=R3,OU=corda,L=New York,C=USA"), BOC_PUBKEY)
+val BOC: Party get() = Party(X500Name("CN=BankOfCorda,O=R3,OU=corda,L=New York,C=US"), BOC_PUBKEY)
 val BOC_PARTY_REF = BOC.ref(OpaqueBytes.of(1)).reference
 
 val BIG_CORP_KEY: KeyPair by lazy { generateKeyPair() }

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -1,5 +1,8 @@
 package net.corda.demobench.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.google.common.net.HostAndPort
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
@@ -11,6 +14,7 @@ import net.corda.nodeapi.User
 import net.corda.nodeapi.config.parseAs
 import net.corda.webserver.WebServerConfig
 import org.junit.Test
+import java.io.StringWriter
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.assertEquals
@@ -114,6 +118,19 @@ class NodeConfigTest {
         assertFalse(config.isCashIssuer)
     }
 
+    /**
+     * Reformat JSON via Jackson to ensure a consistent format for comparison purposes.
+     */
+    private fun prettyPrint(content: String): String {
+        val mapper = ObjectMapper()
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        mapper.enable(SerializationFeature.INDENT_OUTPUT)
+        val sw = StringWriter()
+        val parsed = mapper.readTree(content)
+        mapper.writeValue(sw, parsed)
+        return sw.toString()
+    }
+
     @Test
     fun `test config text`() {
         val config = createConfig(
@@ -126,10 +143,10 @@ class NodeConfigTest {
                 services = listOf("my.service"),
                 users = listOf(user("jenny"))
         )
-        assertEquals("{"
+        assertEquals(prettyPrint("{"
                 + "\"extraAdvertisedServiceIds\":[\"my.service\"],"
                 + "\"h2port\":30001,"
-                + "\"myLegalName\":\"MyName\","
+                + "\"myLegalName\":\"My Name\","
                 + "\"nearestCity\":\"Stockholm\","
                 + "\"p2pAddress\":\"localhost:10001\","
                 + "\"rpcAddress\":\"localhost:40002\","
@@ -138,7 +155,7 @@ class NodeConfigTest {
                 + "],"
                 + "\"useTestClock\":true,"
                 + "\"webAddress\":\"localhost:20001\""
-                + "}", config.toText().stripWhitespace())
+                + "}"), prettyPrint(config.toText()))
     }
 
     @Test
@@ -155,12 +172,12 @@ class NodeConfigTest {
         )
         config.networkMap = NetworkMapConfig(DUMMY_NOTARY.name, 12345)
 
-        assertEquals("{"
+        assertEquals(prettyPrint("{"
                 + "\"extraAdvertisedServiceIds\":[\"my.service\"],"
                 + "\"h2port\":30001,"
-                + "\"myLegalName\":\"MyName\","
+                + "\"myLegalName\":\"My Name\","
                 + "\"nearestCity\":\"Stockholm\","
-                + "\"networkMapService\":{\"address\":\"localhost:12345\",\"legalName\":\"CN=NotaryService,O=R3,OU=corda,L=London,C=UK\"},"
+                + "\"networkMapService\":{\"address\":\"localhost:12345\",\"legalName\":\"CN=Notary Service,O=R3,OU=corda,L=Zurich,C=CH\"},"
                 + "\"p2pAddress\":\"localhost:10001\","
                 + "\"rpcAddress\":\"localhost:40002\","
                 + "\"rpcUsers\":["
@@ -168,7 +185,7 @@ class NodeConfigTest {
                 + "],"
                 + "\"useTestClock\":true,"
                 + "\"webAddress\":\"localhost:20001\""
-                + "}", config.toText().stripWhitespace())
+                + "}"), prettyPrint(config.toText()))
     }
 
     @Test

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
@@ -177,7 +177,7 @@ fun main(args: Array<String>) {
         val issuerGBP = startNode(X500Name("CN=UK Bank Plc,O=UK Bank Plc,L=London,C=UK"), rpcUsers = arrayListOf(manager),
                 advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.GBP"))),
                 customOverrides = mapOf("nearestCity" to "London"))
-        val issuerUSD = startNode(X500Name("CN=USA Bank Corp,O=USA Bank Corp,L=New York,C=USA"), rpcUsers = arrayListOf(manager),
+        val issuerUSD = startNode(X500Name("CN=USA Bank Corp,O=USA Bank Corp,L=New York,C=US"), rpcUsers = arrayListOf(manager),
                 advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.USD"))),
                 customOverrides = mapOf("nearestCity" to "New York"))
 


### PR DESCRIPTION
Clean up X500 names in Corda simulation, and ensure they're consistent with the standard test names. This includes using the locations present in those test names, which requires updates to the node config test.