### PR TITLE
Fix deserialisation check for JDK on all platforms.

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -34,6 +34,7 @@ task buildCordaJAR(type: FatCapsule) {
         appClassPath = ["jolokia-agent-war-${project.rootProject.ext.jolokia_version}.war"]
         javaAgents = ["quasar-core-${quasar_version}-jdk8.jar"]
         systemProperties['visualvm.display.name'] = 'Corda'
+        systemProperties['jdk.serialFilter'] = 'maxbytes=0'
         minJavaVersion = '1.8.0'
         minUpdateVersion['1.8'] = java8_minUpdateVersion
         caplets = ['CordaCaplet']

--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -181,9 +181,9 @@ Corda will now exit...""")
 }
 
 private fun disableJavaDeserialization() {
-    // ObjectInputFilter and friends are in java.io in Java 9 but sun.misc in backports, so we use the system property interface for portability:
-    System.setProperty("jdk.serialFilter", "maxbytes=0")
-    // Attempt a deserialization so that ObjectInputFilter (permanently) inits itself:
+    // ObjectInputFilter and friends are in java.io in Java 9 but sun.misc in backports, so we are using the system property interface for portability.
+    // This property has been set in the Capsule. Anywhere else may be too late.
+    // Attempt at deserialization so that ObjectInputFilter (permanently) inits itself:
     val data = ByteArrayOutputStream().apply { ObjectOutputStream(this).use { it.writeObject(object : Serializable {}) } }.toByteArray()
     try {
         withLevel("java.io.serialization", "WARN") {
@@ -191,7 +191,7 @@ private fun disableJavaDeserialization() {
         }
         javaIsTooOld()
     } catch (e: InvalidClassException) {
-        // Good, our system property is honoured (assuming ObjectInputFilter wasn't inited earlier).
+        // Good, our system property is honoured.
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -573,10 +573,11 @@ class DriverDSL(
                 // Write node.conf
                 writeConfig(nodeConf.baseDirectory, "node.conf", config)
 
-                val systemProperties = mapOf(
+                val systemProperties = overriddenSystemProperties + mapOf(
                         "name" to nodeConf.myLegalName,
-                        "visualvm.display.name" to "corda-${nodeConf.myLegalName}"
-                ) + overriddenSystemProperties
+                        "visualvm.display.name" to "corda-${nodeConf.myLegalName}",
+                        "jdk.serialFilter" to "maxbytes=0"  // disable deserialisation
+                )
                 val extraJvmArguments = systemProperties.map { "-D${it.key}=${it.value}" } +
                         "-javaagent:$quasarJarPath"
                 val loggingLevel = if (debugPort == null) "INFO" else "DEBUG"


### PR DESCRIPTION
We need to set the jdk.serialFilter system property in the Capsule, as anywhere else may be too late. E.g. for the JVM on Windows.