### PR TITLE
Change CashIssueFlow to use anonymous identity

### DIFF
--- a/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
+++ b/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
@@ -113,11 +113,13 @@ class NodeMonitorModelTest : DriverBasedTest() {
 
     @Test
     fun `cash issue works end to end`() {
+        val anonymous = false
         rpc.startFlow(::CashIssueFlow,
                 Amount(100, USD),
                 OpaqueBytes(ByteArray(1, { 1 })),
                 aliceNode.legalIdentity,
-                notaryNode.notaryIdentity
+                notaryNode.notaryIdentity,
+                anonymous
         )
 
         vaultUpdates.expectEvents(isStrict = false) {
@@ -138,8 +140,9 @@ class NodeMonitorModelTest : DriverBasedTest() {
 
     @Test
     fun `cash issue and move`() {
-        rpc.startFlow(::CashIssueFlow, 100.DOLLARS, OpaqueBytes.of(1), aliceNode.legalIdentity, notaryNode.notaryIdentity).returnValue.getOrThrow()
-        rpc.startFlow(::CashPaymentFlow, 100.DOLLARS, bobNode.legalIdentity).returnValue.getOrThrow()
+        val anonymous = false
+        rpc.startFlow(::CashIssueFlow, 100.DOLLARS, OpaqueBytes.of(1), aliceNode.legalIdentity, notaryNode.notaryIdentity, anonymous).returnValue.getOrThrow()
+        rpc.startFlow(::CashPaymentFlow, 100.DOLLARS, bobNode.legalIdentity, anonymous).returnValue.getOrThrow()
 
         var issueSmId: StateMachineRunId? = null
         var moveSmId: StateMachineRunId? = null

--- a/client/mock/src/main/kotlin/net/corda/client/mock/EventGenerator.kt
+++ b/client/mock/src/main/kotlin/net/corda/client/mock/EventGenerator.kt
@@ -26,7 +26,7 @@ open class EventGenerator(val parties: List<Party>, val currencies: List<Currenc
 
     protected val issueCashGenerator = amountGenerator.combine(partyGenerator, issueRefGenerator, currencyGenerator) { amount, to, issueRef, ccy ->
         addToMap(ccy, amount)
-        CashFlowCommand.IssueCash(Amount(amount, ccy), issueRef, to, notary)
+        CashFlowCommand.IssueCash(Amount(amount, ccy), issueRef, to, notary, anonymous = true)
     }
 
     protected val exitCashGenerator = amountGenerator.combine(issueRefGenerator, currencyGenerator) { amount, issueRef, ccy ->
@@ -35,7 +35,7 @@ open class EventGenerator(val parties: List<Party>, val currencies: List<Currenc
     }
 
     open val moveCashGenerator = amountGenerator.combine(partyGenerator, currencyGenerator) { amountIssued, recipient, currency ->
-        CashFlowCommand.PayCash(Amount(amountIssued, currency), recipient)
+        CashFlowCommand.PayCash(Amount(amountIssued, currency), recipient, anonymous = true)
     }
 
     open val issuerGenerator = Generator.frequency(listOf(
@@ -71,11 +71,11 @@ class ErrorFlowsEventGenerator(parties: List<Party>, currencies: List<Currency>,
     }
 
     val normalMoveGenerator = amountGenerator.combine(partyGenerator, currencyGenerator) { amountIssued, recipient, currency ->
-        CashFlowCommand.PayCash(Amount(amountIssued, currency), recipient)
+        CashFlowCommand.PayCash(Amount(amountIssued, currency), recipient, anonymous = true)
     }
 
     val errorMoveGenerator = partyGenerator.combine(currencyGenerator) { recipient, currency ->
-        CashFlowCommand.PayCash(Amount(currencyMap[currency]!! * 2, currency), recipient)
+        CashFlowCommand.PayCash(Amount(currencyMap[currency]!! * 2, currency), recipient, anonymous = true)
     }
 
     override val moveCashGenerator = Generator.frequency(listOf(

--- a/core/src/main/kotlin/net/corda/core/identity/AnonymisedIdentity.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AnonymisedIdentity.kt
@@ -1,0 +1,16 @@
+package net.corda.flows
+
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.serialization.CordaSerializable
+import org.bouncycastle.cert.X509CertificateHolder
+import java.security.cert.CertPath
+
+@CordaSerializable
+data class AnonymisedIdentity(
+        val certPath: CertPath,
+        val certificate: X509CertificateHolder,
+        val identity: AnonymousParty) {
+    constructor(myIdentity: Pair<X509CertificateHolder, CertPath>) : this(myIdentity.second,
+            myIdentity.first,
+            AnonymousParty(myIdentity.second.certificates.last().publicKey))
+}

--- a/core/src/main/kotlin/net/corda/core/identity/AnonymisedIdentity.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AnonymisedIdentity.kt
@@ -3,6 +3,7 @@ package net.corda.flows
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.cert.X509CertificateHolder
+import java.security.PublicKey
 import java.security.cert.CertPath
 
 @CordaSerializable
@@ -10,7 +11,6 @@ data class AnonymisedIdentity(
         val certPath: CertPath,
         val certificate: X509CertificateHolder,
         val identity: AnonymousParty) {
-    constructor(myIdentity: Pair<X509CertificateHolder, CertPath>) : this(myIdentity.second,
-            myIdentity.first,
-            AnonymousParty(myIdentity.second.certificates.last().publicKey))
+    constructor(certPath: CertPath, certificate: X509CertificateHolder, identity: PublicKey)
+            : this(certPath, certificate, AnonymousParty(identity))
 }

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -350,6 +350,16 @@ inline fun <T : Any, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startFlow
         arg3: D
 ): FlowHandle<T> = startFlowDynamic(R::class.java, arg0, arg1, arg2, arg3)
 
+inline fun <T : Any, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+        @Suppress("UNUSED_PARAMETER")
+        flowConstructor: (A, B, C, D, E) -> R,
+        arg0: A,
+        arg1: B,
+        arg2: C,
+        arg3: D,
+        arg4: E
+): FlowHandle<T> = startFlowDynamic(R::class.java, arg0, arg1, arg2, arg3, arg4)
+
 /**
  * Same again, except this time with progress-tracking enabled.
  */

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -2,9 +2,11 @@ package net.corda.core.node.services
 
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.contracts.Contract
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.messaging.DataFeed
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.ServiceHub
 import net.corda.core.randomOrNull
 import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.asn1.x500.X500Name
@@ -62,6 +64,17 @@ interface NetworkMapCache {
      * or the appropriate oracle for a contract.
      */
     fun getRecommended(type: ServiceType, contract: Contract, vararg party: Party): NodeInfo? = getNodesWithService(type).firstOrNull()
+
+    /**
+     * Look up the node info for a specific party. Will attempt to de-anonymise the party if applicable; if the party
+     * is anonymised and the well known party cannot be resolved, it is impossible ot identify the node and therefore this
+     * returns null.
+     *
+     * @param party party to retrieve node information for.
+     * @return the node for the identity, or null if the node could not be found. This does not necessarily mean there is
+     * no node for the party, only that this cache is unaware of it.
+     */
+    fun getNodeByLegalIdentity(party: AbstractParty): NodeInfo?
 
     /** Look up the node info for a legal name. */
     fun getNodeByLegalName(principal: X500Name): NodeInfo? = partyNodes.singleOrNull { it.legalIdentity.name == principal }

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -488,7 +488,15 @@ interface KeyManagementService {
     @Suspendable
     fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath>
 
-    /** Using the provided signing [PublicKey] internally looks up the matching [PrivateKey] and signs the data.
+    /**
+     * Filter some keys down to the set that this node owns (has private keys for).
+     *
+     * @param candidateKeys keys which this node may own.
+     */
+    fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey>
+
+    /**
+     * Using the provided signing [PublicKey] internally looks up the matching [PrivateKey] and signs the data.
      * @param bytes The data to sign over using the chosen key.
      * @param publicKey The [PublicKey] partner to an internally held [PrivateKey], either derived from the node's primary identity,
      * or previously generated via the [freshKey] method.

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -21,6 +21,7 @@ import net.corda.core.toFuture
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
+import net.corda.flows.AnonymisedIdentity
 import org.bouncycastle.cert.X509CertificateHolder
 import rx.Observable
 import rx.subjects.PublishSubject
@@ -486,7 +487,7 @@ interface KeyManagementService {
      * @return X.509 certificate and path to the trust root.
      */
     @Suspendable
-    fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath>
+    fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): AnonymisedIdentity
 
     /**
      * Filter some keys down to the set that this node owns (has private keys for).

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -113,6 +113,7 @@ object DefaultKryoCustomizer {
             register(BCRSAPublicKey::class.java, PublicKeySerializer)
             register(BCSphincs256PrivateKey::class.java, PrivateKeySerializer)
             register(BCSphincs256PublicKey::class.java, PublicKeySerializer)
+            register(sun.security.ec.ECPublicKeyImpl::class.java, PublicKeySerializer)
 
             val customization = KryoSerializationCustomization(this)
             pluginRegistries.forEach { it.customizeSerialization(customization) }

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -73,7 +73,7 @@ object DefaultKryoCustomizer {
 
             noReferencesWithin<WireTransaction>()
 
-            register(sun.security.ec.ECPublicKeyImpl::class.java, PublicKeySerializer)
+            register(sun.security.ec.ECPublicKeyImpl::class.java, ECPublicKeyImplSerializer)
             register(EdDSAPublicKey::class.java, Ed25519PublicKeySerializer)
             register(EdDSAPrivateKey::class.java, Ed25519PrivateKeySerializer)
 

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -387,6 +387,20 @@ object Ed25519PublicKeySerializer : Serializer<EdDSAPublicKey>() {
     }
 }
 
+/** For serialising an ed25519 public key */
+@ThreadSafe
+object ECPublicKeyImplSerializer : Serializer<sun.security.ec.ECPublicKeyImpl>() {
+    override fun write(kryo: Kryo, output: Output, obj: sun.security.ec.ECPublicKeyImpl) {
+        output.writeBytesWithLength(obj.encoded)
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<sun.security.ec.ECPublicKeyImpl>): sun.security.ec.ECPublicKeyImpl {
+        val A = input.readBytesWithLength()
+        val der = sun.security.util.DerValue(A)
+        return sun.security.ec.ECPublicKeyImpl.parse(der) as sun.security.ec.ECPublicKeyImpl
+    }
+}
+
 // TODO Implement standardized serialization of CompositeKeys. See JIRA issue: CORDA-249.
 @ThreadSafe
 object CompositeKeySerializer : Serializer<CompositeKey>() {

--- a/core/src/main/kotlin/net/corda/flows/ContractUpgradeFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ContractUpgradeFlow.kt
@@ -58,9 +58,12 @@ class ContractUpgradeFlow<OldState : ContractState, out NewState : ContractState
         }
     }
 
-    override fun assembleTx(): Pair<SignedTransaction, Iterable<AbstractParty>> {
+    override fun assembleTx(): AbstractStateReplacementFlow.UpgradeTx {
         val baseTx = assembleBareTx(originalState, modification)
-        val stx = serviceHub.signInitialTransaction(baseTx)
-        return stx to originalState.state.data.participants
+        val participantKeys = originalState.state.data.participants.map { it.owningKey }.toSet()
+        // TODO: We need a much faster way of finding our key in the transaction
+        val myKey = serviceHub.keyManagementService.filterMyKeys(participantKeys).single()
+        val stx = serviceHub.signInitialTransaction(baseTx, myKey)
+        return AbstractStateReplacementFlow.UpgradeTx(stx, participantKeys, myKey)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -173,9 +173,11 @@ class ContractUpgradeFlowTest {
     @Test
     fun `upgrade Cash to v2`() {
         // Create some cash.
-        val result = a.services.startFlow(CashIssueFlow(Amount(1000, USD), OpaqueBytes.of(1), a.info.legalIdentity, notary)).resultFuture
+        val anonymous = false
+        val result = a.services.startFlow(CashIssueFlow(Amount(1000, USD), OpaqueBytes.of(1), a.info.legalIdentity, notary, anonymous)).resultFuture
         mockNet.runNetwork()
-        val stateAndRef = result.getOrThrow().tx.outRef<Cash.State>(0)
+        val stx = result.getOrThrow().stx
+        val stateAndRef = stx.tx.outRef<Cash.State>(0)
         val baseState = a.database.transaction { a.vault.unconsumedStates<ContractState>().single() }
         assertTrue(baseState.state.data is Cash.State, "Contract state is old version.")
         // Starts contract upgrade flow.

--- a/core/src/test/kotlin/net/corda/flows/TxKeyFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/flows/TxKeyFlowTests.kt
@@ -40,7 +40,7 @@ class TxKeyFlowTests {
         val requesterFlow = aliceNode.services.startFlow(TxKeyFlow.Requester(bob))
 
         // Get the results
-        val actual: Map<Party, TxKeyFlow.AnonymousIdentity> = requesterFlow.resultFuture.getOrThrow()
+        val actual: Map<Party, AnonymisedIdentity> = requesterFlow.resultFuture.getOrThrow()
         assertEquals(2, actual.size)
         // Verify that the generated anonymous identities do not match the well known identities
         val aliceAnonymousIdentity = actual[alice] ?: throw IllegalStateException()

--- a/core/src/test/kotlin/net/corda/flows/TxKeyFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/flows/TxKeyFlowTests.kt
@@ -40,7 +40,7 @@ class TxKeyFlowTests {
         val requesterFlow = aliceNode.services.startFlow(TxKeyFlow.Requester(bob))
 
         // Get the results
-        val actual: Map<Party, AnonymisedIdentity> = requesterFlow.resultFuture.getOrThrow()
+        val actual: Map<Party, AnonymisedIdentity> = requesterFlow.resultFuture.getOrThrow().toMap()
         assertEquals(2, actual.size)
         // Verify that the generated anonymous identities do not match the well known identities
         val aliceAnonymousIdentity = actual[alice] ?: throw IllegalStateException()

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -67,7 +67,8 @@ class IntegrationTestingTutorial {
                             i.DOLLARS,
                             issueRef,
                             bob.nodeInfo.legalIdentity,
-                            notary.nodeInfo.notaryIdentity
+                            notary.nodeInfo.notaryIdentity,
+                            false // Not anonymised
                     ).returnValue)
                 }
             }.forEach(Thread::join) // Ensure the stack of futures is populated.
@@ -90,7 +91,7 @@ class IntegrationTestingTutorial {
 
             // START 5
             for (i in 1..10) {
-                bobProxy.startFlow(::CashPaymentFlow, i.DOLLARS, alice.nodeInfo.legalIdentity).returnValue.getOrThrow()
+                bobProxy.startFlow(::CashPaymentFlow, i.DOLLARS, alice.nodeInfo.legalIdentity, false).returnValue.getOrThrow()
             }
 
             aliceVaultUpdates.expectEvents {

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
@@ -48,7 +48,8 @@ class FxTransactionBuildTutorialTest {
         val flowHandle1 = nodeA.services.startFlow(CashIssueFlow(DOLLARS(1000),
                 OpaqueBytes.of(0x01),
                 nodeA.info.legalIdentity,
-                notaryNode.info.notaryIdentity))
+                notaryNode.info.notaryIdentity,
+                false))
         // Wait for the flow to stop and print
         flowHandle1.resultFuture.getOrThrow()
         printBalances()
@@ -57,7 +58,8 @@ class FxTransactionBuildTutorialTest {
         val flowHandle2 = nodeB.services.startFlow(CashIssueFlow(POUNDS(1000),
                 OpaqueBytes.of(0x01),
                 nodeB.info.legalIdentity,
-                notaryNode.info.notaryIdentity))
+                notaryNode.info.notaryIdentity,
+                false))
         // Wait for flow to come to an end and print
         flowHandle2.resultFuture.getOrThrow()
         printBalances()

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
@@ -429,7 +429,7 @@ class Obligation<P : Any> : Contract {
     /**
      * Generate a transaction performing close-out netting of two or more states.
      *
-     * @param signer the party who will sign the transaction. Must be one of the obligor or beneficiary.
+     * @param signer the party which will sign the transaction. Must be one of the obligor or beneficiary.
      * @param states two or more states, which must be compatible for bilateral netting (same issuance definitions,
      * and same parties involved).
      */
@@ -458,7 +458,7 @@ class Obligation<P : Any> : Contract {
      * @param amountIssued the amount to be exited, represented as a quantity of issued currency.
      * @param assetStates the asset states to take funds from. No checks are done about ownership of these states, it is
      * the responsibility of the caller to check that they do not exit funds held by others.
-     * @return the public keys who must sign the transaction for it to be valid.
+     * @return the public keys which must sign the transaction for it to be valid.
      */
     @Suppress("unused")
     fun generateExit(tx: TransactionBuilder, amountIssued: Amount<Issued<Terms<P>>>,

--- a/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
@@ -207,13 +207,15 @@ abstract class OnLedgerAsset<T : Any, C : CommandData, S : FungibleAsset<T>> : C
         @JvmStatic
         fun <S : FungibleAsset<T>, T: Any> generateIssue(tx: TransactionBuilder,
                                                          transactionState: TransactionState<S>,
-                                                         issueCommand: CommandData) {
+                                                         issueCommand: CommandData): Set<PublicKey> {
             check(tx.inputStates().isEmpty())
             check(tx.outputStates().map { it.data }.filterIsInstance(transactionState.javaClass).isEmpty())
             require(transactionState.data.amount.quantity > 0)
             val at = transactionState.data.amount.token.issuer
+            val commandSigner = at.party.owningKey
             tx.addOutputState(transactionState)
-            tx.addCommand(issueCommand, at.party.owningKey)
+            tx.addCommand(issueCommand, commandSigner)
+            return setOf(commandSigner)
         }
     }
 

--- a/finance/src/main/kotlin/net/corda/flows/AbstractCashFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/AbstractCashFlow.kt
@@ -3,30 +3,44 @@ package net.corda.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
+import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 
 /**
  * Initiates a flow that produces an Issue/Move or Exit Cash transaction.
  */
-abstract class AbstractCashFlow(override val progressTracker: ProgressTracker) : FlowLogic<SignedTransaction>() {
+abstract class AbstractCashFlow<T>(override val progressTracker: ProgressTracker) : FlowLogic<T>() {
     companion object {
+        object GENERATING_ID : ProgressTracker.Step("Generating anonymous identities")
         object GENERATING_TX : ProgressTracker.Step("Generating transaction")
         object SIGNING_TX : ProgressTracker.Step("Signing transaction")
         object FINALISING_TX : ProgressTracker.Step("Finalising transaction")
 
-        fun tracker() = ProgressTracker(GENERATING_TX, SIGNING_TX, FINALISING_TX)
+        fun tracker() = ProgressTracker(GENERATING_ID, GENERATING_TX, SIGNING_TX, FINALISING_TX)
     }
 
     @Suspendable
-    internal fun finaliseTx(participants: Set<Party>, tx: SignedTransaction, message: String) {
+    protected fun finaliseTx(participants: Set<Party>, tx: SignedTransaction, message: String) {
         try {
             subFlow(FinalityFlow(tx, participants))
         } catch (e: NotaryException) {
             throw CashException(message, e)
         }
     }
+
+    /**
+     * Combined signed transaction and identity lookup map, which is the resulting data from regular cash flows.
+     * Specialised flows for unit tests differ from this.
+     *
+     * @param stx the signed transaction.
+     * @param identities a mapping from the original identities of the parties to the anonymised equivalents.
+     */
+    @CordaSerializable
+    data class Result(val stx: SignedTransaction, val identities: TxKeyFlow.TxIdentities)
 }
 
 class CashException(message: String, cause: Throwable) : FlowException(message, cause)

--- a/finance/src/main/kotlin/net/corda/flows/CashExitFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/CashExitFlow.kt
@@ -9,7 +9,6 @@ import net.corda.core.contracts.issuedBy
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import java.util.*
@@ -22,16 +21,20 @@ import java.util.*
  * issuer.
  */
 @StartableByRPC
-class CashExitFlow(val amount: Amount<Currency>, val issueRef: OpaqueBytes, progressTracker: ProgressTracker) : AbstractCashFlow(progressTracker) {
+class CashExitFlow(val amount: Amount<Currency>, val issueRef: OpaqueBytes, progressTracker: ProgressTracker) : AbstractCashFlow<AbstractCashFlow.Result>(progressTracker) {
     constructor(amount: Amount<Currency>, issueRef: OpaqueBytes) : this(amount, issueRef, tracker())
 
     companion object {
         fun tracker() = ProgressTracker(GENERATING_TX, SIGNING_TX, FINALISING_TX)
     }
 
+    /**
+     * @return the signed transaction, and a mapping of parties to new anonymous identities generated
+     * (for this flow this map is always empty).
+     */
     @Suspendable
     @Throws(CashException::class)
-    override fun call(): SignedTransaction {
+    override fun call(): AbstractCashFlow.Result {
         progressTracker.currentStep = GENERATING_TX
         val builder: TransactionBuilder = TransactionType.General.Builder(notary = null as Party?)
         val issuer = serviceHub.myInfo.legalIdentity.ref(issueRef)
@@ -67,6 +70,6 @@ class CashExitFlow(val amount: Amount<Currency>, val issueRef: OpaqueBytes, prog
         // Commit the transaction
         progressTracker.currentStep = FINALISING_TX
         finaliseTx(participants, tx, "Unable to notarise exit")
-        return tx
+        return Result(tx, TxKeyFlow.TxIdentities())
     }
 }

--- a/finance/src/main/kotlin/net/corda/flows/CashFlowCommand.kt
+++ b/finance/src/main/kotlin/net/corda/flows/CashFlowCommand.kt
@@ -6,14 +6,13 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.OpaqueBytes
-import net.corda.core.transactions.SignedTransaction
 import java.util.*
 
 /**
  * A command to initiate the cash flow with.
  */
 sealed class CashFlowCommand {
-    abstract fun startFlow(proxy: CordaRPCOps): FlowHandle<SignedTransaction>
+    abstract fun startFlow(proxy: CordaRPCOps): FlowHandle<AbstractCashFlow.Result>
 
     /**
      * A command to initiate the Cash flow with.
@@ -21,8 +20,9 @@ sealed class CashFlowCommand {
     data class IssueCash(val amount: Amount<Currency>,
                          val issueRef: OpaqueBytes,
                          val recipient: Party,
-                         val notary: Party) : CashFlowCommand() {
-        override fun startFlow(proxy: CordaRPCOps) = proxy.startFlow(::CashIssueFlow, amount, issueRef, recipient, notary)
+                         val notary: Party,
+                         val anonymous: Boolean) : CashFlowCommand() {
+        override fun startFlow(proxy: CordaRPCOps) = proxy.startFlow(::CashIssueFlow, amount, issueRef, recipient, notary, anonymous)
     }
 
     /**
@@ -31,8 +31,9 @@ sealed class CashFlowCommand {
      * @param amount the amount of currency to issue on to the ledger.
      * @param recipient the party to issue the cash to.
      */
-    data class PayCash(val amount: Amount<Currency>, val recipient: Party, val issuerConstraint: Party? = null) : CashFlowCommand() {
-        override fun startFlow(proxy: CordaRPCOps) = proxy.startFlow(::CashPaymentFlow, amount, recipient)
+    data class PayCash(val amount: Amount<Currency>, val recipient: Party, val issuerConstraint: Party? = null,
+                       val anonymous: Boolean) : CashFlowCommand() {
+        override fun startFlow(proxy: CordaRPCOps) = proxy.startFlow(::CashPaymentFlow, amount, recipient, anonymous)
     }
 
     /**

--- a/finance/src/test/kotlin/net/corda/flows/CashExitFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/flows/CashExitFlowTests.kt
@@ -3,8 +3,8 @@ package net.corda.flows
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.`issued by`
-import net.corda.core.identity.Party
 import net.corda.core.getOrThrow
+import net.corda.core.identity.Party
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
@@ -51,7 +51,7 @@ class CashExitFlowTests {
         val future = bankOfCordaNode.services.startFlow(CashExitFlow(exitAmount,
                 ref)).resultFuture
         mockNet.runNetwork()
-        val exitTx = future.getOrThrow().tx
+        val exitTx = future.getOrThrow().stx.tx
         val expected = (initialBalance - exitAmount).`issued by`(bankOfCorda.ref(ref))
         assertEquals(1, exitTx.inputs.size)
         assertEquals(1, exitTx.outputs.size)

--- a/finance/src/test/kotlin/net/corda/flows/CashIssueFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/flows/CashIssueFlowTests.kt
@@ -3,8 +3,8 @@ package net.corda.flows
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.`issued by`
-import net.corda.core.identity.Party
 import net.corda.core.getOrThrow
+import net.corda.core.identity.Party
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
@@ -46,7 +46,7 @@ class CashIssueFlowTests {
                 bankOfCorda,
                 notary)).resultFuture
         mockNet.runNetwork()
-        val issueTx = future.getOrThrow()
+        val issueTx = future.getOrThrow().stx
         val output = issueTx.tx.outputs.single().data as Cash.State
         assertEquals(expected.`issued by`(bankOfCorda.ref(ref)), output.amount)
     }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -459,7 +459,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         val storageServices = initialiseStorageService(configuration.baseDirectory)
         storage = storageServices.first
         checkpointStorage = storageServices.second
-        netMapCache = InMemoryNetworkMapCache()
+        netMapCache = InMemoryNetworkMapCache(services)
         network = makeMessagingService()
         schemas = makeSchemaService()
         vault = makeVaultService(configuration.dataSourceProperties)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -260,6 +260,8 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
                 rpcFlows = emptyList()
             }
 
+            // TODO: Investigate having class path scanning find this flow
+            registerInitiatedFlow(TxKeyFlow.Provider::class.java)
             // TODO Remove this once the cash stuff is in its own CorDapp
             registerInitiatedFlow(IssuerFlow.Issuer::class.java)
 

--- a/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
@@ -5,7 +5,6 @@ import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.crypto.keys
 import net.corda.core.crypto.sign
-import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
@@ -69,6 +68,10 @@ class E2ETestKeyManagementService(val identityService: IdentityService,
             val pk = publicKey.keys.first { keys.containsKey(it) }
             KeyPair(pk, keys[pk]!!)
         }
+    }
+
+    override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> {
+        return mutex.locked { candidateKeys.filter { it in this.keys } }
     }
 
     override fun sign(bytes: ByteArray, publicKey: PublicKey): DigitalSignature.WithKey {

--- a/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
@@ -9,6 +9,7 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SingletonSerializeAsToken
+import net.corda.flows.AnonymisedIdentity
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
@@ -57,7 +58,7 @@ class E2ETestKeyManagementService(val identityService: IdentityService,
         return keyPair.public
     }
 
-    override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> {
+    override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): AnonymisedIdentity {
         return freshCertificate(identityService, freshKey(), identity, getSigner(identity.owningKey), revocationEnabled)
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
@@ -4,6 +4,7 @@ import net.corda.core.crypto.*
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
+import net.corda.flows.AnonymisedIdentity
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
@@ -30,7 +31,7 @@ fun freshCertificate(identityService: IdentityService,
                      subjectPublicKey: PublicKey,
                      issuer: PartyAndCertificate,
                      issuerSigner: ContentSigner,
-                     revocationEnabled: Boolean = false): Pair<X509CertificateHolder, CertPath> {
+                     revocationEnabled: Boolean = false): AnonymisedIdentity {
     val issuerCertificate = issuer.certificate
     val window = X509Utilities.getCertificateValidityWindow(Duration.ZERO, Duration.ofDays(10 * 365), issuerCertificate)
     val ourCertificate = Crypto.createCertificate(CertificateType.IDENTITY, issuerCertificate.subject, issuerSigner, issuer.name, subjectPublicKey, window)
@@ -39,7 +40,7 @@ fun freshCertificate(identityService: IdentityService,
     identityService.registerAnonymousIdentity(AnonymousParty(subjectPublicKey),
             issuer.party,
             ourCertPath)
-    return Pair(issuerCertificate, ourCertPath)
+    return AnonymisedIdentity(ourCertPath, issuerCertificate, subjectPublicKey)
 }
 
 fun getSigner(issuerKeyPair: KeyPair): ContentSigner {

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -60,6 +60,10 @@ class PersistentKeyManagementService(val identityService: IdentityService,
 
     override val keys: Set<PublicKey> get() = mutex.locked { keys.keys }
 
+    override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> {
+        return mutex.locked { candidateKeys.filter { it in this.keys } }
+    }
+
     override fun freshKey(): PublicKey {
         val keyPair = generateKeyPair()
         mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -9,6 +9,7 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SingletonSerializeAsToken
+import net.corda.flows.AnonymisedIdentity
 import net.corda.node.utilities.*
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.operator.ContentSigner
@@ -72,7 +73,7 @@ class PersistentKeyManagementService(val identityService: IdentityService,
         return keyPair.public
     }
 
-    override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> {
+    override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): AnonymisedIdentity {
         return freshCertificate(identityService, freshKey(), identity, getSigner(identity.owningKey), revocationEnabled)
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
@@ -27,7 +27,7 @@ open class MockServiceHubInternal(
         val network: MessagingService? = null,
         val identity: IdentityService? = MOCK_IDENTITY_SERVICE,
         val storage: TxWritableStorageService? = MockStorageService(),
-        val mapCache: NetworkMapCacheInternal? = MockNetworkMapCache(),
+        val mapCache: NetworkMapCacheInternal? = null,
         val scheduler: SchedulerService? = null,
         val overrideClock: Clock? = NodeClock(),
         val schemas: SchemaService? = NodeSchemaService(),
@@ -46,7 +46,7 @@ open class MockServiceHubInternal(
     override val networkService: MessagingService
         get() = network ?: throw UnsupportedOperationException()
     override val networkMapCache: NetworkMapCacheInternal
-        get() = mapCache ?: throw UnsupportedOperationException()
+        get() = mapCache ?: MockNetworkMapCache(this)
     override val storageService: StorageService
         get() = storage ?: throw UnsupportedOperationException()
     override val schedulerService: SchedulerService

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -60,6 +60,7 @@ class ArtemisMessagingTests {
     var messagingClient: NodeMessagingClient? = null
     var messagingServer: ArtemisMessagingServer? = null
 
+    // TODO: We should have a dummy service hub rather than change behaviour in tests
     val networkMapCache = InMemoryNetworkMapCache(serviceHub = null)
 
     val rpcOps = object : RPCOps {

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -60,7 +60,7 @@ class ArtemisMessagingTests {
     var messagingClient: NodeMessagingClient? = null
     var messagingServer: ArtemisMessagingServer? = null
 
-    val networkMapCache = InMemoryNetworkMapCache()
+    val networkMapCache = InMemoryNetworkMapCache(serviceHub = null)
 
     val rpcOps = object : RPCOps {
         override val protocolVersion: Int get() = throw UnsupportedOperationException()

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
 import net.corda.core.utilities.*
+import net.corda.flows.AnonymisedIdentity
 import net.corda.flows.TxKeyFlow
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.testing.ALICE_PUBKEY
@@ -136,14 +137,14 @@ class InMemoryIdentityServiceTests {
         }
     }
 
-    private fun createParty(x500Name: X500Name, ca: CertificateAndKeyPair): Pair<PartyAndCertificate, TxKeyFlow.AnonymousIdentity> {
+    private fun createParty(x500Name: X500Name, ca: CertificateAndKeyPair): Pair<PartyAndCertificate, AnonymisedIdentity> {
         val certFactory = CertificateFactory.getInstance("X509")
         val issuerKeyPair = generateKeyPair()
         val issuer = getTestPartyAndCertificate(x500Name, issuerKeyPair.public, ca)
         val txKey = Crypto.generateKeyPair()
         val txCert = X509Utilities.createCertificate(CertificateType.IDENTITY, issuer.certificate, issuerKeyPair, x500Name, txKey.public)
         val txCertPath = certFactory.generateCertPath(listOf(txCert.cert) + issuer.certPath.certificates)
-        return Pair(issuer, TxKeyFlow.AnonymousIdentity(txCertPath, txCert, AnonymousParty(txKey.public)))
+        return Pair(issuer, AnonymisedIdentity(txCertPath, txCert, AnonymousParty(txKey.public)))
     }
 
     /**

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryNetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryNetworkMapCacheTest.kt
@@ -1,17 +1,24 @@
 package net.corda.node.services.network
 
 import net.corda.core.getOrThrow
+import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.ALICE
 import net.corda.core.utilities.BOB
 import net.corda.node.utilities.transaction
 import net.corda.testing.node.MockNetwork
+import org.junit.After
 import org.junit.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals
 
 class InMemoryNetworkMapCacheTest {
     private val mockNet = MockNetwork()
+
+    @After
+    fun teardown() {
+        mockNet.stopNodes()
+    }
 
     @Test
     fun registerWithNetwork() {
@@ -28,6 +35,8 @@ class InMemoryNetworkMapCacheTest {
         val nodeB = mockNet.createNode(null, -1, MockNetwork.DefaultFactory, true, BOB.name, null, entropy, ServiceInfo(NetworkMapService.type))
         assertEquals(nodeA.info.legalIdentity, nodeB.info.legalIdentity)
 
+        mockNet.runNetwork()
+
         // Node A currently knows only about itself, so this returns node A
         assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeA.info)
 
@@ -36,5 +45,18 @@ class InMemoryNetworkMapCacheTest {
         }
         // The details of node B write over those for node A
         assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeB.info)
+    }
+
+    @Test
+    fun `getNodeByLegalIdentity`() {
+        val (n0, n1) = mockNet.createTwoNodes()
+        val node0Cache: NetworkMapCache = n0.services.networkMapCache
+        val expected = n1.info
+
+        mockNet.runNetwork()
+        val actual = node0Cache.getNodeByLegalIdentity(n1.info.legalIdentity)
+        assertEquals(expected, actual)
+
+        // TODO: Should have a test case with anonymous lookup
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -328,10 +328,11 @@ class FlowFrameworkTests {
                 2000.DOLLARS,
                 OpaqueBytes.of(0x01),
                 node1.info.legalIdentity,
-                notary1.info.notaryIdentity))
+                notary1.info.notaryIdentity,
+                anonymous = false))
         // We pay a couple of times, the notary picking should go round robin
         for (i in 1..3) {
-            node1.services.startFlow(CashPaymentFlow(500.DOLLARS, node2.info.legalIdentity))
+            node1.services.startFlow(CashPaymentFlow(500.DOLLARS, node2.info.legalIdentity, anonymous = false))
             mockNet.runNetwork()
         }
         val endpoint = mockNet.messagingNetwork.endpoint(notary1.network.myAddress as InMemoryMessagingNetwork.PeerHandle)!!

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
@@ -19,8 +19,9 @@ class BankOfCordaHttpAPITest {
                     startNode(BOC.name, setOf(ServiceInfo(SimpleNotaryService.type))),
                     startNode(BIGCORP_LEGAL_NAME)
             ).getOrThrow()
+            val anonymous = true
             val nodeBankOfCordaApiAddr = startWebserver(nodeBankOfCorda).getOrThrow().listenAddress
-            assertTrue(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name)))
+            assertTrue(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name, anonymous)))
         }, isDebug = true)
     }
 }

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -39,25 +39,28 @@ class BankOfCordaRPCClientTest {
             val vaultUpdatesBigCorp = bigCorpProxy.vaultAndUpdates().second
 
             // Kick-off actual Issuer Flow
+            // TODO: Update checks below to reflect states consumed/produced under anonymisation
+            val anonymous = false
             bocProxy.startFlow(
                     ::IssuanceRequester,
                     1000.DOLLARS,
                     nodeBigCorporation.nodeInfo.legalIdentity,
                     BIG_CORP_PARTY_REF,
-                    nodeBankOfCorda.nodeInfo.legalIdentity).returnValue.getOrThrow()
+                    nodeBankOfCorda.nodeInfo.legalIdentity,
+                    anonymous).returnValue.getOrThrow()
 
             // Check Bank of Corda Vault Updates
             vaultUpdatesBoc.expectEvents {
                 sequence(
                         // ISSUE
                         expect { update ->
-                            require(update.consumed.isEmpty()) { update.consumed.size }
-                            require(update.produced.size == 1) { update.produced.size }
+                            require(update.consumed.isEmpty()) { "Expected 0 consumed states, actual: $update" }
+                            require(update.produced.size == 1) { "Expected 1 produced states, actual: $update" }
                         },
                         // MOVE
                         expect { update ->
-                            require(update.consumed.size == 1) { update.consumed.size }
-                            require(update.produced.isEmpty()) { update.produced.size }
+                            require(update.consumed.size == 1) { "Expected 1 consumed states, actual: $update" }
+                            require(update.produced.isEmpty()) { "Expected 0 produced states, actual: $update" }
                         }
                 )
             }

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
@@ -68,7 +68,8 @@ private class BankOfCordaDriver {
             }, isDebug = true)
         } else {
             try {
-                val requestParams = IssueRequestParams(options.valueOf(quantity), options.valueOf(currency), BIGCORP_LEGAL_NAME, "1", BOC.name)
+                val anonymous = true
+                val requestParams = IssueRequestParams(options.valueOf(quantity), options.valueOf(currency), BIGCORP_LEGAL_NAME, "1", BOC.name, anonymous)
                 when (role) {
                     Role.ISSUE_CASH_RPC -> {
                         println("Requesting Cash via RPC ...")

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt
@@ -44,7 +44,7 @@ class BankOfCordaClientApi(val hostAndPort: HostAndPort) {
             val amount = Amount(params.amount, currency(params.currency))
             val issuerToPartyRef = OpaqueBytes.of(params.issueToPartyRefAsString.toByte())
 
-            return proxy.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty).returnValue.getOrThrow()
+            return proxy.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty, params.anonymous).returnValue.getOrThrow().stx
         }
     }
 }

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
@@ -20,7 +20,8 @@ import javax.ws.rs.core.Response
 class BankOfCordaWebApi(val rpc: CordaRPCOps) {
     data class IssueRequestParams(val amount: Long, val currency: String,
                                   val issueToPartyName: X500Name, val issueToPartyRefAsString: String,
-                                  val issuerBankName: X500Name)
+                                  val issuerBankName: X500Name,
+                                  val anonymous: Boolean)
 
     private companion object {
         val logger = loggerFor<BankOfCordaWebApi>()
@@ -48,11 +49,12 @@ class BankOfCordaWebApi(val rpc: CordaRPCOps) {
 
         val amount = Amount(params.amount, currency(params.currency))
         val issuerToPartyRef = OpaqueBytes.of(params.issueToPartyRefAsString.toByte())
+        val anonymous = params.anonymous
 
         // invoke client side of Issuer Flow: IssuanceRequester
         // The line below blocks and waits for the future to resolve.
         val status = try {
-            rpc.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty).returnValue.getOrThrow()
+            rpc.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty, anonymous).returnValue.getOrThrow()
             logger.info("Issue request completed successfully: $params")
             Response.Status.CREATED
         } catch (e: FlowException) {

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -51,7 +51,8 @@ class TraderDemoTest : NodeBasedTest() {
         val expectedBCash = clientB.cashCount + 1
         val expectedPaper = listOf(clientA.commercialPaperCount + 1, clientB.commercialPaperCount)
 
-        clientA.runBuyer(amount = 100.DOLLARS)
+        // TODO: Enable anonymisation
+        clientA.runBuyer(amount = 100.DOLLARS, anonymous = false)
         clientB.runSeller(counterparty = nodeA.info.legalIdentity.name, amount = 5.DOLLARS)
 
         assertThat(clientA.cashCount).isGreaterThan(originalACash)

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
@@ -43,14 +43,14 @@ class TraderDemoClientApi(val rpc: CordaRPCOps) {
         return vault.filterStatesOfType<CommercialPaper.State>().size
     }
 
-    fun runBuyer(amount: Amount<Currency> = 30000.DOLLARS) {
+    fun runBuyer(amount: Amount<Currency> = 30000.DOLLARS, anonymous: Boolean = true) {
         val bankOfCordaParty = rpc.partyFromX500Name(BOC.name)
                 ?: throw Exception("Unable to locate ${BOC.name} in Network Map Service")
         val me = rpc.nodeIdentity()
         val amounts = calculateRandomlySizedAmounts(amount, 3, 10, Random())
         // issuer random amounts of currency totaling 30000.DOLLARS in parallel
         val resultFutures = amounts.map { pennies ->
-            rpc.startFlow(::IssuanceRequester, Amount(pennies, amount.token), me.legalIdentity, OpaqueBytes.of(1), bankOfCordaParty).returnValue
+            rpc.startFlow(::IssuanceRequester, Amount(pennies, amount.token), me.legalIdentity, OpaqueBytes.of(1), bankOfCordaParty, anonymous).returnValue
         }
 
         Futures.allAsList(resultFutures).getOrThrow()

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
@@ -5,6 +5,8 @@ import com.google.common.net.HostAndPort
 import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.ServiceHub
+import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.utilities.getTestPartyAndCertificate
 import net.corda.node.services.network.InMemoryNetworkMapCache
@@ -17,7 +19,7 @@ import java.math.BigInteger
 /**
  * Network map cache with no backing map service.
  */
-class MockNetworkMapCache : InMemoryNetworkMapCache() {
+class MockNetworkMapCache(serviceHub: ServiceHub) : InMemoryNetworkMapCache(serviceHub) {
     private companion object {
         val BANK_C = getTestPartyAndCertificate(getTestX509Name("Bank C"), entropyToKeyPair(BigInteger.valueOf(1000)).public)
         val BANK_D = getTestPartyAndCertificate(getTestX509Name("Bank D"), entropyToKeyPair(BigInteger.valueOf(2000)).public)

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
@@ -6,7 +6,6 @@ import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceHub
-import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.utilities.getTestPartyAndCertificate
 import net.corda.node.services.network.InMemoryNetworkMapCache

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -104,6 +104,8 @@ class MockKeyManagementService(val identityService: IdentityService,
         return k.public
     }
 
+    override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> = candidateKeys.filter { it in this.keys }
+
     override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> {
         return freshCertificate(identityService, freshKey(), identity, getSigner(identity.owningKey), revocationEnabled)
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -15,6 +15,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_CA
 import net.corda.core.utilities.getTestPartyAndCertificate
+import net.corda.flows.AnonymisedIdentity
 import net.corda.node.services.database.HibernateConfiguration
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.keys.freshCertificate
@@ -106,7 +107,7 @@ class MockKeyManagementService(val identityService: IdentityService,
 
     override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> = candidateKeys.filter { it in this.keys }
 
-    override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> {
+    override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): AnonymisedIdentity {
         return freshCertificate(identityService, freshKey(), identity, getSigner(identity.owningKey), revocationEnabled)
     }
 

--- a/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
@@ -43,7 +43,8 @@ class SimpleNode(val config: NodeConfiguration, val address: HostAndPort = freeL
     val identityService: IdentityService = InMemoryIdentityService(trustRoot = trustRoot)
     val keyService: KeyManagementService = E2ETestKeyManagementService(identityService, setOf(identity))
     val executor = ServiceAffinityExecutor(config.myLegalName.commonName, 1)
-    val broker = ArtemisMessagingServer(config, address.port, rpcAddress.port, InMemoryNetworkMapCache(), userService)
+    // TODO: We should have a dummy service hub rather than change behaviour in tests
+    val broker = ArtemisMessagingServer(config, address.port, rpcAddress.port, InMemoryNetworkMapCache(serviceHub = null), userService)
     val networkMapRegistrationFuture: SettableFuture<Unit> = SettableFuture.create<Unit>()
     val network = database.transaction {
         NodeMessagingClient(

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -22,11 +22,7 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ALICE
 import net.corda.core.utilities.BOB
 import net.corda.core.utilities.DUMMY_NOTARY
-import net.corda.flows.CashExitFlow
-import net.corda.flows.CashFlowCommand
-import net.corda.flows.CashIssueFlow
-import net.corda.flows.CashPaymentFlow
-import net.corda.flows.IssuerFlow
+import net.corda.flows.*
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
@@ -136,10 +132,11 @@ class ExplorerSimulation(val options: OptionSet) {
 
     private fun startSimulation(eventGenerator: EventGenerator, maxIterations: Int) {
         // Log to logger when flow finish.
-        fun FlowHandle<SignedTransaction>.log(seq: Int, name: String) {
+        fun FlowHandle<AbstractCashFlow.Result>.log(seq: Int, name: String) {
             val out = "[$seq] $name $id :"
             returnValue.success {
-                Main.log.info("$out ${it.id} ${(it.tx.outputs.first().data as Cash.State).amount}")
+                val (stx, idenities) = it
+                Main.log.info("$out ${stx.id} ${(stx.tx.outputs.first().data as Cash.State).amount}")
             }.failure {
                 Main.log.info("$out ${it.message}")
             }
@@ -179,11 +176,12 @@ class ExplorerSimulation(val options: OptionSet) {
                 currencies = listOf(GBP, USD)
         )
         val maxIterations = 100_000
+        val anonymous = true
         // Pre allocate some money to each party.
         eventGenerator.parties.forEach {
             for (ref in 0..1) {
                 for ((currency, issuer) in issuers) {
-                    CashFlowCommand.IssueCash(Amount(1_000_000, currency), OpaqueBytes(ByteArray(1, { ref.toByte() })), it, notaryNode.nodeInfo.notaryIdentity).startFlow(issuer)
+                    CashFlowCommand.IssueCash(Amount(1_000_000, currency), OpaqueBytes(ByteArray(1, { ref.toByte() })), it, notaryNode.nodeInfo.notaryIdentity, anonymous).startFlow(issuer)
                 }
             }
         }

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
@@ -117,13 +117,14 @@ val crossCashTest = LoadTest<CrossCashCommand, CrossCashState>(
 
         generate = { (nodeVaults), parallelism ->
             val nodeMap = simpleNodes.associateBy { it.info.legalIdentity }
+            val anonymous = true
             Generator.pickN(parallelism, simpleNodes).bind { nodes ->
                 Generator.sequence(
                         nodes.map { node ->
                             val quantities = nodeVaults[node.info.legalIdentity] ?: mapOf()
                             val possibleRecipients = nodeMap.keys.toList()
                             val moves = quantities.map {
-                                it.value.toDouble() / 1000 to generateMove(it.value, USD, node.info.legalIdentity, possibleRecipients)
+                                it.value.toDouble() / 1000 to generateMove(it.value, USD, node.info.legalIdentity, possibleRecipients, anonymous)
                             }
                             val exits = quantities.mapNotNull {
                                 if (it.key == node.info.legalIdentity) {
@@ -133,7 +134,7 @@ val crossCashTest = LoadTest<CrossCashCommand, CrossCashState>(
                                 }
                             }
                             val command = Generator.frequency(
-                                    listOf(1.0 to generateIssue(10000, USD, notary.info.notaryIdentity, possibleRecipients)) + moves + exits
+                                    listOf(1.0 to generateIssue(10000, USD, notary.info.notaryIdentity, possibleRecipients, anonymous)) + moves + exits
                             )
                             command.map { CrossCashCommand(it, nodeMap[node.info.legalIdentity]!!) }
                         }

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/GenerateHelpers.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/GenerateHelpers.kt
@@ -15,13 +15,14 @@ fun generateIssue(
         max: Long,
         currency: Currency,
         notary: Party,
-        possibleRecipients: List<Party>
+        possibleRecipients: List<Party>,
+        anonymous: Boolean
 ): Generator<CashFlowCommand.IssueCash> {
     return generateAmount(1, max, Generator.pure(currency)).combine(
             Generator.pure(OpaqueBytes.of(0)),
             Generator.pickOne(possibleRecipients)
     ) { amount, ref, recipient ->
-        CashFlowCommand.IssueCash(amount, ref, recipient, notary)
+        CashFlowCommand.IssueCash(amount, ref, recipient, notary, anonymous)
     }
 }
 
@@ -29,12 +30,13 @@ fun generateMove(
         max: Long,
         currency: Currency,
         issuer: Party,
-        possibleRecipients: List<Party>
+        possibleRecipients: List<Party>,
+        anonymous: Boolean
 ): Generator<CashFlowCommand.PayCash> {
     return generateAmount(1, max, Generator.pure(Issued(PartyAndReference(issuer, OpaqueBytes.of(0)), currency))).combine(
             Generator.pickOne(possibleRecipients)
     ) { amount, recipient ->
-        CashFlowCommand.PayCash(amount.withoutIssuer(), recipient, issuer)
+        CashFlowCommand.PayCash(amount.withoutIssuer(), recipient, issuer, anonymous)
     }
 }
 

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt
@@ -38,7 +38,7 @@ val selfIssueTest = LoadTest<SelfIssueCommand, SelfIssueState>(
 
         generate = { _, parallelism ->
             val generateIssue = Generator.pickOne(simpleNodes).bind { node ->
-                generateIssue(1000, USD, notary.info.notaryIdentity, listOf(node.info.legalIdentity)).map {
+                generateIssue(1000, USD, notary.info.notaryIdentity, listOf(node.info.legalIdentity), anonymous = true).map {
                     SelfIssueCommand(it, node)
                 }
             }

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/StabilityTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/StabilityTest.kt
@@ -19,7 +19,7 @@ object StabilityTest {
                 val nodeMap = simpleNodes.associateBy { it.info.legalIdentity }
                 Generator.sequence(simpleNodes.map { node ->
                     val possibleRecipients = nodeMap.keys.toList()
-                    val moves = 0.5 to generateMove(1, USD, node.info.legalIdentity, possibleRecipients)
+                    val moves = 0.5 to generateMove(1, USD, node.info.legalIdentity, possibleRecipients, anonymous = true)
                     val exits = 0.5 to generateExit(1, USD)
                     val command = Generator.frequency(listOf(moves, exits))
                     command.map { CrossCashCommand(it, nodeMap[node.info.legalIdentity]!!) }
@@ -42,7 +42,7 @@ object StabilityTest {
             "Self issuing cash randomly",
             generate = { _, parallelism ->
                 val generateIssue = Generator.pickOne(simpleNodes).bind { node ->
-                    generateIssue(1000, USD, notary.info.notaryIdentity, listOf(node.info.legalIdentity)).map {
+                    generateIssue(1000, USD, notary.info.notaryIdentity, listOf(node.info.legalIdentity), anonymous = true).map {
                         SelfIssueCommand(it, node)
                     }
                 }


### PR DESCRIPTION
Modify `CashIssueFlow` to use an anonymous identity for the recipient. This requires splitting the
flow into two parts so that the recipient can issue keys when needed, as well as adding infrastructure to support this generally.