### PR TITLE
Fix a bug with transactions that have >10mb of attachments

### DIFF
--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -5,6 +5,7 @@ import com.google.common.hash.HashingInputStream
 import net.corda.client.rpc.CordaRPCConnection
 import net.corda.client.rpc.notUsed
 import net.corda.contracts.asset.Cash
+import net.corda.core.InputStreamAndHash
 import net.corda.core.contracts.DOLLARS
 import net.corda.core.contracts.POUNDS
 import net.corda.core.contracts.SWISS_FRANCS
@@ -16,7 +17,6 @@ import net.corda.core.node.services.Vault
 import net.corda.core.node.services.vault.*
 import net.corda.core.seconds
 import net.corda.core.utilities.OpaqueBytes
-import net.corda.core.sizedInputStreamAndHash
 import net.corda.core.utilities.loggerFor
 import net.corda.flows.CashIssueFlow
 import net.corda.flows.CashPaymentFlow
@@ -78,7 +78,7 @@ class StandaloneCordaRPClientTest {
 
     @Test
     fun `test attachments`() {
-        val attachment = sizedInputStreamAndHash(attachmentSize)
+        val attachment = InputStreamAndHash.createInMemoryTestZip(attachmentSize, 1)
         assertFalse(rpcProxy.attachmentExists(attachment.sha256))
         val id = WrapperStream(attachment.inputStream).use { rpcProxy.uploadAttachment(it) }
         assertEquals(attachment.sha256, id, "Attachment has incorrect SHA256 hash")

--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -291,37 +291,39 @@ fun extractZipFile(inputStream: InputStream, toDirectory: Path) {
     }
 }
 
-/**
- * Get a valid InputStream from an in-memory zip as required for tests.
- * Note that a slightly bigger than numOfExpectedBytes size is expected.
- */
-@Throws(IllegalArgumentException::class)
-fun sizedInputStreamAndHash(numOfExpectedBytes: Int): InputStreamAndHash {
-    if (numOfExpectedBytes <= 0) throw IllegalArgumentException("A positive number of numOfExpectedBytes is required.")
-    val baos = ByteArrayOutputStream()
-    ZipOutputStream(baos).use({ zos ->
-        val arraySize = 1024
-        val bytes = ByteArray(arraySize)
-        val n = (numOfExpectedBytes - 1) / arraySize + 1 // same as Math.ceil(numOfExpectedBytes/arraySize).
-        zos.setLevel(Deflater.NO_COMPRESSION)
-        zos.putNextEntry(ZipEntry("z"))
-        for (i in 0 until n) {
-            zos.write(bytes, 0, arraySize)
-        }
-        zos.closeEntry()
-    })
-    return getInputStreamAndHashFromOutputStream(baos)
-}
-
 /** Convert a [ByteArrayOutputStream] to [InputStreamAndHash]. */
-fun getInputStreamAndHashFromOutputStream(baos: ByteArrayOutputStream): InputStreamAndHash {
-    // TODO: Consider converting OutputStream to InputStream without creating a ByteArray, probably using piped streams.
+fun ByteArrayOutputStream.getInputStreamAndHash(baos: ByteArrayOutputStream): InputStreamAndHash {
     val bytes = baos.toByteArray()
-    // TODO: Consider calculating sha256 on the fly using a DigestInputStream.
     return InputStreamAndHash(ByteArrayInputStream(bytes), bytes.sha256())
 }
 
-data class InputStreamAndHash(val inputStream: InputStream, val sha256: SecureHash.SHA256)
+data class InputStreamAndHash(val inputStream: InputStream, val sha256: SecureHash.SHA256) {
+    companion object {
+        /**
+         * Get a valid InputStream from an in-memory zip as required for some tests. The zip consists of a single file
+         * called "z" that contains the given content byte repeated the given number of times.
+         * Note that a slightly bigger than numOfExpectedBytes size is expected.
+         */
+        @Throws(IllegalArgumentException::class)
+        @JvmStatic
+        fun createInMemoryTestZip(numOfExpectedBytes: Int, content: Byte): InputStreamAndHash {
+            require(numOfExpectedBytes > 0)
+            val baos = ByteArrayOutputStream()
+            ZipOutputStream(baos).use { zos ->
+                val arraySize = 1024
+                val bytes = ByteArray(arraySize) { content }
+                val n = (numOfExpectedBytes - 1) / arraySize + 1 // same as Math.ceil(numOfExpectedBytes/arraySize).
+                zos.setLevel(Deflater.NO_COMPRESSION)
+                zos.putNextEntry(ZipEntry("z"))
+                for (i in 0 until n) {
+                    zos.write(bytes, 0, arraySize)
+                }
+                zos.closeEntry()
+            }
+            return baos.getInputStreamAndHash(baos)
+        }
+    }
+}
 
 // TODO: Generic csv printing utility for clases.
 

--- a/core/src/main/kotlin/net/corda/core/flows/FetchAttachmentsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FetchAttachmentsFlow.kt
@@ -15,8 +15,7 @@ import net.corda.core.serialization.SerializeAsTokenContext
  */
 @InitiatingFlow
 class FetchAttachmentsFlow(requests: Set<SecureHash>,
-                           otherSide: Party) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide) {
-
+                           otherSide: Party) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide, ByteArray::class.java) {
     override fun load(txid: SecureHash): Attachment? = serviceHub.attachments.openAttachment(txid)
 
     override fun convert(wire: ByteArray): Attachment = FetchedAttachment({ wire })

--- a/core/src/main/kotlin/net/corda/core/flows/FetchTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FetchTransactionsFlow.kt
@@ -14,7 +14,7 @@ import net.corda.core.transactions.SignedTransaction
  */
 @InitiatingFlow
 class FetchTransactionsFlow(requests: Set<SecureHash>, otherSide: Party) :
-        FetchDataFlow<SignedTransaction, SignedTransaction>(requests, otherSide) {
+        FetchDataFlow<SignedTransaction, SignedTransaction>(requests, otherSide, SignedTransaction::class.java) {
 
     override fun load(txid: SecureHash): SignedTransaction? = serviceHub.validatedTransactions.getTransaction(txid)
 }

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -27,11 +27,22 @@ If you have APT installed and OpenJFX is part of your Unix distribution's packag
 ***************************************************************************
 
 Some of the unit tests, and our serialization framework in general, rely on the constructor parameter names being visible
-to Java reflection.  Make sure you have specified the `-parameters` option to the Java compiler.  We attempt to set this globally
+to Java reflection.  Make sure you have specified the ``-parameters`` option to the Java compiler.  We attempt to set this globally
 for gradle and IntelliJ, but it's possible this option is not present in your environment for some reason.
 
 IDEA issues
 -----------
+
+Fiber classes not instrumented
+******************************
+
+If you run JUnit tests that use flows then IntelliJ will use a default JVM command line of just ``-ea``, which is
+insufficient. You will need to open the run config and change it to read ``-ea -javaagent:lib/quasar.jar`` and make
+sure the working directory is set to the root of the Corda repository. Alternatively, make sure you have the quasar.jar
+file in your application source tree and set the paths appropriately so the JVM can find it.
+
+You can edit the default JUnit run config in the run configs window to avoid having to do this every time you pick a
+new test to run.
 
 No source files are present
 ***************************

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -1,0 +1,73 @@
+package net.corda.node.services.statemachine
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.InputStreamAndHash
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.messaging.startFlow
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.unwrap
+import net.corda.testing.BOB
+import net.corda.testing.DUMMY_NOTARY
+import net.corda.testing.aliceBobAndNotary
+import net.corda.testing.contracts.DummyState
+import net.corda.testing.driver.driver
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Check that we can add lots of large attachments to a transaction and that it works OK, e.g. does not hit the
+ * transaction size limit (which should only consider the hashes).
+ */
+class LargeTransactionsTest {
+    @StartableByRPC @InitiatingFlow
+    class SendLargeTransactionFlow(val hash1: SecureHash, val hash2: SecureHash, val hash3: SecureHash, val hash4: SecureHash) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val tx = TransactionBuilder(notary = DUMMY_NOTARY)
+                    .addOutputState(DummyState())
+                    .addAttachment(hash1)
+                    .addAttachment(hash2)
+                    .addAttachment(hash3)
+                    .addAttachment(hash4)
+            val stx = serviceHub.signInitialTransaction(tx, serviceHub.legalIdentityKey)
+            // Send to the other side and wait for it to trigger resolution from us.
+            sendAndReceive<Unit>(serviceHub.networkMapCache.getNodeByLegalName(BOB.name)!!.legalIdentity, stx)
+        }
+    }
+
+    @InitiatedBy(SendLargeTransactionFlow::class) @Suppress("UNUSED")
+    class ReceiveLargeTransactionFlow(private val counterParty: Party) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val stx = receive<SignedTransaction>(counterParty).unwrap { it }
+            subFlow(ResolveTransactionsFlow(stx, counterParty))
+            // Unblock the other side by sending some dummy object (Unit is fine here as it's a singleton).
+            send(counterParty, Unit)
+        }
+    }
+
+    @Test
+    fun checkCanSendLargeTransactions() {
+        // These 4 attachments yield a transaction that's got >10mb attached, so it'd push us over the Artemis
+        // max message size.
+        val bigFile1 = InputStreamAndHash.createInMemoryTestZip(1024*1024*3, 0)
+        val bigFile2 = InputStreamAndHash.createInMemoryTestZip(1024*1024*3, 1)
+        val bigFile3 = InputStreamAndHash.createInMemoryTestZip(1024*1024*3, 2)
+        val bigFile4 = InputStreamAndHash.createInMemoryTestZip(1024*1024*3, 3)
+        driver(startNodesInProcess = true) {
+            val (alice, _, _) = aliceBobAndNotary()
+            alice.useRPC {
+                val hash1 = it.uploadAttachment(bigFile1.inputStream)
+                val hash2 = it.uploadAttachment(bigFile2.inputStream)
+                val hash3 = it.uploadAttachment(bigFile3.inputStream)
+                val hash4 = it.uploadAttachment(bigFile4.inputStream)
+                assertEquals(hash1, bigFile1.sha256)
+                // Should not throw any exceptions.
+                it.startFlow(::SendLargeTransactionFlow, hash1, hash2, hash3, hash4).returnValue.get()
+            }
+        }
+    }
+}

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -3,6 +3,8 @@ package net.corda.attachmentdemo
 import co.paralleluniverse.fibers.Suspendable
 import joptsimple.OptionParser
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.InputStreamAndHash
+import net.corda.core.InputStreamAndHash.Companion.createInMemoryTestZip
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.TransactionForContract
@@ -16,7 +18,6 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startTrackedFlow
-import net.corda.core.sizedInputStreamAndHash
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.Emoji
 import net.corda.core.utilities.NetworkHostAndPort
@@ -72,7 +73,7 @@ fun main(args: Array<String>) {
 
 /** An in memory test zip attachment of at least numOfClearBytes size, will be used. */
 fun sender(rpc: CordaRPCOps, numOfClearBytes: Int = 1024) { // default size 1K.
-    val (inputStream, hash) = sizedInputStreamAndHash(numOfClearBytes)
+    val (inputStream, hash) = InputStreamAndHash.createInMemoryTestZip(numOfClearBytes, 0)
     sender(rpc, inputStream, hash)
 }
 


### PR DESCRIPTION
A user has encountered a bug whereby our limit of 10mb per transaction and per attachment is not being respected due to our use of batching in the fetch flows.  There should be no such limit on attachment sizes (or rather it should be a lot higher) but we put one in place to temporarily avoid upstream Artemis large message handling bugs. Once those are fixed we can re-batch this code if we want, and allow >10mb attachments.

This PR has a few commits:

* 3 which make some minor test utility changes and doc improvements.
* 1 which de-batches the test flow, and makes a new integration test pass. The integration test reproduces the bug reported to us by this user.