### PR TITLE
Allow RPC for internal classes with special serialisers.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/RPCStructures.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/RPCStructures.kt
@@ -61,7 +61,6 @@ class RPCKryo(observableSerializer: Serializer<Observable<Any>>) : CordaKryo(mak
     }
 
     override fun getRegistration(type: Class<*>): Registration {
-        type.requireExternal("RPC not allowed to deserialise internal classes")
         if (Observable::class.java != type && Observable::class.java.isAssignableFrom(type)) {
             return super.getRegistration(Observable::class.java)
         }
@@ -71,6 +70,7 @@ class RPCKryo(observableSerializer: Serializer<Observable<Any>>) : CordaKryo(mak
         if (ListenableFuture::class.java != type && ListenableFuture::class.java.isAssignableFrom(type)) {
             return super.getRegistration(ListenableFuture::class.java)
         }
+        type.requireExternal("RPC not allowed to deserialise internal classes")
         return super.getRegistration(type)
     }
 }


### PR DESCRIPTION
The `HashCheckingStream` class is internal to the node, but we can still serialise it with the standard `InputStreamSerializer`. So check for standard serialisers before checking whether the class in internal.

The `HashCheckingStream` is also not closed by `InputStreamSerializer` and so validate the hash once we reach the end of the stream instead.