### PR TITLE
Make serialise putObject function an open function

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationOutput.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationOutput.kt
@@ -34,7 +34,7 @@ open class SerializationOutput(internal val serializerFactory: SerializerFactory
                     // Our object
                     writeObject(obj, this)
                     // The schema
-                    putObject(Schema(schemaHistory.toList()), this)
+                    writeSchema(Schema(schemaHistory.toList()), this)
                 }
             }
             val bytes = ByteArray(data.encodedSize().toInt() + 8)
@@ -53,7 +53,7 @@ open class SerializationOutput(internal val serializerFactory: SerializerFactory
         writeObject(obj, data, obj.javaClass)
     }
 
-    open fun putObject(schema: Schema, data: Data) {
+    open fun writeSchema(schema: Schema, data: Data) {
         data.putObject(schema)
     }
 

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationOutput.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializationOutput.kt
@@ -34,7 +34,7 @@ open class SerializationOutput(internal val serializerFactory: SerializerFactory
                     // Our object
                     writeObject(obj, this)
                     // The schema
-                    putObject(Schema(schemaHistory.toList()))
+                    putObject(Schema(schemaHistory.toList()), this)
                 }
             }
             val bytes = ByteArray(data.encodedSize().toInt() + 8)
@@ -51,6 +51,10 @@ open class SerializationOutput(internal val serializerFactory: SerializerFactory
 
     internal fun writeObject(obj: Any, data: Data) {
         writeObject(obj, data, obj.javaClass)
+    }
+
+    open fun putObject(schema: Schema, data: Data) {
+        data.putObject(schema)
     }
 
     internal fun writeObjectOrNull(obj: Any?, data: Data, type: Type) {


### PR DESCRIPTION
For testing I need to be able to mess with the schema before it gets
added to the envelope, extract the function where that happens and make
it open so the tests can do what they want