### PR TITLE
Remove 'mustSign' field from transactions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -326,7 +326,6 @@ object WireTransactionSerializer : Serializer<WireTransaction>() {
         kryo.writeClassAndObject(output, obj.outputs)
         kryo.writeClassAndObject(output, obj.commands)
         kryo.writeClassAndObject(output, obj.notary)
-        kryo.writeClassAndObject(output, obj.mustSign)
         kryo.writeClassAndObject(output, obj.type)
         kryo.writeClassAndObject(output, obj.timeWindow)
     }
@@ -354,10 +353,9 @@ object WireTransactionSerializer : Serializer<WireTransaction>() {
             val outputs = kryo.readClassAndObject(input) as List<TransactionState<ContractState>>
             val commands = kryo.readClassAndObject(input) as List<Command>
             val notary = kryo.readClassAndObject(input) as Party?
-            val signers = kryo.readClassAndObject(input) as List<PublicKey>
             val transactionType = kryo.readClassAndObject(input) as TransactionType
             val timeWindow = kryo.readClassAndObject(input) as TimeWindow?
-            return WireTransaction(inputs, attachmentHashes, outputs, commands, notary, signers, transactionType, timeWindow)
+            return WireTransaction(inputs, attachmentHashes, outputs, commands, notary, transactionType, timeWindow)
         }
     }
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt
@@ -20,16 +20,9 @@ abstract class BaseTransaction(
          */
         val notary: Party?,
         /**
-         * Public keys that need to be fulfilled by signatures in order for the transaction to be valid.
-         * In a [SignedTransaction] this list is used to check whether there are any missing signatures. Note that
-         * there is nothing that forces the list to be the _correct_ list of signers for this transaction until
-         * the transaction is verified by using [LedgerTransaction.verify].
-         *
-         * It includes the notary key, if the notary field is set.
-         */
-        val mustSign: List<PublicKey>,
-        /**
          * Pointer to a class that defines the behaviour of this transaction: either normal, or "notary changing".
+         *
+         * TODO: this field can be removed – transaction type check can be done based on existence of the NotaryChange command
          */
         val type: TransactionType,
         /**
@@ -48,12 +41,11 @@ abstract class BaseTransaction(
         if (other === this) return true
         return other is BaseTransaction &&
                 notary == other.notary &&
-                mustSign == other.mustSign &&
                 type == other.type &&
                 timeWindow == other.timeWindow
     }
 
-    override fun hashCode() = Objects.hash(notary, mustSign, type, timeWindow)
+    override fun hashCode() = Objects.hash(notary, type, timeWindow)
 
     override fun toString(): String = "${javaClass.simpleName}(id=$id)"
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/FullTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/FullTransaction.kt
@@ -1,0 +1,303 @@
+package net.corda.core.transactions
+
+import net.corda.core.contracts.*
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.MerkleTree
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.isFulfilledBy
+import net.corda.core.identity.Party
+import net.corda.core.node.ServiceHub
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.SerializedBytes
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
+import java.security.PublicKey
+import java.security.SignatureException
+
+interface TransactionBase : NamedByHash {
+    /** The inputs of this transaction. Note that in BaseTransaction subclasses the type of this list may change! */
+    val inputs: List<*>
+
+    /**
+     * If present, the notary for this transaction. If absent then the transaction is not notarised at all.
+     * This is intended for issuance/genesis transactions that don't consume any other states and thus can't
+     * double spend anything.
+     */
+    val notary: Party?
+}
+
+abstract class AbstractCoreTransaction : TransactionBase {
+    override val id: SecureHash get() = merkleTree.hash
+
+    val merkleTree: MerkleTree by lazy { MerkleTree.getMerkleTree(availableComponentHashes) }
+
+    /**
+     * Calculate the hashes of the sub-components of the transaction, that are used to build its Merkle tree.
+     * The root of the tree is the transaction identifier. The tree structure is helpful for privacy, please
+     * see the user-guide section "Transaction tear-offs" to learn more about this topic.
+     */
+    private val availableComponentHashes: List<SecureHash> get() = availableComponents.map { serializedHash(it) }
+
+    protected abstract val availableComponents: List<Any>
+
+    abstract fun resolveFullTransaction(services: ServiceHub, sigs: List<DigitalSignature.WithKey>): AbstractFullTransaction
+}
+
+abstract class AbstractFullTransaction : TransactionBase {
+    protected abstract var signatures: List<DigitalSignature.WithKey>
+    abstract val requiredSigningKeys: Set<PublicKey>
+    abstract val outputs: List<TransactionState<ContractState>>
+
+    abstract fun verify()
+
+    protected abstract val coreTransaction: AbstractCoreTransaction
+
+    override val id: SecureHash get() = coreTransaction.id
+
+    val sigs: List<DigitalSignature.WithKey> get() = signatures
+
+    fun addSignature(vararg signature: DigitalSignature.WithKey) {
+        signatures += signature
+    }
+
+    fun verifySignatures(vararg allowedToBeMissing: PublicKey) {
+        checkSignaturesAreValid()
+
+        val missing = getMissingSignatures()
+        if (missing.isNotEmpty()) {
+            val allowed = allowedToBeMissing.toSet()
+            val needed = missing - allowed
+            if (needed.isNotEmpty())
+                throw SignaturesMissingException(needed, needed.map { it.toString() }, id)
+        }
+    }
+
+    fun toTransactionAndSignatures(): TransactionForStorage {
+        return TransactionForStorage(coreTransaction.serialize(), sigs)
+    }
+
+    /**
+     * Mathematically validates the signatures that are present on this transaction. This does not imply that
+     * the signatures are by the right keys, or that there are sufficient signatures, just that they aren't
+     * corrupt. If you use this function directly you'll need to do the other checks yourself. Probably you
+     * want [verifySignatures] instead.
+     *
+     * @throws SignatureException if a signature fails to verify.
+     */
+    @Throws(SignatureException::class)
+    fun checkSignaturesAreValid() {
+        for (sig in sigs) {
+            sig.verify(id.bytes)
+        }
+    }
+
+    private fun getMissingSignatures(): Set<PublicKey> {
+        val sigKeys = sigs.map { it.by }.toSet()
+        // TODO Problem is that we can get single PublicKey wrapped as CompositeKey in allowedToBeMissing/mustSign
+        //  equals on CompositeKey won't catch this case (do we want to single PublicKey be equal to the same key wrapped in CompositeKey with threshold 1?)
+        val missing = requiredSigningKeys.filter { !it.isFulfilledBy(sigKeys) }.toSet()
+        return missing
+    }
+
+    @CordaSerializable
+    class SignaturesMissingException(val missing: Set<PublicKey>, val descriptions: List<String>, override val id: SecureHash) : NamedByHash, SignatureException() {
+        override fun toString(): String {
+            return "Missing signatures for $descriptions on transaction ${id.prefixChars()} for ${missing.joinToString()}"
+        }
+    }
+}
+
+data class NotaryChangeCoreTransaction(
+        override val inputs: List<StateRef>,
+        override val notary: Party,
+        val newNotary: Party) : AbstractCoreTransaction() {
+
+    override fun resolveFullTransaction(services: ServiceHub, sigs: List<DigitalSignature.WithKey>): NotaryChangeFullTransaction {
+        val resolveStateRef = { state: StateRef -> services.loadState(state) }
+        val resolvedInputs = inputs.map { ref ->
+            resolveStateRef(ref).let { net.corda.core.contracts.StateAndRef(it, ref) }
+        }
+        return NotaryChangeFullTransaction(resolvedInputs, notary, newNotary, sigs)
+    }
+
+    override val availableComponents: List<Any>
+        get() = mutableListOf(inputs).flatten() + listOf(notary, newNotary)
+}
+
+
+data class NotaryChangeFullTransaction(
+        override val inputs: List<StateAndRef<*>>,
+        override val notary: Party,
+        val newNotary: Party,
+        override var signatures: List<DigitalSignature.WithKey>
+) : AbstractFullTransaction() {
+
+    override val outputs: List<TransactionState<ContractState>>
+        get() = inputs.map { it.state.copy(notary = newNotary) }
+
+    override val coreTransaction: AbstractCoreTransaction
+        get() {
+            return NotaryChangeCoreTransaction(
+                    inputs.map { it.ref },
+                    notary,
+                    newNotary
+            )
+        }
+
+    override val requiredSigningKeys: Set<PublicKey>
+        get() = inputs.flatMap { it.state.data.participants }.map { it.owningKey }.toSet()
+
+    override fun verify() {}
+
+}
+
+data class GeneralCoreTransaction(
+        override val inputs: List<StateRef>,
+        /** Hashes of the ZIP/JAR files that are needed to interpret the contents of this wire transaction. */
+        val attachments: List<SecureHash>,
+        val outputs: List<TransactionState<ContractState>>,
+        /** Ordered list of ([CommandData], [PublicKey]) pairs that instruct the contracts what to do. */
+        val commands: List<Command>,
+        val timeWindow: TimeWindow?,
+        override val notary: Party?) : AbstractCoreTransaction() {
+
+    override fun resolveFullTransaction(services: ServiceHub, sigs: List<DigitalSignature.WithKey>): FullTransaction {
+        val resolveIdentity = { key: PublicKey -> services.identityService.partyFromKey(key) }
+        val resolveAttachment = { id: SecureHash -> services.attachments.openAttachment(id) }
+        val resolveStateRef = { state: StateRef -> services.loadState(state) }
+
+        // Look up public keys to authenticated identities. This is just a stub placeholder and will all change in future.
+        val authenticatedArgs = commands.map {
+            val parties = it.signers.mapNotNull { pk -> resolveIdentity(pk) }
+            net.corda.core.contracts.AuthenticatedObject(it.signers, parties, it.value)
+        }
+        // Open attachments specified in this transaction. If we haven't downloaded them, we fail.
+        val attachments = attachments.map { resolveAttachment(it) ?: throw net.corda.core.contracts.AttachmentResolutionException(it) }
+        val resolvedInputs = inputs.map { ref ->
+            resolveStateRef(ref).let { net.corda.core.contracts.StateAndRef(it, ref) }
+        }
+        return FullTransaction(resolvedInputs, outputs, authenticatedArgs, attachments, timeWindow, notary, sigs)
+    }
+
+
+    override val availableComponents: List<Any>
+        get() = mutableListOf(inputs, outputs, attachments, commands).flatten() + listOf(notary, timeWindow).filterNotNull()
+}
+
+
+@CordaSerializable
+data class FullTransaction(
+        /** The resolved input states which will be consumed/invalidated by the execution of this transaction. */
+        override val inputs: List<StateAndRef<*>>,
+        override val outputs: List<TransactionState<ContractState>>,
+
+        /** Arbitrary data passed to the program of each input state. */
+        val commands: List<AuthenticatedObject<CommandData>>,
+        /** A list of [Attachment] objects identified by the transaction that are needed for this transaction to verify. */
+        val attachments: List<Attachment>,
+        val timeWindow: TimeWindow?,
+        override val notary: Party?,
+        override var signatures: List<DigitalSignature.WithKey>) : AbstractFullTransaction() {
+    init {
+        verifyNoNotaryChange()
+        verifyEncumbrances()
+    }
+
+    override val coreTransaction: GeneralCoreTransaction get() {
+        return GeneralCoreTransaction(
+                inputs.map { it.ref },
+                attachments.map { it.id },
+                outputs,
+                commands.map { Command(it.value, it.signers) },
+                timeWindow,
+                notary)
+    }
+
+    /** Public keys that need to be fulfilled by signatures in order for the transaction to be valid. */
+    override val requiredSigningKeys: Set<PublicKey> get() {
+        val commandKeys = commands.flatMap { it.signers }.toSet()
+        // TODO: prevent notary field from being set if there are no inputs and no timestamp
+        return if (notary != null && (inputs.isNotEmpty() || timeWindow != null)) {
+            (commandKeys + notary.owningKey).filterNotNull().toSet()
+        } else {
+            commandKeys
+        }
+    }
+
+    override fun verify() {
+        verifyEncumbrances()
+        verifyNoNotaryChange()
+        verifyContracts()
+    }
+
+    fun verifyContracts() {
+        fun toTransactionForContract(): TransactionForContract {
+            return TransactionForContract(inputs.map { it.state.data }, outputs.map { it.data }, attachments, commands, id,
+                    inputs.map { it.state.notary }.singleOrNull(), timeWindow)
+        }
+
+        val ctx = toTransactionForContract()
+        // TODO: This will all be replaced in future once the sandbox and contract constraints work is done.
+        val contracts = (ctx.inputs.map { it.contract } + ctx.outputs.map { it.contract }).toSet()
+        for (contract in contracts) {
+            try {
+                contract.verify(ctx)
+            } catch(e: Throwable) {
+                throw TransactionVerificationException.ContractRejection(id, contract, e)
+            }
+        }
+    }
+
+
+    /**
+     * Make sure the notary has stayed the same. As we can't tell how inputs and outputs connect, if there
+     * are any inputs, all outputs must have the same notary.
+     *
+     * TODO: Is that the correct set of restrictions? May need to come back to this, see if we can be more
+     *       flexible on output notaries.
+     */
+    private fun verifyNoNotaryChange() {
+        if (notary != null && inputs.isNotEmpty()) {
+            outputs.forEach {
+                if (it.notary != notary) {
+                    throw TransactionVerificationException.NotaryChangeInWrongTransactionType(id, notary, it.notary)
+                }
+            }
+        }
+    }
+
+    private fun verifyEncumbrances() {
+        // Validate that all encumbrances exist within the set of input states.
+        val encumberedInputs = inputs.filter { it.state.encumbrance != null }
+        encumberedInputs.forEach { (state, ref) ->
+            val encumbranceStateExists = inputs.any {
+                it.ref.txhash == ref.txhash && it.ref.index == state.encumbrance
+            }
+            if (!encumbranceStateExists) {
+                throw TransactionVerificationException.TransactionMissingEncumbranceException(
+                        id,
+                        state.encumbrance!!,
+                        TransactionVerificationException.Direction.INPUT
+                )
+            }
+        }
+
+        // Check that, in the outputs, an encumbered state does not refer to itself as the encumbrance,
+        // and that the number of outputs can contain the encumbrance.
+        for ((i, output) in outputs.withIndex()) {
+            val encumbranceIndex = output.encumbrance ?: continue
+            if (encumbranceIndex == i || encumbranceIndex >= outputs.size) {
+                throw TransactionVerificationException.TransactionMissingEncumbranceException(
+                        id,
+                        encumbranceIndex,
+                        TransactionVerificationException.Direction.OUTPUT)
+            }
+        }
+    }
+}
+
+data class TransactionForStorage(private val txBits: SerializedBytes<AbstractCoreTransaction>,
+                                 private val sigs: List<DigitalSignature.WithKey>) {
+    fun resolveToFullTransaction(services: ServiceHub) = txBits.deserialize().resolveFullTransaction(services, sigs)
+}
+

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -31,10 +31,9 @@ class LedgerTransaction(
         /** The hash of the original serialised WireTransaction. */
         override val id: SecureHash,
         notary: Party?,
-        signers: List<PublicKey>,
         timeWindow: TimeWindow?,
         type: TransactionType
-) : BaseTransaction(inputs, outputs, notary, signers, type, timeWindow) {
+) : BaseTransaction(inputs, outputs, notary, type, timeWindow) {
     init {
         checkInvariants()
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -32,7 +32,6 @@ interface TraversableTransaction {
     val outputs: List<TransactionState<ContractState>>
     val commands: List<Command>
     val notary: Party?
-    val mustSign: List<PublicKey>
     val type: TransactionType?
     val timeWindow: TimeWindow?
 
@@ -55,7 +54,6 @@ interface TraversableTransaction {
             // torn-off transaction and id calculation.
             val result = mutableListOf(inputs, attachments, outputs, commands).flatten().toMutableList()
             notary?.let { result += it }
-            result.addAll(mustSign)
             type?.let { result += it }
             timeWindow?.let { result += it }
             return result
@@ -80,7 +78,6 @@ class FilteredLeaves(
         override val outputs: List<TransactionState<ContractState>>,
         override val commands: List<Command>,
         override val notary: Party?,
-        override val mustSign: List<PublicKey>,
         override val type: TransactionType?,
         override val timeWindow: TimeWindow?
 ) : TraversableTransaction {

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -105,7 +105,7 @@ data class SignedTransaction(val txBits: SerializedBytes<WireTransaction>,
         val sigKeys = sigs.map { it.by }.toSet()
         // TODO Problem is that we can get single PublicKey wrapped as CompositeKey in allowedToBeMissing/mustSign
         //  equals on CompositeKey won't catch this case (do we want to single PublicKey be equal to the same key wrapped in CompositeKey with threshold 1?)
-        val missing = tx.mustSign.filter { !it.isFulfilledBy(sigKeys) }.toSet()
+        val missing = tx.requiredSigningKeys.filter { !it.isFulfilledBy(sigKeys) }.toSet()
         return missing
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -33,10 +33,9 @@ class WireTransaction(
         /** Ordered list of ([CommandData], [PublicKey]) pairs that instruct the contracts what to do. */
         override val commands: List<Command>,
         notary: Party?,
-        signers: List<PublicKey>,
         type: TransactionType,
         timeWindow: TimeWindow?
-) : BaseTransaction(inputs, outputs, notary, signers, type, timeWindow), TraversableTransaction {
+) : BaseTransaction(inputs, outputs, notary, type, timeWindow), TraversableTransaction {
     init {
         checkInvariants()
     }
@@ -52,6 +51,17 @@ class WireTransaction(
             val wtx = data.bytes.deserialize<WireTransaction>(kryo)
             wtx.cachedBytes = data
             return wtx
+        }
+    }
+
+    /** Public keys that need to be fulfilled by signatures in order for the transaction to be valid. */
+    val requiredSigningKeys: Set<PublicKey> get() {
+        val commandKeys = commands.flatMap { it.signers }.toSet()
+        // TODO: prevent notary field from being set if there are no inputs and no timestamp
+        return if (notary != null && (inputs.isNotEmpty() || timeWindow != null)) {
+            commandKeys + notary.owningKey
+        } else {
+            commandKeys
         }
     }
 
@@ -104,7 +114,7 @@ class WireTransaction(
         val resolvedInputs = inputs.map { ref ->
             resolveStateRef(ref)?.let { StateAndRef(it, ref) } ?: throw TransactionResolutionException(ref.txhash)
         }
-        return LedgerTransaction(resolvedInputs, outputs, authenticatedArgs, attachments, id, notary, mustSign, timeWindow, type)
+        return LedgerTransaction(resolvedInputs, outputs, authenticatedArgs, attachments, id, notary, timeWindow, type)
     }
 
     /**
@@ -132,7 +142,6 @@ class WireTransaction(
                 outputs.filter { filtering.test(it) },
                 commands.filter { filtering.test(it) },
                 notNullFalse(notary) as Party?,
-                mustSign.filter { filtering.test(it) },
                 notNullFalse(type) as TransactionType?,
                 notNullFalse(timeWindow) as TimeWindow?
         )

--- a/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/TestConstants.kt
@@ -2,6 +2,8 @@
 
 package net.corda.core.utilities
 
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.crypto.*
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
@@ -66,6 +68,8 @@ val DUMMY_CA: CertificateAndKeyPair by lazy {
     val cert = X509Utilities.createSelfSignedCACertificate(X500Name("CN=Dummy CA,OU=Corda,O=R3 Ltd,L=London,C=GB"), DUMMY_CA_KEY)
     CertificateAndKeyPair(cert, DUMMY_CA_KEY)
 }
+
+fun dummyCommand(vararg signers: PublicKey) = Command(object : TypeOnlyCommandData() {}, signers.toList())
 
 /**
  * Build a test party with a nonsense certificate authority for testing purposes.

--- a/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/AbstractStateReplacementFlow.kt
@@ -8,8 +8,6 @@ import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
@@ -193,7 +191,7 @@ abstract class AbstractStateReplacementFlow {
         private fun checkMySignatureRequired(tx: WireTransaction) {
             // TODO: use keys from the keyManagementService instead
             val myKey = serviceHub.myInfo.legalIdentity.owningKey
-            require(myKey in tx.mustSign) { "Party is not a participant for any of the input states of transaction ${tx.id}" }
+            require(myKey in tx.requiredSigningKeys) { "Party is not a participant for any of the input states of transaction ${tx.id}" }
         }
 
         @Suspendable

--- a/core/src/main/kotlin/net/corda/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/flows/CollectSignaturesFlow.kt
@@ -19,7 +19,7 @@ import java.security.PublicKey
  *
  * You would typically use this flow after you have built a transaction with the TransactionBuilder and signed it with
  * your key pair. If there are additional signatures to collect then they can be collected using this flow. Signatures
- * are collected based upon the [WireTransaction.mustSign] property which contains the union of all the PublicKeys
+ * are collected based upon the [WireTransaction.requiredSigningKeys] property which contains the union of all the PublicKeys
  * listed in the transaction's commands as well as a notary's public key, if required. This flow returns a
  * [SignedTransaction] which can then be passed to the [FinalityFlow] for notarisation. The other side of this flow is
  * the [SignTransactionFlow].
@@ -80,7 +80,7 @@ class CollectSignaturesFlow(val partiallySignedTx: SignedTransaction,
         // Usually just the Initiator and possibly an oracle would have signed at this point.
         val myKey = serviceHub.myInfo.legalIdentity.owningKey
         val signed = partiallySignedTx.sigs.map { it.by }
-        val notSigned = partiallySignedTx.tx.mustSign - signed
+        val notSigned = partiallySignedTx.tx.requiredSigningKeys - signed
 
         // One of the signatures collected so far MUST be from the initiator of this flow.
         require(partiallySignedTx.sigs.any { it.by == myKey }) {
@@ -115,7 +115,7 @@ class CollectSignaturesFlow(val partiallySignedTx: SignedTransaction,
     /**
      * Lookup the [Party] object for each [PublicKey] using the [ServiceHub.networkMapCache].
      */
-    @Suspendable private fun keysToParties(keys: List<PublicKey>): List<Party> = keys.map {
+    @Suspendable private fun keysToParties(keys: Collection<PublicKey>): List<Party> = keys.map {
         // TODO: Revisit when IdentityService supports resolution of a (possibly random) public key to a legal identity key.
         val partyNode = serviceHub.networkMapCache.getNodeByLegalIdentityKey(it)
                 ?: throw IllegalStateException("Party ${it.toBase58String()} not found on the network.")
@@ -223,7 +223,7 @@ abstract class SignTransactionFlow(val otherParty: Party,
             "The Initiator of CollectSignaturesFlow must have signed the transaction."
         }
         val signed = stx.sigs.map { it.by }
-        val allSigners = stx.tx.mustSign
+        val allSigners = stx.tx.requiredSigningKeys
         val notSigned = allSigners - signed
         stx.verifySignatures(*notSigned.toTypedArray())
     }
@@ -253,7 +253,7 @@ abstract class SignTransactionFlow(val otherParty: Party,
     @Suspendable private fun checkMySignatureRequired(stx: SignedTransaction) {
         // TODO: Revisit when key management is properly fleshed out.
         val myKey = serviceHub.myInfo.legalIdentity.owningKey
-        require(myKey in stx.tx.mustSign) {
+        require(myKey in stx.tx.requiredSigningKeys) {
             "Party is not a participant for any of the input states of transaction ${stx.id}"
         }
     }

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
@@ -37,9 +37,8 @@ class TransactionTests {
                 inputs = listOf(StateRef(SecureHash.randomSHA256(), 0)),
                 attachments = emptyList(),
                 outputs = emptyList(),
-                commands = emptyList(),
+                commands = listOf(dummyCommand(compKey, DUMMY_KEY_1.public, DUMMY_KEY_2.public)),
                 notary = DUMMY_NOTARY,
-                signers = listOf(compKey, DUMMY_KEY_1.public, DUMMY_KEY_2.public),
                 type = TransactionType.General,
                 timeWindow = null
         )
@@ -65,9 +64,8 @@ class TransactionTests {
                 inputs = listOf(StateRef(SecureHash.randomSHA256(), 0)),
                 attachments = emptyList(),
                 outputs = emptyList(),
-                commands = emptyList(),
+                commands = listOf(dummyCommand(DUMMY_KEY_1.public, DUMMY_KEY_2.public)),
                 notary = DUMMY_NOTARY,
-                signers = listOf(DUMMY_KEY_1.public, DUMMY_KEY_2.public),
                 type = TransactionType.General,
                 timeWindow = null
         )
@@ -100,7 +98,6 @@ class TransactionTests {
         val commands = emptyList<AuthenticatedObject<CommandData>>()
         val attachments = emptyList<Attachment>()
         val id = SecureHash.randomSHA256()
-        val signers = listOf(DUMMY_NOTARY_KEY.public)
         val timeWindow: TimeWindow? = null
         val transaction: LedgerTransaction = LedgerTransaction(
                 inputs,
@@ -109,7 +106,6 @@ class TransactionTests {
                 attachments,
                 id,
                 null,
-                signers,
                 timeWindow,
                 TransactionType.General
         )
@@ -127,7 +123,6 @@ class TransactionTests {
         val commands = emptyList<AuthenticatedObject<CommandData>>()
         val attachments = emptyList<Attachment>()
         val id = SecureHash.randomSHA256()
-        val signers = listOf(DUMMY_NOTARY_KEY.public)
         val timeWindow: TimeWindow? = null
         val transaction: LedgerTransaction = LedgerTransaction(
                 inputs,
@@ -136,7 +131,6 @@ class TransactionTests {
                 attachments,
                 id,
                 DUMMY_NOTARY,
-                signers,
                 timeWindow,
                 TransactionType.General
         )
@@ -154,7 +148,6 @@ class TransactionTests {
         val commands = emptyList<AuthenticatedObject<CommandData>>()
         val attachments = emptyList<Attachment>()
         val id = SecureHash.randomSHA256()
-        val signers = listOf(DUMMY_NOTARY_KEY.public)
         val timeWindow: TimeWindow? = null
         val transaction: LedgerTransaction = LedgerTransaction(
                 inputs,
@@ -163,7 +156,6 @@ class TransactionTests {
                 attachments,
                 id,
                 notary,
-                signers,
                 timeWindow,
                 TransactionType.General
         )

--- a/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
@@ -112,7 +112,6 @@ class PartialMerkleTreeTest {
         assertEquals(1, leaves.commands.size)
         assertEquals(1, leaves.outputs.size)
         assertEquals(1, leaves.inputs.size)
-        assertEquals(1, leaves.mustSign.size)
         assertEquals(0, leaves.attachments.size)
         assertTrue(mt.filteredLeaves.timeWindow != null)
         assertEquals(null, mt.filteredLeaves.type)
@@ -227,7 +226,6 @@ class PartialMerkleTreeTest {
                 outputs = testTx.outputs,
                 commands = testTx.commands,
                 notary = notary,
-                signers = listOf(MEGA_CORP_PUBKEY, DUMMY_PUBKEY_1),
                 type = TransactionType.General,
                 timeWindow = timeWindow
         )

--- a/finance/src/test/kotlin/net/corda/contracts/testing/Generators.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/testing/Generators.kt
@@ -73,7 +73,6 @@ class WiredTransactionGenerator : Generator<WireTransaction>(WireTransaction::cl
                 outputs = TransactionStateGenerator(ContractStateGenerator()).generateList(random, status),
                 commands = commands,
                 notary = PartyGenerator().generate(random, status),
-                signers = commands.flatMap { it.signers },
                 type = TransactionType.General,
                 timeWindow = TimeWindowGenerator().generate(random, status)
         )

--- a/node-schemas/src/test/kotlin/net/corda/node/services/vault/schemas/VaultSchemaTest.kt
+++ b/node-schemas/src/test/kotlin/net/corda/node/services/vault/schemas/VaultSchemaTest.kt
@@ -116,7 +116,6 @@ class VaultSchemaTest {
         val commands = emptyList<AuthenticatedObject<CommandData>>()
         val attachments = emptyList<Attachment>()
         val id = SecureHash.randomSHA256()
-        val signers = listOf(DUMMY_NOTARY_KEY.public)
         val timeWindow: TimeWindow? = null
         transaction = LedgerTransaction(
                 inputs,
@@ -125,7 +124,6 @@ class VaultSchemaTest {
                 attachments,
                 id,
                 notary,
-                signers,
                 timeWindow,
                 TransactionType.General
         )
@@ -148,7 +146,6 @@ class VaultSchemaTest {
         val commands = emptyList<AuthenticatedObject<CommandData>>()
         val attachments = emptyList<Attachment>()
         val id = SecureHash.randomSHA256()
-        val signers = listOf(DUMMY_NOTARY_KEY.public)
         val timeWindow: TimeWindow? = null
         return LedgerTransaction(
                 inputs,
@@ -157,7 +154,6 @@ class VaultSchemaTest {
                 attachments,
                 id,
                 notary,
-                signers,
                 timeWindow,
                 TransactionType.General
         )

--- a/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
@@ -215,7 +215,6 @@ class RequeryConfigurationTest {
                 outputs = emptyList(),
                 commands = emptyList(),
                 notary = DUMMY_NOTARY,
-                signers = emptyList(),
                 type = TransactionType.General,
                 timeWindow = null
         )

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -152,7 +152,6 @@ class DBTransactionStorageTests {
                 outputs = emptyList(),
                 commands = emptyList(),
                 notary = DUMMY_NOTARY,
-                signers = emptyList(),
                 type = TransactionType.General,
                 timeWindow = null
         )

--- a/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
@@ -327,7 +327,7 @@ data class TestLedgerDSLInterpreter private constructor(
  * @return List of [SignedTransaction]s.
  */
 fun signAll(transactionsToSign: List<WireTransaction>, extraKeys: List<KeyPair>) = transactionsToSign.map { wtx ->
-    check(wtx.mustSign.isNotEmpty())
+    check(wtx.requiredSigningKeys.isNotEmpty())
     val bits = wtx.serialize()
     require(bits == wtx.serialized)
     val signatures = ArrayList<DigitalSignature.WithKey>()
@@ -336,7 +336,7 @@ fun signAll(transactionsToSign: List<WireTransaction>, extraKeys: List<KeyPair>)
     (ALL_TEST_KEYS + extraKeys).forEach {
         keyLookup[it.public] = it
     }
-    wtx.mustSign.expandedCompositeKeys.forEach {
+    wtx.requiredSigningKeys.expandedCompositeKeys.forEach {
         val key = keyLookup[it] ?: throw IllegalArgumentException("Missing required key for ${it.toStringShort()}")
         signatures += key.sign(wtx.id)
     }


### PR DESCRIPTION
Introduce the NotaryChange command that specifies all the input state participants that need to sign a notary change transaction. This makes the mustSign field redundant.

The NotaryChange command also allows the transaction _type_ field to be dropped, since at this point it doesn't seem like we're going to introduce any new transaction types apart from "general" and "notary change".