### PR TITLE
Support fuzzy matching for identities.

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/jackson/JacksonSupport.kt
@@ -40,23 +40,23 @@ object JacksonSupport {
         fun partyFromName(partyName: String): Party?
         fun partyFromX500Name(name: X500Name): Party?
         fun partyFromKey(owningKey: PublicKey): Party?
-        fun partiesFromName(query: String, exactMatch: Boolean): Set<Party>
+        fun partiesFromName(query: String): Set<Party>
     }
 
-    class RpcObjectMapper(val rpc: CordaRPCOps, factory: JsonFactory) : PartyObjectMapper, ObjectMapper(factory) {
+    class RpcObjectMapper(val rpc: CordaRPCOps, factory: JsonFactory, val fuzzyIdentityMatch: Boolean) : PartyObjectMapper, ObjectMapper(factory) {
         @Suppress("OverridingDeprecatedMember", "DEPRECATION")
         override fun partyFromName(partyName: String): Party? = rpc.partyFromName(partyName)
         override fun partyFromX500Name(name: X500Name): Party? = rpc.partyFromX500Name(name)
         override fun partyFromKey(owningKey: PublicKey): Party? = rpc.partyFromKey(owningKey)
-        override fun partiesFromName(query: String, exactMatch: Boolean) = rpc.partiesFromName(query, exactMatch)
+        override fun partiesFromName(query: String) = rpc.partiesFromName(query, fuzzyIdentityMatch)
     }
 
-    class IdentityObjectMapper(val identityService: IdentityService, factory: JsonFactory) : PartyObjectMapper, ObjectMapper(factory) {
+    class IdentityObjectMapper(val identityService: IdentityService, factory: JsonFactory, val fuzzyIdentityMatch: Boolean) : PartyObjectMapper, ObjectMapper(factory) {
         @Suppress("OverridingDeprecatedMember", "DEPRECATION")
         override fun partyFromName(partyName: String): Party? = identityService.partyFromName(partyName)
         override fun partyFromX500Name(name: X500Name): Party? = identityService.partyFromX500Name(name)
         override fun partyFromKey(owningKey: PublicKey): Party? = identityService.partyFromKey(owningKey)
-        override fun partiesFromName(query: String, exactMatch: Boolean) = identityService.partiesFromName(query, exactMatch)
+        override fun partiesFromName(query: String) = identityService.partiesFromName(query, fuzzyIdentityMatch)
     }
 
     class NoPartyObjectMapper(factory: JsonFactory) : PartyObjectMapper, ObjectMapper(factory) {
@@ -64,7 +64,7 @@ object JacksonSupport {
         override fun partyFromName(partyName: String): Party? = throw UnsupportedOperationException()
         override fun partyFromX500Name(name: X500Name): Party? = throw UnsupportedOperationException()
         override fun partyFromKey(owningKey: PublicKey): Party? = throw UnsupportedOperationException()
-        override fun partiesFromName(query: String, exactMatch: Boolean) = throw UnsupportedOperationException()
+        override fun partiesFromName(query: String) = throw UnsupportedOperationException()
     }
 
     val cordaModule: Module by lazy {
@@ -109,17 +109,31 @@ object JacksonSupport {
         }
     }
 
-    /** Mapper requiring RPC support to deserialise parties from names */
+    /**
+     * Creates a Jackson ObjectMapper that uses RPC to deserialise parties from string names.
+     *
+     * If [fuzzyIdentityMatch] is false, fields mapped to [Party] objects must be in X.500 name form and precisely
+     * match an identity known from the network map. If true, the name is matched more leniently but if the match
+     * is ambiguous a [JsonParseException] is thrown.
+     */
     @JvmStatic @JvmOverloads
-    fun createDefaultMapper(rpc: CordaRPCOps, factory: JsonFactory = JsonFactory()): ObjectMapper = configureMapper(RpcObjectMapper(rpc, factory))
+    fun createDefaultMapper(rpc: CordaRPCOps, factory: JsonFactory = JsonFactory(),
+                            fuzzyIdentityMatch: Boolean = false): ObjectMapper = configureMapper(RpcObjectMapper(rpc, factory, fuzzyIdentityMatch))
 
     /** For testing or situations where deserialising parties is not required */
     @JvmStatic @JvmOverloads
     fun createNonRpcMapper(factory: JsonFactory = JsonFactory()): ObjectMapper = configureMapper(NoPartyObjectMapper(factory))
 
-    /** For testing with an in memory identity service */
+    /**
+     * Creates a Jackson ObjectMapper that uses an [IdentityService] directly inside the node to deserialise parties from string names.
+     *
+     * If [fuzzyIdentityMatch] is false, fields mapped to [Party] objects must be in X.500 name form and precisely
+     * match an identity known from the network map. If true, the name is matched more leniently but if the match
+     * is ambiguous a [JsonParseException] is thrown.
+     */
     @JvmStatic @JvmOverloads
-    fun createInMemoryMapper(identityService: IdentityService, factory: JsonFactory = JsonFactory()) = configureMapper(IdentityObjectMapper(identityService, factory))
+    fun createInMemoryMapper(identityService: IdentityService, factory: JsonFactory = JsonFactory(),
+                             fuzzyIdentityMatch: Boolean = false) = configureMapper(IdentityObjectMapper(identityService, factory, fuzzyIdentityMatch))
 
     private fun configureMapper(mapper: ObjectMapper): ObjectMapper = mapper.apply {
         enable(SerializationFeature.INDENT_OUTPUT)
@@ -175,7 +189,7 @@ object JacksonSupport {
                 val principal = X500Name(parser.text)
                 mapper.partyFromX500Name(principal) ?: throw JsonParseException(parser, "Could not find a Party with name $principal")
             } else {
-                val nameMatches = mapper.partiesFromName(parser.text, false)
+                val nameMatches = mapper.partiesFromName(parser.text)
                 if (nameMatches.isEmpty()) {
                     val key = try {
                         parsePublicKeyBase58(parser.text)

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -244,6 +244,16 @@ interface CordaRPCOps : RPCOps {
      */
     fun partyFromX500Name(x500Name: X500Name): Party?
 
+    /**
+     * Returns a list of candidate matches for a given string, with optional fuzzy(ish) matching. Fuzzy matching may
+     * get smarter with time e.g. to correct spelling errors, so you should not hard-code indexes into the results
+     * but rather show them via a user interface and let the user pick the one they wanted.
+     *
+     * @param query The string to check against the X.500 name components
+     * @param exactMatch If true, a case sensitive match is done against each component of each X.500 name.
+     */
+    fun partiesFromName(query: String, exactMatch: Boolean): Set<Party>
+
     /** Enumerates the class names of the flows that this node knows about. */
     fun registeredFlows(): List<String>
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -64,7 +64,7 @@ interface IdentityService {
     // but for now this is not supported.
 
     fun partyFromKey(key: PublicKey): Party?
-    @Deprecated("Use partyFromX500Name")
+    @Deprecated("Use partyFromX500Name or partiesFromName")
     fun partyFromName(name: String): Party?
     fun partyFromX500Name(principal: X500Name): Party?
 
@@ -97,6 +97,16 @@ interface IdentityService {
      * Get the certificate chain showing an anonymous party is owned by the given party.
      */
     fun pathForAnonymous(anonymousParty: AnonymousParty): CertPath?
+
+    /**
+     * Returns a list of candidate matches for a given string, with optional fuzzy(ish) matching. Fuzzy matching may
+     * get smarter with time e.g. to correct spelling errors, so you should not hard-code indexes into the results
+     * but rather show them via a user interface and let the user pick the one they wanted.
+     *
+     * @param query The string to check against the X.500 name components
+     * @param exactMatch If true, a case sensitive match is done against each component of each X.500 name.
+     */
+    fun partiesFromName(query: String, exactMatch: Boolean): Set<Party>
 
     class UnknownAnonymousPartyException(msg: String) : Exception(msg)
 }

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,8 +7,11 @@ from the previous milestone release.
 UNRELEASED
 ----------
 
-Milestone 12.0 - First Public Beta
-----------------------------------
+* A new RPC has been added to support fuzzy matching of X.500 names, for instance, to translate from user input to
+  an unambiguous identity by searching the network map.
+
+Milestone 12
+------------
 
 * Quite a few changes have been made to the flow API which should make things simpler when writing CorDapps:
 
@@ -97,6 +100,7 @@ Milestone 12.0 - First Public Beta
 * The certificate hierarchy has been changed in order to allow corda node to sign keys with proper certificate chain.
      * The corda node will now be issued a restricted client CA for identity/transaction key signing.
      * TLS certificate are now stored in `sslkeystore.jks` and identity keys are stored in `nodekeystore.jks`
+
 .. warning:: The old keystore will need to be removed when upgrading to this version.
 
 Milestone 11.1

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -8,6 +8,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
 import net.corda.core.messaging.*
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.NetworkMapCache
@@ -174,7 +175,8 @@ class CordaRPCOpsImpl(
     @Suppress("DEPRECATION")
     @Deprecated("Use partyFromX500Name instead")
     override fun partyFromName(name: String) = services.identityService.partyFromName(name)
-    override fun partyFromX500Name(x500Name: X500Name)= services.identityService.partyFromX500Name(x500Name)
+    override fun partyFromX500Name(x500Name: X500Name) = services.identityService.partyFromX500Name(x500Name)
+    override fun partiesFromName(query: String, exactMatch: Boolean): Set<Party> = services.identityService.partiesFromName(query, exactMatch)
 
     override fun registeredFlows(): List<String> = services.rpcFlows.map { it.name }.sorted()
 

--- a/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
@@ -184,7 +184,7 @@ object InteractiveShell {
     private val yamlInputMapper: ObjectMapper by lazy {
         // Return a standard Corda Jackson object mapper, configured to use YAML by default and with extra
         // serializers.
-        JacksonSupport.createInMemoryMapper(node.services.identityService, YAMLFactory()).apply {
+        JacksonSupport.createInMemoryMapper(node.services.identityService, YAMLFactory(), true).apply {
             val rpcModule = SimpleModule()
             rpcModule.addDeserializer(InputStream::class.java, InputStreamDeserializer)
             registerModule(rpcModule)


### PR DESCRIPTION
Matching can be done with case insensitive substrings in the identity service, RPC and shell. In future cleverer matching should be possible, e.g. using Lucene or RDBMS free text search features.