### PR TITLE
Enable anonymisation in integration testing tutorial

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -78,7 +78,7 @@ open class FinalityFlow(val transactions: Iterable<SignedTransaction>,
     /**
      * Broadcast a transaction to the participants. By default calls [BroadcastTransactionFlow], however can be
      * overridden for more complex transaction delivery protocols (for example where not all parties know each other).
-     * This implementation will filter out any participants for who there is no well known identity.
+     * This implementation will filter out any participants for whom there is no well known identity.
      *
      * @param participants the participants to send the transaction to. This is expected to include extra participants
      * and exclude the local node.

--- a/core/src/main/kotlin/net/corda/core/flows/TransactionKeyFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/TransactionKeyFlow.kt
@@ -31,7 +31,6 @@ class TransactionKeyFlow(val otherSide: Party,
     override fun call(): LinkedHashMap<Party, AnonymisedIdentity> {
         progressTracker.currentStep = AWAITING_KEY
         val legalIdentityAnonymous = serviceHub.keyManagementService.freshKeyAndCert(serviceHub.myInfo.legalIdentityAndCert, revocationEnabled)
-        serviceHub.identityService.registerAnonymousIdentity(legalIdentityAnonymous.identity, serviceHub.myInfo.legalIdentity, legalIdentityAnonymous.certPath)
 
         // Special case that if we're both parties, a single identity is generated
         val identities = LinkedHashMap<Party, AnonymisedIdentity>()
@@ -39,6 +38,7 @@ class TransactionKeyFlow(val otherSide: Party,
             identities.put(otherSide, legalIdentityAnonymous)
         } else {
             val otherSideAnonymous = sendAndReceive<AnonymisedIdentity>(otherSide, legalIdentityAnonymous).unwrap { validateIdentity(otherSide, it) }
+            serviceHub.identityService.registerAnonymousIdentity(otherSideAnonymous.identity, otherSide, otherSideAnonymous.certPath)
             identities.put(serviceHub.myInfo.legalIdentity, legalIdentityAnonymous)
             identities.put(otherSide, otherSideAnonymous)
         }

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -8,6 +8,7 @@ import net.corda.core.getOrThrow
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.Vault
+import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.testing.ALICE
 import net.corda.testing.BOB
@@ -57,8 +58,9 @@ class IntegrationTestingTutorial {
             // END 2
 
             // START 3
-            val bobVaultUpdates = bobProxy.vaultAndUpdates().second
-            val aliceVaultUpdates = aliceProxy.vaultAndUpdates().second
+            val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)
+            val (_, bobVaultUpdates) = bobProxy.vaultTrackByCriteria<Cash.State>(Cash.State::class.java, criteria)
+            val (_, aliceVaultUpdates) = aliceProxy.vaultTrackByCriteria<Cash.State>(Cash.State::class.java, criteria)
             // END 3
 
             // START 4
@@ -70,8 +72,7 @@ class IntegrationTestingTutorial {
                             i.DOLLARS,
                             issueRef,
                             bob.nodeInfo.legalIdentity,
-                            notary.nodeInfo.notaryIdentity,
-                            false // Not anonymised
+                            notary.nodeInfo.notaryIdentity
                     ).returnValue)
                 }
             }.forEach(Thread::join) // Ensure the stack of futures is populated.
@@ -94,7 +95,7 @@ class IntegrationTestingTutorial {
 
             // START 5
             for (i in 1..10) {
-                bobProxy.startFlow(::CashPaymentFlow, i.DOLLARS, alice.nodeInfo.legalIdentity, false).returnValue.getOrThrow()
+                bobProxy.startFlow(::CashPaymentFlow, i.DOLLARS, alice.nodeInfo.legalIdentity).returnValue.getOrThrow()
             }
 
             aliceVaultUpdates.expectEvents {

--- a/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/TwoPartyTradeFlow.kt
@@ -145,7 +145,7 @@ object TwoPartyTradeFlow {
 
             // Notarise and record the transaction.
             progressTracker.currentStep = RECORDING
-            return subFlow(FinalityFlow(twiceSignedTx, setOf(otherParty, serviceHub.myInfo.legalIdentity))).single()
+            return subFlow(FinalityFlow(twiceSignedTx)).single()
         }
 
         @Suspendable

--- a/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
+++ b/finance/src/test/kotlin/net/corda/flows/IssuerFlowTest.kt
@@ -44,9 +44,10 @@ class IssuerFlowTest(val anonymous: Boolean) {
     @Before
     fun start() {
         mockNet = MockNetwork(threadPerNode = true)
-        notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
-        bankOfCordaNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOC.name)
-        bankClientNode = mockNet.createPartyNode(notaryNode.network.myAddress, MEGA_CORP.name)
+        val basketOfNodes = mockNet.createSomeNodes(2)
+        bankOfCordaNode = basketOfNodes.partyNodes[0]
+        bankClientNode = basketOfNodes.partyNodes[1]
+        notaryNode = basketOfNodes.notaryNode
     }
 
     @After


### PR DESCRIPTION
Enable anonymisation in integration testing tutorial, and as a requirement fix a bug where the counterparty anonymous identity was not registered by `TransactionKeyFlow`.

Enforces that all parties are identified during `FinalityFlow` to avoid silently failing to deliver transactions to a party.