### PR TITLE
Introduce utility changes for X.500 names

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/config/ConfigUtilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/config/ConfigUtilities.kt
@@ -4,6 +4,7 @@ import com.google.common.net.HostAndPort
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigUtil
 import net.corda.core.noneOrSingle
+import org.bouncycastle.asn1.x500.X500Name
 import org.slf4j.LoggerFactory
 import java.net.Proxy
 import java.net.URL
@@ -70,6 +71,7 @@ private fun Config.getSingleValue(path: String, type: KType): Any? {
         Path::class -> Paths.get(getString(path))
         URL::class -> URL(getString(path))
         Properties::class -> getConfig(path).toProperties()
+        X500Name::class -> X500Name(getString(path))
         else -> if (typeClass.java.isEnum) {
             parseEnum(typeClass.java, getString(path))
         } else {

--- a/node/src/integration-test/kotlin/net/corda/node/driver/DriverTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/driver/DriverTests.kt
@@ -8,6 +8,7 @@ import net.corda.core.node.services.ServiceInfo
 import net.corda.core.readLines
 import net.corda.core.utilities.DUMMY_BANK_A
 import net.corda.core.utilities.DUMMY_NOTARY
+import net.corda.core.utilities.DUMMY_REGULATOR
 import net.corda.node.LOGS_DIRECTORY_NAME
 import net.corda.node.services.api.RegulatorService
 import net.corda.node.services.transactions.SimpleNotaryService
@@ -42,7 +43,7 @@ class DriverTests {
     fun `simple node startup and shutdown`() {
         val handles = driver {
             val notary = startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type)))
-            val regulator = startNode("CN=Regulator,O=R3,OU=corda,L=London,C=UK", setOf(ServiceInfo(RegulatorService.type)))
+            val regulator = startNode(DUMMY_REGULATOR.name, setOf(ServiceInfo(RegulatorService.type)))
             listOf(nodeMustBeUp(notary), nodeMustBeUp(regulator))
         }
         handles.map { nodeMustBeDown(it) }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -437,7 +437,9 @@ private class VerifyingNettyConnector(configuration: MutableMap<String, Any>?,
                                       protocolManager: ClientProtocolManager?) :
         NettyConnector(configuration, handler, listener, closeExecutor, threadPool, scheduledThreadPool, protocolManager) {
     private val server = configuration?.get(ArtemisMessagingServer::class.java.name) as? ArtemisMessagingServer
-    private val expectedCommonName = configuration?.get(ArtemisTcpTransport.VERIFY_PEER_COMMON_NAME) as? String
+    private val expectedCommonName = (configuration?.get(ArtemisTcpTransport.VERIFY_PEER_COMMON_NAME) as? String)?.let {
+        X500Name(it)
+    }?.commonName
 
     override fun createConnection(): Connection? {
         val connection = super.createConnection() as NettyConnection?

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RPCDispatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RPCDispatcher.kt
@@ -184,9 +184,15 @@ abstract class RPCDispatcher(val ops: RPCOps, val userService: RPCUserService, v
         val rpcUser = userService.getUser(validatedUser)
         if (rpcUser != null) {
             return rpcUser
-        } else if (X500Name(validatedUser).commonName == nodeLegalName) {
-            return nodeUser
         } else {
+            try {
+                if (X500Name(validatedUser) == X500Name(nodeLegalName)) {
+                    return nodeUser
+                }
+            } catch(ex: IllegalArgumentException) {
+                // Can't parse the validated user as an X500 name, so can't match the node legal name.
+                // Fall through to exception below.
+            }
             throw IllegalArgumentException("Validated user '$validatedUser' is not an RPC user nor the NODE user")
         }
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -162,7 +162,7 @@ data class TestNodeConfiguration(
         override val keyStorePassword: String = "cordacadevpass",
         override val trustStorePassword: String = "trustpass",
         override val rpcUsers: List<User> = emptyList(),
-        override val dataSourceProperties: Properties = makeTestDataSourceProperties(myLegalName),
+        override val dataSourceProperties: Properties = makeTestDataSourceProperties(X500Name(myLegalName)),
         override val nearestCity: String = "Null Island",
         override val emailAddress: String = "",
         override val exportJMXto: String = "",
@@ -181,7 +181,7 @@ fun testConfiguration(baseDirectory: Path, legalName: String, basePort: Int): Fu
             emailAddress = "",
             keyStorePassword = "cordacadevpass",
             trustStorePassword = "trustpass",
-            dataSourceProperties = makeTestDataSourceProperties(legalName),
+            dataSourceProperties = makeTestDataSourceProperties(X500Name(legalName)),
             certificateSigningService = URL("http://localhost"),
             rpcUsers = emptyList(),
             verifierType = VerifierType.InMemory,
@@ -198,7 +198,7 @@ fun testConfiguration(baseDirectory: Path, legalName: String, basePort: Int): Fu
 }
 
 @JvmOverloads
-fun configureTestSSL(legalName: String = "Mega Corp."): SSLConfiguration = object : SSLConfiguration {
+fun configureTestSSL(legalName: String = MEGA_CORP.name): SSLConfiguration = object : SSLConfiguration {
     override val certificatesDirectory = Files.createTempDirectory("certs")
     override val keyStorePassword: String get() = "cordacadevpass"
     override val trustStorePassword: String get() = "trustpass"

--- a/test-utils/src/main/kotlin/net/corda/testing/messaging/SimpleMQClient.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/messaging/SimpleMQClient.kt
@@ -7,12 +7,16 @@ import net.corda.nodeapi.ConnectionDirection
 import net.corda.nodeapi.config.SSLConfiguration
 import net.corda.testing.configureTestSSL
 import org.apache.activemq.artemis.api.core.client.*
+import org.bouncycastle.asn1.x500.X500Name
 
 /**
  * As the name suggests this is a simple client for connecting to MQ brokers.
  */
 class SimpleMQClient(val target: HostAndPort,
-                     override val config: SSLConfiguration? = configureTestSSL("SimpleMQClient")) : ArtemisMessagingComponent() {
+                     override val config: SSLConfiguration? = configureTestSSL(DEFAULT_MQ_LEGAL_NAME)) : ArtemisMessagingComponent() {
+    companion object {
+        val DEFAULT_MQ_LEGAL_NAME = "SimpleMQClient"
+    }
     lateinit var sessionFactory: ClientSessionFactory
     lateinit var session: ClientSession
     lateinit var producer: ClientProducer

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -35,6 +35,7 @@ import net.corda.node.utilities.AffinityExecutor.ServiceAffinityExecutor
 import net.corda.testing.MOCK_VERSION_INFO
 import net.corda.testing.TestNodeConfiguration
 import org.apache.activemq.artemis.utils.ReusableLatch
+import org.bouncycastle.asn1.x500.X500Name
 import org.slf4j.Logger
 import java.math.BigInteger
 import java.nio.file.FileSystem
@@ -158,7 +159,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
                     id,
                     serverThread,
                     makeServiceEntries(),
-                    configuration.myLegalName,
+                    configuration.myLegalName.toString(),
                     database)
                     .start()
                     .getOrThrow()
@@ -287,9 +288,9 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
 
         val config = TestNodeConfiguration(
                 baseDirectory = path,
-                myLegalName = legalName ?: "Mock Company $id",
+                myLegalName = legalName ?: "CN=Mock Company $id,OU=Corda QA Department,O=R3 CEV,L=New York,C=US",
                 networkMapService = null,
-                dataSourceProperties = makeTestDataSourceProperties("node_${id}_net_$networkId"))
+                dataSourceProperties = makeTestDataSourceProperties(X500Name("CN=node_${id}_net_$networkId,OU=Corda QA Department,O=R3 CEV,L=New York,C=US")))
         val node = nodeFactory.create(config, this, networkMapAddress, advertisedServices.toSet(), id, overrideServices, entropyRoot)
         if (start) {
             node.setup().start()

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -179,7 +179,7 @@ class MockStorageService(override val attachments: AttachmentStorage = MockAttac
  *
  * @param nodeName Reflects the "instance" of the in-memory database.  Defaults to a random string.
  */
-fun makeTestDataSourceProperties(nodeName: String = SecureHash.randomSHA256().toString()): Properties {
+fun makeTestDataSourceProperties(nodeName: X500Name = X509Utilities.getDevX509Name(SecureHash.randomSHA256().toString())): Properties {
     val props = Properties()
     props.setProperty("dataSourceClassName", "org.h2.jdbcx.JdbcDataSource")
     props.setProperty("dataSource.url", "jdbc:h2:mem:${nodeName}_persistence;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE")


### PR DESCRIPTION
Infrastructure changes ahead of using X.500 distinguished names for all party names, to reduce the number of places where we convert to/from strings, as well as correcting display of names.