### PR TITLE
Build capsules using runtime dependencies instead of compile ones.

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -23,7 +23,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').compileJava) {
     applicationClass 'net.corda.node.Corda'
     archiveName "corda-${corda_release_version}.jar"
     applicationSource = files(
-            project(':node').configurations.compile,
+            project(':node').configurations.runtime,
             project(':node').jar,
             '../build/classes/main/CordaCaplet.class',
             '../build/classes/main/CordaCaplet$1.class',

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -29,7 +29,7 @@ task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').co
     applicationClass 'net.corda.explorer.Main'
     archiveName "node-explorer-${corda_release_version}.jar"
     applicationSource = files(
-        project(':tools:explorer').configurations.compile,
+        project(':tools:explorer').configurations.runtime,
         project(':tools:explorer').jar,
         '../build/classes/main/ExplorerCaplet.class'
     )

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -23,7 +23,7 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').compileJava
     applicationClass 'net.corda.webserver.WebServer'
     archiveName "corda-webserver-${corda_release_version}.jar"
     applicationSource = files(
-            project(':webserver').configurations.compile,
+            project(':webserver').configurations.runtime,
             project(':webserver').jar,
             new File(project(':node').buildDir, 'classes/main/CordaCaplet.class'),
             new File(project(':node').buildDir, 'classes/main/CordaCaplet$1.class'),


### PR DESCRIPTION
We should really include runtime dependencies here, which should also contain the compile dependencies.