### PR TITLE
Remove tolerance from TimeWindowChecker

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/TimeWindowChecker.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/TimeWindowChecker.kt
@@ -1,8 +1,6 @@
 package net.corda.core.node.services
 
 import net.corda.core.contracts.TimeWindow
-import net.corda.core.utilities.seconds
-import net.corda.core.until
 import java.time.Clock
 
 /**

--- a/core/src/main/kotlin/net/corda/core/node/services/TimeWindowChecker.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/TimeWindowChecker.kt
@@ -4,23 +4,21 @@ import net.corda.core.contracts.TimeWindow
 import net.corda.core.utilities.seconds
 import net.corda.core.until
 import java.time.Clock
-import java.time.Duration
 
 /**
- * Checks if the given time-window falls within the allowed tolerance interval.
+ * Checks if the current instant provided by the input clock falls within the provided time-window.
  */
-class TimeWindowChecker(val clock: Clock = Clock.systemUTC(),
-                        val tolerance: Duration = 30.seconds) {
+class TimeWindowChecker(val clock: Clock = Clock.systemUTC()) {
     fun isValid(timeWindow: TimeWindow): Boolean {
-        val untilTime = timeWindow.untilTime
         val fromTime = timeWindow.fromTime
+        val untilTime = timeWindow.untilTime
 
         val now = clock.instant()
 
         // We don't need to test for (fromTime == null && untilTime == null) or backwards bounds because the TimeWindow
         // constructor already checks that.
-        if (untilTime != null && untilTime until now > tolerance) return false
-        if (fromTime != null && now until fromTime > tolerance) return false
+        if (fromTime != null && now < fromTime) return false
+        if (untilTime != null && now > untilTime) return false
         return true
     }
 }

--- a/core/src/test/kotlin/net/corda/core/node/services/TimeWindowCheckerTests.kt
+++ b/core/src/test/kotlin/net/corda/core/node/services/TimeWindowCheckerTests.kt
@@ -11,23 +11,29 @@ import kotlin.test.assertTrue
 
 class TimeWindowCheckerTests {
     val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
-    val timeWindowChecker = TimeWindowChecker(clock, tolerance = 30.seconds)
+    val timeWindowChecker = TimeWindowChecker(clock)
 
     @Test
     fun `should return true for valid time-window`() {
         val now = clock.instant()
-        val timeWindowPast = TimeWindow.between(now - 60.seconds, now - 29.seconds)
-        val timeWindowFuture = TimeWindow.between(now + 29.seconds, now + 60.seconds)
-        assertTrue { timeWindowChecker.isValid(timeWindowPast) }
-        assertTrue { timeWindowChecker.isValid(timeWindowFuture) }
+        val timeWindowBetween = TimeWindow.between(now - 10.seconds, now + 10.seconds)
+        val timeWindowFromOnly = TimeWindow.fromOnly(now - 10.seconds)
+        val timeWindowUntilOnly = TimeWindow.untilOnly(now + 10.seconds)
+        assertTrue { timeWindowChecker.isValid(timeWindowBetween) }
+        assertTrue { timeWindowChecker.isValid(timeWindowFromOnly) }
+        assertTrue { timeWindowChecker.isValid(timeWindowUntilOnly) }
     }
 
     @Test
     fun `should return false for invalid time-window`() {
         val now = clock.instant()
-        val timeWindowPast = TimeWindow.between(now - 60.seconds, now - 31.seconds)
-        val timeWindowFuture = TimeWindow.between(now + 31.seconds, now + 60.seconds)
-        assertFalse { timeWindowChecker.isValid(timeWindowPast) }
-        assertFalse { timeWindowChecker.isValid(timeWindowFuture) }
+        val timeWindowBetweenPast = TimeWindow.between(now - 10.seconds, now - 2.seconds)
+        val timeWindowBetweenFuture = TimeWindow.between(now + 2.seconds, now + 10.seconds)
+        val timeWindowFromOnlyFuture = TimeWindow.fromOnly(now + 10.seconds)
+        val timeWindowUntilOnlyPast = TimeWindow.untilOnly(now - 10.seconds)
+        assertFalse { timeWindowChecker.isValid(timeWindowBetweenPast) }
+        assertFalse { timeWindowChecker.isValid(timeWindowBetweenFuture) }
+        assertFalse { timeWindowChecker.isValid(timeWindowFromOnlyFuture) }
+        assertFalse { timeWindowChecker.isValid(timeWindowUntilOnlyPast) }
     }
 }


### PR DESCRIPTION
As agreed, the client should add a tolerance value when creating the transaction, thus no tolerance is required on the notary side.