### PR TITLE
Update BC to 1.57 to reduce timing side-channel attacks

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,5 +1,5 @@
 gradlePluginsVersion=0.12.4
 kotlinVersion=1.1.1
 guavaVersion=21.0
-bouncycastleVersion=1.56
+bouncycastleVersion=1.57
 typesafeConfigVersion=1.3.1


### PR DESCRIPTION
Among other fixes, BC-1.57 EC FixedPointCombMultiplier avoids 'infinity' point in lookup tables, reducing timing side-channels.