### PR TITLE
Add certificate subject name check on node startup

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -611,7 +611,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         val tlsIdentity = identitiesKeystore.getX509Certificate(X509Utilities.CORDA_CLIENT_TLS).subject
 
         require(tlsIdentity == configuration.myLegalName) {
-            "Expected '${tlsIdentity.commonName}' but got '${tlsIdentity.commonName}' from the keystore."
+            "Expected '${configuration.myLegalName}' but got '$tlsIdentity' from the keystore."
         }
     }
 


### PR DESCRIPTION
* Added SSL certificate name checks on node startup to make it fail fast instead of failing when it connect to other node.  This PR address issue #715 .