### PR TITLE
Class and interface serialisation blacklisting

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/CordaPluginRegistry.kt
+++ b/core/src/main/kotlin/net/corda/core/node/CordaPluginRegistry.kt
@@ -36,11 +36,13 @@ abstract class CordaPluginRegistry {
     open val servicePlugins: List<Function<PluginServiceHub, out Any>> get() = emptyList()
 
     /**
-     * Optionally whitelist types for use in object serialization, as we lock down the types that can be serialized.
+     * Optionally whitelist/blacklist types for use in object serialization, as we lock down the types that can be serialized.
      *
      * For example, if you add a new [net.corda.core.contracts.ContractState] it needs to be whitelisted.  You can do that
      * either by adding the [net.corda.core.serialization.CordaSerializable] annotation or via this method.
-     **
+     * The same applies for blacklisting as the input interface [SerializationCustomization] supports
+     * both addToWhitelist and addToBlacklist methods.
+     *
      * @return true if you register types, otherwise you will be filtered out of the list of plugins considered in future.
      */
     open fun customizeSerialization(custom: SerializationCustomization): Boolean = false

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -17,24 +17,33 @@ fun Kryo.addToWhitelist(type: Class<*>) = ((classResolver as? CordaClassResolver
 
 fun Kryo.addToBlacklist(type: Class<*>) = ((classResolver as? CordaClassResolver)?.blacklist as? MutableClassList)?.add(type)
 
+/** Support both a whitelist and a blacklist. */
 fun makeStandardClassResolver(): ClassResolver {
     return CordaClassResolver(GlobalTransientClassList(BuiltInExceptionsClassList()), GlobalTransientClassList(EmptyClassList))
 }
 
+/** Allow everything for serialisation. */
 fun makeAcceptAllClassResolver(): ClassResolver {
     return CordaClassResolver(AllClassList, EmptyClassList)
 }
 
+/** Allow everything except those in the blacklist. */
 fun makeBlackListOnlyClassResolver(): ClassResolver {
     return CordaClassResolver(AllClassList, GlobalTransientClassList(EmptyClassList))
 }
 
+/**
+ * Handles class registration for serialisation.
+ * It requires a whitelist [ClassList] for those allowed to be serialised.
+ * and a blacklist [ClassList] for those not permitted to be serialised.
+ */
 class CordaClassResolver(val whitelist: ClassList, val blacklist: ClassList) : DefaultClassResolver() {
     /** Returns the registration for the specified class, or null if the class is not registered.  */
     override fun getRegistration(type: Class<*>): Registration? {
         return super.getRegistration(type) ?: checkClass(type)
     }
     // both white and black lists are enabled.
+    // TODO: check if separate whitelist and blacklist enable is required.
     private var classListsEnabled = true
 
     fun disableWhiteAndBlackLists() {

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -18,11 +18,15 @@ fun Kryo.addToWhitelist(type: Class<*>) {
 }
 
 fun makeStandardClassResolver(): ClassResolver {
-    return CordaClassResolver(GlobalTransientClassList(BuiltInExceptionsClassList()), )
+    return CordaClassResolver(GlobalTransientClassList(BuiltInExceptionsClassList()), EmptyClassList) // TODO: blacklist -> GlobalTransient
 }
 
-fun makeNoClassListClassResolver(): ClassResolver {
+fun makeAcceptAllClassResolver(): ClassResolver {
     return CordaClassResolver(AllClassList, EmptyClassList)
+}
+
+fun makeBlackListOnlyClassResolver(): ClassResolver {
+    return CordaClassResolver(AllClassList, EmptyClassList) // TODO: blacklist -> GlobalTransient
 }
 
 class CordaClassResolver(val whitelist: ClassList, val blacklist: ClassList) : DefaultClassResolver() {
@@ -57,6 +61,7 @@ class CordaClassResolver(val whitelist: ClassList, val blacklist: ClassList) : D
         // It's safe to have the Class already, since Kryo loads it with initialisation off.
         // First check for blacklisted classes.
         if (blacklist.hasListed(type)) {
+            print("BlackListed ${Util.className(type)}" + blacklist.javaClass.name)
             throw KryoException("Class ${Util.className(type)} is blacklisted and cannot be used in serialization")
         }
         // Check for @CordaSerizalizable annotation or whitelisted.
@@ -161,7 +166,6 @@ class GlobalTransientClassList(val delegate: ClassList) : MutableClassList, Clas
         classlist += entry.name
     }
 }
-
 
 /**
  * This class is not currently used, but can be installed to log a large number of missing entries from the whitelist

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -17,6 +17,10 @@ fun Kryo.addToWhitelist(type: Class<*>) {
     ((classResolver as? CordaClassResolver)?.whitelist as? MutableClassList)?.add(type)
 }
 
+fun Kryo.addToBlacklist(type: Class<*>) {
+    ((classResolver as? CordaClassResolver)?.blacklist as? MutableClassList)?.add(type)
+}
+
 fun makeStandardClassResolver(): ClassResolver {
     return CordaClassResolver(GlobalTransientClassList(BuiltInExceptionsClassList()), EmptyClassList) // TODO: blacklist -> GlobalTransient
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaNotSerializable.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaNotSerializable.kt
@@ -1,0 +1,21 @@
+package net.corda.core.serialization
+
+import java.lang.annotation.Inherited
+
+/**
+ * This annotation is a marker to indicate that a class should NOT be serialised when a flow checkpoints.
+ *
+ * As flows are arbitrary code in which it is convenient to do many things,
+ * that means we can often end up pulling in a lot of junk that doesn't make sense to put in a checkpoint and thus deserialization is not required.
+ * Also, it is critical to identify that a class is not intended to be deserialized by the node, to avoid
+ * a security compromise later when a vulnerability is discovered in the deserialisation of a class that just happens to
+ * be on the classpath, perhaps from a 3rd party library, as has been witnessed elsewhere.
+ *
+ * It also makes it possible for a code reviewer to clearly identify the classes that should never be passed on the wire or stored.
+ *
+ * TODO: As we approach a long term wire format, this annotation will only be permitted on classes that meet certain criteria.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Inherited
+annotation class CordaNotSerializable

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -70,6 +70,7 @@ import kotlin.reflect.jvm.javaType
  * in invalid states, thus violating system invariants. It isn't designed to handle malicious streams and therefore,
  * isn't usable beyond the prototyping stage. But that's fine: we can revisit serialisation technologies later after
  * a formal evaluation process.
+ * Update: one can use class blacklisting to meet some (if not all) of the aforementioned security requirements.
  *
  * We now distinguish between internal, storage related Kryo and external, network facing Kryo.  We presently use
  * some non-whitelisted classes as part of internal storage.

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -459,12 +459,12 @@ object KotlinObjectSerializer : Serializer<DeserializeAsKotlinObjectDef>() {
 }
 
 // No ClassResolver only constructor.  MapReferenceResolver is the default as used by Kryo in other constructors.
-private val internalKryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeNoWhitelistClassResolver())) }.build()
+private val internalKryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeNoClassListClassResolver())) }.build()
 private val kryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeStandardClassResolver())) }.build()
 
 // No ClassResolver only constructor.  MapReferenceResolver is the default as used by Kryo in other constructors.
 @VisibleForTesting
-fun createTestKryo(): Kryo = DefaultKryoCustomizer.customize(CordaKryo(makeNoWhitelistClassResolver()))
+fun createTestKryo(): Kryo = DefaultKryoCustomizer.customize(CordaKryo(makeNoClassListClassResolver()))
 
 /**
  * We need to disable whitelist checking during calls from our Kryo code to register a serializer, since it checks
@@ -472,38 +472,38 @@ fun createTestKryo(): Kryo = DefaultKryoCustomizer.customize(CordaKryo(makeNoWhi
  */
 open class CordaKryo(classResolver: ClassResolver) : Kryo(classResolver, MapReferenceResolver()) {
     override fun register(type: Class<*>?): Registration {
-        (classResolver as? CordaClassResolver)?.disableWhitelist()
+        (classResolver as? CordaClassResolver)?.disableWhiteAndBlackLists()
         try {
             return super.register(type)
         } finally {
-            (classResolver as? CordaClassResolver)?.enableWhitelist()
+            (classResolver as? CordaClassResolver)?.enableWhiteAndBlackLists()
         }
     }
 
     override fun register(type: Class<*>?, id: Int): Registration {
-        (classResolver as? CordaClassResolver)?.disableWhitelist()
+        (classResolver as? CordaClassResolver)?.disableWhiteAndBlackLists()
         try {
             return super.register(type, id)
         } finally {
-            (classResolver as? CordaClassResolver)?.enableWhitelist()
+            (classResolver as? CordaClassResolver)?.enableWhiteAndBlackLists()
         }
     }
 
     override fun register(type: Class<*>?, serializer: Serializer<*>?): Registration {
-        (classResolver as? CordaClassResolver)?.disableWhitelist()
+        (classResolver as? CordaClassResolver)?.disableWhiteAndBlackLists()
         try {
             return super.register(type, serializer)
         } finally {
-            (classResolver as? CordaClassResolver)?.enableWhitelist()
+            (classResolver as? CordaClassResolver)?.enableWhiteAndBlackLists()
         }
     }
 
     override fun register(registration: Registration?): Registration {
-        (classResolver as? CordaClassResolver)?.disableWhitelist()
+        (classResolver as? CordaClassResolver)?.disableWhiteAndBlackLists()
         try {
             return super.register(registration)
         } finally {
-            (classResolver as? CordaClassResolver)?.enableWhitelist()
+            (classResolver as? CordaClassResolver)?.enableWhiteAndBlackLists()
         }
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -459,12 +459,12 @@ object KotlinObjectSerializer : Serializer<DeserializeAsKotlinObjectDef>() {
 }
 
 // No ClassResolver only constructor.  MapReferenceResolver is the default as used by Kryo in other constructors.
-private val internalKryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeNoClassListClassResolver())) }.build()
+private val internalKryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeBlackListOnlyClassResolver())) }.build()
 private val kryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeStandardClassResolver())) }.build()
 
 // No ClassResolver only constructor.  MapReferenceResolver is the default as used by Kryo in other constructors.
 @VisibleForTesting
