### PR TITLE
Removing repository addition from Quasar Plugin

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.12.4
+gradlePluginsVersion=0.13.0
 kotlinVersion=1.1.1
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/gradle-plugins/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/gradle-plugins/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -10,11 +10,6 @@ import org.gradle.api.tasks.JavaExec
  */
 class QuasarPlugin implements Plugin<Project> {
     void apply(Project project) {
-
-        project.repositories {
-            mavenCentral()
-        }
-
         project.configurations.create("quasar")
 //        To add a local .jar dependency:
 //        project.dependencies.add("quasar", project.files("${project.rootProject.projectDir}/lib/quasar.jar"))


### PR DESCRIPTION
This plugin was modifying project repositories - this is not behaviour a gradle plugin should be doing and it made downstream gradle configurations nearly impossible to debug.