### PR TITLE
Make RPC client reaper threads into daemons.

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -157,7 +157,7 @@ class RPCClientProxyHandler(
         lifeCycle.requireState(State.UNSTARTED)
         reaperExecutor = Executors.newScheduledThreadPool(
                 1,
-                ThreadFactoryBuilder().setNameFormat("rpc-client-reaper-%d").build()
+                ThreadFactoryBuilder().setNameFormat("rpc-client-reaper-%d").setDaemon(true).build()
         )
         reaperScheduledFuture = reaperExecutor!!.scheduleAtFixedRate(
                 this::reapObservables,


### PR DESCRIPTION
Failing to close an RPC client is currently preventing the JVM from shutting down because of running non-daemon `rpc-client-reaper-*` threads. While these clients really _should_ be shutdown cleanly, having the JVMs failing to terminate is more serious.

Make the `rpc-client-reaper-*` threads into daemon threads.