### PR TITLE
Clean up X.500 names in X509UtilitiesTest

### DIFF
--- a/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
@@ -1,6 +1,7 @@
 package net.corda.core.crypto
 
 import net.corda.core.div
+import net.corda.testing.MEGA_CORP
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.GeneralName
 import org.junit.Rule
@@ -30,7 +31,7 @@ class X509UtilitiesTest {
 
     @Test
     fun `create valid self-signed CA certificate`() {
-        val caCertAndKey = X509Utilities.createSelfSignedCACert("Test Cert")
+        val caCertAndKey = X509Utilities.createSelfSignedCACert(X500Name("CN=Test Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"))
         assertTrue { caCertAndKey.certificate.subjectDN.name.contains("CN=Test Cert") } // using our subject common name
         assertEquals(caCertAndKey.certificate.issuerDN, caCertAndKey.certificate.subjectDN) //self-signed
         caCertAndKey.certificate.checkValidity(Date()) // throws on verification problems
@@ -42,7 +43,7 @@ class X509UtilitiesTest {
     @Test
     fun `load and save a PEM file certificate`() {
         val tmpCertificateFile = tempFile("cacert.pem")
-        val caCertAndKey = X509Utilities.createSelfSignedCACert("Test Cert")
+        val caCertAndKey = X509Utilities.createSelfSignedCACert(X500Name("CN=Test Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"))
         X509Utilities.saveCertificateAsPEMFile(caCertAndKey.certificate, tmpCertificateFile)
         val readCertificate = X509Utilities.loadCertificateFromPEMFile(tmpCertificateFile)
         assertEquals(caCertAndKey.certificate, readCertificate)
@@ -50,8 +51,8 @@ class X509UtilitiesTest {
 
     @Test
     fun `create valid server certificate chain`() {
-        val caCertAndKey = X509Utilities.createSelfSignedCACert("Test CA Cert")
-        val subjectDN = X509Utilities.getDevX509Name("Server Cert")
+        val caCertAndKey = X509Utilities.createSelfSignedCACert(X500Name("CN=Test CA Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US"))
+        val subjectDN = X500Name("CN=Server Cert,OU=Corda QA Department,O=R3 CEV,L=New York,C=US")
         val keyPair = X509Utilities.generateECDSAKeyPairForSSL()
         val serverCert = X509Utilities.createServerCert(subjectDN, keyPair.public, caCertAndKey, listOf("alias name"), listOf("10.0.0.54"))
         assertTrue { serverCert.subjectDN.name.contains("CN=Server Cert") } // using our subject common name
@@ -138,7 +139,7 @@ class X509UtilitiesTest {
         val caCertAndKey = X509Utilities.loadCertificateAndKey(caKeyStore, "cakeypass", X509Utilities.CORDA_INTERMEDIATE_CA_PRIVATE_KEY)
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverkeypass", caKeyStore, "cakeypass", "Mega Corp.")
+        X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverkeypass", caKeyStore, "cakeypass", X500Name(MEGA_CORP.name))
 
         // Load back server certificate
         val serverKeyStore = X509Utilities.loadKeyStore(tmpServerKeyStore, "serverstorepass")
@@ -147,7 +148,7 @@ class X509UtilitiesTest {
         serverCertAndKey.certificate.checkValidity(Date())
         serverCertAndKey.certificate.verify(caCertAndKey.certificate.publicKey)
 
-        assertTrue { serverCertAndKey.certificate.subjectDN.name.contains("CN=Mega Corp.") }
+        assertTrue { serverCertAndKey.certificate.subjectDN.name.contains(X500Name(MEGA_CORP.name).commonName) }
 
         // Now sign something with private key and verify against certificate public key
         val testData = "123456".toByteArray()
@@ -175,7 +176,7 @@ class X509UtilitiesTest {
                 "trustpass")
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        val keyStore = X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverstorepass", caKeyStore, "cakeypass", "Mega Corp.")
+        val keyStore = X509Utilities.createKeystoreForSSL(tmpServerKeyStore, "serverstorepass", "serverstorepass", caKeyStore, "cakeypass", X500Name(MEGA_CORP.name))
         val trustStore = X509Utilities.loadKeyStore(tmpTrustStore, "trustpass")
 
         val context = SSLContext.getInstance("TLS")
@@ -248,7 +249,7 @@ class X509UtilitiesTest {
         val peerChain = clientSocket.session.peerCertificates
         val peerX500Principal = (peerChain[0] as X509Certificate).subjectX500Principal
         val x500name = X500Name(peerX500Principal.name)
-        assertEquals("Mega Corp.", x500name.commonName)
+        assertEquals(X500Name(MEGA_CORP.name), x500name)
 
 
         val output = DataOutputStream(clientSocket.outputStream)


### PR DESCRIPTION
Expand string names in X509UtilitiesTest into full X500 names, so it's clearer what the final name will be. Also use the standard MEGA_CORP identity rather than making up our own.
