### PR TITLE
Upgrade to Netty 4.1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
     ext.guava_version = constants.getProperty("guavaVersion")
     ext.quickcheck_version = '0.7'
     ext.okhttp_version = '3.5.0'
-    ext.netty_version = '4.1.5.Final'
+    ext.netty_version = '4.1.9.Final'
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.2'
     ext.junit_version = '4.12'


### PR DESCRIPTION
The explicit dependency on `netty-all` was added to Node so that Artemis and `io-catalyst` would agree which Netty artifacts to use. Artemis 2.1.0 uses Netty 4.1.9.Final rather than 4.1.5.Final, so update Gradle to agree.

This is probably just a documentation fix, because Gradle seems to accept the transitive 4.1.9.Final dependency over the explicit 4.1.5.Final one.