### PR TITLE
Require user R3CEV for DemoBench DMG signing key.

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     ext.pkg_outDir = "$buildDir/javapackage"
     ext.dist_source = "$pkg_source/demobench-$version"
     ext.pkg_version = "$version".indexOf('-') >= 0 ? "$version".substring(0, "$version".indexOf('-')) : version
+    ext.pkg_macosxKeyUserName = 'R3CEV'
 
     repositories {
         mavenLocal()
@@ -160,8 +161,9 @@ task javapackage(dependsOn: distZip) {
                 include '**/*.wsf'
                 include '**/*.manifest'
             }
-            filter {
-                line -> line.replaceAll('@pkg_version@', pkg_version)
+            filter { line ->
+                line.replaceAll('@pkg_version@', pkg_version)
+                    .replaceAll('@signingKeyUserName@', pkg_macosxKeyUserName)
             }
             into "$pkg_source/package"
         }
@@ -192,6 +194,9 @@ task javapackage(dependsOn: distZip) {
                     include(name: 'explorer/*.jar')
                 }
             }
+
+            // This is specific to MacOSX packager.
+            bundleArgument(arg: 'mac.signing-key-user-name', value: pkg_macosxKeyUserName)
 
             platform {
                 property(name: 'java.util.logging.config.class', value: 'net.corda.demobench.config.LoggingConfig')

--- a/tools/demobench/package/macosx/Corda DemoBench-post-image.sh
+++ b/tools/demobench/package/macosx/Corda DemoBench-post-image.sh
@@ -9,7 +9,7 @@ function signApplication() {
 
     # Resign the embedded JRE because we have included "bin/java"
     # after javapackager had already signed the JRE installation.
-    if ! (codesign --force --sign "$IDENTITY" --verbose "$APPDIR/Contents/PlugIns/Java.runtime"); then
+    if ! (codesign --force --sign "$IDENTITY" --preserve-metadata=identifier,entitlements,requirements --verbose "$APPDIR/Contents/PlugIns/Java.runtime"); then
         echo "**** Failed to resign the embedded JVM"
         return 1
     fi
@@ -27,7 +27,7 @@ fi
 cd ..
 
 # Sign the application using a 'Developer ID Application' key on our keychain.
-if ! (signApplication "Corda DemoBench.app" "Developer ID Application: "); then
+if ! (signApplication "Corda DemoBench.app" "Developer ID Application: @signingKeyUserName@"); then
     echo "**** Failed to sign the application - ABORT SIGNING"
 fi
 


### PR DESCRIPTION
Ensure that we're using R3's Developer ID Application key when signing the DMG.
The user could conceivably have multiple Developer ID Application keys on the keychain, and the code-signing step fails if the choice of key is ambiguous.