### PR TITLE
Move AMQP Field toward a more OO design

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializationInput.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializationInput.kt
@@ -133,7 +133,8 @@ class DeserializationInput(internal val serializerFactory: SerializerFactory = S
             // Look up serializer in factory by descriptor
             val serializer = serializerFactory.get(obj.descriptor, schema)
             if (serializer.type != type && !serializer.type.isSubClassOf(type))
-                throw NotSerializableException("Described type with descriptor ${obj.descriptor} was expected to be of type $type")
+                throw NotSerializableException("Described type with descriptor ${obj.descriptor} was " +
+                        "expected to be of type $type but was ${serializer.type}")
             return serializer.readObject(obj.described, schema, this)
         } else if (obj is Binary) {
             return obj.array

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializedGenericArrayType.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializedGenericArrayType.kt
@@ -13,6 +13,6 @@ class DeserializedGenericArrayType(private val componentType: Type) : GenericArr
     override fun toString(): String = typeName
     override fun hashCode(): Int = Objects.hashCode(componentType)
     override fun equals(other: Any?): Boolean {
-        return other is GenericArrayType && componentType.equals(other.genericComponentType)
+        return other is GenericArrayType && (componentType == other.genericComponentType)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -204,8 +204,20 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
             } else {
                 findCustomSerializer(clazz, declaredType) ?: run {
                     if (type.isArray()) {
-                        whitelisted(type.componentType())
-                        ArraySerializer(type, this)
+                        println ("Array: ${type.componentType()}, ${type.componentType()::class.java}")
+                        println (clazz)
+                        println (declaredType)
+                        println ("${clazz.componentType.isPrimitive()}")
+                        if (clazz.componentType.isPrimitive) {
+                            println ("primitive array")
+                            whitelisted(type.componentType())
+                            PrimArraySerializer.make(type, this)
+                        }
+                        else {
+                            println ("non primitive array")
+                            whitelisted(type.componentType())
+                            ArraySerializer.make (type, this)
+                        }
                     } else if (clazz.kotlin.objectInstance != null) {
                         whitelisted(clazz)
                         SingletonSerializer(clazz, clazz.kotlin.objectInstance!!, this)
@@ -293,14 +305,19 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
 
         private val namesOfPrimitiveTypes: Map<String, Class<*>> = primitiveTypeNames.map { it.value to it.key }.toMap()
 
-        fun nameForType(type: Type): String {
-            if (type is Class<*>) {
-                return primitiveTypeName(type) ?: if (type.isArray) "${nameForType(type.componentType)}[]" else type.name
-            } else if (type is ParameterizedType) {
-                return "${nameForType(type.rawType)}<${type.actualTypeArguments.joinToString { nameForType(it) }}>"
-            } else if (type is GenericArrayType) {
-                return "${nameForType(type.genericComponentType)}[]"
-            } else throw NotSerializableException("Unable to render type $type to a string.")
+        fun nameForType(type: Type) : String {
+            println ("nameForType $type - ${(type as Class<*>).isArray} - ${type?.componentType?.isPrimitive}")
+            val result = when (type) {
+                is Class<*> -> primitiveTypeName(type) ?: if (type.isArray) {
+                    if (type.componentType.isPrimitive) "${nameForType(type.componentType)}[p]" else "${nameForType(type.componentType)}[]"
+                } else type.name
+                is ParameterizedType -> "${nameForType(type.rawType)}<${type.actualTypeArguments.joinToString { nameForType(it) }}>"
+                is GenericArrayType -> "${nameForType(type.genericComponentType)}[]"
+                else -> throw NotSerializableException("Unable to render type $type to a string.")
+            }
+
+            println ("nameForType = $result")
+            return result
         }
 
         private fun typeForName(name: String): Type {
@@ -312,6 +329,18 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
                     java.lang.reflect.Array.newInstance(elementType, 0).javaClass
                 } else {
                     throw NotSerializableException("Not able to deserialize array type: $name")
+                }
+            } else if (name.endsWith("[p]")) {
+                when(name) {
+                    "int[p]" -> IntArray::class.java
+                    "char[p]" -> CharArray::class.java
+                    "boolean[p]" -> BooleanArray::class.java
+                    "float[p]" -> FloatArray::class.java
+                    "double[p]" -> DoubleArray::class.java
+                    "short[p]" -> ShortArray::class.java
+                    "byte[p]" -> ByteArray::class.java
+                    "long[p]" -> LongArray::class.java
+                    else -> throw NotSerializableException("Not able to deserialize array type: $name")
                 }
             } else {
                 DeserializedParameterizedType.make(name)

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -1,8 +1,8 @@
 package net.corda.core.serialization.amqp
 
 import org.junit.Test
-import java.io.ByteArrayOutputStream
 import kotlin.test.assertEquals
+import org.apache.qpid.proton.codec.Data
 
 /**
  * Prior to certain fixes being made within the [PropertySerializaer] classes these simple
@@ -11,6 +11,25 @@ import kotlin.test.assertEquals
  * as such
  */
 class DeserializeSimpleTypesTests {
+    class TestSerializationOutput(
+            private val verbose: Boolean,
+            serializerFactory: SerializerFactory = SerializerFactory()) : SerializationOutput(serializerFactory) {
+
+        override fun writeSchema(schema: Schema, data: Data) {
+            if(verbose) println(schema)
+            super.writeSchema(schema, data)
+        }
+    }
+
+    companion object {
+        /**
+         * If you want to see the schema encoded into the envelope after serialisation change this to true
+         */
+        private const val VERBOSE = false
+    }
+
+    val sf = SerializerFactory()
+
     @Test
     fun testChar() {
         data class C(val c: Char)
@@ -29,6 +48,186 @@ class DeserializeSimpleTypesTests {
         val deserializedC = DeserializationInput().deserialize(serialisedC)
 
         assertEquals(c.c, deserializedC.c)
+    }
+
+    @Test
+    fun testArrayOfInt() {
+        class IA(val ia: Array<Int>)
+
+        val ia = IA(arrayOf(1, 2, 3))
+
+        assertEquals("class [Ljava.lang.Integer;", ia.ia::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(ia.ia::class.java), "int[]")
+
+        val serialisedIA = TestSerializationOutput(VERBOSE, sf).serialize(ia)
+        val deserializedIA = DeserializationInput(sf).deserialize(serialisedIA)
+
+        assertEquals(ia.ia.size, deserializedIA.ia.size)
+        assertEquals(ia.ia[0], deserializedIA.ia[0])
+        assertEquals(ia.ia[1], deserializedIA.ia[1])
+        assertEquals(ia.ia[2], deserializedIA.ia[2])
+    }
+
+    @Test
+    fun testArrayOfInteger() {
+        class IA (val ia: Array<Integer>)
+        val ia = IA(arrayOf(Integer(1), Integer(2), Integer(3)))
+
+        assertEquals("class [Ljava.lang.Integer;", ia.ia::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(ia.ia::class.java), "int[]")
+
+        val serialisedIA = TestSerializationOutput(VERBOSE, sf).serialize(ia)
+        val deserializedIA = DeserializationInput(sf).deserialize(serialisedIA)
+
+        assertEquals(ia.ia.size, deserializedIA.ia.size)
+        assertEquals(ia.ia[0], deserializedIA.ia[0])
+        assertEquals(ia.ia[1], deserializedIA.ia[1])
+        assertEquals(ia.ia[2], deserializedIA.ia[2])
+    }
+
+    /**
+     * Test unboxed primitives
+     */
+    @Test
+    fun testIntArray() {
+        class IA (val ia: IntArray)
+        val v = IntArray(3)
+        v[0] = 1; v[1] = 2; v[2] = 3
+        val ia = IA(v)
+
+        assertEquals("class [I", ia.ia::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(ia.ia::class.java), "int[p]")
+
+        val serialisedIA = TestSerializationOutput(VERBOSE, sf).serialize(ia)
+        val deserializedIA = DeserializationInput(sf).deserialize(serialisedIA)
+
+        assertEquals(ia.ia.size, deserializedIA.ia.size)
+        assertEquals(ia.ia[0], deserializedIA.ia[0])
+        assertEquals(ia.ia[1], deserializedIA.ia[1])
+        assertEquals(ia.ia[2], deserializedIA.ia[2])
+    }
+
+    @Test
+    fun testArrayOfChars() {
+        class C (val c: Array<Char>)
+        val c = C(arrayOf ('a', 'b', 'c'))
+
+        assertEquals("class [Ljava.lang.Character;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "char[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+    }
+
+    @Test
+    fun testCharArray() {
+        class C(val c: CharArray)
+        val v = CharArray(3)
+        v[0] = 'a'; v[1] = 'b'; v[2] = 'c'
+        val c = C(v)
+
+        assertEquals("class [C", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "char[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+    }
+
+    @Test
+    fun testArrayOfBoolean() {
+        class C (val c: Array<Boolean>)
+        val c = C(arrayOf (true, false, false, true))
+
+        assertEquals("class [Ljava.lang.Boolean;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "boolean[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+        assertEquals(c.c[3], deserializedC.c[3])
+    }
+
+    @Test
+    fun testBooleanArray() {
+        class C(val c: BooleanArray)
+        val c = C(BooleanArray(4))
+        c.c[0] = true; c.c[1] = false; c.c[2] = false; c.c[3] = true
+
+        assertEquals("class [Z", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "boolean[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+        assertEquals(c.c[3], deserializedC.c[3])
+    }
+
+    @Test
+    fun testArrayOfByte() {
+        class C(val c: Array<Byte>)
+    }
+
+    @Test
+    fun testByteArray() {
+        class C(val c: ByteArray)
+    }
+
+    @Test
+    fun testArrayOfShort() {
+        class C(val c: Array<Short>)
+    }
+
+    @Test
+    fun testShortArray() {
+        class C(val c: ShortArray)
+    }
+
+    @Test
+    fun testArrayOfLong() {
+        class C(val c: Array<Long>)
+    }
+
+    @Test
+    fun testLongArray() {
+        class C(val c: LongArray)
+    }
+
+    @Test
+    fun testArrayOfFloat() {
+        class C(val c: Array<Float>)
+    }
+
+    @Test
+    fun testFloatArray() {
+        class C(val c: FloatArray)
+    }
+
+    @Test
+    fun testArrayOfDouble() {
+        class C(val c: Array<Double>)
+    }
+
+    @Test
+    fun testDoubleArray() {
+        class C(val c: DoubleArray)
     }
 }
 


### PR DESCRIPTION
rather than have mandatory and multiple as boolean flags on the class
that other functions have to switch against make them inherited
interface properties that allows distinct functions to be written and
thus the question of which type it is to only be asked once, at
creation, rather than every time one of those flags is inspected

This will be useful in the main carpenter / serialiser synthesis where mandatory types -> nullable / non nullable is important