### PR TITLE
Customise the error message according to why Corda cannot boot.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -169,14 +169,13 @@ private fun assertCanNormalizeEmptyPath() {
     try {
         Paths.get("").normalize()
     } catch (e: ArrayIndexOutOfBoundsException) {
-        javaIsTooOld()
+        failStartUp("You are using a version of Java that is not supported (${System.getProperty("java.version")}). Please upgrade to the latest version.")
     }
 }
 
-private fun javaIsTooOld(): Nothing {
-    println("""
-You are using a version of Java that is not supported (${System.getProperty("java.version")}). Please upgrade to the latest version.
-Corda will now exit...""")
+private fun failStartUp(message: String): Nothing {
+    println(message)
+    println("Corda will now exit...")
     exitProcess(1)
 }
 
@@ -189,7 +188,8 @@ private fun disableJavaDeserialization() {
         withLevel("java.io.serialization", "WARN") {
             ObjectInputStream(data.inputStream()).use { it.readObject() } // Logs REJECTED at INFO, which we don't want users to see.
         }
-        javaIsTooOld()
+        // JDK 8u121 is the earliest JDK8 JVM that supports this functionality.
+        failStartUp("Corda forbids Java deserialisation. Please upgrade to at least JDK 8u121 and set system property 'jdk.serialFilter' to 'maxbytes=0' when booting Corda.")
     } catch (e: InvalidClassException) {
         // Good, our system property is honoured.
     }

--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -181,7 +181,8 @@ private fun failStartUp(message: String): Nothing {
 
 private fun disableJavaDeserialization() {
     // ObjectInputFilter and friends are in java.io in Java 9 but sun.misc in backports, so we are using the system property interface for portability.
-    // This property has been set in the Capsule. Anywhere else may be too late.
+    // This property has already been set in the Capsule. Anywhere else may be too late, but we'll repeat it here for developers.
+    System.setProperty("jdk.serialFilter", "maxbytes=0")
     // Attempt at deserialization so that ObjectInputFilter (permanently) inits itself:
     val data = ByteArrayOutputStream().apply { ObjectOutputStream(this).use { it.writeObject(object : Serializable {}) } }.toByteArray()
     try {

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -575,8 +575,7 @@ class DriverDSL(
 
                 val systemProperties = overriddenSystemProperties + mapOf(
                         "name" to nodeConf.myLegalName,
-                        "visualvm.display.name" to "corda-${nodeConf.myLegalName}",
-                        "jdk.serialFilter" to "maxbytes=0"  // disable deserialisation
+                        "visualvm.display.name" to "corda-${nodeConf.myLegalName}"
                 )
                 val extraJvmArguments = systemProperties.map { "-D${it.key}=${it.value}" } +
                         "-javaagent:$quasarJarPath"


### PR DESCRIPTION
Give the user more useful information when Corda refuses to boot.