### PR TITLE
Upgrade Artemis to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     ext.capsule_version = '1.0.1'
 
     ext.asm_version = '0.5.3'
-    ext.artemis_version = '1.5.3'
+    ext.artemis_version = '2.1.0'
     ext.jackson_version = '2.8.5'
     ext.jetty_version = '9.3.9.v20160517'
     ext.jersey_version = '2.25'

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -38,6 +38,7 @@ import net.corda.nodeapi.ArtemisMessagingComponent.NetworkMapAddress
 import net.corda.nodeapi.ArtemisTcpTransport
 import net.corda.nodeapi.ConnectionDirection
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException
+import org.apache.activemq.artemis.api.core.RoutingType
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient
 import org.apache.activemq.artemis.api.core.client.ClientMessage
 import org.bouncycastle.asn1.x500.X500Name
@@ -189,7 +190,7 @@ class Node(override val configuration: FullNodeConfiguration,
         session.start()
 
         val queueName = "$IP_REQUEST_PREFIX$requestId"
-        session.createQueue(queueName, queueName, false)
+        session.createQueue(queueName, RoutingType.MULTICAST, queueName, false)
 
         val consumer = session.createConsumer(queueName)
         val artemisMessage: ClientMessage = consumer.receive(10.seconds.toMillis()) ?:

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -30,12 +30,12 @@ import org.apache.activemq.artemis.core.config.Configuration
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl
 import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration
+import org.apache.activemq.artemis.core.message.impl.CoreMessage
 import org.apache.activemq.artemis.core.remoting.impl.netty.*
 import org.apache.activemq.artemis.core.security.Role
 import org.apache.activemq.artemis.core.server.ActiveMQServer
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.core.server.impl.RoutingContextImpl
-import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
 import org.apache.activemq.artemis.spi.core.remoting.*
@@ -447,7 +447,7 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
         }
 
         fun sendResponse(remoteAddress: String?) {
-            val responseMessage = ServerMessageImpl(random63BitValue(), 0).apply {
+            val responseMessage = CoreMessage(random63BitValue(), 0).apply {
                 putStringProperty(ipDetectResponseProperty, remoteAddress)
             }
             val routingContext = RoutingContextImpl(null)

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
@@ -32,6 +32,7 @@ import net.corda.nodeapi.VerifierApi.VERIFICATION_REQUESTS_QUEUE_NAME
 import net.corda.nodeapi.VerifierApi.VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX
 import org.apache.activemq.artemis.api.core.ActiveMQObjectClosedException
 import org.apache.activemq.artemis.api.core.Message.*
+import org.apache.activemq.artemis.api.core.RoutingType
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.client.*
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient.DEFAULT_ACK_BATCH_SIZE
@@ -521,7 +522,7 @@ class NodeMessagingClient(override val config: NodeConfiguration,
             val queueQuery = session!!.queueQuery(SimpleString(queueName))
             if (!queueQuery.isExists) {
                 log.info("Create fresh queue $queueName bound on same address")
-                session!!.createQueue(queueName, queueName, true)
+                session!!.createQueue(queueName, RoutingType.MULTICAST, queueName, true)
             }
         }
     }


### PR DESCRIPTION
Seems like in 2.0.0 there haven't been any major changes for Artemis core, most work was done for better support of other protocols, like AMQP.

(this change is needed because I want to submit a patch to Artemis, and it makes sense to upgrade to the latest)