### PR TITLE
Remove verifier from test-utils because it's unused.

### DIFF
--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile project(':client:jfx')
     compile project(':node')
     testCompile project(':test-utils')
+    testCompile project(':verifier')
 
     compile "org.graphstream:gs-core:1.3"
     compile("org.graphstream:gs-ui:1.3") {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     compile project(':core')
     compile project(':node')
     compile project(':webserver')
-    compile project(':verifier')
     compile project(':client:mock')
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"


### PR DESCRIPTION
The verifier is a standalone "fat" jar, so we don't want other projects to depend upon it transitively.