### PR TITLE
Modify how Gradle creates capsules.

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -19,15 +19,12 @@ configurations {
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-dependencies {
-    compile project(':node')
-}
-
-task buildCordaJAR(type: FatCapsule) {
+task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').compileJava) {
     applicationClass 'net.corda.node.Corda'
     archiveName "corda-${corda_release_version}.jar"
     applicationSource = files(
-            project.tasks.findByName('jar'),
+            project(':node').configurations.compile,
+            project(':node').jar,
             '../build/classes/main/CordaCaplet.class',
             '../build/classes/main/CordaCaplet$1.class',
             "$rootDir/config/dev/log4j2.xml"

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -25,14 +25,14 @@ repositories {
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-dependencies {
-    compile project(':tools:explorer')
-}
-
-task buildExplorerJAR(type: FatCapsule) {
+task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').compileJava) {
     applicationClass 'net.corda.explorer.Main'
     archiveName "node-explorer-${corda_release_version}.jar"
-    applicationSource = files(project.tasks.findByName('jar'), '../build/classes/main/ExplorerCaplet.class')
+    applicationSource = files(
+        project(':tools:explorer').configurations.compile,
+        project(':tools:explorer').jar,
+        '../build/classes/main/ExplorerCaplet.class'
+    )
     classifier 'fat'
 
     capsuleManifest {

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -19,17 +19,14 @@ configurations {
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-dependencies {
-    compile project(':webserver')
-}
-
-task buildWebserverJar(type: FatCapsule) {
+task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').compileJava) {
     applicationClass 'net.corda.webserver.WebServer'
     archiveName "corda-webserver-${corda_release_version}.jar"
     applicationSource = files(
-            project.tasks.findByName('jar'),
-            new File(project(':node').rootDir, 'node/build/classes/main/CordaCaplet.class'),
-            new File(project(':node').rootDir, 'node/build/classes/main/CordaCaplet$1.class'),
+            project(':webserver').configurations.compile,
+            project(':webserver').jar,
+            new File(project(':node').buildDir, 'classes/main/CordaCaplet.class'),
+            new File(project(':node').buildDir, 'classes/main/CordaCaplet$1.class'),
             "$rootDir/config/dev/log4j2.xml"
     )
     from 'NOTICE' // Copy CDDL notice


### PR DESCRIPTION
We were originally packaging empty `capsule-0.12-SNAPSHOT.jar` and `webcapsule-0.12-SNAPSHOT.jar` artifacts into Node and WebServer respectively. This is currently harmless, except that we already have a third-party artifact called `capsule`. So rewrite the Gradle tasks that create capsules.