### PR TITLE
Change party equality conditions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/identity/AbstractParty.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AbstractParty.kt
@@ -13,11 +13,23 @@ import java.security.PublicKey
 @CordaSerializable
 abstract class AbstractParty(val owningKey: PublicKey) {
     /** Anonymised parties do not include any detail apart from owning key, so equality is dependent solely on the key */
-    override fun equals(other: Any?): Boolean = other is AbstractParty && this.owningKey == other.owningKey
+    // TODO: Should [AnonymousParty] and [Party] ever be considered equal, or should this be false if they're not the
+    //       same type?
+    override fun equals(other: Any?): Boolean {
+        return if (other is AbstractParty) {
+            if (this.nameOrNull != null && other.nameOrNull != null)
+                this.nameOrNull == other.nameOrNull
+            else
+                this.owningKey == other.owningKey
+        } else {
+            false
+        }
+    }
 
-    override fun hashCode(): Int = owningKey.hashCode()
+    override fun hashCode(): Int = nameOrNull?.hashCode() ?: owningKey.hashCode()
+
     abstract fun toAnonymous(): AnonymousParty
-    abstract fun nameOrNull(): X500Name?
+    abstract val nameOrNull: X500Name?
 
     abstract fun ref(bytes: OpaqueBytes): PartyAndReference
     fun ref(vararg bytes: Byte) = ref(OpaqueBytes.of(*bytes))

--- a/core/src/main/kotlin/net/corda/core/identity/AbstractParty.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AbstractParty.kt
@@ -9,25 +9,15 @@ import java.security.PublicKey
 /**
  * An [AbstractParty] contains the common elements of [Party] and [AnonymousParty], specifically the owning key of
  * the party. In most cases [Party] or [AnonymousParty] should be used, depending on use-case.
+ *
+ * We don't override equals/hashCode here as [Party] and [AnonymousParty] are intentionally never equal. Equality on
+ * [Party] means "These are the same party", on [AnonymousParty] it means "These have the same key", which are very
+ * different tests. In the unlikely case that the two need to be tested, resolve the anonymous party to the full
+ * party first if possible, or convert the full party to an anonymous party otherwise. Think very carefully about intent
+ * before doing so, though.
  */
 @CordaSerializable
 abstract class AbstractParty(val owningKey: PublicKey) {
-    /** Anonymised parties do not include any detail apart from owning key, so equality is dependent solely on the key */
-    // TODO: Should [AnonymousParty] and [Party] ever be considered equal, or should this be false if they're not the
-    //       same type?
-    override fun equals(other: Any?): Boolean {
-        return if (other is AbstractParty) {
-            if (this.nameOrNull != null && other.nameOrNull != null)
-                this.nameOrNull == other.nameOrNull
-            else
-                this.owningKey == other.owningKey
-        } else {
-            false
-        }
-    }
-
-    override fun hashCode(): Int = nameOrNull?.hashCode() ?: owningKey.hashCode()
-
     abstract fun toAnonymous(): AnonymousParty
     abstract val nameOrNull: X500Name?
 

--- a/core/src/main/kotlin/net/corda/core/identity/AnonymousParty.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AnonymousParty.kt
@@ -11,6 +11,16 @@ import java.security.PublicKey
  * information such as name. It is intended to represent a party on the distributed ledger.
  */
 class AnonymousParty(owningKey: PublicKey) : AbstractParty(owningKey) {
+    override fun equals(other: Any?): Boolean {
+        return if (other is AnonymousParty) {
+            this.owningKey == other.owningKey
+        } else {
+            false
+        }
+    }
+
+    override fun hashCode(): Int = owningKey.hashCode()
+
     // Use the key as the bulk of the toString(), but include a human readable identifier as well, so that [Party]
     // can put in the key and actual name
     override fun toString() = "${owningKey.toBase58String()} <Anonymous>"

--- a/core/src/main/kotlin/net/corda/core/identity/AnonymousParty.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AnonymousParty.kt
@@ -15,7 +15,7 @@ class AnonymousParty(owningKey: PublicKey) : AbstractParty(owningKey) {
     // can put in the key and actual name
     override fun toString() = "${owningKey.toBase58String()} <Anonymous>"
 
-    override fun nameOrNull(): X500Name? = null
+    override val nameOrNull: X500Name? = null
 
     override fun ref(bytes: OpaqueBytes): PartyAndReference = PartyAndReference(this, bytes)
     override fun toAnonymous() = this

--- a/core/src/main/kotlin/net/corda/core/identity/Party.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/Party.kt
@@ -27,6 +27,16 @@ import java.security.PublicKey
  */
 // TODO: Remove "open" from [Party] once deprecated crypto.Party class is removed
 open class Party(val name: X500Name, owningKey: PublicKey) : AbstractParty(owningKey) {
+    override fun equals(other: Any?): Boolean {
+        return if (other is Party) {
+            this.name == other.name
+        } else {
+            false
+        }
+    }
+
+    override fun hashCode(): Int = name.hashCode()
+
     override fun toAnonymous(): AnonymousParty = AnonymousParty(owningKey)
     override fun toString() = "${owningKey.toBase58String()} ($name)"
     override val nameOrNull = name

--- a/core/src/main/kotlin/net/corda/core/identity/Party.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/Party.kt
@@ -29,7 +29,7 @@ import java.security.PublicKey
 open class Party(val name: X500Name, owningKey: PublicKey) : AbstractParty(owningKey) {
     override fun toAnonymous(): AnonymousParty = AnonymousParty(owningKey)
     override fun toString() = "${owningKey.toBase58String()} ($name)"
-    override fun nameOrNull(): X500Name? = name
+    override val nameOrNull = name
 
     override fun ref(bytes: OpaqueBytes): PartyAndReference = PartyAndReference(this.toAnonymous(), bytes)
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -63,7 +63,7 @@ interface NetworkMapCache {
     fun getRecommended(type: ServiceType, contract: Contract, vararg party: Party): NodeInfo? = getNodesWithService(type).firstOrNull()
 
     /** Look up the node info for a legal name. */
-    fun getNodeByLegalName(principal: X500Name): NodeInfo? = partyNodes.singleOrNull { it.legalIdentity.name == principal }
+    fun getNodeByLegalName(name: X500Name): NodeInfo?
 
     /**
      * In general, nodes can advertise multiple identities: a legal identity, and separate identities for each of

--- a/core/src/test/kotlin/net/corda/core/identity/PartyTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/PartyTest.kt
@@ -27,8 +27,9 @@ class PartyTest {
         val differentKey = entropyToKeyPair(BigInteger.valueOf(7201702L)).public
         val anonymousParty = AnonymousParty(key)
         val party = Party(ALICE.name, key)
-        assertEquals<AbstractParty>(party, anonymousParty)
-        assertEquals<AbstractParty>(anonymousParty, party)
+        // Full parties and anonymouse parties are never equal, they're different types for a reason
+        assertNotEquals<AbstractParty>(party, anonymousParty)
+        assertNotEquals<AbstractParty>(anonymousParty, party)
         assertNotEquals<AbstractParty>(AnonymousParty(differentKey), anonymousParty)
         assertNotEquals<AbstractParty>(AnonymousParty(differentKey), party)
     }

--- a/core/src/test/kotlin/net/corda/core/identity/PartyTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/PartyTest.kt
@@ -2,6 +2,7 @@ package net.corda.core.identity
 
 import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.utilities.ALICE
+import net.corda.core.utilities.BOB
 import org.junit.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals
@@ -9,7 +10,19 @@ import kotlin.test.assertNotEquals
 
 class PartyTest {
     @Test
-    fun `equality`() {
+    fun `equality between full and full parties`() {
+        val keyA = entropyToKeyPair(BigInteger.valueOf(20170207L)).public
+        val keyB = entropyToKeyPair(BigInteger.valueOf(7201702L)).public
+        val partyWithKeyA = Party(ALICE.name, keyA)
+        val partyWithKeyB = Party(ALICE.name, keyB)
+        val differentParty = Party(BOB.name, keyA)
+        assertEquals<AbstractParty>(partyWithKeyA, partyWithKeyB)
+        assertNotEquals<AbstractParty>(partyWithKeyA, differentParty)
+        assertNotEquals<AbstractParty>(partyWithKeyB, differentParty)
+    }
+
+    @Test
+    fun `equality between anonymous and full parties`() {
         val key = entropyToKeyPair(BigInteger.valueOf(20170207L)).public
         val differentKey = entropyToKeyPair(BigInteger.valueOf(7201702L)).public
         val anonymousParty = AnonymousParty(key)
@@ -18,5 +31,17 @@ class PartyTest {
         assertEquals<AbstractParty>(anonymousParty, party)
         assertNotEquals<AbstractParty>(AnonymousParty(differentKey), anonymousParty)
         assertNotEquals<AbstractParty>(AnonymousParty(differentKey), party)
+    }
+
+    @Test
+    fun `equality between anonymous parties`() {
+        val key = entropyToKeyPair(BigInteger.valueOf(20170207L)).public
+        val differentKey = entropyToKeyPair(BigInteger.valueOf(7201702L)).public
+        val partyA = AnonymousParty(key)
+        val partyB = AnonymousParty(key)
+        assertEquals<AbstractParty>(partyB, partyA)
+        assertEquals<AbstractParty>(partyA, partyB)
+        assertNotEquals<AbstractParty>(AnonymousParty(differentKey), partyA)
+        assertNotEquals<AbstractParty>(AnonymousParty(differentKey), partyB)
     }
 }

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -164,7 +164,9 @@ class CashTests {
         assertTrue(tx.inputs.isEmpty())
         val s = tx.outputs[0].data as Cash.State
         assertEquals(100.DOLLARS `issued by` MINI_CORP.ref(12, 34), s.amount)
-        assertEquals(MINI_CORP as AbstractParty, s.amount.token.issuer.party)
+        // We have to anonymise MINI_CORP before passing it in, as full parties and anonymous parties are not intended to
+        // be tested against each other.
+        assertEquals(MINI_CORP.toAnonymous(), s.amount.token.issuer.party)
         assertEquals(DUMMY_PUBKEY_1, s.owner)
         assertTrue(tx.commands[0].value is Cash.Commands.Issue)
         assertEquals(MINI_CORP_PUBKEY, tx.commands[0].signers[0])

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryNetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryNetworkMapCacheTest.kt
@@ -23,18 +23,18 @@ class InMemoryNetworkMapCacheTest {
 
     @Test
     fun `key collision`() {
-        val entropy = BigInteger.valueOf(24012017L)
-        val nodeA = network.createNode(null, -1, MockNetwork.DefaultFactory, true, ALICE.name, null, entropy, ServiceInfo(NetworkMapService.type))
-        val nodeB = network.createNode(null, -1, MockNetwork.DefaultFactory, true, BOB.name, null, entropy, ServiceInfo(NetworkMapService.type))
+        // Create two nodes with the same name, but different keys
+        val nodeA = network.createNode(null, -1, MockNetwork.DefaultFactory, true, ALICE.name, null, ServiceInfo(NetworkMapService.type))
+        val nodeB = network.createNode(null, -1, MockNetwork.DefaultFactory, true, ALICE.name, null, ServiceInfo(NetworkMapService.type))
         assertEquals(nodeA.info.legalIdentity, nodeB.info.legalIdentity)
 
         // Node A currently knows only about itself, so this returns node A
-        assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeA.info)
+        assertEquals(nodeA.info, nodeA.netMapCache.getNodeByLegalName(nodeA.info.legalIdentity.name))
 
         nodeA.database.transaction {
             nodeA.netMapCache.addNode(nodeB.info)
         }
         // The details of node B write over those for node A
-        assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeB.info)
+        assertEquals(nodeB.info, nodeA.netMapCache.getNodeByLegalName(nodeA.info.legalIdentity.name))
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -338,7 +338,7 @@ class NodeVaultServiceTest {
             val spendableStatesUSD = vaultSvc.unconsumedStatesForSpending<Cash.State>(200.DOLLARS, lockId = UUID.randomUUID(),
                     onlyFromIssuerParties = setOf(BOC), withIssuerRefs = setOf(OpaqueBytes.of(1), OpaqueBytes.of(2))).toList()
             assertThat(spendableStatesUSD).hasSize(2)
-            assertThat(spendableStatesUSD[0].state.data.amount.token.issuer.party).isEqualTo(BOC)
+            assertThat(spendableStatesUSD[0].state.data.amount.token.issuer.party).isEqualTo(BOC.toAnonymous())
             assertThat(spendableStatesUSD[0].state.data.amount.token.issuer.reference).isEqualTo(BOC.ref(1).reference)
             assertThat(spendableStatesUSD[1].state.data.amount.token.issuer.reference).isEqualTo(BOC.ref(2).reference)
         }

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/TransactionViewer.kt
@@ -246,7 +246,7 @@ class TransactionViewer : CordaView("Transactions") {
                                 val anonymousIssuer: AnonymousParty = data.amount.token.issuer.party
                                 val issuer: AbstractParty = anonymousIssuer.resolveIssuer().value ?: anonymousIssuer
                                 // TODO: Anonymous should probably be italicised or similar
-                                label(issuer.nameOrNull()?.let { PartyNameFormatter.short.format(it) } ?: "Anonymous") {
+                                label(issuer.nameOrNull?.let { PartyNameFormatter.short.format(it) } ?: "Anonymous") {
                                     tooltip(anonymousIssuer.owningKey.toBase58String())
                                 }
                             }

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt
@@ -128,10 +128,10 @@ class CashViewer : CordaView("Cash") {
             }
             equivLabel.textProperty().bind(equivAmount.map { it.token.currencyCode.toString() })
             // TODO: Anonymous should probably be italicised or similar
-            issuerValueLabel.textProperty().bind(SimpleStringProperty(resolvedIssuer.nameOrNull()?.let {
+            issuerValueLabel.textProperty().bind(SimpleStringProperty(resolvedIssuer.nameOrNull?.let {
                 PartyNameFormatter.short.format(it)
             } ?: "Anonymous"))
-            issuerValueLabel.apply { tooltip(resolvedIssuer.nameOrNull()?.let { PartyNameFormatter.full.format(it) } ?: "Anonymous") }
+            issuerValueLabel.apply { tooltip(resolvedIssuer.nameOrNull?.let { PartyNameFormatter.full.format(it) } ?: "Anonymous") }
             originatedValueLabel.text = stateRow.originated.toString()
             amountValueLabel.text = amountFormatter.format(amountNoIssuer)
             equivValueLabel.textProperty().bind(equivAmount.map { equivFormatter.format(it) })
@@ -235,7 +235,7 @@ class CashViewer : CordaView("Cash") {
             val node = it.value.value
             when (node) {
             // TODO: Anonymous should probably be italicised or similar
-                is ViewerNode.IssuerNode -> SimpleStringProperty(node.issuer.nameOrNull()?.let { PartyNameFormatter.short.format(it) } ?: "Anonymous")
+                is ViewerNode.IssuerNode -> SimpleStringProperty(node.issuer.nameOrNull?.let { PartyNameFormatter.short.format(it) } ?: "Anonymous")
                 is ViewerNode.CurrencyNode -> node.amount.map { it.token.toString() }
             }
         }


### PR DESCRIPTION
This changes the conditions under which parties are considered equivalent, to:

* For `Party` and `Party`; comparison on name
* For `AnonymousParty` and `AnonymousParty`; comparison on key
* For `Party` and `AnonymousParty`; never equal

This is so that for full parties, they're equivalent if the underlying identity is the same, and for anonymous parties they're equal if the keys match (which is really only so they can be used in maps and sets).
