### PR TITLE
Move FlowSessionException into core so that it can be serialised.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowException.kt
@@ -17,3 +17,11 @@ open class FlowException(override val message: String?, override val cause: Thro
     constructor(cause: Throwable?) : this(cause?.toString(), cause)
     constructor() : this(null, null)
 }
+
+/**
+ * Thrown when a flow session ends unexpectedly due to a type mismatch (the other side sent an object of a type
+ * that we were not expecting), or the other side had an internal error, or the other side terminated when we
+ * were waiting for a response.
+ */
+@CordaSerializable
+class FlowSessionException(message: String) : RuntimeException(message)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionMessage.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.statemachine
 import net.corda.core.crypto.Party
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSessionException
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.UntrustworthyData
 
@@ -48,11 +49,3 @@ fun <T> ReceivedSessionMessage<SessionData>.checkPayloadIs(type: Class<T>): Untr
                 "${message.payload.javaClass.name} (${message.payload})")
     }
 }
-
-/**
- * Thrown when a flow session ends unexpectedly due to a type mismatch (the other side sent an object of a type
- * that we were not expecting), or the other side had an internal error, or the other side terminated when we
- * were waiting for a response.
- */
-@CordaSerializable
-class FlowSessionException(message: String) : RuntimeException(message)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -12,6 +12,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSessionException
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.node.services.PartyInfo
@@ -45,7 +46,6 @@ import net.corda.testing.sequence
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType
-import org.bouncycastle.asn1.x500.X500Name
 import org.junit.After
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
FlowSessionException is currently in node, which prevents it from being serialised and sent to the client. Move this exception into core.