### PR TITLE
Disable occasionally-failing test until we upgrade Artemis

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -218,11 +218,24 @@ class RPCStabilityTests {
 
     @Test
     fun `client reconnects to rebooted server`() {
-        // With Artemis 1.5.3 this test fails maybe 1 in 100 times and retrying doesn't work, so disable until we upgrade:
-        if (ArtemisConstants::class.java.`package`.implementationVersion == "1.5.3") return
-        // Once we've upgraded make the test fail reliably, in the Artemis 2.1.0 case that takes 25 trials:
-        val trials = 25
         // TODO: Remove multiple trials when we fix the Artemis bug (which should have its own test(s)).
+        if (ArtemisConstants::class.java.`package`.implementationVersion == "1.5.3") {
+            // The test fails maybe 1 in 100 times, so to stay green until we upgrade Artemis, retry if it fails:
+            while (true) {
+                try {
+                    `client reconnects to rebooted server`(1)
+                } catch (e: TimeoutException) {
+                    continue
+                }
+                break
+            }
+        } else {
+            // We've upgraded Artemis so make the test fail reliably, in the 2.1.0 case that takes 25 trials:
+            `client reconnects to rebooted server`(25)
+        }
+    }
+
+    private fun `client reconnects to rebooted server`(trials: Int) {
         rpcDriver {
             val coreBurner = thread {
                 while (!Thread.interrupted()) {

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -218,10 +218,11 @@ class RPCStabilityTests {
 
     @Test
     fun `client reconnects to rebooted server`() {
-        // Artemis 2.1.0 has a bug that makes this test fail, and 25 trials are needed to make it fail reliably.
-        // In the success case 25 trials take 2 minutes, so I've disabled them for the known-good Artemis version.
+        // With Artemis 1.5.3 this test fails maybe 1 in 100 times and retrying doesn't work, so disable until we upgrade:
+        if (ArtemisConstants::class.java.`package`.implementationVersion == "1.5.3") return
+        // Once we've upgraded make the test fail reliably, in the Artemis 2.1.0 case that takes 25 trials:
+        val trials = 25
         // TODO: Remove multiple trials when we fix the Artemis bug (which should have its own test(s)).
-        val trials = if (ArtemisConstants::class.java.`package`.implementationVersion == "1.5.3") 1 else 25
         rpcDriver {
             val coreBurner = thread {
                 while (!Thread.interrupted()) {

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -29,7 +29,7 @@ import java.time.Duration
 import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
-
+import kotlin.test.fail
 
 class RPCStabilityTests {
 
@@ -221,14 +221,15 @@ class RPCStabilityTests {
         // TODO: Remove multiple trials when we fix the Artemis bug (which should have its own test(s)).
         if (ArtemisConstants::class.java.`package`.implementationVersion == "1.5.3") {
             // The test fails maybe 1 in 100 times, so to stay green until we upgrade Artemis, retry if it fails:
-            while (true) {
+            for (i in (1..3)) {
                 try {
                     `client reconnects to rebooted server`(1)
                 } catch (e: TimeoutException) {
                     continue
                 }
-                break
+                return
             }
+            fail("Test failed 3 times, which is vanishingly unlikely unless something has changed.")
         } else {
             // We've upgraded Artemis so make the test fail reliably, in the 2.1.0 case that takes 25 trials:
             `client reconnects to rebooted server`(25)


### PR DESCRIPTION
Background:
* Test failed frequently after Artemis upgrade
* So we downgraded Artemis, and made the test impl depend on Artemis version
* But now I've noticed the test also fails occasionally with current Artemis
* This PR defers the problem until we upgrade Artemis
* There is indeed a bug in Artemis, Andrius has reproduced it and reported it to them
