### PR TITLE
Move AttachmentClassLoader away from main API files

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/AttachmentsClassLoader.kt
@@ -1,8 +1,7 @@
-package net.corda.core.node
+package net.corda.core.serialization
 
 import net.corda.core.contracts.Attachment
 import net.corda.core.crypto.SecureHash
-import net.corda.core.serialization.CordaSerializable
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.FileNotFoundException

--- a/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CordaClassResolver.kt
@@ -5,7 +5,6 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.util.DefaultClassResolver
 import com.esotericsoftware.kryo.util.Util
-import net.corda.core.node.AttachmentsClassLoader
 import net.corda.core.utilities.loggerFor
 import java.io.PrintWriter
 import java.lang.reflect.Modifier

--- a/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/Kryo.kt
@@ -11,7 +11,6 @@ import net.corda.core.contracts.*
 import net.corda.core.crypto.*
 import net.corda.core.crypto.composite.CompositeKey
 import net.corda.core.identity.Party
-import net.corda.core.node.AttachmentsClassLoader
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.LazyPool
 import net.corda.core.utilities.OpaqueBytes

--- a/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/CordaClassResolverTests.kt
@@ -5,7 +5,6 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.util.MapReferenceResolver
 import net.corda.core.node.AttachmentClassLoaderTests
-import net.corda.core.node.AttachmentsClassLoader
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.testing.node.MockAttachmentStorage
 import org.junit.Rule


### PR DESCRIPTION
The AttachementClassLoader is really an implementation detail of the serialisation. It should be put with that code and not look like it is a required bit of API.