### PR TITLE
Cleaned up incorrect references to vault query and persistence.

### DIFF
--- a/docs/source/api-index.rst
+++ b/docs/source/api-index.rst
@@ -6,7 +6,7 @@ This section describes the APIs that are available for the development of CorDap
 * :doc:`api-states`
 * :doc:`api-persistence`
 * :doc:`api-contracts`
-* :doc:`api-vault`
+* :doc:`api-vault-query`
 * :doc:`api-transactions`
 * :doc:`api-flows`
 * :doc:`api-core-types`

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -1,5 +1,5 @@
-API: Vault
-==========
+API: Vault Query
+================
 
 Corda has been architected from the ground up to encourage usage of industry standard, proven query frameworks and libraries for accessing RDBMS backed transactional stores (including the Vault).
 
@@ -66,7 +66,7 @@ There are four implementations of this interface which can be chained together t
 	   
 	   .. note:: All contract states that extend ``LinearState`` or ``DealState`` now automatically persist those interfaces common state attributes to the **vault_linear_states** table.
 
-	4. ``VaultCustomQueryCriteria`` provides the means to specify one or many arbitrary expressions on attributes defined by a custom contract state that implements its own schema as described in the api-persistence_ documentation and associated examples. Custom criteria expressions are expressed using one of several type-safe ``CriteriaExpression``: BinaryLogical, Not, ColumnPredicateExpression. The ColumnPredicateExpression allows for specification arbitrary criteria using the previously enumerated operator types. Furthermore, a rich DSL is provided to enable simple construction of custom criteria using any combination of ``ColumnPredicate``.
+	4. ``VaultCustomQueryCriteria`` provides the means to specify one or many arbitrary expressions on attributes defined by a custom contract state that implements its own schema as described in the :doc:`Persistence </api-persistence>` documentation and associated examples. Custom criteria expressions are expressed using one of several type-safe ``CriteriaExpression``: BinaryLogical, Not, ColumnPredicateExpression. The ColumnPredicateExpression allows for specification arbitrary criteria using the previously enumerated operator types. Furthermore, a rich DSL is provided to enable simple construction of custom criteria using any combination of ``ColumnPredicate``.
 
     .. note:: It is a requirement to register any custom contract schemas to be used in Vault Custom queries in the associated `CordaPluginRegistry` configuration for the respective CorDapp using the ``requiredSchemas`` configuration field (which specifies a set of `MappedSchema`)
 
@@ -85,10 +85,9 @@ Examples of these ``QueryCriteria`` objects are presented below for Kotlin and J
 
 .. note:: When specifying the Contract Type as a parameterised type to the QueryCriteria in Kotlin, queries now include all concrete implementations of that type if this is an interface. Previously, it was only possible to query on Concrete types (or the universe of all Contract States).
 
-The Vault Query API leverages the rich semantics of the underlying JPA Hibernate_ based Persistence_ framework adopted by Corda.
+The Vault Query API leverages the rich semantics of the underlying JPA Hibernate_ based :doc:`Persistence </api-persistence>` framework adopted by Corda.
 
 .. _Hibernate: https://docs.jboss.org/hibernate/jpa/2.1/api/
-.. _Persistence: https://docs.corda.net/api-persistence.html
 
 .. note:: Permissioning at the database level will be enforced at a later date to ensure authenticated, role-based, read-only access to underlying Corda tables.
 

--- a/docs/source/node-internals-index.rst
+++ b/docs/source/node-internals-index.rst
@@ -8,4 +8,3 @@ Node internals
    vault
    serialization
    messaging
-   persistence

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -22,7 +22,7 @@ state schemas defined by CorDapp developers when modelling new contract types. C
 simple but sophisticated builder DSL (see ``QueryCriteriaUtils``). The new Vault Query service is usable by flows and by
 RPC clients alike via two simple API functions: ``queryBy()`` and ``trackBy()``. The former provides point-in-time
 snapshot queries whilst the later supplements the snapshot with dynamic streaming of updates.
-See :doc:`vault-query` for full details.
+See :doc:`api-vault-query` for full details.
 
 We have written a comprehensive Hello, World! tutorial, showing developers how to build a CorDapp from start
 to finish. The tutorial shows how the core elements of a CorDapp - states, contracts and flows - fit together

--- a/docs/source/vault.rst
+++ b/docs/source/vault.rst
@@ -46,7 +46,7 @@ Note the following:
 * the vault performs fungible state spending (and in future, fungible state optimisation management including merging, splitting and re-issuance)
 * vault extensions represent additional custom plugin code a developer may write to query specific custom contract state attributes.
 * customer "Off Ledger" (private store) represents internal organisational data that may be joined with the vault data to perform additional reporting or processing
-* a :doc:`vault query API <api-vault-query>` is exposed to developers using standard Corda RPC and CorDapp plugin mechanisms
+* a :doc:`Vault Query API </api-vault-query>` is exposed to developers using standard Corda RPC and CorDapp plugin mechanisms
 * a vault update API is internally used by transaction recording flows.
 * the vault database schemas are directly accessible via JDBC for customer joins and queries
 

--- a/docs/source/vault.rst
+++ b/docs/source/vault.rst
@@ -46,7 +46,7 @@ Note the following:
 * the vault performs fungible state spending (and in future, fungible state optimisation management including merging, splitting and re-issuance)
 * vault extensions represent additional custom plugin code a developer may write to query specific custom contract state attributes.
 * customer "Off Ledger" (private store) represents internal organisational data that may be joined with the vault data to perform additional reporting or processing
-* a :doc:`vault query API <api-vault>` is exposed to developers using standard Corda RPC and CorDapp plugin mechanisms
+* a :doc:`vault query API <api-vault-query>` is exposed to developers using standard Corda RPC and CorDapp plugin mechanisms
 * a vault update API is internally used by transaction recording flows.
 * the vault database schemas are directly accessible via JDBC for customer joins and queries
 


### PR DESCRIPTION
Vault Query API is distinct to the existing Vault Service API.
Clarified naming and fixed incorrect references to both Vault Query and Persistence docs.