### PR TITLE
Change PartyAndCertificate to an aggregate class

### DIFF
--- a/core/src/main/kotlin/net/corda/core/identity/Party.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/Party.kt
@@ -3,6 +3,7 @@ package net.corda.core.identity
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.crypto.CertificateAndKeyPair
 import net.corda.core.crypto.toBase58String
+import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.OpaqueBytes
 import org.bouncycastle.asn1.x500.X500Name
 import java.security.PublicKey
@@ -26,7 +27,7 @@ import java.security.PublicKey
  *
  * @see CompositeKey
  */
-open class Party(val name: X500Name, owningKey: PublicKey) : AbstractParty(owningKey) {
+class Party(val name: X500Name, owningKey: PublicKey) : AbstractParty(owningKey) {
     constructor(certAndKey: CertificateAndKeyPair) : this(certAndKey.certificate.subject, certAndKey.keyPair.public)
     override fun toString() = name.toString()
     override fun nameOrNull(): X500Name? = name

--- a/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt
@@ -1,5 +1,6 @@
 package net.corda.core.identity
 
+import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.cert.X509CertificateHolder
 import java.security.PublicKey
@@ -8,6 +9,23 @@ import java.security.cert.CertPath
 /**
  * A full party plus the X.509 certificate and path linking the party back to a trust root.
  */
-class PartyAndCertificate(name: X500Name, owningKey: PublicKey,
-                          val certificate: X509CertificateHolder,
-                          val certPath: CertPath) : Party(name, owningKey)
+@CordaSerializable
+class PartyAndCertificate(val party: Party,
+                               val certificate: X509CertificateHolder,
+                               val certPath: CertPath) {
+    constructor(name: X500Name, owningKey: PublicKey, certificate: X509CertificateHolder, certPath: CertPath) : this(Party(name, owningKey), certificate, certPath)
+    val name: X500Name
+        get() = party.name
+    val owningKey: PublicKey
+        get() = party.owningKey
+
+    override fun equals(other: Any?): Boolean {
+        return if (other is PartyAndCertificate)
+            party == other.party
+        else
+            false
+    }
+
+    override fun hashCode(): Int = party.hashCode()
+    override fun toString(): String = party.toString()
+}

--- a/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt
@@ -7,25 +7,18 @@ import java.security.PublicKey
 import java.security.cert.CertPath
 
 /**
- * A full party plus the X.509 certificate and path linking the party back to a trust root.
+ * A party plus the X.509 certificate and path linking the party back to a trust root.
  */
 @CordaSerializable
-class PartyAndCertificate(val party: Party,
+data class PartyAndCertificate(val party: Party,
                                val certificate: X509CertificateHolder,
                                val certPath: CertPath) {
     constructor(name: X500Name, owningKey: PublicKey, certificate: X509CertificateHolder, certPath: CertPath) : this(Party(name, owningKey), certificate, certPath)
+
     val name: X500Name
         get() = party.name
     val owningKey: PublicKey
         get() = party.owningKey
 
-    override fun equals(other: Any?): Boolean {
-        return if (other is PartyAndCertificate)
-            party == other.party
-        else
-            false
-    }
-
-    override fun hashCode(): Int = party.hashCode()
     override fun toString(): String = party.toString()
 }

--- a/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/PartyAndCertificate.kt
@@ -7,18 +7,27 @@ import java.security.PublicKey
 import java.security.cert.CertPath
 
 /**
- * A party plus the X.509 certificate and path linking the party back to a trust root.
+ * A full party plus the X.509 certificate and path linking the party back to a trust root. Equality of
+ * [PartyAndCertificate] instances is based on the party only, as certificate and path are data associated with the party,
+ * not part of the identifier themselves.
  */
 @CordaSerializable
 data class PartyAndCertificate(val party: Party,
                                val certificate: X509CertificateHolder,
                                val certPath: CertPath) {
     constructor(name: X500Name, owningKey: PublicKey, certificate: X509CertificateHolder, certPath: CertPath) : this(Party(name, owningKey), certificate, certPath)
-
     val name: X500Name
         get() = party.name
     val owningKey: PublicKey
         get() = party.owningKey
 
+    override fun equals(other: Any?): Boolean {
+        return if (other is PartyAndCertificate)
+            party == other.party
+        else
+            false
+    }
+
+    override fun hashCode(): Int = party.hashCode()
     override fun toString(): String = party.toString()
 }

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -11,7 +11,6 @@ import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.StateMachineTransactionMapping
@@ -232,18 +231,18 @@ interface CordaRPCOps : RPCOps {
     /**
      * Returns the [Party] corresponding to the given key, if found.
      */
-    fun partyFromKey(key: PublicKey): PartyAndCertificate?
+    fun partyFromKey(key: PublicKey): Party?
 
     /**
      * Returns the [Party] with the given name as it's [Party.name]
      */
     @Deprecated("Use partyFromX500Name instead")
-    fun partyFromName(name: String): PartyAndCertificate?
+    fun partyFromName(name: String): Party?
 
     /**
      * Returns the [Party] with the X.500 principal as it's [Party.name]
      */
-    fun partyFromX500Name(x500Name: X500Name): PartyAndCertificate?
+    fun partyFromX500Name(x500Name: X500Name): Party?
 
     /** Enumerates the class names of the flows that this node knows about. */
     fun registeredFlows(): List<String>

--- a/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt
@@ -32,7 +32,10 @@ data class NodeInfo(val address: SingleMessageRecipient,
         get() = legalIdentityAndCert.party
     val notaryIdentity: Party
         get() = advertisedServices.single { it.info.type.isNotary() }.identity.party
-    fun serviceIdentities(type: ServiceType): List<PartyAndCertificate> {
+    fun serviceIdentities(type: ServiceType): List<Party> {
+        return advertisedServices.filter { it.info.type.isSubTypeOf(type) }.map { it.identity.party }
+    }
+    fun servideIdentitiesAndCert(type: ServiceType): List<PartyAndCertificate> {
         return advertisedServices.filter { it.info.type.isSubTypeOf(type) }.map { it.identity }
     }
 }

--- a/core/src/main/kotlin/net/corda/core/node/PluginServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/PluginServiceHub.kt
@@ -2,7 +2,6 @@ package net.corda.core.node
 
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 
 /**
  * A service hub to be used by the [CordaPluginRegistry]
@@ -10,5 +9,5 @@ import net.corda.core.identity.PartyAndCertificate
 interface PluginServiceHub : ServiceHub {
     @Deprecated("This is no longer used. Instead annotate the flows produced by your factory with @InitiatedBy and have " +
             "them point to the initiating flow class.", level = DeprecationLevel.ERROR)
-    fun registerFlowInitiator(initiatingFlowClass: Class<out FlowLogic<*>>, serviceFlowFactory: (PartyAndCertificate) -> FlowLogic<*>) = Unit
+    fun registerFlowInitiator(initiatingFlowClass: Class<out FlowLogic<*>>, serviceFlowFactory: (Party) -> FlowLogic<*>) = Unit
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -1,10 +1,8 @@
 package net.corda.core.node.services
 
 import net.corda.core.contracts.PartyAndReference
-import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.AnonymousParty
-import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.*
+import net.corda.core.node.NodeInfo
 import org.bouncycastle.asn1.x500.X500Name
 import java.security.InvalidAlgorithmParameterException
 import java.security.PublicKey
@@ -37,7 +35,7 @@ interface IdentityService {
      * certificate chain for the anonymous party.
      */
     @Throws(CertificateExpiredException::class, CertificateNotYetValidException::class, InvalidAlgorithmParameterException::class)
-    fun registerAnonymousIdentity(anonymousParty: AnonymousParty, fullParty: PartyAndCertificate, path: CertPath)
+    fun registerAnonymousIdentity(anonymousParty: AnonymousParty, party: Party, path: CertPath)
 
     /**
      * Asserts that an anonymous party maps to the given full party, by looking up the certificate chain associated with
@@ -52,16 +50,16 @@ interface IdentityService {
      * Get all identities known to the service. This is expensive, and [partyFromKey] or [partyFromX500Name] should be
      * used in preference where possible.
      */
-    fun getAllIdentities(): Iterable<Party>
+    fun getAllIdentities(): Iterable<PartyAndCertificate>
 
     // There is no method for removing identities, as once we are made aware of a Party we want to keep track of them
     // indefinitely. It may be that in the long term we need to drop or archive very old Party information for space,
     // but for now this is not supported.
 
-    fun partyFromKey(key: PublicKey): PartyAndCertificate?
+    fun partyFromKey(key: PublicKey): Party?
     @Deprecated("Use partyFromX500Name")
-    fun partyFromName(name: String): PartyAndCertificate?
-    fun partyFromX500Name(principal: X500Name): PartyAndCertificate?
+    fun partyFromName(name: String): Party?
+    fun partyFromX500Name(principal: X500Name): Party?
 
     /**
      * Resolve the well known identity of a party. If the party passed in is already a well known identity
@@ -69,7 +67,7 @@ interface IdentityService {
      *
      * @return the well known identity, or null if unknown.
      */
-    fun partyFromAnonymous(party: AbstractParty): PartyAndCertificate?
+    fun partyFromAnonymous(party: AbstractParty): Party?
 
     /**
      * Resolve the well known identity of a party. If the party passed in is already a well known identity

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -52,6 +52,13 @@ interface IdentityService {
      */
     fun getAllIdentities(): Iterable<PartyAndCertificate>
 
+    /**
+     * Get the certificate and path for a well known identity.
+     *
+     * @return the party and certificate, or null if unknown.
+     */
+    fun certificateFromParty(party: Party): PartyAndCertificate?
+
     // There is no method for removing identities, as once we are made aware of a Party we want to keep track of them
     // indefinitely. It may be that in the long term we need to drop or archive very old Party information for space,
     // but for now this is not supported.

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -11,9 +11,9 @@ import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
 
 /**
- * An identity service maintains an bidirectional map of [Party]s to their associated public keys and thus supports
- * lookup of a party given its key. This is obviously very incomplete and does not reflect everything a real identity
- * service would provide.
+ * An identity service maintains a directory of parties by their associated distinguished name/public keys and thus
+ * supports lookup of a party given its key, or name. The service also manages the certificates linking confidential
+ * identities back to the well known identity (i.e. the identity in the network map) of a party.
  */
 interface IdentityService {
     /**

--- a/core/src/main/kotlin/net/corda/core/node/services/PartyInfo.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/PartyInfo.kt
@@ -1,6 +1,7 @@
 package net.corda.core.node.services
 
 import net.corda.core.identity.Party
+import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceEntry
 
@@ -8,10 +9,10 @@ import net.corda.core.node.ServiceEntry
  * Holds information about a [Party], which may refer to either a specific node or a service.
  */
 sealed class PartyInfo {
-    abstract val party: Party
+    abstract val party: PartyAndCertificate
 
     data class Node(val node: NodeInfo) : PartyInfo() {
-        override val party get() = node.legalIdentity
+        override val party get() = node.legalIdentityAndCert
     }
 
     data class Service(val service: ServiceEntry) : PartyInfo() {

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -21,7 +21,6 @@ import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
 import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.operator.ContentSigner
 import rx.Observable
 import java.io.InputStream
 import java.security.PublicKey

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -3,6 +3,7 @@
 package net.corda.core.utilities
 
 import net.corda.core.crypto.*
+import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import org.bouncycastle.asn1.x500.X500Name
 import java.math.BigInteger
@@ -21,39 +22,42 @@ val DUMMY_KEY_2: KeyPair by lazy { generateKeyPair() }
 
 val DUMMY_NOTARY_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(20)) }
 /** Dummy notary identity for tests and simulations */
-val DUMMY_NOTARY: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Notary Service,O=R3,OU=corda,L=Zurich,C=CH"), DUMMY_NOTARY_KEY.public)
+val DUMMY_NOTARY_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Notary Service,O=R3,OU=corda,L=Zurich,C=CH"), DUMMY_NOTARY_KEY.public)
+val DUMMY_NOTARY: Party get() = DUMMY_NOTARY_IDENTITY.party
 
 val DUMMY_MAP_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(30)) }
 /** Dummy network map service identity for tests and simulations */
-val DUMMY_MAP: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Network Map Service,O=R3,OU=corda,L=Amsterdam,C=NL"), DUMMY_MAP_KEY.public)
+val DUMMY_MAP: Party get() = Party(X500Name("CN=Network Map Service,O=R3,OU=corda,L=Amsterdam,C=NL"), DUMMY_MAP_KEY.public)
 
 val DUMMY_BANK_A_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(40)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_A: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Bank A,O=Bank A,L=London,C=UK"), DUMMY_BANK_A_KEY.public)
+val DUMMY_BANK_A: Party get() = Party(X500Name("CN=Bank A,O=Bank A,L=London,C=UK"), DUMMY_BANK_A_KEY.public)
 
 val DUMMY_BANK_B_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(50)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_B: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Bank B,O=Bank B,L=New York,C=US"), DUMMY_BANK_B_KEY.public)
+val DUMMY_BANK_B: Party get() = Party(X500Name("CN=Bank B,O=Bank B,L=New York,C=US"), DUMMY_BANK_B_KEY.public)
 
 val DUMMY_BANK_C_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(60)) }
 /** Dummy bank identity for tests and simulations */
-val DUMMY_BANK_C: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Bank C,O=Bank C,L=Tokyo,C=JP"), DUMMY_BANK_C_KEY.public)
+val DUMMY_BANK_C: Party get() = Party(X500Name("CN=Bank C,O=Bank C,L=Tokyo,C=JP"), DUMMY_BANK_C_KEY.public)
 
 val ALICE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(70)) }
 /** Dummy individual identity for tests and simulations */
