### PR TITLE
Correct construction of anonymous parties

### DIFF
--- a/core/src/main/kotlin/net/corda/flows/TxKeyFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/TxKeyFlow.kt
@@ -84,6 +84,6 @@ object TxKeyFlow {
             val identity: AnonymousParty) {
         constructor(myIdentity: Pair<X509CertificateHolder, CertPath>) : this(myIdentity.second,
                 myIdentity.first,
-                AnonymousParty(myIdentity.second.certificates.last().publicKey))
+                AnonymousParty(myIdentity.second.certificates.first().publicKey))
     }
 }


### PR DESCRIPTION
Correct construction of anonymous parties to use the first certificate (the target) rather than the last (the trust root). Worked because early tests used single certificate paths, but later work introducing multi-certificate paths reveal it's rather broken.