### PR TITLE
Fixes for Network Visualiser

### DIFF
--- a/core/src/main/resources/net/corda/core/node/cities.txt
+++ b/core/src/main/resources/net/corda/core/node/cities.txt
@@ -997,3 +997,6 @@ Bristol (GB)	-2.57	51.45
 Yokosuka (JP)	139.67	35.28
 Akola (IN)	77	20.72
 Belgaum (IN)	74.5	15.87
+# These have been added back by hand
+Cairo (EG)	31.25	30.06
+Zurich (CH)	8.55	47.36

--- a/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/simulation/Simulation.kt
@@ -2,7 +2,6 @@ package net.corda.simulation
 
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import net.corda.core.crypto.X509Utilities
 import net.corda.core.flatMap
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.SingleMessageRecipient
@@ -123,7 +122,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
                     // TODO: Make a more realistic legal name
-                    myLegalName = "CN=Rates Service Provider,O=R3,OU=corda,L=London,C=UK",
+                    myLegalName = "CN=Rates Service Provider,O=R3,OU=corda,L=Madrid,C=ES",
                     nearestCity = "Madrid",
                     networkMapService = null)
             return object : SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot) {
@@ -147,7 +146,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             val cfg = TestNodeConfiguration(
                     baseDirectory = config.baseDirectory,
                     // TODO: Make a more realistic legal name
-                    myLegalName = "Regulator A,O=R3,OU=corda,L=London,C=UK",
+                    myLegalName = "CN=Regulator A,O=R3,OU=corda,L=Paris,C=FR",
                     nearestCity = "Paris",
                     networkMapService = null)
             return object : SimulatedNode(cfg, network, networkMapAddr, advertisedServices, id, overrideServices, entropyRoot) {

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/VisualiserViewModel.kt
@@ -7,9 +7,12 @@ import javafx.scene.layout.StackPane
 import javafx.scene.shape.Circle
 import javafx.scene.shape.Line
 import javafx.util.Duration
+import net.corda.core.crypto.commonName
 import net.corda.core.utilities.ProgressTracker
+import net.corda.node.services.config.NodeConfiguration
 import net.corda.simulation.IRSSimulation
 import net.corda.testing.node.MockNetwork
+import org.bouncycastle.asn1.x500.X500Name
 import java.util.*
 
 class VisualiserViewModel {
@@ -114,13 +117,13 @@ class VisualiserViewModel {
         bankCount = simulation.banks.size
         serviceCount = simulation.serviceProviders.size + simulation.regulators.size
         for ((index, bank) in simulation.banks.withIndex()) {
-            nodesToWidgets[bank] = makeNodeWidget(bank, "bank", bank.configuration.myLegalName, NetworkMapVisualiser.NodeType.BANK, index)
+            nodesToWidgets[bank] = makeNodeWidget(bank, "bank", bank.configuration.displayName, NetworkMapVisualiser.NodeType.BANK, index)
         }
         for ((index, service) in simulation.serviceProviders.withIndex()) {
-            nodesToWidgets[service] = makeNodeWidget(service, "network-service", service.configuration.myLegalName, NetworkMapVisualiser.NodeType.SERVICE, index)
+            nodesToWidgets[service] = makeNodeWidget(service, "network-service", service.configuration.displayName, NetworkMapVisualiser.NodeType.SERVICE, index)
         }
         for ((index, service) in simulation.regulators.withIndex()) {
-            nodesToWidgets[service] = makeNodeWidget(service, "regulator", service.configuration.myLegalName, NetworkMapVisualiser.NodeType.SERVICE, index + simulation.serviceProviders.size)
+            nodesToWidgets[service] = makeNodeWidget(service, "regulator", service.configuration.displayName, NetworkMapVisualiser.NodeType.SERVICE, index + simulation.serviceProviders.size)
         }
     }
 
@@ -218,4 +221,10 @@ class VisualiserViewModel {
         view.root.children.add(bullet)
     }
 
+}
+
+private val NodeConfiguration.displayName: String get() = try {
+    X500Name(myLegalName).commonName
+} catch(ex: IllegalArgumentException) {
+    myLegalName
 }


### PR DESCRIPTION
* Restore missing cities to cities.txt.
* Only display the common name for each node, not the full X500 name.