### PR TITLE
Compile caplets against correct version of capsule.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ buildscript {
     // TODO: Sort this alphabetically.
     ext.kotlin_version = constants.getProperty("kotlinVersion")
     ext.quasar_version = '0.7.6'    // TODO: Upgrade to 0.7.7+ when Quasar bug 238 is resolved.
+
+    // gradle-capsule-plugin:1.0.2 contains capsule:1.0.1
+    // TODO: Upgrade gradle-capsule-plugin to a version with capsule:1.0.3
+    ext.capsule_version = '1.0.1'
+
     ext.asm_version = '0.5.3'
     ext.artemis_version = '1.5.3'
     ext.jackson_version = '2.8.5'
@@ -68,6 +73,7 @@ buildscript {
 plugins {
     // TODO The capsule plugin requires the newer DSL plugin block.It would be nice if we could unify all the plugins into one style,
     // but the DSL has some restrictions e.g can't be used on the allprojects section. So we should revisit this if there are improvements in Gradle.
+    // Version 1.0.2 of this plugin uses capsule:1.0.1
     id "us.kirchmeier.capsule" version "1.0.2"
 }
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -126,7 +126,8 @@ dependencies {
     compile "org.hibernate:hibernate-java8:$hibernate_version"
 
     // Capsule is a library for building independently executable fat JARs.
-    compile 'co.paralleluniverse:capsule:1.0.3'
+    // We only need this dependency to compile our Caplet against.
+    compileOnly "co.paralleluniverse:capsule:$capsule_version"
 
     // Java Atomix: RAFT library
     compile 'io.atomix.copycat:copycat-client:1.2.3'

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     compile project(':node')
     compile project(':finance')
 
+    // Capsule is a library for building independently executable fat JARs.
+    // We only need this dependency to compile our Caplet against.
+    compileOnly "co.paralleluniverse:capsule:$capsule_version"
+
     // FontAwesomeFX: The "FontAwesome" icon library.
     compile 'de.jensd:fontawesomefx-fontawesome:4.7.0'
 


### PR DESCRIPTION
The version of Capsule that we use is determined by the version of `gradle-capsule-plugin`.
`gradle-capsule-plugin:1.0.2` actually uses `capsule:1.0.1` rather than `capsule:1.0.3`, so update
Gradle to reflect the real situation.