### PR TITLE
Replace certificate path generation

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/X509Utilities.kt
@@ -10,7 +10,6 @@ import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.util.io.pem.PemReader
-import java.io.ByteArrayInputStream
 import java.io.FileReader
 import java.io.FileWriter
 import java.io.InputStream
@@ -127,22 +126,6 @@ object X509Utilities {
                           nameConstraints: NameConstraints? = null): X509CertificateHolder {
         val window = getCertificateValidityWindow(validityWindow.first, validityWindow.second, issuerCertificate)
         return Crypto.createCertificate(certificateType, issuerCertificate.subject, issuerKeyPair, subject, subjectPublicKey, window, nameConstraints)
-    }
-
-    /**
-     * Build a certificate path from a trusted root certificate to a target certificate. This will always return a path
-     * directly from the target to the root.
-     *
-     * @param trustedRoot trusted root certificate that will be the start of the path.
-     * @param certificates certificates in the path.
-     * @param revocationEnabled whether revocation of certificates in the path should be checked.
-     */
-    fun createCertificatePath(trustedRoot: X509CertificateHolder, vararg certificates: X509CertificateHolder, revocationEnabled: Boolean): CertPath {
-        val certFactory = CertificateFactory.getInstance("X509")
-        val trustedRootX509 = certFactory.generateCertificate(ByteArrayInputStream(trustedRoot.encoded)) as X509Certificate
-        val params = PKIXParameters(setOf(TrustAnchor(trustedRootX509, null)))
-        params.isRevocationEnabled = revocationEnabled
-        return certFactory.generateCertPath(certificates.map { certFactory.generateCertificate(ByteArrayInputStream(it.encoded)) }.toList())
     }
 
     fun validateCertificateChain(trustedRoot: X509CertificateHolder, vararg certificates: Certificate) {

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -9,6 +9,10 @@ import org.bouncycastle.asn1.x500.X500Name
 import java.math.BigInteger
 import java.security.KeyPair
 import java.security.PublicKey
+import java.security.cert.CertStore
+import java.security.cert.CertificateFactory
+import java.security.cert.CollectionCertStoreParameters
+import java.security.cert.X509Certificate
 import java.time.Instant
 
 // A dummy time at which we will be pretending test transactions are created.
@@ -70,7 +74,8 @@ val DUMMY_CA: CertificateAndKeyPair by lazy {
  * Build a test party with a nonsense certificate authority for testing purposes.
  */
 fun getTestPartyAndCertificate(name: X500Name, publicKey: PublicKey, ca: CertificateAndKeyPair = DUMMY_CA): PartyAndCertificate {
-    val cert = X509Utilities.createCertificate(CertificateType.IDENTITY, ca.certificate, ca.keyPair, name, publicKey)
-    val certPath = X509Utilities.createCertificatePath(ca.certificate, cert, revocationEnabled = false)
-    return PartyAndCertificate(name, publicKey, cert, certPath)
+    val certFactory = CertificateFactory.getInstance("X509")
+    val certHolder = X509Utilities.createCertificate(CertificateType.IDENTITY, ca.certificate, ca.keyPair, name, publicKey)
+    val certPath = certFactory.generateCertPath(listOf(certHolder.cert, ca.certificate.cert))
+    return PartyAndCertificate(name, publicKey, certHolder, certPath)
 }

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -9,10 +9,7 @@ import org.bouncycastle.asn1.x500.X500Name
 import java.math.BigInteger
 import java.security.KeyPair
 import java.security.PublicKey
-import java.security.cert.CertStore
 import java.security.cert.CertificateFactory
-import java.security.cert.CollectionCertStoreParameters
-import java.security.cert.X509Certificate
 import java.time.Instant
 
 // A dummy time at which we will be pretending test transactions are created.
@@ -73,9 +70,9 @@ val DUMMY_CA: CertificateAndKeyPair by lazy {
 /**
  * Build a test party with a nonsense certificate authority for testing purposes.
  */
-fun getTestPartyAndCertificate(name: X500Name, publicKey: PublicKey, ca: CertificateAndKeyPair = DUMMY_CA): PartyAndCertificate {
+fun getTestPartyAndCertificate(name: X500Name, publicKey: PublicKey, trustRoot: CertificateAndKeyPair = DUMMY_CA): PartyAndCertificate {
     val certFactory = CertificateFactory.getInstance("X509")
-    val certHolder = X509Utilities.createCertificate(CertificateType.IDENTITY, ca.certificate, ca.keyPair, name, publicKey)
-    val certPath = certFactory.generateCertPath(listOf(certHolder.cert, ca.certificate.cert))
+    val certHolder = X509Utilities.createCertificate(CertificateType.IDENTITY, trustRoot.certificate, trustRoot.keyPair, name, publicKey)
+    val certPath = certFactory.generateCertPath(listOf(certHolder.cert, trustRoot.certificate.cert))
     return PartyAndCertificate(name, publicKey, certHolder, certPath)
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
@@ -16,8 +16,7 @@ import org.junit.Test
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.InputStream
-import java.security.cert.CertPath
-import java.security.cert.X509Certificate
+import java.security.cert.*
 import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
@@ -152,10 +151,11 @@ class KryoTests {
 
     @Test
     fun `serialize - deserialize X509CertPath`() {
+        val certFactory = CertificateFactory.getInstance("X509")
         val rootCAKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         val rootCACert = X509Utilities.createSelfSignedCACertificate(ALICE.name, rootCAKey)
         val certificate = X509Utilities.createCertificate(CertificateType.TLS, rootCACert, rootCAKey, BOB.name, BOB_PUBKEY)
-        val expected = X509Utilities.createCertificatePath(rootCACert, certificate, revocationEnabled = false)
+        val expected = certFactory.generateCertPath(listOf(rootCACert.cert, certificate.cert))
         val serialized = expected.serialize(kryo).bytes
         val actual: CertPath = serialized.deserialize(kryo)
         assertEquals(expected, actual)

--- a/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/KryoTests.kt
@@ -155,7 +155,7 @@ class KryoTests {
         val rootCAKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
         val rootCACert = X509Utilities.createSelfSignedCACertificate(ALICE.name, rootCAKey)
         val certificate = X509Utilities.createCertificate(CertificateType.TLS, rootCACert, rootCAKey, BOB.name, BOB_PUBKEY)
-        val expected = certFactory.generateCertPath(listOf(rootCACert.cert, certificate.cert))
+        val expected = certFactory.generateCertPath(listOf(certificate.cert, rootCACert.cert))
         val serialized = expected.serialize(kryo).bytes
         val actual: CertPath = serialized.deserialize(kryo)
         assertEquals(expected, actual)

--- a/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
@@ -1,9 +1,6 @@
 package net.corda.node.services.keys
 
-import net.corda.core.crypto.CertificateType
-import net.corda.core.crypto.ContentSignerBuilder
-import net.corda.core.crypto.Crypto
-import net.corda.core.crypto.X509Utilities
+import net.corda.core.crypto.*
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
@@ -13,6 +10,7 @@ import java.security.KeyPair
 import java.security.PublicKey
 import java.security.Security
 import java.security.cert.CertPath
+import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.*
@@ -21,10 +19,10 @@ import java.util.*
  * Generates a new random [KeyPair], adds it to the internal key storage, then generates a corresponding
  * [X509Certificate] and adds it to the identity service.
  *
- * @param subjectPublicKey public key of new identity.
- * @param issuerSigner a content signer for the issuer.
  * @param identityService issuer service to use when registering the certificate.
+ * @param subjectPublicKey public key of new identity.
  * @param issuer issuer to generate a key and certificate for. Must be an identity this node has the private key for.
+ * @param issuerSigner a content signer for the issuer.
  * @param revocationEnabled whether to check revocation status of certificates in the certificate path.
  * @return X.509 certificate and path to the trust root.
  */
@@ -36,10 +34,8 @@ fun freshCertificate(identityService: IdentityService,
     val issuerCertificate = issuer.certificate
     val window = X509Utilities.getCertificateValidityWindow(Duration.ZERO, Duration.ofDays(10 * 365), issuerCertificate)
     val ourCertificate = Crypto.createCertificate(CertificateType.IDENTITY, issuerCertificate.subject, issuerSigner, issuer.name, subjectPublicKey, window)
-    val actualPublicKey = Crypto.toSupportedPublicKey(ourCertificate.subjectPublicKeyInfo)
-    require(subjectPublicKey == actualPublicKey)
-    val ourCertPath = X509Utilities.createCertificatePath(issuerCertificate, ourCertificate, revocationEnabled = revocationEnabled)
-    require(Arrays.equals(ourCertificate.subjectPublicKeyInfo.encoded, subjectPublicKey.encoded))
+    val certFactory = CertificateFactory.getInstance("X509")
+    val ourCertPath = certFactory.generateCertPath(listOf(ourCertificate.cert) + issuer.certPath.certificates)
     identityService.registerAnonymousIdentity(AnonymousParty(subjectPublicKey),
             issuer.party,
             ourCertPath)

--- a/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
@@ -35,7 +35,7 @@ object ServiceIdentityGenerator {
         val keyPairs = (1..dirs.size).map { generateKeyPair() }
         val notaryKey = CompositeKey.Builder().addKeys(keyPairs.map { it.public }).build(threshold)
         val certFactory = CertificateFactory.getInstance("X509")
-        val notaryCert = X509Utilities.createCertificate(CertificateType.INTERMEDIATE_CA, serviceCa.certificate,
+        val notaryCert = X509Utilities.createCertificate(CertificateType.IDENTITY, serviceCa.certificate,
             serviceCa.keyPair, serviceName, notaryKey)
         val notaryCertPath = certFactory.generateCertPath(listOf(serviceCa.certificate.cert, notaryCert.cert))
         val notaryParty = PartyAndCertificate(serviceName, notaryKey, notaryCert, notaryCertPath)

--- a/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/ServiceIdentityGenerator.kt
@@ -34,9 +34,10 @@ object ServiceIdentityGenerator {
         log.trace { "Generating a group identity \"serviceName\" for nodes: ${dirs.joinToString()}" }
         val keyPairs = (1..dirs.size).map { generateKeyPair() }
         val notaryKey = CompositeKey.Builder().addKeys(keyPairs.map { it.public }).build(threshold)
+        val certFactory = CertificateFactory.getInstance("X509")
         val notaryCert = X509Utilities.createCertificate(CertificateType.INTERMEDIATE_CA, serviceCa.certificate,
             serviceCa.keyPair, serviceName, notaryKey)
-        val notaryCertPath = X509Utilities.createCertificatePath(serviceCa.certificate, notaryCert, revocationEnabled = false)
+        val notaryCertPath = certFactory.generateCertPath(listOf(serviceCa.certificate.cert, notaryCert.cert))
         val notaryParty = PartyAndCertificate(serviceName, notaryKey, notaryCert, notaryCertPath)
         val notaryPartyBytes = notaryParty.serialize()
         val privateKeyFile = "$serviceId-private-key"


### PR DESCRIPTION
Use the certificate factory directly to build paths rather than assembling them via an interim API call. After reducing the complexity of the utility API, it's replacing two lines of code, at which point it seems better to make the behaviour clearer rather than having a function hide what's actually going on.