### PR TITLE
Apply @Suspendable on all flow methods that call vault generateSpend

### DIFF
--- a/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
+++ b/finance/src/main/java/net/corda/contracts/JavaCommercialPaper.java
@@ -1,5 +1,6 @@
 package net.corda.contracts;
 
+import co.paralleluniverse.fibers.*;
 import com.google.common.collect.*;
 import kotlin.*;
 import net.corda.contracts.asset.*;
@@ -311,6 +312,7 @@ public class JavaCommercialPaper implements Contract {
         return generateIssue(issuance, faceValue, maturityDate, notary, null);
     }
 
+    @Suspendable
     public void generateRedeem(TransactionBuilder tx, StateAndRef<State> paper, VaultService vault) throws InsufficientBalanceException {
         vault.generateSpend(tx, StructuresKt.withoutIssuer(paper.getState().getData().getFaceValue()), paper.getState().getData().getOwner(), null);
         tx.addInputState(paper);

--- a/finance/src/main/kotlin/net/corda/contracts/CommercialPaper.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/CommercialPaper.kt
@@ -1,5 +1,6 @@
 package net.corda.contracts
 
+import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.asset.sumCashBy
 import net.corda.contracts.clause.AbstractIssue
 import net.corda.core.contracts.*
@@ -214,6 +215,7 @@ class CommercialPaper : Contract {
      * @throws InsufficientBalanceException if the vault doesn't contain enough money to pay the redeemer.
      */
     @Throws(InsufficientBalanceException::class)
+    @Suspendable
     fun generateRedeem(tx: TransactionBuilder, paper: StateAndRef<State>, vault: VaultService) {
         // Add the cash movement using the states in our vault.
         val amount = paper.state.data.faceValue.let { amount -> Amount(amount.quantity, amount.token.product) }

--- a/finance/src/main/kotlin/net/corda/contracts/CommercialPaperLegacy.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/CommercialPaperLegacy.kt
@@ -1,5 +1,6 @@
 package net.corda.contracts
 
+import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.asset.sumCashBy
 import net.corda.core.contracts.*
 import net.corda.core.crypto.NullPublicKey
@@ -124,6 +125,7 @@ class CommercialPaperLegacy : Contract {
     }
 
     @Throws(InsufficientBalanceException::class)
+    @Suspendable
     fun generateRedeem(tx: TransactionBuilder, paper: StateAndRef<State>, vault: VaultService) {
         // Add the cash movement using the states in our vault.
         vault.generateSpend(tx, paper.state.data.faceValue.withoutIssuer(), paper.state.data.owner)

--- a/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
@@ -209,6 +209,7 @@ object TwoPartyTradeFlow {
             return ptx.toSignedTransaction(checkSufficientSignatures = false)
         }
 
+        @Suspendable
         private fun assembleSharedTX(tradeRequest: SellerTradeInfo): Pair<TransactionBuilder, List<PublicKey>> {
             val ptx = TransactionType.General.Builder(notary)
 


### PR DESCRIPTION
This is a general Quasar requirement which surfaced as a bug in the `TwoPartyTradeFlow` whereby the `Buyer` call flow was calling a private method `assembleSharedTX` (non-annotated with @Suspendable) which in turn was calling the vault `generateSpend` @Suspendable annotated method.
This PR ensures all callers to `generateSpend` are also annotated with @Suspendable.

The manifestation of this error caused the following unhelpful exception:
**Caught exception from flow
// java.lang.IllegalStateException: No transaction in context.**

