### PR TITLE
Remove mock identity service

### DIFF
--- a/core/src/test/kotlin/net/corda/core/flows/TxKeyFlowUtilitiesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/TxKeyFlowUtilitiesTests.kt
@@ -4,7 +4,6 @@ import net.corda.core.identity.Party
 import net.corda.core.utilities.ALICE
 import net.corda.core.utilities.BOB
 import net.corda.core.utilities.DUMMY_NOTARY
-import net.corda.testing.MOCK_IDENTITY_SERVICE
 import net.corda.testing.node.MockNetwork
 import org.junit.Before
 import org.junit.Test
@@ -17,7 +16,6 @@ class TxKeyFlowUtilitiesTests {
     @Before
     fun before() {
         net = MockNetwork(false)
-        net.identities += MOCK_IDENTITY_SERVICE.identities
     }
 
     @Test

--- a/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
+++ b/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
@@ -4,11 +4,11 @@ import com.google.common.util.concurrent.ListenableFuture
 import net.corda.contracts.testing.calculateRandomlySizedAmounts
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.DOLLARS
-import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.currency
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowStateMachine
 import net.corda.core.getOrThrow
+import net.corda.core.identity.Party
 import net.corda.core.map
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.transactions.SignedTransaction
@@ -40,13 +40,14 @@ class IssuerFlowTest {
             bankClientNode = net.createPartyNode(notaryNode.info.address, MEGA_CORP.name)
 
             // using default IssueTo Party Reference
-            val issueToPartyAndRef = bankClientNode.info.legalIdentity.ref(OpaqueBytes.of(123))
-            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, 1000000.DOLLARS, issueToPartyAndRef)
+            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, 1000000.DOLLARS,
+                    bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
             assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
 
             // try to issue an amount of a restricted currency
             assertFailsWith<FlowException> {
-                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(100000L, currency("BRL")), issueToPartyAndRef).issueRequestResult.getOrThrow()
+                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(100000L, currency("BRL")),
+                        bankClientNode.info.legalIdentity, OpaqueBytes.of(123)).issueRequestResult.getOrThrow()
             }
 
             bankOfCordaNode.stop()
@@ -62,8 +63,8 @@ class IssuerFlowTest {
             bankOfCordaNode = net.createPartyNode(notaryNode.info.address, BOC.name)
 
             // using default IssueTo Party Reference
-            val issueToPartyAndRef = bankOfCordaNode.info.legalIdentity.ref(OpaqueBytes.of(123))
-            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankOfCordaNode, 1000000.DOLLARS, issueToPartyAndRef)
+            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankOfCordaNode, 1000000.DOLLARS,
+                    bankOfCordaNode.info.legalIdentity, OpaqueBytes.of(123))
             assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
 
             bankOfCordaNode.stop()
