### PR TITLE
Fix Bank of Corda, Trader and Notary demos. 

### DIFF
--- a/docs/source/running-the-demos.rst
+++ b/docs/source/running-the-demos.rst
@@ -123,7 +123,7 @@ You will notice that successive transactions get signed by different members of 
 
 To run the Raft version of the demo from the command line in Unix:
 
-1. Run ``./gradlew samples:notary-demo:deployNodes``, which will create all three types of notaries nodes directories
+1. Run ``./gradlew samples:notary-demo:deployNodes``, which will create all three types of notaries' node directories
 with configs under ``samples/notary-demo/build/nodes/nodesRaft`` (``nodesBFT`` and ``nodesSingle`` for BFT and Single notaries).
 2. Run ``./samples/notary-demo/build/nodes/nodesRaft/runnodes``, which will start the nodes in separate terminal windows/tabs.
    Wait until a "Node started up and registered in ..." message appears on each of the terminals
@@ -132,7 +132,7 @@ with configs under ``samples/notary-demo/build/nodes/nodesRaft`` (``nodesBFT`` a
 
 To run from the command line in Windows:
 
-1. Run ``gradlew samples:notary-demo:deployNodes``, which will create all three types of notaries nodes directories
+1. Run ``gradlew samples:notary-demo:deployNodes``, which will create all three types of notaries' node directories
 with configs under ``samples/notary-demo/build/nodes/nodesRaft`` (``nodesBFT`` and ``nodesSingle`` for BFT and Single notaries).
 2. Run ``samples\notary-demo\build\nodes\nodesRaft\runnodes``, which will start the nodes in separate terminal windows/tabs.
    Wait until a "Node started up and registered in ..." message appears on each of the terminals

--- a/docs/source/running-the-demos.rst
+++ b/docs/source/running-the-demos.rst
@@ -123,21 +123,23 @@ You will notice that successive transactions get signed by different members of 
 
 To run the Raft version of the demo from the command line in Unix:
 
-1. Run ``./gradlew samples:notary-demo:deployNodesRaft``, which will create node directories with configs under ``samples/notary-demo/build/nodes``.
-2. Run ``./samples/notary-demo/build/nodes/runnodes``, which will start the nodes in separate terminal windows/tabs.
+1. Run ``./gradlew samples:notary-demo:deployNodes``, which will create all three types of notaries nodes directories
+with configs under ``samples/notary-demo/build/nodes/nodesRaft`` (``nodesBFT`` and ``nodesSingle`` for BFT and Single notaries).
+2. Run ``./samples/notary-demo/build/nodes/nodesRaft/runnodes``, which will start the nodes in separate terminal windows/tabs.
    Wait until a "Node started up and registered in ..." message appears on each of the terminals
 3. Run ``./gradlew samples:notary-demo:notarise`` to make a call to the "Party" node to initiate notarisation requests
    In a few seconds you will see a message "Notarised 10 transactions" with a list of transaction ids and the signer public keys
 
 To run from the command line in Windows:
 
-1. Run ``gradlew samples:notary-demo:deployNodesRaft``, which will create node directories with configs under ``samples\notary-demo\build\nodes``.
-2. Run ``samples\notary-demo\build\nodes\runnodes``, which will start the nodes in separate terminal windows/tabs.
+1. Run ``gradlew samples:notary-demo:deployNodes``, which will create all three types of notaries nodes directories
+with configs under ``samples/notary-demo/build/nodes/nodesRaft`` (``nodesBFT`` and ``nodesSingle`` for BFT and Single notaries).
+2. Run ``samples\notary-demo\build\nodes\nodesRaft\runnodes``, which will start the nodes in separate terminal windows/tabs.
    Wait until a "Node started up and registered in ..." message appears on each of the terminals
 3. Run ``gradlew samples:notary-demo:notarise`` to make a call to the "Party" node to initiate notarisation requests
    In a few seconds you will see a message "Notarised 10 transactions" with a list of transaction ids and the signer public keys
 
-To run the BFT SMaRt notary demo, use ``deployNodesBFT`` instead of ``deployNodesRaft``. For a single notary node, use ``deployNodesSingle``.
+To run the BFT SMaRt notary demo, use ``nodesBFT`` instead of ``nodesRaft`` in the path. For a single notary node, use ``nodesSingle``.
 
 Notary nodes store consumed states in a replicated commit log, which is backed by a H2 database on each node.
 You can ascertain that the commit log is synchronised across the cluster by accessing and comparing each of the nodes' backing stores

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -52,7 +52,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = []
     }
     node {
-        name "CN=BankOfCorda,O=R3,OU=Corda QA Department,L=New York,C=US"
+        name "CN=BankOfCorda,O=R3,L=New York,C=US"
         nearestCity "New York"
         advertisedServices = ["corda.issuer.USD"]
         p2pPort 10005

--- a/samples/notary-demo/build.gradle
+++ b/samples/notary-demo/build.gradle
@@ -49,15 +49,20 @@ publishing {
     }
 }
 
+task deployNodes(dependsOn: ['deployNodesSingle', 'deployNodesRaft', 'deployNodesBFT'])
+
 task deployNodesSingle(type: Cordform, dependsOn: 'jar') {
+    directory "./build/nodes/nodesSingle"
     definitionClass = 'net.corda.notarydemo.SingleNotaryCordform'
 }
 
 task deployNodesRaft(type: Cordform, dependsOn: 'jar') {
+    directory "./build/nodes/nodesRaft"
     definitionClass = 'net.corda.notarydemo.RaftNotaryCordform'
 }
 
 task deployNodesBFT(type: Cordform, dependsOn: 'jar') {
+    directory "./build/nodes/nodesBFT"
     definitionClass = 'net.corda.notarydemo.BFTNotaryCordform'
 }
 

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -85,7 +85,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = ext.rpcUsers
     }
     node {
-        name "CN=BankOfCorda,O=R3,OU=corda,L=New York,C=US"
+        name "CN=BankOfCorda,O=R3,L=New York,C=US"
         nearestCity "London"
         advertisedServices = []
         p2pPort 10011


### PR DESCRIPTION
In Notary demo, introduce deployNodes task, that deploys all three types of Notary into different directories (so there is no need to do clean, when you want to run them one after another).