### PR TITLE
Cordapps now exclude the META-INF of dependencies.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.13.1
+gradlePluginsVersion=0.13.2
 kotlinVersion=1.1.1
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
@@ -24,9 +24,11 @@ class Cordformation implements Plugin<Project> {
         // Note: project.afterEvaluate did not have full dependency resolution completed, hence a task is used instead
         def task = project.task('configureCordappFatJar') {
             doLast {
-                project.tasks.jar.from getDirectNonCordaDependencies(project).collect {
-                    project.zipTree(it).matching { exclude { it.path.contains('META-INF') } }
-                }.flatten()
+                project.tasks.jar.from(getDirectNonCordaDependencies(project).collect { project.zipTree(it)}) {
+                    exclude "META-INF/*.SF"
+                    exclude "META-INF/*.DSA"
+                    exclude "META-INF/*.RSA"
+                }
             }
         }
         project.tasks.jar.dependsOn task
@@ -45,7 +47,7 @@ class Cordformation implements Plugin<Project> {
         }, filePathInJar).asFile()
     }
 
-    static def getDirectNonCordaDependencies(Project project) {
+    private static def getDirectNonCordaDependencies(Project project) {
         def coreCordaNames = ['jfx', 'mock', 'rpc', 'core', 'corda', 'cordform-common', 'corda-webserver', 'finance', 'node', 'node-api', 'node-schemas', 'test-utils', 'jackson', 'verifier', 'webserver', 'capsule', 'webcapsule']
         def excludes = coreCordaNames.collect { [group: 'net.corda', name: it] } + [
                 [group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib'],

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
@@ -24,7 +24,9 @@ class Cordformation implements Plugin<Project> {
         // Note: project.afterEvaluate did not have full dependency resolution completed, hence a task is used instead
         def task = project.task('configureCordappFatJar') {
             doLast {
-                project.tasks.jar.from getDirectNonCordaDependencies(project).collect { project.zipTree(it) }.flatten()
+                project.tasks.jar.from getDirectNonCordaDependencies(project).collect {
+                    project.zipTree(it).matching { exclude { it.path.contains('META-INF') } }
+                }.flatten()
             }
         }
         project.tasks.jar.dependsOn task


### PR DESCRIPTION
This fixes the notary demo and future cordapps that will be broken.

For reference there is a workaround for all cordapps built on M13 and that is to add the following to the cordapp's project;

    jar {
        exclude 'META-INF/**'
    }