### PR TITLE
Add Cash flows to default RPC flow list, so they can be invoked by shell commands.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -244,10 +244,13 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
             }
 
             val flows = scanForFlows()
-            // TODO Remove all Cash flows from default list once they are split into separate CorDapp.
             rpcFlows = flows.filter { it.isUserInvokable() && it.isAnnotationPresent(StartableByRPC::class.java) } +
                     // Add any core flows here
-                    listOf(ContractUpgradeFlow::class.java, CashIssueFlow::class.java, CashExitFlow::class.java, CashPaymentFlow::class.java)
+                    listOf(ContractUpgradeFlow::class.java,
+                            // TODO Remove all Cash flows from default list once they are split into separate CorDapp.
+                            CashIssueFlow::class.java,
+                            CashExitFlow::class.java,
+                            CashPaymentFlow::class.java)
 
             runOnStop += Runnable { net.stop() }
             _networkMapRegistrationFuture.setFuture(registerWithNetworkMapIfConfigured())

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -244,9 +244,10 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
             }
 
             val flows = scanForFlows()
+            // TODO Remove all Cash flows from default list once they are split into separate CorDapp.
             rpcFlows = flows.filter { it.isUserInvokable() && it.isAnnotationPresent(StartableByRPC::class.java) } +
                     // Add any core flows here
-                    listOf(ContractUpgradeFlow::class.java)
+                    listOf(ContractUpgradeFlow::class.java, CashIssueFlow::class.java, CashExitFlow::class.java, CashPaymentFlow::class.java)
 
             runOnStop += Runnable { net.stop() }
             _networkMapRegistrationFuture.setFuture(registerWithNetworkMapIfConfigured())


### PR DESCRIPTION
It should be removed once we separate cash flows into cordapp.