### PR TITLE
Refactor transaction serialization caching

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/DefaultKryoCustomizer.kt
@@ -60,7 +60,7 @@ object DefaultKryoCustomizer {
             instantiatorStrategy = CustomInstantiatorStrategy()
 
             register(Arrays.asList("").javaClass, ArraysAsListSerializer())
-            register(SignedTransaction::class.java, ImmutableClassSerializer(SignedTransaction::class))
+            register(SignedTransaction::class.java, SignedTransactionSerializer)
             register(WireTransaction::class.java, WireTransactionSerializer)
             register(SerializedBytes::class.java, SerializedBytesSerializer)
 

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -135,7 +135,3 @@ class SerializedBytes<T : Any>(bytes: ByteArray) : OpaqueBytes(bytes) {
     // It's OK to use lazy here because SerializedBytes is configured to use the ImmutableClassSerializer.
     val hash: SecureHash by lazy { bytes.sha256() }
 }
-
-// The more specific deserialize version results in the bytes being cached, which is faster.
-@JvmName("SerializedBytesWireTransaction")
-fun SerializedBytes<WireTransaction>.deserialize(serializationFactory: SerializationFactory = SERIALIZATION_FACTORY, context: SerializationContext = P2P_CONTEXT): WireTransaction = WireTransaction.deserialize(this, serializationFactory, context)

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -178,7 +178,7 @@ open class TransactionBuilder(
                 throw IllegalStateException("Missing signatures on the transaction for the public keys: ${missing.joinToString()}")
         }
         val wtx = toWireTransaction()
-        return SignedTransaction(wtx.serialize(), ArrayList(currentSigs))
+        return SignedTransaction(wtx, ArrayList(currentSigs))
     }
 
     /**

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
@@ -19,8 +19,7 @@ import kotlin.test.assertFailsWith
 
 class TransactionTests : TestDependencyInjectionBase() {
     private fun makeSigned(wtx: WireTransaction, vararg keys: KeyPair): SignedTransaction {
-        val bytes: SerializedBytes<WireTransaction> = wtx.serialized
-        return SignedTransaction(bytes, keys.map { it.sign(wtx.id.bytes) })
+        return SignedTransaction(wtx, keys.map { it.sign(wtx.id.bytes) })
     }
 
     @Test

--- a/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
@@ -6,6 +6,7 @@ import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash.Companion.zeroHash
 import net.corda.core.identity.Party
+import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.WireTransaction
 import net.corda.testing.*
@@ -110,7 +111,7 @@ class PartialMerkleTreeTest : TestDependencyInjectionBase() {
 
         val mt = testTx.buildFilteredTransaction(Predicate(::filtering))
         val leaves = mt.filteredLeaves
-        val d = WireTransaction.deserialize(testTx.serialized)
+        val d = testTx.serialize().deserialize()
         assertEquals(testTx.id, d.id)
         assertEquals(1, leaves.commands.size)
         assertEquals(1, leaves.outputs.size)

--- a/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
@@ -104,4 +104,18 @@ class TransactionSerializationTests : TestDependencyInjectionBase() {
         val stx = notaryServices.addSignature(ptx)
         assertEquals(TEST_TX_TIME, stx.tx.timeWindow?.midpoint)
     }
+
+    @Test
+    fun storeAndLoadWhenSigning() {
+        val ptx = megaCorpServices.signInitialTransaction(tx)
+        ptx.verifySignaturesExcept(notaryServices.key.public)
+
+        val stored = ptx.serialize()
+        val loaded = stored.deserialize()
+
+        assertEquals(loaded, ptx)
+
+        val final = notaryServices.addSignature(loaded)
+        final.verifyRequiredSignatures()
+    }
 }

--- a/finance/src/test/kotlin/net/corda/contracts/testing/Generators.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/testing/Generators.kt
@@ -84,7 +84,7 @@ class SignedTransactionGenerator : Generator<SignedTransaction>(SignedTransactio
     override fun generate(random: SourceOfRandomness, status: GenerationStatus): SignedTransaction {
         val wireTransaction = WiredTransactionGenerator().generate(random, status)
         return SignedTransaction(
-                txBits = wireTransaction.serialized,
+                wtx = wireTransaction,
                 sigs = listOf(NullSignature)
         )
     }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -605,7 +605,6 @@ class TwoPartyTradeFlowTests {
             vararg extraSigningNodes: AbstractNode): Map<SecureHash, SignedTransaction> {
 
         val signed = wtxToSign.map {
-            val bits = it.serialize()
             val id = it.id
             val sigs = mutableListOf<DigitalSignature.WithKey>()
             sigs.add(node.services.keyManagementService.sign(id.bytes, node.services.legalIdentityKey))
@@ -613,7 +612,7 @@ class TwoPartyTradeFlowTests {
             extraSigningNodes.forEach { currentNode ->
                 sigs.add(currentNode.services.keyManagementService.sign(id.bytes, currentNode.info.legalIdentity.owningKey))
             }
-            SignedTransaction(bits, sigs)
+            SignedTransaction(it, sigs)
         }
         return node.database.transaction {
             node.services.recordTransactions(signed)

--- a/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
@@ -214,6 +214,6 @@ class RequeryConfigurationTest : TestDependencyInjectionBase() {
                 type = TransactionType.General,
                 timeWindow = null
         )
-        return SignedTransaction(wtx.serialized, listOf(DigitalSignature.WithKey(NullPublicKey, ByteArray(1))))
+        return SignedTransaction(wtx, listOf(DigitalSignature.WithKey(NullPublicKey, ByteArray(1))))
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -152,6 +152,6 @@ class DBTransactionStorageTests : TestDependencyInjectionBase() {
                 type = TransactionType.General,
                 timeWindow = null
         )
-        return SignedTransaction(wtx.serialized, listOf(DigitalSignature.WithKey(NullPublicKey, ByteArray(1))))
+        return SignedTransaction(wtx, listOf(DigitalSignature.WithKey(NullPublicKey, ByteArray(1))))
     }
 }

--- a/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestDSL.kt
@@ -284,7 +284,7 @@ data class TestLedgerDSLInterpreter private constructor(
     override fun verifies(): EnforceVerifyOrFail {
         try {
             val usedInputs = mutableSetOf<StateRef>()
-            services.recordTransactions(transactionsUnverified.map { SignedTransaction(it.serialized, listOf(NullSignature)) })
+            services.recordTransactions(transactionsUnverified.map { SignedTransaction(it, listOf(NullSignature)) })
             for ((_, value) in transactionWithLocations) {
                 val wtx = value.transaction
                 val ltx = wtx.toLedgerTransaction(services)
@@ -296,7 +296,7 @@ data class TestLedgerDSLInterpreter private constructor(
                     throw DoubleSpentInputs(txIds)
                 }
                 usedInputs.addAll(wtx.inputs)
-                services.recordTransactions(SignedTransaction(wtx.serialized, listOf(NullSignature)))
+                services.recordTransactions(SignedTransaction(wtx, listOf(NullSignature)))
             }
             return EnforceVerifyOrFail.Token
         } catch (exception: TransactionVerificationException) {
@@ -330,8 +330,6 @@ data class TestLedgerDSLInterpreter private constructor(
  */
 fun signAll(transactionsToSign: List<WireTransaction>, extraKeys: List<KeyPair>) = transactionsToSign.map { wtx ->
     check(wtx.mustSign.isNotEmpty())
-    val bits = wtx.serialize()
-    require(bits == wtx.serialized)
     val signatures = ArrayList<DigitalSignature.WithKey>()
     val keyLookup = HashMap<PublicKey, KeyPair>()
 
@@ -342,7 +340,7 @@ fun signAll(transactionsToSign: List<WireTransaction>, extraKeys: List<KeyPair>)
         val key = keyLookup[it] ?: throw IllegalArgumentException("Missing required key for ${it.toStringShort()}")
         signatures += key.sign(wtx.id)
     }
-    SignedTransaction(bits, signatures)
+    SignedTransaction(wtx, signatures)
 }
 
 /**


### PR DESCRIPTION
…erialized form.

Since we now calculate the transaction id as the Merkle root hash instead of the hash of the serialized bytes of the whole transaction, the txBits property serves no purpose.

EDIT: txBits are actually needed so we can move transactions around without a large serialization overhead, so keeping it and just changing the serialization caching behaviour