### PR TITLE
Move keyPairFromEntropy to Crypto.kt

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -1,9 +1,8 @@
 package net.corda.core.crypto
 
 import net.corda.core.random63BitValue
-import net.i2p.crypto.eddsa.EdDSAEngine
-import net.i2p.crypto.eddsa.EdDSAKey
-import net.i2p.crypto.eddsa.EdDSASecurityProvider
+import net.i2p.crypto.eddsa.*
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable
 import org.bouncycastle.asn1.ASN1EncodableVector
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
@@ -18,6 +17,8 @@ import org.bouncycastle.cert.bc.BcX509ExtensionUtils
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.jcajce.provider.util.AsymmetricKeyInfoConverter
+import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
+import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.interfaces.ECKey
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -28,6 +29,8 @@ import org.bouncycastle.pqc.jcajce.spec.SPHINCS256KeyGenParameterSpec
 import java.math.BigInteger
 import java.security.*
 import java.security.cert.X509Certificate
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
@@ -509,6 +512,44 @@ object Crypto {
         else
             keyPairGenerator.initialize(signatureScheme.keySize, newSecureRandom())
         return keyPairGenerator.generateKeyPair()
+    }
+
+    /**
+     * Generate a [KeyPair] using the default signature scheme.
+     * @return a new [KeyPair].
+     */
+    fun generateKeyPair(): KeyPair = generateKeyPair(DEFAULT_SIGNATURE_SCHEME)
+
+    /**
+     * Returns a key pair derived from the given [BigInteger] entropy. This is useful for unit tests
+     * and other cases where you want hard-coded private keys.
+     * Currently, [EDDSA_ED25519_SHA512] is the sole scheme supported for this operation.
+     * @param signatureScheme a supported [SignatureScheme], see [Crypto].
+     * @param entropy a [BigInteger] value.
+     * @return a new [KeyPair] from an entropy input.
+     * @throws IllegalArgumentException if the requested signature scheme is not supported for KeyPair generation using an entropy input.
+     */
+    fun generateKeyPairFromEntropy(signatureScheme: SignatureScheme, entropy: BigInteger): KeyPair {
+        when (signatureScheme) {
+            EDDSA_ED25519_SHA512 -> return generateEdDSAKeyPairFromEntropy(entropy)
+        }
+        throw IllegalArgumentException("Unsupported signature scheme for fixed entropy-based key pair generation: $signatureScheme.schemeCodeName")
+    }
+    
+    /**
+     * Returns a [DEFAULT_SIGNATURE_SCHEME] key pair derived from the given [BigInteger] entropy.
+     * @param entropy a [BigInteger] value.
+     * @return a new [KeyPair] from an entropy input.
+     */
+    fun generateKeyPairFromEntropy(entropy: BigInteger): KeyPair = generateKeyPairFromEntropy(DEFAULT_SIGNATURE_SCHEME, entropy)
+
+    // custom key pair generator from entropy.
+    private fun generateEdDSAKeyPairFromEntropy(entropy: BigInteger): KeyPair {
+        val params = EDDSA_ED25519_SHA512.algSpec as EdDSANamedCurveSpec
+        val bytes = entropy.toByteArray().copyOf(params.curve.field.getb() / 8) // need to pad the entropy to the valid seed length.
+        val priv = EdDSAPrivateKeySpec(bytes, params)
+        val pub = EdDSAPublicKeySpec(priv.a, params)
+        return KeyPair(EdDSAPublicKey(pub), EdDSAPrivateKey(priv))
     }
 
     /** Check if the requested signature scheme is supported by the system. */

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -4,6 +4,8 @@ import net.corda.core.random63BitValue
 import net.i2p.crypto.eddsa.*
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable
+import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
+import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import org.bouncycastle.asn1.ASN1EncodableVector
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import org.bouncycastle.asn1.DERSequence
@@ -17,8 +19,6 @@ import org.bouncycastle.cert.bc.BcX509ExtensionUtils
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.jcajce.provider.util.AsymmetricKeyInfoConverter
-import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
-import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.interfaces.ECKey
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -28,9 +28,9 @@ import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
 import org.bouncycastle.pqc.jcajce.spec.SPHINCS256KeyGenParameterSpec
 import java.math.BigInteger
 import java.security.*
-import java.security.cert.X509Certificate
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
+import java.security.cert.X509Certificate
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
@@ -515,12 +515,6 @@ object Crypto {
     }
 
     /**
-     * Generate a [KeyPair] using the default signature scheme.
-     * @return a new [KeyPair].
-     */
-    fun generateKeyPair(): KeyPair = generateKeyPair(DEFAULT_SIGNATURE_SCHEME)
-
-    /**
      * Returns a key pair derived from the given [BigInteger] entropy. This is useful for unit tests
      * and other cases where you want hard-coded private keys.
      * Currently, [EDDSA_ED25519_SHA512] is the sole scheme supported for this operation.
@@ -535,7 +529,7 @@ object Crypto {
         }
         throw IllegalArgumentException("Unsupported signature scheme for fixed entropy-based key pair generation: $signatureScheme.schemeCodeName")
     }
-    
+
     /**
      * Returns a [DEFAULT_SIGNATURE_SCHEME] key pair derived from the given [BigInteger] entropy.
      * @param entropy a [BigInteger] value.

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -4,11 +4,7 @@ package net.corda.core.crypto
 
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.OpaqueBytes
-import net.i2p.crypto.eddsa.EdDSAPrivateKey
 import net.i2p.crypto.eddsa.EdDSAPublicKey
-import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable
-import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
-import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import java.math.BigInteger
 import java.security.*
 
@@ -148,16 +144,9 @@ fun generateKeyPair(): KeyPair = Crypto.generateKeyPair()
 /**
  * Returns a key pair derived from the given private key entropy. This is useful for unit tests and other cases where
  * you want hard-coded private keys.
- * This currently works for EdDSA ED25519 only.
+ * This currently works for the default signature scheme EdDSA ed25519 only.
  */
-fun entropyToKeyPair(entropy: BigInteger): KeyPair {
-    val params = EdDSANamedCurveTable.getByName("ED25519")
-    val bytes = entropy.toByteArray().copyOf(params.curve.field.getb() / 8)
-    val priv = EdDSAPrivateKeySpec(bytes, params)
-    val pub = EdDSAPublicKeySpec(priv.a, params)
-    val keyPair = KeyPair(EdDSAPublicKey(pub), EdDSAPrivateKey(priv))
-    return keyPair
-}
+fun entropyToKeyPair(entropy: BigInteger): KeyPair = Crypto.generateKeyPairFromEntropy(entropy)
 
 /**
  * Helper function for signing.


### PR DESCRIPTION
Move the implementation of entropyToKeyPair from CryptoUtils to Crypto, as per convention and for security reasons, all important cryptographic operations/calculations should be done inside Crypto.
Currently EdDSA is the sole algorithm supported, as we need more sophisticated deterministic key generation algorithms per case.