### PR TITLE
Deterministic Key Generation for ECDSA and EdDSA

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -542,7 +542,7 @@ object Crypto {
      * generated child keys from depending solely on the key itself, current method uses normal elliptic curve keys
      * without a chain-code and the generated key relies solely on the security of the private key.
      *
-     * Although without a chain-code, we lose the aforementioned property of not depending solely on the key,
+     * Although without a chain-code we lose the aforementioned property of not depending solely on the key,
      * it should be mentioned that the cryptographic strength of the HMAC depends upon the size of the secret key.
      * @see <a href="https://en.wikipedia.org/wiki/Hash-based_message_authentication_code#Security">HMAC Security</a>
      * Thus, as long as the master key is kept secret and has enough entropy (~256 bits for EC-schemes), the system

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -144,7 +144,7 @@ fun generateKeyPair(): KeyPair = Crypto.generateKeyPair()
  * you want hard-coded private keys.
  * This currently works for the default signature scheme EdDSA ed25519 only.
  */
-fun entropyToKeyPair(entropy: BigInteger): KeyPair = Crypto.generateKeyPairFromEntropy(entropy)
+fun entropyToKeyPair(entropy: BigInteger): KeyPair = Crypto.deriveKeyPairFromEntropy(entropy)
 
 /**
  * Helper function for signing.


### PR DESCRIPTION
This version applies the BIP32 logic, with some modifications, mainly due to the fact that extension chain code for keys is not currently utilised in Corda.

**Algorithm:** each new private key is generated using the HMAC-SHA512 function, where the hmac-key is the private key and the hmac-data is a seed input, accordingly. The public key is then easily computed as a scalar multiplication on the curve.

**Note:** Current logic does not include a serialisation/padding mechanism for the HMAC inputs.
Solution: A compatible approach (easy to  implement) would be to have **HMAC-512(SHA256(private_key), SHA256(seed))**
@mikehearn and @mnesbit what are your thoughts on it?