-val ALICE: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Alice Corp,O=Alice Corp,L=London,C=UK"), ALICE_KEY.public)
+val ALICE_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Alice Corp,O=Alice Corp,L=London,C=UK"), ALICE_KEY.public)
+val ALICE: Party get() = ALICE_IDENTITY.party
 
 val BOB_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(80)) }
 /** Dummy individual identity for tests and simulations */
-val BOB: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Bob Plc,O=Bob Plc,L=London,C=UK"), BOB_KEY.public)
+val BOB_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Bob Plc,O=Bob Plc,L=London,C=UK"), BOB_KEY.public)
+val BOB: Party get() = BOB_IDENTITY.party
 
 val CHARLIE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(90)) }
 /** Dummy individual identity for tests and simulations */
-val CHARLIE: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Charlie Ltd,O=Charlie Ltd,L=London,C=UK"), CHARLIE_KEY.public)
+val CHARLIE: Party get() = Party(X500Name("CN=Charlie Ltd,O=Charlie Ltd,L=London,C=UK"), CHARLIE_KEY.public)
 
 val DUMMY_REGULATOR_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(100)) }
 /** Dummy regulator for tests and simulations */
-val DUMMY_REGULATOR: PartyAndCertificate get() = getTestPartyAndCertificate(X500Name("CN=Regulator A,OU=Corda,O=AMF,L=Paris,C=FR"), DUMMY_REGULATOR_KEY.public)
+val DUMMY_REGULATOR: Party get() = Party(X500Name("CN=Regulator A,OU=Corda,O=AMF,L=Paris,C=FR"), DUMMY_REGULATOR_KEY.public)
 
 val DUMMY_CA_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(110)) }
 val DUMMY_CA: CertificateAndKeyPair by lazy {

--- a/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
@@ -10,7 +10,6 @@ import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
@@ -120,7 +119,7 @@ abstract class AbstractStateReplacementFlow {
 
     // Type parameter should ideally be Unit but that prevents Java code from subclassing it (https://youtrack.jetbrains.com/issue/KT-15964).
     // We use Void? instead of Unit? as that's what you'd use in Java.
-    abstract class Acceptor<in T>(val otherSide: PartyAndCertificate,
+    abstract class Acceptor<in T>(val otherSide: Party,
                                   override val progressTracker: ProgressTracker = tracker()) : FlowLogic<Void?>() {
         companion object {
             object VERIFYING : ProgressTracker.Step("Verifying state replacement proposal")

--- a/core/src/main/kotlin/net/corda/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/CollectSignaturesFlow.kt
@@ -7,7 +7,6 @@ import net.corda.core.crypto.toBase58String
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.ServiceHub
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
@@ -173,7 +172,7 @@ class CollectSignaturesFlow(val partiallySignedTx: SignedTransaction,
  *
  * @param otherParty The counter-party which is providing you a transaction to sign.
  */
-abstract class SignTransactionFlow(val otherParty: PartyAndCertificate,
+abstract class SignTransactionFlow(val otherParty: Party,
                                    override val progressTracker: ProgressTracker = tracker()) : FlowLogic<SignedTransaction>() {
 
     companion object {

--- a/core/src/main/kotlin/net/corda/flows/FetchAttachmentsFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FetchAttachmentsFlow.kt
@@ -5,7 +5,7 @@ import net.corda.core.contracts.Attachment
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
 import net.corda.core.flows.InitiatingFlow
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.serialization.SerializationToken
 import net.corda.core.serialization.SerializeAsToken
 import net.corda.core.serialization.SerializeAsTokenContext
@@ -16,7 +16,7 @@ import net.corda.core.serialization.SerializeAsTokenContext
  */
 @InitiatingFlow
 class FetchAttachmentsFlow(requests: Set<SecureHash>,
-                           otherSide: PartyAndCertificate) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide) {
+                           otherSide: Party) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide) {
 
     override fun load(txid: SecureHash): Attachment? = serviceHub.storageService.attachments.openAttachment(txid)
 

--- a/core/src/main/kotlin/net/corda/flows/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FetchDataFlow.kt
@@ -6,7 +6,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.UntrustworthyData
 import net.corda.core.utilities.unwrap
@@ -32,7 +31,7 @@ import java.util.*
  */
 abstract class FetchDataFlow<T : NamedByHash, in W : Any>(
         protected val requests: Set<SecureHash>,
-        protected val otherSide: PartyAndCertificate) : FlowLogic<FetchDataFlow.Result<T>>() {
+        protected val otherSide: Party) : FlowLogic<FetchDataFlow.Result<T>>() {
 
     @CordaSerializable
     class DownloadedVsRequestedDataMismatch(val requested: SecureHash, val got: SecureHash) : IllegalArgumentException()

--- a/core/src/main/kotlin/net/corda/flows/FetchTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/FetchTransactionsFlow.kt
@@ -2,7 +2,7 @@ package net.corda.flows
 
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.InitiatingFlow
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
 
 /**
@@ -14,7 +14,7 @@ import net.corda.core.transactions.SignedTransaction
  * the database, because it's up to the caller to actually verify the transactions are valid.
  */
 @InitiatingFlow
-class FetchTransactionsFlow(requests: Set<SecureHash>, otherSide: PartyAndCertificate) :
+class FetchTransactionsFlow(requests: Set<SecureHash>, otherSide: Party) :
         FetchDataFlow<SignedTransaction, SignedTransaction>(requests, otherSide) {
 
     override fun load(txid: SecureHash): SignedTransaction? {

--- a/core/src/main/kotlin/net/corda/flows/NotaryChangeFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryChangeFlow.kt
@@ -4,11 +4,9 @@ import net.corda.core.contracts.*
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
-import java.security.PublicKey
 
 /**
  * A flow to be used for changing a state's Notary. This is required since all input states to a transaction
@@ -22,7 +20,7 @@ import java.security.PublicKey
 @InitiatingFlow
 class NotaryChangeFlow<out T : ContractState>(
         originalState: StateAndRef<T>,
-        newNotary: PartyAndCertificate,
+        newNotary: Party,
         progressTracker: ProgressTracker = tracker())
     : AbstractStateReplacementFlow.Instigator<T, T, Party>(originalState, newNotary, progressTracker) {
 

--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -11,7 +11,6 @@ import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.UniquenessException
 import net.corda.core.node.services.UniquenessProvider
@@ -97,7 +96,7 @@ object NotaryFlow {
      * Additional transaction validation logic can be added when implementing [receiveAndVerifyTx].
      */
     // See AbstractStateReplacementFlow.Acceptor for why it's Void?
-    abstract class Service(val otherSide: PartyAndCertificate,
+    abstract class Service(val otherSide: Party,
                            val timeWindowChecker: TimeWindowChecker,
                            val uniquenessProvider: UniquenessProvider) : FlowLogic<Void?>() {
         @Suspendable

--- a/core/src/main/kotlin/net/corda/flows/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ResolveTransactionsFlow.kt
@@ -5,7 +5,7 @@ import net.corda.core.checkedAdd
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.getOrThrow
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
@@ -30,7 +30,7 @@ import java.util.*
  * The flow returns a list of verified [LedgerTransaction] objects, in a depth-first order.
  */
 class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
-                              private val otherSide: PartyAndCertificate) : FlowLogic<List<LedgerTransaction>>() {
+                              private val otherSide: Party) : FlowLogic<List<LedgerTransaction>>() {
 
     companion object {
         private fun dependencyIDs(wtx: WireTransaction) = wtx.inputs.map { it.txhash }.toSet()
@@ -82,14 +82,14 @@ class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
     /**
      * Resolve the full history of a transaction and verify it with its dependencies.
      */
-    constructor(stx: SignedTransaction, otherSide: PartyAndCertificate) : this(stx.tx, otherSide) {
+    constructor(stx: SignedTransaction, otherSide: Party) : this(stx.tx, otherSide) {
         this.stx = stx
     }
 
     /**
      * Resolve the full history of a transaction and verify it with its dependencies.
      */
-    constructor(wtx: WireTransaction, otherSide: PartyAndCertificate) : this(dependencyIDs(wtx), otherSide) {
+    constructor(wtx: WireTransaction, otherSide: Party) : this(dependencyIDs(wtx), otherSide) {
         this.wtx = wtx
     }
 

--- a/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
@@ -113,7 +113,7 @@ object TwoPartyDealFlow {
             if (regulators.isNotEmpty()) {
                 // Copy the transaction to every regulator in the network. This is obviously completely bogus, it's
                 // just for demo purposes.
-                regulators.forEach { send(it.serviceIdentities(ServiceType.regulator).first().party, ftx) }
+                regulators.forEach { send(it.serviceIdentities(ServiceType.regulator).first(), ftx) }
             }
 
             progressTracker.currentStep = COPYING_TO_COUNTERPARTY

--- a/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
@@ -7,7 +7,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceType
 import net.corda.core.seconds
@@ -46,7 +45,7 @@ object TwoPartyDealFlow {
 
         abstract val payload: Any
         abstract val notaryNode: NodeInfo
-        abstract val otherParty: PartyAndCertificate
+        abstract val otherParty: Party
         abstract val myKey: PublicKey
 
         @Suspendable override fun call(): SignedTransaction {
@@ -114,7 +113,7 @@ object TwoPartyDealFlow {
             if (regulators.isNotEmpty()) {
                 // Copy the transaction to every regulator in the network. This is obviously completely bogus, it's
                 // just for demo purposes.
-                regulators.forEach { send(it.serviceIdentities(ServiceType.regulator).first(), ftx) }
+                regulators.forEach { send(it.serviceIdentities(ServiceType.regulator).first().party, ftx) }
             }
 
             progressTracker.currentStep = COPYING_TO_COUNTERPARTY
@@ -150,7 +149,7 @@ object TwoPartyDealFlow {
     /**
      * One side of the flow for inserting a pre-agreed deal.
      */
-    open class Instigator(override val otherParty: PartyAndCertificate,
+    open class Instigator(override val otherParty: Party,
                           override val payload: AutoOffer,
                           override val myKey: PublicKey,
                           override val progressTracker: ProgressTracker = Primary.tracker()) : Primary() {

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -7,7 +7,6 @@ import net.corda.core.contracts.TransactionType
 import net.corda.core.contracts.requireThat
 import net.corda.core.getOrThrow
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
 import net.corda.flows.CollectSignaturesFlow
@@ -55,7 +54,7 @@ class CollectSignaturesFlowTests {
     // "collectSignaturesFlow" and "SignTransactionFlow" can be used in practise.
     object TestFlow {
         @InitiatingFlow
-        class Initiator(val state: DummyContract.MultiOwnerState, val otherParty: PartyAndCertificate) : FlowLogic<SignedTransaction>() {
+        class Initiator(val state: DummyContract.MultiOwnerState, val otherParty: Party) : FlowLogic<SignedTransaction>() {
             @Suspendable
             override fun call(): SignedTransaction {
                 send(otherParty, state)
@@ -115,7 +114,7 @@ class CollectSignaturesFlowTests {
         }
 
         @InitiatedBy(TestFlowTwo.Initiator::class)
-        class Responder(val otherParty: PartyAndCertificate) : FlowLogic<SignedTransaction>() {
+        class Responder(val otherParty: Party) : FlowLogic<SignedTransaction>() {
             @Suspendable override fun call(): SignedTransaction {
                 val flow = object : SignTransactionFlow(otherParty) {
                     @Suspendable override fun checkTransaction(stx: SignedTransaction) = requireThat {

--- a/core/src/test/kotlin/net/corda/core/flows/TxKeyFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/TxKeyFlowTests.kt
@@ -3,7 +3,6 @@ package net.corda.core.flows
 import net.corda.core.getOrThrow
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.utilities.ALICE
 import net.corda.core.utilities.BOB
 import net.corda.core.utilities.DUMMY_NOTARY
@@ -30,12 +29,12 @@ class TxKeyFlowTests {
         val notaryNode = net.createNotaryNode(null, DUMMY_NOTARY.name)
         val aliceNode = net.createPartyNode(notaryNode.info.address, ALICE.name)
         val bobNode = net.createPartyNode(notaryNode.info.address, BOB.name)
-        val alice: PartyAndCertificate = aliceNode.services.myInfo.legalIdentity
-        val bob: PartyAndCertificate = bobNode.services.myInfo.legalIdentity
-        aliceNode.services.identityService.registerIdentity(bob)
-        aliceNode.services.identityService.registerIdentity(notaryNode.info.legalIdentity)
-        bobNode.services.identityService.registerIdentity(alice)
-        bobNode.services.identityService.registerIdentity(notaryNode.info.legalIdentity)
+        val alice: Party = aliceNode.services.myInfo.legalIdentity
+        val bob: Party = bobNode.services.myInfo.legalIdentity
+        aliceNode.services.identityService.registerIdentity(bobNode.info.legalIdentityAndCert)
+        aliceNode.services.identityService.registerIdentity(notaryNode.info.legalIdentityAndCert)
+        bobNode.services.identityService.registerIdentity(aliceNode.info.legalIdentityAndCert)
+        bobNode.services.identityService.registerIdentity(notaryNode.info.legalIdentityAndCert)
 
         // Run the flows
         bobNode.registerInitiatedFlow(TxKeyFlow.Provider::class.java)

--- a/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
@@ -7,7 +7,6 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.getOrThrow
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.RPCOps
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.services.ServiceInfo
@@ -140,7 +139,7 @@ class AttachmentSerializationTest {
 
     private fun launchFlow(clientLogic: ClientLogic, rounds: Int) {
         server.registerFlowFactory(ClientLogic::class.java, object : InitiatedFlowFactory<ServerLogic> {
-            override fun createFlow(platformVersion: Int, otherParty: PartyAndCertificate, sessionInit: SessionInit): ServerLogic {
+            override fun createFlow(platformVersion: Int, otherParty: Party, sessionInit: SessionInit): ServerLogic {
                 return ServerLogic(otherParty)
             }
         }, ServerLogic::class.java, track = false)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,9 +43,9 @@ UNRELEASED
     * There is a new ``AbstractParty`` superclass to ``Party``, which contains just the public key. This now replaces
       use of ``Party`` and ``PublicKey`` in state objects, and allows use of full or anonymised parties depending on
       use-case.
-    * A new ``PartyAndCertificate`` class has been added which contains an X.509 certificate and certificate path back
-      to a network trust root. This is widely used in place of ``Party`` inside Corda, with the exception of a few cases
-      where proof of identity is not required.
+    * A new ``PartyAndCertificate`` class has been added which aggregates a Party along with an X.509 certificate and
+      certificate path back to a network trust root. This is used where a Party and its proof of identity are required,
+      for example in identity registration.
     * Names of parties are now stored as a ``X500Name`` rather than a ``String``, to correctly enforce basic structure of the
       name. As a result all node legal names must now be structured as X.500 distinguished names.
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -26,8 +26,8 @@ import java.util.*
 @CordaSerializable
 private data class FxRequest(val tradeId: String,
                              val amount: Amount<Issued<Currency>>,
-                             val owner: PartyAndCertificate,
-                             val counterparty: PartyAndCertificate,
+                             val owner: Party,
+                             val counterparty: Party,
                              val notary: Party? = null)
 
 @CordaSerializable
@@ -103,8 +103,8 @@ private fun prepareOurInputsAndOutputs(serviceHub: ServiceHub, request: FxReques
 class ForeignExchangeFlow(val tradeId: String,
                           val baseCurrencyAmount: Amount<Issued<Currency>>,
                           val quoteCurrencyAmount: Amount<Issued<Currency>>,
-                          val baseCurrencyBuyer: PartyAndCertificate,
-                          val baseCurrencySeller: PartyAndCertificate) : FlowLogic<SecureHash>() {
+                          val baseCurrencyBuyer: Party,
+                          val baseCurrencySeller: Party) : FlowLogic<SecureHash>() {
     @Suspendable
     override fun call(): SecureHash {
         // Select correct sides of the Fx exchange to query for.
@@ -208,7 +208,7 @@ class ForeignExchangeFlow(val tradeId: String,
 }
 
 @InitiatedBy(ForeignExchangeFlow::class)
-class ForeignExchangeRemoteFlow(val source: PartyAndCertificate) : FlowLogic<Unit>() {
+class ForeignExchangeRemoteFlow(val source: Party) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         // Initial receive from remote party

--- a/finance/src/main/kotlin/net/corda/contracts/testing/VaultFiller.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/testing/VaultFiller.kt
@@ -99,7 +99,7 @@ fun ServiceHub.fillWithSomeTestCash(howMuch: Amount<Currency>,
     // We will allocate one state to one transaction, for simplicities sake.
     val cash = Cash()
     val transactions: List<SignedTransaction> = amounts.map { pennies ->
-        val issuance = TransactionType.General.Builder(null)
+        val issuance = TransactionType.General.Builder(null as Party?)
         cash.generateIssue(issuance, Amount(pennies, Issued(issuedBy.copy(reference = ref), howMuch.token)), me, outputNotary)
         issuance.signWith(issuerKey)
 

--- a/finance/src/main/kotlin/net/corda/flows/CashExitFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/CashExitFlow.kt
@@ -33,7 +33,7 @@ class CashExitFlow(val amount: Amount<Currency>, val issueRef: OpaqueBytes, prog
     @Throws(CashException::class)
     override fun call(): SignedTransaction {
         progressTracker.currentStep = GENERATING_TX
-        val builder: TransactionBuilder = TransactionType.General.Builder(null)
+        val builder: TransactionBuilder = TransactionType.General.Builder(notary = null as Party?)
         val issuer = serviceHub.myInfo.legalIdentity.ref(issueRef)
         val exitStates = serviceHub.vaultService.unconsumedStatesForSpending<Cash.State>(amount, setOf(issuer.party), builder.notary, builder.lockId, setOf(issuer.reference))
         try {

--- a/finance/src/main/kotlin/net/corda/flows/CashIssueFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/CashIssueFlow.kt
@@ -35,7 +35,7 @@ class CashIssueFlow(val amount: Amount<Currency>,
     @Suspendable
     override fun call(): SignedTransaction {
         progressTracker.currentStep = GENERATING_TX
-        val builder: TransactionBuilder = TransactionType.General.Builder(notary = null)
+        val builder: TransactionBuilder = TransactionType.General.Builder(notary = notary)
         val issuer = serviceHub.myInfo.legalIdentity.ref(issueRef)
         // TODO: Get a transaction key, don't just re-use the owning key
         Cash().generateIssue(builder, amount.issuedBy(issuer), recipient, notary)

--- a/finance/src/main/kotlin/net/corda/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/CashPaymentFlow.kt
@@ -30,7 +30,7 @@ open class CashPaymentFlow(
     @Suspendable
     override fun call(): SignedTransaction {
         progressTracker.currentStep = GENERATING_TX
-        val builder: TransactionBuilder = TransactionType.General.Builder(null)
+        val builder: TransactionBuilder = TransactionType.General.Builder(null as Party?)
         // TODO: Have some way of restricting this to states the caller controls
         val (spendTX, keysForSigning) = try {
             serviceHub.vaultService.generateSpend(

--- a/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
@@ -6,7 +6,7 @@ import net.corda.core.contracts.*
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AnonymousParty
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.seconds
 import net.corda.core.serialization.CordaSerializable
@@ -52,7 +52,7 @@ object TwoPartyTradeFlow {
             val sellerOwnerKey: PublicKey
     )
 
-    open class Seller(val otherParty: PartyAndCertificate,
+    open class Seller(val otherParty: Party,
                       val notaryNode: NodeInfo,
                       val assetToSell: StateAndRef<OwnableState>,
                       val price: Amount<Currency>,
@@ -107,8 +107,8 @@ object TwoPartyTradeFlow {
         // express flow state machines on top of the messaging layer.
     }
 
-    open class Buyer(val otherParty: PartyAndCertificate,
-                     val notary: PartyAndCertificate,
+    open class Buyer(val otherParty: Party,
+                     val notary: Party,
                      val acceptablePrice: Amount<Currency>,
                      val typeToBuy: Class<out OwnableState>) : FlowLogic<SignedTransaction>() {
         // DOCSTART 2

--- a/finance/src/test/java/net/corda/flows/AbstractStateReplacementFlowTest.java
+++ b/finance/src/test/java/net/corda/flows/AbstractStateReplacementFlowTest.java
@@ -1,7 +1,7 @@
 package net.corda.flows;
 
 import net.corda.core.identity.Party;
-import net.corda.core.identity.PartyAndCertificate;
+import net.corda.core.identity.Party;
 import net.corda.core.utilities.*;
 import org.jetbrains.annotations.*;
 
@@ -10,7 +10,7 @@ public class AbstractStateReplacementFlowTest {
 
     // Acceptor used to have a type parameter of Unit which prevented Java code from subclassing it (https://youtrack.jetbrains.com/issue/KT-15964).
     private static class TestAcceptorCanBeInheritedInJava extends AbstractStateReplacementFlow.Acceptor {
-        public TestAcceptorCanBeInheritedInJava(@NotNull PartyAndCertificate otherSide, @NotNull ProgressTracker progressTracker) {
+        public TestAcceptorCanBeInheritedInJava(@NotNull Party otherSide, @NotNull ProgressTracker progressTracker) {
             super(otherSide, progressTracker);
         }
 

--- a/node/src/main/kotlin/net/corda/node/driver/Driver.kt
+++ b/node/src/main/kotlin/net/corda/node/driver/Driver.kt
@@ -14,7 +14,6 @@ import net.corda.core.crypto.X509Utilities
 import net.corda.core.crypto.appendToCommonName
 import net.corda.core.crypto.commonName
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.ShutdownHook
 import net.corda.core.internal.addShutdownHook
 import net.corda.core.messaging.CordaRPCOps
@@ -97,7 +96,7 @@ interface DriverDSLExposedInterface : CordformContext {
             clusterSize: Int = 3,
             type: ServiceType = RaftValidatingNotaryService.type,
             verifierType: VerifierType = VerifierType.InMemory,
-            rpcUsers: List<User> = emptyList()): Future<Pair<PartyAndCertificate, List<NodeHandle>>>
+            rpcUsers: List<User> = emptyList()): Future<Pair<Party, List<NodeHandle>>>
 
     /**
      * Starts a web server for a node
@@ -562,7 +561,7 @@ class DriverDSL(
             type: ServiceType,
             verifierType: VerifierType,
             rpcUsers: List<User>
-    ): ListenableFuture<Pair<PartyAndCertificate, List<NodeHandle>>> {
+    ): ListenableFuture<Pair<Party, List<NodeHandle>>> {
         val nodeNames = (0 until clusterSize).map { DUMMY_NOTARY.name.appendToCommonName(" $it") }
         val paths = nodeNames.map { baseDirectory(it) }
         ServiceIdentityGenerator.generateToDisk(paths, DUMMY_CA, type.id, notaryName)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -349,13 +349,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     }
 
     private fun <F : FlowLogic<*>> registerInitiatedFlowInternal(initiatedFlow: Class<F>, track: Boolean): Observable<F> {
-        val ctor = try {
-            initiatedFlow.getDeclaredConstructor(PartyAndCertificate::class.java).apply { isAccessible = true }
-        } catch(ex: NoSuchMethodException) {
-            // Fall back to a constructor that takes in a Party
-            // TODO: Consider removing for 1.0 release, as flows should generally take the more detailed class
-            initiatedFlow.getDeclaredConstructor(Party::class.java).apply { isAccessible = true }
-        }
+        val ctor = initiatedFlow.getDeclaredConstructor(Party::class.java).apply { isAccessible = true }
         val initiatingFlow = initiatedFlow.requireAnnotation<InitiatedBy>().value.java
         val (version, classWithAnnotation) = initiatingFlow.flowVersionAndInitiatingClass
         require(classWithAnnotation == initiatingFlow) {
@@ -403,7 +397,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
      * @suppress
      */
     @VisibleForTesting
-    fun installCoreFlow(clientFlowClass: KClass<out FlowLogic<*>>, flowFactory: (PartyAndCertificate, Int) -> FlowLogic<*>) {
+    fun installCoreFlow(clientFlowClass: KClass<out FlowLogic<*>>, flowFactory: (Party, Int) -> FlowLogic<*>) {
         require(clientFlowClass.java.flowVersionAndInitiatingClass.first == 1) {
             "${InitiatingFlow::class.java.name}.version not applicable for core flows; their version is the node's platform version"
         }
@@ -667,13 +661,12 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     protected open fun makeIdentityService(): IdentityService {
         val keyStore = KeyStoreUtilities.loadKeyStore(configuration.trustStoreFile, configuration.trustStorePassword)
         val trustRoot = keyStore.getCertificate(X509Utilities.CORDA_ROOT_CA) as? X509Certificate
-        val service = InMemoryIdentityService(trustRoot = trustRoot)
-        service.registerIdentity(info.legalIdentity)
-        services.networkMapCache.partyNodes.forEach { service.registerIdentity(it.legalIdentity) }
+        val service = InMemoryIdentityService(setOf(info.legalIdentityAndCert), trustRoot = trustRoot)
+        services.networkMapCache.partyNodes.forEach { service.registerIdentity(it.legalIdentityAndCert) }
         netMapCache.changed.subscribe { mapChange ->
             // TODO how should we handle network map removal
             if (mapChange is MapChange.Added) {
-                service.registerIdentity(mapChange.node.legalIdentity)
+                service.registerIdentity(mapChange.node.legalIdentityAndCert)
             }
         }
         return service

--- a/node/src/main/kotlin/net/corda/node/internal/InitiatedFlowFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/InitiatedFlowFactory.kt
@@ -2,20 +2,19 @@ package net.corda.node.internal
 
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.node.services.statemachine.SessionInit
 
 interface InitiatedFlowFactory<out F : FlowLogic<*>> {
-    fun createFlow(platformVersion: Int, otherParty: PartyAndCertificate, sessionInit: SessionInit): F
+    fun createFlow(platformVersion: Int, otherParty: Party, sessionInit: SessionInit): F
 
-    data class Core<out F : FlowLogic<*>>(val factory: (PartyAndCertificate, Int) -> F) : InitiatedFlowFactory<F> {
-        override fun createFlow(platformVersion: Int, otherParty: PartyAndCertificate, sessionInit: SessionInit): F {
+    data class Core<out F : FlowLogic<*>>(val factory: (Party, Int) -> F) : InitiatedFlowFactory<F> {
+        override fun createFlow(platformVersion: Int, otherParty: Party, sessionInit: SessionInit): F {
             return factory(otherParty, platformVersion)
         }
     }
 
     data class CorDapp<out F : FlowLogic<*>>(val version: Int, val factory: (Party) -> F) : InitiatedFlowFactory<F> {
-        override fun createFlow(platformVersion: Int, otherParty: PartyAndCertificate, sessionInit: SessionInit): F {
+        override fun createFlow(platformVersion: Int, otherParty: Party, sessionInit: SessionInit): F {
             // TODO Add support for multiple versions of the same flow when CorDapps are loaded in separate class loaders
             if (sessionInit.flowVerison == version) return factory(otherParty)
             throw SessionRejectException(

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -5,7 +5,6 @@ import net.corda.core.contracts.requireThat
 import net.corda.core.crypto.subject
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.*
-import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.IdentityService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.loggerFor
@@ -75,6 +74,8 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate>,
         principalToParties[party.name] = party
     }
 
+    override fun certificateFromParty(party: Party): PartyAndCertificate? = principalToParties[party.name]
+
     // We give the caller a copy of the data set to avoid any locking problems
     override fun getAllIdentities(): Iterable<PartyAndCertificate> = ArrayList(keyToParties.values)
 
@@ -111,7 +112,7 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate>,
 
     @Throws(CertificateExpiredException::class, CertificateNotYetValidException::class, InvalidAlgorithmParameterException::class)
     override fun registerAnonymousIdentity(anonymousParty: AnonymousParty, party: Party, path: CertPath) {
-        val fullParty = principalToParties[party.name] ?: throw IllegalArgumentException("Unknown identity ${party.name}")
+        val fullParty = certificateFromParty(party) ?: throw IllegalArgumentException("Unknown identity ${party.name}")
         require(path.certificates.isNotEmpty()) { "Certificate path must contain at least one certificate" }
         // Validate the chain first, before we do anything clever with it
         val validator = CertPathValidator.getInstance("PKIX")

--- a/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
@@ -41,7 +41,7 @@ fun freshCertificate(identityService: IdentityService,
     val ourCertPath = X509Utilities.createCertificatePath(issuerCertificate, ourCertificate, revocationEnabled = revocationEnabled)
     require(Arrays.equals(ourCertificate.subjectPublicKeyInfo.encoded, subjectPublicKey.encoded))
     identityService.registerAnonymousIdentity(AnonymousParty(subjectPublicKey),
-            issuer,
+            issuer.party,
             ourCertPath)
     return Pair(issuerCertificate, ourCertPath)
 }

--- a/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
@@ -61,7 +61,7 @@ open class InMemoryNetworkMapCache : SingletonSerializeAsToken(), NetworkMapCach
         }
         for ((_, value) in registeredNodes) {
             for (service in value.advertisedServices) {
-                if (service.identity == party) {
+                if (service.identity.party == party) {
                     return PartyInfo.Service(service)
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
@@ -5,7 +5,6 @@ import net.corda.core.ThreadBox
 import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.SignedData
 import net.corda.core.crypto.isFulfilledBy
-import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.SingleMessageRecipient
@@ -83,7 +82,7 @@ interface NetworkMapService {
     @CordaSerializable
     data class FetchMapResponse(val nodes: List<NodeRegistration>?, val version: Int)
 
-    data class QueryIdentityRequest(val identity: Party,
+    data class QueryIdentityRequest(val identity: PartyAndCertificate,
                                     override val replyTo: SingleMessageRecipient,
                                     override val sessionID: Long = random63BitValue()) : ServiceRequestMessage
 
@@ -253,7 +252,7 @@ abstract class AbstractNetworkMapService(services: ServiceHubInternal,
         // in on different threads, there is no risk of a race condition while checking
         // sequence numbers.
         val registrationInfo = try {
-            nodeRegistrations.compute(node.legalIdentity) { _, existing: NodeRegistrationInfo? ->
+            nodeRegistrations.compute(node.legalIdentityAndCert) { _, existing: NodeRegistrationInfo? ->
                 require(!((existing == null || existing.reg.type == REMOVE) && change.type == REMOVE)) {
                     "Attempting to de-register unknown node"
                 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManager.kt
@@ -18,7 +18,6 @@ import net.corda.core.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.*
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
@@ -340,7 +339,7 @@ class StateMachineManager(val serviceHub: ServiceHubInternal,
                 waitingForResponse is WaitForLedgerCommit && message is ErrorSessionEnd
     }
 
-    private fun onSessionInit(sessionInit: SessionInit, receivedMessage: ReceivedMessage, sender: PartyAndCertificate) {
+    private fun onSessionInit(sessionInit: SessionInit, receivedMessage: ReceivedMessage, sender: Party) {
         logger.trace { "Received $sessionInit from $sender" }
         val otherPartySessionId = sessionInit.initiatorSessionId
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
@@ -3,7 +3,7 @@ package net.corda.node.services.transactions
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.DigitalSignature
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
@@ -42,11 +42,11 @@ class BFTNonValidatingNotaryService(config: BFTSMaRtConfig,
         private val log = loggerFor<BFTNonValidatingNotaryService>()
     }
 
-    override val serviceFlowFactory: (PartyAndCertificate, Int) -> FlowLogic<Void?> = { otherParty, _ ->
+    override val serviceFlowFactory: (Party, Int) -> FlowLogic<Void?> = { otherParty, _ ->
         ServiceFlow(otherParty, client)
     }
 
-    private class ServiceFlow(val otherSide: PartyAndCertificate, val client: BFTSMaRt.Client) : FlowLogic<Void?>() {
+    private class ServiceFlow(val otherSide: Party, val client: BFTSMaRt.Client) : FlowLogic<Void?>() {
         @Suspendable
         override fun call(): Void? {
             val stx = receive<FilteredTransaction>(otherSide).unwrap { it }
@@ -81,7 +81,7 @@ class BFTNonValidatingNotaryService(config: BFTSMaRtConfig,
             return response.serialize().bytes
         }
 
-        fun verifyAndCommitTx(ftx: FilteredTransaction, callerIdentity: PartyAndCertificate): BFTSMaRt.ReplicaResponse {
+        fun verifyAndCommitTx(ftx: FilteredTransaction, callerIdentity: Party): BFTSMaRt.ReplicaResponse {
             return try {
                 val id = ftx.rootHash
                 val inputs = ftx.filteredLeaves.inputs

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt
@@ -13,7 +13,7 @@ import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
 import net.corda.core.crypto.sign
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.serialization.CordaSerializable
@@ -51,7 +51,7 @@ import java.util.*
 object BFTSMaRt {
     /** Sent from [Client] to [Server]. */
     @CordaSerializable
-    data class CommitRequest(val tx: Any, val callerIdentity: PartyAndCertificate)
+    data class CommitRequest(val tx: Any, val callerIdentity: Party)
 
     /** Sent from [Server] to [Client]. */
     @CordaSerializable
@@ -83,7 +83,7 @@ object BFTSMaRt {
          * Sends a transaction commit request to the BFT cluster. The [proxy] will deliver the request to every
          * replica, and block until a sufficient number of replies are received.
          */
-        fun commitTransaction(transaction: Any, otherSide: PartyAndCertificate): ClusterResponse {
+        fun commitTransaction(transaction: Any, otherSide: Party): ClusterResponse {
             require(transaction is FilteredTransaction || transaction is SignedTransaction) { "Unsupported transaction type: ${transaction.javaClass.name}" }
             val request = CommitRequest(transaction, otherSide)
             val responseBytes = proxy.invokeOrdered(request.serialize().bytes)
@@ -178,7 +178,7 @@ object BFTSMaRt {
          */
         abstract fun executeCommand(command: ByteArray): ByteArray?
 
-        protected fun commitInputStates(states: List<StateRef>, txId: SecureHash, callerIdentity: PartyAndCertificate) {
+        protected fun commitInputStates(states: List<StateRef>, txId: SecureHash, callerIdentity: Party) {
             log.debug { "Attempting to commit inputs for transaction: $txId" }
             val conflicts = mutableMapOf<StateRef, UniquenessProvider.ConsumingTx>()
             db.transaction {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.transactions
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.transactions.FilteredTransaction
@@ -9,7 +9,7 @@ import net.corda.core.utilities.unwrap
 import net.corda.flows.NotaryFlow
 import net.corda.flows.TransactionParts
 
-class NonValidatingNotaryFlow(otherSide: PartyAndCertificate,
+class NonValidatingNotaryFlow(otherSide: Party,
                               timeWindowChecker: TimeWindowChecker,
                               uniquenessProvider: UniquenessProvider) : NotaryFlow.Service(otherSide, timeWindowChecker, uniquenessProvider) {
     /**

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NotaryService.kt
@@ -2,15 +2,14 @@ package net.corda.node.services.transactions
 
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 
 interface NotaryService {
 
     /**
      * Factory for producing notary service flows which have the corresponding sends and receives as NotaryFlow.Client.
-     * The first parameter is the client [PartyAndCertificate] making the request and the second is the platform version
+     * The first parameter is the client [Party] making the request and the second is the platform version
      * of the client's node. Use this version parameter to provide backwards compatibility if the notary flow protocol
      * changes.
      */
-    val serviceFlowFactory: (PartyAndCertificate, Int) -> FlowLogic<Void?>
+    val serviceFlowFactory: (Party, Int) -> FlowLogic<Void?>
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 
 /** A non-validating notary service operated by a group of mutually trusting parties, uses the Raft algorithm to achieve consensus. */
@@ -11,7 +11,7 @@ class RaftNonValidatingNotaryService(val timeWindowChecker: TimeWindowChecker,
         val type = SimpleNotaryService.type.getSubType("raft")
     }
 
-    override val serviceFlowFactory: (PartyAndCertificate, Int) -> FlowLogic<Void?> = { otherParty, _ ->
+    override val serviceFlowFactory: (Party, Int) -> FlowLogic<Void?> = { otherParty, _ ->
         NonValidatingNotaryFlow(otherParty, timeWindowChecker, uniquenessProvider)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 
 /** A validating notary service operated by a group of mutually trusting parties, uses the Raft algorithm to achieve consensus. */
@@ -11,7 +11,7 @@ class RaftValidatingNotaryService(val timeWindowChecker: TimeWindowChecker,
         val type = ValidatingNotaryService.type.getSubType("raft")
     }
 
-    override val serviceFlowFactory: (PartyAndCertificate, Int) -> FlowLogic<Void?> = { otherParty, _ ->
+    override val serviceFlowFactory: (Party, Int) -> FlowLogic<Void?> = { otherParty, _ ->
         ValidatingNotaryFlow(otherParty, timeWindowChecker, uniquenessProvider)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.ServiceType
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.UniquenessProvider
@@ -13,7 +13,7 @@ class SimpleNotaryService(val timeWindowChecker: TimeWindowChecker,
         val type = ServiceType.notary.getSubType("simple")
     }
 
-    override val serviceFlowFactory: (PartyAndCertificate, Int) -> FlowLogic<Void?> = { otherParty, _ ->
+    override val serviceFlowFactory: (Party, Int) -> FlowLogic<Void?> = { otherParty, _ ->
         NonValidatingNotaryFlow(otherParty, timeWindowChecker, uniquenessProvider)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
@@ -2,7 +2,7 @@ package net.corda.node.services.transactions
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.TransactionVerificationException
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.transactions.SignedTransaction
@@ -17,7 +17,7 @@ import java.security.SignatureException
  * has its input states "blocked" by a transaction from another party, and needs to establish whether that transaction was
  * indeed valid.
  */
-class ValidatingNotaryFlow(otherSide: PartyAndCertificate,
+class ValidatingNotaryFlow(otherSide: Party,
                            timeWindowChecker: TimeWindowChecker,
                            uniquenessProvider: UniquenessProvider) :
         NotaryFlow.Service(otherSide, timeWindowChecker, uniquenessProvider) {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.ServiceType
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.UniquenessProvider
@@ -13,7 +13,7 @@ class ValidatingNotaryService(val timeWindowChecker: TimeWindowChecker,
         val type = ServiceType.notary.getSubType("validating")
     }
 
-    override val serviceFlowFactory: (PartyAndCertificate, Int) -> FlowLogic<Void?> = { otherParty, _ ->
+    override val serviceFlowFactory: (Party, Int) -> FlowLogic<Void?> = { otherParty, _ ->
         ValidatingNotaryFlow(otherParty, timeWindowChecker, uniquenessProvider)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/DatabaseSupport.kt
@@ -6,6 +6,7 @@ import com.zaxxer.hikari.HikariDataSource
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.parsePublicKeyBase58
 import net.corda.core.crypto.toBase58String
+import net.corda.core.identity.PartyAndCertificate
 import net.corda.node.utilities.StrandLocalTransactionManager.Boundary
 import org.bouncycastle.cert.X509CertificateHolder
 import org.h2.jdbc.JdbcBlob
@@ -284,9 +285,9 @@ fun Table.secureHash(name: String) = this.registerColumn<SecureHash>(name, Secur
 fun Table.party(nameColumnName: String,
                 keyColumnName: String) = PartyColumns(this.varchar(nameColumnName, length = 255), this.publicKey(keyColumnName))
 fun Table.partyAndCertificate(nameColumnName: String,
-                keyColumnName: String,
-                certificateColumnName: String,
-                pathColumnName: String) = PartyAndCertificateColumns(this.varchar(nameColumnName, length = 255), this.publicKey(keyColumnName),
+                              keyColumnName: String,
+                              certificateColumnName: String,
+                              pathColumnName: String) = PartyAndCertificateColumns(this.varchar(nameColumnName, length = 255), this.publicKey(keyColumnName),
         this.certificate(certificateColumnName), this.certificatePath(pathColumnName))
 fun Table.uuidString(name: String) = this.registerColumn<UUID>(name, UUIDStringColumnType)
 fun Table.localDate(name: String) = this.registerColumn<LocalDate>(name, LocalDateColumnType)

--- a/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
@@ -1,7 +1,9 @@
 package net.corda.node.utilities
 
-import net.corda.core.crypto.*
-import net.corda.core.identity.Party
+import net.corda.core.crypto.CertificateAndKeyPair
+import net.corda.core.crypto.CompositeKey
+import net.corda.core.crypto.X509Utilities
+import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.serialize
 import net.corda.core.serialization.storageKryo

--- a/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
+++ b/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
@@ -17,6 +17,7 @@ import net.corda.jackson.JacksonSupport
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.shell.InteractiveShell
 import net.corda.testing.MEGA_CORP
+import net.corda.testing.MEGA_CORP_IDENTITY
 import org.junit.Test
 import org.slf4j.Logger
 import java.util.*
@@ -33,7 +34,7 @@ class InteractiveShellTest {
         override fun call() = a
     }
 
-    private val ids = InMemoryIdentityService(listOf(MEGA_CORP), trustRoot = DUMMY_CA.certificate)
+    private val ids = InMemoryIdentityService(listOf(MEGA_CORP_IDENTITY), trustRoot = DUMMY_CA.certificate)
     private val om = JacksonSupport.createInMemoryMapper(ids, YAMLFactory())
 
     private fun check(input: String, expected: String) {

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -13,8 +13,6 @@ import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.map
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.*
@@ -485,8 +483,8 @@ class TwoPartyTradeFlowTests {
                                   sellerNode: MockNetwork.MockNode,
                                   buyerNode: MockNetwork.MockNode,
                                   assetToSell: StateAndRef<OwnableState>): RunResult {
-        sellerNode.services.identityService.registerIdentity(buyerNode.info.legalIdentity)
-        buyerNode.services.identityService.registerIdentity(sellerNode.info.legalIdentity)
+        sellerNode.services.identityService.registerIdentity(buyerNode.info.legalIdentityAndCert)
+        buyerNode.services.identityService.registerIdentity(sellerNode.info.legalIdentityAndCert)
         val buyerFlows: Observable<BuyerAcceptor> = buyerNode.registerInitiatedFlow(BuyerAcceptor::class.java)
         val firstBuyerFiber = buyerFlows.toFuture().map { it.stateMachine }
         val seller = SellerInitiator(buyerNode.info.legalIdentity, notaryNode.info, assetToSell, 1000.DOLLARS)
@@ -495,7 +493,7 @@ class TwoPartyTradeFlowTests {
     }
 
     @InitiatingFlow
-    class SellerInitiator(val buyer: PartyAndCertificate,
+    class SellerInitiator(val buyer: Party,
                           val notary: NodeInfo,
                           val assetToSell: StateAndRef<OwnableState>,
                           val price: Amount<Currency>) : FlowLogic<SignedTransaction>() {
@@ -512,10 +510,10 @@ class TwoPartyTradeFlowTests {
     }
 
     @InitiatedBy(SellerInitiator::class)
-    class BuyerAcceptor(val seller: PartyAndCertificate) : FlowLogic<SignedTransaction>() {
+    class BuyerAcceptor(val seller: Party) : FlowLogic<SignedTransaction>() {
         @Suspendable
         override fun call(): SignedTransaction {
-            val (notary, price) = receive<Pair<PartyAndCertificate, Amount<Currency>>>(seller).unwrap {
+            val (notary, price) = receive<Pair<Party, Amount<Currency>>>(seller).unwrap {
                 require(serviceHub.networkMapCache.isNotary(it.first)) { "${it.first} is not a notary" }
                 it
             }

--- a/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
@@ -3,7 +3,6 @@ package net.corda.node.services
 import com.codahale.metrics.MetricRegistry
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.*
 import net.corda.core.serialization.SerializeAsToken

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -77,7 +77,7 @@ class NotaryChangeTests {
     fun `should throw when a participant refuses to change Notary`() {
         val state = issueMultiPartyState(clientNodeA, clientNodeB, oldNotaryNode)
         val newEvilNotary = getTestPartyAndCertificate(X500Name("CN=Evil Notary,O=Evil R3,OU=corda,L=London,C=UK"), generateKeyPair().public)
-        val flow = NotaryChangeFlow(state, newEvilNotary)
+        val flow = NotaryChangeFlow(state, newEvilNotary.party)
         val future = clientNodeA.services.startFlow(flow)
 
         net.runNetwork()

--- a/node/src/test/kotlin/net/corda/node/services/network/AbstractNetworkMapServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/AbstractNetworkMapServiceTest.kt
@@ -198,7 +198,7 @@ abstract class AbstractNetworkMapServiceTest<out S : AbstractNetworkMapService> 
     }
 
     private fun MockNode.identityQuery(): NodeInfo? {
-        val request = QueryIdentityRequest(info.legalIdentity, info.address)
+        val request = QueryIdentityRequest(info.legalIdentityAndCert, info.address)
         val response = services.networkService.sendRequest<QueryIdentityResponse>(QUERY_TOPIC, request, mapServiceNode.info.address)
         network.runNetwork()
         return response.getOrThrow().node

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
@@ -22,13 +22,17 @@ import kotlin.test.assertNull
 class InMemoryIdentityServiceTests {
     @Test
     fun `get all identities`() {
-        val service = InMemoryIdentityService(setOf(ALICE_IDENTITY, BOB_IDENTITY), emptyMap(), DUMMY_CA.certificate)
+        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate)
+        // Nothing registered, so empty set
         assertNull(service.getAllIdentities().firstOrNull())
+
+        service.registerIdentity(ALICE_IDENTITY)
         var expected = setOf<Party>(ALICE)
         var actual = service.getAllIdentities().map { it.party }.toHashSet()
         assertEquals(expected, actual)
 
         // Add a second party and check we get both back
+        service.registerIdentity(BOB_IDENTITY)
         expected = setOf<Party>(ALICE, BOB)
         actual = service.getAllIdentities().map { it.party }.toHashSet()
         assertEquals(expected, actual)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
@@ -9,7 +9,7 @@ import net.corda.core.contracts.USD
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.unconsumedStates
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_NOTARY
@@ -93,13 +93,13 @@ class DataVendingServiceTests {
     }
 
     @InitiatingFlow
-    private class NotifyTxFlow(val otherParty: PartyAndCertificate, val stx: SignedTransaction) : FlowLogic<Unit>() {
+    private class NotifyTxFlow(val otherParty: Party, val stx: SignedTransaction) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() = send(otherParty, NotifyTxRequest(stx))
     }
 
     @InitiatedBy(NotifyTxFlow::class)
-    private class InitiateNotifyTxFlow(val otherParty: PartyAndCertificate) : FlowLogic<Unit>() {
+    private class InitiateNotifyTxFlow(val otherParty: Party) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() = subFlow(NotifyTransactionHandler(otherParty))
     }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -14,7 +14,6 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSessionException
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.node.services.PartyInfo
 import net.corda.core.node.services.ServiceInfo
@@ -674,10 +673,10 @@ class FlowFrameworkTests {
 
     private inline fun <reified P : FlowLogic<*>> MockNode.registerFlowFactory(
         initiatingFlowClass: KClass<out FlowLogic<*>>,
-        noinline flowFactory: (PartyAndCertificate) -> P): ListenableFuture<P>
+        noinline flowFactory: (Party) -> P): ListenableFuture<P>
     {
         val observable = registerFlowFactory(initiatingFlowClass.java, object : InitiatedFlowFactory<P> {
-            override fun createFlow(platformVersion: Int, otherParty: PartyAndCertificate, sessionInit: SessionInit): P {
+            override fun createFlow(platformVersion: Int, otherParty: Party, sessionInit: SessionInit): P {
                 return flowFactory(otherParty)
             }
         }, P::class.java, track = true)

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
@@ -7,7 +7,6 @@ import net.corda.core.crypto.*
 import net.corda.core.exists
 import net.corda.core.mapToArray
 import net.corda.core.utilities.ALICE
-import net.corda.core.utilities.getTestPartyAndCertificate
 import net.corda.testing.TestNodeConfiguration
 import net.corda.testing.getTestX509Name
 import org.bouncycastle.cert.X509CertificateHolder
@@ -15,7 +14,6 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.security.cert.Certificate
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
@@ -89,7 +89,7 @@ object NodeInterestRates {
     @CordaService
     class Oracle(val identity: Party, private val signingKey: PublicKey, val services: ServiceHub) : AcceptsFileUpload, SingletonSerializeAsToken() {
         constructor(services: PluginServiceHub) : this(
-            services.myInfo.serviceIdentities(type).first().party,
+            services.myInfo.serviceIdentities(type).first(),
             services.myInfo.serviceIdentities(type).first().owningKey.keys.first { services.keyManagementService.keys.contains(it) },
             services
         )

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
@@ -89,7 +89,7 @@ object NodeInterestRates {
     @CordaService
     class Oracle(val identity: Party, private val signingKey: PublicKey, val services: ServiceHub) : AcceptsFileUpload, SingletonSerializeAsToken() {
         constructor(services: PluginServiceHub) : this(
-            services.myInfo.serviceIdentities(type).first(),
+            services.myInfo.serviceIdentities(type).first().party,
             services.myInfo.serviceIdentities(type).first().owningKey.keys.first { services.keyManagementService.keys.contains(it) },
             services
         )

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -9,7 +9,6 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.SchedulableFlow
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceType
 import net.corda.core.seconds
@@ -31,7 +30,7 @@ object FixingFlow {
      * who does what in the flow.
      */
     @InitiatedBy(FixingRoleDecider::class)
-    class Fixer(override val otherParty: PartyAndCertificate) : TwoPartyDealFlow.Secondary<FixingSession>() {
+    class Fixer(override val otherParty: Party) : TwoPartyDealFlow.Secondary<FixingSession>() {
 
         private lateinit var txState: TransactionState<*>
         private lateinit var deal: FixableDealState
@@ -63,7 +62,7 @@ object FixingFlow {
             val ptx = TransactionType.General.Builder(txState.notary)
 
             val oracle = serviceHub.networkMapCache.getNodesWithService(handshake.payload.oracleType).first()
-            val oracleParty = oracle.serviceIdentities(handshake.payload.oracleType).first()
+            val oracleParty = oracle.serviceIdentities(handshake.payload.oracleType).first().party
 
             // DOCSTART 1
             val addFixing = object : RatesFixFlow(ptx, oracleParty, fixOf, BigDecimal.ZERO, BigDecimal.ONE) {
@@ -97,7 +96,7 @@ object FixingFlow {
      * is just the "side" of the flow run by the party with the floating leg as a way of deciding who
      * does what in the flow.
      */
-    class Floater(override val otherParty: PartyAndCertificate,
+    class Floater(override val otherParty: Party,
                   override val payload: FixingSession,
                   override val progressTracker: ProgressTracker = TwoPartyDealFlow.Primary.tracker()) : TwoPartyDealFlow.Primary() {
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -62,7 +62,7 @@ object FixingFlow {
             val ptx = TransactionType.General.Builder(txState.notary)
 
             val oracle = serviceHub.networkMapCache.getNodesWithService(handshake.payload.oracleType).first()
-            val oracleParty = oracle.serviceIdentities(handshake.payload.oracleType).first().party
+            val oracleParty = oracle.serviceIdentities(handshake.payload.oracleType).first()
 
             // DOCSTART 1
             val addFixing = object : RatesFixFlow(ptx, oracleParty, fixOf, BigDecimal.ZERO, BigDecimal.ONE) {

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/simulation/IRSSimulation.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/simulation/IRSSimulation.kt
@@ -15,7 +15,6 @@ import net.corda.core.flows.FlowStateMachine
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.linearHeadsOfType
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_CA
@@ -48,7 +47,7 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
 
     override fun startMainSimulation(): ListenableFuture<Unit> {
         val future = SettableFuture.create<Unit>()
-        om = JacksonSupport.createInMemoryMapper(InMemoryIdentityService((banks + regulators + networkMap).map { it.info.legalIdentity }, trustRoot = DUMMY_CA.certificate))
+        om = JacksonSupport.createInMemoryMapper(InMemoryIdentityService((banks + regulators + networkMap).map { it.info.legalIdentityAndCert }, trustRoot = DUMMY_CA.certificate))
 
         startIRSDealBetween(0, 1).success {
             // Next iteration is a pause.
@@ -131,7 +130,7 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
         node2.registerInitiatedFlow(FixingFlow.Fixer::class.java)
 
         @InitiatingFlow
-        class StartDealFlow(val otherParty: PartyAndCertificate,
+        class StartDealFlow(val otherParty: Party,
                             val payload: AutoOffer,
                             val myKey: PublicKey) : FlowLogic<SignedTransaction>() {
             @Suspendable

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/testing/NodeInterestRatesTest.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/testing/NodeInterestRatesTest.kt
@@ -217,7 +217,7 @@ class NodeInterestRatesTest {
         }
         val tx = TransactionType.General.Builder(null)
         val fixOf = NodeInterestRates.parseFixOf("LIBOR 2016-03-16 1M")
-        val oracle = n2.info.serviceIdentities(NodeInterestRates.type).first()
+        val oracle = n2.info.serviceIdentities(NodeInterestRates.type).first().party
         val flow = FilteredRatesFlow(tx, oracle, fixOf, "0.675".bd, "0.1".bd)
         LogHelper.setLevel("rates")
         net.runNetwork()

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/testing/NodeInterestRatesTest.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/testing/NodeInterestRatesTest.kt
@@ -217,7 +217,7 @@ class NodeInterestRatesTest {
         }
         val tx = TransactionType.General.Builder(null)
         val fixOf = NodeInterestRates.parseFixOf("LIBOR 2016-03-16 1M")
-        val oracle = n2.info.serviceIdentities(NodeInterestRates.type).first().party
+        val oracle = n2.info.serviceIdentities(NodeInterestRates.type).first()
         val flow = FilteredRatesFlow(tx, oracle, fixOf, "0.675".bd, "0.1".bd)
         LogHelper.setLevel("rates")
         net.runNetwork()

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt
@@ -5,11 +5,11 @@ import net.corda.client.rpc.notUsed
 import net.corda.core.contracts.DealState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.filterStatesOfType
-import net.corda.core.crypto.*
+import net.corda.core.crypto.parsePublicKeyBase58
+import net.corda.core.crypto.toBase58String
 import net.corda.core.getOrThrow
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.DUMMY_MAP
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response
 
 @Path("simmvaluationdemo")
 class PortfolioApi(val rpc: CordaRPCOps) {
-    private val ownParty: PartyAndCertificate get() = rpc.nodeIdentity().legalIdentity
+    private val ownParty: Party get() = rpc.nodeIdentity().legalIdentity
     private val portfolioUtils = PortfolioApiUtils(ownParty)
 
     private inline fun <reified T : DealState> dealsWith(party: AbstractParty): List<StateAndRef<T>> {
@@ -49,7 +49,7 @@ class PortfolioApi(val rpc: CordaRPCOps) {
      * DSL to get a party and then executing the passed function with the party as a parameter.
      * Used as such: withParty(name) { doSomethingWith(it) }
      */
-    private fun withParty(partyName: String, func: (PartyAndCertificate) -> Response): Response {
+    private fun withParty(partyName: String, func: (Party) -> Response): Response {
         val otherParty = rpc.partyFromKey(parsePublicKeyBase58(partyName))
         return if (otherParty != null) {
             func(otherParty)

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt
@@ -6,7 +6,6 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
@@ -21,7 +20,7 @@ object IRSTradeFlow {
 
     @InitiatingFlow
     @StartableByRPC
-    class Requester(val swap: SwapData, val otherParty: PartyAndCertificate) : FlowLogic<SignedTransaction>() {
+    class Requester(val swap: SwapData, val otherParty: Party) : FlowLogic<SignedTransaction>() {
         @Suspendable
         override fun call(): SignedTransaction {
             require(serviceHub.networkMapCache.notaryNodes.isNotEmpty()) { "No notary nodes registered" }

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
@@ -15,8 +15,6 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.node.PluginServiceHub
 import net.corda.core.node.services.dealsWith
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
@@ -186,7 +184,7 @@ object SimmFlow {
      * Receives and validates a portfolio and comes to consensus over the portfolio initial margin using SIMM.
      */
     @InitiatedBy(Requester::class)
-    class Receiver(val replyToParty: PartyAndCertificate) : FlowLogic<Unit>() {
+    class Receiver(val replyToParty: Party) : FlowLogic<Unit>() {
         lateinit var ownParty: Party
         lateinit var offer: OfferMessage
 

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/StateRevisionFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/StateRevisionFlow.kt
@@ -3,7 +3,6 @@ package net.corda.vega.flows
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.seconds
 import net.corda.core.transactions.SignedTransaction
 import net.corda.flows.AbstractStateReplacementFlow
@@ -27,7 +26,7 @@ object StateRevisionFlow {
         }
     }
 
-    open class Receiver<in T>(otherParty: PartyAndCertificate) : AbstractStateReplacementFlow.Acceptor<T>(otherParty) {
+    open class Receiver<in T>(otherParty: Party) : AbstractStateReplacementFlow.Acceptor<T>(otherParty) {
         override fun verifyProposal(proposal: AbstractStateReplacementFlow.Proposal<T>) {
             val proposedTx = proposal.stx.tx
             val state = proposal.stateRef

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
@@ -7,7 +7,7 @@ import net.corda.core.contracts.TransactionGraphSearch
 import net.corda.core.div
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
-import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.Emoji
@@ -17,7 +17,7 @@ import net.corda.flows.TwoPartyTradeFlow
 import java.util.*
 
 @InitiatedBy(SellerFlow::class)
-class BuyerFlow(val otherParty: PartyAndCertificate) : FlowLogic<Unit>() {
+class BuyerFlow(val otherParty: Party) : FlowLogic<Unit>() {
 
     object STARTING_BUY : ProgressTracker.Step("Seller connected, purchasing commercial paper asset")
 

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
@@ -12,7 +12,6 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
 import net.corda.core.seconds
 import net.corda.core.transactions.SignedTransaction
@@ -25,10 +24,10 @@ import java.util.*
 
 @InitiatingFlow
 @StartableByRPC
-class SellerFlow(val otherParty: PartyAndCertificate,
+class SellerFlow(val otherParty: Party,
                  val amount: Amount<Currency>,
                  override val progressTracker: ProgressTracker) : FlowLogic<SignedTransaction>() {
-    constructor(otherParty: PartyAndCertificate, amount: Amount<Currency>) : this(otherParty, amount, tracker())
+    constructor(otherParty: Party, amount: Amount<Currency>) : this(otherParty, amount, tracker())
 
     companion object {
         val PROSPECTUS_HASH = SecureHash.parse("decd098666b9657314870e192ced0c3519c2c9d395507a238338f8d003929de9")

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -9,6 +9,8 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.X509Utilities
 import net.corda.core.crypto.commonName
 import net.corda.core.crypto.generateKeyPair
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.VersionInfo
@@ -31,6 +33,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyPair
 import java.security.PublicKey
+import java.security.cert.CertPath
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -66,22 +69,27 @@ val ALICE_PUBKEY: PublicKey get() = ALICE_KEY.public
 val BOB_PUBKEY: PublicKey get() = BOB_KEY.public
 val CHARLIE_PUBKEY: PublicKey get() = CHARLIE_KEY.public
 
-val MEGA_CORP: PartyAndCertificate get() = getTestPartyAndCertificate(X509Utilities.getDevX509Name("MegaCorp"), MEGA_CORP_PUBKEY)
-val MINI_CORP: PartyAndCertificate get() = getTestPartyAndCertificate(X509Utilities.getDevX509Name("MiniCorp"), MINI_CORP_PUBKEY)
+val MEGA_CORP_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(X509Utilities.getDevX509Name("MegaCorp"), MEGA_CORP_PUBKEY)
+val MEGA_CORP: Party get() = MEGA_CORP_IDENTITY.party
+val MINI_CORP_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(X509Utilities.getDevX509Name("MiniCorp"), MINI_CORP_PUBKEY)
+val MINI_CORP: Party get() = MINI_CORP_IDENTITY.party
 
 val BOC_KEY: KeyPair by lazy { generateKeyPair() }
 val BOC_PUBKEY: PublicKey get() = BOC_KEY.public
-val BOC: PartyAndCertificate get() = getTestPartyAndCertificate(getTestX509Name("BankOfCorda"), BOC_PUBKEY)
+val BOC_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(getTestX509Name("BankOfCorda"), BOC_PUBKEY)
+val BOC: Party get() = BOC_IDENTITY.party
 val BOC_PARTY_REF = BOC.ref(OpaqueBytes.of(1)).reference
 
 val BIG_CORP_KEY: KeyPair by lazy { generateKeyPair() }
 val BIG_CORP_PUBKEY: PublicKey get() = BIG_CORP_KEY.public
-val BIG_CORP: PartyAndCertificate get() = getTestPartyAndCertificate(X509Utilities.getDevX509Name("BigCorporation"), BIG_CORP_PUBKEY)
+val BIG_CORP_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(X509Utilities.getDevX509Name("BigCorporation"), BIG_CORP_PUBKEY)
+val BIG_CORP: Party get() = BIG_CORP_IDENTITY.party
 val BIG_CORP_PARTY_REF = BIG_CORP.ref(OpaqueBytes.of(1)).reference
 
 val ALL_TEST_KEYS: List<KeyPair> get() = listOf(MEGA_CORP_KEY, MINI_CORP_KEY, ALICE_KEY, BOB_KEY, DUMMY_NOTARY_KEY)
 
-val MOCK_IDENTITY_SERVICE: IdentityService get() = InMemoryIdentityService(listOf(MEGA_CORP, MINI_CORP, DUMMY_NOTARY), emptyMap(), DUMMY_CA.certificate)
+val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_NOTARY_IDENTITY)
+val MOCK_IDENTITY_SERVICE: IdentityService get() = InMemoryIdentityService(MOCK_IDENTITIES, emptyMap(), DUMMY_CA.certificate)
 
 val MOCK_VERSION_INFO = VersionInfo(1, "Mock release", "Mock revision", "Mock Vendor")
 

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -3,6 +3,7 @@ package net.corda.testing.node
 import net.corda.core.contracts.Attachment
 import net.corda.core.crypto.*
 import net.corda.core.flows.StateMachineRunId
+import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo
@@ -13,6 +14,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.DUMMY_CA
 import net.corda.core.utilities.DUMMY_NOTARY
+import net.corda.core.utilities.DUMMY_NOTARY_IDENTITY
 import net.corda.core.utilities.getTestPartyAndCertificate
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.keys.freshCertificate
@@ -24,6 +26,7 @@ import net.corda.node.services.transactions.InMemoryTransactionVerifierService
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.MINI_CORP
+import net.corda.testing.MOCK_IDENTITIES
 import net.corda.testing.MOCK_VERSION_INFO
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.operator.ContentSigner
@@ -66,8 +69,7 @@ open class MockServices(vararg val keys: KeyPair) : ServiceHub {
     }
 
     override val storageService: TxWritableStorageService = MockStorageService()
-    override final val identityService: IdentityService = InMemoryIdentityService(listOf(MEGA_CORP, MINI_CORP, DUMMY_NOTARY),
-            trustRoot = DUMMY_CA.certificate)
+    override final val identityService: IdentityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
     override val keyManagementService: KeyManagementService = MockKeyManagementService(identityService, *keys)
 
     override val vaultService: VaultService get() = throw UnsupportedOperationException()


### PR DESCRIPTION
Change PartyAndCertificate to an aggregate class instead of a subclass of Party. This
reduces the changes compared to M11, as well as avoiding risk of accidental serialization
of a PartyAndCertificate (which may be very large) where a Party is expected.

Cleaned up initial nodes known to the identity service, in particular mock nodes now know
about themselves; previously full nodes registered themselves but mock nodes did not.