### PR TITLE
Alter some logging patterns to a more explicit form.

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -13,7 +13,7 @@
 
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="%highlight{%level{length=1} %d{HH:mm:ss} [%t] %c{2}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}" />
+            <PatternLayout pattern="%highlight{%level{length=1} %date{HH:mm:ss} [%t] %c{2}.%method - %msg%n}{INFO=white,WARN=red,FATAL=bright red}" />
         </Console>
 
         <!-- Required for printBasicInfo -->
@@ -25,9 +25,9 @@
              those that are older than 60 days, but keep the most recent 10 GB -->
         <RollingFile name="RollingFile-Appender"
                      fileName="${sys:log-path}/${log-name}.log"
-                     filePattern="${archive}/${log-name}.%d{yyyy-MM-dd}-%i.log.gz">
+                     filePattern="${archive}/${log-name}.%date{yyyy-MM-dd}-%i.log.gz">
 
-            <PatternLayout pattern="[%-5level] %d{ISO8601}{GMT+0} [%t] %c{2}.%M - %msg%n"/>
+            <PatternLayout pattern="[%-5level] %date{ISO8601}{GMT+0} [%t] %c{2}.%method - %msg%n"/>
 
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/config/test/log4j2.xml
+++ b/config/test/log4j2.xml
@@ -5,7 +5,7 @@
     </Properties>
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%-5level] %d{HH:mm:ss.SSS} [%t] %c{2}.%M - %msg%n" />
+            <PatternLayout pattern="[%-5level] %date{HH:mm:ss.SSS} [%t] %c{2}.%method - %msg%n" />
         </Console>
         <!-- Required for printBasicInfo -->
         <Console name="Console-Appender-Println" target="SYSTEM_OUT">

--- a/samples/simm-valuation-demo/src/main/resources/log4j2.xml
+++ b/samples/simm-valuation-demo/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
         <Console name="Console-Appender" target="SYSTEM_OUT">
             <PatternLayout>
                 <pattern>
-                    [%-5level] %d{HH:mm:ss.SSS} [%t] %c{2}.%M - %msg%n
+                    [%-5level] %date{HH:mm:ss.SSS} [%t] %c{2}.%method - %msg%n
                 </pattern>>
             </PatternLayout>
         </Console>
@@ -27,9 +27,9 @@
              those that are older than 60 days, but keep the most recent 10 GB -->
         <RollingFile name="RollingFile-Appender"
                      fileName="${log-path}/${log-name}.log"
-                     filePattern="${archive}/${log-name}.%d{yyyy-MM-dd}-%i.log.gz">
+                     filePattern="${archive}/${log-name}.%date{yyyy-MM-dd}-%i.log.gz">
 
-            <PatternLayout pattern="[%-5level] %d{ISO8601}{GMT+0} [%t] %c{2} - %msg%n"/>
+            <PatternLayout pattern="[%-5level] %date{ISO8601}{GMT+0} [%t] %c{2} - %msg%n"/>
 
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/tools/demobench/src/main/resources/log4j2.xml
+++ b/tools/demobench/src/main/resources/log4j2.xml
@@ -16,9 +16,9 @@
              those that are older than 60 days, but keep the most recent 10 GB -->
         <RollingFile name="RollingFile-Appender"
                      fileName="${sys:log-path}/${log-name}.log"
-                     filePattern="${archive}/${log-name}.%d{yyyy-MM-dd}-%i.log.gz">
+                     filePattern="${archive}/${log-name}.%date{yyyy-MM-dd}-%i.log.gz">
 
-            <PatternLayout pattern="%d{ISO8601}{GMT+0} [%-5level] %c{1} - %msg%n"/>
+            <PatternLayout pattern="%date{ISO8601}{GMT+0} [%-5level] %c{1} - %msg%n"/>
 
             <Policies>
                 <TimeBasedTriggeringPolicy/>

--- a/tools/demobench/src/test/resources/log4j2-test.xml
+++ b/tools/demobench/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="%date %highlight{%level %c{1}.%M - %msg%n}{INFO=white,WARN=red,FATAL=bright red}"/>
+            <PatternLayout pattern="%date %highlight{%level %c{1}.%method - %msg%n}{INFO=white,WARN=red,FATAL=bright red}"/>
         </Console>
     </Appenders>
 


### PR DESCRIPTION
Log4J2 supports the following [conversion patterns](https://logging.apache.org/log4j/2.x/manual/layouts.html#Patterns) within its configuration files. Most of these patterns have several synonyms, e.g.

    %d, %date   -> Date
    %m, %msg    -> Message
    %M, %method -> Method name
    %c, %logger -> Logger name
    %t, %thread -> Thread name

We use some of the more explicit forms already, e.g. `%msg`. This patch expands on this slightly by replacing `%d` with `%date` and `%M` with `%method` across all of our `log4j2(-test).xml` files. The intention here is to make the files both more readable (e.g. I had no idea what `%M` was for until I looked it up) and consistent.

We could also extend this to include `%t -> %thread` and/or `%c -> %logger`, if required.

It is also my hope that this patch will resolve the disagreement in #894.