### PR TITLE
Try to copy the CorDapp if we fail to create a symlink, e.g. on Win10.

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt
@@ -92,6 +92,10 @@ class Explorer internal constructor(private val explorerController: ExplorerCont
                     Files.copy(path, destPath)
                 } catch(e: FileAlreadyExistsException) {
                     // OK, don't care ...
+                } catch (e: IOException) {
+                    // Windows 10 might not allow this user to create a symlink
+                    log.warn("Failed to create symlink '{}' for '{}': {}", destPath, path, e.message)
+                    Files.copy(path, destPath)
                 }
             }
         }


### PR DESCRIPTION
Windows 10 throws a `FileSystemException` (child of `IOException`) if the user is not permitted to create symlinks. So catch any `IOException` thrown by `createSymbolicLink()` and try to copy the file instead.

Fixes #658