### PR TITLE
Add utility for extracting parties from a contract state

### DIFF
--- a/core/src/main/kotlin/net/corda/core/identity/AnonymousPartyExtractor.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AnonymousPartyExtractor.kt
@@ -1,0 +1,10 @@
+package net.corda.core.identity
+
+/**
+ * Extractor for when an [AnonymousParty] is encountered, returns the object directly.
+ */
+class AnonymousPartyExtractor : PartyExtractor<AnonymousParty> {
+    override fun extractParties(spider: AnonymousPartySpider, obj: AnonymousParty, written: MutableList<Any>): Set<AnonymousParty> {
+        return setOf(obj)
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/identity/AnonymousPartySpider.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AnonymousPartySpider.kt
@@ -1,0 +1,45 @@
+package net.corda.core.identity
+
+import net.corda.core.contracts.ContractState
+
+/**
+ * Spider utility for exploring a contract state object and extracting the anonymous parties contained within.
+ * Uses [ClassPartyExtractor] to extract parties from objects by default, but custom extractors can be
+ * added via [registerExtractor].
+ */
+class AnonymousPartySpider {
+    private companion object {
+        val DEFAULT_EXTRACTOR = ClassPartyExtractor()
+    }
+
+    private val extractors: HashMap<Class<*>, PartyExtractor<*>> = HashMap()
+
+    init {
+        registerExtractor(AnonymousParty::class.java, AnonymousPartyExtractor())
+    }
+
+    /**
+     * Register a new extractor for the given class.
+     */
+    fun <T: Any> registerExtractor(clazz: Class<T>, extractor: PartyExtractor<T>) {
+        extractors[clazz] = extractor
+    }
+
+    /**
+     * Extract the anonymous parties from a contract state.
+     */
+    fun extractParties(obj: ContractState) = extractParties(obj, ArrayList<Any>())
+
+    /**
+     * Extract the anonymous parties from an object.
+     *
+     * @param obj object to extract anonymous parties from.
+     * @param written list of objects that have already been processed.
+     */
+    internal fun extractParties(obj: Any, written: MutableList<Any>): Set<AnonymousParty> {
+        val extractor = extractors[obj.javaClass] ?: DEFAULT_EXTRACTOR
+        // Find the method via reflection so that the receiving class can use generics, without problems in casting here
+        val method = extractor.javaClass.getMethod("extractParties", AnonymousPartySpider::class.java, Any::class.java, MutableList::class.java) ?: throw IllegalStateException("Could not find extractParties() function")
+        return method.invoke(extractor, this, obj, written) as Set<AnonymousParty>
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/identity/ClassAnonymousPartyExtractor.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/ClassAnonymousPartyExtractor.kt
@@ -1,0 +1,33 @@
+package net.corda.core.identity
+
+/**
+ * Default extractor for parties from an object. Uses reflection to determine fields on a class, filters out any
+ * synthetic or primitive
+ */
+class ClassPartyExtractor : PartyExtractor<Any> {
+    override fun extractParties(spider: AnonymousPartySpider, obj: Any, written: MutableList<Any>): Set<AnonymousParty> {
+        return obj.javaClass.declaredFields
+                // Ignore synthetic fields, which are JVM generated
+                // Ignore primitive types as they're never parties nor can contain parties
+                .filter { field ->
+                    !field.isSynthetic
+                            && !field.type.isPrimitive }
+                .map { field ->
+                    val previousValue = field.isAccessible
+                    field.isAccessible = true
+                    try {
+                        field.get(obj)
+                    } finally {
+                        field.isAccessible = previousValue
+                    }
+                }
+                .filter { value ->
+                    value != null &&
+                        !written.contains(value) }
+                .flatMap { value ->
+                    written.add(value)
+                    spider.extractParties(value, written)
+                }
+                .toSet()
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/identity/PartyExtractor.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/PartyExtractor.kt
@@ -1,0 +1,18 @@
+package net.corda.core.identity
+
+/**
+ * Extractor for parties from an object.
+ *
+ * @param T type of object this extractor works on.
+ */
+interface PartyExtractor<T> {
+    /**
+     * Extract the parties from the given object.
+     *
+     * @param spider spider controlling the extraction process, for any object types this extractor doesn't know
+     * how to handle.
+     * @param obj object to extract from.
+     * @param written list of objects that have already been processed.
+     */
+    fun extractParties(spider: AnonymousPartySpider, obj: T, written: MutableList<Any>): Set<AnonymousParty>
+}

--- a/core/src/test/kotlin/net/corda/core/identity/AnonymousPartyExtractorTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/AnonymousPartyExtractorTest.kt
@@ -1,0 +1,18 @@
+package net.corda.core.identity
+
+import net.corda.core.utilities.ALICE
+import net.corda.testing.ALICE_PUBKEY
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AnonymousPartyExtractorTest {
+    @Test
+    fun `extracts an anonymous party`() {
+        val expected = AnonymousParty(ALICE_PUBKEY)
+        val extractor = AnonymousPartyExtractor()
+        val spider = AnonymousPartySpider()
+        val actual = extractor.extractParties(spider, expected, mutableListOf()).singleOrNull()
+        assertEquals(expected, actual)
+    }
+}

--- a/core/src/test/kotlin/net/corda/core/identity/AnonymousPartySpiderTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/AnonymousPartySpiderTest.kt
@@ -1,0 +1,30 @@
+package net.corda.core.identity
+
+import net.corda.contracts.asset.Obligation
+import net.corda.core.contracts.GBP
+import net.corda.core.contracts.Issued
+import net.corda.core.crypto.SecureHash
+import net.corda.core.utilities.nonEmptySetOf
+import net.corda.testing.ALICE_PUBKEY
+import net.corda.testing.BOC
+import org.junit.Test
+import java.time.Instant
+import java.util.*
+import kotlin.test.assertEquals
+
+/**
+ * Created by rossnicoll on 09/05/2017.
+ */
+class AnonymousPartySpiderTest {
+    @Test
+    fun `extracts a single anonymous party`() {
+        val expected = AnonymousParty(ALICE_PUBKEY)
+        val acceptableContracts = nonEmptySetOf(SecureHash.randomSHA256() as SecureHash)
+        val acceptablePayments = nonEmptySetOf(Issued<Currency>(BOC.ref(1), GBP))
+        val terms = Obligation.Terms<Currency>(acceptableContracts, acceptablePayments, Instant.now())
+        val state = Obligation.State(Obligation.Lifecycle.NORMAL, expected, terms, 1000, BOC.owningKey)
+        val spider = AnonymousPartySpider()
+        val actual = spider.extractParties(state).singleOrNull()
+        assertEquals(expected, actual)
+    }
+}

--- a/core/src/test/kotlin/net/corda/core/identity/ClassPartyExtractorTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/ClassPartyExtractorTest.kt
@@ -1,0 +1,28 @@
+package net.corda.core.identity
+
+import net.corda.contracts.asset.Obligation
+import net.corda.core.contracts.GBP
+import net.corda.core.contracts.Issued
+import net.corda.core.crypto.SecureHash
+import net.corda.core.utilities.nonEmptySetOf
+import net.corda.testing.ALICE_PUBKEY
+import net.corda.testing.BOC
+import org.junit.Test
+import java.time.Instant
+import java.util.*
+import kotlin.test.assertEquals
+
+class ClassPartyExtractorTest {
+    @Test
+    fun `extracts a single anonymous party`() {
+        val expected = AnonymousParty(ALICE_PUBKEY)
+        val acceptableContracts = nonEmptySetOf(SecureHash.randomSHA256() as SecureHash)
+        val acceptablePayments = nonEmptySetOf(Issued<Currency>(BOC.ref(1), GBP))
+        val terms = Obligation.Terms<Currency>(acceptableContracts, acceptablePayments, Instant.now())
+        val state = Obligation.State(Obligation.Lifecycle.NORMAL, expected, terms, 1000, BOC.owningKey)
+        val extractor = ClassPartyExtractor()
+        val spider = AnonymousPartySpider()
+        val actual = extractor.extractParties(spider, state, mutableListOf()).singleOrNull()
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
This is very rough currently - wanted to raise it for discussion, but it may be that in reality flows hand out keys and certificates before a state exists, and this isn't needed. Going to pause this work and update the cash flows next.
