### PR TITLE
Pass ports instead of hostAndPorts to the message broker. Pass an add…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -85,8 +85,8 @@ import javax.security.cert.X509Certificate
  */
 @ThreadSafe
 class ArtemisMessagingServer(override val config: NodeConfiguration,
-                             val p2pHostPort: HostAndPort,
-                             val rpcHostPort: HostAndPort?,
+                             val p2pPort: Int,
+                             val rpcPort: Int?,
                              val networkMapCache: NetworkMapCache,
                              val userService: RPCUserService) : ArtemisMessagingComponent() {
     companion object {
@@ -156,9 +156,9 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
             registerPostQueueDeletionCallback { address, qName -> log.debug { "Queue deleted: $qName for $address" } }
         }
         activeMQServer.start()
-        printBasicNodeInfo("Listening on address", p2pHostPort.toString())
-        if (rpcHostPort != null) {
-            printBasicNodeInfo("RPC service listening on address", rpcHostPort.toString())
+        printBasicNodeInfo("Listening on port", p2pPort.toString())
+        if (rpcPort != null) {
+            printBasicNodeInfo("RPC service listening on port", rpcPort.toString())
         }
     }
 
@@ -170,9 +170,9 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
         val connectionDirection = ConnectionDirection.Inbound(
                 acceptorFactoryClassName = NettyAcceptorFactory::class.java.name
         )
-        val acceptors = mutableSetOf(createTcpTransport(connectionDirection, "0.0.0.0", p2pHostPort.port))
-        if (rpcHostPort != null) {
-            acceptors.add(createTcpTransport(connectionDirection, "0.0.0.0", rpcHostPort.port, enableSSL = false))
+        val acceptors = mutableSetOf(createTcpTransport(connectionDirection, "0.0.0.0", p2pPort))
+        if (rpcPort != null) {
+            acceptors.add(createTcpTransport(connectionDirection, "0.0.0.0", rpcPort, enableSSL = false))
         }
         acceptorConfigurations = acceptors
         // Enable built in message deduplication. Note we still have to do our own as the delayed commits

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -93,15 +93,20 @@ fun generateStateRef() = StateRef(SecureHash.randomSHA256(), 0)
 
 private val freePortCounter = AtomicInteger(30000)
 /**
+ * Returns a localhost address with a free port.
+ *
+ * Unsafe for getting multiple ports!
+ * Use [getFreeLocalPorts] for getting multiple ports.
+ */
+fun freeLocalHostAndPort(): HostAndPort = HostAndPort.fromParts("localhost", freePort())
+
+/**
  * Returns a free port.
  *
  * Unsafe for getting multiple ports!
  * Use [getFreeLocalPorts] for getting multiple ports.
  */
-fun freeLocalHostAndPort(): HostAndPort {
-    val freePort = freePortCounter.getAndAccumulate(0) { prev, _ -> 30000 + (prev - 30000 + 1) % 10000 }
-    return HostAndPort.fromParts("localhost", freePort)
-}
+fun freePort(): Int = freePortCounter.getAndAccumulate(0) { prev, _ -> 30000 + (prev - 30000 + 1) % 10000 }
 
 /**
  * Creates a specified number of ports for use by the Node.

--- a/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
@@ -43,7 +43,7 @@ class SimpleNode(val config: NodeConfiguration, val address: HostAndPort = freeL
     val identityService: IdentityService = InMemoryIdentityService()
     val keyService: KeyManagementService = E2ETestKeyManagementService(identityService, setOf(identity))
     val executor = ServiceAffinityExecutor(config.myLegalName.commonName, 1)
-    val broker = ArtemisMessagingServer(config, address, rpcAddress, InMemoryNetworkMapCache(), userService)
+    val broker = ArtemisMessagingServer(config, address.port, rpcAddress.port, InMemoryNetworkMapCache(), userService)
     val networkMapRegistrationFuture: SettableFuture<Unit> = SettableFuture.create<Unit>()
     val net = database.transaction {
         NodeMessagingClient(


### PR DESCRIPTION
…ress for the NodeMessagingClient to advertise to the network map service.

This is a patch from internal to keep things in sync.