### PR TITLE
Clean up cash tests

### DIFF
--- a/finance/src/test/kotlin/net/corda/flows/CashExitFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/flows/CashExitFlowTests.kt
@@ -3,8 +3,9 @@ package net.corda.flows
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.`issued by`
-import net.corda.core.identity.Party
+import net.corda.core.flows.TxKeyFlow
 import net.corda.core.getOrThrow
+import net.corda.core.identity.Party
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
@@ -29,6 +30,7 @@ class CashExitFlowTests {
         val nodes = mockNet.createTwoNodes()
         notaryNode = nodes.first
         bankOfCordaNode = nodes.second
+        bankOfCordaNode.registerInitiatedFlow(TxKeyFlow.Provider::class.java)
         notary = notaryNode.info.notaryIdentity
         bankOfCorda = bankOfCordaNode.info.legalIdentity
 

--- a/finance/src/test/kotlin/net/corda/flows/CashIssueFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/flows/CashIssueFlowTests.kt
@@ -3,8 +3,9 @@ package net.corda.flows
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.`issued by`
-import net.corda.core.identity.Party
+import net.corda.core.flows.TxKeyFlow
 import net.corda.core.getOrThrow
+import net.corda.core.identity.Party
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
@@ -27,6 +28,7 @@ class CashIssueFlowTests {
         val nodes = mockNet.createTwoNodes()
         notaryNode = nodes.first
         bankOfCordaNode = nodes.second
+        bankOfCordaNode.registerInitiatedFlow(TxKeyFlow.Provider::class.java)
         notary = notaryNode.info.notaryIdentity
         bankOfCorda = bankOfCordaNode.info.legalIdentity
 

--- a/finance/src/test/kotlin/net/corda/flows/CashPaymentFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/flows/CashPaymentFlowTests.kt
@@ -3,8 +3,9 @@ package net.corda.flows
 import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.`issued by`
-import net.corda.core.identity.Party
+import net.corda.core.flows.TxKeyFlow
 import net.corda.core.getOrThrow
+import net.corda.core.identity.Party
 import net.corda.core.serialization.OpaqueBytes
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
@@ -12,8 +13,11 @@ import net.corda.testing.node.MockNetwork.MockNode
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.security.PublicKey
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class CashPaymentFlowTests {
     private val mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin())
@@ -48,15 +52,17 @@ class CashPaymentFlowTests {
     @Test
     fun `pay some cash`() {
         val payTo = notaryNode.info.legalIdentity
-        val expected = 500.DOLLARS
-        val future = bankOfCordaNode.services.startFlow(CashPaymentFlow(expected,
+        val expectedPayment = 500.DOLLARS
+        val expectedChange = 1500.DOLLARS
+        val future = bankOfCordaNode.services.startFlow(CashPaymentFlow(expectedPayment,
                 payTo)).resultFuture
         mockNet.runNetwork()
         val paymentTx = future.getOrThrow()
         val states = paymentTx.tx.outputs.map { it.data }.filterIsInstance<Cash.State>()
         val ourState = states.single { it.owner.owningKey != payTo.owningKey }
         val paymentState = states.single { it.owner.owningKey == payTo.owningKey }
-        assertEquals(expected.`issued by`(bankOfCorda.ref(ref)), paymentState.amount)
+        assertEquals(expectedChange.`issued by`(bankOfCorda.ref(ref)), ourState.amount)
+        assertEquals(expectedPayment.`issued by`(bankOfCorda.ref(ref)), paymentState.amount)
     }
 
     @Test

--- a/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
+++ b/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
@@ -18,6 +18,7 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.IssuerFlow.IssuanceRequester
 import net.corda.testing.BOC
 import net.corda.testing.MEGA_CORP
+import net.corda.testing.ledger
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
@@ -35,7 +36,6 @@ class IssuerFlowTest {
     lateinit var bankOfCordaNode: MockNode
     lateinit var bankClientNode: MockNode
 
-    @Before
     fun start() {
         notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
         bankOfCordaNode = mockNet.createPartyNode(notaryNode.info.address, BOC.name)
@@ -49,44 +49,55 @@ class IssuerFlowTest {
         mockNet.runNetwork()
     }
 
-    @After
     fun cleanUp() {
-        // mockNet.stopNodes()
+        mockNet.stopNodes()
     }
 
     @Test
     fun `test issuer flow`() {
-        // using default IssueTo Party Reference
-        val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, 1000000.DOLLARS,
-                bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
-        assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
+        ledger {
+            start()
+            // using default IssueTo Party Reference
+            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, 1000000.DOLLARS,
+                    bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
+            assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
 
-        // try to issue an amount of a restricted currency
-        assertFailsWith<FlowException> {
-            runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(100000L, currency("BRL")),
-                    bankClientNode.info.legalIdentity, OpaqueBytes.of(123)).issueRequestResult.getOrThrow()
+            // try to issue an amount of a restricted currency
+            assertFailsWith<FlowException> {
+                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(100000L, currency("BRL")),
+                        bankClientNode.info.legalIdentity, OpaqueBytes.of(123)).issueRequestResult.getOrThrow()
+            }
+            cleanUp()
         }
     }
 
     @Test
     fun `test issue flow to self`() {
-        // using default IssueTo Party Reference
-        val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankOfCordaNode, 1000000.DOLLARS,
-                bankOfCordaNode.info.legalIdentity, OpaqueBytes.of(123))
-        assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
+        ledger {
+            start()
+            // using default IssueTo Party Reference
+            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankOfCordaNode, 1000000.DOLLARS,
+                    bankOfCordaNode.info.legalIdentity, OpaqueBytes.of(123))
+            assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
+            cleanUp()
+        }
     }
 
     @Test
     fun `test concurrent issuer flow`() {
-        // this test exercises the Cashflow issue and move subflows to ensure consistent spending of issued states
-        val amount = 10000.DOLLARS
-        val amounts = calculateRandomlySizedAmounts(10000.DOLLARS, 10, 10, Random())
-        val handles = amounts.map { pennies ->
-            runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(pennies, amount.token),
-                    bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
-        }
-        handles.forEach {
-            require(it.issueRequestResult.get() is SignedTransaction)
+        ledger {
+            start()
+            // this test exercises the Cashflow issue and move subflows to ensure consistent spending of issued states
+            val amount = 10000.DOLLARS
+            val amounts = calculateRandomlySizedAmounts(10000.DOLLARS, 10, 10, Random())
+            val handles = amounts.map { pennies ->
+                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(pennies, amount.token),
+                        bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
+            }
+            handles.forEach {
+                require(it.issueRequestResult.get() is SignedTransaction)
+            }
+            cleanUp()
         }
     }
 

--- a/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
+++ b/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
@@ -18,7 +18,6 @@ import net.corda.core.utilities.DUMMY_NOTARY
 import net.corda.flows.IssuerFlow.IssuanceRequester
 import net.corda.testing.BOC
 import net.corda.testing.MEGA_CORP
-import net.corda.testing.ledger
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
@@ -52,48 +51,42 @@ class IssuerFlowTest {
 
     @After
     fun cleanUp() {
-        mockNet.stopNodes()
+        // mockNet.stopNodes()
     }
 
     @Test
     fun `test issuer flow`() {
-        ledger {
-            // using default IssueTo Party Reference
-            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, 1000000.DOLLARS,
-                    bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
-            assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
+        // using default IssueTo Party Reference
+        val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, 1000000.DOLLARS,
+                bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
+        assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
 
-            // try to issue an amount of a restricted currency
-            assertFailsWith<FlowException> {
-                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(100000L, currency("BRL")),
-                        bankClientNode.info.legalIdentity, OpaqueBytes.of(123)).issueRequestResult.getOrThrow()
-            }
+        // try to issue an amount of a restricted currency
+        assertFailsWith<FlowException> {
+            runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(100000L, currency("BRL")),
+                    bankClientNode.info.legalIdentity, OpaqueBytes.of(123)).issueRequestResult.getOrThrow()
         }
     }
 
     @Test
     fun `test issue flow to self`() {
-        ledger {
-            // using default IssueTo Party Reference
-            val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankOfCordaNode, 1000000.DOLLARS,
-                    bankOfCordaNode.info.legalIdentity, OpaqueBytes.of(123))
-            assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
-        }
+        // using default IssueTo Party Reference
+        val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankOfCordaNode, 1000000.DOLLARS,
+                bankOfCordaNode.info.legalIdentity, OpaqueBytes.of(123))
+        assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
     }
 
     @Test
     fun `test concurrent issuer flow`() {
-        ledger {
-            // this test exercises the Cashflow issue and move subflows to ensure consistent spending of issued states
-            val amount = 10000.DOLLARS
-            val amounts = calculateRandomlySizedAmounts(10000.DOLLARS, 10, 10, Random())
-            val handles = amounts.map { pennies ->
-                runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(pennies, amount.token),
-                        bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
-            }
-            handles.forEach {
-                require(it.issueRequestResult.get() is SignedTransaction)
-            }
+        // this test exercises the Cashflow issue and move subflows to ensure consistent spending of issued states
+        val amount = 10000.DOLLARS
+        val amounts = calculateRandomlySizedAmounts(10000.DOLLARS, 10, 10, Random())
+        val handles = amounts.map { pennies ->
+            runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(pennies, amount.token),
+                    bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
+        }
+        handles.forEach {
+            require(it.issueRequestResult.get() is SignedTransaction)
         }
     }
 

--- a/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
+++ b/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.currency
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowStateMachine
+import net.corda.core.flows.TxKeyFlow
 import net.corda.core.getOrThrow
 import net.corda.core.identity.Party
 import net.corda.core.map
@@ -18,8 +19,11 @@ import net.corda.flows.IssuerFlow.IssuanceRequester
 import net.corda.testing.BOC
 import net.corda.testing.MEGA_CORP
 import net.corda.testing.ledger
+import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import rx.Observable
 import java.util.*
@@ -27,19 +31,33 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class IssuerFlowTest {
-    lateinit var mockNet: MockNetwork
+    var mockNet: MockNetwork = MockNetwork(servicePeerAllocationStrategy = RoundRobin())
     lateinit var notaryNode: MockNode
     lateinit var bankOfCordaNode: MockNode
     lateinit var bankClientNode: MockNode
 
+    @Before
+    fun start() {
+        notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
+        bankOfCordaNode = mockNet.createPartyNode(notaryNode.info.address, BOC.name)
+        bankClientNode = mockNet.createPartyNode(notaryNode.info.address, MEGA_CORP.name)
+        val nodes = listOf(notaryNode, bankOfCordaNode, bankClientNode)
+        nodes.forEach { node ->
+            nodes.map { it.info.legalIdentityAndCert }.forEach(node.services.identityService::registerIdentity)
+            node.registerInitiatedFlow(TxKeyFlow.Provider::class.java)
+        }
+
+        mockNet.runNetwork()
+    }
+
+    @After
+    fun cleanUp() {
+        mockNet.stopNodes()
+    }
+
     @Test
     fun `test issuer flow`() {
-        mockNet = MockNetwork(false, true)
         ledger {
-            notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
-            bankOfCordaNode = mockNet.createPartyNode(notaryNode.info.address, BOC.name)
-            bankClientNode = mockNet.createPartyNode(notaryNode.info.address, MEGA_CORP.name)
-
             // using default IssueTo Party Reference
             val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, 1000000.DOLLARS,
                     bankClientNode.info.legalIdentity, OpaqueBytes.of(123))
@@ -50,36 +68,22 @@ class IssuerFlowTest {
                 runIssuerAndIssueRequester(bankOfCordaNode, bankClientNode, Amount(100000L, currency("BRL")),
                         bankClientNode.info.legalIdentity, OpaqueBytes.of(123)).issueRequestResult.getOrThrow()
             }
-
-            bankOfCordaNode.stop()
-            bankClientNode.stop()
         }
     }
 
     @Test
     fun `test issue flow to self`() {
-        mockNet = MockNetwork(false, true)
         ledger {
-            notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
-            bankOfCordaNode = mockNet.createPartyNode(notaryNode.info.address, BOC.name)
-
             // using default IssueTo Party Reference
             val (issuer, issuerResult) = runIssuerAndIssueRequester(bankOfCordaNode, bankOfCordaNode, 1000000.DOLLARS,
                     bankOfCordaNode.info.legalIdentity, OpaqueBytes.of(123))
             assertEquals(issuerResult.get(), issuer.get().resultFuture.get())
-
-            bankOfCordaNode.stop()
         }
     }
 
     @Test
     fun `test concurrent issuer flow`() {
-        mockNet = MockNetwork(false, true)
         ledger {
-            notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
-            bankOfCordaNode = mockNet.createPartyNode(notaryNode.info.address, BOC.name)
-            bankClientNode = mockNet.createPartyNode(notaryNode.info.address, MEGA_CORP.name)
-
             // this test exercises the Cashflow issue and move subflows to ensure consistent spending of issued states
             val amount = 10000.DOLLARS
             val amounts = calculateRandomlySizedAmounts(10000.DOLLARS, 10, 10, Random())
@@ -90,9 +94,6 @@ class IssuerFlowTest {
             handles.forEach {
                 require(it.issueRequestResult.get() is SignedTransaction)
             }
-
-            bankOfCordaNode.stop()
-            bankClientNode.stop()
         }
     }
 


### PR DESCRIPTION
Clean up cash tests ahead of anonymisation work. This simplifies some boiler plate setup/teardown
and ensures idenities and flows are correctly registered.