### PR TITLE
Remove scheduler service from ServiceHub

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -39,7 +39,6 @@ interface ServiceHub : ServicesForResolution {
     val keyManagementService: KeyManagementService
     override val storageService: StorageService
     val networkMapCache: NetworkMapCache
-    val schedulerService: SchedulerService
     val transactionVerifierService: TransactionVerifierService
     val clock: Clock
     val myInfo: NodeInfo

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -364,28 +364,6 @@ interface TxWritableStorageService : StorageService {
 }
 
 /**
- * Provides access to schedule activity at some point in time.  This interface might well be expanded to
- * increase the feature set in the future.
- *
- * If the point in time is in the past, the expectation is that the activity will happen shortly after it is scheduled.
- *
- * The main consumer initially is an observer of the vault to schedule activities based on transactions as they are
- * recorded.
- */
-interface SchedulerService {
-    /**
-     * Schedule a new activity for a TX output, probably because it was just produced.
-     *
-     * Only one activity can be scheduled for a particular [StateRef] at any one time.  Scheduling a [ScheduledStateRef]
-     * replaces any previously scheduled [ScheduledStateRef] for any one [StateRef].
-     */
-    fun scheduleStateActivity(action: ScheduledStateRef)
-
-    /** Unschedule all activity for a TX output, probably because it was consumed. */
-    fun unscheduleStateActivity(ref: StateRef)
-}
-
-/**
  * Provides verification service. The implementation may be a simple in-memory verify() call or perhaps an IPC/RPC.
  */
 interface TransactionVerifierService {

--- a/node/src/main/kotlin/net/corda/node/services/api/SchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/SchedulerService.kt
@@ -1,0 +1,26 @@
+package net.corda.node.services.api
+
+import net.corda.core.contracts.ScheduledStateRef
+import net.corda.core.contracts.StateRef
+
+/**
+ * Provides access to schedule activity at some point in time.  This interface might well be expanded to
+ * increase the feature set in the future.
+ *
+ * If the point in time is in the past, the expectation is that the activity will happen shortly after it is scheduled.
+ *
+ * The main consumer initially is an observer of the vault to schedule activities based on transactions as they are
+ * recorded.
+ */
+interface SchedulerService {
+    /**
+     * Schedule a new activity for a TX output, probably because it was just produced.
+     *
+     * Only one activity can be scheduled for a particular [StateRef] at any one time.  Scheduling a [ScheduledStateRef]
+     * replaces any previously scheduled [ScheduledStateRef] for any one [StateRef].
+     */
+    fun scheduleStateActivity(action: ScheduledStateRef)
+
+    /** Unschedule all activity for a TX output, probably because it was consumed. */
+    fun unscheduleStateActivity(ref: StateRef)
+}

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -65,6 +65,7 @@ abstract class ServiceHubInternal : PluginServiceHub {
     abstract val flowLogicRefFactory: FlowLogicRefFactory
     abstract val schemaService: SchemaService
     abstract override val networkMapCache: NetworkMapCacheInternal
+    abstract val schedulerService: SchedulerService
 
     abstract val networkService: MessagingService
 

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -10,15 +10,14 @@ import net.corda.core.contracts.StateRef
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRefFactory
-import net.corda.core.node.services.SchedulerService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.trace
+import net.corda.node.services.api.SchedulerService
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.utilities.*
 import org.apache.activemq.artemis.utils.ReusableLatch
-import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.statements.InsertStatement
 import java.time.Instant

--- a/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
@@ -11,10 +11,7 @@ import net.corda.core.node.services.*
 import net.corda.core.transactions.SignedTransaction
 import net.corda.node.internal.ServiceFlowInfo
 import net.corda.node.serialization.NodeClock
-import net.corda.node.services.api.MonitoringService
-import net.corda.node.services.api.NetworkMapCacheInternal
-import net.corda.node.services.api.SchemaService
-import net.corda.node.services.api.ServiceHubInternal
+import net.corda.node.services.api.*
 import net.corda.node.services.messaging.MessagingService
 import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.services.statemachine.StateMachineManager

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -59,7 +59,6 @@ open class MockServices(val key: KeyPair = generateKeyPair()) : ServiceHub {
     override val vaultService: VaultService get() = throw UnsupportedOperationException()
     override val networkMapCache: NetworkMapCache get() = throw UnsupportedOperationException()
     override val clock: Clock get() = Clock.systemUTC()
-    override val schedulerService: SchedulerService get() = throw UnsupportedOperationException()
     override val myInfo: NodeInfo get() = NodeInfo(object : SingleMessageRecipient {}, Party(MEGA_CORP.name, key.public), MOCK_VERSION_INFO.platformVersion)
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
 


### PR DESCRIPTION
The scheduler service is an internal component of the node machinery. It should not be directly visible on the ServiceHub, because flows should record SchedulableState items to the vault and they will automatically be run.