### PR TITLE
Prevent DemoBench hanging on shutdown

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
@@ -54,8 +54,7 @@ class NodeRPC(config: NodeConfig, start: (NodeConfig, CordaRPCOps) -> Unit, invo
     override fun close() {
         timer.cancel()
         try {
-            // TODO: Uncomment when https://github.com/corda/corda/issues/689 is fixed
-            // rpcConnection?.close()
+            rpcConnection?.close()
         } catch (e: Exception) {
             log.error("Failed to close RPC connection (Error: {})", e.message)
         }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -41,7 +41,7 @@ class NodeTabView : Fragment() {
         const val textWidth = 465.0
 
         val jvm by inject<JVMConfig>()
-        val cordappPathsFile = jvm.dataHome / "cordapp-paths.txt"
+        val cordappPathsFile: Path = jvm.dataHome / "cordapp-paths.txt"
 
         fun loadDefaultCordappPaths(): MutableList<Path> {
             if (cordappPathsFile.exists())


### PR DESCRIPTION
We need to close the RPC client in order to destroy the non-daemon `rpc-client-reaper-*` thread(s). Sleep instead when the node exits, just long enough for the RPC client to realise that the other end of the connection is now dead.