### PR TITLE
Store notaries's identity composite key in keystore

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
@@ -22,7 +22,6 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.bouncycastle.asn1.x509.GeneralName
 import org.bouncycastle.asn1.x509.GeneralSubtree
 import org.bouncycastle.asn1.x509.NameConstraints
-import org.bouncycastle.cert.path.CertPath
 import org.junit.Test
 import java.nio.file.Files
 
@@ -118,7 +117,7 @@ class MQSecurityAsNodeTest : MQSecurityTest() {
                         X509Utilities.CORDA_CLIENT_CA,
                         clientKey.private,
                         keyPass,
-                        CertPath(arrayOf(clientCACert, intermediateCA.certificate, rootCACert)))
+                        arrayOf(clientCACert, intermediateCA.certificate, rootCACert))
                 clientCAKeystore.save(nodeKeystore, keyStorePassword)
 
                 val tlsKeystore = loadOrCreateKeyStore(sslKeystore, keyStorePassword)
@@ -126,7 +125,7 @@ class MQSecurityAsNodeTest : MQSecurityTest() {
                         X509Utilities.CORDA_CLIENT_TLS,
                         tlsKey.private,
                         keyPass,
-                        CertPath(arrayOf(clientTLSCert, clientCACert, intermediateCA.certificate, rootCACert)))
+                        arrayOf(clientTLSCert, clientCACert, intermediateCA.certificate, rootCACert))
                 tlsKeystore.save(sslKeystore, keyStorePassword)
             }
         }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -240,10 +240,8 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
                 .filter {
                     val serviceType = getServiceType(it)
                     if (serviceType != null && info.serviceIdentities(serviceType).isEmpty()) {
-                        log.debug {
-                            "Ignoring ${it.name} as a Corda service since $serviceType is not one of our " +
-                                    "advertised services"
-                        }
+                        log.debug { "Ignoring ${it.name} as a Corda service since $serviceType is not one of our " +
+                                "advertised services" }
                         false
                     } else {
                         true
@@ -379,13 +377,13 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         _services.rpcFlows += scanResult
                 .getClassesWithAnnotation(FlowLogic::class, StartableByRPC::class)
                 .filter { it.isUserInvokable() } +
-                // Add any core flows here
-                listOf(
-                        ContractUpgradeFlow::class.java,
-                        // TODO Remove all Cash flows from default list once they are split into separate CorDapp.
-                        CashIssueFlow::class.java,
-                        CashExitFlow::class.java,
-                        CashPaymentFlow::class.java)
+                    // Add any core flows here
+                    listOf(
+                            ContractUpgradeFlow::class.java,
+                            // TODO Remove all Cash flows from default list once they are split into separate CorDapp.
+                            CashIssueFlow::class.java,
+                            CashExitFlow::class.java,
+                            CashPaymentFlow::class.java)
     }
 
     /**
@@ -711,6 +709,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         // "permissioned". The identity file is what gets distributed and contains the node's legal name along with
         // the public key. Obviously in a real system this would need to be a certificate chain of some kind to ensure
         // the legal name is actually validated in some way.
+
         // TODO: Integrate with Key management service?
         val keyStore = KeyStoreWrapper(configuration.nodeKeystore, configuration.keyStorePassword)
         val privateKeyAlias = "$serviceId-private-key"

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -802,10 +802,11 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         override val keyManagementService by lazy { makeKeyManagementService(identityService) }
         override val schedulerService by lazy { NodeSchedulerService(this, unfinishedSchedules = busyNodeLatch) }
         override val identityService by lazy {
-            val keystore = KeyStoreWrapper(configuration.trustStoreFile, configuration.trustStorePassword)
+            val trustStore = KeyStoreWrapper(configuration.trustStoreFile, configuration.trustStorePassword)
+            val caKeyStore = KeyStoreWrapper(configuration.nodeKeystore, configuration.keyStorePassword)
             makeIdentityService(
-                    keystore.getX509Certificate(X509Utilities.CORDA_ROOT_CA).cert,
-                    keystore.certificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA),
+                    trustStore.getX509Certificate(X509Utilities.CORDA_ROOT_CA).cert,
+                    caKeyStore.certificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA),
                     info.legalIdentityAndCert)
         }
         override val attachments: AttachmentStorage get() = this@AbstractNode.attachments

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -98,7 +98,7 @@ fun createKeystoreForCordaNode(sslKeyStorePath: Path,
             X509Utilities.CORDA_CLIENT_CA,
             clientKey.private,
             keyPass,
-            org.bouncycastle.cert.path.CertPath(arrayOf(clientCACert, intermediateCACert, rootCACert)))
+            arrayOf(clientCACert, intermediateCACert, rootCACert))
     clientCAKeystore.save(clientCAKeystorePath, storePassword)
 
     val tlsKeystore = loadOrCreateKeyStore(sslKeyStorePath, storePassword)
@@ -106,6 +106,6 @@ fun createKeystoreForCordaNode(sslKeyStorePath: Path,
             X509Utilities.CORDA_CLIENT_TLS,
             tlsKey.private,
             keyPass,
-            org.bouncycastle.cert.path.CertPath(arrayOf(clientTLSCert, clientCACert, intermediateCACert, rootCACert)))
+            arrayOf(clientTLSCert, clientCACert, intermediateCACert, rootCACert))
     tlsKeystore.save(sslKeyStorePath, storePassword)
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/KeyStoreUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/KeyStoreUtilities.kt
@@ -7,13 +7,14 @@ import net.corda.core.internal.exists
 import net.corda.core.internal.read
 import net.corda.core.internal.write
 import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.cert.path.CertPath
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.file.Path
 import java.security.*
+import java.security.cert.CertPath
 import java.security.cert.Certificate
+import java.security.cert.CertificateFactory
 
 val KEYSTORE_TYPE = "JKS"
 
@@ -78,7 +79,11 @@ fun loadKeyStore(input: InputStream, storePassword: String): KeyStore {
  * @param chain the sequence of certificates starting with the public key certificate for this key and extending to the root CA cert.
  */
 fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain: CertPath) {
-    addOrReplaceKey(alias, key, password, chain.certificates.map { it.cert }.toTypedArray<Certificate>())
+    addOrReplaceKey(alias, key, password, chain.certificates.toTypedArray<Certificate>())
+}
+
+fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain: Array<out X509CertificateHolder>) {
+    addOrReplaceKey(alias, key, password, chain.map { it.cert }.toTypedArray<Certificate>())
 }
 
 /**
@@ -89,7 +94,7 @@ fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain
  * but for SSL purposes this is recommended.
  * @param chain the sequence of certificates starting with the public key certificate for this key and extending to the root CA cert.
  */
-fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain: Array<Certificate>) {
+fun KeyStore.addOrReplaceKey(alias: String, key: Key, password: CharArray, chain: Array<out Certificate>) {
     if (containsAlias(alias)) {
         this.deleteEntry(alias)
     }
@@ -167,4 +172,45 @@ fun KeyStore.getSupportedKey(alias: String, keyPassword: String): PrivateKey {
     val keyPass = keyPassword.toCharArray()
     val key = getKey(alias, keyPass) as PrivateKey
     return Crypto.toSupportedPrivateKey(key)
+}
+
+class KeyStoreWrapper(private val storePath: Path, private val storePassword: String) {
+    private val keyStore = storePath.read { KeyStoreUtilities.loadKeyStore(it, storePassword) }
+
+    fun certificateAndKeyPair(alias: String): CertificateAndKeyPair? {
+        return if (keyStore.containsAlias(alias)) keyStore.getCertificateAndKeyPair(alias, storePassword) else null
+    }
+
+    private fun createCertificate(serviceName: X500Name, pubKey: PublicKey): CertPath {
+        val clientCertPath = keyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_CA)
+        // Assume key password = store password.
+        val clientCA = certificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA)!!
+        // Create new keys and store in keystore.
+        val cert = X509Utilities.createCertificate(CertificateType.IDENTITY, clientCA.certificate, clientCA.keyPair, serviceName, pubKey)
+        val certPath = CertificateFactory.getInstance("X509").generateCertPath(listOf(cert.cert) + clientCertPath)
+        require(certPath.certificates.isNotEmpty()) { "Certificate path cannot be empty" }
+        return certPath
+    }
+
+    fun saveNewKeyPair(serviceName: X500Name, privateKeyAlias: String, keyPair: KeyPair) {
+        val certPath = createCertificate(serviceName, keyPair.public)
+        // Assume key password = store password.
+        keyStore.addOrReplaceKey(privateKeyAlias, keyPair.private, storePassword.toCharArray(), certPath.certificates.toTypedArray())
+        keyStore.save(storePath, storePassword)
+    }
+
+    fun savePublicKey(serviceName: X500Name, pubKeyAlias: String, pubKey: PublicKey) {
+        val certPath = createCertificate(serviceName, pubKey)
+        // Assume key password = store password.
+        keyStore.addOrReplaceCertificate(pubKeyAlias, certPath.certificates.first())
+        keyStore.save(storePath, storePassword)
+    }
+
+    fun containsAlias(alias: String) = keyStore.containsAlias(alias)
+
+    fun getX509Certificate(alias: String) = keyStore.getX509Certificate(alias)
+
+    fun getCertificateChain(alias: String): Array<out Certificate> = keyStore.getCertificateChain(alias)
+
+    fun getCertificate(alias: String): Certificate = keyStore.getCertificate(alias)
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -49,7 +49,7 @@ class NetworkRegistrationHelper(val config: NodeConfiguration, val certService: 
                 val selfSignCert = X509Utilities.createSelfSignedCACertificate(config.myLegalName, keyPair)
                 // Save to the key store.
                 caKeyStore.addOrReplaceKey(SELF_SIGNED_PRIVATE_KEY, keyPair.private, privateKeyPassword.toCharArray(),
-                        CertPath(arrayOf(selfSignCert)))
+                        arrayOf(selfSignCert))
                 caKeyStore.save(config.nodeKeystore, keystorePassword)
             }
             val keyPair = caKeyStore.getKeyPair(SELF_SIGNED_PRIVATE_KEY, privateKeyPassword)


### PR DESCRIPTION
* Store composite key in keystore from file for notaries's identity.
* Some refactoring.

added a TODO to make `ServiceIdentityGenerator.generateToDisk` write to keystore instead of writing keys to file, that will be on a different PR as its more involved.