### PR TITLE
Add timezones to non-test logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,12 +103,6 @@ allprojects {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
-    // Use manual resource copying of log4j2.xml rather than source sets.
-    // This prevents problems in IntelliJ with regard to duplicate source roots.
-    processTestResources {
-        from file("$rootDir/config/test/log4j2.xml")
-    }
-
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-Xlint:-options" << "-parameters"
     }

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -36,9 +36,6 @@ sourceSets {
 }
 
 processSmokeTestResources {
-    from(file("$rootDir/config/test/log4j2.xml")) {
-        rename 'log4j2\\.xml', 'log4j2-test.xml'
-    }
     from(project(':node:capsule').tasks.buildCordaJAR) {
         rename 'corda-(.*)', 'corda.jar'
     }

--- a/config/dev/log4j2-corda.xml
+++ b/config/dev/log4j2-corda.xml
@@ -13,7 +13,7 @@
 
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="%highlight{%level{length=1} %d{HH:mm:ss} [%t] %c{2}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}" />
+            <PatternLayout pattern="%highlight{%level{length=1} %d{HH:mm:ssZ} [%t] %c{2}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}" />
         </Console>
 
         <!-- Required for printBasicInfo -->
@@ -27,7 +27,7 @@
                      fileName="${sys:log-path}/${log-name}.log"
                      filePattern="${archive}/${log-name}.%d{yyyy-MM-dd}-%i.log.gz">
 
-            <PatternLayout pattern="[%-5level] %d{ISO8601}{GMT+0} [%t] %c{2}.%M - %msg%n"/>
+            <PatternLayout pattern="[%-5level] %d{ISO8601}{UTC}Z [%t] %c{2}.%M - %msg%n"/>
 
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
@@ -104,7 +104,6 @@ class Node extends CordformNode {
         installWebserverJar()
         installBuiltPlugin()
         installCordapps()
-        installDependencies()
         installConfig()
     }
 
@@ -169,23 +168,6 @@ class Node extends CordformNode {
         project.copy {
             from cordapps
             into pluginsDir
-        }
-    }
-
-    /**
-     * Installs other dependencies to this node's dependencies directory.
-     */
-    private void installDependencies() {
-        def cordaJar = verifyAndGetCordaJar()
-        def webJar = verifyAndGetWebserverJar()
-        def depsDir = new File(nodeDir, "dependencies")
-        def coreDeps = project.zipTree(cordaJar).getFiles().collect { it.getName() }
-        def appDeps = project.configurations.runtime.filter {
-            (it != cordaJar) && (it != webJar) && !project.configurations.cordapp.contains(it) && !coreDeps.contains(it.getName())
-        }
-        project.copy {
-            from appDeps
-            into depsDir
         }
     }
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -55,7 +55,7 @@ sourceSets {
 // Use manual resource copying of log4j2.xml rather than source sets.
 // This prevents problems in IntelliJ with regard to duplicate source roots.
 processResources {
-    from file("$rootDir/config/dev/log4j2.xml")
+    from file("$rootDir/config/dev/log4j2-corda.xml")
 }
 
 processSmokeTestResources {

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -25,9 +25,9 @@ task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').compileJava) {
     applicationSource = files(
             project(':node').configurations.runtime,
             project(':node').jar,
+            '../build/classes/main/AbstractCordaCaplet.class',
             '../build/classes/main/CordaCaplet.class',
-            '../build/classes/main/CordaCaplet$1.class',
-            "$rootDir/config/dev/log4j2.xml"
+            "$rootDir/config/dev/log4j2-corda.xml"
     )
     from 'NOTICE' // Copy CDDL notice
 
@@ -40,6 +40,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').compileJava) {
         // javaAgents = ["quasar-core-${quasar_version}-jdk8.jar=${quasarExcludeExpression}"]
         javaAgents = ["quasar-core-${quasar_version}-jdk8.jar"]
         systemProperties['visualvm.display.name'] = 'Corda'
+        systemProperties['log4j.configurationFile'] = 'classpath:log4j2-corda.xml'
         minJavaVersion = '1.8.0'
         minUpdateVersion['1.8'] = java8_minUpdateVersion
         caplets = ['CordaCaplet']

--- a/node/src/integration-test/kotlin/net/corda/node/BootTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/BootTests.kt
@@ -11,12 +11,12 @@ import net.corda.testing.driver.driver
 import net.corda.node.internal.NodeStartup
 import net.corda.node.services.startFlowPermission
 import net.corda.nodeapi.User
+import net.corda.testing.ProjectStructure.projectRootDir
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import java.io.*
 import java.nio.file.Files
-import java.nio.file.Paths
 import kotlin.test.assertEquals
 
 class BootTests {
@@ -33,7 +33,7 @@ class BootTests {
 
     @Test
     fun `double node start doesn't write into log file`() {
-        val logConfigFile = Paths.get("..", "config", "dev", "log4j2.xml").toAbsolutePath()
+        val logConfigFile = projectRootDir / "config" / "dev" / "log4j2-corda.xml"
         assertThat(logConfigFile).isRegularFile()
         driver(isDebug = true, systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())) {
             val alice = startNode(ALICE.name).get()

--- a/node/src/main/java/AbstractCordaCaplet.java
+++ b/node/src/main/java/AbstractCordaCaplet.java
@@ -1,0 +1,29 @@
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+public class AbstractCordaCaplet extends Capsule {
+    protected AbstractCordaCaplet(Capsule pred) {
+        super(pred);
+    }
+
+    /**
+     * Overriding the Caplet classpath generation via the intended interface in Capsule.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> T attribute(Map.Entry<String, T> attr) {
+        T value = super.attribute(attr);
+        // Equality is used here because Capsule never instantiates these attributes but instead reuses the ones
+        // defined as public static final fields on the Capsule class, therefore referential equality is safe.
+        if (ATTR_APP_CLASS_PATH == attr) {
+            // TODO: Make directory configurable via the capsule manifest.
+            // TODO: Add working directory variable to capsules string replacement variables.
+            File pluginsPath = new File("plugins");
+            pluginsPath.mkdir(); // XXX: Can't we do this somewhere else?
+            ((List<Path>) value).add(pluginsPath.toPath().toAbsolutePath().resolve("*")); // Literal asterisk.
+        }
+        return value;
+    }
+}

--- a/node/src/main/java/CordaCaplet.java
+++ b/node/src/main/java/CordaCaplet.java
@@ -2,63 +2,18 @@
 // must also be in the default package. When using Kotlin there are a whole host of exceptions
 // trying to construct this from Capsule, so it is written in Java.
 
-import sun.misc.*;
+import sun.misc.Signal;
 
-import java.io.*;
-import java.nio.file.*;
-import java.util.*;
-
-public class CordaCaplet extends Capsule {
-
+public class CordaCaplet extends AbstractCordaCaplet {
     protected CordaCaplet(Capsule pred) {
         super(pred);
-    }
-
-    /**
-     * Overriding the Caplet classpath generation via the intended interface in Capsule.
-     */
-    @Override
-    @SuppressWarnings("unchecked")
-    protected <T> T attribute(Map.Entry<String, T> attr) {
-        // Equality is used here because Capsule never instantiates these attributes but instead reuses the ones
-        // defined as public static final fields on the Capsule class, therefore referential equality is safe.
-        if (ATTR_APP_CLASS_PATH == attr) {
-            T cp = super.attribute(attr);
-            List<Path> classpath = augmentClasspath((List<Path>) cp, "plugins");
-            return (T) augmentClasspath(classpath, "dependencies");
-        }
-        return super.attribute(attr);
-    }
-
-    // TODO: Make directory configurable via the capsule manifest.
-    // TODO: Add working directory variable to capsules string replacement variables.
-    private List<Path> augmentClasspath(List<Path> classpath, String dirName) {
-        File dir = new File(dirName);
-        if (!dir.exists()) {
-            dir.mkdir();
-        }
-
-        File[] files = dir.listFiles();
-        for (File file : files) {
-            if (file.isFile() && isJAR(file)) {
-                classpath.add(file.toPath().toAbsolutePath());
-            }
-        }
-        return classpath;
     }
 
     @Override
     protected void liftoff() {
         super.liftoff();
-        Signal.handle(new Signal("INT"), new SignalHandler() {
-            @Override
-            public void handle(Signal signal) {
-                // Disable Ctrl-C for this process, so the child process can handle it in the shell instead.
-            }
+        Signal.handle(new Signal("INT"), signal -> {
+            // Disable Ctrl-C for this process, so the child process can handle it in the shell instead.
         });
-    }
-
-    private Boolean isJAR(File file) {
-        return file.getName().toLowerCase().endsWith(".jar");
     }
 }

--- a/samples/network-visualiser/build.gradle
+++ b/samples/network-visualiser/build.gradle
@@ -41,6 +41,7 @@ task deployVisualiser(type: FatCapsule) {
     applicationClass 'net.corda.netmap.NetworkMapVisualiser'
     reallyExecutable
     capsuleManifest {
+        systemProperties['log4j.configurationFile'] = 'classpath:log4j2-corda.xml'
         minJavaVersion = '1.8.0'
         javaAgents = [configurations.quasar.singleFile.name]
     }

--- a/samples/simm-valuation-demo/src/main/resources/log4j2.xml
+++ b/samples/simm-valuation-demo/src/main/resources/log4j2.xml
@@ -29,7 +29,7 @@
                      fileName="${log-path}/${log-name}.log"
                      filePattern="${archive}/${log-name}.%d{yyyy-MM-dd}-%i.log.gz">
 
-            <PatternLayout pattern="[%-5level] %d{ISO8601}{GMT+0} [%t] %c{2} - %msg%n"/>
+            <PatternLayout pattern="[%-5level] %d{ISO8601}{UTC}Z [%t] %c{2} - %msg%n"/>
 
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/smoke-test-utils/src/main/resources/log4j2-test.xml
+++ b/smoke-test-utils/src/main/resources/log4j2-test.xml
@@ -5,7 +5,7 @@
     </Properties>
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%-5level] %d{HH:mm:ss.SSS} [%t] %c{2}.%M - %msg%n" />
+            <PatternLayout pattern="[%-5level] %d{HH:mm:ss,SSS} [%t] %c{2}.%M - %msg%n" />
         </Console>
         <!-- Required for printBasicInfo -->
         <Console name="Console-Appender-Println" target="SYSTEM_OUT">

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -27,6 +27,7 @@ sourceSets {
 }
 
 dependencies {
+    compile project(':smoke-test-utils')
     compile project(':finance')
     compile project(':core')
     compile project(':node')

--- a/test-utils/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/test-utils/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -13,9 +13,9 @@ import net.corda.node.internal.NodeStartup
 import net.corda.node.services.api.RegulatorService
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.ArtemisMessagingComponent
+import net.corda.testing.ProjectStructure.projectRootDir
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.nio.file.Paths
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
@@ -70,7 +70,7 @@ class DriverTests {
     @Test
     fun `debug mode enables debug logging level`() {
         // Make sure we're using the log4j2 config which writes to the log file
-        val logConfigFile = Paths.get("..", "config", "dev", "log4j2.xml").toAbsolutePath()
+        val logConfigFile = projectRootDir / "config" / "dev" / "log4j2-corda.xml"
         assertThat(logConfigFile).isRegularFile()
         driver(isDebug = true, systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())) {
             val baseDirectory = startNode(DUMMY_BANK_A.name).getOrThrow().configuration.baseDirectory

--- a/test-utils/src/main/kotlin/net/corda/testing/ProjectStructure.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/ProjectStructure.kt
@@ -1,0 +1,16 @@
+package net.corda.testing
+
+import net.corda.core.div
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+object ProjectStructure {
+    val projectRootDir: Path = run {
+        var dir = Paths.get(javaClass.getResource("/").toURI())
+        while (!Files.isDirectory(dir / ".git")) {
+            dir = dir.parent
+        }
+        dir
+    }
+}

--- a/test-utils/src/main/kotlin/net/corda/testing/RPCDriver.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/RPCDriver.kt
@@ -12,7 +12,6 @@ import net.corda.core.div
 import net.corda.core.map
 import net.corda.core.messaging.RPCOps
 import net.corda.core.random63BitValue
-import net.corda.core.utilities.ProcessUtilities
 import net.corda.node.services.RPCUserService
 import net.corda.node.services.messaging.ArtemisMessagingServer
 import net.corda.node.services.messaging.RPCServer

--- a/test-utils/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -400,7 +400,7 @@ class ShutdownManager(private val executorService: ExecutorService) {
                 registeredShutdowns
             }
         }
-        val shutdowns = shutdownFutures.map { ErrorOr.catch { it.get(1, SECONDS) } }
+        val shutdowns = shutdownFutures.map { ErrorOr.catch { it.getOrThrow(1.seconds) } }
         shutdowns.reversed().forEach { errorOrShutdown ->
             errorOrShutdown.match(
                     onValue = { shutdown ->

--- a/tools/demobench/src/main/resources/log4j2.xml
+++ b/tools/demobench/src/main/resources/log4j2.xml
@@ -18,7 +18,7 @@
                      fileName="${sys:log-path}/${log-name}.log"
                      filePattern="${archive}/${log-name}.%d{yyyy-MM-dd}-%i.log.gz">
 
-            <PatternLayout pattern="%d{ISO8601}{GMT+0} [%-5level] %c{1} - %msg%n"/>
+            <PatternLayout pattern="%d{ISO8601}{UTC}Z [%-5level] %c{1} - %msg%n"/>
 
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/tools/demobench/src/test/resources/log4j2-test.xml
+++ b/tools/demobench/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="%date %highlight{%level %c{1}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}"/>
+            <PatternLayout pattern="%d %highlight{%level %c{1}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}"/>
         </Console>
     </Appenders>
 

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -15,7 +15,7 @@ mainClassName = 'net.corda.explorer.Main'
 // Use manual resource copying of log4j2.xml rather than source sets.
 // This prevents problems in IntelliJ with regard to duplicate source roots.
 processResources {
-    from file("$rootDir/config/dev/log4j2.xml")
+    from file("$rootDir/config/dev/log4j2-corda.xml")
 }
 
 dependencies {

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -31,6 +31,7 @@ task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').co
     applicationSource = files(
         project(':tools:explorer').configurations.runtime,
         project(':tools:explorer').jar,
+        new File(project(':node').buildDir, 'classes/main/AbstractCordaCaplet.class'),
         '../build/classes/main/ExplorerCaplet.class'
     )
     classifier 'fat'
@@ -38,6 +39,7 @@ task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').co
     capsuleManifest {
         applicationVersion = corda_release_version
         systemProperties['visualvm.display.name'] = 'Node Explorer'
+        systemProperties['log4j.configurationFile'] = 'classpath:log4j2-corda.xml'
         minJavaVersion = '1.8.0'
         minUpdateVersion['1.8'] = java8_minUpdateVersion
         caplets = ['ExplorerCaplet']

--- a/tools/explorer/src/main/java/ExplorerCaplet.java
+++ b/tools/explorer/src/main/java/ExplorerCaplet.java
@@ -1,49 +1,5 @@
-import java.io.*;
-import java.nio.file.*;
-import java.util.*;
-
-public class ExplorerCaplet extends Capsule {
-
-    @SuppressWarnings("unused")
+public class ExplorerCaplet extends AbstractCordaCaplet {
     protected ExplorerCaplet(Capsule pred) {
         super(pred);
     }
-
-    /**
-     * Overriding the Caplet classpath generation via the intended interface in Capsule.
-     */
-    @Override
-    @SuppressWarnings("unchecked")
-    protected <T> T attribute(Map.Entry<String, T> attr) {
-        // Equality is used here because Capsule never instantiates these attributes but instead reuses the ones
-        // defined as public static final fields on the Capsule class, therefore referential equality is safe.
-        if (ATTR_APP_CLASS_PATH == attr) {
-            T cp = super.attribute(attr);
-            List<Path> classpath = augmentClasspath((List<Path>) cp, "plugins");
-            return (T) augmentClasspath(classpath, "dependencies");
-        }
-        return super.attribute(attr);
-    }
-
-    // TODO: Make directory configurable via the capsule manifest.
-    // TODO: Add working directory variable to capsules string replacement variables.
-    private List<Path> augmentClasspath(List<Path> classpath, String dirName) {
-        File dir = new File(dirName);
-        if (!dir.exists()) {
-            dir.mkdir();
-        }
-
-        File[] files = dir.listFiles();
-        for (File file : files) {
-            if (file.isFile() && isJAR(file)) {
-                classpath.add(file.toPath().toAbsolutePath());
-            }
-        }
-        return classpath;
-    }
-
-    private Boolean isJAR(File file) {
-        return file.getName().toLowerCase().endsWith(".jar");
-    }
-
 }

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -23,7 +23,7 @@ sourceSets {
 // Use manual resource copying of log4j2.xml rather than source sets.
 // This prevents problems in IntelliJ with regard to duplicate source roots.
 processResources {
-    from file("$rootDir/config/dev/log4j2.xml")
+    from file("$rootDir/config/dev/log4j2-corda.xml")
 }
 
 dependencies {

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -13,7 +13,7 @@ import net.corda.core.div
 import net.corda.core.map
 import net.corda.core.random63BitValue
 import net.corda.core.transactions.LedgerTransaction
-import net.corda.core.utilities.ProcessUtilities
+import net.corda.testing.driver.ProcessUtilities
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.config.configureDevKeyAndTrustStores
 import net.corda.nodeapi.ArtemisMessagingComponent.Companion.NODE_USER

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -20,7 +20,7 @@ sourceSets {
 }
 
 processResources {
-    from file("$rootDir/config/dev/log4j2.xml")
+    from file("$rootDir/config/dev/log4j2-corda.xml")
     from file("$rootDir/config/dev/jolokia-access.xml")
 }
 

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -25,9 +25,9 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').compileJava
     applicationSource = files(
             project(':webserver').configurations.runtime,
             project(':webserver').jar,
+            new File(project(':node').buildDir, 'classes/main/AbstractCordaCaplet.class'),
             new File(project(':node').buildDir, 'classes/main/CordaCaplet.class'),
-            new File(project(':node').buildDir, 'classes/main/CordaCaplet$1.class'),
-            "$rootDir/config/dev/log4j2.xml"
+            "$rootDir/config/dev/log4j2-corda.xml"
     )
     from 'NOTICE' // Copy CDDL notice
 
@@ -35,6 +35,7 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').compileJava
         applicationVersion = corda_release_version
         javaAgents = ["quasar-core-${quasar_version}-jdk8.jar"]
         systemProperties['visualvm.display.name'] = 'Corda Webserver'
+        systemProperties['log4j.configurationFile'] = 'classpath:log4j2-corda.xml'
         minJavaVersion = '1.8.0'
         minUpdateVersion['1.8'] = java8_minUpdateVersion
         caplets = ['CordaCaplet']


### PR DESCRIPTION
* Consistently use comma as millis separator
* Move test config file so it's available in intellij without gradle assemble
* Explicit logging config for nodes, so the test config is overridden when test-utils is in use
* Remove redundant node dependencies directory and classpath entries, this fixes the multiple slf4j bindings warning
* Unduplicate caplet code
* Make 2 tests runnable in any working dir