### PR TITLE
Forbid classes from packages under net.corda.node.* from being serialised.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -473,3 +473,6 @@ fun <T> Class<T>.checkNotUnorderedHashMap() {
         throw NotSerializableException("Map type $this is unstable under iteration. Suggested fix: use LinkedHashMap instead.")
     }
 }
+
+fun Class<*>.requireExternal(msg: String = "Internal class")
+        = require(!name.startsWith("net.corda.node.") && !name.contains(".internal.")) { "$msg: $name" }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/RPCStructures.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/RPCStructures.kt
@@ -5,6 +5,7 @@ package net.corda.nodeapi
 import com.esotericsoftware.kryo.Registration
 import com.esotericsoftware.kryo.Serializer
 import com.google.common.util.concurrent.ListenableFuture
+import net.corda.core.requireExternal
 import net.corda.core.serialization.*
 import net.corda.core.toFuture
 import net.corda.core.toObservable
@@ -60,6 +61,7 @@ class RPCKryo(observableSerializer: Serializer<Observable<Any>>) : CordaKryo(mak
     }
 
     override fun getRegistration(type: Class<*>): Registration {
+        type.requireExternal("RPC not allowed to deserialise internal classes")
         if (Observable::class.java != type && Observable::class.java.isAssignableFrom(type)) {
             return super.getRegistration(Observable::class.java)
         }


### PR DESCRIPTION
We cannot send internal node classes over RPC because the clients cannot deserialise them. Check for this in the node.