### PR TITLE
Improve notary error reporting

### DIFF
--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -170,8 +170,13 @@ sealed class NotaryError {
     /** Thrown if the time specified in the timestamp command is outside the allowed tolerance */
     object TimestampInvalid : NotaryError()
 
-    data class TransactionInvalid(val msg: String) : NotaryError()
-    data class SignaturesInvalid(val msg: String) : NotaryError()
+    data class TransactionInvalid(val msg: String) : NotaryError() {
+        override fun toString() = msg
+    }
+
+    data class SignaturesInvalid(val msg: String) : NotaryError() {
+        override fun toString() = msg
+    }
 
     data class SignaturesMissing(val cause: SignedTransaction.SignaturesMissingException) : NotaryError() {
         override fun toString() = cause.toString()


### PR DESCRIPTION
Improve `toString()` on `NotaryException` to provide the actual cause instead of forgetting it.