### PR TITLE
Reverting "Upgrade Artemis to 2.1.0" 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     ext.capsule_version = '1.0.1'
 
     ext.asm_version = '0.5.3'
-    ext.artemis_version = '2.1.0'
+    ext.artemis_version = '1.5.3'
     ext.jackson_version = '2.8.5'
     ext.jetty_version = '9.3.9.v20160517'
     ext.jersey_version = '2.25'

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -41,7 +41,6 @@ import net.corda.nodeapi.ArtemisTcpTransport
 import net.corda.nodeapi.ConnectionDirection
 import net.corda.nodeapi.internal.addShutdownHook
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException
-import org.apache.activemq.artemis.api.core.RoutingType
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient
 import org.apache.activemq.artemis.api.core.client.ClientMessage
 import org.bouncycastle.asn1.x500.X500Name
@@ -209,7 +208,7 @@ class Node(override val configuration: FullNodeConfiguration,
         session.start()
 
         val queueName = "$IP_REQUEST_PREFIX$requestId"
-        session.createQueue(queueName, RoutingType.MULTICAST, queueName, false)
+        session.createQueue(queueName, queueName, false)
 
         val consumer = session.createConsumer(queueName)
         val artemisMessage: ClientMessage = consumer.receive(10.seconds.toMillis()) ?:

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -30,12 +30,12 @@ import org.apache.activemq.artemis.core.config.Configuration
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl
 import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration
-import org.apache.activemq.artemis.core.message.impl.CoreMessage
 import org.apache.activemq.artemis.core.remoting.impl.netty.*
 import org.apache.activemq.artemis.core.security.Role
 import org.apache.activemq.artemis.core.server.ActiveMQServer
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.core.server.impl.RoutingContextImpl
+import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
 import org.apache.activemq.artemis.spi.core.remoting.*
@@ -446,7 +446,7 @@ class ArtemisMessagingServer(override val config: NodeConfiguration,
         }
 
         fun sendResponse(remoteAddress: String?) {
-            val responseMessage = CoreMessage(random63BitValue(), 0).apply {
+            val responseMessage = ServerMessageImpl(random63BitValue(), 0).apply {
                 putStringProperty(ipDetectResponseProperty, remoteAddress)
             }
             val routingContext = RoutingContextImpl(null)

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
@@ -32,7 +32,6 @@ import net.corda.nodeapi.VerifierApi.VERIFICATION_REQUESTS_QUEUE_NAME
 import net.corda.nodeapi.VerifierApi.VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX
 import org.apache.activemq.artemis.api.core.ActiveMQObjectClosedException
 import org.apache.activemq.artemis.api.core.Message.*
-import org.apache.activemq.artemis.api.core.RoutingType
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.client.*
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient.DEFAULT_ACK_BATCH_SIZE
@@ -514,7 +513,7 @@ class NodeMessagingClient(override val config: NodeConfiguration,
             val queueQuery = session!!.queueQuery(SimpleString(queueName))
             if (!queueQuery.isExists) {
                 log.info("Create fresh queue $queueName bound on same address")
-                session!!.createQueue(queueName, RoutingType.MULTICAST, queueName, true)
+                session!!.createQueue(queueName, queueName, true)
             }
         }
     }


### PR DESCRIPTION
The new version seems to introduce a race condition that causes a RPC stability test to randomly hang. We don't actually need to upgrade until our patch is in (could be 2.2.0 or 2.3.0), so I'll revisit the issue then.

This reverts commit 81d32fd6a7d95d2004967796e5ea7e37d5b7b80c.