-fun createTestKryo(): Kryo = DefaultKryoCustomizer.customize(CordaKryo(makeNoClassListClassResolver()))
+fun createTestKryo(): Kryo = DefaultKryoCustomizer.customize(CordaKryo(makeAcceptAllClassResolver()))
 
 /**
  * We need to disable whitelist checking during calls from our Kryo code to register a serializer, since it checks

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationCustomization.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationCustomization.kt
@@ -4,10 +4,15 @@ import com.esotericsoftware.kryo.Kryo
 
 interface SerializationCustomization {
     fun addToWhitelist(type: Class<*>)
+    fun addToBlacklist(type: Class<*>)
 }
 
 class KryoSerializationCustomization(val kryo: Kryo) : SerializationCustomization {
     override fun addToWhitelist(type: Class<*>) {
         kryo.addToWhitelist(type)
+    }
+
+    override fun addToBlacklist(type: Class<*>) {
+        kryo.addToBlacklist(type)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -157,9 +157,9 @@ class SerializerFactory(val whitelist: ClassList = AllClassList, val blacklist: 
 
     private fun blacklisted(clazz: Class<*>): Boolean {
         if (blacklist.hasListed(clazz) || clazz.isAnnotationPresent(CordaNotSerializable::class.java)) {
-            return false
-        } else {
             throw NotSerializableException("Class $clazz is on the blacklist or annotated with @CordaNotSerializable.")
+        } else {
+            return false
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -2,8 +2,8 @@ package net.corda.core.serialization.amqp
 
 import com.google.common.primitives.Primitives
 import net.corda.core.checkNotUnorderedHashMap
-import net.corda.core.serialization.AllWhitelist
-import net.corda.core.serialization.ClassWhitelist
+import net.corda.core.serialization.AllClassList
+import net.corda.core.serialization.ClassList
 import net.corda.core.serialization.CordaSerializable
 import org.apache.qpid.proton.amqp.*
 import java.io.NotSerializableException
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe
 // TODO: apply class loader logic and an "app context" throughout this code.
 // TODO: schema evolution solution when the fingerprints do not line up.
 @ThreadSafe
-class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
+class SerializerFactory(val whitelist: ClassList = AllClassList) {
     private val serializersByType = ConcurrentHashMap<Type, AMQPSerializer>()
     private val serializersByDescriptor = ConcurrentHashMap<Any, AMQPSerializer>()
 

--- a/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
@@ -74,67 +74,67 @@ class CordaClassResolverTests {
     fun `Annotation on enum works for specialised entries`() {
         // TODO: Remove this suppress when we upgrade to kotlin 1.1 or when JetBrain fixes the bug.
         @Suppress("UNSUPPORTED_FEATURE")
-        CordaClassResolver(EmptyClassList, ).getRegistration(Foo.Bar::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(Foo.Bar::class.java)
     }
 
     @Test
     fun `Annotation on array element works`() {
         val values = arrayOf(Element())
-        CordaClassResolver(EmptyClassList, ).getRegistration(values.javaClass)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(values.javaClass)
     }
 
     @Test
     fun `Annotation not needed on abstract class`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(AbstractClass::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(AbstractClass::class.java)
     }
 
     @Test
     fun `Annotation not needed on interface`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(Interface::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(Interface::class.java)
     }
 
     @Test
     fun `Calling register method on modified Kryo does not consult the whitelist`() {
-        val kryo = CordaKryo(CordaClassResolver(EmptyClassList, ))
+        val kryo = CordaKryo(CordaClassResolver(EmptyClassList, EmptyClassList))
         kryo.register(NotSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Calling register method on unmodified Kryo does consult the whitelist`() {
-        val kryo = Kryo(CordaClassResolver(EmptyClassList, ), MapReferenceResolver())
+        val kryo = Kryo(CordaClassResolver(EmptyClassList, EmptyClassList), MapReferenceResolver())
         kryo.register(NotSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation is needed without whitelisting`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(NotSerializable::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(NotSerializable::class.java)
     }
 
     @Test
     fun `Annotation is not needed with whitelisting`() {
-        val resolver = CordaClassResolver(GlobalTransientClassList(EmptyClassList), )
+        val resolver = CordaClassResolver(GlobalTransientClassList(EmptyClassList), EmptyClassList)
         (resolver.whitelist as MutableClassList).add(NotSerializable::class.java)
         resolver.getRegistration(NotSerializable::class.java)
     }
 
     @Test
     fun `Annotation not needed on Object`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(Object::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(Object::class.java)
     }
 
     @Test
     fun `Annotation not needed on primitive`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(Integer.TYPE)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(Integer.TYPE)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation does not work for custom serializable`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(CustomSerializable::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(CustomSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation does not work in conjunction with Kryo annotation`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(DefaultSerializable::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(DefaultSerializable::class.java)
     }
 
     private fun importJar(storage: AttachmentStorage) = AttachmentClassLoaderTests.ISOLATED_CONTRACTS_JAR_PATH.openStream().use { storage.importAttachment(it) }
@@ -145,19 +145,19 @@ class CordaClassResolverTests {
         val attachmentHash = importJar(storage)
         val classLoader = AttachmentsClassLoader(arrayOf(attachmentHash).map { storage.openAttachment(it)!! })
         val attachedClass = Class.forName("net.corda.contracts.isolated.AnotherDummyContract", true, classLoader)
-        CordaClassResolver(EmptyClassList, ).getRegistration(attachedClass)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(attachedClass)
     }
 
     @Test
     fun `Annotation is inherited from interfaces`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(SerializableViaInterface::class.java)
-        CordaClassResolver(EmptyClassList, ).getRegistration(SerializableViaSubInterface::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(SerializableViaInterface::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(SerializableViaSubInterface::class.java)
     }
 
     @Test
     fun `Annotation is inherited from superclass`() {
-        CordaClassResolver(EmptyClassList, ).getRegistration(SubElement::class.java)
-        CordaClassResolver(EmptyClassList, ).getRegistration(SubSubElement::class.java)
-        CordaClassResolver(EmptyClassList, ).getRegistration(SerializableViaSuperSubInterface::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(SubElement::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(SubSubElement::class.java)
+        CordaClassResolver(EmptyClassList, EmptyClassList).getRegistration(SerializableViaSuperSubInterface::class.java)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
@@ -74,67 +74,67 @@ class CordaClassResolverTests {
     fun `Annotation on enum works for specialised entries`() {
         // TODO: Remove this suppress when we upgrade to kotlin 1.1 or when JetBrain fixes the bug.
         @Suppress("UNSUPPORTED_FEATURE")
-        CordaClassResolver(EmptyClassList).getRegistration(Foo.Bar::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(Foo.Bar::class.java)
     }
 
     @Test
     fun `Annotation on array element works`() {
         val values = arrayOf(Element())
-        CordaClassResolver(EmptyClassList).getRegistration(values.javaClass)
+        CordaClassResolver(EmptyClassList, ).getRegistration(values.javaClass)
     }
 
     @Test
     fun `Annotation not needed on abstract class`() {
-        CordaClassResolver(EmptyClassList).getRegistration(AbstractClass::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(AbstractClass::class.java)
     }
 
     @Test
     fun `Annotation not needed on interface`() {
-        CordaClassResolver(EmptyClassList).getRegistration(Interface::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(Interface::class.java)
     }
 
     @Test
     fun `Calling register method on modified Kryo does not consult the whitelist`() {
-        val kryo = CordaKryo(CordaClassResolver(EmptyClassList))
+        val kryo = CordaKryo(CordaClassResolver(EmptyClassList, ))
         kryo.register(NotSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Calling register method on unmodified Kryo does consult the whitelist`() {
-        val kryo = Kryo(CordaClassResolver(EmptyClassList), MapReferenceResolver())
+        val kryo = Kryo(CordaClassResolver(EmptyClassList, ), MapReferenceResolver())
         kryo.register(NotSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation is needed without whitelisting`() {
-        CordaClassResolver(EmptyClassList).getRegistration(NotSerializable::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(NotSerializable::class.java)
     }
 
     @Test
     fun `Annotation is not needed with whitelisting`() {
-        val resolver = CordaClassResolver(GlobalTransientClassList(EmptyClassList))
+        val resolver = CordaClassResolver(GlobalTransientClassList(EmptyClassList), )
         (resolver.whitelist as MutableClassList).add(NotSerializable::class.java)
         resolver.getRegistration(NotSerializable::class.java)
     }
 
     @Test
     fun `Annotation not needed on Object`() {
-        CordaClassResolver(EmptyClassList).getRegistration(Object::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(Object::class.java)
     }
 
     @Test
     fun `Annotation not needed on primitive`() {
-        CordaClassResolver(EmptyClassList).getRegistration(Integer.TYPE)
+        CordaClassResolver(EmptyClassList, ).getRegistration(Integer.TYPE)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation does not work for custom serializable`() {
-        CordaClassResolver(EmptyClassList).getRegistration(CustomSerializable::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(CustomSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation does not work in conjunction with Kryo annotation`() {
-        CordaClassResolver(EmptyClassList).getRegistration(DefaultSerializable::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(DefaultSerializable::class.java)
     }
 
     private fun importJar(storage: AttachmentStorage) = AttachmentClassLoaderTests.ISOLATED_CONTRACTS_JAR_PATH.openStream().use { storage.importAttachment(it) }
@@ -145,19 +145,19 @@ class CordaClassResolverTests {
         val attachmentHash = importJar(storage)
         val classLoader = AttachmentsClassLoader(arrayOf(attachmentHash).map { storage.openAttachment(it)!! })
         val attachedClass = Class.forName("net.corda.contracts.isolated.AnotherDummyContract", true, classLoader)
-        CordaClassResolver(EmptyClassList).getRegistration(attachedClass)
+        CordaClassResolver(EmptyClassList, ).getRegistration(attachedClass)
     }
 
     @Test
     fun `Annotation is inherited from interfaces`() {
-        CordaClassResolver(EmptyClassList).getRegistration(SerializableViaInterface::class.java)
-        CordaClassResolver(EmptyClassList).getRegistration(SerializableViaSubInterface::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(SerializableViaInterface::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(SerializableViaSubInterface::class.java)
     }
 
     @Test
     fun `Annotation is inherited from superclass`() {
-        CordaClassResolver(EmptyClassList).getRegistration(SubElement::class.java)
-        CordaClassResolver(EmptyClassList).getRegistration(SubSubElement::class.java)
-        CordaClassResolver(EmptyClassList).getRegistration(SerializableViaSuperSubInterface::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(SubElement::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(SubSubElement::class.java)
+        CordaClassResolver(EmptyClassList, ).getRegistration(SerializableViaSuperSubInterface::class.java)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
@@ -140,7 +140,7 @@ class CordaClassResolverTests {
 
     @Test
     fun `Annotation is not needed with whitelisting`() {
-        val resolver = CordaClassResolver(GlobalTransientClassList(EmptyClassList), EmptyClassList)
+        val resolver = CordaClassResolver(GlobalTransientWhiteList(EmptyClassList), EmptyClassList)
         (resolver.whitelist as MutableClassList).add(NotSerializable::class.java)
         resolver.getRegistration(NotSerializable::class.java)
     }
@@ -239,7 +239,7 @@ class CordaClassResolverTests {
     fun `check blacklisted class`() {
         expectedEx.expect(KryoException::class.java)
         expectedEx.expectMessage("Class net.corda.core.serialization.NotSerializable is blacklisted and cannot be used in serialization")
-        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientClassList(EmptyClassList))
+        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientBlackList(EmptyClassList))
         (resolver.blacklist as MutableClassList).add(NotSerializable::class.java)
         resolver.getRegistration(NotSerializable::class.java)
     }
@@ -248,7 +248,7 @@ class CordaClassResolverTests {
     fun `blacklisting is always checked before whitelisting`() {
         expectedEx.expect(KryoException::class.java)
         expectedEx.expectMessage("Class net.corda.core.serialization.NotSerializable is blacklisted and cannot be used in serialization")
-        val resolver = CordaClassResolver(GlobalTransientClassList(EmptyClassList), GlobalTransientClassList(EmptyClassList))
+        val resolver = CordaClassResolver(GlobalTransientWhiteList(EmptyClassList), GlobalTransientBlackList(EmptyClassList))
         // add to whitelist.
         (resolver.whitelist as MutableClassList).add(NotSerializable::class.java)
         // add to blacklist.
@@ -261,7 +261,7 @@ class CordaClassResolverTests {
     fun `blacklisting is always checked beforeCordaSerializable annotated class`() {
         expectedEx.expect(KryoException::class.java)
         expectedEx.expectMessage("Class net.corda.core.serialization.Element is blacklisted and cannot be used in serialization")
-        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientClassList(EmptyClassList))
+        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientBlackList(EmptyClassList))
         (resolver.blacklist as MutableClassList).add(Element::class.java)
         resolver.getRegistration(Element::class.java)
     }
@@ -270,7 +270,7 @@ class CordaClassResolverTests {
     fun `blacklisting is always checked before CordaSerializable annotated subclass`() {
         expectedEx.expect(KryoException::class.java)
         expectedEx.expectMessage("Class net.corda.core.serialization.SubElement is blacklisted and cannot be used in serialization")
-        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientClassList(EmptyClassList))
+        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientBlackList(EmptyClassList))
         (resolver.blacklist as MutableClassList).add(SubElement::class.java)
         resolver.getRegistration(SubElement::class.java)
     }
@@ -279,7 +279,7 @@ class CordaClassResolverTests {
     fun `blacklisting is always checked beforeCordaSerializable annotated subsubclass`() {
         expectedEx.expect(KryoException::class.java)
         expectedEx.expectMessage("Class net.corda.core.serialization.SubSubElement is blacklisted and cannot be used in serialization")
-        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientClassList(EmptyClassList))
+        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientBlackList(EmptyClassList))
         (resolver.blacklist as MutableClassList).add(SubSubElement::class.java)
         resolver.getRegistration(SubSubElement::class.java)
     }
@@ -288,7 +288,7 @@ class CordaClassResolverTests {
     fun `blacklisting is always checked before CordaSerializable class inherited from interfaces`() {
         expectedEx.expect(KryoException::class.java)
         expectedEx.expectMessage("Class net.corda.core.serialization.SerializableViaInterface is blacklisted and cannot be used in serialization")
-        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientClassList(EmptyClassList))
+        val resolver = CordaClassResolver(EmptyClassList, GlobalTransientBlackList(EmptyClassList))
         (resolver.blacklist as MutableClassList).add(SerializableViaInterface::class.java)
         resolver.getRegistration(SerializableViaInterface::class.java)
     }

--- a/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
@@ -74,67 +74,67 @@ class CordaClassResolverTests {
     fun `Annotation on enum works for specialised entries`() {
         // TODO: Remove this suppress when we upgrade to kotlin 1.1 or when JetBrain fixes the bug.
         @Suppress("UNSUPPORTED_FEATURE")
-        CordaClassResolver(EmptyWhitelist).getRegistration(Foo.Bar::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(Foo.Bar::class.java)
     }
 
     @Test
     fun `Annotation on array element works`() {
         val values = arrayOf(Element())
-        CordaClassResolver(EmptyWhitelist).getRegistration(values.javaClass)
+        CordaClassResolver(EmptyClassList).getRegistration(values.javaClass)
     }
 
     @Test
     fun `Annotation not needed on abstract class`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(AbstractClass::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(AbstractClass::class.java)
     }
 
     @Test
     fun `Annotation not needed on interface`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(Interface::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(Interface::class.java)
     }
 
     @Test
     fun `Calling register method on modified Kryo does not consult the whitelist`() {
-        val kryo = CordaKryo(CordaClassResolver(EmptyWhitelist))
+        val kryo = CordaKryo(CordaClassResolver(EmptyClassList))
         kryo.register(NotSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Calling register method on unmodified Kryo does consult the whitelist`() {
-        val kryo = Kryo(CordaClassResolver(EmptyWhitelist), MapReferenceResolver())
+        val kryo = Kryo(CordaClassResolver(EmptyClassList), MapReferenceResolver())
         kryo.register(NotSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation is needed without whitelisting`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(NotSerializable::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(NotSerializable::class.java)
     }
 
     @Test
     fun `Annotation is not needed with whitelisting`() {
-        val resolver = CordaClassResolver(GlobalTransientClassWhiteList(EmptyWhitelist))
-        (resolver.whitelist as MutableClassWhitelist).add(NotSerializable::class.java)
+        val resolver = CordaClassResolver(GlobalTransientClassList(EmptyClassList))
+        (resolver.whitelist as MutableClassList).add(NotSerializable::class.java)
         resolver.getRegistration(NotSerializable::class.java)
     }
 
     @Test
     fun `Annotation not needed on Object`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(Object::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(Object::class.java)
     }
 
     @Test
     fun `Annotation not needed on primitive`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(Integer.TYPE)
+        CordaClassResolver(EmptyClassList).getRegistration(Integer.TYPE)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation does not work for custom serializable`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(CustomSerializable::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(CustomSerializable::class.java)
     }
 
     @Test(expected = KryoException::class)
     fun `Annotation does not work in conjunction with Kryo annotation`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(DefaultSerializable::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(DefaultSerializable::class.java)
     }
 
     private fun importJar(storage: AttachmentStorage) = AttachmentClassLoaderTests.ISOLATED_CONTRACTS_JAR_PATH.openStream().use { storage.importAttachment(it) }
@@ -145,19 +145,19 @@ class CordaClassResolverTests {
         val attachmentHash = importJar(storage)
         val classLoader = AttachmentsClassLoader(arrayOf(attachmentHash).map { storage.openAttachment(it)!! })
         val attachedClass = Class.forName("net.corda.contracts.isolated.AnotherDummyContract", true, classLoader)
-        CordaClassResolver(EmptyWhitelist).getRegistration(attachedClass)
+        CordaClassResolver(EmptyClassList).getRegistration(attachedClass)
     }
 
     @Test
     fun `Annotation is inherited from interfaces`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(SerializableViaInterface::class.java)
-        CordaClassResolver(EmptyWhitelist).getRegistration(SerializableViaSubInterface::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(SerializableViaInterface::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(SerializableViaSubInterface::class.java)
     }
 
     @Test
     fun `Annotation is inherited from superclass`() {
-        CordaClassResolver(EmptyWhitelist).getRegistration(SubElement::class.java)
-        CordaClassResolver(EmptyWhitelist).getRegistration(SubSubElement::class.java)
-        CordaClassResolver(EmptyWhitelist).getRegistration(SerializableViaSuperSubInterface::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(SubElement::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(SubSubElement::class.java)
+        CordaClassResolver(EmptyClassList).getRegistration(SerializableViaSuperSubInterface::class.java)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/SerializationOutputTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/SerializationOutputTests.kt
@@ -1,7 +1,7 @@
 package net.corda.core.serialization.amqp
 
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.EmptyWhitelist
+import net.corda.core.serialization.EmptyClassList
 import org.apache.qpid.proton.codec.DecoderImpl
 import org.apache.qpid.proton.codec.EncoderImpl
 import org.junit.Test
@@ -170,13 +170,13 @@ class SerializationOutputTests {
     @Test(expected = NotSerializableException::class)
     fun `test whitelist`() {
         val obj = Woo2(4)
-        serdes(obj, SerializerFactory(EmptyWhitelist))
+        serdes(obj, SerializerFactory(EmptyClassList))
     }
 
     @Test
     fun `test annotation whitelisting`() {
         val obj = AnnotatedWoo(5)
-        serdes(obj, SerializerFactory(EmptyWhitelist))
+        serdes(obj, SerializerFactory(EmptyClassList))
     }
 
     @Test(expected = NotSerializableException::class)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/serialization/DefaultBlacklist.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/serialization/DefaultBlacklist.kt
@@ -1,0 +1,19 @@
+package net.corda.nodeapi.serialization
+
+import net.corda.core.node.CordaPluginRegistry
+import net.corda.core.serialization.SerializationCustomization
+import java.util.*
+
+class DefaultBlacklist : CordaPluginRegistry() {
+    override fun customizeSerialization(custom: SerializationCustomization): Boolean {
+        custom.apply {
+            // TODO: Turn this into an array and use map {}.
+            addToBlacklist(HashSet::class.java)
+            addToBlacklist(HashMap::class.java)
+            addToBlacklist(Thread::class.java)
+            addToBlacklist(ClassLoader::class.java)
+            // TODO: add more blacklisted classes such as anything related to files/IO, lang.invoke.* etc.
+        }
+        return true
+    }
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/serialization/DefaultBlacklist.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/serialization/DefaultBlacklist.kt
@@ -2,14 +2,11 @@ package net.corda.nodeapi.serialization
 
 import net.corda.core.node.CordaPluginRegistry
 import net.corda.core.serialization.SerializationCustomization
-import java.util.*
 
 class DefaultBlacklist : CordaPluginRegistry() {
     override fun customizeSerialization(custom: SerializationCustomization): Boolean {
         custom.apply {
             // TODO: Turn this into an array and use map {}.
-            addToBlacklist(HashSet::class.java)
-            addToBlacklist(HashMap::class.java)
             addToBlacklist(Thread::class.java)
             addToBlacklist(ClassLoader::class.java)
             // TODO: add more blacklisted classes such as anything related to files/IO, lang.invoke.* etc.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/serialization/DefaultWhitelist.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/serialization/DefaultWhitelist.kt
@@ -40,7 +40,6 @@ class DefaultWhitelist : CordaPluginRegistry() {
             addToWhitelist(Unit::class.java)
             addToWhitelist(java.io.ByteArrayInputStream::class.java)
             addToWhitelist(java.lang.Class::class.java)
-            addToWhitelist(java.math.BigDecimal::class.java)
             addToWhitelist(java.security.KeyPair::class.java)
 
             // Matches the list in TimeSerializers.addDefaultSerializers:

--- a/node-api/src/main/resources/META-INF/services/net.corda.core.node.CordaPluginRegistry
+++ b/node-api/src/main/resources/META-INF/services/net.corda.core.node.CordaPluginRegistry
@@ -1,2 +1,3 @@
 # Register a ServiceLoader service extending from net.corda.core.node.CordaPluginRegistry
 net.corda.nodeapi.serialization.DefaultWhitelist
+net.corda.nodeapi.serialization.DefaultBlacklist


### PR DESCRIPTION
CordaClassResolver now requires both a white and a blacklist.
Some key concepts:
- Blacklisting is always checked before whitelisting
- {White,Black}-listing inheritance is now allowed. We should consider however a model where you can define, using a second param, if inheritance is permitted.
- There are two global transient lists (one for white, one for black).
- Exception is always descriptive (if in whitelist or blacklist)

What is left:
1. List of known blacklisted classes/interfaces (will do/decide in an upcoming PR)
2. different lists for p2p and storage Kryo
3. links to wiki when throwing (it would help if we had error codes)
4. Having discuss it with Rick, we must consider if we should remove annotations and keep white/blacklisting only, because dealing with both ways will get much more complex to handle (inheritance, global/per app, p2p vs storage... etc).