### PR TITLE
Comment that vault returns the total number of available states.

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
@@ -193,6 +193,7 @@ class NodeTerminalView : Fragment() {
             val (stateInit, stateNext) = ops.vaultTrackBy<ContractState>(paging = pageSpecification)
 
             txCount = txInit.size
+            // This is the total number of states in the vault, regardless of pagination.
             stateCount = stateInit.totalStatesAvailable
 
             Platform.runLater {


### PR DESCRIPTION
The total number of states returned by the query is irrespective of the pagination.