### PR TITLE
Infrastructure for anonymous cash flows

### DIFF
--- a/core/src/main/kotlin/net/corda/core/identity/AnonymisedIdentity.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/AnonymisedIdentity.kt
@@ -1,0 +1,16 @@
+package net.corda.flows
+
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.serialization.CordaSerializable
+import org.bouncycastle.cert.X509CertificateHolder
+import java.security.cert.CertPath
+
+@CordaSerializable
+data class AnonymisedIdentity(
+        val certPath: CertPath,
+        val certificate: X509CertificateHolder,
+        val identity: AnonymousParty) {
+    constructor(myIdentity: Pair<X509CertificateHolder, CertPath>) : this(myIdentity.second,
+            myIdentity.first,
+            AnonymousParty(myIdentity.second.certificates.last().publicKey))
+}

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -2,8 +2,10 @@ package net.corda.core.node.services
 
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.contracts.Contract
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.ServiceHub
 import net.corda.core.randomOrNull
 import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.asn1.x500.X500Name
@@ -61,6 +63,17 @@ interface NetworkMapCache {
      * or the appropriate oracle for a contract.
      */
     fun getRecommended(type: ServiceType, contract: Contract, vararg party: Party): NodeInfo? = getNodesWithService(type).firstOrNull()
+
+    /**
+     * Look up the node info for a specific party. Will attempt to de-anonymise the party if applicable; if the party
+     * is anonymised and the well known party cannot be resolved, it is impossible ot identify the node and therefore this
+     * returns null.
+     *
+     * @param party party to retrieve node information for.
+     * @return the node for the identity, or null if the node could not be found. This does not necessarily mean there is
+     * no node for the party, only that this cache is unaware of it.
+     */
+    fun getNodeByLegalIdentity(party: AbstractParty): NodeInfo?
 
     /** Look up the node info for a legal name. */
     fun getNodeByLegalName(principal: X500Name): NodeInfo? = partyNodes.singleOrNull { it.legalIdentity.name == principal }

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -470,7 +470,15 @@ interface KeyManagementService {
     @Suspendable
     fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath>
 
-    /** Using the provided signing [PublicKey] internally looks up the matching [PrivateKey] and signs the data.
+    /**
+     * Filter some keys down to the set that this node owns (has private keys for).
+     *
+     * @param candidateKeys keys which this node may own.
+     */
+    fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey>
+
+    /**
+     * Using the provided signing [PublicKey] internally looks up the matching [PrivateKey] and signs the data.
      * @param bytes The data to sign over using the chosen key.
      * @param publicKey The [PublicKey] partner to an internally held [PrivateKey], either derived from the node's primary identity,
      * or previously generated via the [freshKey] method.

--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -112,6 +112,7 @@ object DefaultKryoCustomizer {
             register(BCRSAPublicKey::class.java, PublicKeySerializer)
             register(BCSphincs256PrivateKey::class.java, PrivateKeySerializer)
             register(BCSphincs256PublicKey::class.java, PublicKeySerializer)
+            register(sun.security.ec.ECPublicKeyImpl::class.java, PublicKeySerializer)
 
             val customization = KryoSerializationCustomization(this)
             pluginRegistries.forEach { it.customizeSerialization(customization) }

--- a/core/src/main/kotlin/net/corda/flows/ContractUpgradeFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/ContractUpgradeFlow.kt
@@ -58,9 +58,12 @@ class ContractUpgradeFlow<OldState : ContractState, out NewState : ContractState
         }
     }
 
-    override fun assembleTx(): Pair<SignedTransaction, Iterable<AbstractParty>> {
+    override fun assembleTx(): AbstractStateReplacementFlow.UpgradeTx {
         val baseTx = assembleBareTx(originalState, modification)
-        val stx = serviceHub.signInitialTransaction(baseTx)
-        return stx to originalState.state.data.participants
+        val participantKeys = originalState.state.data.participants.map { it.owningKey }.toSet()
+        // TODO: We need a much faster way of finding our key in the transaction
+        val myKey = serviceHub.keyManagementService.filterMyKeys(participantKeys).single()
+        val stx = serviceHub.signInitialTransaction(baseTx, myKey)
+        return AbstractStateReplacementFlow.UpgradeTx(stx, participantKeys, myKey)
     }
 }

--- a/core/src/test/kotlin/net/corda/flows/TxKeyFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/flows/TxKeyFlowTests.kt
@@ -40,7 +40,7 @@ class TxKeyFlowTests {
         val requesterFlow = aliceNode.services.startFlow(TxKeyFlow.Requester(bob))
 
         // Get the results
-        val actual: Map<Party, TxKeyFlow.AnonymousIdentity> = requesterFlow.resultFuture.getOrThrow()
+        val actual: Map<Party, AnonymisedIdentity> = requesterFlow.resultFuture.getOrThrow()
         assertEquals(2, actual.size)
         // Verify that the generated anonymous identities do not match the well known identities
         val aliceAnonymousIdentity = actual[alice] ?: throw IllegalStateException()

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -43,12 +43,12 @@ private fun gatherOurInputs(serviceHub: ServiceHub,
     // Collect cash type inputs
     val cashStates = serviceHub.vaultService.unconsumedStates<Cash.State>()
     // extract our identity for convenience
-    val ourIdentity = serviceHub.myInfo.legalIdentity
+    val ourKeys = serviceHub.keyManagementService.keys
     // Filter down to our own cash states with right currency and issuer
     val suitableCashStates = cashStates.filter {
         val state = it.state.data
-        (state.owner == ourIdentity)
-                && (state.amount.token == amountRequired.token)
+        // TODO: We may want to have the list of our states pre-cached somewhere for performance
+        (state.owner.owningKey in ourKeys) && (state.amount.token == amountRequired.token)
     }
     require(!suitableCashStates.isEmpty()) { "Insufficient funds" }
     var remaining = amountRequired.quantity
@@ -134,9 +134,6 @@ class ForeignExchangeFlow(val tradeId: String,
             require(it.inputs.all { it.state.notary == notary }) {
                 "notary of remote states must be same as for our states"
             }
-            require(it.inputs.all { it.state.data.owner == remoteRequestWithNotary.owner }) {
-                "The inputs are not owned by the correct counterparty"
-            }
             require(it.inputs.all { it.state.data.amount.token == remoteRequestWithNotary.amount.token }) {
                 "Inputs not of the correct currency"
             }
@@ -202,7 +199,7 @@ class ForeignExchangeFlow(val tradeId: String,
         // We have already validated their response and trust our own data
         // so we can sign. Note the returned SignedTransaction is still not fully signed
         // and would not pass full verification yet.
-        return serviceHub.signInitialTransaction(builder)
+        return serviceHub.signInitialTransaction(builder, ourSigners.single())
     }
     // DOCEND 3
 }
@@ -236,10 +233,12 @@ class ForeignExchangeRemoteFlow(val source: Party) : FlowLogic<Unit>() {
         val ourResponse = prepareOurInputsAndOutputs(serviceHub, request)
 
         // Send back our proposed states and await the full transaction to verify
+        val ourKeys = serviceHub.keyManagementService.keys
+        val ourKey = serviceHub.keyManagementService.filterMyKeys(ourResponse.inputs.flatMap { it.state.data.participants }.map { it.owningKey }).single()
         val proposedTrade = sendAndReceive<SignedTransaction>(source, ourResponse).unwrap {
             val wtx = it.tx
             // check all signatures are present except our own and the notary
-            it.verifySignatures(serviceHub.myInfo.legalIdentity.owningKey, wtx.notary!!.owningKey)
+            it.verifySignatures(ourKey, wtx.notary!!.owningKey)
 
             // We need to fetch their complete input states and dependencies so that verify can operate
             checkDependencies(it)
@@ -253,7 +252,7 @@ class ForeignExchangeRemoteFlow(val source: Party) : FlowLogic<Unit>() {
         }
 
         // assuming we have completed state and business level validation we can sign the trade
-        val ourSignature = serviceHub.createSignature(proposedTrade)
+        val ourSignature = serviceHub.createSignature(proposedTrade, ourKey)
 
         // send the other side our signature.
         send(source, ourSignature)

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Obligation.kt
@@ -429,7 +429,7 @@ class Obligation<P : Any> : Contract {
     /**
      * Generate a transaction performing close-out netting of two or more states.
      *
-     * @param signer the party who will sign the transaction. Must be one of the obligor or beneficiary.
+     * @param signer the party which will sign the transaction. Must be one of the obligor or beneficiary.
      * @param states two or more states, which must be compatible for bilateral netting (same issuance definitions,
      * and same parties involved).
      */
@@ -458,7 +458,7 @@ class Obligation<P : Any> : Contract {
      * @param amountIssued the amount to be exited, represented as a quantity of issued currency.
      * @param assetStates the asset states to take funds from. No checks are done about ownership of these states, it is
      * the responsibility of the caller to check that they do not exit funds held by others.
-     * @return the public keys who must sign the transaction for it to be valid.
+     * @return the public keys which must sign the transaction for it to be valid.
      */
     @Suppress("unused")
     fun generateExit(tx: TransactionBuilder, amountIssued: Amount<Issued<Terms<P>>>,

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -447,7 +447,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         val storageServices = initialiseStorageService(configuration.baseDirectory)
         storage = storageServices.first
         checkpointStorage = storageServices.second
-        netMapCache = InMemoryNetworkMapCache()
+        netMapCache = InMemoryNetworkMapCache(services)
         network = makeMessagingService()
         schemas = makeSchemaService()
         vault = makeVaultService(configuration.dataSourceProperties)

--- a/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/E2ETestKeyManagementService.kt
@@ -5,7 +5,6 @@ import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.crypto.keys
 import net.corda.core.crypto.sign
-import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService
@@ -69,6 +68,10 @@ class E2ETestKeyManagementService(val identityService: IdentityService,
             val pk = publicKey.keys.first { keys.containsKey(it) }
             KeyPair(pk, keys[pk]!!)
         }
+    }
+
+    override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> {
+        return mutex.locked { candidateKeys.filter { it in this.keys } }
     }
 
     override fun sign(bytes: ByteArray, publicKey: PublicKey): DigitalSignature.WithKey {

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -60,6 +60,10 @@ class PersistentKeyManagementService(val identityService: IdentityService,
 
     override val keys: Set<PublicKey> get() = mutex.locked { keys.keys }
 
+    override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> {
+        return mutex.locked { candidateKeys.filter { it in this.keys } }
+    }
+
     override fun freshKey(): PublicKey {
         val keyPair = generateKeyPair()
         mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
@@ -4,11 +4,14 @@ import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import net.corda.core.bufferUntilSubscribed
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.map
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.DEFAULT_SESSION_ID
+import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.NetworkMapCache.MapChange
 import net.corda.core.node.services.PartyInfo
 import net.corda.core.serialization.SingletonSerializeAsToken
@@ -34,9 +37,13 @@ import javax.annotation.concurrent.ThreadSafe
 
 /**
  * Extremely simple in-memory cache of the network map.
+ *
+ * @param serviceHub an optional service hub from which we'll take the identity service. We take a service hub rather
+ * than the identity service directly, as this avoids problems with service start sequence (network map cache
+ * and identity services depend on each other). Should always be provided except for unit test cases.
  */
 @ThreadSafe
-open class InMemoryNetworkMapCache : SingletonSerializeAsToken(), NetworkMapCacheInternal {
+open class InMemoryNetworkMapCache(private val serviceHub: ServiceHub?) : SingletonSerializeAsToken(), NetworkMapCacheInternal {
     companion object {
         val logger = loggerFor<InMemoryNetworkMapCache>()
     }
@@ -70,6 +77,17 @@ open class InMemoryNetworkMapCache : SingletonSerializeAsToken(), NetworkMapCach
     }
 
     override fun getNodeByLegalIdentityKey(identityKey: PublicKey): NodeInfo? = registeredNodes[identityKey]
+    override fun getNodeByLegalIdentity(party: AbstractParty): NodeInfo? {
+        val wellKnownParty = if (serviceHub != null) {
+            serviceHub.identityService.partyFromAnonymous(party)
+        } else {
+            party
+        }
+
+        return wellKnownParty?.let {
+            getNodeByLegalIdentityKey(it.owningKey)
+        }
+    }
 
     override fun track(): Pair<List<NodeInfo>, Observable<MapChange>> {
         synchronized(_changed) {

--- a/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
+++ b/node/src/test/kotlin/net/corda/node/services/MockServiceHubInternal.kt
@@ -27,7 +27,7 @@ open class MockServiceHubInternal(
         val network: MessagingService? = null,
         val identity: IdentityService? = MOCK_IDENTITY_SERVICE,
         val storage: TxWritableStorageService? = MockStorageService(),
-        val mapCache: NetworkMapCacheInternal? = MockNetworkMapCache(),
+        val mapCache: NetworkMapCacheInternal? = null,
         val scheduler: SchedulerService? = null,
         val overrideClock: Clock? = NodeClock(),
         val schemas: SchemaService? = NodeSchemaService(),
@@ -46,7 +46,7 @@ open class MockServiceHubInternal(
     override val networkService: MessagingService
         get() = network ?: throw UnsupportedOperationException()
     override val networkMapCache: NetworkMapCacheInternal
-        get() = mapCache ?: throw UnsupportedOperationException()
+        get() = mapCache ?: MockNetworkMapCache(this)
     override val storageService: StorageService
         get() = storage ?: throw UnsupportedOperationException()
     override val schedulerService: SchedulerService

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -60,7 +60,7 @@ class ArtemisMessagingTests {
     var messagingClient: NodeMessagingClient? = null
     var messagingServer: ArtemisMessagingServer? = null
 
-    val networkMapCache = InMemoryNetworkMapCache()
+    val networkMapCache = InMemoryNetworkMapCache(serviceHub = null)
 
     val rpcOps = object : RPCOps {
         override val protocolVersion: Int get() = throw UnsupportedOperationException()

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryNetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryNetworkMapCacheTest.kt
@@ -1,17 +1,24 @@
 package net.corda.node.services.network
 
 import net.corda.core.getOrThrow
+import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.ALICE
 import net.corda.core.utilities.BOB
 import net.corda.node.utilities.transaction
 import net.corda.testing.node.MockNetwork
+import org.junit.After
 import org.junit.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals
 
 class InMemoryNetworkMapCacheTest {
     private val mockNet = MockNetwork()
+
+    @After
+    fun teardown() {
+        mockNet.stopNodes()
+    }
 
     @Test
     fun registerWithNetwork() {
@@ -28,6 +35,8 @@ class InMemoryNetworkMapCacheTest {
         val nodeB = mockNet.createNode(null, -1, MockNetwork.DefaultFactory, true, BOB.name, null, entropy, ServiceInfo(NetworkMapService.type))
         assertEquals(nodeA.info.legalIdentity, nodeB.info.legalIdentity)
 
+        mockNet.runNetwork()
+
         // Node A currently knows only about itself, so this returns node A
         assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeA.info)
 
@@ -36,5 +45,18 @@ class InMemoryNetworkMapCacheTest {
         }
         // The details of node B write over those for node A
         assertEquals(nodeA.netMapCache.getNodeByLegalIdentityKey(nodeA.info.legalIdentity.owningKey), nodeB.info)
+    }
+
+    @Test
+    fun `getNodeByLegalIdentity`() {
+        val (n0, n1) = mockNet.createTwoNodes()
+        val node0Cache: NetworkMapCache = n0.services.networkMapCache
+        val expected = n1.info
+
+        mockNet.runNetwork()
+        val actual = node0Cache.getNodeByLegalIdentity(n1.info.legalIdentity)
+        assertEquals(expected, actual)
+
+        // TODO: Should have a test case with anonymous lookup
     }
 }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNetworkMapCache.kt
@@ -5,6 +5,8 @@ import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.identity.Party
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.ServiceHub
+import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.utilities.getTestPartyAndCertificate
 import net.corda.node.services.network.InMemoryNetworkMapCache
@@ -17,7 +19,7 @@ import java.math.BigInteger
 /**
  * Network map cache with no backing map service.
  */
-class MockNetworkMapCache : InMemoryNetworkMapCache() {
+class MockNetworkMapCache(serviceHub: ServiceHub) : InMemoryNetworkMapCache(serviceHub) {
     private companion object {
         val BANK_C = getTestPartyAndCertificate(getTestX509Name("Bank C"), entropyToKeyPair(BigInteger.valueOf(1000)).public)
         val BANK_D = getTestPartyAndCertificate(getTestX509Name("Bank D"), entropyToKeyPair(BigInteger.valueOf(2000)).public)

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -99,6 +99,8 @@ class MockKeyManagementService(val identityService: IdentityService,
         return k.public
     }
 
+    override fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey> = candidateKeys.filter { it in this.keys }
+
     override fun freshKeyAndCert(identity: PartyAndCertificate, revocationEnabled: Boolean): Pair<X509CertificateHolder, CertPath> {
         return freshCertificate(identityService, freshKey(), identity, getSigner(identity.owningKey), revocationEnabled)
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
@@ -43,7 +43,8 @@ class SimpleNode(val config: NodeConfiguration, val address: HostAndPort = freeL
     val identityService: IdentityService = InMemoryIdentityService(trustRoot = trustRoot)
     val keyService: KeyManagementService = E2ETestKeyManagementService(identityService, setOf(identity))
     val executor = ServiceAffinityExecutor(config.myLegalName.commonName, 1)
-    val broker = ArtemisMessagingServer(config, address.port, rpcAddress.port, InMemoryNetworkMapCache(), userService)
+    // TODO: We should have a dummy service hub rather than change behaviour in tests
+    val broker = ArtemisMessagingServer(config, address.port, rpcAddress.port, InMemoryNetworkMapCache(serviceHub = null), userService)
     val networkMapRegistrationFuture: SettableFuture<Unit> = SettableFuture.create<Unit>()
     val network = database.transaction {
         NodeMessagingClient(


### PR DESCRIPTION
* Add functions for:
    * Retrieving nodes via their legal identity
    * Filtering a set of public keys down to those the node has corresponding private keys for
* Modify contract upgrade flows to handle identifying participants after an anomymisation step
* Correct terminology: "party who" -> "party which"