### PR TITLE
Update smoke tests to start/stop on Windows.

### DIFF
--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/NodeProcess.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/NodeProcess.kt
@@ -5,7 +5,6 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.client.rpc.CordaRPCConnection
 import net.corda.core.utilities.loggerFor
 import java.io.File
-import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -22,7 +21,7 @@ class NodeProcess(
     private companion object {
         val log = loggerFor<NodeProcess>()
         val javaPath: Path = Paths.get(System.getProperty("java.home"), "bin", "java")
-        val corda: URI = this::class.java.getResource("/corda.jar").toURI()
+        val corda = File(this::class.java.getResource("/corda.jar").toURI())
         val buildDir: Path = Paths.get(System.getProperty("build.dir"))
         val capsuleDir: Path = buildDir.resolve("capsule")
     }
@@ -33,9 +32,12 @@ class NodeProcess(
     }
 
     override fun close() {
+        log.info("Stopping node '${config.commonName}'")
         node.destroy()
-        val isDead = node.waitFor(60, SECONDS)
-        assertTrue(isDead, "Node '${config.commonName}' has not shutdown correctly")
+        if (!node.waitFor(60, SECONDS)) {
+            log.warn("Node '${config.commonName}' has not shutdown correctly")
+            node.destroyForcibly()
+        }
 
         log.info("Deleting Artemis directories, because they're large!")
         nodeDir.resolve("artemis").toFile().deleteRecursively()
@@ -43,7 +45,7 @@ class NodeProcess(
 
     class Factory(val nodesDir: Path) {
         init {
-            assertTrue(nodesDir.toFile().forceDirectory(), "Nodes directory does not exist")
+            assertTrue(nodesDir.toFile().forceDirectory(), "Directory '$nodesDir' does not exist")
         }
 
         fun create(config: NodeConfig): NodeProcess {
@@ -61,6 +63,10 @@ class NodeProcess(
             try {
                 setupExecutor.scheduleWithFixedDelay({
                     try {
+                        if (!process.isAlive) {
+                            log.error("Node '${config.commonName}' has died.")
+                            return@scheduleWithFixedDelay
+                        }
                         val conn = client.start(user.username, user.password)
                         conn.close()
 
@@ -72,9 +78,9 @@ class NodeProcess(
                 }, 5, 1, SECONDS)
 
                 val setupOK = setupExecutor.awaitTermination(120, SECONDS)
-                assertTrue(setupOK, "Failed to create RPC connection")
+                assertTrue(setupOK && process.isAlive, "Failed to create RPC connection")
             } catch (e: Exception) {
-                process.destroy()
+                process.destroyForcibly()
                 throw e
             } finally {
                 setupExecutor.shutdownNow()

--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration.ofSeconds
 import java.util.Currency
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.*
 import net.corda.client.rpc.CordaRPCConnection
 import net.corda.client.rpc.notUsed
@@ -33,6 +34,7 @@ class StandaloneCordaRPClientTest {
         val nodesDir: Path = buildDir.resolve("nodes")
         val user = User("user1", "test", permissions = setOf("ALL"))
         val factory = NodeProcess.Factory(nodesDir)
+        val port = AtomicInteger(15000)
         const val attachmentSize = 2116
         const val timeout = 60L
     }
@@ -44,9 +46,9 @@ class StandaloneCordaRPClientTest {
 
     private val notaryConfig = NodeConfig(
         party = DUMMY_NOTARY,
-        p2pPort = 10002,
-        rpcPort = 10003,
-        webPort = 10004,
+        p2pPort = port.andIncrement,
+        rpcPort = port.andIncrement,
+        webPort = port.andIncrement,
         extraServices = listOf("corda.notary.validating"),
         users = listOf(user)
     )
@@ -61,14 +63,16 @@ class StandaloneCordaRPClientTest {
 
     @After
     fun done() {
-        connection.close()
-        notary.close()
+        try {
+            connection.close()
+        } finally {
+            notary.close()
+        }
     }
 
     @Test
     fun `test attachment upload`() {
         val attachment = sizedInputStreamAndHash(attachmentSize)
-
         assertFalse(rpcProxy.attachmentExists(attachment.sha256))
         val id = WrapperStream(attachment.inputStream).use { rpcProxy.uploadAttachment(it) }
         assertEquals(id, attachment.sha256, "Attachment has incorrect SHA256 hash")
@@ -138,7 +142,7 @@ class StandaloneCordaRPClientTest {
         val cashBalance = rpcProxy.getCashBalances()
         log.info("Cash Balances: $cashBalance")
         assertEquals(1, cashBalance.size)
-        assertEquals(629.POUNDS, cashBalance.get(Currency.getInstance("GBP")))
+        assertEquals(629.POUNDS, cashBalance[Currency.getInstance("GBP")])
     }
 
 


### PR DESCRIPTION
This allows the smoke tests to run on Windows. However, Corda on Windows runs as a subprocess of the Capsule's JVM. This means that killing the process only removes the Capsule and leave Corda itself running. I think that this is only fixable via the Capsule unless Java can also destroy all subprocesses.