### PR TITLE
Vault Query Pagination simplification

### DIFF
--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -13,10 +13,7 @@ import net.corda.core.getOrThrow
 import net.corda.core.messaging.*
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.Vault
-import net.corda.core.node.services.vault.PageSpecification
-import net.corda.core.node.services.vault.QueryCriteria
-import net.corda.core.node.services.vault.Sort
-import net.corda.core.node.services.vault.SortAttribute
+import net.corda.core.node.services.vault.*
 import net.corda.core.seconds
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.sizedInputStreamAndHash
@@ -190,7 +187,7 @@ class StandaloneCordaRPClientTest {
                 .returnValue.getOrThrow(timeout)
 
         val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)
-        val paging = PageSpecification(0, 10)
+        val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
         val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Standard(Sort.VaultStateAttribute.RECORDED_TIME), Sort.Direction.DESC)))
 
         val queryResults = rpcProxy.vaultQueryBy<Cash.State>(criteria, paging, sorting)

--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -187,7 +187,7 @@ class StandaloneCordaRPClientTest {
                 .returnValue.getOrThrow(timeout)
 
         val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)
-        val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
+        val paging = PageSpecification(STARTING_PAGE_NUM, 10)
         val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Standard(Sort.VaultStateAttribute.RECORDED_TIME), Sort.Direction.DESC)))
 
         val queryResults = rpcProxy.vaultQueryBy<Cash.State>(criteria, paging, sorting)

--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -187,7 +187,7 @@ class StandaloneCordaRPClientTest {
                 .returnValue.getOrThrow(timeout)
 
         val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)
