### PR TITLE
Removed duplicate identity attribute (parties) from DealState.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -276,21 +276,6 @@ interface DealState : LinearState {
     val ref: String
 
     /**
-     * Exposes the Parties involved in a generic way.
-     *
-     * Appears to duplicate [participants] a property of [ContractState]. However [participants] only holds public keys.
-     * Currently we need to hard code Party objects into [ContractState]s. [Party] objects are a wrapper for public
-     * keys which also contain some identity information about the public key owner. You can keep track of individual
-     * parties by adding a property for each one to the state, or you can append parties to the [parties] list if you
-     * are implementing [DealState]. We need to do this as identity management in Corda is currently incomplete,
-     * therefore the only way to record identity information is in the [ContractState]s themselves. When identity
-     * management is completed, parties to a transaction will only record public keys in the [DealState] and through a
-     * separate process exchange certificates to ascertain identities. Thus decoupling identities from
-     * [ContractState]s.
-     * */
-    val parties: List<AbstractParty>
-
-    /**
      * Generate a partial transaction representing an agreement (command) to this deal, allowing a general
      * deal/agreement flow to generate the necessary transaction for potential implementations.
      *

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -366,7 +366,7 @@ inline fun <reified T : LinearState> VaultService.linearHeadsOfType() =
 // TODO: Remove this from the interface
 // @Deprecated("This function will be removed in a future milestone", ReplaceWith("queryBy(LinearStateQueryCriteria(dealPartyName = listOf(<String>)))"))
 inline fun <reified T : DealState> VaultService.dealsWith(party: AbstractParty) = linearHeadsOfType<T>().values.filter {
-    it.state.data.parties.any { it == party }
+    it.state.data.participants.any { it == party }
 }
 
 class StatesNotAvailableException(override val message: String?, override val cause: Throwable? = null) : FlowException(message, cause) {

--- a/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
@@ -186,7 +186,7 @@ object TwoPartyDealFlow {
             // And add a request for a time-window: it may be that none of the contracts need this!
             // But it can't hurt to have one.
             ptx.addTimeWindow(serviceHub.clock.instant(), 30.seconds)
-            return Pair(ptx, arrayListOf(deal.parties.single { it == serviceHub.myInfo.legalIdentity as AbstractParty }.owningKey))
+            return Pair(ptx, arrayListOf(deal.participants.single { it == serviceHub.myInfo.legalIdentity as AbstractParty }.owningKey))
         }
     }
 }

--- a/finance/src/main/kotlin/net/corda/contracts/testing/DummyDealContract.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/testing/DummyDealContract.kt
@@ -20,8 +20,7 @@ class DummyDealContract : Contract {
             override val contract: Contract = DummyDealContract(),
             override val participants: List<AbstractParty> = listOf(),
             override val linearId: UniqueIdentifier = UniqueIdentifier(),
-            override val ref: String,
-            override val parties: List<AnonymousParty> = listOf()) : DealState {
+            override val ref: String) : DealState {
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
             return participants.any { it.owningKey.containsAny(ourKeys) }
         }

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
@@ -667,14 +667,11 @@ class InterestRateSwap : Contract {
         override val ref = common.tradeID
 
         override val participants: List<AbstractParty>
-            get() = parties
+            get() = listOf(fixedLeg.fixedRatePayer, floatingLeg.floatingRatePayer)
 
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
             return fixedLeg.fixedRatePayer.owningKey.containsAny(ourKeys) || floatingLeg.floatingRatePayer.owningKey.containsAny(ourKeys)
         }
-
-        override val parties: List<AbstractParty>
-            get() = listOf(fixedLeg.fixedRatePayer, floatingLeg.floatingRatePayer)
 
         override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
             val nextFixingOf = nextFixingOf() ?: return null

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
@@ -50,7 +50,7 @@ object AutoOfferFlow {
             require(serviceHub.networkMapCache.notaryNodes.isNotEmpty()) { "No notary nodes registered" }
             val notary = serviceHub.networkMapCache.notaryNodes.first().notaryIdentity
             // need to pick which ever party is not us
-            val otherParty = notUs(dealToBeOffered.parties).map { serviceHub.identityService.partyFromAnonymous(it) }.requireNoNulls().single()
+            val otherParty = notUs(dealToBeOffered.participants).map { serviceHub.identityService.partyFromAnonymous(it) }.requireNoNulls().single()
             progressTracker.currentStep = DEALING
             val myKey = serviceHub.legalIdentityKey
             val instigator = Instigator(

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -44,7 +44,7 @@ object FixingFlow {
             // validate the party that initiated is the one on the deal and that the recipient corresponds with it.
             // TODO: this is in no way secure and will be replaced by general session initiation logic in the future
             // Also check we are one of the parties
-            require(deal.parties.count { it.owningKey == serviceHub.myInfo.legalIdentity.owningKey } == 1)
+            require(deal.participants.count { it.owningKey == serviceHub.myInfo.legalIdentity.owningKey } == 1)
 
             return handshake
         }
@@ -55,7 +55,7 @@ object FixingFlow {
             val fixOf = deal.nextFixingOf()!!
 
             // TODO Do we need/want to substitute in new public keys for the Parties?
-            val myOldParty = deal.parties.single { it.owningKey == serviceHub.myInfo.legalIdentity.owningKey }
+            val myOldParty = deal.participants.single { it.owningKey == serviceHub.myInfo.legalIdentity.owningKey }
 
             val newDeal = deal
 
@@ -107,7 +107,7 @@ object FixingFlow {
         }
 
         override val myKey: PublicKey get() {
-            dealToFix.state.data.parties.single { it.owningKey == serviceHub.myInfo.legalIdentity.owningKey }
+            dealToFix.state.data.participants.single { it.owningKey == serviceHub.myInfo.legalIdentity.owningKey }
             return serviceHub.legalIdentityKey
         }
 
@@ -148,7 +148,7 @@ object FixingFlow {
             progressTracker.nextStep()
             val dealToFix = serviceHub.loadState(ref)
             val fixableDeal = (dealToFix.data as FixableDealState)
-            val parties = fixableDeal.parties.sortedBy { it.owningKey.toBase58String() }
+            val parties = fixableDeal.participants.sortedBy { it.owningKey.toBase58String() }
             val myKey = serviceHub.myInfo.legalIdentity.owningKey
             if (parties[0].owningKey == myKey) {
                 val fixing = FixingSession(ref, fixableDeal.oracleType)

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/api/PortfolioApi.kt
@@ -42,7 +42,7 @@ class PortfolioApi(val rpc: CordaRPCOps) {
     private inline fun <reified T : DealState> dealsWith(party: AbstractParty): List<StateAndRef<T>> {
         val (vault, vaultUpdates) = rpc.vaultAndUpdates()
         vaultUpdates.notUsed()
-        return vault.filterStatesOfType<T>().filter { it.state.data.parties.any { it == party } }
+        return vault.filterStatesOfType<T>().filter { it.state.data.participants.any { it == party } }
     }
 
     /**

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
@@ -21,17 +21,14 @@ data class IRSState(val swap: SwapData,
                     override val contract: OGTrade,
                     override val linearId: UniqueIdentifier = UniqueIdentifier(swap.id.first + swap.id.second)) : DealState {
     override val ref: String = linearId.externalId!! // Same as the constructor for UniqueIdentified
-    override val parties: List<AbstractParty> get() = listOf(buyer, seller)
+    override val participants: List<AbstractParty> get() = listOf(buyer, seller)
 
     override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-        return parties.flatMap { it.owningKey.keys }.intersect(ourKeys).isNotEmpty()
+        return participants.flatMap { it.owningKey.keys }.intersect(ourKeys).isNotEmpty()
     }
 
     override fun generateAgreement(notary: Party): TransactionBuilder {
         val state = IRSState(swap, buyer, seller, OGTrade())
-        return TransactionType.General.Builder(notary).withItems(state, Command(OGTrade.Commands.Agree(), parties.map { it.owningKey }))
+        return TransactionType.General.Builder(notary).withItems(state, Command(OGTrade.Commands.Agree(), participants.map { it.owningKey }))
     }
-
-    override val participants: List<AbstractParty>
-        get() = parties
 }

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/OGTrade.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/OGTrade.kt
@@ -45,8 +45,8 @@ data class OGTrade(override val legalContractReference: SecureHash = SecureHash.
                 require(inputs.size == 0) { "Inputs must be empty" }
                 require(outputs.size == 1) { "" }
                 require(outputs[0].buyer != outputs[0].seller)
-                require(outputs[0].parties.containsAll(outputs[0].participants))
-                require(outputs[0].parties.containsAll(listOf(outputs[0].buyer, outputs[0].seller)))
+                require(outputs[0].participants.containsAll(outputs[0].participants))
+                require(outputs[0].participants.containsAll(listOf(outputs[0].buyer, outputs[0].seller)))
                 require(outputs[0].swap.startDate.isBefore(outputs[0].swap.endDate))
                 require(outputs[0].swap.notional > BigDecimal(0))
                 require(outputs[0].swap.tradeDate.isBefore(outputs[0].swap.endDate))

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
@@ -27,12 +27,9 @@ data class PortfolioState(val portfolio: List<StateRef>,
     @CordaSerializable
     data class Update(val portfolio: List<StateRef>? = null, val valuation: PortfolioValuation? = null)
 
-    override val parties: List<AbstractParty> get() = _parties.toList()
+    override val participants: List<AbstractParty> get() = _parties.toList()
     override val ref: String = linearId.toString()
-    val valuer: AbstractParty get() = parties[0]
-
-    override val participants: List<AbstractParty>
-        get() = parties
+    val valuer: AbstractParty get() = participants[0]
 
     override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity {
         val flow = flowLogicRefFactory.create(SimmRevaluation.Initiator::class.java, thisStateRef, LocalDate.now())
@@ -40,11 +37,11 @@ data class PortfolioState(val portfolio: List<StateRef>,
     }
 
     override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-        return parties.flatMap { it.owningKey.keys }.intersect(ourKeys).isNotEmpty()
+        return participants.flatMap { it.owningKey.keys }.intersect(ourKeys).isNotEmpty()
     }
 
     override fun generateAgreement(notary: Party): TransactionBuilder {
-        return TransactionType.General.Builder(notary).withItems(copy(), Command(PortfolioSwap.Commands.Agree(), parties.map { it.owningKey }))
+        return TransactionType.General.Builder(notary).withItems(copy(), Command(PortfolioSwap.Commands.Agree(), participants.map { it.owningKey }))
     }
 
     override fun generateRevision(notary: Party, oldState: StateAndRef<*>, updatedValue: Update): TransactionBuilder {
@@ -55,7 +52,7 @@ data class PortfolioState(val portfolio: List<StateRef>,
         val tx = TransactionType.General.Builder(notary)
         tx.addInputState(oldState)
         tx.addOutputState(copy(portfolio = portfolio, valuation = valuation))
-        tx.addCommand(PortfolioSwap.Commands.Update(), parties.map { it.owningKey })
+        tx.addCommand(PortfolioSwap.Commands.Update(), participants.map { it.owningKey })
         return tx
     }
 }

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioSwap.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioSwap.kt
@@ -70,8 +70,7 @@ data class PortfolioSwap(override val legalContractReference: SecureHash = Secur
                 requireThat {
                     "there are no inputs" using (inputs.size == 0)
                     "there is one output" using (outputs.size == 1)
-                    "valuer must be a party" using (outputs[0].parties.contains(outputs[0].valuer))
-                    "all participants must be parties" using (outputs[0].parties.containsAll(outputs[0].participants))
+                    "valuer must be a party" using (outputs[0].participants.contains(outputs[0].valuer))
                 }
 
                 return setOf(command.value)

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt
@@ -22,8 +22,8 @@ object SimmRevaluation {
             val stateAndRef = serviceHub.vaultService.linearHeadsOfType<PortfolioState>().values.first { it.ref == curStateRef }
             val curState = stateAndRef.state.data
             val myIdentity = serviceHub.myInfo.legalIdentity
-            if (myIdentity == curState.parties[0]) {
-                val otherParty = serviceHub.identityService.partyFromAnonymous(curState.parties[1])
+            if (myIdentity == curState.participants[0]) {
+                val otherParty = serviceHub.identityService.partyFromAnonymous(curState.participants[1])
                 require(otherParty != null) { "Other party must be known by this node" }
                 subFlow(SimmFlow.Requester(otherParty!!, valuationDate, stateAndRef))
             }


### PR DESCRIPTION
Removed duplicate identity attribute (parties) from DealState.
All references to 'parties' now refer to the inherited 'participants' attribute from ContractState.