### PR TITLE
Simpler Blacklist implementation for internal Kryo

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/AllButBlacklisted.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/AllButBlacklisted.kt
@@ -4,26 +4,30 @@ import sun.misc.Unsafe
 import sun.security.util.Password
 import java.io.*
 import java.lang.invoke.*
-import java.lang.reflect.*
-import java.net.*
+import java.lang.reflect.AccessibleObject
+import java.lang.reflect.Modifier
+import java.lang.reflect.Parameter
+import java.lang.reflect.ReflectPermission
+import java.net.DatagramSocket
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URLConnection
 import java.security.*
 import java.sql.Connection
-import java.util.HashMap
+import java.util.*
 import java.util.logging.Handler
 import java.util.zip.ZipFile
 import kotlin.collections.HashSet
 import kotlin.collections.LinkedHashSet
 
 /**
- * This object keeps a set of blacklisted classes and interfaces that should not be used
- * for serialisation when a flow checkpoints.
+ * This is a [ClassWhitelist] implementation where everything is whitelisted except for blacklisted classes and interfaces.
  * In practice, as flows are arbitrary code in which it is convenient to do many things,
  * we can often end up pulling in a lot of objects that do not make sense to put in a checkpoint.
- * Please note that black-listing check precedes white-listing,
- * thus even if a class/interface is whitelisted or annotated as [CordaSerializable] it won't be serialised if
- * this or any of its superclasses and/or implemented interfaces is in the blacklist.
+ * Thus, by blacklisting classes/interfaces we don't expect to be serialised, we can better handle/monitor the aforementioned behaviour.
+ * Inheritance works for blacklisted items, but one can specifically exclude classes from blacklisting as well.
  */