-        val paging = PageSpecification(STARTING_PAGE_NUM, 10)
+        val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
         val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Standard(Sort.VaultStateAttribute.RECORDED_TIME), Sort.Direction.DESC)))
 
         val queryResults = rpcProxy.vaultQueryBy<Cash.State>(criteria, paging, sorting)

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -14,6 +14,8 @@ import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.Vault
+import net.corda.core.node.services.VaultQueryException
+import net.corda.core.node.services.vault.DEFAULT_PAGE_SIZE
 import net.corda.core.node.services.vault.PageSpecification
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.Sort
@@ -78,13 +80,18 @@ interface CordaRPCOps : RPCOps {
      * and returns a [Vault.Page] object containing the following:
      *  1. states as a List of <StateAndRef> (page number and size defined by [PageSpecification])
      *  2. states metadata as a List of [Vault.StateMetadata] held in the Vault States table.
-     *  3. the [PageSpecification] used in the query
-     *  4. a total number of results available (for subsequent paging if necessary)
-     *  5. status types used in this query: UNCONSUMED, CONSUMED, ALL
-     *  6. other results (aggregate functions with/without using value groups)
+     *  3. total number of results available if [PageSpecification] supplied (otherwise returns -1)
+     *  4. status types used in this query: UNCONSUMED, CONSUMED, ALL
+     *  5. other results (aggregate functions with/without using value groups)
      *
-     * Note: a default [PageSpecification] is applied to the query returning the 1st page (indexed from 0) with up to 200 entries.
-     *       It is the responsibility of the Client to request further pages and/or specify a more suitable [PageSpecification].
+     * @throws VaultQueryException if the query cannot be executed for any reason
+     *        (missing criteria or parsing error, paging errors, unsupported query, underlying database error)
+     *
+     * Notes
+     *   If no [PageSpecification] is provided, a maximum of [DEFAULT_PAGE_SIZE] results will be returned.
+     *   API users must specify a [PageSpecification] if they are expecting more than [DEFAULT_PAGE_SIZE] results,
+     *   otherwise a [VaultQueryException] will be thrown alerting to this condition.
+     *   It is the responsibility of the API user to request further pages and/or specify a more suitable [PageSpecification].
      */
     // DOCSTART VaultQueryByAPI
     @RPCReturnsObservables

--- a/core/src/main/kotlin/net/corda/core/node/services/Services.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/Services.kt
@@ -132,7 +132,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
     data class Page<out T : ContractState>(val states: List<StateAndRef<T>>,
                                            val statesMetadata: List<StateMetadata>,
                                            val pageable: PageSpecification,
-                                           val totalStatesAvailable: Int,
+                                           val totalStatesAvailable: Long,
                                            val stateTypes: StateStatus,
                                            val otherResults: List<Any>)
 

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -119,7 +119,7 @@ fun <O, C> getColumnName(column: Column<O, C>): String {
  *  paging and sorting capability:
  *  https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html
  */
-const val DEFAULT_PAGE_NUM = 0
+const val DEFAULT_PAGE_NUM = 1
 const val DEFAULT_PAGE_SIZE = 200
 
 /**
@@ -129,7 +129,7 @@ const val DEFAULT_PAGE_SIZE = 200
 const val MAX_PAGE_SIZE = 512
 
 /**
- * PageSpecification allows specification of a page number (starting from 0 as default) and page size (defaulting to
+ * PageSpecification allows specification of a page number (starting from 1 as default) and page size (defaulting to
  * [DEFAULT_PAGE_SIZE] with a maximum page size of [MAX_PAGE_SIZE]
  */
 @CordaSerializable

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -133,7 +133,9 @@ const val MAX_PAGE_SIZE = 512
  * [DEFAULT_PAGE_SIZE] with a maximum page size of [MAX_PAGE_SIZE]
  */
 @CordaSerializable
-data class PageSpecification(val pageNumber: Int = DEFAULT_PAGE_NUM, val pageSize: Int = DEFAULT_PAGE_SIZE)
+data class PageSpecification(val pageNumber: Int = DEFAULT_PAGE_NUM, val pageSize: Int = DEFAULT_PAGE_SIZE) {
+    val isDefault = (pageSize == DEFAULT_PAGE_SIZE && pageNumber == DEFAULT_PAGE_NUM)
+}
 
 /**
  * Sort allows specification of a set of entity attribute names and their associated directionality

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -119,7 +119,8 @@ fun <O, C> getColumnName(column: Column<O, C>): String {
  *  paging and sorting capability:
  *  https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html
  */
-const val DEFAULT_PAGE_NUM = 1
+const val STARTING_PAGE_NUM = 1
+const val DEFAULT_PAGE_NUM = -1
 const val DEFAULT_PAGE_SIZE = 200
 
 /**
@@ -129,8 +130,10 @@ const val DEFAULT_PAGE_SIZE = 200
 const val MAX_PAGE_SIZE = 512
 
 /**
- * PageSpecification allows specification of a page number (starting from 1 as default) and page size (defaulting to
- * [DEFAULT_PAGE_SIZE] with a maximum page size of [MAX_PAGE_SIZE]
+ * [PageSpecification] allows specification of a page number (starting from [STARTING_PAGE_NUM]) and page size
+ * (defaulting to [DEFAULT_PAGE_SIZE] with a maximum page size of [MAX_PAGE_SIZE])
+ * Note: we default the page number to [DEFAULT_PAGE_SIZE] to enable queries without requiring a page specification
+ * but enabling detection of large results sets that fall out of the [DEFAULT_PAGE_SIZE] requirement.
  */
 @CordaSerializable
 data class PageSpecification(val pageNumber: Int = DEFAULT_PAGE_NUM, val pageSize: Int = DEFAULT_PAGE_SIZE) {

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -119,8 +119,7 @@ fun <O, C> getColumnName(column: Column<O, C>): String {
  *  paging and sorting capability:
  *  https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html
  */
-const val STARTING_PAGE_NUM = 1
-const val DEFAULT_PAGE_NUM = -1
+const val DEFAULT_PAGE_NUM = 1
 const val DEFAULT_PAGE_SIZE = 200
 
 /**
@@ -129,15 +128,15 @@ const val DEFAULT_PAGE_SIZE = 200
 const val MAX_PAGE_SIZE = Int.MAX_VALUE
 
 /**
- * [PageSpecification] allows specification of a page number (starting from [STARTING_PAGE_NUM]) and page size
+ * [PageSpecification] allows specification of a page number (starting from [DEFAULT_PAGE_NUM]) and page size
  * (defaulting to [DEFAULT_PAGE_SIZE] with a maximum page size of [MAX_PAGE_SIZE])
  * Note: we default the page number to [DEFAULT_PAGE_SIZE] to enable queries without requiring a page specification
  * but enabling detection of large results sets that fall out of the [DEFAULT_PAGE_SIZE] requirement.
  * [MAX_PAGE_SIZE] should be used with extreme caution as results may exceed your JVM memory footprint.
  */
 @CordaSerializable
-data class PageSpecification(val pageNumber: Int = DEFAULT_PAGE_NUM, val pageSize: Int = DEFAULT_PAGE_SIZE) {
-    val isDefault = (pageSize == DEFAULT_PAGE_SIZE && pageNumber == DEFAULT_PAGE_NUM)
+data class PageSpecification(val pageNumber: Int = -1, val pageSize: Int = DEFAULT_PAGE_SIZE) {
+    val isDefault = (pageSize == DEFAULT_PAGE_SIZE && pageNumber == -1)
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -124,16 +124,16 @@ const val DEFAULT_PAGE_NUM = -1
 const val DEFAULT_PAGE_SIZE = 200
 
 /**
- * Note: this maximum size will be configurable in future (to allow for large JVM heap sized node configurations)
- *       Use [PageSpecification] to correctly handle a number of bounded pages of [MAX_PAGE_SIZE].
+ * Note: use [PageSpecification] to correctly handle a number of bounded pages of a pre-configured page size.
  */
-const val MAX_PAGE_SIZE = 512
+const val MAX_PAGE_SIZE = Int.MAX_VALUE
 
 /**
  * [PageSpecification] allows specification of a page number (starting from [STARTING_PAGE_NUM]) and page size
  * (defaulting to [DEFAULT_PAGE_SIZE] with a maximum page size of [MAX_PAGE_SIZE])
  * Note: we default the page number to [DEFAULT_PAGE_SIZE] to enable queries without requiring a page specification
  * but enabling detection of large results sets that fall out of the [DEFAULT_PAGE_SIZE] requirement.
+ * [MAX_PAGE_SIZE] should be used with extreme caution as results may exceed your JVM memory footprint.
  */
 @CordaSerializable
 data class PageSpecification(val pageNumber: Int = DEFAULT_PAGE_NUM, val pageSize: Int = DEFAULT_PAGE_SIZE) {

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -417,10 +417,11 @@ This query returned an ``Iterable<StateAndRef<T>>``
 
 The query returns a ``Vault.Page`` result containing:
 
-	- states as a ``List<StateAndRef<T : ContractState>>`` sized according to the default Page specification of ``DEFAULT_PAGE_NUM`` (0) and ``DEFAULT_PAGE_SIZE`` (200).
+	- states as a ``List<StateAndRef<T : ContractState>>`` up to a maximum of ``DEFAULT_PAGE_SIZE`` (200) where no ``PageSpecification`` provided, otherwise returns results according to the parameters ``pageNumber`` and ``pageSize`` specified in the supplied ``PageSpecification``.
 	- states metadata as a ``List<Vault.StateMetadata>`` containing Vault State metadata held in the Vault states table.
-	- the ``PagingSpecification`` used in the query
-	- a ``total`` number of results available. This value can be used issue subsequent queries with appropriately specified ``PageSpecification`` (according to your paging needs and/or maximum memory capacity for holding large data sets). Note it is your responsibility to manage page numbers and sizes.
+	- a ``total`` number of results available if ``PageSpecification`` provided (otherwise returns -1). For pagination, this value can be used to issue subsequent queries with appropriately specified ``PageSpecification`` parameters (according to your paging needs and/or maximum memory capacity for holding large data sets). Note it is your responsibility to manage page numbers and sizes.
+	- status types used in this query: UNCONSUMED, CONSUMED, ALL
+	- other results as a [List] of any type (eg. aggregate function results with/without group by)
 
 2. ServiceHub usage obtaining linear heads for a given contract state type
    

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -48,7 +48,7 @@ The API provides both static (snapshot) and dynamic (snapshot with streaming upd
 .. note:: Streaming updates are only filtered based on contract type and state status (UNCONSUMED, CONSUMED, ALL)
 
 Simple pagination (page number and size) and sorting (directional ordering using standard or custom property attributes) is also specifiable.
-Defaults are defined for Paging (pageNumber = 0, pageSize = 200) and Sorting (direction = ASC).
+Defaults are defined for Paging (pageNumber = 1, pageSize = 200) and Sorting (direction = ASC).
 
 The ``QueryCriteria`` interface provides a flexible mechanism for specifying different filtering criteria, including and/or composition and a rich set of operators to include: binary logical (AND, OR), comparison (LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL), equality (EQUAL, NOT_EQUAL), likeness (LIKE, NOT_LIKE), nullability (IS_NULL, NOT_NULL), and collection based (IN, NOT_IN). Standard SQL-92 aggregate functions (SUM, AVG, MIN, MAX, COUNT) are also supported.
 
@@ -103,6 +103,13 @@ An example of a custom query in Java is illustrated here:
     :end-before: DOCEND VaultJavaQueryExample3
 
 .. note:: Current queries by ``Party`` specify the ``AbstractParty`` which may be concrete or anonymous. In the later case, where an anonymous party does not have an associated X500Name, then no query results will ever be produced. For performance reasons, queries do not use PublicKey as search criteria. Ongoing design work on identity manangement is likely to enhance identity based queries (including composite key criteria selection).
+
+Pagination
+----------
+The API provides support for paging where large numbers of results are expected (by default, a page size is set to 200 results).
+Defining a sensible default page size enables efficient checkpointing within flows, and frees the developer from worrying about pagination where
+result sets are expected to be constrained to 200 or fewer entries. Where large result sets are expected (such as using the RPC API for reporting and/or UI display), it is strongly recommended to define a ``PageSpecification`` to correctly process results with efficient memory utilistion. A fail-fast mode is in place to alert API users to the need for pagination where a single query returns more than 200 results and no ``PageSpecification``
+has been supplied.
 
 Example usage
 -------------

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -111,6 +111,8 @@ Defining a sensible default page size enables efficient checkpointing within flo
 result sets are expected to be constrained to 200 or fewer entries. Where large result sets are expected (such as using the RPC API for reporting and/or UI display), it is strongly recommended to define a ``PageSpecification`` to correctly process results with efficient memory utilistion. A fail-fast mode is in place to alert API users to the need for pagination where a single query returns more than 200 results and no ``PageSpecification``
 has been supplied.
 
+.. note:: A pages maximum size ``MAX_PAGE_SIZE`` is defined as ``Int.MAX_VALUE`` and should be used with extreme caution as results returned may exceed your JVM's memory footprint.
+
 Example usage
 -------------
 

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -293,7 +293,7 @@ Track unconsumed linear states:
     :end-before: DOCEND VaultQueryExample16
 
 .. note:: This will return both Deal and Linear states.
-    
+
 Track unconsumed deal states:
 
 .. literalinclude:: ../../node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -377,6 +377,17 @@ Track unconsumed deal states or linear states (with snapshot including specifica
     :language: java
     :start-after: DOCSTART VaultJavaQueryExample4
     :end-before: DOCEND VaultJavaQueryExample4
+
+Behavioural notes
+-----------------
+1. **TrackBy** updates do not take into account the full criteria specification due to different and more restrictive syntax
+   in `observables <https://github.com/ReactiveX/RxJava/wiki>`_ filtering (vs full SQL-92 JDBC filtering as used in snapshot views).
+   Specifically, dynamic updates are filtered by ``contractType`` and ``stateType`` (UNCONSUMED, CONSUMED, ALL) only.
+2. **QueryBy** and **TrackBy snapshot views** using pagination may return different result sets as each paging request is a
+   separate SQL query on the underlying database, and it is entirely conceivable that state modifications are taking
+   place in between and/or in parallel to paging requests.
+   When using pagination, always check the value of the ``totalStatesAvailable`` (from the ``Vault.Page`` result) and
+   adjust further paging requests appropriately.
 
 Other use case scenarios
 ------------------------

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -95,6 +95,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
             }
             is ColumnPredicate.BinaryComparison -> {
                 column as Path<Comparable<Any?>?>
+                @Suppress("UNCHECKED_CAST")
                 val literal = columnPredicate.rightLiteral as Comparable<Any?>?
                 when (columnPredicate.operator) {
                     BinaryComparisonOperator.GREATER_THAN -> criteriaBuilder.greaterThan(column, literal)
@@ -117,8 +118,11 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
                 }
             }
             is ColumnPredicate.Between -> {
+                @Suppress("UNCHECKED_CAST")
                 column as Path<Comparable<Any?>?>
+                @Suppress("UNCHECKED_CAST")
                 val fromLiteral = columnPredicate.rightFromLiteral as Comparable<Any?>?
+                @Suppress("UNCHECKED_CAST")
                 val toLiteral = columnPredicate.rightToLiteral as Comparable<Any?>?
                 criteriaBuilder.between(column, fromLiteral, toLiteral)
             }
@@ -164,6 +168,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         val columnPredicate = expression.predicate
         when (columnPredicate) {
             is ColumnPredicate.AggregateFunction -> {
+                @Suppress("UNCHECKED_CAST")
                 column as Path<Long?>?
                 val aggregateExpression =
                     when (columnPredicate.type) {

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -74,8 +74,6 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                     // pagination
                     if (paging.pageNumber < DEFAULT_PAGE_NUM) throw VaultQueryException("Page specification: invalid page number ${paging.pageNumber} [page numbers start from $DEFAULT_PAGE_NUM]")
                     if (paging.pageSize < 1) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [must be a value between 1 and $MAX_PAGE_SIZE]")
-                    if ((paging.pageNumber != DEFAULT_PAGE_NUM) && (paging.pageSize * (paging.pageNumber - 1) >= totalStates))
-                        throw VaultQueryException("Requested more results than available [${paging.pageSize} * ${paging.pageNumber} >= $totalStates]")
                 }
 
                 query.firstResult = (paging.pageNumber - 1) * paging.pageSize

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -73,7 +73,7 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                 if (!paging.isDefault) {
                     // pagination
                     if (paging.pageNumber < DEFAULT_PAGE_NUM) throw VaultQueryException("Page specification: invalid page number ${paging.pageNumber} [page numbers start from $DEFAULT_PAGE_NUM]")
-                    if (paging.pageSize < 0) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [must be a value between 0 and $MAX_PAGE_SIZE]")
+                    if (paging.pageSize < 1) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [must be a value between 1 and $MAX_PAGE_SIZE]")
                     if ((paging.pageNumber != DEFAULT_PAGE_NUM) && (paging.pageSize * (paging.pageNumber - 1) >= totalStates))
                         throw VaultQueryException("Requested more results than available [${paging.pageSize} * ${paging.pageNumber} >= $totalStates]")
                 }

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -72,10 +72,10 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                 // pagination checks
                 if (!paging.isDefault) {
                     // pagination
-                    if (paging.pageNumber < DEFAULT_PAGE_NUM) throw VaultQueryException("Page specification: invalid page number ${paging.pageNumber} [page numbers start from ${DEFAULT_PAGE_NUM}]")
-                    if (paging.pageSize < 0 || paging.pageSize > MAX_PAGE_SIZE) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [maximum page size is ${MAX_PAGE_SIZE}]")
+                    if (paging.pageNumber < STARTING_PAGE_NUM) throw VaultQueryException("Page specification: invalid page number ${paging.pageNumber} [page numbers start from $STARTING_PAGE_NUM]")
+                    if (paging.pageSize < 0 || paging.pageSize > MAX_PAGE_SIZE) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [maximum page size is $MAX_PAGE_SIZE]")
 
-                    if ((paging.pageNumber != DEFAULT_PAGE_NUM) && (paging.pageSize * (paging.pageNumber - 1) >= totalStates))
+                    if ((paging.pageNumber != STARTING_PAGE_NUM) && (paging.pageSize * (paging.pageNumber - 1) >= totalStates))
                         throw VaultQueryException("Requested more results than available [${paging.pageSize} * ${paging.pageNumber} >= $totalStates]")
                 }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -73,8 +73,7 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                 if (!paging.isDefault) {
                     // pagination
                     if (paging.pageNumber < STARTING_PAGE_NUM) throw VaultQueryException("Page specification: invalid page number ${paging.pageNumber} [page numbers start from $STARTING_PAGE_NUM]")
-                    if (paging.pageSize < 0 || paging.pageSize > MAX_PAGE_SIZE) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [maximum page size is $MAX_PAGE_SIZE]")
-
+                    if (paging.pageSize < 0) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [must be a value between 0 and $MAX_PAGE_SIZE]")
                     if ((paging.pageNumber != STARTING_PAGE_NUM) && (paging.pageSize * (paging.pageNumber - 1) >= totalStates))
                         throw VaultQueryException("Requested more results than available [${paging.pageSize} * ${paging.pageNumber} >= $totalStates]")
                 }

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -1,63 +1,45 @@
 package net.corda.node.services.vault;
 
-import com.google.common.collect.ImmutableSet;
-import kotlin.Pair;
-import net.corda.contracts.DealState;
-import net.corda.contracts.asset.Cash;
+import com.google.common.collect.*;
+import kotlin.*;
+import net.corda.contracts.*;
+import net.corda.contracts.asset.*;
 import net.corda.core.contracts.*;
-import net.corda.testing.contracts.DummyLinearContract;
 import net.corda.core.crypto.*;
-import net.corda.core.identity.AbstractParty;
-import net.corda.core.messaging.DataFeed;
-import net.corda.core.node.services.Vault;
-import net.corda.core.node.services.VaultQueryException;
-import net.corda.core.node.services.VaultQueryService;
-import net.corda.core.node.services.VaultService;
+import net.corda.core.identity.*;
+import net.corda.core.messaging.*;
+import net.corda.core.node.services.*;
 import net.corda.core.node.services.vault.*;
-import net.corda.core.node.services.vault.QueryCriteria.LinearStateQueryCriteria;
-import net.corda.core.node.services.vault.QueryCriteria.VaultCustomQueryCriteria;
-import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria;
-import net.corda.core.schemas.MappedSchema;
-import net.corda.core.schemas.testing.DummyLinearStateSchemaV1;
-import net.corda.core.utilities.OpaqueBytes;
-import net.corda.core.transactions.SignedTransaction;
-import net.corda.core.transactions.WireTransaction;
-import net.corda.node.services.database.HibernateConfiguration;
-import net.corda.node.services.schema.NodeSchemaService;
-import net.corda.schemas.CashSchemaV1;
-import net.corda.testing.TestConstants;
-import net.corda.testing.contracts.VaultFiller;
-import net.corda.testing.node.MockServices;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.exposed.sql.Database;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import net.corda.core.node.services.vault.QueryCriteria.*;
+import net.corda.core.schemas.*;
+import net.corda.core.schemas.testing.*;
+import net.corda.core.transactions.*;
+import net.corda.core.utilities.*;
+import net.corda.node.services.database.*;
+import net.corda.node.services.schema.*;
+import net.corda.schemas.*;
+import net.corda.testing.*;
+import net.corda.testing.contracts.*;
+import net.corda.testing.node.*;
+import org.jetbrains.annotations.*;
+import org.jetbrains.exposed.sql.*;
+import org.junit.*;
 import rx.Observable;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.lang.reflect.Field;
+import java.io.*;
+import java.lang.reflect.*;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import java.util.stream.*;
 
-import static net.corda.contracts.asset.CashKt.getDUMMY_CASH_ISSUER;
-import static net.corda.contracts.asset.CashKt.getDUMMY_CASH_ISSUER_KEY;
-import static net.corda.core.node.services.vault.QueryCriteriaUtils.DEFAULT_PAGE_NUM;
-import static net.corda.testing.CoreTestUtils.getBOC;
-import static net.corda.testing.CoreTestUtils.getBOC_KEY;
-import static net.corda.testing.CoreTestUtils.getBOC_PUBKEY;
-import static net.corda.core.contracts.ContractsDSL.USD;
-import static net.corda.core.node.services.vault.QueryCriteriaUtils.MAX_PAGE_SIZE;
-import static net.corda.node.utilities.DatabaseSupportKt.configureDatabase;
+import static net.corda.contracts.asset.CashKt.*;
+import static net.corda.core.contracts.ContractsDSL.*;
+import static net.corda.core.node.services.vault.QueryCriteriaUtils.*;
+import static net.corda.node.utilities.DatabaseSupportKt.*;
 import static net.corda.node.utilities.DatabaseSupportKt.transaction;
-import static net.corda.testing.CoreTestUtils.getMEGA_CORP;
-import static net.corda.testing.CoreTestUtils.getMEGA_CORP_KEY;
-import static net.corda.testing.node.MockServicesKt.makeTestDataSourceProperties;
+import static net.corda.testing.CoreTestUtils.*;
+import static net.corda.testing.node.MockServicesKt.*;
 import static net.corda.core.utilities.ByteArrays.toHexString;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class VaultQueryJavaTests {
 
@@ -220,7 +202,7 @@ public class VaultQueryJavaTests {
             QueryCriteria compositeCriteria1 = dealCriteriaAll.or(linearCriteriaAll);
             QueryCriteria compositeCriteria2 = vaultCriteria.and(compositeCriteria1);
 
-            PageSpecification pageSpec  = new PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE);
+            PageSpecification pageSpec  = new PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE);
             Sort.SortColumn sortByUid = new Sort.SortColumn(new SortAttribute.Standard(Sort.LinearStateAttribute.UUID), Sort.Direction.DESC);
             Sort sorting = new Sort(ImmutableSet.of(sortByUid));
             Vault.Page<LinearState> results = vaultQuerySvc.queryBy(LinearState.class, compositeCriteria2, pageSpec, sorting);
@@ -329,7 +311,7 @@ public class VaultQueryJavaTests {
             QueryCriteria dealOrLinearIdCriteria = dealCriteria.or(linearCriteria);
             QueryCriteria compositeCriteria = dealOrLinearIdCriteria.and(vaultCriteria);
 
-            PageSpecification pageSpec  = new PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE);
+            PageSpecification pageSpec  = new PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE);
             Sort.SortColumn sortByUid = new Sort.SortColumn(new SortAttribute.Standard(Sort.LinearStateAttribute.UUID), Sort.Direction.DESC);
             Sort sorting = new Sort(ImmutableSet.of(sortByUid));
             DataFeed<Vault.Page<ContractState>, Vault.Update> results = vaultQuerySvc.trackBy(ContractState.class, compositeCriteria, pageSpec, sorting);

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -129,7 +129,7 @@ public class VaultQueryJavaTests {
             List<StateRef> stateRefs = stateRefsStream.collect(Collectors.toList());
 
             SortAttribute.Standard sortAttribute = new SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_TXN_ID);
-            Sort sorting = new Sort(Arrays.asList(new Sort.SortColumn(sortAttribute, Sort.Direction.ASC)));
+            Sort sorting = new Sort(Collections.singletonList(new Sort.SortColumn(sortAttribute, Sort.Direction.ASC)));
             VaultQueryCriteria criteria = new VaultQueryCriteria(Vault.StateStatus.UNCONSUMED, null, stateRefs);
             Vault.Page<DummyLinearContract.State> results = vaultQuerySvc.queryBy(DummyLinearContract.State.class, criteria, sorting);
 
@@ -215,6 +215,7 @@ public class VaultQueryJavaTests {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void customQueryForCashStatesWithAmountOfCurrencyGreaterOrEqualThanQuantity() {
         transaction(database, tx -> {
 
@@ -391,6 +392,7 @@ public class VaultQueryJavaTests {
      */
 
     @Test
+    @SuppressWarnings("unchecked")
     public void aggregateFunctionsWithoutGroupClause() {
         transaction(database, tx -> {
 
@@ -435,6 +437,7 @@ public class VaultQueryJavaTests {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void aggregateFunctionsWithSingleGroupClause() {
         transaction(database, tx -> {
 
@@ -455,11 +458,11 @@ public class VaultQueryJavaTests {
                 Field pennies = CashSchemaV1.PersistentCashState.class.getDeclaredField("pennies");
                 Field currency = CashSchemaV1.PersistentCashState.class.getDeclaredField("currency");
 
-                QueryCriteria sumCriteria = new VaultCustomQueryCriteria(Builder.sum(pennies, Arrays.asList(currency)));
+                QueryCriteria sumCriteria = new VaultCustomQueryCriteria(Builder.sum(pennies, Collections.singletonList(currency)));
                 QueryCriteria countCriteria = new VaultCustomQueryCriteria(Builder.count(pennies));
-                QueryCriteria maxCriteria = new VaultCustomQueryCriteria(Builder.max(pennies, Arrays.asList(currency)));
-                QueryCriteria minCriteria = new VaultCustomQueryCriteria(Builder.min(pennies, Arrays.asList(currency)));
-                QueryCriteria avgCriteria = new VaultCustomQueryCriteria(Builder.avg(pennies, Arrays.asList(currency)));
+                QueryCriteria maxCriteria = new VaultCustomQueryCriteria(Builder.max(pennies, Collections.singletonList(currency)));
+                QueryCriteria minCriteria = new VaultCustomQueryCriteria(Builder.min(pennies, Collections.singletonList(currency)));
+                QueryCriteria avgCriteria = new VaultCustomQueryCriteria(Builder.avg(pennies, Collections.singletonList(currency)));
 
                 QueryCriteria criteria = sumCriteria.and(countCriteria).and(maxCriteria).and(minCriteria).and(avgCriteria);
                 Vault.Page<Cash.State> results = vaultQuerySvc.queryBy(Cash.State.class, criteria);
@@ -505,6 +508,7 @@ public class VaultQueryJavaTests {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void aggregateFunctionsSumByIssuerAndCurrencyAndSortByAggregateSum() {
         transaction(database, tx -> {
 

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -45,6 +45,7 @@ import java.util.stream.StreamSupport;
 
 import static net.corda.contracts.asset.CashKt.getDUMMY_CASH_ISSUER;
 import static net.corda.contracts.asset.CashKt.getDUMMY_CASH_ISSUER_KEY;
+import static net.corda.core.node.services.vault.QueryCriteriaUtils.DEFAULT_PAGE_NUM;
 import static net.corda.testing.CoreTestUtils.getBOC;
 import static net.corda.testing.CoreTestUtils.getBOC_KEY;
 import static net.corda.testing.CoreTestUtils.getBOC_PUBKEY;
@@ -219,7 +220,7 @@ public class VaultQueryJavaTests {
             QueryCriteria compositeCriteria1 = dealCriteriaAll.or(linearCriteriaAll);
             QueryCriteria compositeCriteria2 = vaultCriteria.and(compositeCriteria1);
 
-            PageSpecification pageSpec  = new PageSpecification(0, MAX_PAGE_SIZE);
+            PageSpecification pageSpec  = new PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE);
             Sort.SortColumn sortByUid = new Sort.SortColumn(new SortAttribute.Standard(Sort.LinearStateAttribute.UUID), Sort.Direction.DESC);
             Sort sorting = new Sort(ImmutableSet.of(sortByUid));
             Vault.Page<LinearState> results = vaultQuerySvc.queryBy(LinearState.class, compositeCriteria2, pageSpec, sorting);
@@ -328,7 +329,7 @@ public class VaultQueryJavaTests {
             QueryCriteria dealOrLinearIdCriteria = dealCriteria.or(linearCriteria);
             QueryCriteria compositeCriteria = dealOrLinearIdCriteria.and(vaultCriteria);
 
-            PageSpecification pageSpec  = new PageSpecification(0, MAX_PAGE_SIZE);
+            PageSpecification pageSpec  = new PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE);
             Sort.SortColumn sortByUid = new Sort.SortColumn(new SortAttribute.Standard(Sort.LinearStateAttribute.UUID), Sort.Direction.DESC);
             Sort sorting = new Sort(ImmutableSet.of(sortByUid));
             DataFeed<Vault.Page<ContractState>, Vault.Update> results = vaultQuerySvc.trackBy(ContractState.class, compositeCriteria, pageSpec, sorting);

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -202,7 +202,7 @@ public class VaultQueryJavaTests {
             QueryCriteria compositeCriteria1 = dealCriteriaAll.or(linearCriteriaAll);
             QueryCriteria compositeCriteria2 = vaultCriteria.and(compositeCriteria1);
 
-            PageSpecification pageSpec  = new PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE);
+            PageSpecification pageSpec  = new PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE);
             Sort.SortColumn sortByUid = new Sort.SortColumn(new SortAttribute.Standard(Sort.LinearStateAttribute.UUID), Sort.Direction.DESC);
             Sort sorting = new Sort(ImmutableSet.of(sortByUid));
             Vault.Page<LinearState> results = vaultQuerySvc.queryBy(LinearState.class, compositeCriteria2, pageSpec, sorting);
@@ -311,7 +311,7 @@ public class VaultQueryJavaTests {
             QueryCriteria dealOrLinearIdCriteria = dealCriteria.or(linearCriteria);
             QueryCriteria compositeCriteria = dealOrLinearIdCriteria.and(vaultCriteria);
 
-            PageSpecification pageSpec  = new PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE);
+            PageSpecification pageSpec  = new PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE);
             Sort.SortColumn sortByUid = new Sort.SortColumn(new SortAttribute.Standard(Sort.LinearStateAttribute.UUID), Sort.Direction.DESC);
             Sort sorting = new Sort(ImmutableSet.of(sortByUid));
             DataFeed<Vault.Page<ContractState>, Vault.Update> results = vaultQuerySvc.trackBy(ContractState.class, compositeCriteria, pageSpec, sorting);

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -805,7 +805,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
             // DOCSTART VaultQueryExample7
-            val pagingSpec = PageSpecification(STARTING_PAGE_NUM, 10)
+            val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, 10)
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val results = vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
             // DOCEND VaultQueryExample7
@@ -862,7 +862,7 @@ class VaultQueryTests {
 
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
-            val pagingSpec = PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE + 1)  // overflow = -2147483648
+            val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE + 1)  // overflow = -2147483648
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
         }

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -805,7 +805,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
             // DOCSTART VaultQueryExample7
-            val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, 10)
+            val pagingSpec = PageSpecification(STARTING_PAGE_NUM, 10)
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val results = vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
             // DOCEND VaultQueryExample7
@@ -862,7 +862,7 @@ class VaultQueryTests {
 
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
-            val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE + 1)
+            val pagingSpec = PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE + 1)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -862,8 +862,7 @@ class VaultQueryTests {
 
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
-            val pagingSpec = PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE + 1)
-
+            val pagingSpec = PageSpecification(STARTING_PAGE_NUM, MAX_PAGE_SIZE + 1)  // overflow = -2147483648
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
         }

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -823,7 +823,7 @@ class VaultQueryTests {
 
             // Last page implies we need to perform a row count for the Query first,
             // and then re-query for a given offset defined by (count - pageSize)
-            val pagingSpec = PageSpecification(9, 10)
+            val pagingSpec = PageSpecification(10, 10)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val results = vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
@@ -845,7 +845,7 @@ class VaultQueryTests {
 
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
-            val pagingSpec = PageSpecification(-1, 10)
+            val pagingSpec = PageSpecification(0, 10)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
@@ -862,7 +862,7 @@ class VaultQueryTests {
 
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
-            val pagingSpec = PageSpecification(0, MAX_PAGE_SIZE + 1)
+            val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE + 1)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
@@ -879,7 +879,7 @@ class VaultQueryTests {
 
             services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
 
-            val pagingSpec = PageSpecification(10, 10)  // this requests results 101 .. 110
+            val pagingSpec = PageSpecification(11, 10)  // this requests results 101 .. 110
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -1797,7 +1797,7 @@ class VaultQueryTests {
                 updates
             }
 
-        updates?.expectEvents {
+        updates.expectEvents {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
@@ -1844,7 +1844,7 @@ class VaultQueryTests {
                 updates
             }
 
-        updates?.expectEvents {
+        updates.expectEvents {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
@@ -1891,7 +1891,7 @@ class VaultQueryTests {
                 updates
             }
 
-        updates?.expectEvents {
+        updates.expectEvents {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
@@ -1947,7 +1947,7 @@ class VaultQueryTests {
                 updates
             }
 
-        updates?.expectEvents {
+        updates.expectEvents {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
@@ -1997,7 +1997,7 @@ class VaultQueryTests {
                 updates
             }
 
-        updates?.expectEvents {
+        updates.expectEvents {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -868,23 +868,6 @@ class VaultQueryTests {
         }
     }
 
-    // pagination: out or range request (page number * page size) > total rows available
-    @Test
-    fun `out of range page request`() {
-        expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("Requested more results than available")
-
-        database.transaction {
-
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
-
-            val pagingSpec = PageSpecification(11, 10)  // this requests results 101 .. 110
-
-            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-            vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)
-        }
-    }
-
     // pagination not specified but more than DEFAULT_PAGE_SIZE results available (fail-fast test)
     @Test
     fun `pagination not specified but more than default results available`() {


### PR DESCRIPTION
Pagination continues to be optional, but with following changes:
1) If no `PageSpecification` provided then a maximum of MAX_PAGE_SIZE (200) results will be returned, otherwise we fail-fast with a `VaultQueryException`to alert the API user to the need to specify a `PageSpecification`.
Internally, we no longer need to calculate a results count (thus eliminating an expensive SQL query) unless a `PageSpecification` is supplied (note: that a value of -1 is returned for total_results in this scenario).
Internally, we now use the `AggregateFunction` capability to perform the count.
2) Paging now starts from 1 (was previously 0).