### PR TITLE
rename SignedTransaction.signWithECDSA to signWith

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -3,11 +3,11 @@ package net.corda.core.transactions
 import net.corda.core.contracts.AttachmentResolutionException
 import net.corda.core.contracts.NamedByHash
 import net.corda.core.contracts.TransactionResolutionException
-import net.corda.core.node.ServiceHub
 import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.crypto.sign
+import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import java.security.KeyPair
@@ -152,6 +152,9 @@ data class SignedTransaction(val txBits: SerializedBytes<WireTransaction>,
      * @return a digital signature of the transaction.
      */
     fun signWith(keyPair: KeyPair) = keyPair.sign(this.id.bytes)
+
+    @Deprecated("This is scheduled to be removed in a future release", ReplaceWith("signWith(keyPair)"))
+    fun signWithECDSA(keyPair: KeyPair) = keyPair.sign(this.id.bytes)
 
     override fun toString(): String = "${javaClass.simpleName}(id=$id)"
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -148,12 +148,10 @@ data class SignedTransaction(val txBits: SerializedBytes<WireTransaction>,
 
     /**
      * Utility to simplify the act of signing the transaction.
-     *
      * @param keyPair the signer's public/private key pair.
-     *
      * @return a digital signature of the transaction.
      */
-    fun signWithECDSA(keyPair: KeyPair) = keyPair.sign(this.id.bytes)
+    fun signWith(keyPair: KeyPair) = keyPair.sign(this.id.bytes)
 
     override fun toString(): String = "${javaClass.simpleName}(id=$id)"
 }


### PR DESCRIPTION
rename SignedTransaction.signWithECDSA to signWith, as it is now independent on the scheme.