### PR TITLE
Generic PublicKey.toStringShort()

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -110,12 +110,8 @@ fun PublicKey.isValid(content: ByteArray, signature: DigitalSignature) : Boolean
     return Crypto.isValid(this, signature.bytes, content)
 }
 
-/** Render a public key to a string, using a short form if it's an elliptic curve public key */
-fun PublicKey.toStringShort(): String {
-    return (this as? EdDSAPublicKey)?.let { key ->
-        "DL" + key.abyte.toBase58()   // DL -> Distributed Ledger
-    } ?: toString()
-}
+/** Render a public key to its hash (in Base58) of its serialised form using the DL prefix. */
+fun PublicKey.toStringShort(): String  = "DL" + this.toSHA256Bytes().toBase58()
 
 val PublicKey.keys: Set<PublicKey> get() {
     return if (this is CompositeKey) this.leafKeys

--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -65,3 +65,4 @@ fun String.hexToBase64(): String = hexToByteArray().toBase64()
 //       structure, e.g. mapping a PublicKey to a condition with the specific feature (ED25519).
 fun parsePublicKeyBase58(base58String: String): PublicKey = base58String.base58ToByteArray().deserialize<PublicKey>()
 fun PublicKey.toBase58String(): String = this.serialize().bytes.toBase58()
+fun PublicKey.toSHA256Bytes(): ByteArray = this.serialize().bytes.sha256().bytes

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -417,6 +417,7 @@ object PrivateKeySerializer : Serializer<PrivateKey>() {
 @ThreadSafe
 object PublicKeySerializer : Serializer<PublicKey>() {
     override fun write(kryo: Kryo, output: Output, obj: PublicKey) {
+        // TODO: Instead of encoding to the default X509 format, we could have a custom per key type (space-efficient) serialiser.
         output.writeBytesWithLength(obj.encoded)
     }
 

--- a/experimental/src/main/kotlin/net/corda/contracts/universal/PrettyPrint.kt
+++ b/experimental/src/main/kotlin/net/corda/contracts/universal/PrettyPrint.kt
@@ -2,6 +2,7 @@ package net.corda.contracts.universal
 
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.commonName
+import net.corda.core.crypto.toStringShort
 import java.math.BigDecimal
 import java.security.PublicKey
 import java.time.Instant
@@ -65,7 +66,7 @@ private class PrettyPrint(arr : Arrangement) {
 
     init {
         parties.forEach {
-            println( "val ${createPartyName(it)} = Party(\"${it.name.commonName}\", \"${it.owningKey}\")" )
+            println( "val ${createPartyName(it)} = Party(\"${it.name.commonName}\", \"${it.owningKey.toStringShort()}\")" )
         }
     }
 

--- a/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/NotaryDemo.kt
+++ b/samples/raft-notary-demo/src/main/kotlin/net/corda/notarydemo/NotaryDemo.kt
@@ -59,7 +59,7 @@ private class NotaryDemoClientApi(val rpc: CordaRPCOps) {
             "Tx [${tx.tx.id.prefixChars()}..] signed by $signer"
         }.joinToString("\n")
 
-        println("Notary: \"${notary.name}\", with composite key: ${notary.owningKey}\n" +
+        println("Notary: \"${notary.name}\", with composite key: ${notary.owningKey.toStringShort()}\n" +
                 "Notarised ${transactions.size} transactions:\n" + transactionSigners)
     }
 


### PR DESCRIPTION
Addressing the [PublicKey friendly print](https://github.com/corda/corda/issues/621) issue, by using `PublicKey.toStringShort()` when possible.
The new scheme agnostic format for the short string is the key's hash (in Base58) of its serialised form using the DL prefix: `PublicKey.toStringShort(): String  = "DL" + this.toSHA256Bytes().toBase58()`