### PR TITLE
Serialising null chars was broken

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/PropertySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/PropertySerializer.kt
@@ -117,12 +117,12 @@ sealed class PropertySerializer(val name: String, val readMethod: Method, val re
         override fun writeClassInfo(output: SerializationOutput) {}
 
         override fun readProperty(obj: Any?, schema: Schema, input: DeserializationInput): Any? {
-            return if(obj == null) null else (obj as Int).toChar()
+            return if(obj == null) null else (obj as Short).toChar()
         }
 
         override fun writeProperty(obj: Any?, data: Data, output: SerializationOutput) {
             val input = readMethod.invoke(obj)
-            if (input != null) data.putChar((input as Char).toInt()) else data.putNull()
+            if (input != null) data.putShort((input as Char).toShort()) else data.putNull()
         }
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/PropertySerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/PropertySerializer.kt
@@ -113,13 +113,16 @@ sealed class PropertySerializer(val name: String, val readMethod: Method, val re
      * casting back to a char otherwise it's treated as an Integer and a TypeMismatch occurs
      */
     class AMQPCharPropertySerializer(name: String, readMethod: Method) :
-            PropertySerializer(name, readMethod, Char::class.java) {
+            PropertySerializer(name, readMethod, Character::class.java) {
         override fun writeClassInfo(output: SerializationOutput) {}
 
-        override fun readProperty(obj: Any?, schema: Schema, input: DeserializationInput) = (obj as Int).toChar()
+        override fun readProperty(obj: Any?, schema: Schema, input: DeserializationInput): Any? {
+            return if(obj == null) null else (obj as Int).toChar()
+        }
 
         override fun writeProperty(obj: Any?, data: Data, output: SerializationOutput) {
-            data.putChar((readMethod.invoke(obj) as Char).toInt())
+            val input = readMethod.invoke(obj)
+            if (input != null) data.putChar((input as Char).toInt()) else data.putNull()
         }
     }
 }

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -32,11 +32,24 @@ class DeserializeSimpleTypesTests {
     fun testChar() {
         data class C(val c: Char)
 
-        val c = C('c')
-        val serialisedC = SerializationOutput().serialize(c)
-        val deserializedC = DeserializationInput().deserialize(serialisedC)
+        var deserializedC = DeserializationInput().deserialize(SerializationOutput().serialize(C('c')))
+        assertEquals('c', deserializedC.c)
 
-        assertEquals(c.c, deserializedC.c)
+        // CYRILLIC CAPITAL LETTER YU (U+042E)
+        deserializedC = DeserializationInput().deserialize(SerializationOutput().serialize(C('Ю')))
+        assertEquals('Ю', deserializedC.c)
+
+        // 	ARABIC LETTER FEH WITH DOT BELOW (U+06A3)
+        deserializedC = DeserializationInput().deserialize(SerializationOutput().serialize(C('ڣ')))
+        assertEquals('ڣ', deserializedC.c)
+
+        // 	ARABIC LETTER DAD WITH DOT BELOW (U+06FB)
+        deserializedC = DeserializationInput().deserialize(SerializationOutput().serialize(C('ۻ')))
+        assertEquals('ۻ', deserializedC.c)
+
+        // BENGALI LETTER AA (U+0986)
+        deserializedC = DeserializationInput().deserialize(SerializationOutput().serialize(C('আ')))
+        assertEquals('আ', deserializedC.c)
     }
 
     @Test
@@ -150,12 +163,23 @@ class DeserializeSimpleTypesTests {
         assertEquals(SerializerFactory.nameForType(c.c::class.java), "char[p]")
 
         val serialisedC = TestSerializationOutput(VERBOSE, sf).serialize(c)
-        val deserializedC = DeserializationInput(sf).deserialize(serialisedC)
+        var deserializedC = DeserializationInput(sf).deserialize(serialisedC)
 
         assertEquals(c.c.size, deserializedC.c.size)
         assertEquals(c.c[0], deserializedC.c[0])
         assertEquals(c.c[1], deserializedC.c[1])
         assertEquals(c.c[2], deserializedC.c[2])
+
+        // second test with more interesting characters
+        v[0] = 'ই'; v[1] = ' '; v[2] = 'ਔ'
+        val c2 = C(v)
+
+        deserializedC = DeserializationInput(sf).deserialize(TestSerializationOutput(VERBOSE, sf).serialize(c2))
+
+        assertEquals(c2.c.size, deserializedC.c.size)
+        assertEquals(c2.c[0], deserializedC.c[0])
+        assertEquals(c2.c[1], deserializedC.c[1])
+        assertEquals(c2.c[2], deserializedC.c[2])
     }
 
     @Test

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -51,6 +51,17 @@ class DeserializeSimpleTypesTests {
     }
 
     @Test
+    fun testNullCharacter() {
+        data class C(val c: Char?)
+
+        val c = C(null)
+        val serialisedC = SerializationOutput().serialize(c)
+        val deserializedC = DeserializationInput().deserialize(serialisedC)
+
+        assertEquals(c.c, deserializedC.c)
+    }
+
+    @Test
     fun testArrayOfInt() {
         class IA(val ia: Array<Int>)
 


### PR DESCRIPTION
The recent changes that were put in to allow chars to be serialised at
all failed to take into account nullability and thus if a char was null
and that object was first serlialised then desierliased it would throw
a NPE