### PR TITLE
Include log4j2.xml into application jars only.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,10 +97,6 @@ allprojects {
 
     // Use manual resource copying of log4j2.xml rather than source sets.
     // This prevents problems in IntelliJ with regard to duplicate source roots.
-    processResources {
-        from file("$rootDir/config/dev/log4j2.xml")
-    }
-
     processTestResources {
         from file("$rootDir/config/test/log4j2.xml")
     }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -40,6 +40,12 @@ sourceSets {
     }
 }
 
+// Use manual resource copying of log4j2.xml rather than source sets.
+// This prevents problems in IntelliJ with regard to duplicate source roots.
+processResources {
+    from file("$rootDir/config/dev/log4j2.xml")
+}
+
 // To find potential version conflicts, run "gradle htmlDependencyReport" and then look in
 // build/reports/project/dependencies/index.html for green highlighted parts of the tree.
 

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -26,7 +26,12 @@ dependencies {
 task buildCordaJAR(type: FatCapsule) {
     applicationClass 'net.corda.node.Corda'
     archiveName "corda-${corda_release_version}.jar"
-    applicationSource = files(project.tasks.findByName('jar'), '../build/classes/main/CordaCaplet.class', '../build/classes/main/CordaCaplet$1.class', 'config/dev/log4j2.xml')
+    applicationSource = files(
+            project.tasks.findByName('jar'),
+            '../build/classes/main/CordaCaplet.class',
+            '../build/classes/main/CordaCaplet$1.class',
+            "$rootDir/config/dev/log4j2.xml"
+    )
     from 'NOTICE' // Copy CDDL notice
 
     capsuleManifest {

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -12,6 +12,12 @@ apply plugin: 'application'
 sourceCompatibility = 1.8
 mainClassName = 'net.corda.explorer.Main'
 
+// Use manual resource copying of log4j2.xml rather than source sets.
+// This prevents problems in IntelliJ with regard to duplicate source roots.
+processResources {
+    from file("$rootDir/config/dev/log4j2.xml")
+}
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -20,6 +20,12 @@ sourceSets {
     }
 }
 
+// Use manual resource copying of log4j2.xml rather than source sets.
+// This prevents problems in IntelliJ with regard to duplicate source roots.
+processResources {
+    from file("$rootDir/config/dev/log4j2.xml")
+}
+
 dependencies {
     compile project(":node-api")
 

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -20,6 +20,7 @@ sourceSets {
 }
 
 processResources {
+    from file("$rootDir/config/dev/log4j2.xml")
     from file("$rootDir/config/dev/jolokia-access.xml")
 }
 

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -30,7 +30,7 @@ task buildWebserverJar(type: FatCapsule) {
             project.tasks.findByName('jar'),
             new File(project(':node').rootDir, 'node/build/classes/main/CordaCaplet.class'),
             new File(project(':node').rootDir, 'node/build/classes/main/CordaCaplet$1.class'),
-            'config/dev/log4j2.xml'
+            "$rootDir/config/dev/log4j2.xml"
     )
     from 'NOTICE' // Copy CDDL notice
 


### PR DESCRIPTION
An application (e.g. DemoBench) may have its own `log4j2.xml`, but Log4J will use the first `log4j2.xml` file that it finds on the classpath. And so we do not want every Corda library jar to contain a copy of Node's `log4j2.xml`.
Technically, Node Explorer and Verifier should have their own `log4j2.xml` files and not use Node's.

This fixes #633.