@@ -79,14 +80,12 @@ class IssuerFlowTest {
             bankOfCordaNode = net.createPartyNode(notaryNode.info.address, BOC.name)
             bankClientNode = net.createPartyNode(notaryNode.info.address, MEGA_CORP.name)
 
-            // using default IssueTo Party Reference
-            val issueToPartyAndRef = bankClientNode.info.legalIdentity.ref(OpaqueBytes.of(123))
-
             // this test exercises the Cashflow issue and move subflows to ensure consistent spending of issued states
             val amount = 10000.DOLLARS
             val amounts = calculateRandomlySizedAmounts(10000.DOLLARS, 10, 10, Random())
             val handles = amounts.map { pennies ->
-                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(pennies, amount.token), issueToPartyAndRef)
+                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(pennies, amount.token),
+                        bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
             }
             handles.forEach {
                 require(it.issueRequestResult.get() is SignedTransaction)
@@ -98,13 +97,14 @@ class IssuerFlowTest {
     }
 
     private fun runIssuerAndIssueRequester(issuerNode: MockNode, issueToNode: MockNode,
-                                           amount: Amount<Currency>, issueToPartyAndRef: PartyAndReference): RunResult {
-        val resolvedIssuerParty = issuerNode.services.identityService.partyFromAnonymous(issueToPartyAndRef) ?: throw IllegalStateException()
+                                           amount: Amount<Currency>,
+                                           party: Party, ref: OpaqueBytes): RunResult {
+        val issueToPartyAndRef = party.ref(ref)
         val issuerFuture = issuerNode.initiateSingleShotFlow(IssuerFlow.IssuanceRequester::class) { _ ->
-            IssuerFlow.Issuer(resolvedIssuerParty)
+            IssuerFlow.Issuer(party)
         }.map { it.stateMachine }
 
-        val issueRequest = IssuanceRequester(amount, resolvedIssuerParty, issueToPartyAndRef.reference, issuerNode.info.legalIdentity)
+        val issueRequest = IssuanceRequester(amount, party, issueToPartyAndRef.reference, issuerNode.info.legalIdentity)
         val issueRequestResultFuture = issueToNode.services.startFlow(issueRequest).resultFuture
 
         return IssuerFlowTest.RunResult(issuerFuture, issueRequestResultFuture)

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -70,7 +70,6 @@ class TwoPartyTradeFlowTests {
     @Before
     fun before() {
         net = MockNetwork(false)
-        net.identities += MOCK_IDENTITY_SERVICE.identities
         LogHelper.setLevel("platform.trade", "core.contract.TransactionGroup", "recordingmap")
     }
 
@@ -501,6 +500,8 @@ class TwoPartyTradeFlowTests {
                     serviceHub.legalIdentityKey))
         }
 
+        sellerNode.services.identityService.registerIdentity(buyerNode.info.legalIdentity)
+        buyerNode.services.identityService.registerIdentity(sellerNode.info.legalIdentity)
         val buyerFuture = buyerNode.initiateSingleShotFlow(SellerRunnerFlow::class) { otherParty ->
             Buyer(otherParty, notaryNode.info.notaryIdentity, 1000.DOLLARS, CommercialPaper.State::class.java)
         }.map { it.stateMachine }

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -11,6 +11,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.VersionInfo
+import net.corda.core.node.services.IdentityService
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.toFuture
 import net.corda.core.transactions.TransactionBuilder
@@ -18,17 +19,16 @@ import net.corda.core.utilities.*
 import net.corda.node.internal.AbstractNode
 import net.corda.node.internal.NetworkMapInfo
 import net.corda.node.services.config.*
+import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.statemachine.FlowStateMachineImpl
 import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.nodeapi.User
 import net.corda.nodeapi.config.SSLConfiguration
-import net.corda.testing.node.MockIdentityService
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.makeTestDataSourceProperties
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x500.X500NameBuilder
 import org.bouncycastle.asn1.x500.style.BCStyle
-import java.net.ServerSocket
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
@@ -85,7 +85,7 @@ val BIG_CORP_PARTY_REF = BIG_CORP.ref(OpaqueBytes.of(1)).reference
 
 val ALL_TEST_KEYS: List<KeyPair> get() = listOf(MEGA_CORP_KEY, MINI_CORP_KEY, ALICE_KEY, BOB_KEY, DUMMY_NOTARY_KEY)
 
-val MOCK_IDENTITY_SERVICE: MockIdentityService get() = MockIdentityService(listOf(MEGA_CORP, MINI_CORP, DUMMY_NOTARY))
+val MOCK_IDENTITY_SERVICE: IdentityService get() = InMemoryIdentityService(listOf(MEGA_CORP, MINI_CORP, DUMMY_NOTARY))
 
 val MOCK_VERSION_INFO = VersionInfo(1, "Mock release", "Mock revision", "Mock Vendor")
 

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -20,6 +20,7 @@ import net.corda.core.utilities.loggerFor
 import net.corda.node.internal.AbstractNode
 import net.corda.node.internal.ServiceFlowInfo
 import net.corda.node.services.config.NodeConfiguration
+import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.keys.E2ETestKeyManagementService
 import net.corda.node.services.messaging.MessagingService
 import net.corda.node.services.network.InMemoryNetworkMapService
@@ -166,7 +167,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
                     .getOrThrow()
         }
 
-        override fun makeIdentityService() = MockIdentityService(mockNet.identities)
+        override fun makeIdentityService() = InMemoryIdentityService(mockNet.identities)
 
         override fun makeVaultService(dataSourceProperties: Properties): VaultService = NodeVaultService(services, dataSourceProperties)
 


### PR DESCRIPTION
Remove mock identity service and merge it with the in memory identity service. The two services
provide extremely similar functionality, and having two different version for production/test
risks subtle implementation differences. On that note, this patch includes changes to a number
of tests which worked only with mock identity service.