### PR TITLE
Misc. cleanup

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -1,6 +1,7 @@
 package net.corda.core.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.abbreviate
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
@@ -163,7 +164,7 @@ abstract class FlowLogic<out T> {
         }
         logger.debug { "Calling subflow: $subLogic" }
         val result = subLogic.call()
-        logger.debug { "Subflow finished with result $result" }
+        logger.debug { "Subflow finished with result ${result.toString().abbreviate(300)}" }
         // It's easy to forget this when writing flows so we just step it to the DONE state when it completes.
         subLogic.progressTracker?.currentStep = ProgressTracker.DONE
         return result

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
@@ -43,11 +43,13 @@ class BankOfCordaWebApi(val rpc: CordaRPCOps) {
     fun issueAssetRequest(params: IssueRequestParams): Response {
         // Resolve parties via RPC
         val issueToParty = rpc.partyFromX500Name(params.issueToPartyName)
-                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issueToPartyName} in Network Map Service").build()
+                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issueToPartyName} in identity service").build()
         val issuerBankParty = rpc.partyFromX500Name(params.issuerBankName)
-                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issuerBankName} in Network Map Service").build()
+                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issuerBankName} in identity service").build()
         val notaryParty = rpc.partyFromX500Name(params.notaryName)
-                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.notaryName} in Network Map Service").build()
+                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.notaryName} in identity service").build()
+        val notaryNode = rpc.nodeIdentityFromParty(notaryParty)
+                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${notaryParty} in network map service").build()
 
         val amount = Amount(params.amount, currency(params.currency))
         val issuerToPartyRef = OpaqueBytes.of(params.issueToPartyRefAsString.toByte())
@@ -56,7 +58,7 @@ class BankOfCordaWebApi(val rpc: CordaRPCOps) {
         // invoke client side of Issuer Flow: IssuanceRequester
         // The line below blocks and waits for the future to resolve.
         return try {
-            rpc.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty, notaryParty, anonymous).returnValue.getOrThrow()
+            rpc.startFlow(::IssuanceRequester, amount, issueToParty, issuerToPartyRef, issuerBankParty, notaryNode.notaryIdentity, anonymous).returnValue.getOrThrow()
             logger.info("Issue request completed successfully: $params")
             Response.status(Response.Status.CREATED).build()
         } catch (e: Exception) {


### PR DESCRIPTION
Remove logging of the entire return from a fiber, which can now include a certificate (several hundred lines of text).

Correct identity used in the web API test for Bank of Corda.
