### PR TITLE
Remove DigitalSignature.LegallyIdentifiable

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -3,7 +3,6 @@
 package net.corda.core.crypto
 
 import net.corda.core.crypto.composite.CompositeKey
-import net.corda.core.identity.Party
 import net.corda.core.utilities.OpaqueBytes
 import java.math.BigInteger
 import java.security.*
@@ -36,17 +35,6 @@ fun PrivateKey.sign(bytesToSign: ByteArray, publicKey: PublicKey): DigitalSignat
 @Throws(IllegalArgumentException::class, InvalidKeyException::class, SignatureException::class)
 fun KeyPair.sign(bytesToSign: ByteArray) = private.sign(bytesToSign, public)
 fun KeyPair.sign(bytesToSign: OpaqueBytes) = private.sign(bytesToSign.bytes, public)
-fun KeyPair.sign(bytesToSign: OpaqueBytes, party: Party) = sign(bytesToSign.bytes, party)
-
-// TODO This case will need more careful thinking, as party owningKey can be a CompositeKey. One way of doing that is
-//  implementation of CompositeSignature.
-@Throws(InvalidKeyException::class)
-fun KeyPair.sign(bytesToSign: ByteArray, party: Party): DigitalSignature.LegallyIdentifiable {
-    // Quick workaround when we have CompositeKey as Party owningKey.
-    if (party.owningKey is CompositeKey) throw InvalidKeyException("Signing for parties with CompositeKey not supported.")
-    val sig = sign(bytesToSign)
-    return DigitalSignature.LegallyIdentifiable(party, sig.bytes)
-}
 
 /**
  * Utility to simplify the act of verifying a signature.

--- a/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt
@@ -1,6 +1,5 @@
 package net.corda.core.crypto
 
-import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
 import java.security.InvalidKeyException
@@ -46,7 +45,4 @@ open class DigitalSignature(bits: ByteArray) : OpaqueBytes(bits) {
         @Throws(InvalidKeyException::class, SignatureException::class)
         fun isValid(content: ByteArray) = by.isValid(content, this)
     }
-
-    // TODO: consider removing this as whoever needs to identify the signer should be able to derive it from the public key
-    class LegallyIdentifiable(val signer: Party, bits: ByteArray) : WithKey(signer.owningKey, bits)
 }

--- a/docs/source/oracles.rst
+++ b/docs/source/oracles.rst
@@ -112,7 +112,7 @@ Here is an extract from the ``NodeInterestRates.Oracle`` class and supporting ty
    class Oracle {
        fun query(queries: List<FixOf>, deadline: Instant): List<Fix>
 
-       fun sign(ftx: FilteredTransaction, merkleRoot: SecureHash): DigitalSignature.LegallyIdentifiable
+       fun sign(ftx: FilteredTransaction, merkleRoot: SecureHash): DigitalSignature.WithKey
    }
 
 Because the fix contains a timestamp (the ``forDay`` field), that identifies the version of the data being requested,

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -11,14 +11,12 @@ import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.flows.AnonymisedIdentity
 import net.corda.node.utilities.*
-import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.operator.ContentSigner
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.statements.InsertStatement
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
-import java.security.cert.CertPath
 
 /**
  * A persistent re-implementation of [E2ETestKeyManagementService] to support node re-start.

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
@@ -146,7 +146,7 @@ object NodeInterestRates {
         //      Oracle gets signing request for only some of them with a valid partial tree? We sign over a whole transaction.
         //      It will be fixed by adding partial signatures later.
         // DOCSTART 1
-        fun sign(ftx: FilteredTransaction): DigitalSignature.LegallyIdentifiable {
+        fun sign(ftx: FilteredTransaction): DigitalSignature.WithKey {
             if (!ftx.verify()) {
                 throw MerkleTreeException("Rate Fix Oracle: Couldn't verify partial Merkle tree.")
             }
@@ -178,7 +178,7 @@ object NodeInterestRates {
             // version so we can't resolve or check it ourselves. However, that doesn't matter much, as if we sign
             // an invalid transaction the signature is worthless.
             val signature = services.keyManagementService.sign(ftx.rootHash.bytes, signingKey)
-            return DigitalSignature.LegallyIdentifiable(identity, signature.bytes)
+            return DigitalSignature.WithKey(signingKey, signature.bytes)
         }
         // DOCEND 1
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.Fix
 import net.corda.contracts.FixOf
 import net.corda.core.crypto.DigitalSignature
-import net.corda.core.crypto.keys
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
@@ -117,7 +117,7 @@ open class RatesFixFlow(protected val tx: TransactionBuilder,
         override fun call(): DigitalSignature.WithKey {
             val resp = sendAndReceive<DigitalSignature.WithKey>(oracle, SignRequest(partialMerkleTx))
             return resp.unwrap { sig ->
-                check(sig.by in oracle.owningKey.keys)
+                check(oracle.owningKey.isFulfilledBy(listOf(sig.by)))
                 tx.toWireTransaction().checkSignature(sig)
                 sig
             }

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.Fix
 import net.corda.contracts.FixOf
 import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.keys
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
@@ -111,12 +112,12 @@ open class RatesFixFlow(protected val tx: TransactionBuilder,
 
     @InitiatingFlow
     class FixSignFlow(val tx: TransactionBuilder, val oracle: Party,
-                      val partialMerkleTx: FilteredTransaction) : FlowLogic<DigitalSignature.LegallyIdentifiable>() {
+                      val partialMerkleTx: FilteredTransaction) : FlowLogic<DigitalSignature.WithKey>() {
         @Suspendable
-        override fun call(): DigitalSignature.LegallyIdentifiable {
-            val resp = sendAndReceive<DigitalSignature.LegallyIdentifiable>(oracle, SignRequest(partialMerkleTx))
+        override fun call(): DigitalSignature.WithKey {
+            val resp = sendAndReceive<DigitalSignature.WithKey>(oracle, SignRequest(partialMerkleTx))
             return resp.unwrap { sig ->
-                check(sig.signer == oracle)
+                check(sig.by in oracle.owningKey.keys)
                 tx.toWireTransaction().checkSignature(sig)
                 sig
             }


### PR DESCRIPTION
`DigitialSignature.LegallyIdentifiable` has been removed as it is only required for Oracles and we eventually decided that public keys are enough to distinguish between entities (we can always ask to the network map).
This is part of the cleanup before applying the full transaction signature metadata functionality.