### PR TITLE
WIP: Pluggable notary mechanism

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/CordaPluginRegistry.kt
+++ b/core/src/main/kotlin/net/corda/core/node/CordaPluginRegistry.kt
@@ -27,17 +27,6 @@ abstract class CordaPluginRegistry {
     open val requiredFlows: Map<String, Set<String>> get() = emptyMap()
 
     /**
-     * List of lambdas constructing additional long lived services to be hosted within the node.
-     * They expect a single [PluginServiceHub] parameter as input.
-     * The [PluginServiceHub] will be fully constructed before the plugin service is created and will
-     * allow access to the Flow factory and Flow initiation entry points there.
-     */
-    @Suppress("unused")
-    @Deprecated("This is no longer used. If you need to create your own service, such as an oracle, then use the " +
-        "@CordaService annotation. For flow registrations use @InitiatedBy.", level = DeprecationLevel.ERROR)
-    open val servicePlugins: List<Function<PluginServiceHub, out Any>> get() = emptyList()
-
-    /**
      * Optionally whitelist types for use in object serialization, as we lock down the types that can be serialized.
      *
      * For example, if you add a new [net.corda.core.contracts.ContractState] it needs to be whitelisted.  You can do that

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -258,18 +258,6 @@ open class Node(override val configuration: FullNodeConfiguration,
         return networkMapConnection.flatMap { super.registerWithNetworkMap() }
     }
 
-    override fun makeUniquenessProvider(type: ServiceType): UniquenessProvider {
-        return when (type) {
-            RaftValidatingNotaryService.type, RaftNonValidatingNotaryService.type -> with(configuration) {
-                val provider = RaftUniquenessProvider(baseDirectory, notaryNodeAddress!!, notaryClusterAddresses, database, configuration)
-                provider.start()
-                runOnStop += provider::stop
-                provider
-            }
-            else -> PersistentUniquenessProvider()
-        }
-    }
-
     /**
      * If the node is persisting to an embedded H2 database, then expose this via TCP with a JDBC URL of the form:
      * jdbc:h2:tcp://<host>:<port>/node

--- a/node/src/main/kotlin/net/corda/node/services/PluginService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/PluginService.kt
@@ -1,0 +1,12 @@
+package net.corda.node.services
+
+import net.corda.core.serialization.SingletonSerializeAsToken
+
+interface PluginServiceFactory<out T : PluginService> {
+    fun create(services: PluginServiceHub, serializationContext: MutableList<Any>): T
+}
+
+abstract class PluginService: SingletonSerializeAsToken() {
+    open fun start() {}
+    open fun stop() {}
+}

--- a/node/src/main/kotlin/net/corda/node/services/PluginServiceHub.kt
+++ b/node/src/main/kotlin/net/corda/node/services/PluginServiceHub.kt
@@ -1,7 +1,10 @@
-package net.corda.core.node
+package net.corda.node.services
 
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
+import net.corda.core.node.ServiceHub
+import net.corda.node.services.config.NodeConfiguration
+import org.jetbrains.exposed.sql.Database
 
 /**
  * A service hub to be used by the [CordaPluginRegistry]
@@ -10,4 +13,7 @@ interface PluginServiceHub : ServiceHub {
     @Deprecated("This is no longer used. Instead annotate the flows produced by your factory with @InitiatedBy and have " +
             "them point to the initiating flow class.", level = DeprecationLevel.ERROR)
     fun registerFlowInitiator(initiatingFlowClass: Class<out FlowLogic<*>>, serviceFlowFactory: (Party) -> FlowLogic<*>) = Unit
+
+    val db: Database
+    val config: NodeConfiguration
 }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -26,6 +26,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val certificateChainCheckPolicies: List<CertChainPolicyConfig>
     val verifierType: VerifierType
     val messageRedeliveryDelaySeconds: Int
+    val plugins: Properties
 }
 
 data class FullNodeConfiguration(
@@ -58,7 +59,8 @@ data class FullNodeConfiguration(
         val notaryClusterAddresses: List<HostAndPort>,
         override val certificateChainCheckPolicies: List<CertChainPolicyConfig>,
         override val devMode: Boolean = false,
-        val useTestClock: Boolean = false
+        val useTestClock: Boolean = false,
+        override val plugins: Properties = Properties()
 ) : NodeConfiguration {
     /** This is not retrieved from the config file but rather from a command line argument. */
     @Suppress("DEPRECATION")

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftConfiguration.kt
@@ -1,0 +1,9 @@
+package net.corda.node.services.transactions
+
+import com.google.common.net.HostAndPort
+
+// TODO: Move raft notary specific configuration out of FullNodeConfiguration
+class RaftConfiguration(config: net.corda.node.services.config.FullNodeConfiguration) {
+    val notaryNodeAddress: HostAndPort = config.notaryNodeAddress!!
+    val notaryClusterAddresses: List<HostAndPort> = config.notaryClusterAddresses
+}

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
@@ -3,15 +3,43 @@ package net.corda.node.services.transactions
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
+import net.corda.node.services.PluginService
+import net.corda.node.services.PluginServiceFactory
+import net.corda.node.services.PluginServiceHub
+import net.corda.node.services.config.FullNodeConfiguration
 
 /** A non-validating notary service operated by a group of mutually trusting parties, uses the Raft algorithm to achieve consensus. */
 class RaftNonValidatingNotaryService(val timeWindowChecker: TimeWindowChecker,
-                                     val uniquenessProvider: RaftUniquenessProvider) : NotaryService {
+                                     val uniquenessProvider: RaftUniquenessProvider) : PluginService(), NotaryService {
     companion object {
-        val type = SimpleNotaryService.type.getSubType("raft")
+        val type = SimpleNotaryService.Companion.type.getSubType("raft")
+    }
+
+    object Factory : PluginServiceFactory<RaftNonValidatingNotaryService> {
+        override fun create(services: PluginServiceHub, serializationContext: MutableList<Any>): RaftNonValidatingNotaryService {
+            val notaryConfig = RaftConfiguration(services.config as FullNodeConfiguration)
+            val timeWindowChecker = TimeWindowChecker(services.clock)
+            val uniquenessProvider = RaftUniquenessProvider(
+                    services.config.baseDirectory,
+                    notaryConfig.notaryNodeAddress,
+                    notaryConfig.notaryClusterAddresses,
+                    services.db,
+                    services.config
+            )
+            serializationContext.add(uniquenessProvider)
+            return RaftNonValidatingNotaryService(timeWindowChecker, uniquenessProvider)
+        }
     }
 
     override val serviceFlowFactory: (Party, Int) -> FlowLogic<Void?> = { otherParty, _ ->
         NonValidatingNotaryFlow(otherParty, timeWindowChecker, uniquenessProvider)
+    }
+
+    override fun start() {
+        uniquenessProvider.start()
+    }
+
+    override fun stop() {
+        uniquenessProvider.stop()
     }
 }

--- a/notaries/raft-atomix/src/main/kotlin/net/corda/notary/MyRaftNonValidatingNotaryService.kt
+++ b/notaries/raft-atomix/src/main/kotlin/net/corda/notary/MyRaftNonValidatingNotaryService.kt
@@ -1,0 +1,80 @@
+package net.corda.notary
+
+import co.paralleluniverse.fibers.Suspendable
+import com.google.common.net.HostAndPort
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.identity.Party
+import net.corda.core.node.CordaPluginRegistry
+import net.corda.core.node.services.TimeWindowChecker
+import net.corda.core.node.services.UniquenessProvider
+import net.corda.core.transactions.FilteredTransaction
+import net.corda.core.utilities.unwrap
+import net.corda.flows.NotaryFlow
+import net.corda.flows.TransactionParts
+import net.corda.node.services.PluginService
+import net.corda.node.services.PluginServiceFactory
+import net.corda.node.services.PluginServiceHub
+import net.corda.node.services.transactions.SimpleNotaryService
+import net.corda.node.services.transactions.RaftUniquenessProvider
+import java.util.*
+
+/** This is an example of a custom notary service that can be provided as Cordapp */
+class MyRaftNonValidatingNotaryService(val timeWindowChecker: TimeWindowChecker, val uniquenessProvider: RaftUniquenessProvider) : PluginService() {
+    companion object {
+        val type = SimpleNotaryService.type.getSubType("raft.custom")
+    }
+
+    object Factory : PluginServiceFactory<MyRaftNonValidatingNotaryService> {
+        override fun create(services: PluginServiceHub, serializationContext: MutableList<Any>): MyRaftNonValidatingNotaryService {
+            val notaryConfig = MyNotaryConfig(services.config.plugins)
+            val timeWindowChecker = TimeWindowChecker(services.clock)
+            val uniquenessProvider = RaftUniquenessProvider(
+                    services.config.baseDirectory,
+                    notaryConfig.notaryNodeAddress,
+                    notaryConfig.notaryClusterAddresses,
+                    services.db,
+                    services.config
+            )
+            serializationContext.add(uniquenessProvider)
+            return MyRaftNonValidatingNotaryService(timeWindowChecker, uniquenessProvider)
+        }
+    }
+
+    override fun start() {
+        uniquenessProvider.start()
+    }
+
+    override fun stop() {
+        uniquenessProvider.stop()
+    }
+}
+
+@InitiatedBy(NotaryFlow.Client::class)
+class MyRaftNotaryFlow(otherSide: Party) : NotaryFlow.Service(otherSide) {
+    override val uniquenessProvider: UniquenessProvider
+        get() = serviceHub.cordaService(MyRaftNonValidatingNotaryService::class.java).uniquenessProvider
+    override val timeWindowChecker: TimeWindowChecker
+        get() = serviceHub.cordaService(MyRaftNonValidatingNotaryService::class.java).timeWindowChecker
+
+    @Suspendable
+    override fun receiveAndVerifyTx(): TransactionParts {
+        val ftx = receive<FilteredTransaction>(otherSide).unwrap {
+            it.verify()
+            it
+        }
+        return TransactionParts(ftx.rootHash, ftx.filteredLeaves.inputs, ftx.filteredLeaves.timeWindow)
+    }
+}
+
+data class MyNotaryConfig(val properties: Properties) {
+    companion object {
+        val prefix = "raft.custom"
+    }
+
+    private fun getProperty(name: String) = properties.getProperty("${prefix}.$name")
+
+    val notaryNodeAddress: HostAndPort = HostAndPort.fromString(getProperty("notaryNodeAddress"))
+    val notaryClusterAddresses: List<HostAndPort> = getProperty("notaryClusterAddresses").split(",").map { HostAndPort.fromString(it) }
+}
+
+class NotaryPlugin : CordaPluginRegistry()


### PR DESCRIPTION
The goal of this work is to enable custom notary services to be loaded via Cordapps.
It includes a proposed refactoring of the CordaService API and installation mechanism, enabling more complex services such as notaries (or oracles) to be loaded.
The existing notary implementations will still be built-in, but will be decoupled from the Node as much as possible, so they can be easily extracted in the future.

This PR only includes part of required changes as an example.
