### PR TITLE
Disable the DemoBench tab if the node exits abnormally.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
@@ -15,6 +15,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowStateMachine
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.Emoji
+import net.corda.core.utilities.loggerFor
 import net.corda.jackson.JacksonSupport
 import net.corda.jackson.StringToMethodCallParser
 import net.corda.node.internal.Node
@@ -70,6 +71,7 @@ import kotlin.concurrent.thread
 // TODO: Make it notice new shell commands added after the node started.
 
 object InteractiveShell {
+    private val log = loggerFor<InteractiveShell>()
     private lateinit var node: Node
 
     /**
@@ -129,6 +131,7 @@ object InteractiveShell {
         thread(name = "Command line shell terminator", isDaemon = true) {
             // Wait for the shell to finish.
             jlineProcessor.closed()
+            log.info("Command shell has exited")
             terminal.restore()
             node.stop()
         }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -270,8 +270,13 @@ class NodeTabView : Fragment() {
         nodeTab.text = config.legalName.commonName
         nodeTerminalView.open(config) { exitCode ->
             Platform.runLater {
-                if (exitCode == 0)
+                if (exitCode == 0) {
                     nodeTab.requestClose()
+                } else {
+                    // The node did not shut down cleanly. Keep the
+                    // terminal open but ensure that it is disabled.
+                    nodeTerminalView.shutdown()
+                }
                 nodeController.dispose(config)
                 main.forceAtLeastOneTab()
             }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
@@ -229,16 +229,21 @@ class NodeTerminalView : Fragment() {
         }
     }
 
+    fun shutdown() {
+        header.isDisable = true
+        subscriptions.forEach {
+            // Don't allow any exceptions here to halt tab destruction.
+            try { it.unsubscribe() } catch (e: Exception) {}
+        }
+        webServer.close()
+        explorer.close()
+        viewer.close()
+        rpc?.close()
+    }
+
     fun destroy() {
         if (!isDestroyed) {
-            subscriptions.forEach {
-                // Don't allow any exceptions here to halt tab destruction.
-                try { it.unsubscribe() } catch (e: Exception) {}
-            }
-            webServer.close()
-            explorer.close()
-            viewer.close()
-            rpc?.close()
+            shutdown()
             pty?.close()
             isDestroyed = true
         }


### PR DESCRIPTION
DemoBench currently keeps the tab open if the node's exit code is not zero. However, we also need to close the RPC connections and disable all of the controls on the tab.
Also extend logging in the node to record if someone exits via the CRaSH shell.