### PR TITLE
Set java.io.tmpdir to Gradle's build directory for tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,11 @@ allprojects {
         }
     }
 
+    tasks.withType(Test) {
+        // Prevent the project from creating temporary files outside of the build directory.
+        systemProperties['java.io.tmpdir'] = buildDir
+    }
+
     group 'net.corda'
     version "$corda_release_version"
 

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -614,7 +614,8 @@ class DriverDSL(
 
                 val systemProperties = overriddenSystemProperties + mapOf(
                         "name" to nodeConf.myLegalName,
-                        "visualvm.display.name" to "corda-${nodeConf.myLegalName}"
+                        "visualvm.display.name" to "corda-${nodeConf.myLegalName}",
+                        "java.io.tmpdir" to System.getProperty("java.io.tmpdir") // Inherit from parent process
                 )
                 val extraJvmArguments = systemProperties.map { "-D${it.key}=${it.value}" } +
                         "-javaagent:$quasarJarPath"
@@ -646,7 +647,10 @@ class DriverDSL(
                         className = className, // cannot directly get class for this, so just use string
                         arguments = listOf("--base-directory", handle.configuration.baseDirectory.toString()),
                         jdwpPort = debugPort,
-                        extraJvmArguments = listOf("-Dname=node-${handle.configuration.p2pAddress}-webserver"),
+                        extraJvmArguments = listOf(
+                            "-Dname=node-${handle.configuration.p2pAddress}-webserver",
+                            "-Djava.io.tmpdir=${System.getProperty("java.io.tmpdir")}" // Inherit from parent process
+                        ),
                         errorLogPath = Paths.get("error.$className.log")
                 )
             }.flatMap { process -> addressMustBeBound(executorService, handle.webAddress, process).map { process } }


### PR DESCRIPTION
Prevent the unit and integration tests from creating files outside of Gradle's $buildDir.