### PR TITLE
Corda publications and JARs now have cord or corda at the start.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,7 @@ bintrayConfig {
     projectUrl = 'https://github.com/corda/corda'
     gpgSign = true
     gpgPassphrase = System.getenv('CORDA_BINTRAY_GPG_PASSPHRASE')
-    publications = ['jfx', 'mock', 'rpc', 'core', 'corda', 'cordform-common', 'corda-webserver', 'finance', 'node', 'node-api', 'node-schemas', 'test-utils', 'jackson', 'verifier', 'webserver']
+    publications = ['corda-jfx', 'corda-mock', 'corda-rpc', 'corda-core', 'corda', 'cordform-common', 'corda-finance', 'corda-node', 'corda-node-api', 'corda-node-schemas', 'corda-test-utils', 'corda-jackson', 'corda-verifier', 'corda-webserver-impl', 'corda-webserver']
     license {
         name = 'Apache-2.0'
         url = 'https://www.apache.org/licenses/LICENSE-2.0'

--- a/client/jackson/build.gradle
+++ b/client/jackson/build.gradle
@@ -23,3 +23,11 @@ dependencies {
     testCompile "com.pholser:junit-quickcheck-core:$quickcheck_version"
     testCompile "com.pholser:junit-quickcheck-generators:$quickcheck_version"
 }
+
+jar {
+    baseName 'corda-jackson'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -55,3 +55,11 @@ task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
+
+jar {
+    baseName 'corda-jfx'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/client/mock/build.gradle
+++ b/client/mock/build.gradle
@@ -23,3 +23,11 @@ dependencies {
 
     testCompile project(':test-utils')
 }
+
+jar {
+    baseName 'corda-mock'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -78,3 +78,11 @@ task smokeTest(type: Test) {
     classpath = sourceSets.smokeTest.runtimeClasspath
     systemProperties['build.dir'] = buildDir
 }
+
+jar {
+    baseName 'corda-rpc'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.12.3
+gradlePluginsVersion=0.12.4
 kotlinVersion=1.1.2
 guavaVersion=21.0
 bouncycastleVersion=1.56

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -95,3 +95,7 @@ artifacts {
 jar {
     baseName 'corda-core'
 }
+
+publish {
+    name = jar.baseName
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,3 +91,7 @@ task testJar(type: Jar) {
 artifacts {
     testArtifacts testJar
 }
+
+jar {
+    baseName 'corda-core'
+}

--- a/finance/build.gradle
+++ b/finance/build.gradle
@@ -29,3 +29,11 @@ configurations.testCompile {
     // TODO: Remove this exclusion once junit-quickcheck 0.8 is released.
     exclude group: 'javassist', module: 'javassist'
 }
+
+jar {
+    baseName 'corda-finance'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/gradle-plugins/publish-utils/src/main/groovy/net/corda/plugins/PublishTasks.groovy
+++ b/gradle-plugins/publish-utils/src/main/groovy/net/corda/plugins/PublishTasks.groovy
@@ -60,16 +60,17 @@ class PublishTasks implements Plugin<Project> {
     void configureMavenPublish(BintrayConfigExtension bintrayConfig) {
         project.apply([plugin: 'maven-publish'])
         project.publishing.publications.create(publishName, MavenPublication) {
-            if(!publishConfig.disableDefaultJar && !publishConfig.publishWar) {
-                from project.components.java
-            } else if(publishConfig.publishWar) {
-                from project.components.web
-            }
             groupId project.group
             artifactId publishName
 
             artifact project.tasks.sourceJar
             artifact project.tasks.javadocJar
+
+            if(!publishConfig.disableDefaultJar && !publishConfig.publishWar) {
+                from project.components.java
+            } else if(publishConfig.publishWar) {
+                from project.components.web
+            }
 
             project.configurations.publish.artifacts.each {
                 project.logger.debug("Adding artifact: $it")

--- a/gradle-plugins/publish-utils/src/main/groovy/net/corda/plugins/PublishTasks.groovy
+++ b/gradle-plugins/publish-utils/src/main/groovy/net/corda/plugins/PublishTasks.groovy
@@ -71,23 +71,14 @@ class PublishTasks implements Plugin<Project> {
                 delegate.artifact it
             }
 
+            if (!publishConfig.disableDefaultJar && !publishConfig.publishWar) {
+                from project.components.java
+            } else if (publishConfig.publishWar) {
+                from project.components.web
+            }
+
             extendPomForMavenCentral(pom, bintrayConfig)
         }
-
-        // This is to ensure that the project is fully evaluated before resolving any dependencies
-        // otherwise the dependencies will have the project name as the artifactId and not the one specified in the
-        // build.gradle.
-        def configureTask = project.task("configure${publishName}Source") {
-            doLast {
-                def publication = ((MavenPublication) project.publishing.publications.getByName(publishName))
-                if (!publishConfig.disableDefaultJar && !publishConfig.publishWar) {
-                    publication.from project.components.java
-                } else if (publishConfig.publishWar) {
-                    publication.from project.components.web
-                }
-            }
-        }
-        project.tasks['publishToMavenLocal'].dependsOn(configureTask)
         project.task("install", dependsOn: "publishToMavenLocal")
     }
 

--- a/gradle-plugins/settings.gradle
+++ b/gradle-plugins/settings.gradle
@@ -3,4 +3,5 @@ include 'publish-utils'
 include 'quasar-utils'
 include 'cordformation'
 include 'cordform-common'
+// TODO: Look into `includeFlat`
 project(':cordform-common').projectDir = new File("$settingsDir/../cordform-common")

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -31,3 +31,11 @@ dependencies {
     testCompile "org.assertj:assertj-core:${assertj_version}"
     testCompile project(':test-utils')
 }
+
+jar {
+    baseName 'corda-node-api'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/node-schemas/build.gradle
+++ b/node-schemas/build.gradle
@@ -25,3 +25,11 @@ sourceSets {
         }
     }
 }
+
+jar {
+    baseName 'corda-node-schemas'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/node-schemas/build.gradle
+++ b/node-schemas/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     compile project(':core')
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "junit:junit:$junit_version"
-    testCompile project(':test-utils')
 
     // Requery: SQL based query & persistence for Kotlin
     kapt "io.requery:requery-processor:$requery_version"

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -174,3 +174,11 @@ task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
+
+jar {
+    baseName 'corda-node'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -34,3 +34,11 @@ dependencies {
     // OkHTTP: Simple HTTP library.
     compile "com.squareup.okhttp3:okhttp:$okhttp_version"
 }
+
+jar {
+    baseName 'corda-test-utils'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -67,12 +67,13 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-build.dependsOn standaloneJar
-
-jar {
-    baseName 'corda-verifier'
+artifacts {
+    publish standaloneJar {
+        classifier ""
+    }
 }
 
 publish {
-    name = jar.baseName
+    name = 'corda-verifier'
+    disableDefaultJar = true
 }

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -68,3 +68,11 @@ task integrationTest(type: Test) {
 }
 
 build.dependsOn standaloneJar
+
+jar {
+    baseName 'corda-verifier'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -65,3 +65,11 @@ task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
+
+jar {
+    baseName 'corda-webserver-impl'
+}
+
+publish {
+    name = jar.baseName
+}

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -48,7 +48,6 @@ dependencies {
 
     // JOpt: for command line flags.
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
-
     // Jersey for JAX-RS implementation for use in Jetty
     compile "org.glassfish.jersey.core:jersey-server:$jersey_version"
     compile "org.glassfish.jersey.containers:jersey-container-servlet-core:$jersey_version"

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     // JOpt: for command line flags.
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
+
     // Jersey for JAX-RS implementation for use in Jetty
     compile "org.glassfish.jersey.core:jersey-server:$jersey_version"
     compile "org.glassfish.jersey.containers:jersey-container-servlet-core:$jersey_version"


### PR DESCRIPTION
Why: It is standard for projects with multiple publications to have <project>- at the start or some other prefix. 