### PR TITLE
Don't blindly add SimpleFieldAccess as interface to carpented classes

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/carpenter/ClassCarpenter.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/carpenter/ClassCarpenter.kt
@@ -306,9 +306,9 @@ class ClassCarpenter {
                             + "with 'get': ${itf.name}.${it.name}")
                 }
 
-                // if we're trying to carpent a class that prior to serialisation / deserialisation
+                // If we're trying to carpent a class that prior to serialisation / deserialisation
                 // was made by a carpenter then we can ignore this (it will implement a plain get
-                // method from SimpleFieldAccess)
+                // method from SimpleFieldAccess).
                 if (fieldNameFromItf.isEmpty() && SimpleFieldAccess::class.java in schema.interfaces) return@forEach
 
                 if ((schema is ClassSchema) and (fieldNameFromItf !in allFields))


### PR DESCRIPTION
This fix really only applies to the testing case where, to test the
carpenter as it integrates with the deserialzer we need classes not
found on the class path. To do this they can be created by a second
class carpenter

However, the original carpenter *always* added SimpleFieldAccess as an
interface to the class it would be creating. Under normal circumstances
that's fine as that interface wouldn't be in the list of interfaces
given to the carpenter for the class it's being asked to created.
However, if as described above the carpenter schema was synthesised from
a class that was carpented it will.

If this happens we get an error as understandably you can't have a
duplicate interface.

Fix is to simply check weather the list of interfaces the schema
describes and only add SimpleFieldAccess if it isn't on it