### PR TITLE
Fix the standalone verifier jar.

### DIFF
--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -52,6 +52,7 @@ task standaloneJar(type: Jar) {
     from {
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    with jar
     exclude("META-INF/*.DSA")
     exclude("META-INF/*.RSA")
     exclude("META-INF/*.SF")
@@ -65,3 +66,5 @@ task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
+
+build.dependsOn standaloneJar


### PR DESCRIPTION
Include the verifier's own classes with the standalone jar, and attach the standalone jar task to the build.