### PR TITLE
Fix downloading attachments from WebServer.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -10,6 +10,7 @@ import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.*
 import net.corda.core.transactions.TransactionBuilder
 import java.io.FileNotFoundException
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.security.PublicKey
@@ -517,7 +518,7 @@ abstract class AbstractAttachment(dataLoader: () -> ByteArray) : Attachment {
     override fun toString() = "${javaClass.simpleName}(id=$id)"
 }
 
-@Throws(FileNotFoundException::class)
+@Throws(IOException::class)
 fun JarInputStream.extractFile(path: String, outputTo: OutputStream) {
     val p = path.toLowerCase().split('\\', '/')
     while (true) {

--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -496,20 +496,7 @@ interface Attachment : NamedByHash {
      *
      * @throws FileNotFoundException if the given path doesn't exist in the attachment.
      */
-    fun extractFile(path: String, outputTo: OutputStream) {
-        val p = path.toLowerCase().split('\\', '/')
-        openAsJAR().use { jar ->
-            while (true) {
-                val e = jar.nextJarEntry ?: break
-                if (e.name.toLowerCase().split('\\', '/') == p) {
-                    jar.copyTo(outputTo)
-                    return
-                }
-                jar.closeEntry()
-            }
-        }
-        throw FileNotFoundException(path)
-    }
+    fun extractFile(path: String, outputTo: OutputStream) = openAsJAR().use { it.extractFile(path, outputTo) }
 }
 
 abstract class AbstractAttachment(dataLoader: () -> ByteArray) : Attachment {
@@ -528,4 +515,18 @@ abstract class AbstractAttachment(dataLoader: () -> ByteArray) : Attachment {
     override fun equals(other: Any?) = other === this || other is Attachment && other.id == this.id
     override fun hashCode() = id.hashCode()
     override fun toString() = "${javaClass.simpleName}(id=$id)"
+}
+
+@Throws(FileNotFoundException::class)
+fun JarInputStream.extractFile(path: String, outputTo: OutputStream) {
+    val p = path.toLowerCase().split('\\', '/')
+    while (true) {
+        val e = nextJarEntry ?: break
+        if (!e.isDirectory && e.name.toLowerCase().split('\\', '/') == p) {
+            copyTo(outputTo)
+            return
+        }
+        closeEntry()
+    }
+    throw FileNotFoundException(path)
 }

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -70,6 +70,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         advertisedServices = []
         p2pPort 10008
         rpcPort 10009
+        webPort 10010
         cordapps = []
         rpcUsers = ext.rpcUsers
     }

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -120,7 +120,7 @@ fun recipient(rpc: CordaRPCOps) {
 
                 // Write out the entries inside this jar.
                 println("Attachment JAR contains these entries:")
-                JarInputStream(connection.inputStream, true).use { it ->
+                JarInputStream(connection.inputStream).use { it ->
                     while (true) {
                         val e = it.nextJarEntry ?: break
                         println("Entry> ${e.name}")

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
@@ -67,7 +67,7 @@ class AttachmentDownloadServlet : HttpServlet() {
         val p = path.toLowerCase().split('\\', '/')
         while (true) {
             val e = nextJarEntry ?: break
-            if (e.name.toLowerCase().split('\\', '/') == p) {
+            if (!e.isDirectory && e.name.toLowerCase().split('\\', '/') == p) {
                 copyTo(outputTo)
                 return
             }

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
@@ -1,11 +1,11 @@
 package net.corda.webserver.servlets
 
+import net.corda.core.contracts.extractFile
 import net.corda.core.crypto.SecureHash
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.loggerFor
 import java.io.FileNotFoundException
 import java.io.IOException
-import java.io.OutputStream
 import java.util.jar.JarInputStream
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
@@ -51,9 +51,7 @@ class AttachmentDownloadServlet : HttpServlet() {
                 } else {
                     val filename = subPath.split('/').last()
                     resp.addHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$filename\"")
-                    JarInputStream(attachment).use { jar ->
-                        jar.extractFile(subPath, out)
-                    }
+                    JarInputStream(attachment).use { it.extractFile(subPath, out) }
                 }
             }
         } catch(e: FileNotFoundException) {
@@ -61,18 +59,5 @@ class AttachmentDownloadServlet : HttpServlet() {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND)
             return
         }
-    }
-
-    private fun JarInputStream.extractFile(path: String, outputTo: OutputStream) {
-        val p = path.toLowerCase().split('\\', '/')
-        while (true) {
-            val e = nextJarEntry ?: break
-            if (!e.isDirectory && e.name.toLowerCase().split('\\', '/') == p) {
-                copyTo(outputTo)
-                return
-            }
-            closeEntry()
-        }
-        throw FileNotFoundException(path)
     }
 }

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
@@ -1,12 +1,17 @@
 package net.corda.webserver.servlets
 
 import net.corda.core.crypto.SecureHash
-import net.corda.core.node.services.StorageService
+import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.loggerFor
 import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.OutputStream
+import java.util.jar.JarInputStream
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.HttpHeaders
+import javax.ws.rs.core.MediaType
 
 /**
  * Allows the node administrator to either download full attachment zips, or individual files within those zips.
@@ -17,11 +22,12 @@ import javax.servlet.http.HttpServletResponse
  * Files are always forced to be downloads, they may not be embedded into web pages for security reasons.
  *
  * TODO: See if there's a way to prevent access by JavaScript.
- * TODO: Provide an endpoint that exposes attachment file listings, to make attachments browseable.
+ * TODO: Provide an endpoint that exposes attachment file listings, to make attachments browsable.
  */
 class AttachmentDownloadServlet : HttpServlet() {
     private val log = loggerFor<AttachmentDownloadServlet>()
 
+    @Throws(IOException::class)
     override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
         val reqPath = req.pathInfo?.substring(1)
         if (reqPath == null) {
@@ -31,26 +37,42 @@ class AttachmentDownloadServlet : HttpServlet() {
 
         try {
             val hash = SecureHash.parse(reqPath.substringBefore('/'))
-            val storage = servletContext.getAttribute("storage") as StorageService
-            val attachment = storage.attachments.openAttachment(hash) ?: throw FileNotFoundException()
+            val rpc = servletContext.getAttribute("rpc") as CordaRPCOps
+            val attachment = rpc.openAttachment(hash)
 
             // Don't allow case sensitive matches inside the jar, it'd just be confusing.
             val subPath = reqPath.substringAfter('/', missingDelimiterValue = "").toLowerCase()
 
-            resp.contentType = "application/octet-stream"
-            if (subPath == "") {
-                resp.addHeader("Content-Disposition", "attachment; filename=\"$hash.zip\"")
-                attachment.open().use { it.copyTo(resp.outputStream) }
-            } else {
-                val filename = subPath.split('/').last()
-                resp.addHeader("Content-Disposition", "attachment; filename=\"$filename\"")
-                attachment.extractFile(subPath, resp.outputStream)
+            resp.contentType = MediaType.APPLICATION_OCTET_STREAM
+            resp.outputStream.use { out ->
+                if (subPath.isEmpty()) {
+                    resp.addHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$hash.zip\"")
+                    attachment.use { it.copyTo(out) }
+                } else {
+                    val filename = subPath.split('/').last()
+                    resp.addHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$filename\"")
+                    JarInputStream(attachment, true).use { jar ->
+                        jar.extractFile(subPath, out)
+                    }
+                }
             }
-            resp.outputStream.close()
         } catch(e: FileNotFoundException) {
             log.warn("404 Not Found whilst trying to handle attachment download request for ${servletContext.contextPath}/$reqPath")
             resp.sendError(HttpServletResponse.SC_NOT_FOUND)
             return
         }
+    }
+
+    private fun JarInputStream.extractFile(path: String, outputTo: OutputStream) {
+        val p = path.toLowerCase().split('\\', '/')
+        while (true) {
+            val e = nextJarEntry ?: break
+            if (e.name.toLowerCase().split('\\', '/') == p) {
+                copyTo(outputTo)
+                return
+            }
+            closeEntry()
+        }
+        throw FileNotFoundException(path)
     }
 }

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/AttachmentDownloadServlet.kt
@@ -51,7 +51,7 @@ class AttachmentDownloadServlet : HttpServlet() {
                 } else {
                     val filename = subPath.split('/').last()
                     resp.addHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$filename\"")
-                    JarInputStream(attachment, true).use { jar ->
+                    JarInputStream(attachment).use { jar ->
                         jar.extractFile(subPath, out)
                     }
                 }

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/CorDappInfoServlet.kt
@@ -6,6 +6,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.CordaPluginRegistry
 import org.glassfish.jersey.server.model.Resource
 import org.glassfish.jersey.server.model.ResourceMethod
+import java.io.IOException
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -16,6 +17,7 @@ import javax.servlet.http.HttpServletResponse
  */
 class CorDappInfoServlet(val plugins: List<CordaPluginRegistry>, val rpc: CordaRPCOps): HttpServlet() {
 
+    @Throws(IOException::class)
     override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
         resp.writer.appendHTML().html {
             head {

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/DataUploadServlet.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/DataUploadServlet.kt
@@ -3,6 +3,7 @@ package net.corda.webserver.servlets
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.loggerFor
 import org.apache.commons.fileupload.servlet.ServletFileUpload
+import java.io.IOException
 import java.util.*
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
@@ -14,6 +15,7 @@ import javax.servlet.http.HttpServletResponse
 class DataUploadServlet : HttpServlet() {
     private val log = loggerFor<DataUploadServlet>()
 
+    @Throws(IOException::class)
     override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
         @Suppress("DEPRECATION") // Bogus warning due to superclass static method being deprecated.
         val isMultipart = ServletFileUpload.isMultipartContent(req)

--- a/webserver/src/main/kotlin/net/corda/webserver/servlets/ResponseFilter.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/servlets/ResponseFilter.kt
@@ -1,5 +1,6 @@
 package net.corda.webserver.servlets
 
+import java.io.IOException
 import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.ContainerResponseContext
 import javax.ws.rs.container.ContainerResponseFilter
@@ -10,6 +11,7 @@ import javax.ws.rs.ext.Provider
  */
 @Provider
 class ResponseFilter : ContainerResponseFilter {
+    @Throws(IOException::class)
     override fun filter(requestContext: ContainerRequestContext, responseContext: ContainerResponseContext) {
         val headers = responseContext.headers
 


### PR DESCRIPTION
The /attachments HTTP endpoint on the WebServer needs to use `CordaRPCOps` instead of `StorageService`. Update `attachment-demo` to test this functionality as well.