### PR TITLE
Cleanup: add an extension function to X509CertificateHolder 

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/KeyStoreUtilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/KeyStoreUtilities.kt
@@ -4,16 +4,13 @@ import net.corda.core.exists
 import net.corda.core.read
 import net.corda.core.write
 import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.path.CertPath
-import org.bouncycastle.crypto.util.PublicKeyFactory
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.file.Path
 import java.security.*
 import java.security.cert.Certificate
-import java.security.cert.X509Certificate
 
 object KeyStoreUtilities {
     val KEYSTORE_TYPE = "JKS"
@@ -80,8 +77,7 @@ object KeyStoreUtilities {
  * @param chain the sequence of certificates starting with the public key certificate for this key and extending to the root CA cert.
  */
 fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain: CertPath) {
-    val converter = JcaX509CertificateConverter()
-    addOrReplaceKey(alias, key, password, chain.certificates.map { it -> converter.getCertificate(it) }.toTypedArray<Certificate>())
+    addOrReplaceKey(alias, key, password, chain.certificates.map { it.cert }.toTypedArray<Certificate>())
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
@@ -147,9 +147,8 @@ object X509Utilities {
 
     fun validateCertificateChain(trustedRoot: X509CertificateHolder, vararg certificates: Certificate) {
         require(certificates.isNotEmpty()) { "Certificate path must contain at least one certificate" }
-        val converter = JcaX509CertificateConverter()
         val certFactory = CertificateFactory.getInstance("X509")
-        val params = PKIXParameters(setOf(TrustAnchor(converter.getCertificate(trustedRoot), null)))
+        val params = PKIXParameters(setOf(TrustAnchor(trustedRoot.cert, null)))
         params.isRevocationEnabled = false
         val certPath = certFactory.generateCertPath(certificates.toList())
         val pathValidator = CertPathValidator.getInstance("PKIX")
@@ -281,6 +280,7 @@ val X500Name.orgName: String? get() = getRDNs(BCStyle.O).firstOrNull()?.first?.v
 val X500Name.location: String get() = getRDNs(BCStyle.L).first().first.value.toString()
 val X500Name.locationOrNull: String? get() = try { location } catch (e: Exception) { null }
 val X509Certificate.subject: X500Name get() = X509CertificateHolder(encoded).subject
+val X509CertificateHolder.cert: X509Certificate get() = JcaX509CertificateConverter().getCertificate(this)
 
 class CertificateStream(val input: InputStream) {
     private val certificateFactory = CertificateFactory.getInstance("X.509")

--- a/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/X509NameConstraintsTest.kt
@@ -5,7 +5,6 @@ import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.GeneralName
 import org.bouncycastle.asn1.x509.GeneralSubtree
 import org.bouncycastle.asn1.x509.NameConstraints
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Test
 import java.security.KeyStore
@@ -17,7 +16,6 @@ import kotlin.test.assertTrue
 class X509NameConstraintsTest {
 
     private fun makeKeyStores(subjectName: X500Name, nameConstraints: NameConstraints): Pair<KeyStore, KeyStore> {
-        val converter = JcaX509CertificateConverter()
         val rootKeys = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         val rootCACert = X509Utilities.createSelfSignedCACertificate(X509Utilities.getDevX509Name("Corda Root CA"), rootKeys)
 
@@ -30,7 +28,7 @@ class X509NameConstraintsTest {
         val keyPass = "password"
         val trustStore = KeyStore.getInstance(KeyStoreUtilities.KEYSTORE_TYPE)
         trustStore.load(null, keyPass.toCharArray())
-        trustStore.addOrReplaceCertificate(X509Utilities.CORDA_ROOT_CA, converter.getCertificate(rootCACert))
+        trustStore.addOrReplaceCertificate(X509Utilities.CORDA_ROOT_CA, rootCACert.cert)
 
         val tlsKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         val tlsCert = X509Utilities.createCertificate(CertificateType.TLS, clientCACert, clientCAKeyPair, subjectName, tlsKey.public)
@@ -38,7 +36,7 @@ class X509NameConstraintsTest {
         val keyStore = KeyStore.getInstance(KeyStoreUtilities.KEYSTORE_TYPE)
         keyStore.load(null, keyPass.toCharArray())
         keyStore.addOrReplaceKey(X509Utilities.CORDA_CLIENT_TLS, tlsKey.private, keyPass.toCharArray(),
-                Stream.of(tlsCert, clientCACert, intermediateCACert, rootCACert).map(converter::getCertificate).toTypedArray<Certificate>())
+                Stream.of(tlsCert, clientCACert, intermediateCACert, rootCACert).map { it.cert }.toTypedArray<Certificate>())
         return Pair(keyStore, trustStore)
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -58,7 +58,6 @@ import net.corda.node.utilities.transaction
 import org.apache.activemq.artemis.utils.ReusableLatch
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.jetbrains.exposed.sql.Database
 import org.slf4j.Logger
 import rx.Observable
@@ -819,9 +818,8 @@ private class KeyStoreWrapper(private val storePath: Path, private val storePass
     }
 
     fun save(serviceName: X500Name, privateKeyAlias: String, keyPair: KeyPair) {
-        val converter = JcaX509CertificateConverter()
         val clientCA = keyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA, storePassword)
-        val cert = converter.getCertificate(X509Utilities.createCertificate(CertificateType.IDENTITY, clientCA.certificate, clientCA.keyPair, serviceName, keyPair.public))
+        val cert = X509Utilities.createCertificate(CertificateType.IDENTITY, clientCA.certificate, clientCA.keyPair, serviceName, keyPair.public).cert
         keyStore.addOrReplaceKey(privateKeyAlias, keyPair.private, storePassword.toCharArray(), arrayOf(cert, *keyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_CA)))
         keyStore.save(storePath, storePassword)
     }

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -6,7 +6,6 @@ import net.corda.core.crypto.X509Utilities.CORDA_CLIENT_CA
 import net.corda.core.crypto.X509Utilities.CORDA_CLIENT_TLS
 import net.corda.core.crypto.X509Utilities.CORDA_ROOT_CA
 import net.corda.node.services.config.NodeConfiguration
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.path.CertPath
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.util.io.pem.PemObject
@@ -72,13 +71,12 @@ class NetworkRegistrationHelper(val config: NodeConfiguration, val certService: 
             println("Node private key and certificate stored in ${config.nodeKeystore}.")
 
             println("Generating SSL certificate for node messaging service.")
-            val converter = JcaX509CertificateConverter()
             val sslKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
             val caCert = caKeyStore.getX509Certificate(CORDA_CLIENT_CA)
             val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, caCert.subject, sslKey.public)
             val sslKeyStore = KeyStoreUtilities.loadOrCreateKeyStore(config.sslKeystore, keystorePassword)
             sslKeyStore.addOrReplaceKey(CORDA_CLIENT_TLS, sslKey.private, privateKeyPassword.toCharArray(),
-                    arrayOf(converter.getCertificate(sslCert), *certificates))
+                    arrayOf(sslCert.cert, *certificates))
             sslKeyStore.save(config.sslKeystore, config.keyStorePassword)
             println("SSL private key and certificate stored in ${config.sslKeystore}.")
             // All done, clean up temp files.

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
@@ -10,7 +10,6 @@ import net.corda.core.utilities.ALICE
 import net.corda.testing.TestNodeConfiguration
 import net.corda.testing.getTestX509Name
 import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -31,9 +30,8 @@ class NetworkRegistrationHelperTest {
                 "CORDA_INTERMEDIATE_CA",
                 "CORDA_ROOT_CA")
                 .map { getTestX509Name(it) }
-        val converter = JcaX509CertificateConverter()
         val certs = identities.stream().map { X509Utilities.createSelfSignedCACertificate(it, Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)) }
-                .map(converter::getCertificate).toTypedArray()
+                .map { it.cert }.toTypedArray()
 
         val certService: NetworkRegistrationService = mock {
             on { submitRequest(any()) }.then { id }


### PR DESCRIPTION
... and use that instead of the verbose JcaX509CertificateConverter construct everywhere.