### PR TITLE
Expand X509Utilities

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TransactionType
 import net.corda.core.crypto.Party
+import net.corda.core.crypto.appendToCommonName
 import net.corda.core.crypto.commonName
 import net.corda.core.div
 import net.corda.core.getOrThrow
@@ -21,8 +22,6 @@ import net.corda.node.utilities.ServiceIdentityGenerator
 import net.corda.node.utilities.transaction
 import net.corda.testing.node.NodeBasedTest
 import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.asn1.x500.X500NameBuilder
-import org.bouncycastle.asn1.x500.style.BCStyle
 import org.junit.Test
 import java.security.KeyPair
 import java.util.*
@@ -34,15 +33,7 @@ class BFTNotaryServiceTests : NodeBasedTest() {
         val notaryCommonName = X500Name("CN=BFT Notary Server,O=R3,OU=corda,L=Zurich,C=CH")
 
         fun buildNodeName(it: Int, notaryName: X500Name): X500Name {
-            val builder = X500NameBuilder()
-            notaryName.rdNs.map { it.first }.forEach { attr ->
-                if (attr.type == BCStyle.CN) {
-                    builder.addRDN(BCStyle.CN, "${attr.value}-$it")
-                } else {
-                    builder.addRDN(attr)
-                }
-            }
-            return builder.build()
+            return notaryName.appendToCommonName("-$it")
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -10,6 +10,7 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.*
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.X509Utilities
+import net.corda.core.crypto.appendToCommonName
 import net.corda.core.crypto.commonName
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
@@ -30,8 +31,6 @@ import net.corda.nodeapi.config.parseAs
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.asn1.x500.X500NameBuilder
-import org.bouncycastle.asn1.x500.style.BCStyle
 import org.slf4j.Logger
 import java.io.File
 import java.net.*
@@ -503,16 +502,7 @@ class DriverDSL(
             verifierType: VerifierType,
             rpcUsers: List<User>
     ): ListenableFuture<Pair<Party, List<NodeHandle>>> {
-        val nodeNames = (1..clusterSize).map {
-            val nameBuilder = X500NameBuilder(BCStyle.INSTANCE)
-            nameBuilder.addRDN(BCStyle.CN, "${DUMMY_NOTARY.name.commonName} $it")
-            DUMMY_NOTARY.name.rdNs.forEach { rdn ->
-                if (rdn.first.type != BCStyle.CN) {
-                    nameBuilder.addRDN(rdn.first)
-                }
-            }
-            nameBuilder.build()
-        }
+        val nodeNames = (1..clusterSize).map { DUMMY_NOTARY.name.appendToCommonName(it.toString()) }
         val paths = nodeNames.map { driverDirectory / it.commonName }
         ServiceIdentityGenerator.generateToDisk(paths, type.id, notaryName)
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -11,6 +11,7 @@ import net.corda.core.contracts.PartyAndReference
 import net.corda.core.crypto.KeyStoreUtilities
 import net.corda.core.crypto.Party
 import net.corda.core.crypto.X509Utilities
+import net.corda.core.crypto.replaceCommonName
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowVersion
@@ -339,7 +340,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     protected open fun makeServiceEntries(): List<ServiceEntry> {
         return advertisedServices.map {
             val serviceId = it.type.id
-            val serviceName = it.name ?: X500Name("CN=$serviceId,${configuration.myLegalName}")
+            val serviceName = it.name ?: configuration.myLegalName.replaceCommonName(serviceId)
             val identity = obtainKeyPair(configuration.baseDirectory, serviceId + "-private-key", serviceId + "-public", serviceName).first
             ServiceEntry(it, identity)
         }


### PR DESCRIPTION
* Mark several functions in X509Utilities as @JvmStatic so they're readily accessible from Java.
* Add functions for modifying common name of an X.500 name, either direct replacement or adding a postfix.