### PR TITLE
Java accessible API for merkle trees

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -11,6 +11,7 @@ import net.corda.core.serialization.p2PKryo
 import net.corda.core.serialization.serialize
 import net.corda.core.serialization.withoutReferences
 import java.security.PublicKey
+import java.util.function.Predicate
 
 fun <T : Any> serializedHash(x: T): SecureHash {
     return p2PKryo().run { kryo -> kryo.withoutReferences { x.serialize(kryo).hash } }
@@ -116,8 +117,9 @@ class FilteredTransaction private constructor(
          * @param wtx WireTransaction to be filtered.
          * @param filtering filtering over the whole WireTransaction
          */
+        @JvmStatic
         fun buildMerkleTransaction(wtx: WireTransaction,
-                                   filtering: (Any) -> Boolean
+                                   filtering: Predicate<Any>
         ): FilteredTransaction {
             val filteredLeaves = wtx.filterWithFun(filtering)
             val merkleTree = wtx.merkleTree

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -13,6 +13,7 @@ import net.corda.core.serialization.p2PKryo
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.Emoji
 import java.security.PublicKey
+import java.util.function.Predicate
 
 /**
  * A transaction ready for serialisation, without any signatures attached. A WireTransaction is usually wrapped
@@ -106,7 +107,7 @@ class WireTransaction(
     /**
      * Build filtered transaction using provided filtering functions.
      */
-    fun buildFilteredTransaction(filtering: (Any) -> Boolean): FilteredTransaction {
+    fun buildFilteredTransaction(filtering: Predicate<Any>): FilteredTransaction {
         return FilteredTransaction.buildMerkleTransaction(this, filtering)
     }
 
@@ -120,15 +121,15 @@ class WireTransaction(
      * @param filtering filtering over the whole WireTransaction
      * @returns FilteredLeaves used in PartialMerkleTree calculation and verification.
      */
-    fun filterWithFun(filtering: (Any) -> Boolean): FilteredLeaves {
-        fun notNullFalse(elem: Any?): Any? = if (elem == null || !filtering(elem)) null else elem
+    fun filterWithFun(filtering: Predicate<Any>): FilteredLeaves {
+        fun notNullFalse(elem: Any?): Any? = if (elem == null || !filtering.test(elem)) null else elem
         return FilteredLeaves(
-                inputs.filter { filtering(it) },
-                attachments.filter { filtering(it) },
-                outputs.filter { filtering(it) },
-                commands.filter { filtering(it) },
+                inputs.filter { filtering.test(it) },
+                attachments.filter { filtering.test(it) },
+                outputs.filter { filtering.test(it) },
+                commands.filter { filtering.test(it) },
                 notNullFalse(notary) as Party?,
-                mustSign.filter { filtering(it) },
+                mustSign.filter { filtering.test(it) },
                 notNullFalse(type) as TransactionType?,
                 notNullFalse(timeWindow) as TimeWindow?
         )

--- a/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/NotaryFlow.kt
@@ -19,6 +19,7 @@ import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
+import java.util.function.Predicate
 
 object NotaryFlow {
     /**
@@ -63,7 +64,7 @@ object NotaryFlow {
             val payload: Any = if (serviceHub.networkMapCache.isValidatingNotary(notaryParty)) {
                 stx
             } else {
-                wtx.buildFilteredTransaction { it is StateRef || it is TimeWindow }
+                wtx.buildFilteredTransaction(Predicate { it is StateRef || it is TimeWindow })
             }
 
             val response = try {

--- a/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
@@ -15,6 +15,7 @@ import net.corda.core.utilities.TEST_TX_TIME
 import net.corda.testing.*
 import org.junit.Test
 import java.security.PublicKey
+import java.util.function.Predicate
 import kotlin.test.*
 
 class PartialMerkleTreeTest {
@@ -104,7 +105,7 @@ class PartialMerkleTreeTest {
             }
         }
 
-        val mt = testTx.buildFilteredTransaction(::filtering)
+        val mt = testTx.buildFilteredTransaction(Predicate(::filtering))
         val leaves = mt.filteredLeaves
         val d = WireTransaction.deserialize(testTx.serialized)
         assertEquals(testTx.id, d.id)
@@ -128,7 +129,7 @@ class PartialMerkleTreeTest {
 
     @Test
     fun `nothing filtered`() {
-        val mt = testTx.buildFilteredTransaction({ false })
+        val mt = testTx.buildFilteredTransaction(Predicate { false })
         assertTrue(mt.filteredLeaves.attachments.isEmpty())
         assertTrue(mt.filteredLeaves.commands.isEmpty())
         assertTrue(mt.filteredLeaves.inputs.isEmpty())

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
@@ -17,6 +17,7 @@ import net.corda.irs.utilities.suggestInterestRateAnnouncementTimeWindow
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
+import java.util.function.Predicate
 
 // This code is unit tested in NodeInterestRates.kt
 
@@ -62,7 +63,7 @@ open class RatesFixFlow(protected val tx: TransactionBuilder,
         tx.addCommand(fix, oracle.owningKey)
         beforeSigning(fix)
         progressTracker.currentStep = SIGNING
-        val mtx = tx.toWireTransaction().buildFilteredTransaction({ filtering(it) })
+        val mtx = tx.toWireTransaction().buildFilteredTransaction(Predicate { filtering(it) })
         val signature = subFlow(FixSignFlow(tx, oracle, mtx))
         tx.addSignatureUnchecked(signature)
     }


### PR DESCRIPTION
The currently exposed merkle tree api is using kotlin function types. Change this to Java Predicate types to improve Java interop.