### PR TITLE
X509Utilities API changes

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -43,6 +43,7 @@ import java.security.cert.X509Certificate
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
+import java.time.Instant
 import java.util.*
 
 /**
@@ -561,15 +562,17 @@ object Crypto {
     fun createCertificate(issuer: X500Name, issuerKeyPair: KeyPair,
                           subject: X500Name, subjectPublicKey: PublicKey,
                           keyUsage: KeyUsage, purposes: List<KeyPurposeId>,
-                          validityWindow: Pair<Date, Date>,
+                          validityWindow: Pair<Instant, Instant>,
                           pathLength: Int? = null, subjectAlternativeName: List<GeneralName>? = null): X509Certificate {
 
         val signatureScheme = findSignatureScheme(issuerKeyPair.private)
         val provider = providerMap[signatureScheme.providerName]
         val serial = BigInteger.valueOf(random63BitValue())
         val keyPurposes = DERSequence(ASN1EncodableVector().apply { purposes.forEach { add(it) } })
+        val notBefore = Date(validityWindow.first.toEpochMilli())
+        val notAfter = Date(validityWindow.second.toEpochMilli())
 
-        val builder = JcaX509v3CertificateBuilder(issuer, serial, validityWindow.first, validityWindow.second, subject, subjectPublicKey)
+        val builder = JcaX509v3CertificateBuilder(issuer, serial, notBefore, notAfter, subject, subjectPublicKey)
                 .addExtension(Extension.subjectKeyIdentifier, false, BcX509ExtensionUtils().createSubjectKeyIdentifier(SubjectPublicKeyInfo.getInstance(subjectPublicKey.encoded)))
                 .addExtension(Extension.basicConstraints, pathLength != null, if (pathLength == null) BasicConstraints(false) else BasicConstraints(pathLength))
                 .addExtension(Extension.keyUsage, false, keyUsage)

--- a/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
@@ -56,7 +56,7 @@ class X509UtilitiesTest {
         val caCertAndKey = X509Utilities.createSelfSignedCACert(getTestX509Name("Test CA Cert"))
         val subjectDN = getTestX509Name("Server Cert")
         val keyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
-        val serverCert = X509Utilities.createServerCert(subjectDN, keyPair.public, caCertAndKey, listOf("alias name"), listOf("10.0.0.54"))
+        val serverCert = X509Utilities.createTlsServerCert(subjectDN, keyPair.public, caCertAndKey, listOf("alias name"), listOf("10.0.0.54"))
         assertTrue { serverCert.subjectDN.name.contains("CN=Server Cert") } // using our subject common name
         assertEquals(caCertAndKey.certificate.issuerDN, serverCert.issuerDN) // Issued by our CA cert
         serverCert.checkValidity(Date()) // throws on verification problems
@@ -106,7 +106,7 @@ class X509UtilitiesTest {
         val tmpKeyStore = tempFile("keystore.jks")
         val ecDSACert = X509Utilities.createSelfSignedCACert(X500Name("CN=Test"))
         val edDSAKeypair = Crypto.generateKeyPair("EDDSA_ED25519_SHA512")
-        val edDSACert = X509Utilities.createServerCert(X500Name("CN=TestEdDSA"), edDSAKeypair.public, ecDSACert, listOf("alias name"), listOf("10.0.0.54"))
+        val edDSACert = X509Utilities.createTlsServerCert(X500Name("CN=TestEdDSA"), edDSAKeypair.public, ecDSACert, listOf("alias name"), listOf("10.0.0.54"))
 
         // Save the EdDSA private key with cert chains.
         val keyStore = KeyStoreUtilities.loadOrCreateKeyStore(tmpKeyStore, "keystorepass")


### PR DESCRIPTION
Add "TLS" to createTlsServerCert() to differentiate it from future work to introduce a non-TLS variant.

Change to using Java 8 time types for certificate validity - does introduce so unnecessary roundtrips, but makes the code significantly easier to read/follow. In particular avoids opaque integers in the code and replaces them with `Duration`.