### PR TITLE
AMQP serialization part 3: some custom serializers, integration with Kryo (disabled)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -29,6 +29,10 @@ fun makeAllButBlacklistedClassResolver(): ClassResolver {
     return CordaClassResolver(AllButBlacklisted)
 }
 
+/**
+ * @param amqpEnabled Setting this to true turns on experimental AMQP serialization for any class annotated with
+ * [CordaSerializable].
+ */
 class CordaClassResolver(val whitelist: ClassWhitelist, val amqpEnabled: Boolean = false) : DefaultClassResolver() {
     /** Returns the registration for the specified class, or null if the class is not registered.  */
     override fun getRegistration(type: Class<*>): Registration? {

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -29,7 +29,7 @@ fun makeAllButBlacklistedClassResolver(): ClassResolver {
     return CordaClassResolver(AllButBlacklisted)
 }
 
-class CordaClassResolver(val whitelist: ClassWhitelist) : DefaultClassResolver() {
+class CordaClassResolver(val whitelist: ClassWhitelist, val amqpEnabled: Boolean = false) : DefaultClassResolver() {
     /** Returns the registration for the specified class, or null if the class is not registered.  */
     override fun getRegistration(type: Class<*>): Registration? {
         return super.getRegistration(type) ?: checkClass(type)
@@ -59,22 +59,29 @@ class CordaClassResolver(val whitelist: ClassWhitelist) : DefaultClassResolver()
             return checkClass(type.superclass)
         }
         // It's safe to have the Class already, since Kryo loads it with initialisation off.
-        // If we use a whitelist with blacklisting capabilities, whitelist.hasListed(type) may throw a NotSerializableException if input class is blacklisted.
+        // If we use a whitelist with blacklisting capabilities, whitelist.hasListed(type) may throw an IllegalStateException if input class is blacklisted.
         // Thus, blacklisting precedes annotation checking.
-        if (!whitelist.hasListed(type) && !checkForAnnotation(type)) {
+        val hasAnnotation = checkForAnnotation(type)
+        if (!whitelist.hasListed(type) && !hasAnnotation) {
             throw KryoException("Class ${Util.className(type)} is not annotated or on the whitelist, so cannot be used in serialization")
         }
         return null
     }
 
     override fun registerImplicit(type: Class<*>): Registration {
-        // We have to set reference to true, since the flag influences how String fields are treated and we want it to be consistent.
-        val references = kryo.references
-        try {
-            kryo.references = true
-            return register(Registration(type, kryo.getDefaultSerializer(type), NAME.toInt()))
-        } finally {
-            kryo.references = references
+        val hasAnnotation = checkForAnnotation(type)
+        if (!hasAnnotation || !amqpEnabled) {
+            // We have to set reference to true, since the flag influences how String fields are treated and we want it to be consistent.
+            val references = kryo.references
+            try {
+                kryo.references = true
+                return register(Registration(type, kryo.getDefaultSerializer(type), NAME.toInt()))
+            } finally {
+                kryo.references = references
+            }
+        } else {
+            // Build AMQP serializer
+            return register(Registration(type, KryoAMQPSerializer, NAME.toInt()))
         }
     }
 
@@ -85,13 +92,13 @@ class CordaClassResolver(val whitelist: ClassWhitelist) : DefaultClassResolver()
         return (type.classLoader !is AttachmentsClassLoader)
                 && !KryoSerializable::class.java.isAssignableFrom(type)
                 && !type.isAnnotationPresent(DefaultSerializer::class.java)
-                && (type.isAnnotationPresent(CordaSerializable::class.java) || hasAnnotationOnInterface(type))
+                && (type.isAnnotationPresent(CordaSerializable::class.java) || hasInheritedAnnotation(type))
     }
 
     // Recursively check interfaces for our annotation.
-    private fun hasAnnotationOnInterface(type: Class<*>): Boolean {
-        return type.interfaces.any { it.isAnnotationPresent(CordaSerializable::class.java) || hasAnnotationOnInterface(it) }
-                || (type.superclass != null && hasAnnotationOnInterface(type.superclass))
+    private fun hasInheritedAnnotation(type: Class<*>): Boolean {
+        return type.interfaces.any { it.isAnnotationPresent(CordaSerializable::class.java) || hasInheritedAnnotation(it) }
+                || (type.superclass != null && hasInheritedAnnotation(type.superclass))
     }
 
     // Need to clear out class names from attachments.

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -65,8 +65,7 @@ class CordaClassResolver(val whitelist: ClassWhitelist, val amqpEnabled: Boolean
         // It's safe to have the Class already, since Kryo loads it with initialisation off.
         // If we use a whitelist with blacklisting capabilities, whitelist.hasListed(type) may throw an IllegalStateException if input class is blacklisted.
         // Thus, blacklisting precedes annotation checking.
-        val hasAnnotation = checkForAnnotation(type)
-        if (!whitelist.hasListed(type) && !hasAnnotation) {
+        if (!whitelist.hasListed(type) && !checkForAnnotation(type)) {
             throw KryoException("Class ${Util.className(type)} is not annotated or on the whitelist, so cannot be used in serialization")
         }
         return null

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -74,6 +74,9 @@ class CordaClassResolver(val whitelist: ClassWhitelist, val amqpEnabled: Boolean
 
     override fun registerImplicit(type: Class<*>): Registration {
         val hasAnnotation = checkForAnnotation(type)
+        // If something is not annotated, or AMQP is disabled, we stay serializing with Kryo.  This will typically be the
+        // case for flow checkpoints (ingoring the case where AMQP is disabled) since our top level messaging data structures
+        // are annotated and once we enter AMQP serialisation we stay with it for the entire object subgraph.
         if (!hasAnnotation || !amqpEnabled) {
             // We have to set reference to true, since the flag influences how String fields are treated and we want it to be consistent.
             val references = kryo.references

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -74,7 +74,7 @@ class CordaClassResolver(val whitelist: ClassWhitelist, val amqpEnabled: Boolean
     override fun registerImplicit(type: Class<*>): Registration {
         val hasAnnotation = checkForAnnotation(type)
         // If something is not annotated, or AMQP is disabled, we stay serializing with Kryo.  This will typically be the
-        // case for flow checkpoints (ingoring the case where AMQP is disabled) since our top level messaging data structures
+        // case for flow checkpoints (ignoring all cases where AMQP is disabled) since our top level messaging data structures
         // are annotated and once we enter AMQP serialisation we stay with it for the entire object subgraph.
         if (!hasAnnotation || !amqpEnabled) {
             // We have to set reference to true, since the flag influences how String fields are treated and we want it to be consistent.

--- a/core/src/main/kotlin/net/corda/core/serialization/KryoAMQPSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/KryoAMQPSerializer.kt
@@ -12,8 +12,7 @@ import net.corda.core.serialization.amqp.SerializerFactory
  * This [Kryo] custom [Serializer] switches the object graph of anything annotated with `@CordaSerializable`
  * to using the AMQP serialization wire format, and simply writes that out as bytes to the wire.
  *
- * Currently this writes a variable length integer to the stream indicating how many bytes of AMQP encoded bytes follow
- * and then that many raw bytes.
+ * There is no need to write out the length, since this can be peeked out of the first few bytes of the stream.
  */
 object KryoAMQPSerializer : Serializer<Any>() {
     internal fun registerCustomSerializers(factory: SerializerFactory) {

--- a/core/src/main/kotlin/net/corda/core/serialization/KryoAMQPSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/KryoAMQPSerializer.kt
@@ -15,7 +15,6 @@ import net.corda.core.serialization.amqp.SerializerFactory
  * Currently this writes a variable length integer to the stream indicating how many bytes of AMQP encoded bytes follow
  * and then that many raw bytes.
  */
-// TODO: Consider setting the immutable flag on the `Serializer` if we make all AMQP types immutable.
 object KryoAMQPSerializer : Serializer<Any>() {
     internal fun registerCustomSerializers(factory: SerializerFactory) {
         factory.apply {
@@ -28,14 +27,15 @@ object KryoAMQPSerializer : Serializer<Any>() {
         }
     }
 
-    // TODO: need to sort out the whitelist...
+    // TODO: need to sort out the whitelist... we currently do not apply the whitelist attached to the [Kryo]
+    // instance to the factory.  We need to do this before turning on AMQP serialization.
     private val serializerFactory = SerializerFactory().apply {
         registerCustomSerializers(this)
     }
 
-    override fun write(kryo: Kryo, output: Output, `object`: Any) {
+    override fun write(kryo: Kryo, output: Output, obj: Any) {
         val amqpOutput = SerializationOutput(serializerFactory)
-        val bytes = amqpOutput.serialize(`object`).bytes
+        val bytes = amqpOutput.serialize(obj).bytes
         output.writeVarInt(bytes.size, true)
         output.write(bytes)
     }

--- a/core/src/main/kotlin/net/corda/core/serialization/KryoAMQPSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/KryoAMQPSerializer.kt
@@ -1,0 +1,39 @@
+package net.corda.core.serialization
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.Serializer
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import net.corda.core.serialization.amqp.DeserializationInput
+import net.corda.core.serialization.amqp.SerializationOutput
+import net.corda.core.serialization.amqp.SerializerFactory
+
+// TODO: Consider setting the immutable flag
+object KryoAMQPSerializer : Serializer<Any>() {
+    internal fun registerCustomSerializers(factory: SerializerFactory) {
+        factory.apply {
+            register(net.corda.core.serialization.amqp.custom.PublicKeySerializer)
+            register(net.corda.core.serialization.amqp.custom.ThrowableSerializer(this))
+            register(net.corda.core.serialization.amqp.custom.X500NameSerializer)
+            register(net.corda.core.serialization.amqp.custom.BigDecimalSerializer)
+            register(net.corda.core.serialization.amqp.custom.CurrencySerializer)
+            register(net.corda.core.serialization.amqp.custom.InstantSerializer(this))
+        }
+    }
+
+    // TODO: need to sort out the whitelist...
+    private val serializerFactory = SerializerFactory().apply {
+        registerCustomSerializers(this)
+    }
+
+    override fun write(kryo: Kryo, output: Output, `object`: Any) {
+        val amqpOutput = SerializationOutput(serializerFactory)
+        kryo.writeObject(output, amqpOutput.serialize(`object`))
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<Any>): Any {
+        val amqpInput = DeserializationInput(serializerFactory)
+        @Suppress("UNCHECKED_CAST")
+        return amqpInput.deserialize(kryo.readObject(input, SerializedBytes::class.java) as SerializedBytes<Any>, type)
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/AMQPPrimitiveSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/AMQPPrimitiveSerializer.kt
@@ -1,6 +1,6 @@
 package net.corda.core.serialization.amqp
 
-import com.google.common.primitives.Primitives
+import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 
@@ -8,7 +8,7 @@ import java.lang.reflect.Type
  * Serializer / deserializer for native AMQP types (Int, Float, String etc).
  */
 class AMQPPrimitiveSerializer(clazz: Class<*>) : AMQPSerializer<Any> {
-    override val typeDescriptor: String = SerializerFactory.primitiveTypeName(Primitives.wrap(clazz))!!
+    override val typeDescriptor: String = SerializerFactory.primitiveTypeName(clazz)!!
     override val type: Type = clazz
 
     // NOOP since this is a primitive type.
@@ -16,8 +16,12 @@ class AMQPPrimitiveSerializer(clazz: Class<*>) : AMQPSerializer<Any> {
     }
 
     override fun writeObject(obj: Any, data: Data, type: Type, output: SerializationOutput) {
-        data.putObject(obj)
+        if (obj is ByteArray) {
+            data.putObject(Binary(obj))
+        } else {
+            data.putObject(obj)
+        }
     }
 
-    override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): Any = obj
+    override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): Any = (obj as? Binary)?.array ?: obj
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/AMQPPrimitiveSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/AMQPPrimitiveSerializer.kt
@@ -6,6 +6,8 @@ import java.lang.reflect.Type
 
 /**
  * Serializer / deserializer for native AMQP types (Int, Float, String etc).
+ *
+ * [ByteArray] is automatically marshalled to/from the Proton-J wrapper, [Binary].
  */
 class AMQPPrimitiveSerializer(clazz: Class<*>) : AMQPSerializer<Any> {
     override val typeDescriptor: String = SerializerFactory.primitiveTypeName(clazz)!!

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/ArraySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/ArraySerializer.kt
@@ -2,8 +2,6 @@ package net.corda.core.serialization.amqp
 
 import org.apache.qpid.proton.codec.Data
 import java.io.NotSerializableException
-import java.lang.reflect.GenericArrayType
-import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
 /**
@@ -12,13 +10,9 @@ import java.lang.reflect.Type
 class ArraySerializer(override val type: Type, factory: SerializerFactory) : AMQPSerializer<Any> {
     override val typeDescriptor = "$DESCRIPTOR_DOMAIN:${fingerprintForType(type, factory)}"
 
-    internal val elementType: Type = makeElementType()
+    internal val elementType: Type = type.componentType()
 
     private val typeNotation: TypeNotation = RestrictedType(type.typeName, null, emptyList(), "list", Descriptor(typeDescriptor, null), emptyList())
-
-    private fun makeElementType(): Type {
-        return (type as? Class<*>)?.componentType ?: (type as GenericArrayType).genericComponentType
-    }
 
     override fun writeClassInfo(output: SerializationOutput) {
         if (output.writeTypeNotations(typeNotation)) {
@@ -44,13 +38,7 @@ class ArraySerializer(override val type: Type, factory: SerializerFactory) : AMQ
     }
 
     private fun <T> List<T>.toArrayOfType(type: Type): Any {
-        val elementType: Class<*> = if (type is Class<*>) {
-            type
-        } else if (type is ParameterizedType) {
-            type.rawType as Class<*>
-        } else {
-            throw NotSerializableException("Unexpected array element type $type")
-        }
+        val elementType = type.asClass() ?: throw NotSerializableException("Unexpected array element type $type")
         val list = this
         return java.lang.reflect.Array.newInstance(elementType, this.size).apply {
             val array = this

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/CollectionSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/CollectionSerializer.kt
@@ -32,7 +32,7 @@ class CollectionSerializer(val declaredType: ParameterizedType, factory: Seriali
 
     private val concreteBuilder: (List<*>) -> Collection<*> = findConcreteType(declaredType.rawType as Class<*>)
 
-    private val typeNotation: TypeNotation = RestrictedType(declaredType.toString(), null, emptyList(), "list", Descriptor(typeDescriptor, null), emptyList())
+    private val typeNotation: TypeNotation = RestrictedType(SerializerFactory.nameForType(declaredType), null, emptyList(), "list", Descriptor(typeDescriptor, null), emptyList())
 
     override fun writeClassInfo(output: SerializationOutput) {
         if (output.writeTypeNotations(typeNotation)) {

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/CustomSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/CustomSerializer.kt
@@ -16,7 +16,7 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
     abstract val additionalSerializers: Iterable<CustomSerializer<out Any>>
 
     /**
-     * This method should return true if the custom serializer can serialize and instance of the class passed as
+     * This method should return true if the custom serializer can serialize an instance of the class passed as the
      * parameter.
      */
     abstract fun isSerializerFor(clazz: Class<*>): Boolean
@@ -50,7 +50,7 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
 
         override fun isSerializerFor(clazz: Class<*>): Boolean = clazz == this.clazz
         override val type: Type get() = clazz
-        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${fingerprintForStrings(superClassSerializer.typeDescriptor, nameForType(clazz))}"
+        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${fingerprintForDescriptors(superClassSerializer.typeDescriptor, nameForType(clazz))}"
         private val typeNotation: TypeNotation = RestrictedType(SerializerFactory.nameForType(clazz), null, emptyList(), SerializerFactory.nameForType(superClassSerializer.type), Descriptor(typeDescriptor, null), emptyList())
         override fun writeClassInfo(output: SerializationOutput) {
             output.writeTypeNotations(typeNotation)

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/CustomSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/CustomSerializer.kt
@@ -1,5 +1,6 @@
 package net.corda.core.serialization.amqp
 
+import net.corda.core.serialization.amqp.SerializerFactory.Companion.nameForType
 import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 
@@ -10,7 +11,7 @@ import java.lang.reflect.Type
 abstract class CustomSerializer<T> : AMQPSerializer<T> {
     /**
      * This is a collection of custom serializers that this custom serializer depends on.  e.g. for proxy objects
-     * that refer to arrays of types etc.
+     * that refer to other custom types etc.
      */
     abstract val additionalSerializers: Iterable<CustomSerializer<out Any>>
 
@@ -31,13 +32,38 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
 
     abstract fun writeDescribedObject(obj: T, data: Data, type: Type, output: SerializationOutput)
 
+    // TODO: should this be a custom serializer at all, or should it just be a plain AMQPSerializer?
+    class SubClass<T>(protected val clazz: Class<*>, protected val superClassSerializer: CustomSerializer<T>) : CustomSerializer<T>() {
+        override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
+        // TODO: should this be empty or contain the schema of the super?
+        override val schemaForDocumentation = Schema(emptyList())
+
+        override fun isSerializerFor(clazz: Class<*>): Boolean = clazz == this.clazz
+        override val type: Type get() = clazz
+        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${fingerprintForStrings(superClassSerializer.typeDescriptor, nameForType(clazz))}"
+        private val typeNotation: TypeNotation = RestrictedType(SerializerFactory.nameForType(clazz), null, emptyList(), SerializerFactory.nameForType(superClassSerializer.type), Descriptor(typeDescriptor, null), emptyList())
+        override fun writeClassInfo(output: SerializationOutput) {
+            output.writeTypeNotations(typeNotation)
+        }
+
+        override val descriptor: Descriptor = Descriptor(typeDescriptor)
+
+        override fun writeDescribedObject(obj: T, data: Data, type: Type, output: SerializationOutput) {
+            superClassSerializer.writeDescribedObject(obj, data, type, output)
+        }
+
+        override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): T {
+            return superClassSerializer.readObject(obj, schema, input)
+        }
+    }
+
     /**
      * Additional base features for a custom serializer that is a particular class.
      */
     abstract class Is<T>(protected val clazz: Class<T>) : CustomSerializer<T>() {
         override fun isSerializerFor(clazz: Class<*>): Boolean = clazz == this.clazz
         override val type: Type get() = clazz
-        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${clazz.name}"
+        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${nameForType(clazz)}"
         override fun writeClassInfo(output: SerializationOutput) {}
         override val descriptor: Descriptor = Descriptor(typeDescriptor)
     }
@@ -48,7 +74,7 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
     abstract class Implements<T>(protected val clazz: Class<T>) : CustomSerializer<T>() {
         override fun isSerializerFor(clazz: Class<*>): Boolean = this.clazz.isAssignableFrom(clazz)
         override val type: Type get() = clazz
-        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${clazz.name}"
+        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${nameForType(clazz)}"
         override fun writeClassInfo(output: SerializationOutput) {}
         override val descriptor: Descriptor = Descriptor(typeDescriptor)
     }
@@ -66,14 +92,14 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
                                val withInheritance: Boolean = true) : CustomSerializer<T>() {
         override fun isSerializerFor(clazz: Class<*>): Boolean = if (withInheritance) this.clazz.isAssignableFrom(clazz) else this.clazz == clazz
         override val type: Type get() = clazz
-        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${clazz.name}"
+        override val typeDescriptor: String = "$DESCRIPTOR_DOMAIN:${nameForType(clazz)}"
         override fun writeClassInfo(output: SerializationOutput) {}
         override val descriptor: Descriptor = Descriptor(typeDescriptor)
 
         private val proxySerializer: ObjectSerializer by lazy { ObjectSerializer(proxyClass, factory) }
 
         override val schemaForDocumentation: Schema by lazy {
-            val typeNotations = mutableSetOf<TypeNotation>(CompositeType(type.typeName, null, emptyList(), descriptor, (proxySerializer.typeNotation as CompositeType).fields))
+            val typeNotations = mutableSetOf<TypeNotation>(CompositeType(nameForType(type), null, emptyList(), descriptor, (proxySerializer.typeNotation as CompositeType).fields))
             for (additional in additionalSerializers) {
                 typeNotations.addAll(additional.schemaForDocumentation.types)
             }
@@ -99,6 +125,29 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
         override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): T {
             @Suppress("UNCHECKED_CAST")
             val proxy = proxySerializer.readObject(obj, schema, input) as P
+            return fromProxy(proxy)
+        }
+    }
+
+    abstract class ToString<T>(clazz: Class<T>, withInheritance: Boolean = false,
+                               private val maker: (String) -> T = clazz.getConstructor(String::class.java).let { `constructor` -> { string -> `constructor`.newInstance(string) } },
+                               private val unmaker: (T) -> String = { obj -> obj.toString() }) : Proxy<T, String>(clazz, String::class.java, /* Unused */ SerializerFactory(), withInheritance) {
+
+        override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
+
+        override val schemaForDocumentation = Schema(listOf(RestrictedType(nameForType(type), "", listOf(nameForType(type)), SerializerFactory.primitiveTypeName(String::class.java)!!, descriptor, emptyList())))
+
+        override fun toProxy(obj: T): String = unmaker(obj)
+
+        override fun fromProxy(proxy: String): T = maker(proxy)
+
+        override fun writeDescribedObject(obj: T, data: Data, type: Type, output: SerializationOutput) {
+            val proxy = toProxy(obj)
+            data.putObject(proxy)
+        }
+
+        override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): T {
+            val proxy = input.readObject(obj, schema, String::class.java) as String
             return fromProxy(proxy)
         }
     }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/CustomSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/CustomSerializer.kt
@@ -68,7 +68,7 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
     }
 
     /**
-     * Additional base features for a custom serializer for a particular class, but not subclasses etc.
+     * Additional base features for a custom serializer for a particular class, that excludes subclasses.
      */
     abstract class Is<T>(protected val clazz: Class<T>) : CustomSerializer<T>() {
         override fun isSerializerFor(clazz: Class<*>): Boolean = clazz == this.clazz
@@ -143,12 +143,12 @@ abstract class CustomSerializer<T> : AMQPSerializer<T> {
      * A custom serializer where the on-wire representation is a string.  For example, a [Currency] might be represented
      * as a 3 character currency code, and converted to and from that string.  By default, it is assumed that the
      * [toString] method will generate the string representation and that there is a constructor that takes such a
-     * string as argument to reconstruct.
+     * string as an argument to reconstruct.
      *
      * @param clazz The type to be marshalled
      * @param withInheritance Whether subclasses of the class can also be marshalled.
      * @param make A lambda for constructing an instance, that defaults to calling a constructor that expects a string.
-     * @param unmake A lambda that extracts the string value an instance, that defaults to the [toString] method.
+     * @param unmake A lambda that extracts the string value for an instance, that defaults to the [toString] method.
      */
     abstract class ToString<T>(clazz: Class<T>, withInheritance: Boolean = false,
                                private val maker: (String) -> T = clazz.getConstructor(String::class.java).let { `constructor` -> { string -> `constructor`.newInstance(string) } },

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializationInput.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializationInput.kt
@@ -2,6 +2,7 @@ package net.corda.core.serialization.amqp
 
 import com.google.common.base.Throwables
 import net.corda.core.serialization.SerializedBytes
+import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.amqp.DescribedType
 import org.apache.qpid.proton.codec.Data
 import java.io.NotSerializableException
@@ -66,15 +67,11 @@ class DeserializationInput(internal val serializerFactory: SerializerFactory = S
             if (serializer.type != type && !serializer.type.isSubClassOf(type))
                 throw NotSerializableException("Described type with descriptor ${obj.descriptor} was expected to be of type $type")
             return serializer.readObject(obj.described, schema, this)
+        } else if (obj is Binary) {
+            return obj.array
         } else {
             return obj
         }
-    }
-
-    private fun Type.isSubClassOf(type: Type): Boolean {
-        return type == Object::class.java ||
-                (this is Class<*> && type is Class<*> && type.isAssignableFrom(this)) ||
-                (this is DeserializedParameterizedType && type is Class<*> && this.rawType == type && this.isFullyWildcarded)
     }
 
     private fun subArraysEqual(a: ByteArray, aOffset: Int, length: Int, b: ByteArray, bOffset: Int): Boolean {

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializedParameterizedType.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializedParameterizedType.kt
@@ -1,5 +1,6 @@
 package net.corda.core.serialization.amqp
 
+import com.google.common.primitives.Primitives
 import java.io.NotSerializableException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -119,7 +120,9 @@ class DeserializedParameterizedType(private val rawType: Class<*>, private val p
 
         private fun makeType(typeName: String, cl: ClassLoader): Type {
             // Not generic
-            return if (typeName == "?") SerializerFactory.AnyType else Class.forName(typeName, false, cl)
+            return if (typeName == "?") SerializerFactory.AnyType else {
+                Primitives.wrap(SerializerFactory.primitiveType(typeName) ?: Class.forName(typeName, false, cl))
+            }
         }
 
         private fun makeParameterizedType(rawTypeName: String, args: MutableList<Type>, cl: ClassLoader): Type {

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/MapSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/MapSerializer.kt
@@ -31,7 +31,7 @@ class MapSerializer(val declaredType: ParameterizedType, factory: SerializerFact
 
     private val concreteBuilder: (Map<*, *>) -> Map<*, *> = findConcreteType(declaredType.rawType as Class<*>)
 
-    private val typeNotation: TypeNotation = RestrictedType(declaredType.toString(), null, emptyList(), "map", Descriptor(typeDescriptor, null), emptyList())
+    private val typeNotation: TypeNotation = RestrictedType(SerializerFactory.nameForType(declaredType), null, emptyList(), "map", Descriptor(typeDescriptor, null), emptyList())
 
     override fun writeClassInfo(output: SerializationOutput) {
         if (output.writeTypeNotations(typeNotation)) {

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/PropertySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/PropertySerializer.kt
@@ -54,7 +54,6 @@ sealed class PropertySerializer(val name: String, val readMethod: Method, val re
 
     companion object {
         fun make(name: String, readMethod: Method, resolvedType: Type, factory: SerializerFactory): PropertySerializer {
-            //val type = readMethod.genericReturnType
             if (SerializerFactory.isPrimitive(resolvedType)) {
                 // This is a little inefficient for performance since it does a runtime check of type.  We could do build time check with lots of subclasses here.
                 return AMQPPrimitivePropertySerializer(name, readMethod, resolvedType)

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/Schema.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/Schema.kt
@@ -355,7 +355,8 @@ private fun fingerprintForType(type: Type, contextType: Type?, alreadySeen: Muta
                     val customSerializer = factory.findCustomSerializer(type, type)
                     if (customSerializer == null) {
                         if (type.kotlin.objectInstance != null) {
-                            // TODO: name collision is too likely for kotlin objects
+                            // TODO: name collision is too likely for kotlin objects, we need to introduce some reference
+                            // to the CorDapp but maybe reference to the JAR in the short term.
                             hasher.putUnencodedChars(type.name)
                         } else {
                             fingerprintForObject(type, contextType, alreadySeen, hasher, factory)
@@ -392,7 +393,7 @@ private fun isCollectionOrMap(type: Class<*>) = Collection::class.java.isAssigna
 
 private fun fingerprintForObject(type: Type, contextType: Type?, alreadySeen: MutableSet<Type>, hasher: Hasher, factory: SerializerFactory): Hasher {
     // Hash the class + properties + interfaces
-    val name = (type as? Class<*>)?.name ?: ((type as? ParameterizedType)?.rawType as? Class<*>)?.name ?: throw NotSerializableException("Expected only Class or ParameterizedType but found $type")
+    val name = type.asClass()?.name ?: throw NotSerializableException("Expected only Class or ParameterizedType but found $type")
     propertiesForSerialization(constructorForDeserialization(type), contextType ?: type, factory).fold(hasher.putUnencodedChars(name)) { orig, prop ->
         fingerprintForType(prop.resolvedType, type, alreadySeen, orig, factory).putUnencodedChars(prop.name).putUnencodedChars(if (prop.mandatory) NOT_NULLABLE_HASH else NULLABLE_HASH)
     }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/Schema.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/Schema.kt
@@ -12,6 +12,7 @@ import java.io.NotSerializableException
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+import java.lang.reflect.TypeVariable
 
 // TODO: get an assigned number as per AMQP spec
 val DESCRIPTOR_TOP_32BITS: Long = 0xc0da0000
@@ -310,6 +311,7 @@ private val ALREADY_SEEN_HASH: String = "Already seen = true"
 private val NULLABLE_HASH: String = "Nullable = true"
 private val NOT_NULLABLE_HASH: String = "Nullable = false"
 private val ANY_TYPE_HASH: String = "Any type = true"
+private val TYPE_VARIABLE_HASH: String = "Any type = true"
 
 /**
  * The method generates a fingerprint for a given JVM [Type] that should be unique to the schema representation.
@@ -320,44 +322,77 @@ private val ANY_TYPE_HASH: String = "Any type = true"
  * different.
  */
 // TODO: write tests
-internal fun fingerprintForType(type: Type, factory: SerializerFactory): String = Base58.encode(fingerprintForType(type, HashSet(), Hashing.murmur3_128().newHasher(), factory).hash().asBytes())
+internal fun fingerprintForType(type: Type, factory: SerializerFactory): String {
+    return Base58.encode(fingerprintForType(type, null, HashSet(), Hashing.murmur3_128().newHasher(), factory).hash().asBytes())
+}
 
-private fun fingerprintForType(type: Type, alreadySeen: MutableSet<Type>, hasher: Hasher, factory: SerializerFactory): Hasher {
+internal fun fingerprintForStrings(vararg typeDescriptors: String): String {
+    val hasher = Hashing.murmur3_128().newHasher()
+    for (typeDescriptor in typeDescriptors) {
+        hasher.putUnencodedChars(typeDescriptor)
+    }
+    return Base58.encode(hasher.hash().asBytes())
+}
+
+private fun fingerprintForType(type: Type, contextType: Type?, alreadySeen: MutableSet<Type>, hasher: Hasher, factory: SerializerFactory): Hasher {
     return if (type in alreadySeen) {
         hasher.putUnencodedChars(ALREADY_SEEN_HASH)
     } else {
         alreadySeen += type
-        if (type is SerializerFactory.AnyType) {
-            hasher.putUnencodedChars(ANY_TYPE_HASH)
-        } else if (type is Class<*>) {
-            if (type.isArray) {
-                fingerprintForType(type.componentType, alreadySeen, hasher, factory).putUnencodedChars(ARRAY_HASH)
-            } else if (SerializerFactory.isPrimitive(type)) {
-                hasher.putUnencodedChars(type.name)
-            } else if (Collection::class.java.isAssignableFrom(type) || Map::class.java.isAssignableFrom(type)) {
+        try {
+            if (type is SerializerFactory.AnyType) {
+                hasher.putUnencodedChars(ANY_TYPE_HASH)
+            } else if (type is Class<*>) {
+                if (type.isArray) {
+                    fingerprintForType(type.componentType, contextType, alreadySeen, hasher, factory).putUnencodedChars(ARRAY_HASH)
+                } else if (SerializerFactory.isPrimitive(type)) {
+                    hasher.putUnencodedChars(type.name)
+                } else if (Collection::class.java.isAssignableFrom(type) || Map::class.java.isAssignableFrom(type)) {
+                    hasher.putUnencodedChars(type.name)
+                } else {
+                    // Need to check if a custom serializer is applicable
+                    val customSerializer = factory.findCustomSerializer(type, type)
+                    if (customSerializer == null) {
+                        if (type.kotlin.objectInstance != null) {
+                            // TODO: name collision is too likely for kotlin objects
+                            hasher.putUnencodedChars(type.name)
+                        } else {
+                            fingerprintForObject(type, contextType, alreadySeen, hasher, factory)
+                        }
+                    } else {
+                        hasher.putUnencodedChars(customSerializer.typeDescriptor)
+                    }
+                }
+            } else if (type is ParameterizedType) {
+                // Hash the rawType + params
+                val clazz = type.rawType as Class<*>
+                val startingHash = if (Collection::class.java.isAssignableFrom(clazz) || Map::class.java.isAssignableFrom(clazz)) {
+                    hasher.putUnencodedChars(clazz.name)
+                } else {
+                    fingerprintForObject(type, type, alreadySeen, hasher, factory)
+                }
+                type.actualTypeArguments.fold(startingHash) { orig, paramType -> fingerprintForType(paramType, type, alreadySeen, orig, factory) }
+            } else if (type is GenericArrayType) {
+                // Hash the element type + some array hash
+                fingerprintForType(type.genericComponentType, contextType, alreadySeen, hasher, factory).putUnencodedChars(ARRAY_HASH)
+            } else if (type is TypeVariable<*>) {
+                // TODO: include bounds
                 hasher.putUnencodedChars(type.name)
             } else {
-                // Need to check if a custom serializer is applicable
-                val customSerializer = factory.findCustomSerializer(type)
-                if (customSerializer == null) {
-                    // Hash the class + properties + interfaces
-                    propertiesForSerialization(constructorForDeserialization(type), type, factory).fold(hasher.putUnencodedChars(type.name)) { orig, param ->
-                        fingerprintForType(param.readMethod.genericReturnType, alreadySeen, orig, factory).putUnencodedChars(param.name).putUnencodedChars(if (param.mandatory) NOT_NULLABLE_HASH else NULLABLE_HASH)
-                    }
-                    interfacesForSerialization(type).map { fingerprintForType(it, alreadySeen, hasher, factory) }
-                    hasher
-                } else {
-                    hasher.putUnencodedChars(customSerializer.typeDescriptor)
-                }
+                throw NotSerializableException("Don't know how to hash")
             }
-        } else if (type is ParameterizedType) {
-            // Hash the rawType + params
-            type.actualTypeArguments.fold(fingerprintForType(type.rawType, alreadySeen, hasher, factory)) { orig, paramType -> fingerprintForType(paramType, alreadySeen, orig, factory) }
-        } else if (type is GenericArrayType) {
-            // Hash the element type + some array hash
-            fingerprintForType(type.genericComponentType, alreadySeen, hasher, factory).putUnencodedChars(ARRAY_HASH)
-        } else {
-            throw NotSerializableException("Don't know how to hash $type")
+        } catch(e: NotSerializableException) {
+            throw NotSerializableException("${e.message} -> $type")
         }
     }
+}
+
+private fun fingerprintForObject(type: Type, contextType: Type?, alreadySeen: MutableSet<Type>, hasher: Hasher, factory: SerializerFactory): Hasher {
+    // Hash the class + properties + interfaces
+    val name = (type as? Class<*>)?.name ?: ((type as? ParameterizedType)?.rawType as? Class<*>)?.name ?: throw NotSerializableException("Expected only Class or ParameterizedType but found $type")
+    propertiesForSerialization(constructorForDeserialization(type), contextType ?: type, factory).fold(hasher.putUnencodedChars(name)) { orig, prop ->
+        fingerprintForType(prop.resolvedType, type, alreadySeen, orig, factory).putUnencodedChars(prop.name).putUnencodedChars(if (prop.mandatory) NOT_NULLABLE_HASH else NULLABLE_HASH)
+    }
+    interfacesForSerialization(type).map { fingerprintForType(it, type, alreadySeen, hasher, factory) }
+    return hasher
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/Schema.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/Schema.kt
@@ -335,6 +335,8 @@ internal fun fingerprintForDescriptors(vararg typeDescriptors: String): String {
     return hasher.hash().asBytes().toBase64()
 }
 
+// This method concatentates various elements of the types recursively as unencoded strings into the hasher, effectively
+// creating a unique string for a type which we then hash in the calling function above.
 private fun fingerprintForType(type: Type, contextType: Type?, alreadySeen: MutableSet<Type>, hasher: Hasher, factory: SerializerFactory): Hasher {
     return if (type in alreadySeen) {
         hasher.putUnencodedChars(ALREADY_SEEN_HASH)
@@ -373,6 +375,7 @@ private fun fingerprintForType(type: Type, contextType: Type?, alreadySeen: Muta
                 } else {
                     fingerprintForObject(type, type, alreadySeen, hasher, factory)
                 }
+                // ... and concatentate the type data for each parameter type.
                 type.actualTypeArguments.fold(startingHash) { orig, paramType -> fingerprintForType(paramType, type, alreadySeen, orig, factory) }
             } else if (type is GenericArrayType) {
                 // Hash the element type + some array hash

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationHelper.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationHelper.kt
@@ -110,7 +110,7 @@ internal fun interfacesForSerialization(type: Type): List<Type> {
 }
 
 private fun exploreType(type: Type?, interfaces: MutableSet<Type>) {
-    val clazz = type?.asClass() //type as? Class<*>) ?: (type as? ParameterizedType)?.rawType as? Class<*>
+    val clazz = type?.asClass()
     if (clazz != null) {
         if (clazz.isInterface) interfaces += type!!
         for (newInterface in clazz.genericInterfaces) {
@@ -147,7 +147,7 @@ fun Data.withList(block: Data.() -> Unit) {
     exit() // exit list
 }
 
-fun resolveTypeVariables(actualType: Type, contextType: Type?): Type {
+private fun resolveTypeVariables(actualType: Type, contextType: Type?): Type {
     val resolvedType = if (contextType != null) TypeToken.of(contextType).resolveType(actualType).type else actualType
     // TODO: surely we check it is concrete at this point with no TypeVariables
     return if (resolvedType is TypeVariable<*>) {
@@ -158,7 +158,7 @@ fun resolveTypeVariables(actualType: Type, contextType: Type?): Type {
     }
 }
 
-fun Type.asClass(): Class<*>? {
+internal fun Type.asClass(): Class<*>? {
     return if (this is Class<*>) {
         this
     } else if (this is ParameterizedType) {
@@ -168,7 +168,7 @@ fun Type.asClass(): Class<*>? {
     } else null
 }
 
-fun Type.asArray(): Type? {
+internal fun Type.asArray(): Type? {
     return if (this is Class<*>) {
         this.arrayClass()
     } else if (this is ParameterizedType) {
@@ -176,20 +176,20 @@ fun Type.asArray(): Type? {
     } else null
 }
 
-fun Class<*>.arrayClass(): Class<*> = java.lang.reflect.Array.newInstance(this, 0).javaClass
+internal fun Class<*>.arrayClass(): Class<*> = java.lang.reflect.Array.newInstance(this, 0).javaClass
 
-fun Type.isArray(): Boolean = (this is Class<*> && this.isArray) || (this is GenericArrayType)
+internal fun Type.isArray(): Boolean = (this is Class<*> && this.isArray) || (this is GenericArrayType)
 
-fun Type.componentType(): Type {
+internal fun Type.componentType(): Type {
     check(this.isArray()) { "$this is not an array type." }
     return (this as? Class<*>)?.componentType ?: (this as GenericArrayType).genericComponentType
 }
 
-fun Class<*>.asParameterizedType(): ParameterizedType {
+internal fun Class<*>.asParameterizedType(): ParameterizedType {
     return DeserializedParameterizedType(this, this.typeParameters)
 }
 
-fun Type.asParameterizedType(): ParameterizedType {
+internal fun Type.asParameterizedType(): ParameterizedType {
     return when (this) {
         is Class<*> -> this.asParameterizedType()
         is ParameterizedType -> this
@@ -197,6 +197,6 @@ fun Type.asParameterizedType(): ParameterizedType {
     }
 }
 
-fun Type.isSubClassOf(type: Type): Boolean {
+internal fun Type.isSubClassOf(type: Type): Boolean {
     return TypeToken.of(this).isSubtypeOf(type)
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationHelper.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationHelper.kt
@@ -110,7 +110,7 @@ internal fun interfacesForSerialization(type: Type): List<Type> {
 }
 
 private fun exploreType(type: Type?, interfaces: MutableSet<Type>) {
-    val clazz = (type as? Class<*>) ?: (type as? ParameterizedType)?.rawType as? Class<*>
+    val clazz = type?.asClass() //type as? Class<*>) ?: (type as? ParameterizedType)?.rawType as? Class<*>
     if (clazz != null) {
         if (clazz.isInterface) interfaces += type!!
         for (newInterface in clazz.genericInterfaces) {

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationHelper.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationHelper.kt
@@ -158,28 +158,6 @@ fun resolveTypeVariables(actualType: Type, contextType: Type?): Type {
     }
 }
 
-fun checkTypeIsResolved(type: Type) {
-    if (type !is Class<*>) {
-        if (type is ParameterizedType) {
-            // Check the raw type and the arguments
-            if (type.rawType !is Class<*>) throw NotSerializableException("ParameterizedType $type has non-Class raw type.")
-            for (paramType in type.actualTypeArguments) {
-                checkTypeIsResolved(paramType)
-            }
-        } else if (type is TypeVariable<*>) {
-            throw NotSerializableException("Found unbound generic type variable $type")
-        } else if (type is WildcardType) {
-            if (type != SerializerFactory.AnyType) {
-                TODO("Wildcards")
-            }
-        } else if (type is GenericArrayType) {
-            checkTypeIsResolved(type.genericComponentType)
-        }
-    } else if (!type.typeParameters.isEmpty()) {
-        //throw NotSerializableException("Generic class with no type variable bound.")
-    }
-}
-
 fun Type.asClass(): Class<*>? {
     return if (this is Class<*>) {
         this

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -73,6 +73,11 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
         }
     }
 
+
+    /**
+     * Try and infer concrete types for any generics type variables for the actual class encountered, based on the declared
+     * type.
+     */
     // TODO: test GenericArrayType
     private fun inferTypeVariables(actualClass: Class<*>?, declaredClass: Class<*>, declaredType: Type): Type? {
         if (declaredType is ParameterizedType) {
@@ -86,6 +91,10 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
         } else return null
     }
 
+    /**
+     * Try and infer concrete types for any generics type variables for the actual class encountered, based on the declared
+     * type, which must be a [ParameterizedType].
+     */
     private fun inferTypeVariables(actualClass: Class<*>?, declaredClass: Class<*>, declaredType: ParameterizedType): Type? {
         if (actualClass == null || declaredClass == actualClass) {
             return null
@@ -146,7 +155,8 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
     }
 
     /**
-     * TODO: Add docs
+     * Register a custom serializer for any type that cannot be serialized or deserialized by the default serializer
+     * that expects to find getters and a constructor with a parameter for each property.
      */
     fun register(customSerializer: CustomSerializer<out Any>) {
         if (!serializersByDescriptor.containsKey(customSerializer.typeDescriptor)) {
@@ -239,7 +249,7 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
     // Recursively check the class, interfaces and superclasses for our annotation.
     internal fun hasAnnotationInHierarchy(type: Class<*>): Boolean {
         return type.isAnnotationPresent(CordaSerializable::class.java) ||
-                type.interfaces.any { it.isAnnotationPresent(CordaSerializable::class.java) || hasAnnotationInHierarchy(it) }
+                type.interfaces.any { hasAnnotationInHierarchy(it) }
                 || (type.superclass != null && hasAnnotationInHierarchy(type.superclass))
     }
 

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.core.serialization.amqp
 
 import com.google.common.primitives.Primitives
+import com.google.common.reflect.TypeResolver
 import net.corda.core.checkNotUnorderedHashMap
 import net.corda.core.serialization.AllWhitelist
 import net.corda.core.serialization.ClassWhitelist
@@ -20,9 +21,9 @@ import javax.annotation.concurrent.ThreadSafe
  * Factory of serializers designed to be shared across threads and invocations.
  */
 // TODO: enums
-// TODO: object references
+// TODO: object references - need better fingerprinting?
 // TODO: class references? (e.g. cheat with repeated descriptors using a long encoding, like object ref proposal)
-// TODO: Inner classes etc
+// TODO: Inner classes etc. Should we allow? Currently not considered.
 // TODO: support for intern-ing of deserialized objects for some core types (e.g. PublicKey) for memory efficiency
 // TODO: maybe support for caching of serialized form of some core types for performance
 // TODO: profile for performance in general
@@ -32,7 +33,13 @@ import javax.annotation.concurrent.ThreadSafe
 // TODO: apply class loader logic and an "app context" throughout this code.
 // TODO: schema evolution solution when the fingerprints do not line up.
 // TODO: allow definition of well known types that are left out of the schema.
-// TODO: automatically support byte[] without having to wrap in [Binary].
+// TODO: generally map Object to '*' all over the place in the schema
+// TODO: found a document that states textual descriptors are Symbols.  Adjust schema class appropriately.
+// TODO: document and alert to the fact that classes cannot default superclass/interface properties otherwise they are "erased" due to matching with constructor.
+// TODO: type name prefixes for interfaces and abstract classes?  Or use label?
+// TODO: generic types should define restricted type alias with source of the wildcarded version, I think, if we're to generate classes from schema
+// TODO: need to rethink matching of constructor to properties in relation to implementing interfaces and needing those properties etc.
+// TODO: need to support super classes as well as interfaces with our current code base... what's involved?  If we continue to ban, what is the impact?
 @ThreadSafe
 class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
     private val serializersByType = ConcurrentHashMap<Type, AMQPSerializer<Any>>()
@@ -42,42 +49,88 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
     /**
      * Look up, and manufacture if necessary, a serializer for the given type.
      *
-     * @param actualType Will be null if there isn't an actual object instance available (e.g. for
+     * @param actualClass Will be null if there isn't an actual object instance available (e.g. for
      * restricted type processing).
      */
     @Throws(NotSerializableException::class)
-    fun get(actualType: Class<*>?, declaredType: Type): AMQPSerializer<Any> {
-        if (declaredType is ParameterizedType) {
-            return serializersByType.computeIfAbsent(declaredType) {
-                // We allow only Collection and Map.
-                val rawType = declaredType.rawType
-                if (rawType is Class<*>) {
-                    checkParameterisedTypesConcrete(declaredType.actualTypeArguments)
-                    if (Collection::class.java.isAssignableFrom(rawType)) {
-                        CollectionSerializer(declaredType, this)
-                    } else if (Map::class.java.isAssignableFrom(rawType)) {
-                        makeMapSerializer(declaredType)
-                    } else {
-                        throw NotSerializableException("Declared types of $declaredType are not supported.")
-                    }
-                } else {
-                    throw NotSerializableException("Declared types of $declaredType are not supported.")
+    fun get(actualClass: Class<*>?, declaredType: Type): AMQPSerializer<Any> {
+        val declaredClass = declaredType.asClass()
+        if (declaredClass != null) {
+            val actualType: Type = inferTypeVariables(actualClass, declaredClass, declaredType) ?: declaredType
+            if (Collection::class.java.isAssignableFrom(declaredClass)) {
+                return serializersByType.computeIfAbsent(declaredType) {
+                    CollectionSerializer(declaredType as? ParameterizedType ?: DeserializedParameterizedType(declaredClass, arrayOf(AnyType), null), this)
                 }
-            }
-        } else if (declaredType is Class<*>) {
-            // Simple classes allowed
-            if (Collection::class.java.isAssignableFrom(declaredType)) {
-                return serializersByType.computeIfAbsent(declaredType) { CollectionSerializer(DeserializedParameterizedType(declaredType, arrayOf(AnyType), null), this) }
-            } else if (Map::class.java.isAssignableFrom(declaredType)) {
-                return serializersByType.computeIfAbsent(declaredType) { makeMapSerializer(DeserializedParameterizedType(declaredType, arrayOf(AnyType, AnyType), null)) }
+            } else if (Map::class.java.isAssignableFrom(declaredClass)) {
+                return serializersByType.computeIfAbsent(declaredClass) {
+                    makeMapSerializer(declaredType as? ParameterizedType ?: DeserializedParameterizedType(declaredClass, arrayOf(AnyType, AnyType), null))
+                }
             } else {
-                return makeClassSerializer(actualType ?: declaredType)
+                return makeClassSerializer(actualClass ?: declaredClass, actualType, declaredType)
             }
-        } else if (declaredType is GenericArrayType) {
-            return serializersByType.computeIfAbsent(declaredType) { ArraySerializer(declaredType, this) }
         } else {
             throw NotSerializableException("Declared types of $declaredType are not supported.")
         }
+    }
+
+    // TODO: test GenericArrayType
+    private fun inferTypeVariables(actualClass: Class<*>?, declaredClass: Class<*>, declaredType: Type): Type? {
+        if (declaredType is ParameterizedType) {
+            return inferTypeVariables(actualClass, declaredClass, declaredType)
+        } else if (declaredType is Class<*>) {
+            // Nothing to infer, otherwise we'd have ParameterizedType
+            return actualClass
+        } else if (declaredType is GenericArrayType) {
+            val declaredComponent = declaredType.genericComponentType
+            return inferTypeVariables(actualClass?.componentType, declaredComponent.asClass()!!, declaredComponent)?.asArray()
+        } else return null
+    }
+
+    private fun inferTypeVariables(actualClass: Class<*>?, declaredClass: Class<*>, declaredType: ParameterizedType): Type? {
+        if (actualClass == null || declaredClass == actualClass) {
+            return null
+        } else if (declaredClass.isAssignableFrom(actualClass)) {
+            return if (actualClass.typeParameters.isNotEmpty()) {
+                // The actual class can never have type variables resolved, so let's try and resolve them
+                // Search for declared type in the inheritance hierarchy and then see if that fills in all the variables
+                val implementationChain: List<Type>? = findPathToDeclared(actualClass, declaredType, mutableListOf<Type>())
+                if (implementationChain != null) {
+                    val start = implementationChain.last()
+                    val rest = implementationChain.dropLast(1).drop(1)
+                    val resolver = rest.reversed().fold(TypeResolver().where(start, declaredType)) {
+                        resolved, chainEntry ->
+                        val newResolved = resolved.resolveType(chainEntry)
+                        TypeResolver().where(chainEntry, newResolved)
+                    }
+                    // The end type is a special case as it is a Class, so we need to fake up a ParameterizedType for it to get the TypeResolver to do anything.
+                    val endType = DeserializedParameterizedType(actualClass, actualClass.typeParameters)
+                    val resolvedType = resolver.resolveType(endType)
+                    resolvedType
+                } else throw NotSerializableException("No inheritance path between actual $actualClass and declared $declaredType.")
+            } else actualClass
+        } else throw NotSerializableException("Found object of type $actualClass in a property expecting $declaredType")
+    }
+
+    // Stop when reach declared type or return null if we don't find it.
+    private fun findPathToDeclared(startingType: Type, declaredType: Type, chain: MutableList<Type>): List<Type>? {
+        chain.add(startingType)
+        val startingClass = startingType.asClass()
+        if (startingClass == declaredType.asClass()) {
+            // We're done...
+            return chain
+        }
+        // Now explore potential options of superclass and all interfaces
+        val superClass = startingClass?.genericSuperclass
+        val superClassChain = if (superClass != null) {
+            val resolved = TypeResolver().where(startingClass.asParameterizedType(), startingType.asParameterizedType()).resolveType(superClass)
+            findPathToDeclared(resolved, declaredType, ArrayList(chain))
+        } else null
+        if (superClassChain != null) return superClassChain
+        for (iface in startingClass?.genericInterfaces ?: emptyArray()) {
+            val resolved = TypeResolver().where(startingClass!!.asParameterizedType(), startingType.asParameterizedType()).resolveType(iface)
+            return findPathToDeclared(resolved, declaredType, ArrayList(chain)) ?: continue
+        }
+        return null
     }
 
     /**
@@ -118,25 +171,10 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
         }
     }
 
-    private fun restrictedTypeForName(name: String): Type {
-        return if (name.endsWith("[]")) {
-            val elementType = restrictedTypeForName(name.substring(0, name.lastIndex - 1))
-            if (elementType is ParameterizedType || elementType is GenericArrayType) {
-                DeserializedGenericArrayType(elementType)
-            } else if (elementType is Class<*>) {
-                java.lang.reflect.Array.newInstance(elementType, 0).javaClass
-            } else {
-                throw NotSerializableException("Not able to deserialize array type: $name")
-            }
-        } else {
-            DeserializedParameterizedType.make(name)
-        }
-    }
-
     private fun processRestrictedType(typeNotation: RestrictedType) {
         serializersByDescriptor.computeIfAbsent(typeNotation.descriptor.name!!) {
             // TODO: class loader logic, and compare the schema.
-            val type = restrictedTypeForName(typeNotation.name)
+            val type = typeForName(typeNotation.name)
             get(null, type)
         }
     }
@@ -144,56 +182,57 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
     private fun processCompositeType(typeNotation: CompositeType) {
         serializersByDescriptor.computeIfAbsent(typeNotation.descriptor.name!!) {
             // TODO: class loader logic, and compare the schema.
-            val clazz = Class.forName(typeNotation.name)
-            get(clazz, clazz)
+            val type = typeForName(typeNotation.name)
+            get(type as? Class<*> ?: (type as? ParameterizedType)?.rawType as? Class<*> ?: throw NotSerializableException("Unable to build composite type for $type"), type)
         }
     }
 
-    private fun checkParameterisedTypesConcrete(actualTypeArguments: Array<out Type>) {
-        for (type in actualTypeArguments) {
-            // Needs to be another parameterised type or a class, or any type.
-            if (type !is Class<*>) {
-                if (type is ParameterizedType) {
-                    checkParameterisedTypesConcrete(type.actualTypeArguments)
-                } else if (type != AnyType) {
-                    throw NotSerializableException("Declared parameterised types containing $type as a parameter are not supported.")
-                }
-            }
-        }
-    }
-
-    private fun makeClassSerializer(clazz: Class<*>): AMQPSerializer<Any> {
-        return serializersByType.computeIfAbsent(clazz) {
+    private fun makeClassSerializer(clazz: Class<*>, type: Type, declaredType: Type): AMQPSerializer<Any> {
+        return serializersByType.computeIfAbsent(type) {
             if (isPrimitive(clazz)) {
                 AMQPPrimitiveSerializer(clazz)
             } else {
-                findCustomSerializer(clazz) ?: {
-                    if (clazz.isArray) {
-                        whitelisted(clazz.componentType)
-                        ArraySerializer(clazz, this)
-                    } else {
+                // TODO: the custom serializer, if it supports subclasses, should output a RestrictedType to map from sub- to super-class to the schema
+                findCustomSerializer(clazz, declaredType) ?: {
+                    if (type.isArray()) {
+                        whitelisted(type.componentType())
+                        ArraySerializer(type, this)
+                    } else if (clazz.kotlin.objectInstance != null) {
                         whitelisted(clazz)
-                        ObjectSerializer(clazz, this)
+                        SingletonSerializer(clazz, clazz.kotlin.objectInstance!!, this)
+                    } else {
+                        whitelisted(type)
+                        ObjectSerializer(type, this)
                     }
                 }()
             }
         }
     }
 
-    internal fun findCustomSerializer(clazz: Class<*>): AMQPSerializer<Any>? {
+    internal fun findCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? {
+        // e.g. Imagine if we provided a Map serializer this way, then it won't work if the declared type is AbstractMap, only Map.
+        // Otherwise it needs to inject additional schema for a RestrictedType source of the super type.  Could be done, but do we need it?
         for (customSerializer in customSerializers) {
             if (customSerializer.isSerializerFor(clazz)) {
-                return customSerializer
+                val declaredSuperClass = declaredType.asClass()?.superclass
+                if (declaredSuperClass == null || !customSerializer.isSerializerFor(declaredSuperClass)) {
+                    return customSerializer
+                } else {
+                    // Make a subclass serializer for the subclass and return that...
+                    @Suppress("UNCHECKED_CAST")
+                    return CustomSerializer.SubClass<Any>(clazz, customSerializer as CustomSerializer<Any>)
+                }
             }
         }
         return null
     }
 
-    private fun whitelisted(clazz: Class<*>): Boolean {
+    private fun whitelisted(type: Type): Boolean {
+        val clazz = type.asClass()!!
         if (whitelist.hasListed(clazz) || hasAnnotationInHierarchy(clazz)) {
             return true
         } else {
-            throw NotSerializableException("Class $clazz is not on the whitelist or annotated with @CordaSerializable.")
+            throw NotSerializableException("Class $type is not on the whitelist or annotated with @CordaSerializable.")
         }
     }
 
@@ -211,9 +250,16 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
     }
 
     companion object {
-        fun isPrimitive(type: Type): Boolean = type is Class<*> && Primitives.wrap(type) in primitiveTypeNames
+        fun isPrimitive(type: Type): Boolean = primitiveTypeName(type) != null
 
-        fun primitiveTypeName(type: Type): String? = primitiveTypeNames[type as? Class<*>]
+        fun primitiveTypeName(type: Type): String? {
+            val clazz = type as? Class<*> ?: return null
+            return primitiveTypeNames[Primitives.unwrap(clazz)]
+        }
+
+        fun primitiveType(type: String): Class<*>? {
+            return namesOfPrimitiveTypes[type]
+        }
 
         private val primitiveTypeNames: Map<Class<*>, String> = mapOf(
                 Boolean::class.java to "boolean",
@@ -221,7 +267,7 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
                 UnsignedByte::class.java to "ubyte",
                 Short::class.java to "short",
                 UnsignedShort::class.java to "ushort",
-                Integer::class.java to "int",
+                Int::class.java to "int",
                 UnsignedInteger::class.java to "uint",
                 Long::class.java to "long",
                 UnsignedLong::class.java to "ulong",
@@ -233,9 +279,36 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
                 Char::class.java to "char",
                 Date::class.java to "timestamp",
                 UUID::class.java to "uuid",
-                Binary::class.java to "binary",
+                ByteArray::class.java to "binary",
                 String::class.java to "string",
                 Symbol::class.java to "symbol")
+
+        private val namesOfPrimitiveTypes: Map<String, Class<*>> = primitiveTypeNames.map { it.value to it.key }.toMap()
+
+        fun nameForType(type: Type): String {
+            if (type is Class<*>) {
+                return primitiveTypeName(type) ?: if (type.isArray) "${nameForType(type.componentType)}[]" else type.name
+            } else if (type is ParameterizedType) {
+                return "${nameForType(type.rawType)}<${type.actualTypeArguments.joinToString { nameForType(it) }}>"
+            } else if (type is GenericArrayType) {
+                return "${nameForType(type.genericComponentType)}[]"
+            } else throw NotSerializableException("Unable to render type $type to a string.")
+        }
+
+        private fun typeForName(name: String): Type {
+            return if (name.endsWith("[]")) {
+                val elementType = typeForName(name.substring(0, name.lastIndex - 1))
+                if (elementType is ParameterizedType || elementType is GenericArrayType) {
+                    DeserializedGenericArrayType(elementType)
+                } else if (elementType is Class<*>) {
+                    java.lang.reflect.Array.newInstance(elementType, 0).javaClass
+                } else {
+                    throw NotSerializableException("Not able to deserialize array type: $name")
+                }
+            } else {
+                DeserializedParameterizedType.make(name)
+            }
+        }
     }
 
     object AnyType : WildcardType {
@@ -246,4 +319,3 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
         override fun toString(): String = "?"
     }
 }
-

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe
 // TODO: apply class loader logic and an "app context" throughout this code.
 // TODO: schema evolution solution when the fingerprints do not line up.
 // TODO: allow definition of well known types that are left out of the schema.
-// TODO: generally map Object to '*' all over the place in the schema
+// TODO: generally map Object to '*' all over the place in the schema and make sure use of '*' amd '?' is consistent and documented in generics.
 // TODO: found a document that states textual descriptors are Symbols.  Adjust schema class appropriately.
 // TODO: document and alert to the fact that classes cannot default superclass/interface properties otherwise they are "erased" due to matching with constructor.
 // TODO: type name prefixes for interfaces and abstract classes?  Or use label?

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SingletonSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SingletonSerializer.kt
@@ -5,16 +5,14 @@ import java.lang.reflect.Type
 
 /**
  * A custom serializer that transports nothing on the wire (except a boolean "false", since AMQP does not support
- * absolutely nothing, or null) when we have a singleton within the node that we just
+ * absolutely nothing, or null as a described type) when we have a singleton within the node that we just
  * want converting back to that singleton instance on the receiving JVM.
  */
 class SingletonSerializer(override val type: Class<*>, val singleton: Any, factory: SerializerFactory) : AMQPSerializer<Any> {
     override val typeDescriptor = "$DESCRIPTOR_DOMAIN:${fingerprintForType(type, factory)}"
-    private val interfaces = interfacesForSerialization(type) // TODO maybe this proves too much and we need annotations to restrict.
+    private val interfaces = interfacesForSerialization(type)
 
-    private fun generateProvides(): List<String> {
-        return interfaces.map { it.typeName }
-    }
+    private fun generateProvides(): List<String> = interfaces.map { it.typeName }
 
     internal val typeNotation: TypeNotation = RestrictedType(type.typeName, "Singleton", generateProvides(), "boolean", Descriptor(typeDescriptor, null), emptyList())
 

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SingletonSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SingletonSerializer.kt
@@ -1,0 +1,30 @@
+package net.corda.core.serialization.amqp
+
+import org.apache.qpid.proton.codec.Data
+import java.lang.reflect.Type
+
+
+class SingletonSerializer(override val type: Class<*>, val singleton: Any, factory: SerializerFactory) : AMQPSerializer<Any> {
+    override val typeDescriptor = "$DESCRIPTOR_DOMAIN:${fingerprintForType(type, factory)}"
+    private val interfaces = interfacesForSerialization(type) // TODO maybe this proves too much and we need annotations to restrict.
+
+    private fun generateProvides(): List<String> {
+        return interfaces.map { it.typeName }
+    }
+
+    internal val typeNotation: TypeNotation = RestrictedType(type.typeName, "Singleton", generateProvides(), "boolean", Descriptor(typeDescriptor, null), emptyList())
+
+    override fun writeClassInfo(output: SerializationOutput) {
+        output.writeTypeNotations(typeNotation)
+    }
+
+    override fun writeObject(obj: Any, data: Data, type: Type, output: SerializationOutput) {
+        data.withDescribed(typeNotation.descriptor) {
+            data.putBoolean(false)
+        }
+    }
+
+    override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): Any {
+        return singleton
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SingletonSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SingletonSerializer.kt
@@ -3,7 +3,11 @@ package net.corda.core.serialization.amqp
 import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 
-
+/**
+ * A custom serializer that transports nothing on the wire (except a boolean "false", since AMQP does not support
+ * absolutely nothing, or null) when we have a singleton within the node that we just
+ * want converting back to that singleton instance on the receiving JVM.
+ */
 class SingletonSerializer(override val type: Class<*>, val singleton: Any, factory: SerializerFactory) : AMQPSerializer<Any> {
     override val typeDescriptor = "$DESCRIPTOR_DOMAIN:${fingerprintForType(type, factory)}"
     private val interfaces = interfacesForSerialization(type) // TODO maybe this proves too much and we need annotations to restrict.

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/BigDecimalSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/BigDecimalSerializer.kt
@@ -1,0 +1,7 @@
+package net.corda.core.serialization.amqp.custom
+
+import net.corda.core.serialization.amqp.CustomSerializer
+import java.math.BigDecimal
+
+
+object BigDecimalSerializer : CustomSerializer.ToString<BigDecimal>(BigDecimal::class.java)

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/BigDecimalSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/BigDecimalSerializer.kt
@@ -5,6 +5,7 @@ import java.math.BigDecimal
 
 /**
  * A serializer for [BigDecimal], utilising the string based helper.  [BigDecimal] seems to have no import/export
- * features that are precision independent other than via a string.
+ * features that are precision independent other than via a string.  The format of the string is discussed in the
+ * documentation for [BigDecimal.toString].
  */
 object BigDecimalSerializer : CustomSerializer.ToString<BigDecimal>(BigDecimal::class.java)

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/BigDecimalSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/BigDecimalSerializer.kt
@@ -3,5 +3,8 @@ package net.corda.core.serialization.amqp.custom
 import net.corda.core.serialization.amqp.CustomSerializer
 import java.math.BigDecimal
 
-
+/**
+ * A serializer for [BigDecimal], utilising the string based helper.  [BigDecimal] seems to have no import/export
+ * features that are precision independent other than via a string.
+ */
 object BigDecimalSerializer : CustomSerializer.ToString<BigDecimal>(BigDecimal::class.java)

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/CurrencySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/CurrencySerializer.kt
@@ -1,0 +1,10 @@
+package net.corda.core.serialization.amqp.custom
+
+import net.corda.core.serialization.amqp.CustomSerializer
+import java.util.*
+
+
+object CurrencySerializer : CustomSerializer.ToString<Currency>(Currency::class.java,
+        withInheritance = false,
+        maker = { Currency.getInstance(it) },
+        unmaker = { it.currencyCode })

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/CurrencySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/CurrencySerializer.kt
@@ -3,7 +3,9 @@ package net.corda.core.serialization.amqp.custom
 import net.corda.core.serialization.amqp.CustomSerializer
 import java.util.*
 
-
+/**
+ * A custom serializer for the [Currency] class, utilizing the currency code string representation.
+ */
 object CurrencySerializer : CustomSerializer.ToString<Currency>(Currency::class.java,
         withInheritance = false,
         maker = { Currency.getInstance(it) },

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/InstantSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/InstantSerializer.kt
@@ -1,0 +1,16 @@
+package net.corda.core.serialization.amqp.custom
+
+import net.corda.core.serialization.amqp.CustomSerializer
+import net.corda.core.serialization.amqp.SerializerFactory
+import java.time.Instant
+
+
+class InstantSerializer(factory: SerializerFactory) : CustomSerializer.Proxy<Instant, InstantSerializer.InstantProxy>(Instant::class.java, InstantProxy::class.java, factory) {
+    override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
+
+    override fun toProxy(obj: Instant): InstantProxy = InstantProxy(obj.epochSecond, obj.nano)
+
+    override fun fromProxy(proxy: InstantProxy): Instant = Instant.ofEpochSecond(proxy.epochSeconds, proxy.nanos.toLong())
+
+    data class InstantProxy(val epochSeconds: Long, val nanos: Int)
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/InstantSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/InstantSerializer.kt
@@ -4,7 +4,9 @@ import net.corda.core.serialization.amqp.CustomSerializer
 import net.corda.core.serialization.amqp.SerializerFactory
 import java.time.Instant
 
-
+/**
+ * A serializer for [Instant] that uses a proxy object to write out the seconds since the epoch and the nanos.
+ */
 class InstantSerializer(factory: SerializerFactory) : CustomSerializer.Proxy<Instant, InstantSerializer.InstantProxy>(Instant::class.java, InstantProxy::class.java, factory) {
     override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
 

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/PublicKeySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/PublicKeySerializer.kt
@@ -2,23 +2,22 @@ package net.corda.core.serialization.amqp.custom
 
 import net.corda.core.crypto.Crypto
 import net.corda.core.serialization.amqp.*
-import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 import java.security.PublicKey
 
-class PublicKeySerializer : CustomSerializer.Implements<PublicKey>(PublicKey::class.java) {
+object PublicKeySerializer : CustomSerializer.Implements<PublicKey>(PublicKey::class.java) {
     override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
 
-    override val schemaForDocumentation = Schema(listOf(RestrictedType(type.toString(), "", listOf(type.toString()), SerializerFactory.primitiveTypeName(Binary::class.java)!!, descriptor, emptyList())))
+    override val schemaForDocumentation = Schema(listOf(RestrictedType(type.toString(), "", listOf(type.toString()), SerializerFactory.primitiveTypeName(ByteArray::class.java)!!, descriptor, emptyList())))
 
     override fun writeDescribedObject(obj: PublicKey, data: Data, type: Type, output: SerializationOutput) {
         // TODO: Instead of encoding to the default X509 format, we could have a custom per key type (space-efficient) serialiser.
-        output.writeObject(Binary(obj.encoded), data, clazz)
+        output.writeObject(obj.encoded, data, clazz)
     }
 
     override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): PublicKey {
-        val A = input.readObject(obj, schema, ByteArray::class.java) as Binary
-        return Crypto.decodePublicKey(A.array)
+        val bits = input.readObject(obj, schema, ByteArray::class.java) as ByteArray
+        return Crypto.decodePublicKey(bits)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/PublicKeySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/PublicKeySerializer.kt
@@ -7,7 +7,7 @@ import java.lang.reflect.Type
 import java.security.PublicKey
 
 /**
- * A serializer that writes out a public key as the encoded bytes and deserializes those encoded bytes.
+ * A serializer that writes out a public key in X.509 format.
  */
 object PublicKeySerializer : CustomSerializer.Implements<PublicKey>(PublicKey::class.java) {
     override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/PublicKeySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/PublicKeySerializer.kt
@@ -6,6 +6,9 @@ import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type
 import java.security.PublicKey
 
+/**
+ * A serializer that writes out a public key as the encoded bytes and deserializes those encoded bytes.
+ */
 object PublicKeySerializer : CustomSerializer.Implements<PublicKey>(PublicKey::class.java) {
     override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
 

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/X500NameSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/X500NameSerializer.kt
@@ -1,0 +1,22 @@
+package net.corda.core.serialization.amqp.custom
+
+import net.corda.core.serialization.amqp.*
+import org.apache.qpid.proton.codec.Data
+import org.bouncycastle.asn1.ASN1InputStream
+import org.bouncycastle.asn1.x500.X500Name
+import java.lang.reflect.Type
+
+object X500NameSerializer : CustomSerializer.Implements<X500Name>(X500Name::class.java) {
+    override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
+
+    override val schemaForDocumentation = Schema(listOf(RestrictedType(type.toString(), "", listOf(type.toString()), SerializerFactory.primitiveTypeName(ByteArray::class.java)!!, descriptor, emptyList())))
+
+    override fun writeDescribedObject(obj: X500Name, data: Data, type: Type, output: SerializationOutput) {
+        output.writeObject(obj.encoded, data, clazz)
+    }
+
+    override fun readObject(obj: Any, schema: Schema, input: DeserializationInput): X500Name {
+        val binary = input.readObject(obj, schema, ByteArray::class.java) as ByteArray
+        return X500Name.getInstance(ASN1InputStream(binary).readObject())
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/X500NameSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/custom/X500NameSerializer.kt
@@ -6,6 +6,9 @@ import org.bouncycastle.asn1.ASN1InputStream
 import org.bouncycastle.asn1.x500.X500Name
 import java.lang.reflect.Type
 
+/**
+ * Custom serializer for X500 names that utilizes their ASN.1 encoding on the wire.
+ */
 object X500NameSerializer : CustomSerializer.Implements<X500Name>(X500Name::class.java) {
     override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
 

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/SerializationOutputTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/SerializationOutputTests.kt
@@ -1,17 +1,26 @@
 package net.corda.core.serialization.amqp
 
+import net.corda.core.contracts.*
+import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowException
+import net.corda.core.identity.AbstractParty
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.EmptyWhitelist
+import net.corda.core.serialization.KryoAMQPSerializer
+import net.corda.core.utilities.CordaRuntimeException
 import net.corda.nodeapi.RPCException
+import net.corda.testing.MEGA_CORP
 import net.corda.testing.MEGA_CORP_PUBKEY
 import org.apache.qpid.proton.codec.DecoderImpl
 import org.apache.qpid.proton.codec.EncoderImpl
 import org.junit.Test
 import java.io.IOException
 import java.io.NotSerializableException
+import java.math.BigDecimal
 import java.nio.ByteBuffer
+import java.time.Instant
 import java.util.*
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -58,11 +67,37 @@ class SerializationOutputTests {
     @Suppress("AddVarianceModifier")
     data class GenericFoo<T>(val bar: String, val pub: T)
 
+    data class ContainsGenericFoo(val contain: GenericFoo<String>)
+
+    data class NestedGenericFoo<T>(val contain: GenericFoo<T>)
+
+    data class ContainsNestedGenericFoo(val contain: NestedGenericFoo<String>)
+
     data class TreeMapWrapper(val tree: TreeMap<Int, Foo>)
 
     data class NavigableMapWrapper(val tree: NavigableMap<Int, Foo>)
 
     data class SortedSetWrapper(val set: SortedSet<Int>)
+
+    open class InheritedGeneric<X>(val foo: X)
+
+    data class ExtendsGeneric(val bar: Int, val pub: String) : InheritedGeneric<String>(pub)
+
+    interface GenericInterface<X> {
+        val pub: X
+    }
+
+    data class ImplementsGenericString(val bar: Int, override val pub: String) : GenericInterface<String>
+
+    data class ImplementsGenericX<Y>(val bar: Int, override val pub: Y) : GenericInterface<Y>
+
+    abstract class AbstractGenericX<Z> : GenericInterface<Z>
+
+    data class InheritGenericX<A>(val duke: Double, override val pub: A) : AbstractGenericX<A>()
+
+    data class CapturesGenericX(val foo: GenericInterface<String>)
+
+    object KotlinObject
 
     class Mismatch(fred: Int) {
         val ginger: Int = fred
@@ -85,7 +120,11 @@ class SerializationOutputTests {
 
     data class PolymorphicProperty(val foo: FooInterface?)
 
-    private fun serdes(obj: Any, factory: SerializerFactory = SerializerFactory(), freshDeserializationFactory: SerializerFactory = SerializerFactory(), expectedEqual: Boolean = true): Any {
+    private fun serdes(obj: Any,
+                       factory: SerializerFactory = SerializerFactory(),
+                       freshDeserializationFactory: SerializerFactory = SerializerFactory(),
+                       expectedEqual: Boolean = true,
+                       expectDeserializedEqual: Boolean = true): Any {
         val ser = SerializationOutput(factory)
         val bytes = ser.serialize(obj)
 
@@ -103,6 +142,7 @@ class SerializationOutputTests {
         // Check that a vanilla AMQP decoder can deserialize without schema.
         val result = decoder.readObject() as Envelope
         assertNotNull(result)
+        println(result.schema)
 
         val des = DeserializationInput(freshDeserializationFactory)
         val desObj = des.deserialize(bytes)
@@ -113,7 +153,7 @@ class SerializationOutputTests {
         val des2 = DeserializationInput(factory)
         val desObj2 = des2.deserialize(ser2.serialize(obj))
         assertTrue(Objects.deepEquals(obj, desObj2) == expectedEqual)
-        assertTrue(Objects.deepEquals(desObj, desObj2))
+        assertTrue(Objects.deepEquals(desObj, desObj2) == expectDeserializedEqual)
 
         // TODO: add some schema assertions to check correctly formed.
         return desObj2
@@ -155,7 +195,7 @@ class SerializationOutputTests {
         serdes(obj)
     }
 
-    @Test
+    @Test(expected = NotSerializableException::class)
     fun `test top level list array`() {
         val obj = arrayOf(listOf("Fred", "Ginger"), listOf("Rogers", "Hammerstein"))
         serdes(obj)
@@ -197,9 +237,48 @@ class SerializationOutputTests {
         serdes(obj)
     }
 
-    @Test(expected = NotSerializableException::class)
+    @Test
     fun `test generic foo`() {
         val obj = GenericFoo("Fred", "Ginger")
+        serdes(obj)
+    }
+
+    @Test
+    fun `test generic foo as property`() {
+        val obj = ContainsGenericFoo(GenericFoo("Fred", "Ginger"))
+        serdes(obj)
+    }
+
+    @Test
+    fun `test nested generic foo as property`() {
+        val obj = ContainsNestedGenericFoo(NestedGenericFoo(GenericFoo("Fred", "Ginger")))
+        serdes(obj)
+    }
+
+    // TODO: Generic interfaces / superclasses
+
+    @Test
+    fun `test extends generic`() {
+        val obj = ExtendsGeneric(1, "Ginger")
+        serdes(obj)
+    }
+
+    @Test
+    fun `test implements generic`() {
+        val obj = ImplementsGenericString(1, "Ginger")
+        serdes(obj)
+    }
+
+    @Test
+    fun `test implements generic captured`() {
+        val obj = CapturesGenericX(ImplementsGenericX(1, "Ginger"))
+        serdes(obj)
+    }
+
+
+    @Test
+    fun `test inherits generic captured`() {
+        val obj = CapturesGenericX(InheritGenericX(1.0, "Ginger"))
         serdes(obj)
     }
 
@@ -246,9 +325,9 @@ class SerializationOutputTests {
     @Test
     fun `test custom serializers on public key`() {
         val factory = SerializerFactory()
-        factory.register(net.corda.core.serialization.amqp.custom.PublicKeySerializer())
+        factory.register(net.corda.core.serialization.amqp.custom.PublicKeySerializer)
         val factory2 = SerializerFactory()
-        factory2.register(net.corda.core.serialization.amqp.custom.PublicKeySerializer())
+        factory2.register(net.corda.core.serialization.amqp.custom.PublicKeySerializer)
         val obj = MEGA_CORP_PUBKEY
         serdes(obj, factory, factory2)
     }
@@ -267,8 +346,9 @@ class SerializationOutputTests {
         val factory2 = SerializerFactory()
         factory2.register(net.corda.core.serialization.amqp.custom.ThrowableSerializer(factory2))
 
-        val obj = IllegalAccessException("message").fillInStackTrace()
-        serdes(obj, factory, factory2, false)
+        val t = IllegalAccessException("message").fillInStackTrace()
+        val desThrowable = serdes(t, factory, factory2, false) as Throwable
+        assertSerializedThrowableEquivalent(t, desThrowable)
     }
 
     @Test
@@ -286,7 +366,19 @@ class SerializationOutputTests {
                 throw IllegalStateException("Layer 2", t)
             }
         } catch(t: Throwable) {
-            serdes(t, factory, factory2, false)
+            val desThrowable = serdes(t, factory, factory2, false) as Throwable
+            assertSerializedThrowableEquivalent(t, desThrowable)
+        }
+    }
+
+    fun assertSerializedThrowableEquivalent(t: Throwable, desThrowable: Throwable) {
+        assertTrue(desThrowable is CordaRuntimeException) // Since we don't handle the other case(s) yet
+        if (desThrowable is CordaRuntimeException) {
+            assertEquals("${t.javaClass.name}: ${t.message}", desThrowable.message)
+            assertTrue(desThrowable is CordaRuntimeException)
+            assertTrue(Objects.deepEquals(t.stackTrace, desThrowable.stackTrace))
+            assertEquals(t.suppressed.size, desThrowable.suppressed.size)
+            t.suppressed.zip(desThrowable.suppressed).forEach { (before, after) -> assertSerializedThrowableEquivalent(before, after) }
         }
     }
 
@@ -307,7 +399,8 @@ class SerializationOutputTests {
                 throw e
             }
         } catch(t: Throwable) {
-            serdes(t, factory, factory2, false)
+            val desThrowable = serdes(t, factory, factory2, false) as Throwable
+            assertSerializedThrowableEquivalent(t, desThrowable)
         }
     }
 
@@ -347,4 +440,88 @@ class SerializationOutputTests {
         serdes(obj)
     }
 
+    @Test
+    fun `test kotlin object`() {
+        serdes(KotlinObject)
+    }
+
+    object FooContract : Contract {
+        override fun verify(tx: TransactionForContract) {
+
+        }
+
+        override val legalContractReference: SecureHash = SecureHash.Companion.sha256("FooContractLegal")
+    }
+
+    class FooState : ContractState {
+        override val contract: Contract
+            get() = FooContract
+        override val participants: List<AbstractParty>
+            get() = emptyList()
+    }
+
+    @Test
+    fun `test transaction state`() {
+        val state = TransactionState<FooState>(FooState(), MEGA_CORP)
+
+        val factory = SerializerFactory()
+        KryoAMQPSerializer.registerCustomSerializers(factory)
+
+        val factory2 = SerializerFactory()
+        KryoAMQPSerializer.registerCustomSerializers(factory2)
+
+        val desState = serdes(state, factory, factory2, expectedEqual = false, expectDeserializedEqual = false)
+        assertTrue(desState is TransactionState<*>)
+        assertTrue((desState as TransactionState<*>).data is FooState)
+        assertTrue(desState.notary == state.notary)
+        assertTrue(desState.encumbrance == state.encumbrance)
+    }
+
+    @Test
+    fun `test currencies serialize`() {
+        val factory = SerializerFactory()
+        factory.register(net.corda.core.serialization.amqp.custom.CurrencySerializer)
+
+        val factory2 = SerializerFactory()
+        factory2.register(net.corda.core.serialization.amqp.custom.CurrencySerializer)
+
+        val obj = Currency.getInstance("USD")
+        serdes(obj, factory, factory2)
+    }
+
+    @Test
+    fun `test big decimals serialize`() {
+        val factory = SerializerFactory()
+        factory.register(net.corda.core.serialization.amqp.custom.BigDecimalSerializer)
+
+        val factory2 = SerializerFactory()
+        factory2.register(net.corda.core.serialization.amqp.custom.BigDecimalSerializer)
+
+        val obj = BigDecimal("100000000000000000000000000000.00")
+        serdes(obj, factory, factory2)
+    }
+
+    @Test
+    fun `test instants serialize`() {
+        val factory = SerializerFactory()
+        factory.register(net.corda.core.serialization.amqp.custom.InstantSerializer(factory))
+
+        val factory2 = SerializerFactory()
+        factory2.register(net.corda.core.serialization.amqp.custom.InstantSerializer(factory2))
+
+        val obj = Instant.now()
+        serdes(obj, factory, factory2)
+    }
+
+    @Test
+    fun `test StateRef serialize`() {
+        val factory = SerializerFactory()
+        factory.register(net.corda.core.serialization.amqp.custom.InstantSerializer(factory))
+
+        val factory2 = SerializerFactory()
+        factory2.register(net.corda.core.serialization.amqp.custom.InstantSerializer(factory2))
+
+        val obj = StateRef(SecureHash.randomSHA256(), 0)
+        serdes(obj, factory, factory2)
+    }
 }


### PR DESCRIPTION
- integrates with Kryo so that any `@CordaSerializable` triggers a switch to using AMQP serialization (but only if a boolean flag is adjusted in the code first, so will be disabled in master)
- using this to discover issues / corner cases that need supporting
- some custom serializers to marshal some of our common types
- some refactoring to handle generics for e.g. Amount<T>
- some bug fixes that @fenryka needs for the carpenter work
- more test cases relating to above work

Plenty of TODOs left to do.