### PR TITLE
DemoBench operates exclusively on localhost, so no need for public IP.

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -56,11 +56,12 @@ class NodeConfig(
             .withValue("rpcUsers", valueFor(users.map(User::toMap).toList()))
             .withValue("h2port", valueFor(h2Port))
             .withValue("useTestClock", valueFor(true))
+            .withValue("detectPublicIp", valueFor(false))
 
     fun toText(): String = toFileConfig().root().render(renderOptions)
 
     fun moveTo(baseDir: Path) = NodeConfig(
-            baseDir, legalName, p2pPort, rpcPort, webPort, h2Port, extraServices, users, networkMap
+        baseDir, legalName, p2pPort, rpcPort, webPort, h2Port, extraServices, users, networkMap
     )
 
     fun install(plugins: Collection<Path>) {

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -142,6 +142,7 @@ class NodeConfigTest {
                 users = listOf(user("jenny"))
         )
         assertEquals(prettyPrint("{"
+                + "\"detectPublicIp\":false,"
                 + "\"extraAdvertisedServiceIds\":[\"my.service\"],"
                 + "\"h2port\":30001,"
                 + "\"myLegalName\":\"CN=My Name,OU=Corda QA Department,O=R3 CEV,L=New York,C=US\","
@@ -169,6 +170,7 @@ class NodeConfigTest {
         config.networkMap = NetworkMapConfig(DUMMY_NOTARY.name, 12345)
 
         assertEquals(prettyPrint("{"
+                + "\"detectPublicIp\":false,"
                 + "\"extraAdvertisedServiceIds\":[\"my.service\"],"
                 + "\"h2port\":30001,"
                 + "\"myLegalName\":\"CN=My Name,OU=Corda QA Department,O=R3 CEV,L=New York,C=US\","
@@ -210,6 +212,7 @@ class NodeConfigTest {
         assertEquals(NetworkMapInfo(localPort(12345), DUMMY_NOTARY.name), fullConfig.networkMapService)
         assertTrue((fullConfig.dataSourceProperties["dataSource.url"] as String).contains("AUTO_SERVER_PORT=30001"))
         assertTrue(fullConfig.useTestClock)
+        assertFalse(fullConfig.detectPublicIp)
     }
 
     @Test


### PR DESCRIPTION
Localhost resolution can be slow on MacOSX, as described [here](http://stackoverflow.com/questions/39636792/jvm-takes-a-long-time-to-resolve-ip-address-for-localhost). DemoBench doesn't need to be affected by this.