### PR TITLE
Update DemoBench packager scripts to fail when packaging fails.

### DIFF
--- a/tools/demobench/package-demobench-dmg.sh
+++ b/tools/demobench/package-demobench-dmg.sh
@@ -7,7 +7,12 @@ if [ -z "$JAVA_HOME" -o ! -x $JAVA_HOME/bin/java ]; then
     exit 1
 fi
 
-$DIRNAME/../../gradlew -PpackageType=dmg javapackage $*
-echo
-echo "Wrote installer to '$(find build/javapackage/bundles -type f)'"
-echo
+if ($DIRNAME/../../gradlew -PpackageType=dmg javapackage $*); then
+    echo
+    echo "Wrote installer to '$(find build/javapackage/bundles -type f)'"
+    echo
+else
+    echo "Failed to create installer."
+    exit 1
+fi
+

--- a/tools/demobench/package-demobench-exe.bat
+++ b/tools/demobench/package-demobench-exe.bat
@@ -9,12 +9,18 @@ set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.
 
 call %DIRNAME%\..\..\gradlew -PpackageType=exe javapackage
+if "%ERRORLEVEL%" neq "0" goto Fail
 @echo
-@echo "Wrote installer to %DIRNAME%\build\javapackage\bundles\"
+@echo Wrote installer to %DIRNAME%\build\javapackage\bundles\
 @echo
 goto end
 
 :NoJavaHome
-@echo "Please set JAVA_HOME correctly"
+@echo Please set JAVA_HOME correctly.
+exit /b 1
+
+:Fail
+@echo Failed to write installer.
+exit /b 1
 
 :end

--- a/tools/demobench/package-demobench-rpm.sh
+++ b/tools/demobench/package-demobench-rpm.sh
@@ -7,7 +7,11 @@ if [ -z "$JAVA_HOME" -o ! -x $JAVA_HOME/bin/java ]; then
     exit 1
 fi
 
-$DIRNAME/../../gradlew -PpackageType=rpm javapackage $*
-echo
-echo "Wrote installer to '$(find $DIRNAME/build/javapackage/bundles -type f)'"
-echo
+if ($DIRNAME/../../gradlew -PpackageType=rpm javapackage $*); then
+    echo
+    echo "Wrote installer to '$(find $DIRNAME/build/javapackage/bundles -type f)'"
+    echo
+else
+    echo "Failed to create installer."
+    exit 1
+fi


### PR DESCRIPTION
Allow TeamCity builds to fail if they cannot package DemoBench successfully.