### PR TITLE
Fix tests that check ports are bound/unbound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ crashlytics-build.properties
 docs/virtualenv/
 
 # bft-smart
-config/currentView
+**/config/currentView
 
 # vim
 *.swp

--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -106,6 +106,7 @@ fun <T> ListenableFuture<T>.failure(executor: Executor, body: (Throwable) -> Uni
 infix fun <T> ListenableFuture<T>.then(body: () -> Unit): ListenableFuture<T> = apply { then(RunOnCallerThread, body) }
 infix fun <T> ListenableFuture<T>.success(body: (T) -> Unit): ListenableFuture<T> = apply { success(RunOnCallerThread, body) }
 infix fun <T> ListenableFuture<T>.failure(body: (Throwable) -> Unit): ListenableFuture<T> = apply { failure(RunOnCallerThread, body) }
+fun <T> ListenableFuture<T>.andForget(log: Logger) = failure(RunOnCallerThread) { log.error("Background task failed:", it) }
 @Suppress("UNCHECKED_CAST") // We need the awkward cast because otherwise F cannot be nullable, even though it's safe.
 infix fun <F, T> ListenableFuture<F>.map(mapper: (F) -> T): ListenableFuture<T> = Futures.transform(this, { (mapper as (F?) -> T)(it) })
 infix fun <F, T> ListenableFuture<F>.flatMap(mapper: (F) -> ListenableFuture<T>): ListenableFuture<T> = Futures.transformAsync(this) { mapper(it!!) }

--- a/core/src/test/kotlin/net/corda/core/UtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/UtilsTest.kt
@@ -1,10 +1,18 @@
 package net.corda.core
 
+import com.google.common.util.concurrent.MoreExecutors
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.same
+import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.*
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.slf4j.Logger
 import rx.subjects.PublishSubject
 import java.util.*
 import java.util.concurrent.CancellationException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class UtilsTest {
     @Test
@@ -56,5 +64,18 @@ class UtilsTest {
         assertThatExceptionOfType(CancellationException::class.java).isThrownBy {
             future.get()
         }
+    }
+
+    @Test
+    fun `andForget works`() {
+        val log = mock<Logger>()
+        val throwable = Exception("Boom")
+        val executor = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor())
+        executor.submit { throw throwable }.andForget(log)
+        executor.shutdown()
+        while (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+            // Do nothing.
+        }
+        verify(log).error(anyString(), same(throwable))
     }
 }

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -618,7 +618,7 @@ class DriverDSL(
         )
         _shutdownManager = ShutdownManager(executorService)
         if (networkMapStartStrategy.startDedicated) {
-            startDedicatedNetworkMapService() // Allow it to start concurrently with other nodes.
+            startDedicatedNetworkMapService().andForget(log) // Allow it to start concurrently with other nodes.
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -618,7 +618,7 @@ class DriverDSL(
         )
         _shutdownManager = ShutdownManager(executorService)
         if (networkMapStartStrategy.startDedicated) {
-            startDedicatedNetworkMapService() // XXX: Wait until started?
+            startDedicatedNetworkMapService() // Allow it to start concurrently with other nodes.
         }
     }
 

--- a/test-utils/src/main/kotlin/net/corda/testing/RPCDriver.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/RPCDriver.kt
@@ -419,7 +419,7 @@ data class RPCDriverDSL(
             server.start()
             driverDSL.shutdownManager.registerShutdown {
                 server.stop()
-                addressMustNotBeBound(driverDSL.executorService, hostAndPort).get()
+                addressMustNotBeBound(driverDSL.executorService, hostAndPort)
             }
             RpcBrokerHandle(
                     hostAndPort = hostAndPort,

--- a/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -10,7 +10,7 @@ import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.ServiceType
 import net.corda.core.utilities.DUMMY_MAP
 import net.corda.core.utilities.WHITESPACE
-import net.corda.node.driver.addressMustNotBeBound
+import net.corda.node.driver.addressMustNotBeBoundFuture
 import net.corda.node.internal.Node
 import net.corda.node.services.config.ConfigHelper
 import net.corda.node.services.config.FullNodeConfiguration
@@ -61,8 +61,8 @@ abstract class NodeBasedTest {
         // Wait until ports are released
         val portNotBoundChecks = nodes.flatMap {
             listOf(
-                    it.configuration.p2pAddress.let { addressMustNotBeBound(shutdownExecutor, it) },
-                    it.configuration.rpcAddress?.let { addressMustNotBeBound(shutdownExecutor, it) }
+                    it.configuration.p2pAddress.let { addressMustNotBeBoundFuture(shutdownExecutor, it) },
+                    it.configuration.rpcAddress?.let { addressMustNotBeBoundFuture(shutdownExecutor, it) }
             )
         }.filterNotNull()
         nodes.clear()


### PR DESCRIPTION
Also RPCDriver.startRpcBroker now waits for port to be unbound, as was probably intended. Same problem seems to have happened a few times, so I've made addressMustBeBound synchronous and you can use addressMustBeBoundFuture if you really want a future.