### PR TITLE
Change master to 0.14-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     file("$projectDir/constants.properties").withInputStream { constants.load(it) }
 
     // Our version: bump this on release.
-    ext.corda_release_version = "0.13-SNAPSHOT"
+    ext.corda_release_version = "0.14-SNAPSHOT"
     // Increment this on any release that changes public APIs anywhere in the Corda platform
     // TODO This is going to be difficult until we have a clear separation throughout the code of what is public and what is internal
     ext.corda_platform_version = 1

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -78,7 +78,6 @@ support for more currencies to the DemoBench and Explorer tools.
   to specify for individual nodes.
 
 * Dependencies changes:
-    * Upgraded Kotlin to v1.1.2.
     * Upgraded Dokka to v0.9.14.
     * Upgraded Gradle Plugins to 0.12.4.
     * Upgraded Apache ActiveMQ Artemis to v2.1.0.


### PR DESCRIPTION
I've also deleted the Kotlin upgrade to 1.1.2 from changelog in master (I did that in M13 already), we are still in 1.1.1.