-object Blacklist : ClassWhitelist {
+object AllButBlacklisted : ClassWhitelist {
 
     private val blacklistedClasses = hashSetOf<String>(
 
@@ -38,10 +42,11 @@ object Blacklist : ClassWhitelist {
             ZipFile::class.java.name,
             Provider::class.java.name,
             SecurityManager::class.java.name,
+            Random::class.java.name,
 
             // known blacklisted interfaces.
             Connection::class.java.name,
-            // TODO: add AutoCloseable, but exclude (hardcode) those we may need, such as InputStream.
+            AutoCloseable::class.java.name,
 
             // java.security.
             PrivateKey::class.java.name,
@@ -56,7 +61,7 @@ object Blacklist : ClassWhitelist {
             ServerSocket::class.java.name,
             Socket::class.java.name,
             URLConnection::class.java.name,
-            // TODO: java.net more classes, interfaces and exceptions.
+            // TODO: add more from java.net.
 
             // java.io classes.
             Console::class.java.name,
@@ -66,7 +71,7 @@ object Blacklist : ClassWhitelist {
             RandomAccessFile::class.java.name,
             Reader::class.java.name,
             Writer::class.java.name,
-            // TODO: java.io more classes, interfaces and exceptions.
+            // TODO: add more from java.io.
 
             // java.lang.invoke classes.
             CallSite::class.java.name, // for all CallSites eg MutableCallSite, VolatileCallSite etc.
@@ -94,23 +99,34 @@ object Blacklist : ClassWhitelist {
             // TODO: add more from java.lang.reflect.
     )
 
+    // specifically exclude classes from the blacklist,
+    // even if any of their superclasses and/or implemented interfaces are blacklisted.
+    private val excludedClasses = hashSetOf<String>(
+            LinkedHashSet::class.java.name,
+            LinkedHashMap::class.java.name,
+            InputStream::class.java.name,
+            BufferedInputStream::class.java.name,
+            Class.forName("sun.net.www.protocol.jar.JarURLConnection\$JarURLInputStream").name
+    )
+
+    /**
+     * This implementation supports inheritance; thus, if a superclass or superinterface is blacklisted, so is the input class.
+     */
     override fun hasListed(type: Class<*>): Boolean {
-        // specifically exclude classes from the blacklist,
-        // even if any of their superclasses and/or implemented interfaces are blacklisted.
-        when (type) {
-            LinkedHashSet::class.java -> return false
-        }
+        // check if excluded.
+        if (type.name in excludedClasses)
+            return true
         // check if listed.
         if (type.name in blacklistedClasses)
-            return true
+            return false
         // inheritance check.
         else {
             val aMatch = blacklistedClasses.firstOrNull { Class.forName(it).isAssignableFrom(type) }
             if (aMatch != null) {
                 // TODO: blacklistedClasses += type.name // add it, so checking is faster next time we encounter this class.
-                return true
+                return false
             }
         }
-        return false
+        return true
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/AllButBlacklisted.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/AllButBlacklisted.kt
@@ -7,8 +7,8 @@ import java.lang.invoke.*
 import java.lang.reflect.*
 import java.net.*
 import java.security.*
-import java.util.*
 import java.sql.Connection
+import java.util.*
 import java.util.logging.Handler
 import java.util.zip.ZipFile
 import kotlin.collections.HashSet
@@ -109,13 +109,14 @@ object AllButBlacklisted : ClassWhitelist {
         if (type.name !in forciblyAllowedClasses) {
             // Check if listed.
             if (type.name in blacklistedClasses)
-                throw NotSerializableException("Class ${type.name} is blacklisted, so it cannot be used in serialization.")
+                throw IllegalStateException("Class ${type.name} is blacklisted, so it cannot be used in serialization.")
             // Inheritance check.
             else {
                 val aMatch = blacklistedClasses.firstOrNull { Class.forName(it).isAssignableFrom(type) }
                 if (aMatch != null) {
                     // TODO: blacklistedClasses += type.name // add it, so checking is faster next time we encounter this class.
-                    throw NotSerializableException("A superclass or (super)interface of ${type.name} is blacklisted, so it cannot be used in serialization.")
+                    val matchType = if (Class.forName(aMatch).isInterface) "superinterface" else "superclass"
+                    throw IllegalStateException("The $matchType $aMatch of ${type.name} is blacklisted, so it cannot be used in serialization.")
                 }
             }
         }

--- a/core/src/main/kotlin/net/corda/core/serialization/Blacklist.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Blacklist.kt
@@ -1,0 +1,92 @@
+package net.corda.core.serialization
+
+import java.io.*
+import java.lang.invoke.*
+import java.net.DatagramSocket
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URLConnection
+import java.sql.Connection
+import java.util.logging.Handler
+
+/**
+ * This object keeps a set of blacklisted classes and interfaces that should not be used
+ * for serialisation when a flow checkpoints.
+ * In practice, as flows are arbitrary code in which it is convenient to do many things,
+ * we can often end up pulling in a lot of objects that do not make sense to put in a checkpoint.
+ * Please note that black-listing check precedes white-listing,
+ * thus even if a class/interface is whitelisted or annotated as [CordaSerializable] it won't be serialised if
+ * this or any of its superclasses and/or implemented interfaces is in the blacklist.
+ */
+object Blacklist : ClassWhitelist {
+
+    private val blacklistedClasses = hashSetOf<String>(
+
+            // known blacklisted classes
+            Thread::class.java.name,
+            HashSet::class.java.name,
+            ClassLoader::class.java.name,
+            Handler::class.java.name, // MemoryHandler, StreamHandler
+
+            // known blacklisted interfaces
+            Connection::class.java.name,
+            // TODO: add AutoCloseable, but exclude (hardcode) those we may need, such as InputStream.
+
+            // java.net classes.
+            DatagramSocket::class.java.name,
+            ServerSocket::class.java.name,
+            Socket::class.java.name,
+            URLConnection::class.java.name,
+            // TODO: java.net more classes, interfaces and exceptions.
+
+            // java.io classes.
+            Console::class.java.name,
+            File::class.java.name,
+            FileDescriptor::class.java.name,
+            FilePermission::class.java.name,
+            RandomAccessFile::class.java.name,
+            Reader::class.java.name,
+            Writer::class.java.name,
+            // TODO: java.io more classes, interfaces and exceptions.
+
+            // java.lang.invoke classes.
+            CallSite::class.java.name, // for all CallSites eg MutableCallSite, VolatileCallSite etc.
+            LambdaMetafactory::class.java.name,
+            MethodHandle::class.java.name,
+            MethodHandleProxies::class.java.name,
+            MethodHandles::class.java.name,
+            MethodHandles.Lookup::class.java.name,
+            MethodType::class.java.name,
+            SerializedLambda::class.java.name,
+            SwitchPoint::class.java.name,
+
+            // java.lang.invoke package interfaces.
+            MethodHandleInfo::class.java.name,
+
+            // java.lang.invoke package exceptions.
+            LambdaConversionException::class.java.name,
+            WrongMethodTypeException::class.java.name
+
+            // TODO: add java.lang.reflect.
+    )
+
+    override fun hasListed(type: Class<*>): Boolean {
+        // specifically exclude classes from the blacklist,
+        // even if any of their superclasses and/or implemented interfaces are blacklisted.
+        when (type) {
+            LinkedHashSet::class.java -> return false
+        }
+        // check if listed.
+        if (type.name in blacklistedClasses)
+            return true
+        // inheritance check.
+        else {
+            val aMatch = blacklistedClasses.firstOrNull { Class.forName(it).isAssignableFrom(type) }
+            if (aMatch != null) {
+                // TODO: blacklistedClasses += type.name -- add it, so checking is faster next time we encounter this class.
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/Blacklist.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Blacklist.kt
@@ -1,5 +1,6 @@
 package net.corda.core.serialization
 
+import sun.misc.Unsafe
 import sun.security.util.Password
 import java.io.*
 import java.lang.invoke.*
@@ -9,6 +10,7 @@ import java.security.*
 import java.sql.Connection
 import java.util.HashMap
 import java.util.logging.Handler
+import java.util.zip.ZipFile
 import kotlin.collections.HashSet
 import kotlin.collections.LinkedHashSet
 
@@ -31,6 +33,11 @@ object Blacklist : ClassWhitelist {
             HashMap::class.java.name,
             ClassLoader::class.java.name,
             Handler::class.java.name, // MemoryHandler, StreamHandler
+            Runtime::class.java.name,
+            Unsafe::class.java.name,
+            ZipFile::class.java.name,
+            Provider::class.java.name,
+            SecurityManager::class.java.name,
 
             // known blacklisted interfaces.
             Connection::class.java.name,
@@ -41,6 +48,8 @@ object Blacklist : ClassWhitelist {
             KeyPair::class.java.name,
             KeyStore::class.java.name,
             Password::class.java.name,
+            AccessController::class.java.name,
+            Permission::class.java.name,
 
             // java.net classes.
             DatagramSocket::class.java.name,

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -25,6 +25,10 @@ fun makeNoWhitelistClassResolver(): ClassResolver {
     return CordaClassResolver(AllWhitelist)
 }
 
+fun makeAllButBlacklistedClassResolver(): ClassResolver {
+    return CordaClassResolver(AllButBlacklisted)
+}
+
 class CordaClassResolver(val whitelist: ClassWhitelist) : DefaultClassResolver() {
     /** Returns the registration for the specified class, or null if the class is not registered.  */
     override fun getRegistration(type: Class<*>): Registration? {
@@ -57,6 +61,7 @@ class CordaClassResolver(val whitelist: ClassWhitelist) : DefaultClassResolver()
         // It's safe to have the Class already, since Kryo loads it with initialisation off.
         val hasAnnotation = checkForAnnotation(type)
         if (!hasAnnotation && !whitelist.hasListed(type)) {
+            // TODO: show another message if the class is blacklisted.
             throw KryoException("Class ${Util.className(type)} is not annotated or on the whitelist, so cannot be used in serialization")
         }
         return null

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -59,9 +59,9 @@ class CordaClassResolver(val whitelist: ClassWhitelist) : DefaultClassResolver()
             return checkClass(type.superclass)
         }
         // It's safe to have the Class already, since Kryo loads it with initialisation off.
-        val hasAnnotation = checkForAnnotation(type)
-        if (!hasAnnotation && !whitelist.hasListed(type)) {
-            // TODO: show another message if the class is blacklisted.
+        // If we use a whitelist with blacklisting capabilities, whitelist.hasListed(type) may throw a NotSerializableException if input class is blacklisted.
+        // Thus, blacklisting precedes annotation checking.
+        if (!whitelist.hasListed(type) && !checkForAnnotation(type)) {
             throw KryoException("Class ${Util.className(type)} is not annotated or on the whitelist, so cannot be used in serialization")
         }
         return null

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -33,7 +33,6 @@ import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.cert.CertPath
 import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
 import java.security.spec.InvalidKeySpecException
 import java.time.Instant
 import java.util.*
@@ -460,7 +459,7 @@ object KotlinObjectSerializer : Serializer<DeserializeAsKotlinObjectDef>() {
 }
 
 // No ClassResolver only constructor.  MapReferenceResolver is the default as used by Kryo in other constructors.
-private val internalKryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeNoWhitelistClassResolver())) }.build()
+private val internalKryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeAllButBlacklistedClassResolver())) }.build()
 private val kryoPool = KryoPool.Builder { DefaultKryoCustomizer.customize(CordaKryo(makeStandardClassResolver())) }.build()
 
 // No ClassResolver only constructor.  MapReferenceResolver is the default as used by Kryo in other constructors.

--- a/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
@@ -8,7 +8,12 @@ import net.corda.core.node.AttachmentClassLoaderTests
 import net.corda.core.node.AttachmentsClassLoader
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.testing.node.MockAttachmentStorage
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
+import java.io.NotSerializableException
+import java.sql.Connection
+import java.util.*
 
 @CordaSerializable
 enum class Foo {
@@ -159,5 +164,77 @@ class CordaClassResolverTests {
         CordaClassResolver(EmptyWhitelist).getRegistration(SubElement::class.java)
         CordaClassResolver(EmptyWhitelist).getRegistration(SubSubElement::class.java)
         CordaClassResolver(EmptyWhitelist).getRegistration(SerializableViaSuperSubInterface::class.java)
+    }
+
+    // Blacklist tests.
+    @get:Rule
+    val expectedEx = ExpectedException.none()
+
+    @Test
+    fun `Check blacklisted class`() {
+        expectedEx.expect(NotSerializableException::class.java)
+        expectedEx.expectMessage("Class java.util.HashSet is blacklisted, so it cannot be used in serialization.")
+        val resolver = CordaClassResolver(AllButBlacklisted)
+        // HashSet is blacklisted.
+        resolver.getRegistration(HashSet::class.java)
+    }
+
+    open class SubHashSet<E> : HashSet<E>()
+    @Test
+    fun `Check blacklisted subclass`() {
+        expectedEx.expect(NotSerializableException::class.java)
+        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$SubHashSet is blacklisted, so it cannot be used in serialization.")
+        val resolver = CordaClassResolver(AllButBlacklisted)
+        // SubHashSet extends the blacklisted HashSet.
+        resolver.getRegistration(SubHashSet::class.java)
+    }
+
+    class SubSubHashSet<E> : SubHashSet<E>()
+    @Test
+    fun `Check blacklisted subsubclass`() {
+        expectedEx.expect(NotSerializableException::class.java)
+        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$SubSubHashSet is blacklisted, so it cannot be used in serialization.")
+        val resolver = CordaClassResolver(AllButBlacklisted)
+        // SubSubHashSet extends SubHashSet, which extends the blacklisted HashSet.
+        resolver.getRegistration(SubSubHashSet::class.java)
+    }
+
+    class ConnectionImpl(val connection: Connection) : Connection by connection
+    @Test
+    fun `Check blacklisted interface impl`() {
+        expectedEx.expect(NotSerializableException::class.java)
+        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$ConnectionImpl is blacklisted, so it cannot be used in serialization.")
+        val resolver = CordaClassResolver(AllButBlacklisted)
+        // ConnectionImpl implements blacklisted Connection.
+        resolver.getRegistration(ConnectionImpl::class.java)
+    }
+
+    interface SubConnection : Connection
+    class SubConnectionImpl(val subConnection: SubConnection) : SubConnection by subConnection
+    @Test
+    fun `Check blacklisted super-interface impl`() {
+        expectedEx.expect(NotSerializableException::class.java)
+        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$SubConnectionImpl is blacklisted, so it cannot be used in serialization.")
+        val resolver = CordaClassResolver(AllButBlacklisted)
+        // SubConnectionImpl implements SubConnection, which extends the blacklisted Connection.
+        resolver.getRegistration(SubConnectionImpl::class.java)
+    }
+
+    @Test
+    fun `Check forcibly allowed`() {
+        val resolver = CordaClassResolver(AllButBlacklisted)
+        // LinkedHashSet is allowed for serialization.
+        resolver.getRegistration(LinkedHashSet::class.java)
+    }
+
+    @CordaSerializable
+    class CordaSerializableHashSet<E> : HashSet<E>()
+    @Test
+    fun `Check blacklist precedes CordaSerializable`() {
+        expectedEx.expect(NotSerializableException::class.java)
+        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$CordaSerializableHashSet is blacklisted, so it cannot be used in serialization.")
+        val resolver = CordaClassResolver(AllButBlacklisted)
+        // CordaSerializableHashSet is @CordaSerializable, but extends the blacklisted HashSet.
+        resolver.getRegistration(CordaSerializableHashSet::class.java)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
@@ -11,7 +11,7 @@ import net.corda.testing.node.MockAttachmentStorage
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
-import java.io.NotSerializableException
+import java.lang.IllegalStateException
 import java.sql.Connection
 import java.util.*
 
@@ -168,11 +168,11 @@ class CordaClassResolverTests {
 
     // Blacklist tests.
     @get:Rule
-    val expectedEx = ExpectedException.none()
+    val expectedEx = ExpectedException.none()!!
 
     @Test
     fun `Check blacklisted class`() {
-        expectedEx.expect(NotSerializableException::class.java)
+        expectedEx.expect(IllegalStateException::class.java)
         expectedEx.expectMessage("Class java.util.HashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(AllButBlacklisted)
         // HashSet is blacklisted.
@@ -182,8 +182,8 @@ class CordaClassResolverTests {
     open class SubHashSet<E> : HashSet<E>()
     @Test
     fun `Check blacklisted subclass`() {
-        expectedEx.expect(NotSerializableException::class.java)
-        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$SubHashSet is blacklisted, so it cannot be used in serialization.")
+        expectedEx.expect(IllegalStateException::class.java)
+        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.core.serialization.CordaClassResolverTests\$SubHashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(AllButBlacklisted)
         // SubHashSet extends the blacklisted HashSet.
         resolver.getRegistration(SubHashSet::class.java)
@@ -192,8 +192,8 @@ class CordaClassResolverTests {
     class SubSubHashSet<E> : SubHashSet<E>()
     @Test
     fun `Check blacklisted subsubclass`() {
-        expectedEx.expect(NotSerializableException::class.java)
-        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$SubSubHashSet is blacklisted, so it cannot be used in serialization.")
+        expectedEx.expect(IllegalStateException::class.java)
+        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.core.serialization.CordaClassResolverTests\$SubSubHashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(AllButBlacklisted)
         // SubSubHashSet extends SubHashSet, which extends the blacklisted HashSet.
         resolver.getRegistration(SubSubHashSet::class.java)
@@ -202,8 +202,8 @@ class CordaClassResolverTests {
     class ConnectionImpl(val connection: Connection) : Connection by connection
     @Test
     fun `Check blacklisted interface impl`() {
-        expectedEx.expect(NotSerializableException::class.java)
-        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$ConnectionImpl is blacklisted, so it cannot be used in serialization.")
+        expectedEx.expect(IllegalStateException::class.java)
+        expectedEx.expectMessage("The superinterface java.sql.Connection of net.corda.core.serialization.CordaClassResolverTests\$ConnectionImpl is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(AllButBlacklisted)
         // ConnectionImpl implements blacklisted Connection.
         resolver.getRegistration(ConnectionImpl::class.java)
@@ -213,8 +213,8 @@ class CordaClassResolverTests {
     class SubConnectionImpl(val subConnection: SubConnection) : SubConnection by subConnection
     @Test
     fun `Check blacklisted super-interface impl`() {
-        expectedEx.expect(NotSerializableException::class.java)
-        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$SubConnectionImpl is blacklisted, so it cannot be used in serialization.")
+        expectedEx.expect(IllegalStateException::class.java)
+        expectedEx.expectMessage("The superinterface java.sql.Connection of net.corda.core.serialization.CordaClassResolverTests\$SubConnectionImpl is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(AllButBlacklisted)
         // SubConnectionImpl implements SubConnection, which extends the blacklisted Connection.
         resolver.getRegistration(SubConnectionImpl::class.java)
@@ -231,8 +231,8 @@ class CordaClassResolverTests {
     class CordaSerializableHashSet<E> : HashSet<E>()
     @Test
     fun `Check blacklist precedes CordaSerializable`() {
-        expectedEx.expect(NotSerializableException::class.java)
-        expectedEx.expectMessage("A superclass or (super)interface of net.corda.core.serialization.CordaClassResolverTests\$CordaSerializableHashSet is blacklisted, so it cannot be used in serialization.")
+        expectedEx.expect(IllegalStateException::class.java)
+        expectedEx.expectMessage("The superclass java.util.HashSet of net.corda.core.serialization.CordaClassResolverTests\$CordaSerializableHashSet is blacklisted, so it cannot be used in serialization.")
         val resolver = CordaClassResolver(AllButBlacklisted)
         // CordaSerializableHashSet is @CordaSerializable, but extends the blacklisted HashSet.
         resolver.getRegistration(CordaSerializableHashSet::class.java)


### PR DESCRIPTION
This is a simpler model than [#784](https://github.com/corda/corda/pull/784), where we use an `AllButBlacklisted `implementation of `ClassWhitelist`.

- `AllButBlacklisted` is a singleton `ClassWhitelist` object that includes a hashset of blacklisted classes and interfaces. Thus, in practice everything still behaves like a whitelist.
- KryoStorage uses the above whitelist
- Inheritance is supported.
- there is an extra `forciblyAllowedClasses` hashset, in which we specifically exclude classes from being blacklisted, even if one or more of their super-classes or super-interfaces are blacklisted. `LinkedHashSet` is such an example.
- hasListed(Class) throws a ~~NotSerializableException~~  IllegalStateException that informs the user if a class is blacklisted.
- due to the above, we receive a blacklist exception before checking for `@CordaSerializable` and thus, practically, blacklisting precedes annotation checking.
- there are some initial entries in both `blacklistedClasses` and `forciblyAllowedClasses`. Let's ensure we update this list regularly.