### PR TITLE
Changed the ServiceLoader.load call to explicitly specify the class loader

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -42,7 +42,7 @@ object DefaultKryoCustomizer {
         // No ClassResolver only constructor.  MapReferenceResolver is the default as used by Kryo in other constructors.
         val unusedKryo = Kryo(makeStandardClassResolver(), MapReferenceResolver())
         val customization = KryoSerializationCustomization(unusedKryo)
-        ServiceLoader.load(CordaPluginRegistry::class.java).toList().filter { it.customizeSerialization(customization) }
+        ServiceLoader.load(CordaPluginRegistry::class.java, this.javaClass.classLoader).toList().filter { it.customizeSerialization(customization) }
     }
 
     fun customize(kryo: Kryo): Kryo {


### PR DESCRIPTION
This change is related to the discussions forum link:

https://discourse.corda.net/t/simple-corda-rpc-client-getting-class-kotlin-collections-emptylist-is-not-annotated-or-on-the-whitelist-so-cannot-be-used-in-serialization/1315

This changes the DefaultKryoCustomizer class to pass the class loader in the ServiceLoader.load call instead of relying on the default behaviour of using the thread context class loader. This allows apps with custom class loader hierarchies to use corda.