### PR TITLE
Making sure non-serialisable objects in FlowException do not interfer…

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -1,7 +1,6 @@
 package net.corda.client.rpc
 
 import net.corda.core.contracts.DOLLARS
-import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.getOrThrow
 import net.corda.core.messaging.*
@@ -9,6 +8,7 @@ import net.corda.core.node.services.ServiceInfo
 import net.corda.core.random63BitValue
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.utilities.ALICE
+import net.corda.flows.CashException
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
 import net.corda.node.internal.Node
@@ -86,11 +86,10 @@ class CordaRPCClientTest : NodeBasedTest() {
     }
 
     @Test
-    fun `FlowException thrown by flow`() {
+    fun `sub-type of FlowException thrown by flow`() {
         login(rpcUser.username, rpcUser.password)
         val handle = connection!!.proxy.startFlow(::CashPaymentFlow, 100.DOLLARS, node.info.legalIdentity)
-        // TODO Restrict this to CashException once RPC serialisation has been fixed
-        assertThatExceptionOfType(FlowException::class.java).isThrownBy {
+        assertThatExceptionOfType(CashException::class.java).isThrownBy {
             handle.returnValue.getOrThrow()
         }
     }

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerification.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerification.kt
@@ -4,7 +4,6 @@ import net.corda.core.crypto.Party
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowException
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.transactions.LedgerTransaction
 import java.security.PublicKey
 import java.util.*
 
@@ -95,25 +94,25 @@ class AttachmentResolutionException(val hash: SecureHash) : FlowException() {
     override fun toString(): String = "Attachment resolution failure for $hash"
 }
 
-sealed class TransactionVerificationException(val tx: LedgerTransaction, cause: Throwable?) : FlowException(cause) {
-    class ContractRejection(tx: LedgerTransaction, val contract: Contract, cause: Throwable?) : TransactionVerificationException(tx, cause)
-    class MoreThanOneNotary(tx: LedgerTransaction) : TransactionVerificationException(tx, null)
-    class SignersMissing(tx: LedgerTransaction, val missing: List<PublicKey>) : TransactionVerificationException(tx, null) {
+sealed class TransactionVerificationException(val txId: SecureHash, cause: Throwable?) : FlowException(cause) {
+    class ContractRejection(txId: SecureHash, val contract: Contract, cause: Throwable?) : TransactionVerificationException(txId, cause)
+    class MoreThanOneNotary(txId: SecureHash) : TransactionVerificationException(txId, null)
+    class SignersMissing(txId: SecureHash, val missing: List<PublicKey>) : TransactionVerificationException(txId, null) {
         override fun toString(): String = "Signers missing: ${missing.joinToString()}"
     }
 
-    class DuplicateInputStates(tx: LedgerTransaction, val duplicates: Set<StateRef>) : TransactionVerificationException(tx, null) {
+    class DuplicateInputStates(txId: SecureHash, val duplicates: Set<StateRef>) : TransactionVerificationException(txId, null) {
         override fun toString(): String = "Duplicate inputs: ${duplicates.joinToString()}"
     }
 
-    class InvalidNotaryChange(tx: LedgerTransaction) : TransactionVerificationException(tx, null)
-    class NotaryChangeInWrongTransactionType(tx: LedgerTransaction, val outputNotary: Party) : TransactionVerificationException(tx, null) {
+    class InvalidNotaryChange(txId: SecureHash) : TransactionVerificationException(txId, null)
+    class NotaryChangeInWrongTransactionType(txId: SecureHash, val txNotary: Party, val outputNotary: Party) : TransactionVerificationException(txId, null) {
         override fun toString(): String {
-            return "Found unexpected notary change in transaction. Tx notary: ${tx.notary}, found: $outputNotary"
+            return "Found unexpected notary change in transaction. Tx notary: $txNotary, found: $outputNotary"
         }
     }
 
-    class TransactionMissingEncumbranceException(tx: LedgerTransaction, val missing: Int, val inOut: Direction) : TransactionVerificationException(tx, null) {
+    class TransactionMissingEncumbranceException(txId: SecureHash, val missing: Int, val inOut: Direction) : TransactionVerificationException(txId, null) {
         override val message: String get() = "Missing required encumbrance $missing in $inOut"
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -17,6 +17,8 @@ import java.security.PublicKey
  *
  * All the above refer to inputs using a (txhash, output index) pair.
  */
+// TODO LedgerTransaction is not supposed to be serialisable as it references attachments, etc. The verification logic
+// currently sends this across to out-of-process verifiers. We'll need to change that first.
 @CordaSerializable
 class LedgerTransaction(
         /** The resolved input states which will be consumed/invalidated by the execution of this transaction. */

--- a/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
@@ -297,7 +297,7 @@ data class TestLedgerDSLInterpreter private constructor(
             }
             return EnforceVerifyOrFail.Token
         } catch (exception: TransactionVerificationException) {
-            val transactionWithLocation = transactionWithLocations[exception.tx.id]
+            val transactionWithLocation = transactionWithLocations[exception.txId]
             val transactionName = transactionWithLocation?.label ?: transactionWithLocation?.location ?: "<unknown>"
             throw VerifiesFailed(transactionName, exception)
         }


### PR DESCRIPTION
…e with the flow session (#651)

Also TransactionVerificationException no longer has reference to non-serialisable LedgerTransaction