### PR TITLE
Add support for serialising arrays of unboxed primitives

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializationInput.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializationInput.kt
@@ -133,7 +133,8 @@ class DeserializationInput(internal val serializerFactory: SerializerFactory = S
             // Look up serializer in factory by descriptor
             val serializer = serializerFactory.get(obj.descriptor, schema)
             if (serializer.type != type && !serializer.type.isSubClassOf(type))
-                throw NotSerializableException("Described type with descriptor ${obj.descriptor} was expected to be of type $type")
+                throw NotSerializableException("Described type with descriptor ${obj.descriptor} was " +
+                        "expected to be of type $type but was ${serializer.type}")
             return serializer.readObject(obj.described, schema, this)
         } else if (obj is Binary) {
             return obj.array

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializedGenericArrayType.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/DeserializedGenericArrayType.kt
@@ -13,6 +13,6 @@ class DeserializedGenericArrayType(private val componentType: Type) : GenericArr
     override fun toString(): String = typeName
     override fun hashCode(): Int = Objects.hashCode(componentType)
     override fun equals(other: Any?): Boolean {
-        return other is GenericArrayType && componentType.equals(other.genericComponentType)
+        return other is GenericArrayType && (componentType == other.genericComponentType)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -203,8 +203,20 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
             } else {
                 findCustomSerializer(clazz, declaredType) ?: run {
                     if (type.isArray()) {
-                        whitelisted(type.componentType())
-                        ArraySerializer(type, this)
+                        println ("Array: ${type.componentType()}, ${type.componentType()::class.java}")
+                        println (clazz)
+                        println (declaredType)
+                        println ("${clazz.componentType.isPrimitive()}")
+                        if (clazz.componentType.isPrimitive) {
+                            println ("primitive array")
+                            whitelisted(type.componentType())
+                            PrimArraySerializer.make(type, this)
+                        }
+                        else {
+                            println ("non primitive array")
+                            whitelisted(type.componentType())
+                            ArraySerializer.make (type, this)
+                        }
                     } else if (clazz.kotlin.objectInstance != null) {
                         whitelisted(clazz)
                         SingletonSerializer(clazz, clazz.kotlin.objectInstance!!, this)
@@ -292,14 +304,19 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
 
         private val namesOfPrimitiveTypes: Map<String, Class<*>> = primitiveTypeNames.map { it.value to it.key }.toMap()
 
-        fun nameForType(type: Type): String {
-            if (type is Class<*>) {
-                return primitiveTypeName(type) ?: if (type.isArray) "${nameForType(type.componentType)}[]" else type.name
-            } else if (type is ParameterizedType) {
-                return "${nameForType(type.rawType)}<${type.actualTypeArguments.joinToString { nameForType(it) }}>"
-            } else if (type is GenericArrayType) {
-                return "${nameForType(type.genericComponentType)}[]"
-            } else throw NotSerializableException("Unable to render type $type to a string.")
+        fun nameForType(type: Type) : String {
+            println ("nameForType $type - ${(type as Class<*>).isArray} - ${type?.componentType?.isPrimitive}")
+            val result = when (type) {
+                is Class<*> -> primitiveTypeName(type) ?: if (type.isArray) {
+                    if (type.componentType.isPrimitive) "${nameForType(type.componentType)}[p]" else "${nameForType(type.componentType)}[]"
+                } else type.name
+                is ParameterizedType -> "${nameForType(type.rawType)}<${type.actualTypeArguments.joinToString { nameForType(it) }}>"
+                is GenericArrayType -> "${nameForType(type.genericComponentType)}[]"
+                else -> throw NotSerializableException("Unable to render type $type to a string.")
+            }
+
+            println ("nameForType = $result")
+            return result
         }
 
         private fun typeForName(name: String): Type {
@@ -311,6 +328,18 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
                     java.lang.reflect.Array.newInstance(elementType, 0).javaClass
                 } else {
                     throw NotSerializableException("Not able to deserialize array type: $name")
+                }
+            } else if (name.endsWith("[p]")) {
+                when(name) {
+                    "int[p]" -> IntArray::class.java
+                    "char[p]" -> CharArray::class.java
+                    "boolean[p]" -> BooleanArray::class.java
+                    "float[p]" -> FloatArray::class.java
+                    "double[p]" -> DoubleArray::class.java
+                    "short[p]" -> ShortArray::class.java
+                    "byte[p]" -> ByteArray::class.java
+                    "long[p]" -> LongArray::class.java
+                    else -> throw NotSerializableException("Not able to deserialize array type: $name")
                 }
             } else {
                 DeserializedParameterizedType.make(name)

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/SerializerFactory.kt
@@ -315,6 +315,9 @@ class SerializerFactory(val whitelist: ClassWhitelist = AllWhitelist) {
                     throw NotSerializableException("Not able to deserialize array type: $name")
                 }
             } else if (name.endsWith("[p]")) {
+                // There is no need to handle the ByteArray case as that type is coercible automatically
+                // to the binary type and is thus handled by the main steriliser and doesn't need a
+                // special case for a primitive array of bytes
                 when(name) {
                     "int[p]" -> IntArray::class.java
                     "char[p]" -> CharArray::class.java

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -53,7 +53,6 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testArrayOfInt() {
         class IA(val ia: Array<Int>)
-
         val ia = IA(arrayOf(1, 2, 3))
 
         assertEquals("class [Ljava.lang.Integer;", ia.ia::class.java.toString())
@@ -182,52 +181,177 @@ class DeserializeSimpleTypesTests {
 
     @Test
     fun testArrayOfByte() {
-        class C(val c: Array<Byte>)
+        class C (val c: Array<Byte>)
+        val c = C(arrayOf (0b0001, 0b0101, 0b1111))
+
+        assertEquals("class [Ljava.lang.Byte;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "byte[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testByteArray() {
         class C(val c: ByteArray)
+        val c = C(ByteArray(3))
+        c.c[0] = 0b0001; c.c[1] = 0b0101; c.c[2] = 0b1111
+
+        assertEquals("class [B", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "binary")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testArrayOfShort() {
         class C(val c: Array<Short>)
+        val c = C(arrayOf (1, 2, 3))
+
+        assertEquals("class [Ljava.lang.Short;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "short[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testShortArray() {
         class C(val c: ShortArray)
+        val c = C(ShortArray(3))
+        c.c[0] = 1; c.c[1] = 2; c.c[2] = 5
+
+        assertEquals("class [S", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "short[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testArrayOfLong() {
         class C(val c: Array<Long>)
+        val c = C(arrayOf (2147483650, -2147483800, 10))
+
+        assertEquals("class [Ljava.lang.Long;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "long[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testLongArray() {
         class C(val c: LongArray)
+        val c = C(LongArray(3))
+        c.c[0] = 2147483650; c.c[1] = -2147483800; c.c[2] = 10
+
+        assertEquals("class [J", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "long[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testArrayOfFloat() {
         class C(val c: Array<Float>)
+        val c = C(arrayOf(10F, 100.023232F, -1455.433400F))
+
+        assertEquals("class [Ljava.lang.Float;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "float[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testFloatArray() {
         class C(val c: FloatArray)
+        val c = C(FloatArray(3))
+        c.c[0] = 10F; c.c[1] = 100.023232F; c.c[2] = -1455.433400F
+
+        assertEquals("class [F", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "float[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testArrayOfDouble() {
         class C(val c: Array<Double>)
+        val c = C(arrayOf(10.0, 100.2, -1455.2))
+
+        assertEquals("class [Ljava.lang.Double;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "double[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 
     @Test
     fun testDoubleArray() {
         class C(val c: DoubleArray)
+        val c = C(DoubleArray(3))
+        c.c[0] = 10.0; c.c[1] = 100.2; c.c[2] = -1455.2
+
+        assertEquals("class [D", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "double[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
     }
 }
 

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -1,8 +1,8 @@
 package net.corda.core.serialization.amqp
 
 import org.junit.Test
-import java.io.ByteArrayOutputStream
 import kotlin.test.assertEquals
+import org.apache.qpid.proton.codec.Data
 
 /**
  * Prior to certain fixes being made within the [PropertySerializaer] classes these simple
@@ -11,6 +11,25 @@ import kotlin.test.assertEquals
  * as such
  */
 class DeserializeSimpleTypesTests {
+    class TestSerializationOutput(
+            private val verbose: Boolean,
+            serializerFactory: SerializerFactory = SerializerFactory()) : SerializationOutput(serializerFactory) {
+
+        override fun writeSchema(schema: Schema, data: Data) {
+            if(verbose) println(schema)
+            super.writeSchema(schema, data)
+        }
+    }
+
+    companion object {
+        /**
+         * If you want to see the schema encoded into the envelope after serialisation change this to true
+         */
+        private const val VERBOSE = false
+    }
+
+    val sf = SerializerFactory()
+
     @Test
     fun testChar() {
         data class C(val c: Char)
@@ -29,6 +48,186 @@ class DeserializeSimpleTypesTests {
         val deserializedC = DeserializationInput().deserialize(serialisedC)
 
         assertEquals(c.c, deserializedC.c)
+    }
+
+    @Test
+    fun testArrayOfInt() {
+        class IA(val ia: Array<Int>)
+
+        val ia = IA(arrayOf(1, 2, 3))
+
+        assertEquals("class [Ljava.lang.Integer;", ia.ia::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(ia.ia::class.java), "int[]")
+
+        val serialisedIA = TestSerializationOutput(VERBOSE, sf).serialize(ia)
+        val deserializedIA = DeserializationInput(sf).deserialize(serialisedIA)
+
+        assertEquals(ia.ia.size, deserializedIA.ia.size)
+        assertEquals(ia.ia[0], deserializedIA.ia[0])
+        assertEquals(ia.ia[1], deserializedIA.ia[1])
+        assertEquals(ia.ia[2], deserializedIA.ia[2])
+    }
+
+    @Test
+    fun testArrayOfInteger() {
+        class IA (val ia: Array<Integer>)
+        val ia = IA(arrayOf(Integer(1), Integer(2), Integer(3)))
+
+        assertEquals("class [Ljava.lang.Integer;", ia.ia::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(ia.ia::class.java), "int[]")
+
+        val serialisedIA = TestSerializationOutput(VERBOSE, sf).serialize(ia)
+        val deserializedIA = DeserializationInput(sf).deserialize(serialisedIA)
+
+        assertEquals(ia.ia.size, deserializedIA.ia.size)
+        assertEquals(ia.ia[0], deserializedIA.ia[0])
+        assertEquals(ia.ia[1], deserializedIA.ia[1])
+        assertEquals(ia.ia[2], deserializedIA.ia[2])
+    }
+
+    /**
+     * Test unboxed primitives
+     */
+    @Test
+    fun testIntArray() {
+        class IA (val ia: IntArray)
+        val v = IntArray(3)
+        v[0] = 1; v[1] = 2; v[2] = 3
+        val ia = IA(v)
+
+        assertEquals("class [I", ia.ia::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(ia.ia::class.java), "int[p]")
+
+        val serialisedIA = TestSerializationOutput(VERBOSE, sf).serialize(ia)
+        val deserializedIA = DeserializationInput(sf).deserialize(serialisedIA)
+
+        assertEquals(ia.ia.size, deserializedIA.ia.size)
+        assertEquals(ia.ia[0], deserializedIA.ia[0])
+        assertEquals(ia.ia[1], deserializedIA.ia[1])
+        assertEquals(ia.ia[2], deserializedIA.ia[2])
+    }
+
+    @Test
+    fun testArrayOfChars() {
+        class C (val c: Array<Char>)
+        val c = C(arrayOf ('a', 'b', 'c'))
+
+        assertEquals("class [Ljava.lang.Character;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "char[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+    }
+
+    @Test
+    fun testCharArray() {
+        class C(val c: CharArray)
+        val v = CharArray(3)
+        v[0] = 'a'; v[1] = 'b'; v[2] = 'c'
+        val c = C(v)
+
+        assertEquals("class [C", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "char[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+    }
+
+    @Test
+    fun testArrayOfBoolean() {
+        class C (val c: Array<Boolean>)
+        val c = C(arrayOf (true, false, false, true))
+
+        assertEquals("class [Ljava.lang.Boolean;", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "boolean[]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+        assertEquals(c.c[3], deserializedC.c[3])
+    }
+
+    @Test
+    fun testBooleanArray() {
+        class C(val c: BooleanArray)
+        val c = C(BooleanArray(4))
+        c.c[0] = true; c.c[1] = false; c.c[2] = false; c.c[3] = true
+
+        assertEquals("class [Z", c.c::class.java.toString())
+        assertEquals(SerializerFactory.nameForType(c.c::class.java), "boolean[p]")
+
+        val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC.c.size)
+        assertEquals(c.c[0], deserializedC.c[0])
+        assertEquals(c.c[1], deserializedC.c[1])
+        assertEquals(c.c[2], deserializedC.c[2])
+        assertEquals(c.c[3], deserializedC.c[3])
+    }
+
+    @Test
+    fun testArrayOfByte() {
+        class C(val c: Array<Byte>)
+    }
+
+    @Test
+    fun testByteArray() {
+        class C(val c: ByteArray)
+    }
+
+    @Test
+    fun testArrayOfShort() {
+        class C(val c: Array<Short>)
+    }
+
+    @Test
+    fun testShortArray() {
+        class C(val c: ShortArray)
+    }
+
+    @Test
+    fun testArrayOfLong() {
+        class C(val c: Array<Long>)
+    }
+
+    @Test
+    fun testLongArray() {
+        class C(val c: LongArray)
+    }
+
+    @Test
+    fun testArrayOfFloat() {
+        class C(val c: Array<Float>)
+    }
+
+    @Test
+    fun testFloatArray() {
+        class C(val c: FloatArray)
+    }
+
+    @Test
+    fun testArrayOfDouble() {
+        class C(val c: Array<Double>)
+    }
+
+    @Test
+    fun testDoubleArray() {
+        class C(val c: DoubleArray)
     }
 }
 

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -4,19 +4,17 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import org.apache.qpid.proton.codec.Data
 
-/**
- * Prior to certain fixes being made within the [PropertySerializaer] classes these simple
- * deserialization operations would've blown up with type mismatch errors where the deserlized
- * char property of the class would've been treated as an Integer and given to the constructor
- * as such
- */
+// Prior to certain fixes being made within the [PropertySerializaer] classes these simple
+// deserialization operations would've blown up with type mismatch errors where the deserlized
+// char property of the class would've been treated as an Integer and given to the constructor
+// as such
 class DeserializeSimpleTypesTests {
     class TestSerializationOutput(
             private val verbose: Boolean,
             serializerFactory: SerializerFactory = SerializerFactory()) : SerializationOutput(serializerFactory) {
 
         override fun writeSchema(schema: Schema, data: Data) {
-            if(verbose) println(schema)
+            if (verbose) println(schema)
             super.writeSchema(schema, data)
         }
     }
@@ -33,6 +31,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testChar() {
         data class C(val c: Char)
+
         val c = C('c')
         val serialisedC = SerializationOutput().serialize(c)
         val deserializedC = DeserializationInput().deserialize(serialisedC)
@@ -43,7 +42,8 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testCharacter() {
         data class C(val c: Character)
-        val c = C(Character ('c'))
+
+        val c = C(Character('c'))
         val serialisedC = SerializationOutput().serialize(c)
         val deserializedC = DeserializationInput().deserialize(serialisedC)
 
@@ -53,6 +53,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testArrayOfInt() {
         class IA(val ia: Array<Int>)
+
         val ia = IA(arrayOf(1, 2, 3))
 
         assertEquals("class [Ljava.lang.Integer;", ia.ia::class.java.toString())
@@ -69,7 +70,8 @@ class DeserializeSimpleTypesTests {
 
     @Test
     fun testArrayOfInteger() {
-        class IA (val ia: Array<Integer>)
+        class IA(val ia: Array<Integer>)
+
         val ia = IA(arrayOf(Integer(1), Integer(2), Integer(3)))
 
         assertEquals("class [Ljava.lang.Integer;", ia.ia::class.java.toString())
@@ -89,7 +91,8 @@ class DeserializeSimpleTypesTests {
      */
     @Test
     fun testIntArray() {
-        class IA (val ia: IntArray)
+        class IA(val ia: IntArray)
+
         val v = IntArray(3)
         v[0] = 1; v[1] = 2; v[2] = 3
         val ia = IA(v)
@@ -108,8 +111,9 @@ class DeserializeSimpleTypesTests {
 
     @Test
     fun testArrayOfChars() {
-        class C (val c: Array<Char>)
-        val c = C(arrayOf ('a', 'b', 'c'))
+        class C(val c: Array<Char>)
+
+        val c = C(arrayOf('a', 'b', 'c'))
 
         assertEquals("class [Ljava.lang.Character;", c.c::class.java.toString())
         assertEquals(SerializerFactory.nameForType(c.c::class.java), "char[]")
@@ -126,6 +130,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testCharArray() {
         class C(val c: CharArray)
+
         val v = CharArray(3)
         v[0] = 'a'; v[1] = 'b'; v[2] = 'c'
         val c = C(v)
@@ -144,8 +149,9 @@ class DeserializeSimpleTypesTests {
 
     @Test
     fun testArrayOfBoolean() {
-        class C (val c: Array<Boolean>)
-        val c = C(arrayOf (true, false, false, true))
+        class C(val c: Array<Boolean>)
+
+        val c = C(arrayOf(true, false, false, true))
 
         assertEquals("class [Ljava.lang.Boolean;", c.c::class.java.toString())
         assertEquals(SerializerFactory.nameForType(c.c::class.java), "boolean[]")
@@ -163,6 +169,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testBooleanArray() {
         class C(val c: BooleanArray)
+
         val c = C(BooleanArray(4))
         c.c[0] = true; c.c[1] = false; c.c[2] = false; c.c[3] = true
 
@@ -181,8 +188,9 @@ class DeserializeSimpleTypesTests {
 
     @Test
     fun testArrayOfByte() {
-        class C (val c: Array<Byte>)
-        val c = C(arrayOf (0b0001, 0b0101, 0b1111))
+        class C(val c: Array<Byte>)
+
+        val c = C(arrayOf(0b0001, 0b0101, 0b1111))
 
         assertEquals("class [Ljava.lang.Byte;", c.c::class.java.toString())
         assertEquals(SerializerFactory.nameForType(c.c::class.java), "byte[]")
@@ -199,6 +207,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testByteArray() {
         class C(val c: ByteArray)
+
         val c = C(ByteArray(3))
         c.c[0] = 0b0001; c.c[1] = 0b0101; c.c[2] = 0b1111
 
@@ -217,7 +226,8 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testArrayOfShort() {
         class C(val c: Array<Short>)
-        val c = C(arrayOf (1, 2, 3))
+
+        val c = C(arrayOf(1, 2, 3))
 
         assertEquals("class [Ljava.lang.Short;", c.c::class.java.toString())
         assertEquals(SerializerFactory.nameForType(c.c::class.java), "short[]")
@@ -234,6 +244,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testShortArray() {
         class C(val c: ShortArray)
+
         val c = C(ShortArray(3))
         c.c[0] = 1; c.c[1] = 2; c.c[2] = 5
 
@@ -252,7 +263,8 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testArrayOfLong() {
         class C(val c: Array<Long>)
-        val c = C(arrayOf (2147483650, -2147483800, 10))
+
+        val c = C(arrayOf(2147483650, -2147483800, 10))
 
         assertEquals("class [Ljava.lang.Long;", c.c::class.java.toString())
         assertEquals(SerializerFactory.nameForType(c.c::class.java), "long[]")
@@ -269,6 +281,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testLongArray() {
         class C(val c: LongArray)
+
         val c = C(LongArray(3))
         c.c[0] = 2147483650; c.c[1] = -2147483800; c.c[2] = 10
 
@@ -287,6 +300,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testArrayOfFloat() {
         class C(val c: Array<Float>)
+
         val c = C(arrayOf(10F, 100.023232F, -1455.433400F))
 
         assertEquals("class [Ljava.lang.Float;", c.c::class.java.toString())
@@ -304,6 +318,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testFloatArray() {
         class C(val c: FloatArray)
+
         val c = C(FloatArray(3))
         c.c[0] = 10F; c.c[1] = 100.023232F; c.c[2] = -1455.433400F
 
@@ -322,6 +337,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testArrayOfDouble() {
         class C(val c: Array<Double>)
+
         val c = C(arrayOf(10.0, 100.2, -1455.2))
 
         assertEquals("class [Ljava.lang.Double;", c.c::class.java.toString())
@@ -339,6 +355,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun testDoubleArray() {
         class C(val c: DoubleArray)
+
         val c = C(DoubleArray(3))
         c.c[0] = 10.0; c.c[1] = 100.2; c.c[2] = -1455.2
 


### PR DESCRIPTION
Arrays of objects are represented in the schema as <type> followed by [], so int[] for example. The problem here is that there is no mapping between that type and weather it is boxed or unboxed, so on deserialisation it will fail since the current assumption is that all types are boxed

To indicate an array of unboxed type we add the syntax <type>[p]