### PR TITLE
Identity certificate handling changes

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -4,11 +4,10 @@ import net.corda.core.contracts.PartyAndReference
 import net.corda.core.identity.*
 import net.corda.core.node.NodeInfo
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.X509CertificateHolder
 import java.security.InvalidAlgorithmParameterException
 import java.security.PublicKey
-import java.security.cert.CertPath
-import java.security.cert.CertificateExpiredException
-import java.security.cert.CertificateNotYetValidException
+import java.security.cert.*
 
 /**
  * An identity service maintains a directory of parties by their associated distinguished name/public keys and thus
@@ -16,15 +15,18 @@ import java.security.cert.CertificateNotYetValidException
  * identities back to the well known identity (i.e. the identity in the network map) of a party.
  */
 interface IdentityService {
+    val trustRoot: X509Certificate?
+    val trustRootHolder: X509CertificateHolder?
+
     /**
      * Verify and then store a well known identity.
      *
-     * @param party a party representing a legal entity.
+     * @param partyAndCertificate a party representing a legal entity.
      * @throws IllegalArgumentException if the certificate path is invalid, or if there is already an existing
      * certificate chain for the anonymous party.
      */
     @Throws(CertificateExpiredException::class, CertificateNotYetValidException::class, InvalidAlgorithmParameterException::class)
-    fun registerIdentity(party: PartyAndCertificate)
+    fun registerIdentity(partyAndCertificate: PartyAndCertificate)
 
     /**
      * Verify and then store an identity.

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -73,6 +73,7 @@ object DefaultKryoCustomizer {
 
             noReferencesWithin<WireTransaction>()
 
+            register(sun.security.ec.ECPublicKeyImpl::class.java, PublicKeySerializer)
             register(EdDSAPublicKey::class.java, Ed25519PublicKeySerializer)
             register(EdDSAPrivateKey::class.java, Ed25519PrivateKeySerializer)
 

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -9,6 +9,10 @@ import org.bouncycastle.asn1.x500.X500Name
 import java.math.BigInteger
 import java.security.KeyPair
 import java.security.PublicKey
+import java.security.cert.CertStore
+import java.security.cert.CertificateFactory
+import java.security.cert.CollectionCertStoreParameters
+import java.security.cert.X509Certificate
 import java.time.Instant
 
 // A dummy time at which we will be pretending test transactions are created.
@@ -70,7 +74,8 @@ val DUMMY_CA: CertificateAndKeyPair by lazy {
  * Build a test party with a nonsense certificate authority for testing purposes.
  */
 fun getTestPartyAndCertificate(name: X500Name, publicKey: PublicKey): PartyAndCertificate {
-    val cert = X509Utilities.createCertificate(CertificateType.IDENTITY, DUMMY_CA.certificate, DUMMY_CA.keyPair, name, publicKey)
-    val certPath = X509Utilities.createCertificatePath(DUMMY_CA.certificate, cert, revocationEnabled = false)
-    return PartyAndCertificate(name, publicKey, cert, certPath)
+    val certFactory = CertificateFactory.getInstance("X509")
+    val certHolder = X509Utilities.createCertificate(CertificateType.IDENTITY, DUMMY_CA.certificate, DUMMY_CA.keyPair, name, publicKey)
+    val certPath = certFactory.generateCertPath(listOf(certHolder.cert, DUMMY_CA.certificate.cert))
+    return PartyAndCertificate(name, publicKey, certHolder, certPath)
 }

--- a/core/src/main/kotlin/net/corda/flows/TxKeyFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/TxKeyFlow.kt
@@ -84,6 +84,6 @@ object TxKeyFlow {
             val identity: AnonymousParty) {
         constructor(myIdentity: Pair<X509CertificateHolder, CertPath>) : this(myIdentity.second,
                 myIdentity.first,
-                AnonymousParty(myIdentity.second.certificates.last().publicKey))
+                AnonymousParty(myIdentity.second.certificates.first().publicKey))
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
@@ -16,8 +16,7 @@ import org.junit.Test
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.InputStream
-import java.security.cert.CertPath
-import java.security.cert.X509Certificate
+import java.security.cert.*
 import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
@@ -152,10 +151,11 @@ class KryoTests {
 
     @Test
     fun `serialize - deserialize X509CertPath`() {
+        val certFactory = CertificateFactory.getInstance("X509")
         val rootCAKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         val rootCACert = X509Utilities.createSelfSignedCACertificate(ALICE.name, rootCAKey)
         val certificate = X509Utilities.createCertificate(CertificateType.TLS, rootCACert, rootCAKey, BOB.name, BOB_PUBKEY)
-        val expected = X509Utilities.createCertificatePath(rootCACert, certificate, revocationEnabled = false)
+        val expected = certFactory.generateCertPath(listOf(rootCACert.cert, certificate.cert))
         val serialized = expected.serialize(kryo).bytes
         val actual: CertPath = serialized.deserialize(kryo)
         assertEquals(expected, actual)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -69,8 +69,9 @@ import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.KeyPair
+import java.security.KeyStore
 import java.security.KeyStoreException
-import java.security.cert.X509Certificate
+import java.security.cert.*
 import java.time.Clock
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -214,7 +215,8 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
 
         // Do all of this in a database transaction so anything that might need a connection has one.
         initialiseDatabasePersistence {
-            val tokenizableServices = makeServices()
+            val keyStoreWrapper = KeyStoreWrapper(configuration.trustStoreFile, configuration.trustStorePassword)
+            val tokenizableServices = makeServices(keyStoreWrapper)
 
             smm = StateMachineManager(services,
                     checkpointStorage,
@@ -437,7 +439,8 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
      * Builds node internal, advertised, and plugin services.
      * Returns a list of tokenizable services to be added to the serialisation context.
      */
-    private fun makeServices(): MutableList<Any> {
+    private fun makeServices(keyStoreWrapper: KeyStoreWrapper): MutableList<Any> {
+        val keyStore = keyStoreWrapper.keyStore
         val storageServices = initialiseStorageService(configuration.baseDirectory)
         storage = storageServices.first
         checkpointStorage = storageServices.second
@@ -750,21 +753,23 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         // the legal name is actually validated in some way.
 
         // TODO: Integrate with Key management service?
+        val certFactory = CertificateFactory.getInstance("X509")
         val keyStore = KeyStoreWrapper(configuration.nodeKeystore, configuration.keyStorePassword)
         val privateKeyAlias = "$serviceId-private-key"
         val privKeyFile = configuration.baseDirectory / privateKeyAlias
         val pubIdentityFile = configuration.baseDirectory / "$serviceId-public"
         val certificateAndKeyPair = keyStore.certificateAndKeyPair(privateKeyAlias)
         val identityCertPathAndKey: Pair<PartyAndCertificate, KeyPair> = if (certificateAndKeyPair != null) {
-            val (cert, keyPair) = certificateAndKeyPair
+            val clientCertPath = keyStore.keyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_CA)
+            val (certHolder, keyPair) = certificateAndKeyPair
             // Get keys from keystore.
-            val loadedServiceName = X509CertificateHolder(cert.encoded).subject
+            val loadedServiceName = X509CertificateHolder(certHolder.encoded).subject
             if (loadedServiceName != serviceName) {
                 throw ConfigurationException("The legal name in the config file doesn't match the stored identity keystore:" +
                         "$serviceName vs $loadedServiceName")
             }
-            val certPath = X509Utilities.createCertificatePath(cert, cert, revocationEnabled = false)
-            Pair(PartyAndCertificate(loadedServiceName, keyPair.public, cert, certPath), keyPair)
+            val certPath = certFactory.generateCertPath(listOf(certHolder.cert) + clientCertPath)
+            Pair(PartyAndCertificate(loadedServiceName, keyPair.public, certHolder, certPath), keyPair)
         } else if (privKeyFile.exists()) {
             // Get keys from key file.
             // TODO: this is here to smooth out the key storage transition, remove this in future release.
@@ -782,15 +787,16 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
             }
             Pair(myIdentity, keyPair)
         } else {
+            val clientCertPath = keyStore.keyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_CA)
             val clientCA = keyStore.certificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA)!!
             // Create new keys and store in keystore.
             log.info("Identity key not found, generating fresh key!")
             val keyPair: KeyPair = generateKeyPair()
-            val cert = X509Utilities.createCertificate(CertificateType.IDENTITY, clientCA.certificate, clientCA.keyPair, serviceName, keyPair.public)
-            val certPath = X509Utilities.createCertificatePath(cert, cert, revocationEnabled = false)
+            val certHolder = X509Utilities.createCertificate(CertificateType.IDENTITY, clientCA.certificate, clientCA.keyPair, serviceName, keyPair.public)
+            val certPath = certFactory.generateCertPath(listOf(certHolder.cert) + clientCertPath)
             keyStore.save(serviceName, privateKeyAlias, keyPair)
             require(certPath.certificates.isNotEmpty()) { "Certificate path cannot be empty" }
-            Pair(PartyAndCertificate(serviceName, keyPair.public, cert, certPath), keyPair)
+            Pair(PartyAndCertificate(serviceName, keyPair.public, certHolder, certPath), keyPair)
         }
         partyKeys += identityCertPathAndKey.second
         return identityCertPathAndKey
@@ -812,8 +818,8 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     }
 }
 
-private class KeyStoreWrapper(private val storePath: Path, private val storePassword: String) {
-    private val keyStore = KeyStoreUtilities.loadKeyStore(storePath, storePassword)
+private class KeyStoreWrapper(val keyStore: KeyStore, val storePath: Path, private val storePassword: String) {
+    constructor(storePath: Path, storePassword: String) : this(KeyStoreUtilities.loadKeyStore(storePath, storePassword), storePath, storePassword)
 
     fun certificateAndKeyPair(alias: String): CertificateAndKeyPair? {
         return if (keyStore.containsAlias(alias)) keyStore.getCertificateAndKeyPair(alias, storePassword) else null

--- a/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
@@ -1,9 +1,6 @@
 package net.corda.node.services.keys
 
-import net.corda.core.crypto.CertificateType
-import net.corda.core.crypto.ContentSignerBuilder
-import net.corda.core.crypto.Crypto
-import net.corda.core.crypto.X509Utilities
+import net.corda.core.crypto.*
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
@@ -13,6 +10,7 @@ import java.security.KeyPair
 import java.security.PublicKey
 import java.security.Security
 import java.security.cert.CertPath
+import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.*
@@ -21,10 +19,10 @@ import java.util.*
  * Generates a new random [KeyPair], adds it to the internal key storage, then generates a corresponding
  * [X509Certificate] and adds it to the identity service.
  *
- * @param subjectPublicKey public key of new identity.
- * @param issuerSigner a content signer for the issuer.
  * @param identityService issuer service to use when registering the certificate.
+ * @param subjectPublicKey public key of new identity.
  * @param issuer issuer to generate a key and certificate for. Must be an identity this node has the private key for.
+ * @param issuerSigner a content signer for the issuer.
  * @param revocationEnabled whether to check revocation status of certificates in the certificate path.
  * @return X.509 certificate and path to the trust root.
  */
@@ -35,11 +33,13 @@ fun freshCertificate(identityService: IdentityService,
                      revocationEnabled: Boolean = false): Pair<X509CertificateHolder, CertPath> {
     val issuerCertificate = issuer.certificate
     val window = X509Utilities.getCertificateValidityWindow(Duration.ZERO, Duration.ofDays(10 * 365), issuerCertificate)
-    val ourCertificate = Crypto.createCertificate(CertificateType.IDENTITY, issuerCertificate.subject, issuerSigner, issuer.name, subjectPublicKey, window)
-    val actualPublicKey = Crypto.toSupportedPublicKey(ourCertificate.subjectPublicKeyInfo)
-    require(subjectPublicKey == actualPublicKey)
-    val ourCertPath = X509Utilities.createCertificatePath(issuerCertificate, ourCertificate, revocationEnabled = revocationEnabled)
-    require(Arrays.equals(ourCertificate.subjectPublicKeyInfo.encoded, subjectPublicKey.encoded))
+    val subjectCertificate = Crypto.createCertificate(CertificateType.IDENTITY, issuerCertificate.subject, issuerSigner, issuer.name, subjectPublicKey, window)
+    // TODO: Remove this once we're happy everything works correctly, this just exists to help catch problems before
+    // the path validator throws something opaque
+    require(Arrays.equals(subjectCertificate.subjectPublicKeyInfo.encoded, subjectPublicKey.encoded))
+
+    val certFactory = CertificateFactory.getInstance("X509")
+    val ourCertPath = certFactory.generateCertPath(listOf(subjectCertificate.cert) + issuer.certPath.certificates)
     identityService.registerAnonymousIdentity(AnonymousParty(subjectPublicKey),
             issuer.party,
             ourCertPath)

--- a/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
@@ -1,9 +1,6 @@
 package net.corda.node.utilities
 
-import net.corda.core.crypto.CertificateAndKeyPair
-import net.corda.core.crypto.CompositeKey
-import net.corda.core.crypto.X509Utilities
-import net.corda.core.crypto.generateKeyPair
+import net.corda.core.crypto.*
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.serialize
 import net.corda.core.serialization.storageKryo
@@ -12,6 +9,7 @@ import net.corda.core.utilities.trace
 import org.bouncycastle.asn1.x500.X500Name
 import java.nio.file.Files
 import java.nio.file.Path
+import java.security.cert.CertificateFactory
 
 object ServiceIdentityGenerator {
     private val log = loggerFor<ServiceIdentityGenerator>()
@@ -40,8 +38,9 @@ object ServiceIdentityGenerator {
         // TODO: This doesn't work until we have composite keys in X.509 certificates, so we make up a certificate that nothing checks
         // val notaryCert = X509Utilities.createCertificate(CertificateType.IDENTITY, serviceCa.certificate,
         //        serviceCa.keyPair, serviceName, notaryKey)
+        val certFactory = CertificateFactory.getInstance("X509")
         val notaryCert = X509Utilities.createSelfSignedCACertificate(serviceName, generateKeyPair())
-        val notaryCertPath = X509Utilities.createCertificatePath(serviceCa.certificate, notaryCert, revocationEnabled = false)
+        val notaryCertPath = certFactory.generateCertPath(listOf(serviceCa.certificate.cert, notaryCert.cert))
         val notaryParty = PartyAndCertificate(serviceName, notaryKey, notaryCert, notaryCertPath).serialize()
 
         keyPairs.zip(dirs) { keyPair, dir ->

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
@@ -6,14 +6,14 @@ import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
 import net.corda.core.utilities.*
+import net.corda.flows.TxKeyFlow
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.testing.ALICE_PUBKEY
 import net.corda.testing.BOB_PUBKEY
 import org.bouncycastle.asn1.x500.X500Name
 import org.junit.Test
 import java.security.KeyPair
-import java.security.cert.CertPath
-import java.security.cert.X509Certificate
+import java.security.cert.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
@@ -51,16 +51,17 @@ class InMemoryIdentityServiceTests {
 
     @Test
     fun `get identity by name with no registered identities`() {
-        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate)
+        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate.cert)
         assertNull(service.partyFromX500Name(ALICE.name))
     }
 
     @Test
     fun `get identity by substring match`() {
-        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate)
+        val trustRoot = DUMMY_CA
+        val service = InMemoryIdentityService(trustRoot = trustRoot.certificate.cert)
         service.registerIdentity(ALICE_IDENTITY)
         service.registerIdentity(BOB_IDENTITY)
-        val (_, _, alicente) = createParty(X500Name("O=Alicente Worldwide,L=London,C=UK"))
+        val alicente = getTestPartyAndCertificate(X500Name("O=Alicente Worldwide,L=London,C=UK"), generateKeyPair().public)
         service.registerIdentity(alicente)
         assertEquals(setOf(ALICE, alicente.party), service.partiesFromName("Alice", false))
         assertEquals(setOf(ALICE), service.partiesFromName("Alice Corp", true))
@@ -69,7 +70,7 @@ class InMemoryIdentityServiceTests {
 
     @Test
     fun `get identity by name`() {
-        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate)
+        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate.cert)
         val identities = listOf("Node A", "Node B", "Node C")
                 .map { getTestPartyAndCertificate(X500Name("CN=$it,O=R3,OU=corda,L=London,C=UK"), generateKeyPair().public) }
         assertNull(service.partyFromX500Name(identities.first().name))
@@ -85,7 +86,7 @@ class InMemoryIdentityServiceTests {
         val rootKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         val rootCert = X509Utilities.createSelfSignedCACertificate(ALICE.name, rootKey)
         val txKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
-        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate)
+        val service = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate.cert)
         // TODO: Generate certificate with an EdDSA key rather than ECDSA
         val identity = Party(CertificateAndKeyPair(rootCert, rootKey))
         val txIdentity = AnonymousParty(txKey.public)
@@ -101,41 +102,43 @@ class InMemoryIdentityServiceTests {
      */
     @Test
     fun `assert ownership`() {
-        val (aliceTxKey, aliceCertPath, alice) = createParty(ALICE.name)
+        val trustRoot = DUMMY_CA
+        val (alice, aliceTxIdentity) = createParty(ALICE.name)
 
-        val bobRootKey = Crypto.generateKeyPair()
-        val bobRootCert = X509Utilities.createSelfSignedCACertificate(BOB.name, bobRootKey)
+        val certFactory = CertificateFactory.getInstance("X509")
+        val bobRootKey = generateKeyPair()
+        val bobRoot = getTestPartyAndCertificate(BOB.name, bobRootKey.public)
         val bobTxKey = Crypto.generateKeyPair()
-        val bobTxCert = X509Utilities.createCertificate(CertificateType.IDENTITY, bobRootCert, bobRootKey, BOB.name, bobTxKey.public)
-        val bobCertPath = X509Utilities.createCertificatePath(bobRootCert, bobTxCert, revocationEnabled = false)
-        val bob = PartyAndCertificate(BOB.name, bobRootKey.public, bobRootCert, bobCertPath)
+        val bobTxCert = X509Utilities.createCertificate(CertificateType.IDENTITY, bobRoot.certificate, bobRootKey, BOB.name, bobTxKey.public)
+        val bobCertPath = certFactory.generateCertPath(listOf(bobTxCert.cert, bobRoot.certificate.cert))
+        val bob = PartyAndCertificate(BOB.name, bobRootKey.public, bobRoot.certificate, bobCertPath)
 
         // Now we have identities, construct the service and let it know about both
-        val service = InMemoryIdentityService(setOf(alice, bob), emptyMap(), null as X509Certificate?)
-        val anonymousAlice = AnonymousParty(aliceTxKey.public)
-        service.registerAnonymousIdentity(anonymousAlice, alice.party, aliceCertPath)
+        val service = InMemoryIdentityService(setOf(alice, bob), emptyMap(), trustRoot.certificate.cert)
+        service.registerAnonymousIdentity(aliceTxIdentity.identity, alice.party, aliceTxIdentity.certPath)
 
         val anonymousBob = AnonymousParty(bobTxKey.public)
         service.registerAnonymousIdentity(anonymousBob, bob.party, bobCertPath)
 
         // Verify that paths are verified
-        service.assertOwnership(alice.party, anonymousAlice)
+        service.assertOwnership(alice.party, aliceTxIdentity.identity)
         service.assertOwnership(bob.party, anonymousBob)
         assertFailsWith<IllegalArgumentException> {
             service.assertOwnership(alice.party, anonymousBob)
         }
         assertFailsWith<IllegalArgumentException> {
-            service.assertOwnership(bob.party, anonymousAlice)
+            service.assertOwnership(bob.party, aliceTxIdentity.identity)
         }
     }
 
-    private fun createParty(x500Name: X500Name): Triple<KeyPair, CertPath, PartyAndCertificate> {
-        val rootKey = Crypto.generateKeyPair()
-        val rootCert = X509Utilities.createSelfSignedCACertificate(x500Name, rootKey)
+    private fun createParty(x500Name: X500Name): Pair<PartyAndCertificate, TxKeyFlow.AnonymousIdentity> {
+        val certFactory = CertificateFactory.getInstance("X509")
+        val issuerKeyPair = generateKeyPair()
+        val issuer = getTestPartyAndCertificate(x500Name, issuerKeyPair.public)
         val txKey = Crypto.generateKeyPair()
-        val txCert = X509Utilities.createCertificate(CertificateType.IDENTITY, rootCert, rootKey, x500Name, txKey.public)
-        val certPath = X509Utilities.createCertificatePath(rootCert, txCert, revocationEnabled = false)
-        return Triple(txKey, certPath, PartyAndCertificate(x500Name, rootKey.public, rootCert, certPath))
+        val txCert = X509Utilities.createCertificate(CertificateType.IDENTITY, issuer.certificate, issuerKeyPair, x500Name, txKey.public)
+        val txCertPath = certFactory.generateCertPath(listOf(txCert.cert) + issuer.certPath.certificates)
+        return Pair(issuer, TxKeyFlow.AnonymousIdentity(txCertPath, txCert, AnonymousParty(txKey.public)))
     }
 
     /**
@@ -144,7 +147,7 @@ class InMemoryIdentityServiceTests {
     @Test
     fun `deanonymising a well known identity`() {
         val expected = ALICE
-        val actual = InMemoryIdentityService(trustRoot = null).partyFromAnonymous(expected)
+        val actual = InMemoryIdentityService(trustRoot = DUMMY_CA.certificate.cert).partyFromAnonymous(expected)
         assertEquals(expected, actual)
     }
 }


### PR DESCRIPTION
Introduce changes in certificate management ahead of enforcing correct certificate paths for all identities:

* Remove the existing certificate path composition utility, and replace it with direct API calls as it's down to  two lines of code now.
* Registering an identity now accepts the full PartyAndCertificate so it can be verified.
* Identity certificates can now sign certificates (for signing transaction key's certificates)
* Standardise the certificate validation logic in the identity service
* Correct several places where the certificate ordering in CertPath is incorrect; target certificate is first, root  last, not vice-versa.