### PR TITLE
Minor: Add a test to ensure "identical" issue transactions have different ids

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -447,6 +447,7 @@ fun JarInputStream.extractFile(path: String, outputTo: OutputStream) {
  */
 @CordaSerializable
 class PrivacySalt(bytes: ByteArray) : OpaqueBytes(bytes) {
+    /** Constructs a salt with a randomly-generated 32 byte value. */
     constructor() : this(secureRandomBytes(32))
 
     init {

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import java.security.KeyPair
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 
 class TransactionTests : TestDependencyInjectionBase() {
     private fun makeSigned(wtx: WireTransaction, vararg keys: KeyPair, notarySig: Boolean = true): SignedTransaction {
@@ -151,5 +152,23 @@ class TransactionTests : TestDependencyInjectionBase() {
         )
 
         assertFailsWith<TransactionVerificationException.NotaryChangeInWrongTransactionType> { buildTransaction() }
+    }
+
+    @Test
+    fun `transactions with identical outputs must have different ids`() {
+        val outputState = TransactionState(DummyContract.SingleOwnerState(0, ALICE), DUMMY_NOTARY)
+        fun buildTransaction() = WireTransaction(
+                inputs = emptyList(),
+                attachments = emptyList(),
+                outputs = listOf(outputState),
+                commands = listOf(dummyCommand(DUMMY_KEY_1.public, DUMMY_KEY_2.public)),
+                notary = null,
+                timeWindow = null
+        )
+
+        val issueTx1 = buildTransaction()
+        val issueTx2 = buildTransaction()
+
+        assertNotEquals(issueTx1.id, issueTx2.id)
     }
 }

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionTests.kt
@@ -155,7 +155,7 @@ class TransactionTests : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `transactions with identical outputs must have different ids`() {
+    fun `transactions with identical contents must have different ids`() {
         val outputState = TransactionState(DummyContract.SingleOwnerState(0, ALICE), DUMMY_NOTARY)
         fun buildTransaction() = WireTransaction(
                 inputs = emptyList(),
@@ -163,7 +163,8 @@ class TransactionTests : TestDependencyInjectionBase() {
                 outputs = listOf(outputState),
                 commands = listOf(dummyCommand(DUMMY_KEY_1.public, DUMMY_KEY_2.public)),
                 notary = null,
-                timeWindow = null
+                timeWindow = null,
+                privacySalt = PrivacySalt() // Randomly-generated – used for calculating the id
         )
 
         val issueTx1 = buildTransaction()

--- a/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
@@ -127,8 +127,11 @@ class PartialMerkleTreeTest : TestDependencyInjectionBase() {
 
     @Test
     fun `same transactions with different notaries have different ids`() {
-        val wtx1 = makeSimpleCashWtx(DUMMY_NOTARY)
-        val wtx2 = makeSimpleCashWtx(MEGA_CORP)
+        // We even use the same privacySalt, and thus the only difference between the two transactions is the notary party.
+        val privacySalt = PrivacySalt()
+        val wtx1 = makeSimpleCashWtx(DUMMY_NOTARY, privacySalt)
+        val wtx2 = makeSimpleCashWtx(MEGA_CORP, privacySalt)
+        assertEquals(wtx1.privacySalt, wtx2.privacySalt)
         assertNotEquals(wtx1.id, wtx2.id)
     }
 
@@ -235,14 +238,20 @@ class PartialMerkleTreeTest : TestDependencyInjectionBase() {
         hm1.serialize()
     }
 
-    private fun makeSimpleCashWtx(notary: Party, timeWindow: TimeWindow? = null, attachments: List<SecureHash> = emptyList()): WireTransaction {
+    private fun makeSimpleCashWtx(
+            notary: Party,
+            privacySalt: PrivacySalt = PrivacySalt(),
+            timeWindow: TimeWindow? = null,
+            attachments: List<SecureHash> = emptyList()
+    ): WireTransaction {
         return WireTransaction(
                 inputs = testTx.inputs,
                 attachments = attachments,
                 outputs = testTx.outputs,
                 commands = testTx.commands,
                 notary = notary,
-                timeWindow = timeWindow
+                timeWindow = timeWindow,
+                privacySalt = privacySalt
         )
     }
 }


### PR DESCRIPTION
Related to privacy salt work