### PR TITLE
Remove cast of nullable type to non-nullable

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
@@ -201,8 +201,8 @@ object X509Utilities {
                                    legalName: X500Name,
                                    signatureScheme: SignatureScheme = DEFAULT_TLS_SIGNATURE_SCHEME) {
 
-        val rootCACert = caKeyStore.getX509Certificate(CORDA_ROOT_CA)
-        val (intermediateCACert, intermediateCAKeyPair) = caKeyStore.getCertificateAndKeyPair(CORDA_INTERMEDIATE_CA, caKeyPassword)
+        val rootCACert = caKeyStore.getX509Certificate(CORDA_ROOT_CA) ?: throw IllegalStateException("Corda root CA private key is not in key store")
+        val (intermediateCACert, intermediateCAKeyPair) = caKeyStore.getCertificateAndKeyPair(CORDA_INTERMEDIATE_CA, caKeyPassword) ?: throw IllegalStateException("Corda intermediate CA private key is not in key store")
 
         val clientKey = generateKeyPair(signatureScheme)
         val nameConstraints = NameConstraints(arrayOf(GeneralSubtree(GeneralName(GeneralName.directoryName, legalName))), arrayOf())

--- a/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
@@ -173,14 +173,14 @@ class X509UtilitiesTest {
 
         // Load signing intermediate CA cert
         val caKeyStore = KeyStoreUtilities.loadKeyStore(tmpCAKeyStore, "cakeystorepass")
-        val caCertAndKey = caKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_INTERMEDIATE_CA, "cakeypass")
+        val caCertAndKey = caKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_INTERMEDIATE_CA, "cakeypass")!!
 
         // Generate server cert and private key and populate another keystore suitable for SSL
         X509Utilities.createKeystoreForCordaNode(tmpSSLKeyStore, tmpServerKeyStore, "serverstorepass", "serverkeypass", caKeyStore, "cakeypass", MEGA_CORP.name)
 
         // Load back server certificate
         val serverKeyStore = KeyStoreUtilities.loadKeyStore(tmpServerKeyStore, "serverstorepass")
-        val serverCertAndKey = serverKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA, "serverkeypass")
+        val serverCertAndKey = serverKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA, "serverkeypass")!!
 
         serverCertAndKey.certificate.checkValidity(Date())
         serverCertAndKey.certificate.verify(caCertAndKey.certificate.publicKey)
@@ -189,7 +189,7 @@ class X509UtilitiesTest {
 
         // Load back server certificate
         val sslKeyStore = KeyStoreUtilities.loadKeyStore(tmpSSLKeyStore, "serverstorepass")
-        val sslCertAndKey = sslKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_TLS, "serverkeypass")
+        val sslCertAndKey = sslKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_TLS, "serverkeypass")!!
 
         sslCertAndKey.certificate.checkValidity(Date())
         sslCertAndKey.certificate.verify(serverCertAndKey.certificate.publicKey)
@@ -291,7 +291,7 @@ class X509UtilitiesTest {
         val peerX500Principal = (peerChain[0] as X509Certificate).subjectX500Principal
         val x500name = X500Name(peerX500Principal.name)
         assertEquals(MEGA_CORP.name, x500name)
-        X509Utilities.validateCertificateChain(trustStore.getX509Certificate(X509Utilities.CORDA_ROOT_CA), *peerChain)
+        X509Utilities.validateCertificateChain(trustStore.getX509Certificate(X509Utilities.CORDA_ROOT_CA)!!, *peerChain)
         val output = DataOutputStream(clientSocket.outputStream)
         output.writeUTF("Hello World")
         var timeout = 0

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -261,7 +261,7 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
     private fun createArtemisSecurityManager(): ActiveMQJAASSecurityManager {
         val keyStore = KeyStoreUtilities.loadKeyStore(config.sslKeystore, config.keyStorePassword)
         val trustStore = KeyStoreUtilities.loadKeyStore(config.trustStoreFile, config.trustStorePassword)
-        val ourCertificate = keyStore.getX509Certificate(CORDA_CLIENT_TLS)
+        val ourCertificate = keyStore.getX509Certificate(CORDA_CLIENT_TLS) ?: throw IllegalStateException("Cannot load client certificate from key store.")
 
         val ourSubjectDN = X500Name(ourCertificate.subjectDN.name)
         // This is a sanity check and should not fail unless things have been misconfigured

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -43,7 +43,7 @@ class NetworkRegistrationHelper(val config: NodeConfiguration, val certService: 
                 caKeyStore.addOrReplaceKey(SELF_SIGNED_PRIVATE_KEY, keyPair.private, privateKeyPassword.toCharArray(), arrayOf(selfSignCert))
                 caKeyStore.save(config.nodeKeystore, keystorePassword)
             }
-            val keyPair = caKeyStore.getKeyPair(SELF_SIGNED_PRIVATE_KEY, privateKeyPassword)
+            val keyPair = caKeyStore.getKeyPair(SELF_SIGNED_PRIVATE_KEY, privateKeyPassword)!!
             val requestId = submitOrResumeCertificateSigningRequest(keyPair)
 
             val certificates = try {
@@ -70,7 +70,7 @@ class NetworkRegistrationHelper(val config: NodeConfiguration, val certService: 
 
             println("Generating SSL certificate for node messaging service.")
             val sslKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
-            val caCert = caKeyStore.getX509Certificate(CORDA_CLIENT_CA)
+            val caCert = caKeyStore.getX509Certificate(CORDA_CLIENT_CA) ?: throw IllegalStateException("Cannot load client certificate from key store.")
             val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, caCert.subject, sslKey.public)
             val sslKeyStore = KeyStoreUtilities.loadOrCreateKeyStore(config.sslKeystore, keystorePassword)
             sslKeyStore.addOrReplaceKey(CORDA_CLIENT_TLS, sslKey.private, privateKeyPassword.toCharArray(), arrayOf(sslCert, *certificates))


### PR DESCRIPTION
`KeyStore.getCertificateAndKeyPair` cast the returned certificate and key pair to X509Certificate, meaning a cast exception is thrown if there's no matching certificate. This is unhelpful for diagnosis of problems, as well as handling of missing data from calling code.