### PR TITLE
smm: Use a single logger for flows, add flow-id in thread-local context

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -13,7 +13,7 @@
 
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="%highlight{%level{length=1} %d{HH:mm:ss} [%t] %c{2}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}" />
+            <PatternLayout pattern="%highlight{%level{length=1} %d{HH:mm:ss} [%t] %X %c{2}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}" />
         </Console>
 
         <!-- Required for printBasicInfo -->
@@ -27,7 +27,7 @@
                      fileName="${sys:log-path}/${log-name}.log"
                      filePattern="${archive}/${log-name}.%d{yyyy-MM-dd}-%i.log.gz">
 
-            <PatternLayout pattern="[%-5level] %d{ISO8601}{GMT+0} [%t] %c{2}.%M - %msg%n"/>
+            <PatternLayout pattern="[%-5level] %d{ISO8601}{GMT+0} [%t] %X %c{2}.%M - %msg%n"/>
 
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/config/test/log4j2.xml
+++ b/config/test/log4j2.xml
@@ -5,7 +5,7 @@
     </Properties>
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%-5level] %d{HH:mm:ss.SSS} [%t] %c{2}.%M - %msg%n" />
+            <PatternLayout pattern="[%-5level] %d{HH:mm:ss.SSS} [%t] %X %c{2}.%M - %msg%n" />
         </Console>
         <!-- Required for printBasicInfo -->
         <Console name="Console-Appender-Println" target="SYSTEM_OUT">


### PR DESCRIPTION
This PR changes flow logging so that a single logger is constructed for all flows, and the flow-id is supplied by a thread-local.

Note that this could allow us to make the logger a static field, should we do this?