### PR TITLE
Replace X509Certificate with X509CertificateHolder

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -22,6 +22,7 @@ val NULL_PARTY = AnonymousParty(NullPublicKey)
 
 // TODO: Clean up this duplication between Null and Dummy public key
 @CordaSerializable
+@Deprecated("Has encoding format problems, consider entropyToKeyPair() instead")
 class DummyPublicKey(val s: String) : PublicKey, Comparable<PublicKey> {
     override fun getAlgorithm() = "DUMMY"
     override fun getEncoded() = s.toByteArray()

--- a/core/src/main/kotlin/net/corda/core/crypto/KeyStoreUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/KeyStoreUtilities.kt
@@ -3,6 +3,10 @@ package net.corda.core.crypto
 import net.corda.core.exists
 import net.corda.core.read
 import net.corda.core.write
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.path.CertPath
+import org.bouncycastle.crypto.util.PublicKeyFactory
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
@@ -75,6 +79,19 @@ object KeyStoreUtilities {
  * but for SSL purposes this is recommended.
  * @param chain the sequence of certificates starting with the public key certificate for this key and extending to the root CA cert.
  */
+fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain: CertPath) {
+    val converter = JcaX509CertificateConverter()
+    addOrReplaceKey(alias, key, password, chain.certificates.map { it -> converter.getCertificate(it) }.toTypedArray<Certificate>())
+}
+
+/**
+ * Helper extension method to add, or overwrite any key data in store.
+ * @param alias name to record the private key and certificate chain under.
+ * @param key cryptographic key to store.
+ * @param password password for unlocking the key entry in the future. This does not have to be the same password as any keys stored,
+ * but for SSL purposes this is recommended.
+ * @param chain the sequence of certificates starting with the public key certificate for this key and extending to the root CA cert.
+ */
 fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain: Array<Certificate>) {
     if (containsAlias(alias)) {
         this.deleteEntry(alias)
@@ -122,8 +139,9 @@ fun KeyStore.getKeyPair(alias: String, keyPassword: String): KeyPair = getCertif
  * @param keyPassword The password for the PrivateKey (not the store access password).
  */
 fun KeyStore.getCertificateAndKeyPair(alias: String, keyPassword: String): CertificateAndKeyPair {
-    val cert = getCertificate(alias) as X509Certificate
-    return CertificateAndKeyPair(cert, KeyPair(Crypto.toSupportedPublicKey(cert.publicKey), getSupportedKey(alias, keyPassword)))
+    val cert = getX509Certificate(alias)
+    val publicKey = Crypto.toSupportedPublicKey(cert.subjectPublicKeyInfo)
+    return CertificateAndKeyPair(cert, KeyPair(publicKey, getSupportedKey(alias, keyPassword)))
 }
 
 /**
@@ -131,7 +149,10 @@ fun KeyStore.getCertificateAndKeyPair(alias: String, keyPassword: String): Certi
  * @param alias The name to lookup the Key and Certificate chain from.
  * @return The X509Certificate found in the KeyStore under the specified alias.
  */
-fun KeyStore.getX509Certificate(alias: String): X509Certificate = getCertificate(alias) as X509Certificate
+fun KeyStore.getX509Certificate(alias: String): X509CertificateHolder {
+    val encoded = getCertificate(alias)?.encoded ?: throw IllegalArgumentException("No certificate under alias \"${alias}\"")
+    return X509CertificateHolder(encoded)
+}
 
 /**
  * Extract a private key from a KeyStore file assuming storage alias is known.

--- a/core/src/main/kotlin/net/corda/core/identity/Party.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/Party.kt
@@ -26,8 +26,8 @@ import java.security.PublicKey
  *
  * @see CompositeKey
  */
-class Party(val name: X500Name, owningKey: PublicKey) : AbstractParty(owningKey) {
-    constructor(certAndKey: CertificateAndKeyPair) : this(X500Name(certAndKey.certificate.subjectDN.name), certAndKey.keyPair.public)
+open class Party(val name: X500Name, owningKey: PublicKey) : AbstractParty(owningKey) {
+    constructor(certAndKey: CertificateAndKeyPair) : this(certAndKey.certificate.subject, certAndKey.keyPair.public)
     override fun toString() = name.toString()
     override fun nameOrNull(): X500Name? = name
 

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -6,6 +6,7 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.X509CertificateHolder
 import java.security.PublicKey
 import java.security.cert.CertPath
 import java.security.cert.X509Certificate
@@ -30,7 +31,7 @@ interface IdentityService {
      */
     // TODO: Move this into internal identity service once available
     @Throws(IllegalArgumentException::class)
-    fun registerPath(trustedRoot: X509Certificate, anonymousParty: AnonymousParty, path: CertPath)
+    fun registerPath(trustedRoot: X509CertificateHolder, anonymousParty: AnonymousParty, path: CertPath)
 
     /**
      * Asserts that an anonymous party maps to the given full party, by looking up the certificate chain associated with

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -20,7 +20,6 @@ import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
 import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.operator.ContentSigner
 import rx.Observable
 import java.io.InputStream
 import java.security.PublicKey

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -3,10 +3,12 @@ package net.corda.core.node.services
 import co.paralleluniverse.fibers.Suspendable
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.contracts.*
-import net.corda.core.crypto.*
+import net.corda.core.crypto.CompositeKey
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.keys
 import net.corda.core.flows.FlowException
 import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.node.services.vault.PageSpecification
 import net.corda.core.node.services.vault.QueryCriteria
@@ -17,6 +19,8 @@ import net.corda.core.toFuture
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.operator.ContentSigner
 import rx.Observable
 import java.io.InputStream
 import java.security.PublicKey
@@ -396,7 +400,7 @@ interface KeyManagementService {
      * @return X.509 certificate and path to the trust root.
      */
     @Suspendable
-    fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509Certificate, CertPath>
+    fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath>
 
     /** Using the provided signing [PublicKey] internally looks up the matching [PrivateKey] and signs the data.
      * @param bytes The data to sign over using the chosen key.

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -18,6 +18,7 @@ import net.corda.core.utilities.NonEmptySetSerializer
 import net.i2p.crypto.eddsa.EdDSAPrivateKey
 import net.i2p.crypto.eddsa.EdDSAPublicKey
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
 import org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey
@@ -102,11 +103,8 @@ object DefaultKryoCustomizer {
 
             register(CertPath::class.java, CertPathSerializer)
             register(X509CertPath::class.java, CertPathSerializer)
-            // TODO: We shouldn't need to serialize raw certificates, and if we do then we need a cleaner solution
-            //       than this mess.
-            val x509CertObjectClazz = Class.forName("org.bouncycastle.jcajce.provider.asymmetric.x509.X509CertificateObject")
-            register(x509CertObjectClazz, X509CertificateSerializer)
             register(X500Name::class.java, X500NameSerializer)
+            register(X509CertificateHolder::class.java, X509CertificateSerializer)
 
             register(BCECPrivateKey::class.java, PrivateKeySerializer)
             register(BCECPublicKey::class.java, PublicKeySerializer)

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -20,6 +20,7 @@ import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import org.bouncycastle.asn1.ASN1InputStream
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.X509CertificateHolder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
@@ -632,16 +633,15 @@ object CertPathSerializer : Serializer<CertPath>() {
 }
 
 /**
- * For serialising an [CX509Certificate] in an X.500 standard format.
+ * For serialising an [CX509CertificateHolder] in an X.500 standard format.
  */
 @ThreadSafe
-object X509CertificateSerializer : Serializer<X509Certificate>() {
-    val factory = CertificateFactory.getInstance("X.509")
-    override fun read(kryo: Kryo, input: Input, type: Class<X509Certificate>): X509Certificate {
-        return factory.generateCertificate(input) as X509Certificate
+object X509CertificateSerializer : Serializer<X509CertificateHolder>() {
+    override fun read(kryo: Kryo, input: Input, type: Class<X509CertificateHolder>): X509CertificateHolder {
+        return X509CertificateHolder(input.readBytes())
     }
 
-    override fun write(kryo: Kryo, output: Output, obj: X509Certificate) {
+    override fun write(kryo: Kryo, output: Output, obj: X509CertificateHolder) {
         output.writeBytes(obj.encoded)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509UtilitiesTest.kt
@@ -5,29 +5,35 @@ import net.corda.core.crypto.Crypto.generateKeyPair
 import net.corda.core.crypto.X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME
 import net.corda.core.crypto.X509Utilities.createSelfSignedCACertificate
 import net.corda.core.div
+import net.corda.core.mapToArray
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.getTestX509Name
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.BasicConstraints
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.asn1.x509.KeyUsage
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.IOException
+import java.math.BigInteger
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.file.Path
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.SecureRandom
+import java.security.cert.Certificate
 import java.security.cert.X509Certificate
 import java.util.*
 import javax.net.ssl.*
 import kotlin.concurrent.thread
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class X509UtilitiesTest {
     @Rule
@@ -38,12 +44,14 @@ class X509UtilitiesTest {
     fun `create valid self-signed CA certificate`() {
         val caKey = generateKeyPair(DEFAULT_TLS_SIGNATURE_SCHEME)
         val caCert = createSelfSignedCACertificate(getTestX509Name("Test Cert"), caKey)
-        assertTrue { caCert.subjectDN.name.contains("CN=Test Cert") } // using our subject common name
-        assertEquals(caCert.issuerDN, caCert.subjectDN) //self-signed
-        caCert.checkValidity(Date()) // throws on verification problems
-        caCert.verify(caKey.public) // throws on verification problems
-        assertTrue { caCert.keyUsage[5] } // Bit 5 == keyCertSign according to ASN.1 spec (see full comment on KeyUsage property)
-        assertTrue { caCert.basicConstraints > 0 } // This returns the signing path length Would be -1 for non-CA certificate
+        assertTrue { caCert.subject.commonName == "Test Cert" } // using our subject common name
+        assertEquals(caCert.issuer, caCert.subject) //self-signed
+        caCert.isValidOn(Date()) // throws on verification problems
+        caCert.isSignatureValid(JcaContentVerifierProviderBuilder().build(caKey.public)) // throws on verification problems
+        val basicConstraints = BasicConstraints.getInstance(caCert.getExtension(Extension.basicConstraints).parsedValue)
+        val keyUsage = KeyUsage.getInstance(caCert.getExtension(Extension.keyUsage).parsedValue)
+        assertFalse { keyUsage.hasUsages(5) } // Bit 5 == keyCertSign according to ASN.1 spec (see full comment on KeyUsage property)
+        assertNull(basicConstraints.pathLenConstraint) // No length constraint specified on this CA certificate
     }
 
     @Test
@@ -60,29 +68,33 @@ class X509UtilitiesTest {
     fun `create valid server certificate chain`() {
         val caKey = generateKeyPair(DEFAULT_TLS_SIGNATURE_SCHEME)
         val caCert = createSelfSignedCACertificate(getTestX509Name("Test CA Cert"), caKey)
-        val subjectDN = getTestX509Name("Server Cert")
+        val subject = getTestX509Name("Server Cert")
         val keyPair = generateKeyPair(DEFAULT_TLS_SIGNATURE_SCHEME)
-        val serverCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, caKey, subjectDN, keyPair.public)
-        assertTrue { serverCert.subjectDN.name.contains("CN=Server Cert") } // using our subject common name
-        assertEquals(caCert.issuerDN, serverCert.issuerDN) // Issued by our CA cert
-        serverCert.checkValidity(Date()) // throws on verification problems
-        serverCert.verify(caKey.public) // throws on verification problems
-        assertFalse { serverCert.keyUsage[5] } // Bit 5 == keyCertSign according to ASN.1 spec (see full comment on KeyUsage property)
-        assertTrue { serverCert.basicConstraints == -1 } // This returns the signing path length should be -1 for non-CA certificate
+        val serverCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, caKey, subject, keyPair.public)
+        assertTrue { serverCert.subject.toString().contains("CN=Server Cert") } // using our subject common name
+        assertEquals(caCert.issuer, serverCert.issuer) // Issued by our CA cert
+        serverCert.isValidOn(Date()) // throws on verification problems
+        serverCert.isSignatureValid(JcaContentVerifierProviderBuilder().build(caKey.public)) // throws on verification problems
+        val basicConstraints = BasicConstraints.getInstance(serverCert.getExtension(Extension.basicConstraints).parsedValue)
+        val keyUsage = KeyUsage.getInstance(serverCert.getExtension(Extension.keyUsage).parsedValue)
+        assertFalse { keyUsage.hasUsages(5) } // Bit 5 == keyCertSign according to ASN.1 spec (see full comment on KeyUsage property)
+        assertNull(basicConstraints.pathLenConstraint) // Non-CA certificate
     }
 
     @Test
     fun `storing EdDSA key in java keystore`() {
         val tmpKeyStore = tempFile("keystore.jks")
 
+        val converter = JcaX509CertificateConverter()
         val keyPair = generateKeyPair(EDDSA_ED25519_SHA512)
         val selfSignCert = createSelfSignedCACertificate(X500Name("CN=Test"), keyPair)
 
-        assertEquals(selfSignCert.publicKey, keyPair.public)
+        assertTrue(Arrays.equals(selfSignCert.subjectPublicKeyInfo.encoded, keyPair.public.encoded))
 
         // Save the EdDSA private key with self sign cert in the keystore.
         val keyStore = KeyStoreUtilities.loadOrCreateKeyStore(tmpKeyStore, "keystorepass")
-        keyStore.setKeyEntry("Key", keyPair.private, "password".toCharArray(), arrayOf(selfSignCert))
+        keyStore.setKeyEntry("Key", keyPair.private, "password".toCharArray(),
+                listOf(selfSignCert).mapToArray(converter::getCertificate))
         keyStore.save(tmpKeyStore, "keystorepass")
 
         // Load the keystore from file and make sure keys are intact.
@@ -105,8 +117,10 @@ class X509UtilitiesTest {
         val edDSACert = X509Utilities.createCertificate(CertificateType.TLS, ecDSACert, ecDSAKey, X500Name("CN=TestEdDSA"), edDSAKeypair.public)
 
         // Save the EdDSA private key with cert chains.
+        val converter = JcaX509CertificateConverter()
         val keyStore = KeyStoreUtilities.loadOrCreateKeyStore(tmpKeyStore, "keystorepass")
-        keyStore.setKeyEntry("Key", edDSAKeypair.private, "password".toCharArray(), arrayOf(ecDSACert, edDSACert))
+        keyStore.setKeyEntry("Key", edDSAKeypair.private, "password".toCharArray(),
+                listOf(ecDSACert, edDSACert).mapToArray(converter::getCertificate))
         keyStore.save(tmpKeyStore, "keystorepass")
 
         // Load the keystore from file and make sure keys are intact.
@@ -182,23 +196,24 @@ class X509UtilitiesTest {
         val serverKeyStore = KeyStoreUtilities.loadKeyStore(tmpServerKeyStore, "serverstorepass")
         val serverCertAndKey = serverKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA, "serverkeypass")
 
-        serverCertAndKey.certificate.checkValidity(Date())
-        serverCertAndKey.certificate.verify(caCertAndKey.certificate.publicKey)
+        serverCertAndKey.certificate.isValidOn(Date())
+        serverCertAndKey.certificate.isSignatureValid(JcaContentVerifierProviderBuilder().build(caCertAndKey.certificate.subjectPublicKeyInfo))
 
-        assertTrue { serverCertAndKey.certificate.subjectDN.name.contains(MEGA_CORP.name.commonName) }
+        assertTrue { serverCertAndKey.certificate.subject.toString().contains(MEGA_CORP.name.commonName) }
 
         // Load back server certificate
         val sslKeyStore = KeyStoreUtilities.loadKeyStore(tmpSSLKeyStore, "serverstorepass")
         val sslCertAndKey = sslKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_TLS, "serverkeypass")
 
-        sslCertAndKey.certificate.checkValidity(Date())
-        sslCertAndKey.certificate.verify(serverCertAndKey.certificate.publicKey)
+        sslCertAndKey.certificate.isValidOn(Date())
+        sslCertAndKey.certificate.isSignatureValid(JcaContentVerifierProviderBuilder().build(serverCertAndKey.certificate.subjectPublicKeyInfo))
 
-        assertTrue { sslCertAndKey.certificate.subjectDN.name.contains(MEGA_CORP.name.commonName) }
+        assertTrue { sslCertAndKey.certificate.subject.toString().contains(MEGA_CORP.name.commonName) }
         // Now sign something with private key and verify against certificate public key
         val testData = "123456".toByteArray()
         val signature = Crypto.doSign(DEFAULT_TLS_SIGNATURE_SCHEME, serverCertAndKey.keyPair.private, testData)
-        assertTrue { Crypto.isValid(DEFAULT_TLS_SIGNATURE_SCHEME, serverCertAndKey.certificate.publicKey, signature, testData) }
+        val publicKey = Crypto.toSupportedPublicKey(serverCertAndKey.certificate.subjectPublicKeyInfo)
+        assertTrue { Crypto.isValid(DEFAULT_TLS_SIGNATURE_SCHEME, publicKey, signature, testData) }
     }
 
     @Test
@@ -330,6 +345,7 @@ class X509UtilitiesTest {
                                               trustStoreFilePath: Path,
                                               trustStorePassword: String
     ): KeyStore {
+        val converter = JcaX509CertificateConverter()
         val rootCAKey = generateKeyPair(DEFAULT_TLS_SIGNATURE_SCHEME)
         val rootCACert = createSelfSignedCACertificate(X509Utilities.getDevX509Name("Corda Node Root CA"), rootCAKey)
 
@@ -339,19 +355,19 @@ class X509UtilitiesTest {
         val keyPass = keyPassword.toCharArray()
         val keyStore = KeyStoreUtilities.loadOrCreateKeyStore(keyStoreFilePath, storePassword)
 
-        keyStore.addOrReplaceKey(X509Utilities.CORDA_ROOT_CA, rootCAKey.private, keyPass, arrayOf(rootCACert))
+        keyStore.addOrReplaceKey(X509Utilities.CORDA_ROOT_CA, rootCAKey.private, keyPass, arrayOf(converter.getCertificate(rootCACert) as Certificate))
 
         keyStore.addOrReplaceKey(X509Utilities.CORDA_INTERMEDIATE_CA,
                 intermediateCAKeyPair.private,
                 keyPass,
-                arrayOf(intermediateCACert, rootCACert))
+                listOf(intermediateCACert, rootCACert).mapToArray<X509CertificateHolder, Certificate>(converter::getCertificate))
 
         keyStore.save(keyStoreFilePath, storePassword)
 
         val trustStore = KeyStoreUtilities.loadOrCreateKeyStore(trustStoreFilePath, trustStorePassword)
 
-        trustStore.addOrReplaceCertificate(X509Utilities.CORDA_ROOT_CA, rootCACert)
-        trustStore.addOrReplaceCertificate(X509Utilities.CORDA_INTERMEDIATE_CA, intermediateCACert)
+        trustStore.addOrReplaceCertificate(X509Utilities.CORDA_ROOT_CA, converter.getCertificate(rootCACert))
+        trustStore.addOrReplaceCertificate(X509Utilities.CORDA_INTERMEDIATE_CA, converter.getCertificate(intermediateCACert))
 
         trustStore.save(trustStoreFilePath, trustStorePassword)
 
@@ -360,10 +376,11 @@ class X509UtilitiesTest {
 
     @Test
     fun `Get correct private key type from Keystore`() {
+        val converter = JcaX509CertificateConverter()
         val keyPair = generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256)
         val selfSignCert = createSelfSignedCACertificate(X500Name("CN=Test"), keyPair)
         val keyStore = KeyStoreUtilities.loadOrCreateKeyStore(tempFile("testKeystore.jks"), "keystorepassword")
-        keyStore.setKeyEntry("Key", keyPair.private, "keypassword".toCharArray(), arrayOf(selfSignCert))
+        keyStore.setKeyEntry("Key", keyPair.private, "keypassword".toCharArray(), arrayOf(converter.getCertificate(selfSignCert)))
 
         val keyFromKeystore = keyStore.getKey("Key", "keypassword".toCharArray())
         val keyFromKeystoreCasted = keyStore.getSupportedKey("Key", "keypassword")

--- a/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
@@ -10,6 +10,7 @@ import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.testing.BOB_PUBKEY
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.bouncycastle.cert.X509CertificateHolder
 import org.junit.Before
 import org.junit.Test
 import org.slf4j.LoggerFactory
@@ -142,10 +143,10 @@ class KryoTests {
     }
 
     @Test
-    fun `serialize - deserialize X509Certififcate`() {
-        val expected = X509Utilities.createSelfSignedCACertificate(ALICE.name, Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME))
+    fun `serialize - deserialize X509CertififcateHolder`() {
+        val expected: X509CertificateHolder = X509Utilities.createSelfSignedCACertificate(ALICE.name, Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME))
         val serialized = expected.serialize(kryo).bytes
-        val actual: X509Certificate = serialized.deserialize(kryo)
+        val actual: X509CertificateHolder = serialized.deserialize(kryo)
         assertEquals(expected, actual)
     }
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -50,6 +50,10 @@ UNRELEASED
          * Names of parties are now stored as a ``X500Name`` rather than a ``String``, to correctly enforce basic structure of the
            name. As a result all node legal names must now be structured as X.500 distinguished names.
 
+    * The Bouncy Castle library ``X509CertificateHolder`` class is now used in place of ``X509Certificate`` in order to
+      have a consistent class used internally. Conversions to/from ``X509Certificate`` are done as required, but should
+      be avoided where possible.
+
     * There are major changes to transaction signing in flows:
 
          * You should use the new ``CollectSignaturesFlow`` and corresponding ``SignTransactionFlow`` which handle most

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
@@ -19,6 +19,7 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.bouncycastle.asn1.x509.GeneralName
 import org.bouncycastle.asn1.x509.GeneralSubtree
 import org.bouncycastle.asn1.x509.NameConstraints
+import org.bouncycastle.cert.path.CertPath
 import org.junit.Test
 import java.nio.file.Files
 
@@ -111,7 +112,7 @@ class MQSecurityAsNodeTest : MQSecurityTest() {
                         X509Utilities.CORDA_CLIENT_CA,
                         clientKey.private,
                         keyPass,
-                        arrayOf(clientCACert, intermediateCA.certificate, rootCACert))
+                        CertPath(arrayOf(clientCACert, intermediateCA.certificate, rootCACert)))
                 clientCAKeystore.save(nodeKeystore, keyStorePassword)
 
                 val tlsKeystore = KeyStoreUtilities.loadOrCreateKeyStore(sslKeystore, keyStorePassword)
@@ -119,7 +120,7 @@ class MQSecurityAsNodeTest : MQSecurityTest() {
                         X509Utilities.CORDA_CLIENT_TLS,
                         tlsKey.private,
                         keyPass,
-                        arrayOf(clientTLSCert, clientCACert, intermediateCA.certificate, rootCACert))
+                        CertPath(arrayOf(clientTLSCert, clientCACert, intermediateCA.certificate, rootCACert)))
                 tlsKeystore.save(sslKeystore, keyStorePassword)
             }
         }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -57,6 +57,7 @@ import net.corda.node.utilities.transaction
 import org.apache.activemq.artemis.utils.ReusableLatch
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.jetbrains.exposed.sql.Database
 import org.slf4j.Logger
 import java.io.IOException
@@ -671,8 +672,10 @@ private class KeyStoreWrapper(private val storePath: Path, private val storePass
 
     fun save(serviceName: X500Name, privateKeyAlias: String, keyPair: KeyPair) {
         val clientCA = keyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA, storePassword)
+        val converter = JcaX509CertificateConverter()
         val cert = X509Utilities.createCertificate(CertificateType.IDENTITY, clientCA.certificate, clientCA.keyPair, serviceName, keyPair.public)
-        keyStore.addOrReplaceKey(privateKeyAlias, keyPair.private, storePassword.toCharArray(), arrayOf(cert, *keyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_CA)))
+        keyStore.addOrReplaceKey(privateKeyAlias, keyPair.private, storePassword.toCharArray(),
+                arrayOf(converter.getCertificate(cert), *keyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_CA)))
         keyStore.save(storePath, storePassword)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -11,6 +11,8 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.trace
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import java.security.InvalidAlgorithmParameterException
 import java.security.PublicKey
 import java.security.cert.*
@@ -82,8 +84,9 @@ class InMemoryIdentityService(identities: Iterable<Party> = emptySet(),
     override fun pathForAnonymous(anonymousParty: AnonymousParty): CertPath? = partyToPath[anonymousParty]
 
     @Throws(CertificateExpiredException::class, CertificateNotYetValidException::class, InvalidAlgorithmParameterException::class)
-    override fun registerPath(trustedRoot: X509Certificate, anonymousParty: AnonymousParty, path: CertPath) {
-        val expectedTrustAnchor = TrustAnchor(trustedRoot, null)
+    override fun registerPath(trustedRoot: X509CertificateHolder, anonymousParty: AnonymousParty, path: CertPath) {
+        val converter = JcaX509CertificateConverter()
+        val expectedTrustAnchor = TrustAnchor(converter.getCertificate(trustedRoot), null)
         require(path.certificates.isNotEmpty()) { "Certificate path must contain at least one certificate" }
         val target = path.certificates.last() as X509Certificate
         require(target.publicKey == anonymousParty.owningKey) { "Certificate path must end with anonymous party's public key" }

--- a/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
@@ -9,11 +9,12 @@ import net.corda.core.identity.Party
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SingletonSerializeAsToken
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.cert.CertPath
-import java.security.cert.X509Certificate
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
 
@@ -56,7 +57,7 @@ class E2ETestKeyManagementService(val identityService: IdentityService,
         return keyPair.public
     }
 
-    override fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509Certificate, CertPath> = freshKeyAndCert(this, identityService, identity, revocationEnabled)
+    override fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> = freshKeyAndCert(this, identityService, identity, revocationEnabled)
 
     private fun getSigningKeyPair(publicKey: PublicKey): KeyPair {
         return mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
@@ -1,12 +1,17 @@
 package net.corda.node.services.keys
 
 import net.corda.core.crypto.CertificateType
+import net.corda.core.crypto.ContentSignerBuilder
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.X509Utilities
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.operator.ContentSigner
+import java.security.KeyPair
+import java.security.Security
 import java.security.cert.CertPath
 import java.security.cert.X509Certificate
 
@@ -23,7 +28,7 @@ import java.security.cert.X509Certificate
 fun freshKeyAndCert(keyManagementService: KeyManagementService,
                     identityService: IdentityService,
                     identity: Party,
-                    revocationEnabled: Boolean = false): Pair<X509Certificate, CertPath> {
+                    revocationEnabled: Boolean = false): Pair<X509CertificateHolder, CertPath> {
     val ourPublicKey = keyManagementService.freshKey()
     // FIXME: Use the actual certificate for the identity the flow is presenting themselves as
     val issuerKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_IDENTITY_SIGNATURE_SCHEME)

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -10,13 +10,14 @@ import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.node.utilities.*
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.operator.ContentSigner
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.statements.InsertStatement
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.cert.CertPath
-import java.security.cert.X509Certificate
 
 /**
  * A persistent re-implementation of [E2ETestKeyManagementService] to support node re-start.
@@ -66,8 +67,7 @@ class PersistentKeyManagementService(val identityService: IdentityService,
         }
         return keyPair.public
     }
-
-    override fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509Certificate, CertPath> = freshKeyAndCert(this, identityService, identity, revocationEnabled)
+    override fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> = freshKeyAndCert(this, identityService, identity, revocationEnabled)
 
     private fun getSigningKeyPair(publicKey: PublicKey): KeyPair {
         return mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
@@ -2,7 +2,9 @@ package net.corda.node.services.network
 
 import com.google.common.annotations.VisibleForTesting
 import net.corda.core.ThreadBox
-import net.corda.core.crypto.*
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.SignedData
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.identity.Party
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.SingleMessageRecipient

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -6,6 +6,8 @@ import net.corda.core.crypto.X509Utilities.CORDA_CLIENT_CA
 import net.corda.core.crypto.X509Utilities.CORDA_CLIENT_TLS
 import net.corda.core.crypto.X509Utilities.CORDA_ROOT_CA
 import net.corda.node.services.config.NodeConfiguration
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.path.CertPath
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.util.io.pem.PemObject
 import java.io.StringWriter
@@ -40,7 +42,8 @@ class NetworkRegistrationHelper(val config: NodeConfiguration, val certService: 
                 val keyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
                 val selfSignCert = X509Utilities.createSelfSignedCACertificate(config.myLegalName, keyPair)
                 // Save to the key store.
-                caKeyStore.addOrReplaceKey(SELF_SIGNED_PRIVATE_KEY, keyPair.private, privateKeyPassword.toCharArray(), arrayOf(selfSignCert))
+                caKeyStore.addOrReplaceKey(SELF_SIGNED_PRIVATE_KEY, keyPair.private, privateKeyPassword.toCharArray(),
+                        CertPath(arrayOf(selfSignCert)))
                 caKeyStore.save(config.nodeKeystore, keystorePassword)
             }
             val keyPair = caKeyStore.getKeyPair(SELF_SIGNED_PRIVATE_KEY, privateKeyPassword)
@@ -69,11 +72,13 @@ class NetworkRegistrationHelper(val config: NodeConfiguration, val certService: 
             println("Node private key and certificate stored in ${config.nodeKeystore}.")
 
             println("Generating SSL certificate for node messaging service.")
+            val converter = JcaX509CertificateConverter()
             val sslKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
             val caCert = caKeyStore.getX509Certificate(CORDA_CLIENT_CA)
             val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, caCert.subject, sslKey.public)
             val sslKeyStore = KeyStoreUtilities.loadOrCreateKeyStore(config.sslKeystore, keystorePassword)
-            sslKeyStore.addOrReplaceKey(CORDA_CLIENT_TLS, sslKey.private, privateKeyPassword.toCharArray(), arrayOf(sslCert, *certificates))
+            sslKeyStore.addOrReplaceKey(CORDA_CLIENT_TLS, sslKey.private, privateKeyPassword.toCharArray(),
+                    arrayOf(converter.getCertificate(sslCert), *certificates))
             sslKeyStore.save(config.sslKeystore, config.keyStorePassword)
             println("SSL private key and certificate stored in ${config.sslKeystore}.")
             // All done, clean up temp files.

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
@@ -5,10 +5,12 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.crypto.*
 import net.corda.core.exists
+import net.corda.core.mapToArray
 import net.corda.core.utilities.ALICE
 import net.corda.testing.TestNodeConfiguration
 import net.corda.testing.getTestX509Name
 import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -29,8 +31,9 @@ class NetworkRegistrationHelperTest {
                 "CORDA_INTERMEDIATE_CA",
                 "CORDA_ROOT_CA")
                 .map { getTestX509Name(it) }
+        val converter = JcaX509CertificateConverter()
         val certs = identities.map { X509Utilities.createSelfSignedCACertificate(it, Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)) }
-                .toTypedArray()
+                .mapToArray(converter::getCertificate)
 
         val certService: NetworkRegistrationService = mock {
             on { submitRequest(any()) }.then { id }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -21,6 +21,7 @@ import net.corda.node.services.vault.NodeVaultService
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.MINI_CORP
 import net.corda.testing.MOCK_VERSION_INFO
+import org.bouncycastle.cert.X509CertificateHolder
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.io.ByteArrayInputStream
@@ -32,7 +33,6 @@ import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.cert.CertPath
-import java.security.cert.X509Certificate
 import java.time.Clock
 import java.util.*
 import java.util.jar.JarInputStream
@@ -91,7 +91,7 @@ class MockKeyManagementService(val identityService: IdentityService,
         return k.public
     }
 
-    override fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509Certificate, CertPath> = freshKeyAndCert(this, identityService, identity, revocationEnabled)
+    override fun freshKeyAndCert(identity: Party, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> = freshKeyAndCert(this, identityService, identity, revocationEnabled)
 
     private fun getSigningKeyPair(publicKey: PublicKey): KeyPair {
         val pk = publicKey.keys.first { keyStore.containsKey(it) }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
@@ -3,6 +3,7 @@ package net.corda.testing.node
 import com.codahale.metrics.MetricRegistry
 import com.google.common.net.HostAndPort
 import com.google.common.util.concurrent.SettableFuture
+import net.corda.core.crypto.CertificateAndKeyPair
 import net.corda.core.crypto.commonName
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.messaging.RPCOps
@@ -30,7 +31,9 @@ import kotlin.concurrent.thread
  * This is a bare-bones node which can only send and receive messages. It doesn't register with a network map service or
  * any other such task that would make it functional in a network and thus left to the user to do so manually.
  */
-class SimpleNode(val config: NodeConfiguration, val address: HostAndPort = freeLocalHostAndPort(), rpcAddress: HostAndPort = freeLocalHostAndPort()) : AutoCloseable {
+class SimpleNode(val config: NodeConfiguration, val address: HostAndPort = freeLocalHostAndPort(),
+                 rpcAddress: HostAndPort = freeLocalHostAndPort(),
+                 networkRoot: CertificateAndKeyPair? = null) : AutoCloseable {
 
     private val databaseWithCloseable: Pair<Closeable, Database> = configureDatabase(config.dataSourceProperties)
     val database: Database get() = databaseWithCloseable.second


### PR DESCRIPTION
Replace X509Certificate with X509CertificateHolder for consistency in implementation of how X.509 certificates are managed. Using the Java standard class entails the actual implementing class being one of several options depending how a certificate is built, which makes serialization/deserialization with Kryo inconsistent as some of these forms cannot be directly built from outside restricted classes.