### PR TITLE
NodeAndWeight deterministic comparator

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -4,7 +4,7 @@ import net.corda.core.crypto.CompositeKey.NodeAndWeight
 import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.asn1.*
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
-import java.math.BigInteger
+import java.nio.ByteBuffer
 import java.security.PublicKey
 import java.util.*
 
@@ -110,11 +110,11 @@ class CompositeKey private constructor (val threshold: Int,
             // We don't allow zero or negative weights. Minimum weight = 1.
             require (weight > 0) { "A non-positive weight was detected. Node info: $this"  }
         }
+
         override fun compareTo(other: NodeAndWeight): Int {
-            if (weight == other.weight) {
-                return BigInteger(1, node.toSHA256Bytes()).compareTo(BigInteger(1, other.node.toSHA256Bytes()))
-            }
-            else return weight.compareTo(other.weight)
+            return if (weight == other.weight) {
+                ByteBuffer.wrap(node.toSHA256Bytes()).compareTo(ByteBuffer.wrap(other.node.toSHA256Bytes()))
+            } else weight.compareTo(other.weight)
         }
 
         override fun toASN1Primitive(): ASN1Primitive {

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -4,6 +4,7 @@ import net.corda.core.crypto.CompositeKey.NodeAndWeight
 import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.asn1.*
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import java.math.BigInteger
 import java.security.PublicKey
 import java.util.*
 
@@ -111,7 +112,7 @@ class CompositeKey private constructor (val threshold: Int,
         }
         override fun compareTo(other: NodeAndWeight): Int {
             if (weight == other.weight) {
-                return node.hashCode().compareTo(other.node.hashCode())
+                return BigInteger(1, node.toSHA256Bytes()).compareTo(BigInteger(1, other.node.toSHA256Bytes()))
             }
             else return weight.compareTo(other.weight)
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -65,4 +65,4 @@ fun String.hexToBase64(): String = hexToByteArray().toBase64()
 //       structure, e.g. mapping a PublicKey to a condition with the specific feature (ED25519).
 fun parsePublicKeyBase58(base58String: String): PublicKey = base58String.base58ToByteArray().deserialize<PublicKey>()
 fun PublicKey.toBase58String(): String = this.serialize().bytes.toBase58()
-fun PublicKey.toSHA256Bytes(): ByteArray = this.encoded.sha256().bytes // Encoded should be deterministic.
+fun PublicKey.toSHA256Bytes(): ByteArray = this.serialize().bytes.sha256().bytes // TODO: decide on the format of hashed key (encoded Vs serialised).

--- a/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/EncodingUtils.kt
@@ -65,4 +65,4 @@ fun String.hexToBase64(): String = hexToByteArray().toBase64()
 //       structure, e.g. mapping a PublicKey to a condition with the specific feature (ED25519).
 fun parsePublicKeyBase58(base58String: String): PublicKey = base58String.base58ToByteArray().deserialize<PublicKey>()
 fun PublicKey.toBase58String(): String = this.serialize().bytes.toBase58()
-fun PublicKey.toSHA256Bytes(): ByteArray = this.serialize().bytes.sha256().bytes
+fun PublicKey.toSHA256Bytes(): ByteArray = this.encoded.sha256().bytes // Encoded should be deterministic.


### PR DESCRIPTION
To construct a `CompositeKey`, `children` were previously sorted using `hashcode` of the underlying public key, which may not be deterministic.
Now, `NodeAndWeight.compareTo` uses the `BigInteger` representation of the SHA256 of public keys to compare between NodeAndWeight objects having the same `weight`. 