### PR TITLE
Excluding experimental from the project unless explicitly enabled.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,9 +15,6 @@ include 'client:mock'
 include 'client:rpc'
 include 'webserver'
 include 'webserver:webcapsule'
-include 'experimental'
-include 'experimental:sandbox'
-include 'experimental:quasar-hook'
 include 'verifier'
 include 'test-utils'
 include 'tools:explorer'
@@ -33,3 +30,10 @@ include 'samples:simm-valuation-demo'
 include 'samples:notary-demo'
 include 'samples:bank-of-corda-demo'
 include 'cordform-common'
+
+// Enable experimental modules with `gradle -Pexperimental`
+if (hasProperty("experimental")) {
+    include 'experimental'
+    include 'experimental:sandbox'
+    include 'experimental:quasar-hook'
+}


### PR DESCRIPTION
Why: Because experimental is experimental. It should not be a concern for anyone who isn't developing it, and especially not a concern for CI. 