### PR TITLE
Node stress testing

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -60,6 +60,7 @@
       <module name="node-schemas_test" target="1.8" />
       <module name="node_integrationTest" target="1.8" />
       <module name="node_main" target="1.8" />
+      <module name="node_stabilityTest" target="1.8" />
       <module name="node_test" target="1.8" />
       <module name="notary-demo_main" target="1.8" />
       <module name="notary-demo_test" target="1.8" />

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -12,6 +12,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.NodeStatus
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.StateMachineTransactionMapping
 import net.corda.core.node.services.Vault
@@ -99,7 +100,7 @@ interface CordaRPCOps : RPCOps {
      *
      * Notes: the snapshot part of the query adheres to the same behaviour as the [queryBy] function.
      *        the [QueryCriteria] applies to both snapshot and deltas (streaming updates).
-    */
+     */
     // DOCSTART VaultTrackByAPI
     @RPCReturnsObservables
     fun <T : ContractState> vaultTrackBy(criteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(),
@@ -112,6 +113,7 @@ interface CordaRPCOps : RPCOps {
 
     // DOCSTART VaultQueryAPIJavaHelpers
     fun <T : ContractState> vaultQueryByCriteria(criteria: QueryCriteria): Vault.Page<T> = vaultQueryBy(criteria = criteria)
+
     fun <T : ContractState> vaultQueryByWithPagingSpec(criteria: QueryCriteria, paging: PageSpecification): Vault.Page<T> = vaultQueryBy(criteria, paging = paging)
     fun <T : ContractState> vaultQueryByWithSorting(criteria: QueryCriteria, sorting: Sort): Vault.Page<T> = vaultQueryBy(criteria, sorting = sorting)
 
@@ -124,8 +126,8 @@ interface CordaRPCOps : RPCOps {
      * Returns a pair of head states in the vault and an observable of future updates to the vault.
      */
     @RPCReturnsObservables
-    // TODO: Remove this from the interface
-    // @Deprecated("This function will be removed in a future milestone", ReplaceWith("vaultTrackBy(QueryCriteria())"))
+            // TODO: Remove this from the interface
+            // @Deprecated("This function will be removed in a future milestone", ReplaceWith("vaultTrackBy(QueryCriteria())"))
     fun vaultAndUpdates(): Pair<List<StateAndRef<ContractState>>, Observable<Vault.Update>>
 
     /**
@@ -246,6 +248,11 @@ interface CordaRPCOps : RPCOps {
 
     /** Enumerates the class names of the flows that this node knows about. */
     fun registeredFlows(): List<String>
+
+    /**
+     * Return status of the node.
+     */
+    fun nodeStatus(): NodeStatus
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -126,8 +126,8 @@ interface CordaRPCOps : RPCOps {
      * Returns a pair of head states in the vault and an observable of future updates to the vault.
      */
     @RPCReturnsObservables
-            // TODO: Remove this from the interface
-            // @Deprecated("This function will be removed in a future milestone", ReplaceWith("vaultTrackBy(QueryCriteria())"))
+    // TODO: Remove this from the interface
+    // @Deprecated("This function will be removed in a future milestone", ReplaceWith("vaultTrackBy(QueryCriteria())"))
     fun vaultAndUpdates(): Pair<List<StateAndRef<ContractState>>, Observable<Vault.Update>>
 
     /**

--- a/core/src/main/kotlin/net/corda/core/node/NodeStatus.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NodeStatus.kt
@@ -1,0 +1,7 @@
+package net.corda.core.node
+
+import net.corda.core.serialization.CordaSerializable
+
+// TODO : Include uptime, number of queues etc and shows the data in Node explorer.
+@CordaSerializable
+data class NodeStatus(val stateMachineCount: Int, val freeMemory: Long, val totalMemory: Long)

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -25,6 +25,8 @@ configurations {
 
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
+    stabilityTestCompile.extendsFrom testCompile
+    stabilityTestRuntime.extendsFrom testRuntime
 }
 
 sourceSets {
@@ -36,6 +38,16 @@ sourceSets {
         }
         resources {
             srcDir file('src/integration-test/resources')
+        }
+    }
+    stabilityTest {
+        kotlin {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/stability-test/kotlin')
+        }
+        resources {
+            srcDir file('src/stability-test/resources')
         }
     }
 }
@@ -174,3 +186,10 @@ task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
+
+task stabilityTest(type: Test) {
+    group = 'build'
+    testClassesDir = sourceSets.stabilityTest.output.classesDir
+    classpath = sourceSets.stabilityTest.runtimeClasspath
+}
+

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -10,6 +10,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.messaging.*
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.NodeStatus
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.StateMachineTransactionMapping
 import net.corda.core.node.services.Vault
@@ -174,9 +175,14 @@ class CordaRPCOpsImpl(
     @Suppress("DEPRECATION")
     @Deprecated("Use partyFromX500Name instead")
     override fun partyFromName(name: String) = services.identityService.partyFromName(name)
-    override fun partyFromX500Name(x500Name: X500Name)= services.identityService.partyFromX500Name(x500Name)
+
+    override fun partyFromX500Name(x500Name: X500Name) = services.identityService.partyFromX500Name(x500Name)
 
     override fun registeredFlows(): List<String> = services.rpcFlows.map { it.name }.sorted()
+
+    override fun nodeStatus(): NodeStatus {
+        return NodeStatus(smm.allStateMachines.size, Runtime.getRuntime().freeMemory(), Runtime.getRuntime().totalMemory())
+    }
 
     companion object {
         private fun stateMachineInfoFromFlowLogic(flowLogic: FlowLogic<*>): StateMachineInfo {

--- a/node/src/stability-test/kotlin/net/corda/node/StabilityTest.kt
+++ b/node/src/stability-test/kotlin/net/corda/node/StabilityTest.kt
@@ -25,6 +25,7 @@ class StabilityTest {
     private val memoryThreshold = 0.95
     private val iteration = 1000
     private val startingFrequency = 8
+    private val statsUpdateRate = 1000L
 
     @Test
     fun `node stress test`() {
@@ -64,7 +65,7 @@ class StabilityTest {
                 cashFlowCommand.startFlow(rpc).returnValue.success { counter.success.incrementAndGet() }.failure { counter.failed.incrementAndGet() }
                 counter.started.incrementAndGet()
             }
-        }, 0, 1000 / frequency.toLong(), TimeUnit.MILLISECONDS)
+        }, 0, 1 / frequency.toLong(), TimeUnit.SECONDS)
 
         return future {
             val stats = mutableListOf<StabilityTestStat>()
@@ -76,7 +77,7 @@ class StabilityTest {
                     executor.shutdown()
                     println("Waiting for State machines to finish.")
                 }
-                Thread.sleep(1000)
+                Thread.sleep(statsUpdateRate)
             }
             val nodeStatus = rpc.nodeStatus()
             stats.add(StabilityTestStat(nodeStatus.stateMachineCount, nodeStatus.freeMemory, nodeStatus.totalMemory, counter.started.get(), counter.success.get(), counter.failed.get()))

--- a/node/src/stability-test/kotlin/net/corda/node/StabilityTest.kt
+++ b/node/src/stability-test/kotlin/net/corda/node/StabilityTest.kt
@@ -1,0 +1,104 @@
+package net.corda.node
+
+import com.google.common.util.concurrent.ListenableFuture
+import net.corda.core.contracts.Amount
+import net.corda.core.contracts.GBP
+import net.corda.core.failure
+import net.corda.core.future
+import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.node.services.ServiceInfo
+import net.corda.core.node.services.ServiceType
+import net.corda.core.serialization.OpaqueBytes
+import net.corda.core.success
+import net.corda.core.utilities.DUMMY_NOTARY
+import net.corda.flows.CashFlowCommand
+import net.corda.node.driver.driver
+import net.corda.node.services.transactions.SimpleNotaryService
+import org.bouncycastle.asn1.x500.X500Name
+import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class StabilityTest {
+    // TODO : Make these configurable.
+    private val memoryThreshold = 0.95
+    private val iteration = 1000
+    private val startingFrequency = 8
+
+    @Test
+    fun `node stress test`() {
+        var frequency = startingFrequency
+        while (true) {
+            // Start nodes for each test.
+            val reachedMemoryThreshold = driver {
+                val notary = startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type))).get()
+                val node1 = startNode(X500Name("CN=Node1"), advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.GBP")))).get()
+                val node2 = startNode(X500Name("CN=Node2"), advertisedServices = setOf(ServiceInfo(ServiceType.corda.getSubType("issuer.GBP")))).get()
+
+                // Pre-issue bunch of cash.
+                startStabilityTest("Node1 Issue", node1.rpc, 100, 100, CashFlowCommand.IssueCash(Amount(100_000, GBP), OpaqueBytes(ByteArray(1, { 0.toByte() })), node1.nodeInfo.legalIdentity, notary.nodeInfo.notaryIdentity)).get()
+                startStabilityTest("Node2 Issue", node2.rpc, 100, 100, CashFlowCommand.IssueCash(Amount(100_000, GBP), OpaqueBytes(ByteArray(1, { 0.toByte() })), node2.nodeInfo.legalIdentity, notary.nodeInfo.notaryIdentity)).get()
+
+                // TODO : output the stats to a file?
+                val node1Test = startStabilityTest("Node1 Pay Node2", node1.rpc, iteration, frequency, CashFlowCommand.PayCash(Amount(1, GBP), node2.nodeInfo.legalIdentity)).get()
+                println(node1Test)
+                val node2Test = startStabilityTest("Node2 Pay Node1", node2.rpc, iteration, frequency, CashFlowCommand.PayCash(Amount(1, GBP), node1.nodeInfo.legalIdentity)).get()
+                println(node2Test)
+                frequency++
+                node1Test.reachedMemoryThreshold && node1Test.reachedMemoryThreshold
+            }
+            if (reachedMemoryThreshold) {
+                break
+            }
+        }
+    }
+
+    private fun startStabilityTest(testName: String, rpc: CordaRPCOps, iteration: Int, frequency: Int, cashFlowCommand: CashFlowCommand): ListenableFuture<StabilityTestReport> {
+        val counter = Counter(AtomicInteger(), AtomicInteger(), AtomicInteger())
+        val startTime = System.currentTimeMillis()
+
+        val executor = Executors.newScheduledThreadPool(20)
+        executor.scheduleAtFixedRate({
+            if (counter.started.get() < iteration) {
+                cashFlowCommand.startFlow(rpc).returnValue.success { counter.success.incrementAndGet() }.failure { counter.failed.incrementAndGet() }
+                counter.started.incrementAndGet()
+            }
+        }, 0, 1000 / frequency.toLong(), TimeUnit.MILLISECONDS)
+
+        return future {
+            val stats = mutableListOf<StabilityTestStat>()
+            while ((!executor.isShutdown && counter.success.get() + counter.failed.get() < iteration) || (executor.isShutdown && counter.success.get() + counter.failed.get() < counter.started.get())) {
+                val nodeStatus = rpc.nodeStatus()
+                stats.add(StabilityTestStat(nodeStatus.stateMachineCount, nodeStatus.freeMemory, nodeStatus.totalMemory, counter.started.get(), counter.success.get(), counter.failed.get()))
+                if (counter.started.get() < iteration && !executor.isShutdown && nodeStatus.freeMemory < nodeStatus.totalMemory * (1 - memoryThreshold)) {
+                    println("Reached memory threshold, stopping the test.")
+                    executor.shutdown()
+                    println("Waiting for State machines to finish.")
+                }
+                Thread.sleep(1000)
+            }
+            val nodeStatus = rpc.nodeStatus()
+            stats.add(StabilityTestStat(nodeStatus.stateMachineCount, nodeStatus.freeMemory, nodeStatus.totalMemory, counter.started.get(), counter.success.get(), counter.failed.get()))
+            StabilityTestReport(testName, startTime, System.currentTimeMillis(), frequency, iteration, stats)
+        }
+    }
+
+    private data class StabilityTestReport(val testName: String, val startedTime: Long, val endTime: Long, val frequency: Int, val iteration: Int, val testStats: List<StabilityTestStat>) {
+        val reachedMemoryThreshold = testStats.last().startedFlows < iteration
+        val duration = (endTime - startedTime) / 1000
+        override fun toString(): String {
+            return "testName: $testName\tduration: ${duration}s\tfrequency: $frequency flow/s\titeration: $iteration\tcompleted: ${testStats.last().startedFlows}\tTPS: ${testStats.last().startedFlows / duration}\n" +
+                    "State Machine\tFree Memory\tTotal Memory\tStarted Flow\tSucceed Flow\tFailed Flow\n" +
+                    testStats.joinToString("\n")
+        }
+    }
+
+    private data class StabilityTestStat(val stateMachineCount: Int, val freeMemory: Long, val totalMemory: Long, val startedFlows: Int, val succeededFlow: Int, val failedFlow: Int) {
+        override fun toString(): String {
+            return "$stateMachineCount\t$freeMemory\t$totalMemory\t$startedFlows\t$succeededFlow\t$failedFlow"
+        }
+    }
+
+    private data class Counter(val started: AtomicInteger, val success: AtomicInteger, val failed: AtomicInteger)
+}


### PR DESCRIPTION
The stress test starts up 3 nodes, Notary, Node1 and Node2.
Cash pay command will be executed on each node at a increasing rate, until the node reaches the memory threshold. A test report will be printed to console after each test.