### PR TITLE
CompositeKey validation checks

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -78,7 +78,7 @@ class CompositeKey private constructor (val threshold: Int,
         for ((_, weight) in children) {
             require (weight > 0) { "Non-positive weight: $weight detected." }
             sum += weight // Minimum weight is 1.
-            require(sum < 1) { "Integer overflow detected. Total weight surpasses the maximum accepted value." }
+            require(sum > 0) { "Integer overflow detected. Total weight surpasses the maximum accepted value." }
         }
         return sum
     }

--- a/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
@@ -4,6 +4,7 @@ import net.corda.core.serialization.OpaqueBytes
 import net.corda.core.serialization.serialize
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -21,7 +22,6 @@ class CompositeKeyTests {
     val aliceSignature = aliceKey.sign(message)
     val bobSignature = bobKey.sign(message)
     val charlieSignature = charlieKey.sign(message)
-    val compositeAliceSignature = CompositeSignaturesWithKeys(listOf(aliceSignature))
 
     @Test
     fun `(Alice) fulfilled by Alice signature`() {
@@ -123,5 +123,116 @@ class CompositeKeyTests {
         // Check the underlying signature is validated
         val brokenBobSignature = DigitalSignature.WithKey(bobSignature.by, aliceSignature.bytes)
         assertFalse { engine.verify(CompositeSignaturesWithKeys(listOf(aliceSignature, brokenBobSignature)).serialize().bytes) }
+    }
+
+    @Test()
+    fun `composite key constraints`() {
+        // Zero weight.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKey(alicePublicKey, 0)
+        }
+        // Negative weight.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKey(alicePublicKey, -1)
+        }
+        // Zero threshold.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKey(alicePublicKey).build(0)
+        }
+        // Negative threshold.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKey(alicePublicKey).build(-1)
+        }
+        // Threshold > Total-weight.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKey(alicePublicKey, 2).addKey(bobPublicKey, 2).build(5)
+        }
+        // Threshold value different than weight of single child node.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKey(alicePublicKey, 3).build(2)
+        }
+        // Aggregated weight integer overflow.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKey(alicePublicKey, Int.MAX_VALUE).addKey(bobPublicKey, Int.MAX_VALUE).build()
+        }
+        // Duplicated children.
+        assertFailsWith(IllegalArgumentException::class) {
+            CompositeKey.Builder().addKeys(alicePublicKey, bobPublicKey, alicePublicKey).build()
+        }
+        // Duplicated composite key children.
+        assertFailsWith(IllegalArgumentException::class) {
+            val node1 = CompositeKey.Builder().addKeys(alicePublicKey, bobPublicKey).build()
+            val node2 = CompositeKey.Builder().addKeys(bobPublicKey, alicePublicKey).build()
+            CompositeKey.Builder().addKeys(node1, node2).build()
+        }
+    }
+
+    @Test()
+    fun `composite key validation with graph cycle detection`() {
+        val node1 = CompositeKey.Builder().addKeys(alicePublicKey, bobPublicKey).build() as CompositeKey
+        val node2 = CompositeKey.Builder().addKeys(alicePublicKey, node1).build() as CompositeKey
+        val node3 = CompositeKey.Builder().addKeys(alicePublicKey, node2).build() as CompositeKey
+        val node4 = CompositeKey.Builder().addKeys(alicePublicKey, node3).build() as CompositeKey
+        val node5 = CompositeKey.Builder().addKeys(alicePublicKey, node4).build() as CompositeKey
+        val node6 = CompositeKey.Builder().addKeys(alicePublicKey, node5, node2).build() as CompositeKey
+
+        // Initially, there is no any graph cycle.
+        node1.checkValidity()
+        node2.checkValidity()
+        node3.checkValidity()
+        node4.checkValidity()
+        node5.checkValidity()
+        // The fact that node6 has a direct reference to node2 and an indirect (via path node5->node4->node3->node2)
+        // does not imply a cycle, as expected (independent paths).
+        node6.checkValidity()
+
+        // We will create a graph cycle between node5 and node3. Node5 has already a reference to node3 (via node4).
+        // To create a cycle, we add a reference (child) from node3 to node5.
+        // Children list is immutable, so reflection is used to inject node5 as an extra NodeAndWeight child of node3.
+        val field = node3.javaClass.getDeclaredField("children")
+        field.isAccessible = true
+        val fixedChildren = node3.children.plus(CompositeKey.NodeAndWeight(node5, 1))
+        field.set(node3, fixedChildren)
+
+        /* A view of the example graph cycle.
+         *
+         *               node6
+         *              /    \
+         *           node5   node2
+         *            /
+         *         node4
+         *         /
+         *      node3
+         *      /   \
+         *   node2  node5
+         *    /
+         * node1
+         *
+         */
+
+        // Detect the graph cycle starting from node3.
+        assertFailsWith(IllegalArgumentException::class) {
+            node3.checkValidity()
+        }
+
+        // Detect the graph cycle starting from node4.
+        assertFailsWith(IllegalArgumentException::class) {
+            node4.checkValidity()
+        }
+
+        // Detect the graph cycle starting from node5.
+        assertFailsWith(IllegalArgumentException::class) {
+            node5.checkValidity()
+        }
+
+        // Detect the graph cycle starting from node6.
+        // Typically, one needs to test on the root node only (thus, a validity check on node6 would be enough).
+        assertFailsWith(IllegalArgumentException::class) {
+            node6.checkValidity()
+        }
+
+        // Node2 (and all paths below it, i.e. Node1) are outside the graph cycle and thus, there is no impact on them.
+        node2.checkValidity()
+        node1.checkValidity()
     }
 }


### PR DESCRIPTION
Some extra validation checks for CompositeKeys
1) Min threshold = 1
2) Min weight = 1
3) threshold <= totalWeight (total = aggregated)
4) Graph cycle detection (to avoid infinite loops)
5) totalWeight integer overflow detection (inherently,  due to 1 & 2, we protect against underflow as well)

Also, because `@CordaSerializable` doesn't invoke the constructor and thus a key may be malformed (i.e. cannot be validated), `isFulfilledBy()` runs a full validity check before checking thresholds are satisfied.

There is also a small fix on the "N of N" requirement, where the total (aggregated) weight value is now taken into account, if threshold is not provided. Previously this was `children.size`.

~_This is not subject for review yet; unit-tests are required._~ Ready for review.