### PR TITLE
Rename IRS Oracle TimeWindow to TimeFrame 

### DIFF
--- a/core/src/main/kotlin/net/corda/core/utilities/TimeFrame.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TimeFrame.kt
@@ -6,7 +6,7 @@ import java.time.Instant
 /**
  * A class representing a window in time from a particular instant, lasting a specified duration.
  */
-data class TimeWindow(val start: Instant, val duration: Duration) {
+data class TimeFrame(val start: Instant, val duration: Duration) {
     val end: Instant
         get() = start + duration
 }

--- a/docs/source/event-scheduling.rst
+++ b/docs/source/event-scheduling.rst
@@ -77,7 +77,7 @@ Let's take an example of the interest rate swap fixings for our scheduled events
                                            flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
             val nextFixingOf = nextFixingOf() ?: return null
 
-            val (instant, duration) = suggestInterestRateAnnouncementTimeWindow(index = nextFixingOf.name,
+            val (instant, duration) = suggestInterestRateAnnouncementTimeFrame(index = nextFixingOf.name,
                                                                                 source = floatingLeg.indexSource,
                                                                                 date = nextFixingOf.forDay)
             return ScheduledActivity(flowLogicRefFactory.create(TwoPartyDealFlow.FixingRoleDecider::class.java,

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
@@ -12,7 +12,7 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.irs.api.NodeInterestRates
 import net.corda.irs.flows.FixingFlow
-import net.corda.irs.utilities.suggestInterestRateAnnouncementTimeWindow
+import net.corda.irs.utilities.suggestInterestRateAnnouncementTimeFrame
 import org.apache.commons.jexl3.JexlBuilder
 import org.apache.commons.jexl3.MapContext
 import java.math.BigDecimal
@@ -677,7 +677,7 @@ class InterestRateSwap : Contract {
             val nextFixingOf = nextFixingOf() ?: return null
 
             // This is perhaps not how we should determine the time point in the business day, but instead expect the schedule to detail some of these aspects
-            val instant = suggestInterestRateAnnouncementTimeWindow(index = nextFixingOf.name, source = floatingLeg.indexSource, date = nextFixingOf.forDay).start
+            val instant = suggestInterestRateAnnouncementTimeFrame(index = nextFixingOf.name, source = floatingLeg.indexSource, date = nextFixingOf.forDay).start
             return ScheduledActivity(flowLogicRefFactory.create(FixingFlow.FixingRoleDecider::class.java, thisStateRef), instant)
         }
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
@@ -13,7 +13,7 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
 import net.corda.irs.flows.RatesFixFlow.FixOutOfRange
-import net.corda.irs.utilities.suggestInterestRateAnnouncementTimeWindow
+import net.corda.irs.utilities.suggestInterestRateAnnouncementTimeFrame
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
@@ -98,7 +98,7 @@ open class RatesFixFlow(protected val tx: TransactionBuilder,
     class FixQueryFlow(val fixOf: FixOf, val oracle: Party) : FlowLogic<Fix>() {
         @Suspendable
         override fun call(): Fix {
-            val deadline = suggestInterestRateAnnouncementTimeWindow(fixOf.name, oracle.name.toString(), fixOf.forDay).end
+            val deadline = suggestInterestRateAnnouncementTimeFrame(fixOf.name, oracle.name.toString(), fixOf.forDay).end
             // TODO: add deadline to receive
             val resp = sendAndReceive<ArrayList<Fix>>(oracle, QueryRequest(listOf(fixOf), deadline))
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/utilities/OracleUtils.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/utilities/OracleUtils.kt
@@ -1,20 +1,20 @@
 package net.corda.irs.utilities
 
-import net.corda.core.utilities.TimeWindow
+import net.corda.core.utilities.TimeFrame
 import java.time.*
 
 /**
  * This whole file exists as short cuts to get demos working.  In reality we'd have static data and/or rules engine
- * defining things like this.  It currently resides in the core module because it needs to be visible to the IRS
+ * defining things like this. It currently resides in the core module because it needs to be visible to the IRS
  * contract.
  */
-// We at some future point may implement more than just this constant announcement window and thus use the params.
+// We at some future point may implement more than just this constant announcement window (time-frame) and thus use the params.
 @Suppress("UNUSED_PARAMETER")
-fun suggestInterestRateAnnouncementTimeWindow(index: String, source: String, date: LocalDate): TimeWindow {
+fun suggestInterestRateAnnouncementTimeFrame(index: String, source: String, date: LocalDate): TimeFrame {
     // TODO: we would ordinarily convert clock to same time zone as the index/source would announce in
-    //       and suggest an announcement time for the interest rate
-    // Here we apply a blanket announcement time of 11:45 London irrespective of source or index
+    //       and suggest an announcement time for the interest rate.
+    // Here we apply a blanket announcement time of 11:45 London irrespective of source or index.
     val time = LocalTime.of(11, 45)
     val zoneId = ZoneId.of("Europe/London")
-    return TimeWindow(ZonedDateTime.of(date, time, zoneId).toInstant(), Duration.ofHours(24))
+    return TimeFrame(ZonedDateTime.of(date, time, zoneId).toInstant(), Duration.ofHours(24))
 }


### PR DESCRIPTION
Required to to distinguish between this and TimeWindow (validation window) used in contracts. As they serve different purposes with contracts TimeWindow, I decided not to merge them.