### PR TITLE
Remove nearestCity from node configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,14 +222,12 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     networkMap "CN=Controller,O=R3,OU=corda,L=London,C=UK"
     node {
         name "CN=Controller,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = ["corda.notary.validating"]
         p2pPort 10002
         cordapps = []
     }
     node {
         name "CN=Bank A,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = []
         p2pPort 10012
         rpcPort 10013
@@ -238,7 +236,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank B,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "New York"
         advertisedServices = []
         p2pPort 10007
         rpcPort 10008

--- a/config/dev/generalnodea.conf
+++ b/config/dev/generalnodea.conf
@@ -1,5 +1,4 @@
 myLegalName : "CN=Bank A,O=Bank A,L=London,C=UK"
-nearestCity : "London"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
 p2pAddress : "localhost:10002"

--- a/config/dev/generalnodeb.conf
+++ b/config/dev/generalnodeb.conf
@@ -1,5 +1,4 @@
 myLegalName : "CN=Bank B,O=Bank A,L=London,C=UK"
-nearestCity : "London"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
 p2pAddress : "localhost:10005"

--- a/config/dev/nameservernode.conf
+++ b/config/dev/nameservernode.conf
@@ -1,5 +1,4 @@
 myLegalName : "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-nearestCity : "London"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
 p2pAddress : "localhost:10000"

--- a/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -56,15 +56,6 @@ public class CordformNode {
     }
 
     /**
-     * Set the nearest city to the node.
-     *
-     * @param nearestCity The name of the nearest city to the node.
-     */
-    public void nearestCity(String nearestCity) {
-        config = config.withValue("nearestCity", ConfigValueFactory.fromAnyRef(nearestCity));
-    }
-
-    /**
      * Set the Artemis P2P port for this node.
      *
      * @param p2pPort The Artemis messaging queue port.

--- a/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
@@ -280,6 +280,7 @@ private fun X500Name.mutateCommonName(mutator: (ASN1Encodable) -> String): X500N
 val X500Name.commonName: String get() = getRDNs(BCStyle.CN).first().first.value.toString()
 val X500Name.orgName: String? get() = getRDNs(BCStyle.O).firstOrNull()?.first?.value?.toString()
 val X500Name.location: String get() = getRDNs(BCStyle.L).first().first.value.toString()
+val X500Name.locationOrNull: String? get() = try { location } catch (e: Exception) { null }
 val X509Certificate.subject: X500Name get() = X509CertificateHolder(encoded).subject
 
 class CertificateStream(val input: InputStream) {

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -35,7 +35,6 @@ NetworkMapService plus Simple Notary configuration file.
 .. parsed-literal::
 
     myLegalName : "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-    nearestCity : "London"
     keyStorePassword : "cordacadevpass"
     trustStorePassword : "trustpass"
     p2pAddress : "localhost:12345"
@@ -55,9 +54,6 @@ path to the node's base directory.
 
 :myLegalName: The legal identity of the node acts as a human readable alias to the node's public key and several demos use
     this to lookup the NodeInfo.
-
-:nearestCity: The location of the node as used to locate coordinates on the world map when running the network simulator
-    demo. See :doc:`network-simulator`.
 
 :keyStorePassword: The password to unlock the KeyStore file (``<workspace>/certificates/sslkeystore.jks``) containing the
     node certificate and private key.

--- a/docs/source/creating-a-cordapp.rst
+++ b/docs/source/creating-a-cordapp.rst
@@ -209,7 +209,6 @@ is a three node example;
         networkMap "CN=Controller,O=R3,OU=corda,L=London,C=UK" // The distinguished name of the node named here will be used as the networkMapService.address on all other nodes.
         node {
             name "CN=Controller,O=R3,OU=corda,L=London,C=UK"
-            nearestCity "London"
             advertisedServices = [ "corda.notary.validating" ]
             p2pPort 10002
             rpcPort 10003
@@ -219,7 +218,6 @@ is a three node example;
         }
         node {
             name "CN=NodeA,O=R3,OU=corda,L=London,C=UK"
-            nearestCity "London"
             advertisedServices = []
             p2pPort 10005
             rpcPort 10006
@@ -229,7 +227,6 @@ is a three node example;
         }
         node {
             name "CN=NodeB,O=R3,OU=corda,L=New York,C=US"
-            nearestCity "New York"
             advertisedServices = []
             p2pPort 10008
             rpcPort 10009

--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -73,7 +73,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     networkMap "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
     node {
         name "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = ["corda.notary.validating"]
         p2pPort 10002
         rpcPort 10003
@@ -82,7 +81,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Alice Corp,O=Alice Corp,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = []
         p2pPort 10005
         rpcPort 10006

--- a/docs/source/example-code/src/main/resources/example-network-map-node.conf
+++ b/docs/source/example-code/src/main/resources/example-network-map-node.conf
@@ -1,5 +1,4 @@
 myLegalName : "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-nearestCity : "London"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
 p2pAddress : "my-network-map:10000"

--- a/docs/source/example-code/src/main/resources/example-node.conf
+++ b/docs/source/example-code/src/main/resources/example-node.conf
@@ -1,5 +1,4 @@
 myLegalName : "CN=Bank A,O=Bank A,L=London,C=UK"
-nearestCity : "London"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
 dataSourceProperties : {

--- a/docs/source/example-code/src/main/resources/example-out-of-process-verifier-node.conf
+++ b/docs/source/example-code/src/main/resources/example-out-of-process-verifier-node.conf
@@ -1,5 +1,4 @@
 myLegalName : "CN=Bank A,O=Bank A,L=London,C=UK"
-nearestCity : "London"
 p2pAddress : "my-corda-node:10002"
 webAddress : "localhost:10003"
 networkMapService : {

--- a/docs/source/permissioning.rst
+++ b/docs/source/permissioning.rst
@@ -22,8 +22,6 @@ The following information from the node configuration file is needed to generate
     .. note:: In a future version the uniqueness requirement will be relaxed to a X.500 name. This will allow differentiation
         between entities with the same name.
 
-:nearestCity: e.g. "London"
-
 :emailAddress: e.g. "admin@company.com"
 
 :certificateSigningService: Doorman server URL. A doorman server will be hosted by R3 in the near

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -777,7 +777,6 @@ like to deploy for testing. See further details below:
       networkMap "CN=Controller,O=R3,OU=corda,L=London,C=UK" // The distinguished name of the node to be used as the network map.
       node {
           name "CN=Controller,O=R3,OU=corda,L=London,C=UK" // Distinguished name of node to be deployed.
-          nearestCity "London"                             // For use with the network visualiser.
           advertisedServices = ["corda.notary.validating"] // A list of services you wish the node to offer.
           p2pPort 10002
           rpcPort 10003                                    // Usually 1 higher than the messaging port.
@@ -786,7 +785,6 @@ like to deploy for testing. See further details below:
       }
       node {                                               // Create an additional node.
           name "CN=NodeA,O=R3,OU=corda,L=London,C=UK"
-          nearestCity "London"
           advertisedServices = []
           p2pPort 10005
           rpcPort 10006

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -155,13 +155,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     }
 
     open fun findMyLocation(): PhysicalLocation? {
-        val location = try {
-            configuration.myLegalName.location
-        } catch (e: Throwable) {
-            log.error("No location information in node legal name")
-            throw IllegalArgumentException("No location information in node legal name")
-        }
-        return CityDatabase[location]
+        return configuration.myLegalName.locationOrNull?.let { CityDatabase[it] }
     }
 
     lateinit var info: NodeInfo

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -154,7 +154,15 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         }
     }
 
-    open fun findMyLocation(): PhysicalLocation? = CityDatabase[configuration.nearestCity]
+    open fun findMyLocation(): PhysicalLocation? {
+        val location = try {
+            configuration.myLegalName.location
+        } catch (e: Throwable) {
+            log.error("No location information in node legal name")
+            throw IllegalArgumentException("No location information in node legal name")
+        }
+        return CityDatabase[location]
+    }
 
     lateinit var info: NodeInfo
     lateinit var storage: TxWritableStorageService

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -21,7 +21,6 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val myLegalName: X500Name
     val networkMapService: NetworkMapInfo?
     val minimumPlatformVersion: Int
-    val nearestCity: String
     val emailAddress: String
     val exportJMXto: String
     val dataSourceProperties: Properties
@@ -40,7 +39,6 @@ data class FullNodeConfiguration(
                 ReplaceWith("baseDirectory"))
         val basedir: Path,
         override val myLegalName: X500Name,
-        override val nearestCity: String,
         override val emailAddress: String,
         override val keyStorePassword: String,
         override val trustStorePassword: String,

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -123,7 +123,6 @@ class NetworkRegistrationHelper(val config: NodeConfiguration, val certService: 
             println("Certificate signing request with the following information will be submitted to the Corda certificate signing server.")
             println()
             println("Legal Name: ${config.myLegalName}")
-            println("Nearest City: ${config.nearestCity}")
             println("Email: ${config.emailAddress}")
             println()
             println("Public Key: ${keyPair.public}")

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -1,5 +1,4 @@
 myLegalName = "Vast Global MegaCorp, Ltd"
-nearestCity = "London"
 emailAddress = "admin@company.com"
 exportJMXto = "http"
 keyStorePassword = "cordacadevpass"

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -48,7 +48,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     networkMap "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
     node {
         name "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices["corda.notary.validating"]
         p2pPort 10002
         rpcPort 10003
@@ -57,7 +56,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank A,O=Bank A,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = []
         p2pPort 10005
         rpcPort 10006
@@ -66,7 +64,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank B,O=Bank B,L=New York,C=US"
-        nearestCity "New York"
         advertisedServices = []
         p2pPort 10008
         rpcPort 10009

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -45,7 +45,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     networkMap "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
     node {
         name "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = ["corda.notary.validating"]
         p2pPort 10002
         rpcPort 10003
@@ -53,7 +52,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=BankOfCorda,O=R3,L=New York,C=US"
-        nearestCity "New York"
         advertisedServices = ["corda.issuer.USD"]
         p2pPort 10005
         rpcPort 10006
@@ -68,7 +66,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=BigCorporation,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "New York"
         advertisedServices = []
         p2pPort 10008
         rpcPort 10009

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -50,7 +50,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     networkMap "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
     node {
         name "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = ["corda.notary.validating", "corda.interest_rates"]
         p2pPort 10002
         rpcPort 10003
@@ -60,7 +59,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank A,O=Bank A,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = []
         p2pPort 10005
         rpcPort 10006
@@ -70,7 +68,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank B,O=Bank B,L=New York,C=US"
-        nearestCity "New York"
         advertisedServices = []
         p2pPort 10008
         rpcPort 10009

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/simulation/Simulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/simulation/Simulation.kt
@@ -2,7 +2,7 @@ package net.corda.irs.simulation
 
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import net.corda.core.crypto.location
+import net.corda.core.crypto.locationOrNull
 import net.corda.core.flatMap
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.SingleMessageRecipient
@@ -58,8 +58,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
                              entropyRoot: BigInteger)
         : MockNetwork.MockNode(config, mockNet, networkMapAddress, advertisedServices, id, overrideServices, entropyRoot) {
         override fun findMyLocation(): PhysicalLocation? {
-            val location = configuration.myLegalName.location
-            return CityDatabase[location]
+            return configuration.myLegalName.locationOrNull?.let { CityDatabase[it] }
         }
     }
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/simulation/Simulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/simulation/Simulation.kt
@@ -2,6 +2,7 @@ package net.corda.irs.simulation
 
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import net.corda.core.crypto.location
 import net.corda.core.flatMap
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.SingleMessageRecipient
@@ -56,7 +57,10 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
                              advertisedServices: Set<ServiceInfo>, id: Int, overrideServices: Map<ServiceInfo, KeyPair>?,
                              entropyRoot: BigInteger)
         : MockNetwork.MockNode(config, mockNet, networkMapAddress, advertisedServices, id, overrideServices, entropyRoot) {
-        override fun findMyLocation(): PhysicalLocation? = CityDatabase[configuration.nearestCity]
+        override fun findMyLocation(): PhysicalLocation? {
+            val location = configuration.myLegalName.location
+            return CityDatabase[location]
+        }
     }
 
     inner class BankFactory : MockNetwork.Factory {

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -61,14 +61,12 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     networkMap "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
     node {
         name "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = ["corda.notary.validating"]
         p2pPort 10002
         cordapps = []
     }
     node {
         name "CN=Bank A,O=Bank A,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = []
         p2pPort 10004
         webPort 10005
@@ -76,7 +74,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank B,O=Bank B,L=New York,C=US"
-        nearestCity "New York"
         advertisedServices = []
         p2pPort 10006
         webPort 10007
@@ -84,7 +81,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank C,O=Bank C,L=Tokyo,C=Japan"
-        nearestCity "Tokyo"
         advertisedServices = []
         p2pPort 10008
         webPort 10009

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -61,14 +61,12 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     networkMap "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
     node {
         name "CN=Notary Service,O=R3,OU=corda,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = ["corda.notary.validating"]
         p2pPort 10002
         cordapps = []
     }
     node {
         name "CN=Bank A,O=Bank A,L=London,C=UK"
-        nearestCity "London"
         advertisedServices = []
         p2pPort 10005
         rpcPort 10006
@@ -77,7 +75,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=Bank B,O=Bank B,L=New York,C=US"
-        nearestCity "New York"
         advertisedServices = []
         p2pPort 10008
         rpcPort 10009
@@ -86,7 +83,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "CN=BankOfCorda,O=R3,L=New York,C=US"
-        nearestCity "London"
         advertisedServices = []
         p2pPort 10011
         cordapps = []

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -151,7 +151,6 @@ data class TestNodeConfiguration(
         override val certificateChainCheckPolicies: List<CertChainPolicyConfig> = emptyList(),
         override val verifierType: VerifierType = VerifierType.InMemory,
         override val messageRedeliveryDelaySeconds: Int = 5) : NodeConfiguration {
-    override val nearestCity = myLegalName.getRDNs(BCStyle.L).single().typesAndValues.single().value.toString()
 }
 
 fun testConfiguration(baseDirectory: Path, legalName: X500Name, basePort: Int): FullNodeConfiguration {
@@ -159,7 +158,6 @@ fun testConfiguration(baseDirectory: Path, legalName: X500Name, basePort: Int): 
             basedir = baseDirectory,
             myLegalName = legalName,
             networkMapService = null,
-            nearestCity = "Null Island",
             emailAddress = "",
             keyStorePassword = "cordacadevpass",
             trustStorePassword = "trustpass",

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
@@ -23,18 +23,12 @@ class InstallFactory : Controller() {
         val webPort = config.parsePort("webAddress")
         val h2Port = config.getInt("h2port")
         val x500name = X500Name(config.getString("myLegalName"))
-        val nearestCity = try {
-            config.getString("nearestCity")
-        } catch (e: ConfigException) {
-            x500name.location
-        }
         val extraServices = config.parseExtraServices("extraAdvertisedServiceIds")
         val tempDir = Files.createTempDirectory(baseDir, ".node")
 
         val nodeConfig = NodeConfig(
                 tempDir,
                 x500name,
-                nearestCity,
                 p2pPort,
                 rpcPort,
                 webPort,

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
@@ -2,10 +2,7 @@ package net.corda.demobench.model
 
 import com.google.common.net.HostAndPort
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigException
-import net.corda.core.crypto.location
 import org.bouncycastle.asn1.x500.X500Name
-
 import tornadofx.*
 import java.io.IOException
 import java.nio.file.Files

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
@@ -2,6 +2,8 @@ package net.corda.demobench.model
 
 import com.google.common.net.HostAndPort
 import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
+import net.corda.core.crypto.location
 import org.bouncycastle.asn1.x500.X500Name
 
 import tornadofx.*
@@ -20,12 +22,19 @@ class InstallFactory : Controller() {
         val rpcPort = config.parsePort("rpcAddress")
         val webPort = config.parsePort("webAddress")
         val h2Port = config.getInt("h2port")
+        val x500name = X500Name(config.getString("myLegalName"))
+        val nearestCity = try {
+            config.getString("nearestCity")
+        } catch (e: ConfigException) {
+            x500name.location
+        }
         val extraServices = config.parseExtraServices("extraAdvertisedServiceIds")
         val tempDir = Files.createTempDirectory(baseDir, ".node")
 
         val nodeConfig = NodeConfig(
                 tempDir,
-                X500Name(config.getString("myLegalName")),
+                x500name,
+                nearestCity,
                 p2pPort,
                 rpcPort,
                 webPort,

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -2,6 +2,7 @@ package net.corda.demobench.model
 
 import com.typesafe.config.*
 import net.corda.core.crypto.location
+import net.corda.core.crypto.locationOrNull
 import net.corda.nodeapi.User
 import org.bouncycastle.asn1.x500.X500Name
 import java.io.File
@@ -26,6 +27,7 @@ class NodeConfig(
         val defaultUser = user("guest")
     }
 
+    val nearestCity: String = legalName.locationOrNull ?: "Neverwhere"
     val nodeDir: Path = baseDir.resolve(key)
     override val pluginDir: Path = nodeDir.resolve("plugins")
     val explorerDir: Path = baseDir.resolve("$key-explorer")

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -12,6 +12,7 @@ import java.nio.file.StandardCopyOption
 class NodeConfig(
         baseDir: Path,
         legalName: X500Name,
+        val nearestCity: String,
         p2pPort: Int,
         val rpcPort: Int,
         val webPort: Int,
@@ -26,7 +27,6 @@ class NodeConfig(
         val defaultUser = user("guest")
     }
 
-    val nearestCity: String? = legalName.location
     val nodeDir: Path = baseDir.resolve(key)
     override val pluginDir: Path = nodeDir.resolve("plugins")
     val explorerDir: Path = baseDir.resolve("$key-explorer")
@@ -45,6 +45,7 @@ class NodeConfig(
      */
     fun toFileConfig(): Config = ConfigFactory.empty()
             .withValue("myLegalName", valueFor(legalName.toString()))
+            .withValue("nearestCity", valueFor(nearestCity.toString()))
             .withValue("p2pAddress", addressValueFor(p2pPort))
             .withValue("extraAdvertisedServiceIds", valueFor(extraServices))
             .withFallback(optional("networkMapService", networkMap, { c, n ->
@@ -60,7 +61,7 @@ class NodeConfig(
     fun toText(): String = toFileConfig().root().render(renderOptions)
 
     fun moveTo(baseDir: Path) = NodeConfig(
-            baseDir, legalName, p2pPort, rpcPort, webPort, h2Port, extraServices, users, networkMap
+            baseDir, legalName, nearestCity, p2pPort, rpcPort, webPort, h2Port, extraServices, users, networkMap
     )
 
     fun install(plugins: Collection<Path>) {

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -1,7 +1,6 @@
 package net.corda.demobench.model
 
 import com.typesafe.config.*
-import net.corda.core.crypto.location
 import net.corda.core.crypto.locationOrNull
 import net.corda.nodeapi.User
 import org.bouncycastle.asn1.x500.X500Name
@@ -27,7 +26,7 @@ class NodeConfig(
         val defaultUser = user("guest")
     }
 
-    val nearestCity: String = legalName.locationOrNull ?: "Neverwhere"
+    val nearestCity: String = legalName.locationOrNull ?: "Unknown location"
     val nodeDir: Path = baseDir.resolve(key)
     override val pluginDir: Path = nodeDir.resolve("plugins")
     val explorerDir: Path = baseDir.resolve("$key-explorer")

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -12,7 +12,6 @@ import java.nio.file.StandardCopyOption
 class NodeConfig(
         baseDir: Path,
         legalName: X500Name,
-        val nearestCity: String,
         p2pPort: Int,
         val rpcPort: Int,
         val webPort: Int,
@@ -45,7 +44,6 @@ class NodeConfig(
      */
     fun toFileConfig(): Config = ConfigFactory.empty()
             .withValue("myLegalName", valueFor(legalName.toString()))
-            .withValue("nearestCity", valueFor(nearestCity.toString()))
             .withValue("p2pAddress", addressValueFor(p2pPort))
             .withValue("extraAdvertisedServiceIds", valueFor(extraServices))
             .withFallback(optional("networkMapService", networkMap, { c, n ->
@@ -61,7 +59,7 @@ class NodeConfig(
     fun toText(): String = toFileConfig().root().render(renderOptions)
 
     fun moveTo(baseDir: Path) = NodeConfig(
-            baseDir, legalName, nearestCity, p2pPort, rpcPort, webPort, h2Port, extraServices, users, networkMap
+            baseDir, legalName, p2pPort, rpcPort, webPort, h2Port, extraServices, users, networkMap
     )
 
     fun install(plugins: Collection<Path>) {

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt
@@ -58,7 +58,6 @@ class NodeController(check: atRuntime = ::checkExists) : Controller() {
                     nearestCity = location.description,
                     country = location.countryCode
                 ),
-                location.description,
                 nodeData.p2pPort.value,
                 nodeData.rpcPort.value,
                 nodeData.webPort.value,

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt
@@ -58,6 +58,7 @@ class NodeController(check: atRuntime = ::checkExists) : Controller() {
                     nearestCity = location.description,
                     country = location.countryCode
                 ),
+                location.description,
                 nodeData.p2pPort.value,
                 nodeData.rpcPort.value,
                 nodeData.webPort.value,

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -15,6 +15,7 @@ import javafx.scene.layout.Priority
 import javafx.stage.FileChooser
 import javafx.util.StringConverter
 import net.corda.core.crypto.commonName
+import net.corda.core.crypto.location
 import net.corda.core.div
 import net.corda.core.exists
 import net.corda.core.node.CityDatabase
@@ -263,7 +264,7 @@ class NodeTabView : Fragment() {
     }
 
     private fun launchNode(config: NodeConfig) {
-        val countryCode = CityDatabase.cityMap[config.nearestCity ?: "Nowhere"]?.countryCode
+        val countryCode = CityDatabase.cityMap[config.legalName.location]?.countryCode
         if (countryCode != null) {
             nodeTab.graphic = ImageView(flags.get()[countryCode]).apply { fitWidth = 24.0; isPreserveRatio = true }
         }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -264,7 +264,7 @@ class NodeTabView : Fragment() {
     }
 
     private fun launchNode(config: NodeConfig) {
-        val countryCode = CityDatabase.cityMap[config.legalName.location]?.countryCode
+        val countryCode = CityDatabase.cityMap[config.nearestCity]?.countryCode
         if (countryCode != null) {
             nodeTab.graphic = ImageView(flags.get()[countryCode]).apply { fitWidth = 24.0; isPreserveRatio = true }
         }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -15,7 +15,6 @@ import javafx.scene.layout.Priority
 import javafx.stage.FileChooser
 import javafx.util.StringConverter
 import net.corda.core.crypto.commonName
-import net.corda.core.crypto.location
 import net.corda.core.div
 import net.corda.core.exists
 import net.corda.core.node.CityDatabase

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
@@ -166,20 +166,15 @@ fun main(args: Array<String>) {
                 startFlowPermission<IssuanceRequester>())
         )
         // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
-        val notary = startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)),
-                customOverrides = mapOf("nearestCity" to "Zurich"))
+        val notary = startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)))
         val alice = startNode(ALICE.name, rpcUsers = arrayListOf(user),
-                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("cash"))),
-                customOverrides = mapOf("nearestCity" to "Milan"))
+                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("cash"))))
         val bob = startNode(BOB.name, rpcUsers = arrayListOf(user),
-                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("cash"))),
-                customOverrides = mapOf("nearestCity" to "Madrid"))
+                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("cash"))))
         val issuerGBP = startNode(X500Name("CN=UK Bank Plc,O=UK Bank Plc,L=London,C=UK"), rpcUsers = arrayListOf(manager),
-                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.GBP"))),
-                customOverrides = mapOf("nearestCity" to "London"))
+                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.GBP"))))
         val issuerUSD = startNode(X500Name("CN=USA Bank Corp,O=USA Bank Corp,L=New York,C=US"), rpcUsers = arrayListOf(manager),
-                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.USD"))),
-                customOverrides = mapOf("nearestCity" to "New York"))
+                advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.USD"))))
 
         val notaryNode = notary.get()
         val aliceNode = alice.get()


### PR DESCRIPTION
Remove nearestCity from node configuration. Now information about the location is always taken from node's legal name. If not present - exception on node startup.
Fixes also: https://github.com/corda/corda/issues/696