### PR TITLE
Remove deprecated signing functions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -137,10 +137,7 @@ interface ServiceHub : ServicesForResolution {
 
     // Helper method to construct an initial partially signed transaction from a [TransactionBuilder].
     private fun signInitialTransaction(builder: TransactionBuilder, publicKey: PublicKey, signatureMetadata: SignatureMetadata): SignedTransaction {
-        val signableData = SignableData(builder.toWireTransaction().id, signatureMetadata)
-        val sig = keyManagementService.sign(signableData, publicKey)
-        builder.addSignatureUnchecked(sig)
-        return builder.toSignedTransaction(false)
+        return builder.toSignedTransaction(keyManagementService, publicKey, signatureMetadata)
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -1,15 +1,16 @@
 package net.corda.core.transactions
 
 import net.corda.core.contracts.*
-import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.*
 import net.corda.core.identity.Party
+import net.corda.core.internal.VisibleForTesting
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.getOrThrow
+import java.security.KeyPair
 import java.security.PublicKey
 import java.security.SignatureException
 import java.util.*
@@ -72,6 +73,12 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
         if (this.tx.notary?.owningKey in keys)
             descriptions.add("notary")
         return descriptions
+    }
+
+    @VisibleForTesting
+    fun withAdditionalSignature(keyPair: KeyPair, signatureMetadata: SignatureMetadata): SignedTransaction {
+        val signableData = SignableData(tx.id, signatureMetadata)
+        return withAdditionalSignature(keyPair.sign(signableData))
     }
 
     /** Returns the same transaction but with an additional (unchecked) signature. */

--- a/docs/source/api-service-hub.rst
+++ b/docs/source/api-service-hub.rst
@@ -24,7 +24,7 @@ Additional, ``ServiceHub`` exposes the following properties:
 
 * ``ServiceHub.loadState`` and ``ServiceHub.toStateAndRef`` to resolve a ``StateRef`` into a ``TransactionState`` or
   a ``StateAndRef``
-* ``ServiceHub.signInitialTransaction`` to sign a ``TransactionBuilder`` and convert it into a ``SignedTransaction``
+* ``ServiceHub.toSignedTransaction`` to sign a ``TransactionBuilder`` and convert it into a ``SignedTransaction``
 * ``ServiceHub.createSignature`` and ``ServiceHub.addSignature`` to create and add signatures to a ``SignedTransaction``
 
 Finally, ``ServiceHub`` exposes the node's legal identity key (via ``ServiceHub.legalIdentityKey``) and its notary

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -276,7 +276,7 @@ Milestone 12
        with the ``PrivateKey`` kept internally to the service.
      * Flows which used to acquire a node's ``KeyPair``, typically via ``ServiceHub.legalIdentityKey``,
        should instead use the helper methods on ``ServiceHub``. In particular to freeze a ``TransactionBuilder`` and
-       generate an initial partially signed ``SignedTransaction`` the flow should use ``ServiceHub.signInitialTransaction``.
+       generate an initial partially signed ``SignedTransaction`` the flow should use ``ServiceHub.toSignedTransaction``.
        Flows generating additional party signatures should use ``ServiceHub.createSignature``. Each of these methods is
        provided with two signatures. One version that signs with the default node key, the other which allows key selection
        by passing in the ``PublicKey`` partner of the desired signing key.

--- a/docs/source/hello-world-flow.rst
+++ b/docs/source/hello-world-flow.rst
@@ -79,7 +79,7 @@ the following:
                 txBuilder.verify(serviceHub)
 
                 // Signing the transaction.
-                val signedTx = serviceHub.signInitialTransaction(txBuilder)
+                val signedTx = serviceHub.toSignedTransaction(txBuilder)
 
                 // Finalising the transaction.
                 subFlow(FinalityFlow(signedTx))
@@ -141,7 +141,7 @@ the following:
                 txBuilder.verify(getServiceHub());
 
                 // Signing the transaction.
-                final SignedTransaction signedTx = getServiceHub().signInitialTransaction(txBuilder);
+                final SignedTransaction signedTx = getServiceHub().toSignedTransaction(txBuilder);
 
                 // Finalising the transaction.
                 subFlow(new FinalityFlow(signedTx));
@@ -229,7 +229,7 @@ Signing the transaction
 Now that we have a valid transaction proposal, we need to sign it. Once the transaction is signed, no-one will be able
 to modify the transaction without invalidating our signature, effectively making the transaction immutable.
 
-The call to ``ServiceHub.signInitialTransaction`` returns a ``SignedTransaction`` - an object that pairs the
+The call to ``ServiceHub.toSignedTransaction`` returns a ``SignedTransaction`` - an object that pairs the
 transaction itself with a list of signatures over that transaction.
 
 Finalising the transaction

--- a/docs/source/tut-two-party-flow.rst
+++ b/docs/source/tut-two-party-flow.rst
@@ -36,7 +36,7 @@ In ``IOUFlow.java``/``IOUFlow.kt``, update ``IOUFlow.call`` as follows:
         txBuilder.verify(serviceHub)
 
         // Signing the transaction.
-        val signedTx = serviceHub.signInitialTransaction(txBuilder)
+        val signedTx = serviceHub.toSignedTransaction(txBuilder)
 
         // Obtaining the counterparty's signature
         val fullySignedTx = subFlow(CollectSignaturesFlow(signedTx))
@@ -56,7 +56,7 @@ In ``IOUFlow.java``/``IOUFlow.kt``, update ``IOUFlow.call`` as follows:
         txBuilder.verify(getServiceHub());
 
         // Signing the transaction.
-        final SignedTransaction signedTx = getServiceHub().signInitialTransaction(txBuilder);
+        final SignedTransaction signedTx = getServiceHub().toSignedTransaction(txBuilder);
 
         // Obtaining the counterparty's signature
         final SignedTransaction fullySignedTx = subFlow(new CollectSignaturesFlow(signedTx, null));

--- a/docs/source/tutorial-contract.rst
+++ b/docs/source/tutorial-contract.rst
@@ -707,7 +707,7 @@ from the ledger). Finally, we add a Redeem command that should be signed by the 
 
 A ``TransactionBuilder`` is not by itself ready to be used anywhere, so first, we must convert it to something that
 is recognised by the network. The most important next step is for the participating entities to sign it. Typically,
-an initiating flow will create an initial partially signed ``SignedTransaction`` by calling the ``serviceHub.signInitialTransaction`` method.
+an initiating flow will create an initial partially signed ``SignedTransaction`` by calling the ``serviceHub.toSignedTransaction`` method.
 Then the frozen ``SignedTransaction`` can be passed to other nodes by the flow, these can sign using ``serviceHub.createSignature`` and distribute.
 The ``CollectSignaturesFlow`` provides a generic implementation of this process that can be used as a ``subFlow`` .
 

--- a/docs/source/using-a-notary.rst
+++ b/docs/source/using-a-notary.rst
@@ -64,7 +64,7 @@ We then sign the transaction, build and record it to our transaction storage:
 .. sourcecode:: kotlin
 
    val mySigningKey: PublicKey = serviceHub.legalIdentityKey
-   val issueTransaction = serviceHub.signInitialTransaction(issueTransaction, mySigningKey)
+   val issueTransaction = serviceHub.toSignedTransaction(issueTransaction, mySigningKey)
    serviceHub.recordTransactions(issueTransaction)
 
 The transaction is recorded and we now have a state (asset) in possession that we can transfer to someone else. Note
@@ -98,7 +98,7 @@ Again we sign the transaction, and build it:
 
    // We build it and add our default identity signature without checking if all signatures are present,
    // Note we know that the notary signature is missing, so thie SignedTransaction is still partial.
-   val moveTransaction = serviceHub.signInitialTransaction(moveTransactionBuilder)
+   val moveTransaction = serviceHub.toSignedTransaction(moveTransactionBuilder)
 
 Next we need to obtain a signature from the notary for the transaction to be valid. Prior to signing, the notary will
 commit our old (input) state so it cannot be used again.

--- a/finance/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.DealState
 import net.corda.core.contracts.requireThat
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.TransactionSignature
 import net.corda.core.flows.CollectSignaturesFlow
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
@@ -12,11 +13,11 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceType
-import net.corda.core.utilities.seconds
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.seconds
 import net.corda.core.utilities.trace
 import net.corda.core.utilities.unwrap
 import java.security.PublicKey
@@ -92,8 +93,12 @@ object TwoPartyDealFlow {
             val handshake = receiveAndValidateHandshake()
 
             progressTracker.currentStep = SIGNING
-            val (utx, additionalSigningPubKeys) = assembleSharedTX(handshake)
-            val ptx = signWithOurKeys(additionalSigningPubKeys, utx)
+            val (utx, additionalSigningPubKeys, additionalSignatures) = assembleSharedTX(handshake)
+            val ptx = if (additionalSignatures.any()) {
+                serviceHub.signInitialTransaction(utx, additionalSigningPubKeys).withAdditionalSignatures(additionalSignatures)
+            } else {
+                serviceHub.signInitialTransaction(utx, additionalSigningPubKeys)
+            }
 
             logger.trace { "Signed proposed transaction." }
 
@@ -136,13 +141,8 @@ object TwoPartyDealFlow {
             return handshake.unwrap { validateHandshake(it) }
         }
 
-        private fun signWithOurKeys(signingPubKeys: List<PublicKey>, ptx: TransactionBuilder): SignedTransaction {
-            // Now sign the transaction with whatever keys we need to move the cash.
-            return serviceHub.signInitialTransaction(ptx, signingPubKeys)
-        }
-
         @Suspendable protected abstract fun validateHandshake(handshake: Handshake<U>): Handshake<U>
-        @Suspendable protected abstract fun assembleSharedTX(handshake: Handshake<U>): Pair<TransactionBuilder, List<PublicKey>>
+        @Suspendable protected abstract fun assembleSharedTX(handshake: Handshake<U>): Triple<TransactionBuilder, List<PublicKey>, List<TransactionSignature>>
     }
 
     @CordaSerializable
@@ -178,14 +178,14 @@ object TwoPartyDealFlow {
             return handshake.copy(payload = autoOffer.copy(dealBeingOffered = deal))
         }
 
-        override fun assembleSharedTX(handshake: Handshake<AutoOffer>): Pair<TransactionBuilder, List<PublicKey>> {
+        override fun assembleSharedTX(handshake: Handshake<AutoOffer>): Triple<TransactionBuilder, List<PublicKey>, List<TransactionSignature>> {
             val deal = handshake.payload.dealBeingOffered
             val ptx = deal.generateAgreement(handshake.payload.notary)
 
             // We set the transaction's time-window: it may be that none of the contracts need this!
             // But it can't hurt to have one.
             ptx.setTimeWindow(serviceHub.clock.instant(), 30.seconds)
-            return Pair(ptx, arrayListOf(deal.participants.single { it == serviceHub.myInfo.legalIdentity as AbstractParty }.owningKey))
+            return Triple(ptx, arrayListOf(deal.participants.single { it == serviceHub.myInfo.legalIdentity as AbstractParty }.owningKey), emptyList())
         }
     }
 }

--- a/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/CommercialPaperTests.kt
@@ -204,6 +204,7 @@ class CommercialPaperTestsGeneric {
     private lateinit var alicesVault: Vault<ContractState>
 
     private val notaryServices = MockServices(DUMMY_NOTARY_KEY)
+    private val issuerServices = MockServices(DUMMY_CASH_ISSUER_KEY)
 
     private lateinit var moveTX: SignedTransaction
 
@@ -216,7 +217,7 @@ class CommercialPaperTestsGeneric {
         aliceVaultService = aliceServices.vaultService
 
         databaseAlice.transaction {
-            alicesVault = aliceServices.fillWithSomeTestCash(9000.DOLLARS, atLeastThisManyStates = 1, atMostThisManyStates = 1)
+            alicesVault = aliceServices.fillWithSomeTestCash(9000.DOLLARS, issuerServices, atLeastThisManyStates = 1, atMostThisManyStates = 1, issuedBy = DUMMY_CASH_ISSUER)
             aliceVaultService = aliceServices.vaultService
         }
 
@@ -226,7 +227,7 @@ class CommercialPaperTestsGeneric {
         bigCorpVaultService = bigCorpServices.vaultService
 
         databaseBigCorp.transaction {
-            bigCorpVault = bigCorpServices.fillWithSomeTestCash(13000.DOLLARS, atLeastThisManyStates = 1, atMostThisManyStates = 1)
+            bigCorpVault = bigCorpServices.fillWithSomeTestCash(13000.DOLLARS, issuerServices, atLeastThisManyStates = 1, atMostThisManyStates = 1, issuedBy = DUMMY_CASH_ISSUER)
             bigCorpVaultService = bigCorpServices.vaultService
         }
 

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -96,17 +96,19 @@ class TwoPartyTradeFlowTests {
             val aliceNode = basketOfNodes.partyNodes[0]
             val bobNode = basketOfNodes.partyNodes[1]
             val bankNode = basketOfNodes.partyNodes[2]
-            val issuer = bankNode.info.legalIdentity.ref(1, 2, 3)
+            val cashIssuer = bankNode.info.legalIdentity.ref(1)
+            val cpIssuer = bankNode.info.legalIdentity.ref(1, 2, 3)
 
             aliceNode.disableDBCloseOnStop()
             bobNode.disableDBCloseOnStop()
 
             bobNode.database.transaction {
-                bobNode.services.fillWithSomeTestCash(2000.DOLLARS, outputNotary = notaryNode.info.notaryIdentity)
+                bobNode.services.fillWithSomeTestCash(2000.DOLLARS, bankNode.services, outputNotary = notaryNode.info.notaryIdentity,
+                        issuedBy = cashIssuer)
             }
 
             val alicesFakePaper = aliceNode.database.transaction {
-                fillUpForSeller(false, issuer, aliceNode.info.legalIdentity,
+                fillUpForSeller(false, cpIssuer, aliceNode.info.legalIdentity,
                         1200.DOLLARS `issued by` bankNode.info.legalIdentity.ref(0), null, notaryNode.info.notaryIdentity).second
             }
 
@@ -142,14 +144,16 @@ class TwoPartyTradeFlowTests {
             val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
             val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
             val bankNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOC.name)
+            val cashIssuer = bankNode.info.legalIdentity.ref(1)
             val cpIssuer = bankNode.info.legalIdentity.ref(1, 2, 3)
 
             aliceNode.disableDBCloseOnStop()
             bobNode.disableDBCloseOnStop()
 
             val cashStates = bobNode.database.transaction {
-                bobNode.services.fillWithSomeTestCash(2000.DOLLARS, notaryNode.info.notaryIdentity, 3, 3)
-            }
+                bobNode.services.fillWithSomeTestCash(2000.DOLLARS, bankNode.services, notaryNode.info.notaryIdentity, 3, 3,
+                            issuedBy = cashIssuer)
+                }
 
             val alicesFakePaper = aliceNode.database.transaction {
                 fillUpForSeller(false, cpIssuer, aliceNode.info.legalIdentity,
@@ -194,6 +198,7 @@ class TwoPartyTradeFlowTests {
             val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
             var bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
             val bankNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOC.name)
+            val cashIssuer = bankNode.info.legalIdentity.ref(1)
             val cpIssuer = bankNode.info.legalIdentity.ref(1, 2, 3)
 
             aliceNode.services.identityService.registerIdentity(bobNode.info.legalIdentityAndCert)
@@ -207,7 +212,8 @@ class TwoPartyTradeFlowTests {
             mockNet.runNetwork() // Clear network map registration messages
 
             bobNode.database.transaction {
-                bobNode.services.fillWithSomeTestCash(2000.DOLLARS, outputNotary = notaryNode.info.notaryIdentity)
+                bobNode.services.fillWithSomeTestCash(2000.DOLLARS, bankNode.services, outputNotary = notaryNode.info.notaryIdentity,
+                        issuedBy = cashIssuer)
             }
             val alicesFakePaper = aliceNode.database.transaction {
                 fillUpForSeller(false, cpIssuer, aliceNode.info.legalIdentity,

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -5,6 +5,7 @@ import net.corda.contracts.Commodity
 import net.corda.contracts.DealState
 import net.corda.contracts.asset.Cash
 import net.corda.contracts.asset.DUMMY_CASH_ISSUER
+import net.corda.contracts.asset.DUMMY_CASH_ISSUER_KEY
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.entropyToKeyPair
@@ -52,15 +53,17 @@ import java.util.*
 class VaultQueryTests : TestDependencyInjectionBase() {
 
     lateinit var services: MockServices
+    lateinit var notaryServices: MockServices
     val vaultSvc: VaultService get() = services.vaultService
     val vaultQuerySvc: VaultQueryService get() = services.vaultQueryService
     lateinit var database: CordaPersistence
 
     @Before
     fun setUp() {
-        val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MEGA_CORP_KEY))
+        val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MEGA_CORP_KEY, DUMMY_NOTARY_KEY))
         database = databaseAndServices.first
         services = databaseAndServices.second
+        notaryServices = MockServices(DUMMY_NOTARY_KEY, DUMMY_CASH_ISSUER_KEY, BOC_KEY, MEGA_CORP_KEY)
     }
 
     @After
@@ -86,7 +89,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         _database.transaction {
 
             // create new states
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 10, 10, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
             val linearStatesXYZ = services.fillWithSomeTestLinearStates(1, "XYZ")
             val linearStatesJKL = services.fillWithSomeTestLinearStates(2, "JKL")
             services.fillWithSomeTestLinearStates(3, "ABC")
@@ -97,10 +100,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             sleep(delay)
 
             // consume some states
-            services.consumeLinearStates(linearStatesXYZ.states.toList())
-            services.consumeLinearStates(linearStatesJKL.states.toList())
-            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" })
-            services.consumeCash(50.DOLLARS)
+            services.consumeLinearStates(linearStatesXYZ.states.toList(), DUMMY_NOTARY)
+            services.consumeLinearStates(linearStatesJKL.states.toList(), DUMMY_NOTARY)
+            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" }, DUMMY_NOTARY)
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
 
             // Total unconsumed states = 4 + 3 + 2 + 1 (new cash change) = 10
             // Total consumed states = 6 + 1 + 2 + 1 = 10
@@ -130,7 +133,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed states simple`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
@@ -157,7 +160,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed states verbose`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
@@ -173,10 +176,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed states with count`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
@@ -184,7 +187,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             assertThat(resultsBeforeConsume.states).hasSize(4)
             assertThat(resultsBeforeConsume.totalStatesAvailable).isEqualTo(4)
 
-            services.consumeCash(75.DOLLARS)
+            services.consumeCash(75.DOLLARS, notary = DUMMY_NOTARY)
 
             val consumedCriteria = VaultQueryCriteria(status = Vault.StateStatus.UNCONSUMED)
             val resultsAfterConsume = vaultQuerySvc.queryBy<ContractState>(consumedCriteria, paging)
@@ -197,7 +200,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed cash states simple`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
@@ -212,7 +215,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed cash states verbose`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
@@ -230,11 +233,11 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
             val stateRefs: MutableList<StateRef> = mutableListOf()
 
-            val issuedStates = services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 10, 10, Random(0L))
+            val issuedStates = services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
             val issuedStateRefs = issuedStates.states.map { it.ref }.toList()
             stateRefs.addAll(issuedStateRefs)
 
-            val spentStates = services.consumeCash(25.DOLLARS)
+            val spentStates = services.consumeCash(25.DOLLARS, notary = DUMMY_NOTARY)
             val consumedStateRefs = spentStates.consumed.map { it.ref }.toList()
             val producedStateRefs = spentStates.produced.map { it.ref }.toList()
             stateRefs.addAll(consumedStateRefs.plus(producedStateRefs))
@@ -259,10 +262,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed cash states sorted by state ref txnId and index`() {
         database.transaction {
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 10, 10, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
             val consumed = mutableSetOf<SecureHash>()
-            services.consumeCash(10.DOLLARS).consumed.forEach { consumed += it.ref.txhash }
-            services.consumeCash(10.DOLLARS).consumed.forEach { consumed += it.ref.txhash }
+            services.consumeCash(10.DOLLARS, notary = DUMMY_NOTARY).consumed.forEach { consumed += it.ref.txhash }
+            services.consumeCash(10.DOLLARS, notary = DUMMY_NOTARY).consumed.forEach { consumed += it.ref.txhash }
 
             val sortAttributeTxnId = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_TXN_ID)
             val sortAttributeIndex = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_INDEX)
@@ -305,7 +308,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed states for contract state types`() {
         database.transaction {
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
@@ -322,14 +325,14 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `consumed states`() {
         database.transaction {
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 states with same externalId
             services.fillWithSomeTestLinearStates(8)
             val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
-            services.consumeLinearStates(linearStates.states.toList())
-            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" })
-            services.consumeCash(50.DOLLARS)
+            services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
+            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" }, DUMMY_NOTARY)
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val results = vaultQuerySvc.queryBy<ContractState>(criteria)
@@ -341,10 +344,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `consumed states with count`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(25.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
@@ -352,7 +355,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             assertThat(resultsBeforeConsume.states).hasSize(4)
             assertThat(resultsBeforeConsume.totalStatesAvailable).isEqualTo(4)
 
-            services.consumeCash(75.DOLLARS)
+            services.consumeCash(75.DOLLARS, notary = DUMMY_NOTARY)
 
             val consumedCriteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val resultsAfterConsume = vaultQuerySvc.queryBy<ContractState>(consumedCriteria, paging)
@@ -364,14 +367,14 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `all states`() {
         database.transaction {
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 results with same UID
             services.fillWithSomeTestLinearStates(8)
             val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
-            services.consumeLinearStates(linearStates.states.toList())
-            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" })
-            services.consumeCash(50.DOLLARS) // generates a new change state!
+            services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
+            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" }, DUMMY_NOTARY)
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY) // generates a new change state!
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val results = vaultQuerySvc.queryBy<ContractState>(criteria)
@@ -383,7 +386,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `all states with count`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
@@ -391,7 +394,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             assertThat(resultsBeforeConsume.states).hasSize(1)
             assertThat(resultsBeforeConsume.totalStatesAvailable).isEqualTo(1)
 
-            services.consumeCash(50.DOLLARS)    // consumed 100 (spent), produced 50 (change)
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)    // consumed 100 (spent), produced 50 (change)
 
             val resultsAfterConsume = vaultQuerySvc.queryBy<ContractState>(criteria, paging)
             assertThat(resultsAfterConsume.states).hasSize(2)
@@ -406,7 +409,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed states by notary`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, CASH_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
@@ -454,7 +457,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed states with soft locking`() {
         database.transaction {
 
-            val issuedStates = services.fillWithSomeTestCash(100.DOLLARS, CASH_NOTARY, 10, 10, Random(0L)).states.toList()
+            val issuedStates = services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 10, 10, Random(0L)).states.toList()
             vaultSvc.softLockReserve(UUID.randomUUID(), NonEmptySet.of(issuedStates[1].ref, issuedStates[2].ref, issuedStates[3].ref))
             val lockId1 = UUID.randomUUID()
             vaultSvc.softLockReserve(lockId1, NonEmptySet.of(issuedStates[4].ref, issuedStates[5].ref))
@@ -498,9 +501,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator EQUAL`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.equal(GBP.currencyCode) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -513,9 +516,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator NOT EQUAL`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.notEqual(GBP.currencyCode) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -528,9 +531,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator GREATER_THAN`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(1.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(10.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.greaterThan(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -543,9 +546,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator GREATER_THAN_OR_EQUAL`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(1.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(10.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.greaterThanOrEqual(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -558,9 +561,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator LESS_THAN`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(1.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(10.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.lessThan(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -573,9 +576,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator LESS_THAN_OR_EQUAL`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(1.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(10.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.lessThanOrEqual(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -588,9 +591,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator BETWEEN`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(1.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(10.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.between(500L, 1500L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -603,9 +606,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator IN`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val currencies = listOf(CHF.currencyCode, GBP.currencyCode)
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.`in`(currencies) }
@@ -619,9 +622,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator NOT IN`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val currencies = listOf(CHF.currencyCode, GBP.currencyCode)
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.notIn(currencies) }
@@ -635,9 +638,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator LIKE`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.like("%BP") }  // GPB
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -650,9 +653,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator NOT LIKE`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.notLike("%BP") }  // GPB
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -665,9 +668,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator IS_NULL`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::issuerParty.isNull() }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -680,9 +683,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `logical operator NOT_NULL`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::issuerParty.notNull() }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -695,11 +698,11 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `aggregate functions without group clause`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(200.DOLLARS, DUMMY_NOTARY, 2, 2, Random(0L))
-            services.fillWithSomeTestCash(300.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.fillWithSomeTestCash(400.POUNDS, DUMMY_NOTARY, 4, 4, Random(0L))
-            services.fillWithSomeTestCash(500.SWISS_FRANCS, DUMMY_NOTARY, 5, 5, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L))
+            services.fillWithSomeTestCash(300.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L))
+            services.fillWithSomeTestCash(500.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
 
             // DOCSTART VaultQueryExample21
             val sum = builder { CashSchemaV1.PersistentCashState::pennies.sum() }
@@ -737,11 +740,11 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `aggregate functions with single group clause`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(200.DOLLARS, DUMMY_NOTARY, 2, 2, Random(0L))
-            services.fillWithSomeTestCash(300.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.fillWithSomeTestCash(400.POUNDS, DUMMY_NOTARY, 4, 4, Random(0L))
-            services.fillWithSomeTestCash(500.SWISS_FRANCS, DUMMY_NOTARY, 5, 5, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L))
+            services.fillWithSomeTestCash(300.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L))
+            services.fillWithSomeTestCash(500.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
 
             // DOCSTART VaultQueryExample22
             val sum = builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) }
@@ -797,10 +800,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `aggregate functions sum by issuer and currency and sort by aggregate sum`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
-            services.fillWithSomeTestCash(200.DOLLARS, DUMMY_NOTARY, 2, 2, Random(0L), issuedBy = BOC.ref(1), issuerKey = BOC_KEY)
-            services.fillWithSomeTestCash(300.POUNDS, DUMMY_NOTARY, 3, 3, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
-            services.fillWithSomeTestCash(400.POUNDS, DUMMY_NOTARY, 4, 4, Random(0L), issuedBy = BOC.ref(2), issuerKey = BOC_KEY)
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
+            services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L), issuedBy = BOC.ref(1))
+            services.fillWithSomeTestCash(300.POUNDS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
+            services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L), issuedBy = BOC.ref(2))
 
             // DOCSTART VaultQueryExample23
             val sum = builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::issuerParty,
@@ -832,7 +835,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `aggregate functions count by contract type`() {
         database.transaction {
             // create new states
-            services.fillWithSomeTestCash(100.DOLLARS, CASH_NOTARY, 10, 10, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 10, 10, Random(0L))
             services.fillWithSomeTestLinearStates(1, "XYZ")
             services.fillWithSomeTestLinearStates(2, "JKL")
             services.fillWithSomeTestLinearStates(3, "ABC")
@@ -858,7 +861,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `aggregate functions count by contract type and state status`() {
         database.transaction {
             // create new states
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 10, 10, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
             val linearStatesXYZ = services.fillWithSomeTestLinearStates(1, "XYZ")
             val linearStatesJKL = services.fillWithSomeTestLinearStates(2, "JKL")
             services.fillWithSomeTestLinearStates(3, "ABC")
@@ -881,10 +884,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             assertThat(dealStateCount).isEqualTo(3L)
 
             // consume some states
-            services.consumeLinearStates(linearStatesXYZ.states.toList())
-            services.consumeLinearStates(linearStatesJKL.states.toList())
-            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" })
-            val cashUpdates = services.consumeCash(50.DOLLARS)
+            services.consumeLinearStates(linearStatesXYZ.states.toList(), DUMMY_NOTARY)
+            services.consumeLinearStates(linearStatesJKL.states.toList(), DUMMY_NOTARY)
+            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" }, DUMMY_NOTARY)
+            val cashUpdates = services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
 
             // UNCONSUMED states (default)
 
@@ -924,7 +927,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed states recorded between two time intervals`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, CASH_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 3, 3, Random(0L))
 
             // DOCSTART VaultQueryExample6
             val start = TODAY
@@ -950,11 +953,11 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `states consumed after time`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
-            services.consumeCash(100.DOLLARS)
+            services.consumeCash(100.DOLLARS, notary = DUMMY_NOTARY)
 
             val asOfDateTime = TODAY
             val consumedAfterExpression = TimeCondition(
@@ -972,7 +975,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `all states with paging specification - first page`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 100, 100, Random(0L))
 
             // DOCSTART VaultQueryExample7
             val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, 10)
@@ -989,7 +992,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `all states with paging specification  - last`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(95.DOLLARS, DUMMY_NOTARY, 95, 95, Random(0L))
+            services.fillWithSomeTestCash(95.DOLLARS, notaryServices, DUMMY_NOTARY, 95, 95, Random(0L))
 
             // Last page implies we need to perform a row count for the Query first,
             // and then re-query for a given offset defined by (count - pageSize)
@@ -1010,7 +1013,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 100, 100, Random(0L))
 
             val pagingSpec = PageSpecification(0, 10)
 
@@ -1027,7 +1030,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 100, 100, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 100, 100, Random(0L))
 
             val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE + 1)  // overflow = -2147483648
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
@@ -1043,7 +1046,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
         database.transaction {
 
-            services.fillWithSomeTestCash(201.DOLLARS, DUMMY_NOTARY, 201, 201, Random(0L))
+            services.fillWithSomeTestCash(201.DOLLARS, notaryServices, DUMMY_NOTARY, 201, 201, Random(0L))
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria)
@@ -1083,8 +1086,8 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed fungible assets`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.fillWithSomeTestCommodity(Amount(100, Commodity.getInstance("FCOJ")!!))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCommodity(Amount(100, Commodity.getInstance("FCOJ")!!), notaryServices)
             services.fillWithSomeTestLinearStates(10)
 
             val results = vaultQuerySvc.queryBy<FungibleAsset<*>>()
@@ -1096,9 +1099,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `consumed fungible assets`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.consumeCash(50.DOLLARS)
-            services.fillWithSomeTestCommodity(Amount(100, Commodity.getInstance("FCOJ")!!))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
+            services.fillWithSomeTestCommodity(Amount(100, Commodity.getInstance("FCOJ")!!), notaryServices)
             services.fillWithSomeTestLinearStates(10)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
@@ -1111,7 +1114,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed cash fungible assets`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
 
             val results = vaultQuerySvc.queryBy<Cash.State>()
@@ -1123,8 +1126,8 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed cash fungible assets after spending`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.consumeCash(50.DOLLARS)
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
             // should now have x2 CONSUMED + x2 UNCONSUMED (one spent + one change)
 
             val results = vaultQuerySvc.queryBy<Cash.State>(FungibleAssetQueryCriteria())
@@ -1137,10 +1140,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `consumed cash fungible assets`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.consumeCash(50.DOLLARS)
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
             val linearStates = services.fillWithSomeTestLinearStates(10)
-            services.consumeLinearStates(linearStates.states.toList())
+            services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val results = vaultQuerySvc.queryBy<Cash.State>(criteria)
@@ -1152,7 +1155,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed linear heads`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
@@ -1165,14 +1168,14 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `consumed linear heads`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 states with same externalId
             services.fillWithSomeTestLinearStates(8)
             val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
-            services.consumeLinearStates(linearStates.states.toList())
-            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" })
-            services.consumeCash(50.DOLLARS)
+            services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
+            services.consumeDeals(dealStates.states.filter { it.state.data.ref == "456" }, DUMMY_NOTARY)
+            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val results = vaultQuerySvc.queryBy<LinearState>(criteria)
@@ -1219,9 +1222,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             val txns = services.fillWithSomeTestLinearStates(1, "TEST")
             val linearState = txns.states.first()
             val linearId = linearState.state.data.linearId
-            services.evolveLinearState(linearState)  // consume current and produce new state reference
-            services.evolveLinearState(linearState)  // consume current and produce new state reference
-            services.evolveLinearState(linearState)  // consume current and produce new state reference
+            services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
 
             // should now have 1 UNCONSUMED & 3 CONSUMED state refs for Linear State with "TEST"
             // DOCSTART VaultQueryExample9
@@ -1239,9 +1242,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
             val txns = services.fillWithSomeTestLinearStates(2, "TEST")
             val linearStates = txns.states.toList()
-            services.evolveLinearStates(linearStates)  // consume current and produce new state reference
-            services.evolveLinearStates(linearStates)  // consume current and produce new state reference
-            services.evolveLinearStates(linearStates)  // consume current and produce new state reference
+            services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
 
             // should now have 1 UNCONSUMED & 3 CONSUMED state refs for Linear State with "TEST"
             val linearStateCriteria = LinearStateQueryCriteria(linearId = linearStates.map { it.state.data.linearId }, status = Vault.StateStatus.ALL)
@@ -1303,7 +1306,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearString"), Sort.Direction.DESC)))
 
             val results = vaultQuerySvc.queryBy<DummyLinearContract.State>((vaultCriteria), sorting = sorting)
-            results.states.forEach { println("${it.state.data.linearString}") }
+            results.states.forEach { println(it.state.data.linearString) }
             assertThat(results.states).hasSize(6)
         }
     }
@@ -1314,9 +1317,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
             val txns = services.fillWithSomeTestLinearStates(1, "TEST")
             val linearState = txns.states.first()
-            val linearState2 = services.evolveLinearState(linearState)  // consume current and produce new state reference
-            val linearState3 = services.evolveLinearState(linearState2)  // consume current and produce new state reference
-            services.evolveLinearState(linearState3)  // consume current and produce new state reference
+            val linearState2 = services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
+            val linearState3 = services.evolveLinearState(linearState2, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearState(linearState3, DUMMY_NOTARY)  // consume current and produce new state reference
 
             // should now have 1 UNCONSUMED & 3 CONSUMED state refs for Linear State with "TEST"
             val linearStateCriteria = LinearStateQueryCriteria(linearId = txns.states.map { it.state.data.linearId }, status = Vault.StateStatus.CONSUMED)
@@ -1399,10 +1402,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed fungible assets for specific issuer party and refs`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)), issuerKey = BOC_KEY, ref = OpaqueBytes.of(1))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(2)), issuerKey = BOC_KEY, ref = OpaqueBytes.of(2))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(3)), issuerKey = BOC_KEY, ref = OpaqueBytes.of(3))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)), ref = OpaqueBytes.of(1))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(2)), ref = OpaqueBytes.of(2))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(3)), ref = OpaqueBytes.of(3))
 
             val criteria = FungibleAssetQueryCriteria(issuerPartyName = listOf(BOC),
                     issuerRef = listOf(BOC.ref(1).reference, BOC.ref(2).reference))
@@ -1414,21 +1417,24 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed fungible assets for selected issuer parties`() {
         // GBP issuer
-        val GBP_CASH_ISSUER_KEY by lazy { entropyToKeyPair(BigInteger.valueOf(1001)) }
-        val GBP_CASH_ISSUER by lazy { Party(X500Name("CN=British Pounds Cash Issuer,O=R3,OU=corda,L=London,C=GB"), GBP_CASH_ISSUER_KEY.public).ref(1) }
+        val gbpCashIssuerKey = entropyToKeyPair(BigInteger.valueOf(1001))
+        val gbpCashIssuer = Party(X500Name("CN=British Pounds Cash Issuer,O=R3,OU=corda,L=London,C=GB"), gbpCashIssuerKey.public).ref(1)
+        val gbpCashIssuerServices = MockServices(gbpCashIssuerKey)
         // USD issuer
-        val USD_CASH_ISSUER_KEY by lazy { entropyToKeyPair(BigInteger.valueOf(1002)) }
-        val USD_CASH_ISSUER by lazy { Party(X500Name("CN=US Dollars Cash Issuer,O=R3,OU=corda,L=New York,C=US"), USD_CASH_ISSUER_KEY.public).ref(1) }
+        val usdCashIssuerKey = entropyToKeyPair(BigInteger.valueOf(1002))
+        val usdCashIssuer = Party(X500Name("CN=US Dollars Cash Issuer,O=R3,OU=corda,L=New York,C=US"), usdCashIssuerKey.public).ref(1)
+        val usdCashIssuerServices = MockServices(usdCashIssuerKey)
         // CHF issuer
-        val CHF_CASH_ISSUER_KEY by lazy { entropyToKeyPair(BigInteger.valueOf(1003)) }
-        val CHF_CASH_ISSUER by lazy { Party(X500Name("CN=Swiss Francs Cash Issuer,O=R3,OU=corda,L=Zurich,C=CH"), CHF_CASH_ISSUER_KEY.public).ref(1) }
+        val chfCashIssuerKey = entropyToKeyPair(BigInteger.valueOf(1003))
+        val chfCashIssuer = Party(X500Name("CN=Swiss Francs Cash Issuer,O=R3,OU=corda,L=Zurich,C=CH"), chfCashIssuerKey.public).ref(1)
+        val chfCashIssuerServices = MockServices(chfCashIssuerKey)
 
         database.transaction {
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (GBP_CASH_ISSUER), issuerKey = (GBP_CASH_ISSUER_KEY))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (USD_CASH_ISSUER), issuerKey = (USD_CASH_ISSUER_KEY))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (CHF_CASH_ISSUER), issuerKey = (CHF_CASH_ISSUER_KEY))
+            services.fillWithSomeTestCash(100.POUNDS, gbpCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (gbpCashIssuer))
+            services.fillWithSomeTestCash(100.DOLLARS, usdCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (usdCashIssuer))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, chfCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (chfCashIssuer))
 
-            val criteria = FungibleAssetQueryCriteria(issuerPartyName = listOf(GBP_CASH_ISSUER.party, USD_CASH_ISSUER.party))
+            val criteria = FungibleAssetQueryCriteria(issuerPartyName = listOf(gbpCashIssuer.party, usdCashIssuer.party))
             val results = vaultQuerySvc.queryBy<FungibleAsset<*>>(criteria)
             assertThat(results.states).hasSize(2)
         }
@@ -1438,9 +1444,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed fungible assets by owner`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 2, 2, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L),
-                    issuedBy = MEGA_CORP.ref(0), issuerKey = MEGA_CORP_KEY, ownedBy = (MEGA_CORP))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L), issuedBy = BOC.ref(1))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
+                    issuedBy = MEGA_CORP.ref(0), ownedBy = (MEGA_CORP))
 
             val criteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP))
             val results = vaultQuerySvc.queryBy<FungibleAsset<*>>(criteria)
@@ -1453,14 +1459,14 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed fungible states for owners`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, CASH_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L),
-                    issuedBy = MEGA_CORP.ref(0), issuerKey = MEGA_CORP_KEY, ownedBy = (MEGA_CORP))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L),
-                    issuedBy = MINI_CORP.ref(0), issuerKey = MINI_CORP_KEY, ownedBy = (MINI_CORP))  // irrelevant to this vault
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
+                    issuedBy = MEGA_CORP.ref(0), ownedBy = (MEGA_CORP))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
+                    issuedBy = BOC.ref(0), ownedBy = (MINI_CORP))  // irrelevant to this vault
 
             // DOCSTART VaultQueryExample5.2
-            val criteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP,MINI_CORP))
+            val criteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP, BOC))
             val results = vaultQuerySvc.queryBy<ContractState>(criteria)
             // DOCEND VaultQueryExample5.2
 
@@ -1474,9 +1480,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         database.transaction {
 
             services.fillWithSomeTestLinearStates(10)
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
 
             // DOCSTART VaultQueryExample12
             val ccyIndex = builder { CashSchemaV1.PersistentCashState::currency.equal(USD.currencyCode) }
@@ -1492,8 +1498,8 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed cash balance for single currency`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(200.DOLLARS, DUMMY_NOTARY, 2, 2, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L))
 
             val sum = builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) }
             val sumCriteria = VaultCustomQueryCriteria(sum)
@@ -1513,12 +1519,12 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed cash balances for all currencies`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(200.DOLLARS, DUMMY_NOTARY, 2, 2, Random(0L))
-            services.fillWithSomeTestCash(300.POUNDS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.fillWithSomeTestCash(400.POUNDS, DUMMY_NOTARY, 4, 4, Random(0L))
-            services.fillWithSomeTestCash(500.SWISS_FRANCS, DUMMY_NOTARY, 5, 5, Random(0L))
-            services.fillWithSomeTestCash(600.SWISS_FRANCS, DUMMY_NOTARY, 6, 6, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L))
+            services.fillWithSomeTestCash(300.POUNDS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L))
+            services.fillWithSomeTestCash(500.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
+            services.fillWithSomeTestCash(600.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 6, 6, Random(0L))
 
             val ccyIndex = builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) }
             val criteria = VaultCustomQueryCriteria(ccyIndex)
@@ -1538,10 +1544,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed fungible assets for quantity greater than`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(10.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
-            services.fillWithSomeTestCash(25.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(50.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(10.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(25.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(50.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
 
             // DOCSTART VaultQueryExample13
             val fungibleAssetCriteria = FungibleAssetQueryCriteria(quantity = builder { greaterThan(2500L) })
@@ -1556,8 +1562,8 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed fungible assets for issuer party`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)), issuerKey = BOC_KEY)
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)))
 
             // DOCSTART VaultQueryExample14
             val criteria = FungibleAssetQueryCriteria(issuerPartyName = listOf(BOC))
@@ -1572,10 +1578,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `unconsumed fungible assets for single currency and quantity greater than`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(50.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(50.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             val ccyIndex = builder { CashSchemaV1.PersistentCashState::currency.equal(GBP.currencyCode) }
             val customCriteria = VaultCustomQueryCriteria(ccyIndex)
@@ -1598,21 +1604,22 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             // MegaCorp™ issues $10,000 of commercial paper, to mature in 30 days, owned by itself.
             val faceValue = 10000.DOLLARS `issued by` DUMMY_CASH_ISSUER
             val commercialPaper =
-                    CommercialPaper().generateIssue(issuance, faceValue, TEST_TX_TIME + 30.days, DUMMY_NOTARY).apply {
-                        setTimeWindow(TEST_TX_TIME, 30.seconds)
-                        signWith(MEGA_CORP_KEY)
-                        signWith(DUMMY_NOTARY_KEY)
-                    }.toSignedTransaction()
+                    CommercialPaper().generateIssue(issuance, faceValue, TEST_TX_TIME + 30.days, DUMMY_NOTARY).let { builder ->
+                        builder.setTimeWindow(TEST_TX_TIME, 30.seconds)
+                        val stx = services.signInitialTransaction(builder, MEGA_CORP_PUBKEY)
+                        notaryServices.addSignature(stx, DUMMY_NOTARY_KEY.public)
+                    }
+
             services.recordTransactions(commercialPaper)
 
             // MegaCorp™ now issues £10,000 of commercial paper, to mature in 30 days, owned by itself.
             val faceValue2 = 10000.POUNDS `issued by` DUMMY_CASH_ISSUER
             val commercialPaper2 =
-                    CommercialPaper().generateIssue(issuance, faceValue2, TEST_TX_TIME + 30.days, DUMMY_NOTARY).apply {
-                        setTimeWindow(TEST_TX_TIME, 30.seconds)
-                        signWith(MEGA_CORP_KEY)
-                        signWith(DUMMY_NOTARY_KEY)
-                    }.toSignedTransaction()
+                    CommercialPaper().generateIssue(issuance, faceValue2, TEST_TX_TIME + 30.days, DUMMY_NOTARY).let { builder ->
+                        builder.setTimeWindow(TEST_TX_TIME, 30.seconds)
+                        val stx = services.signInitialTransaction(builder, MEGA_CORP_PUBKEY)
+                        notaryServices.addSignature(stx, DUMMY_NOTARY_KEY.public)
+                    }
             services.recordTransactions(commercialPaper2)
 
             val ccyIndex = builder { CommercialPaperSchemaV1.PersistentCommercialPaperState::currency.equal(USD.currencyCode) }
@@ -1635,21 +1642,23 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             // MegaCorp™ issues $10,000 of commercial paper, to mature in 30 days, owned by itself.
             val faceValue = 10000.DOLLARS `issued by` DUMMY_CASH_ISSUER
             val commercialPaper =
-                    CommercialPaper().generateIssue(issuance, faceValue, TEST_TX_TIME + 30.days, DUMMY_NOTARY).apply {
-                        setTimeWindow(TEST_TX_TIME, 30.seconds)
-                        signWith(MEGA_CORP_KEY)
-                        signWith(DUMMY_NOTARY_KEY)
-                    }.toSignedTransaction()
+                    CommercialPaper().generateIssue(issuance, faceValue, TEST_TX_TIME + 30.days, DUMMY_NOTARY).let { builder ->
+                        builder.setTimeWindow(TEST_TX_TIME, 30.seconds)
+                        val stx = services.signInitialTransaction(builder, MEGA_CORP_PUBKEY)
+                        notaryServices.addSignature(stx, DUMMY_NOTARY_KEY.public)
+                    }
+            commercialPaper.verifyRequiredSignatures()
             services.recordTransactions(commercialPaper)
 
             // MegaCorp™ now issues £5,000 of commercial paper, to mature in 30 days, owned by itself.
             val faceValue2 = 5000.POUNDS `issued by` DUMMY_CASH_ISSUER
             val commercialPaper2 =
-                    CommercialPaper().generateIssue(issuance, faceValue2, TEST_TX_TIME + 30.days, DUMMY_NOTARY).apply {
-                        setTimeWindow(TEST_TX_TIME, 30.seconds)
-                        signWith(MEGA_CORP_KEY)
-                        signWith(DUMMY_NOTARY_KEY)
-                    }.toSignedTransaction()
+                    CommercialPaper().generateIssue(issuance, faceValue2, TEST_TX_TIME + 30.days, DUMMY_NOTARY).let { builder ->
+                        builder.setTimeWindow(TEST_TX_TIME, 30.seconds)
+                        val stx = services.signInitialTransaction(builder, MEGA_CORP_PUBKEY)
+                        notaryServices.addSignature(stx, DUMMY_NOTARY_KEY.public)
+                    }
+            commercialPaper2.verifyRequiredSignatures()
             services.recordTransactions(commercialPaper2)
 
             val result = builder {
@@ -1675,9 +1684,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     fun `query attempting to use unregistered schema`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             // CashSchemaV3 NOT registered with NodeSchemaService
             val logicalExpression = builder { SampleCashSchemaV3.PersistentCashState::currency.equal(GBP.currencyCode) }
@@ -1697,10 +1706,10 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
         database.transaction {
 
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(10.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
-            services.fillWithSomeTestCash(1.DOLLARS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(10.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
 
             // DOCSTART VaultQueryExample20
             val generalCriteria = VaultQueryCriteria(Vault.StateStatus.ALL)
@@ -1800,7 +1809,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
             services.fillWithSomeTestLinearStates(1, "TEST1")
             val aState = services.fillWithSomeTestLinearStates(1, "TEST2").states
-            services.consumeLinearStates(aState.toList())
+            services.consumeLinearStates(aState.toList(), DUMMY_NOTARY)
             val uuid = services.fillWithSomeTestLinearStates(1, "TEST3").states.first().state.data.linearId.id
 
             // 2 unconsumed states with same external ID, 1 with different external ID
@@ -1871,7 +1880,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         val updates =
             database.transaction {
 
-                services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 5, 5, Random(0L))
+                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
                 val linearStates = services.fillWithSomeTestLinearStates(10).states
                 val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789")).states
 
@@ -1883,14 +1892,14 @@ class VaultQueryTests : TestDependencyInjectionBase() {
                 assertThat(snapshot.statesMetadata).hasSize(5)
 
                 // add more cash
-                services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
+                services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
                 // add another deal
                 services.fillWithSomeTestDeals(listOf("SAMPLE DEAL"))
 
                 // consume stuff
-                services.consumeCash(100.DOLLARS)
-                services.consumeDeals(dealStates.toList())
-                services.consumeLinearStates(linearStates.toList())
+                services.consumeCash(100.DOLLARS, notary = DUMMY_NOTARY)
+                services.consumeDeals(dealStates.toList(), DUMMY_NOTARY)
+                services.consumeLinearStates(linearStates.toList(), DUMMY_NOTARY)
 
                 updates
             }
@@ -1899,12 +1908,12 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 5) {}
                     },
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 1) {}
                     }
             )
@@ -1916,17 +1925,17 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         val updates =
             database.transaction {
 
-                services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 5, 5, Random(0L))
+                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
                 val linearStates = services.fillWithSomeTestLinearStates(10).states
                 val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789")).states
 
                 // add more cash
-                services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
+                services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
                 // add another deal
                 services.fillWithSomeTestDeals(listOf("SAMPLE DEAL"))
 
                 // consume stuff
-                services.consumeCash(100.POUNDS)
+                services.consumeCash(100.POUNDS, notary = DUMMY_NOTARY)
 
                 val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
                 val (snapshot, updates)  = vaultQuerySvc.trackBy<Cash.State>(criteria)
@@ -1935,9 +1944,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
                 assertThat(snapshot.statesMetadata).hasSize(1)
 
                 // consume more stuff
-                services.consumeCash(100.DOLLARS)
-                services.consumeDeals(dealStates.toList())
-                services.consumeLinearStates(linearStates.toList())
+                services.consumeCash(100.DOLLARS, notary = DUMMY_NOTARY)
+                services.consumeDeals(dealStates.toList(), DUMMY_NOTARY)
+                services.consumeLinearStates(linearStates.toList(), DUMMY_NOTARY)
 
                 updates
             }
@@ -1947,12 +1956,12 @@ class VaultQueryTests : TestDependencyInjectionBase() {
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
                         require(consumed.size == 1) {}
-                        require(produced.size == 0) {}
+                        require(produced.isEmpty()) {}
                     },
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
                         require(consumed.size == 5) {}
-                        require(produced.size == 0) {}
+                        require(produced.isEmpty()) {}
                     }
             )
         }
@@ -1963,17 +1972,17 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         val updates =
             database.transaction {
 
-                services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 5, 5, Random(0L))
+                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
                 val linearStates = services.fillWithSomeTestLinearStates(10).states
                 val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789")).states
 
                 // add more cash
-                services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
+                services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
                 // add another deal
                 services.fillWithSomeTestDeals(listOf("SAMPLE DEAL"))
 
                 // consume stuff
-                services.consumeCash(99.POUNDS)
+                services.consumeCash(99.POUNDS, notary = DUMMY_NOTARY)
 
                 val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
                 val (snapshot, updates) = vaultQuerySvc.trackBy<Cash.State>(criteria)
@@ -1982,9 +1991,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
                 assertThat(snapshot.statesMetadata).hasSize(7)
 
                 // consume more stuff
-                services.consumeCash(100.DOLLARS)
-                services.consumeDeals(dealStates.toList())
-                services.consumeLinearStates(linearStates.toList())
+                services.consumeCash(100.DOLLARS, notary = DUMMY_NOTARY)
+                services.consumeDeals(dealStates.toList(), DUMMY_NOTARY)
+                services.consumeLinearStates(linearStates.toList(), DUMMY_NOTARY)
 
                 updates
             }
@@ -1993,12 +2002,12 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 5) {}
                     },
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 1) {}
                     },
                     expect { (consumed, produced, flowId) ->
@@ -2009,7 +2018,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
                         require(consumed.size == 5) {}
-                        require(produced.size == 0) {}
+                        require(produced.isEmpty()) {}
                     }
             )
         }
@@ -2020,7 +2029,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         val updates =
             database.transaction {
 
-                services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
                 val linearStates = services.fillWithSomeTestLinearStates(10).states
                 val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789")).states
 
@@ -2033,14 +2042,14 @@ class VaultQueryTests : TestDependencyInjectionBase() {
                 assertThat(snapshot.statesMetadata).hasSize(13)
 
                 // add more cash
-                services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
+                services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
                 // add another deal
                 services.fillWithSomeTestDeals(listOf("SAMPLE DEAL"))
 
                 // consume stuff
-                services.consumeCash(100.DOLLARS)
-                services.consumeDeals(dealStates.toList())
-                services.consumeLinearStates(linearStates.toList())
+                services.consumeCash(100.DOLLARS, notary = DUMMY_NOTARY)
+                services.consumeDeals(dealStates.toList(), DUMMY_NOTARY)
+                services.consumeLinearStates(linearStates.toList(), DUMMY_NOTARY)
 
                 updates
             }
@@ -2049,17 +2058,17 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 10) {}
                     },
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 3) {}
                     },
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 1) {}
                     }
             )
@@ -2071,7 +2080,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         val updates =
             database.transaction {
 
-                services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
                 val linearStates = services.fillWithSomeTestLinearStates(10).states
                 val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789")).states
 
@@ -2083,14 +2092,14 @@ class VaultQueryTests : TestDependencyInjectionBase() {
                 assertThat(snapshot.statesMetadata).hasSize(3)
 
                 // add more cash
-                services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
+                services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
                 // add another deal
                 services.fillWithSomeTestDeals(listOf("SAMPLE DEAL"))
 
                 // consume stuff
-                services.consumeCash(100.DOLLARS)
-                services.consumeDeals(dealStates.toList())
-                services.consumeLinearStates(linearStates.toList())
+                services.consumeCash(100.DOLLARS, notary = DUMMY_NOTARY)
+                services.consumeDeals(dealStates.toList(), DUMMY_NOTARY)
+                services.consumeLinearStates(linearStates.toList(), DUMMY_NOTARY)
 
                 updates
             }
@@ -2099,12 +2108,12 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 3) {}
                     },
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
-                        require(consumed.size == 0) {}
+                        require(consumed.isEmpty()) {}
                         require(produced.size == 1) {}
                     }
             )

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.vault
 
 import net.corda.contracts.asset.Cash
 import net.corda.contracts.asset.DUMMY_CASH_ISSUER
+import net.corda.contracts.asset.DUMMY_CASH_ISSUER_KEY
 import net.corda.contracts.getCashBalance
 import net.corda.core.contracts.*
 import net.corda.core.identity.AnonymousParty
@@ -34,6 +35,7 @@ import kotlin.test.assertEquals
 
 class VaultWithCashTest : TestDependencyInjectionBase() {
     lateinit var services: MockServices
+    lateinit var issuerServices: MockServices
     val vault: VaultService get() = services.vaultService
     val vaultQuery: VaultQueryService get() = services.vaultQueryService
     lateinit var database: CordaPersistence
@@ -42,9 +44,10 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(VaultWithCashTest::class)
-        val databaseAndServices = makeTestDatabaseAndMockServices()
+        val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(DUMMY_CASH_ISSUER_KEY, DUMMY_NOTARY_KEY))
         database = databaseAndServices.first
         services = databaseAndServices.second
+        issuerServices = MockServices(DUMMY_CASH_ISSUER_KEY, MEGA_CORP_KEY)
     }
 
     @After
@@ -57,7 +60,7 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
     fun splits() {
         database.transaction {
             // Fix the PRNG so that we get the same splits every time.
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 3, 3, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
 
             val w = vaultQuery.queryBy<Cash.State>().states
             assertEquals(3, w.size)
@@ -117,10 +120,8 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
 
         database.transaction {
             // A tx that sends us money.
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 10, 10, Random(0L),
-                    issuedBy = MEGA_CORP.ref(1),
-                    issuerKey = MEGA_CORP_KEY,
-                    ownedBy = AnonymousParty(freshKey))
+            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 10, 10, Random(0L), ownedBy = AnonymousParty(freshKey),
+                    issuedBy = MEGA_CORP.ref(1))
             println("Cash balance: ${services.getCashBalance(USD)}")
 
             assertThat(vaultQuery.queryBy<Cash.State>().states).hasSize(10)
@@ -269,9 +270,9 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
 
         val freshKey = services.keyManagementService.freshKey()
         database.transaction {
-            services.fillWithSomeTestCash(100.DOLLARS, DUMMY_NOTARY, 3, 3, Random(0L), ownedBy = AnonymousParty(freshKey))
-            services.fillWithSomeTestCash(100.SWISS_FRANCS, DUMMY_NOTARY, 2, 2, Random(0L))
-            services.fillWithSomeTestCash(100.POUNDS, DUMMY_NOTARY, 1, 1, Random(0L))
+            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 3, 3, Random(0L), ownedBy = AnonymousParty(freshKey))
+            services.fillWithSomeTestCash(100.SWISS_FRANCS, issuerServices, DUMMY_NOTARY, 2, 2, Random(0L))
+            services.fillWithSomeTestCash(100.POUNDS, issuerServices, DUMMY_NOTARY, 1, 1, Random(0L))
             val cash = vaultQuery.queryBy<Cash.State>().states
             cash.forEach { println(it.state.data.amount) }
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.contracts.Fix
 import net.corda.contracts.FixableDealState
 import net.corda.core.contracts.*
+import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.toBase58String
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
@@ -12,13 +13,13 @@ import net.corda.core.flows.SchedulableFlow
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceType
-import net.corda.core.utilities.seconds
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.utilities.transient
 import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.seconds
 import net.corda.core.utilities.trace
+import net.corda.core.utilities.transient
 import net.corda.flows.TwoPartyDealFlow
 import java.math.BigDecimal
 import java.security.PublicKey
@@ -52,7 +53,7 @@ object FixingFlow {
         }
 
         @Suspendable
-        override fun assembleSharedTX(handshake: TwoPartyDealFlow.Handshake<FixingSession>): Pair<TransactionBuilder, List<PublicKey>> {
+        override fun assembleSharedTX(handshake: TwoPartyDealFlow.Handshake<FixingSession>): Triple<TransactionBuilder, List<PublicKey>, List<TransactionSignature>> {
             @Suppress("UNCHECKED_CAST")
             val fixOf = deal.nextFixingOf()!!
 
@@ -85,9 +86,9 @@ object FixingFlow {
                     }
                 }
             }
-            subFlow(addFixing)
+            val sig = subFlow(addFixing)
             // DOCEND 1
-            return Pair(ptx, arrayListOf(myOldParty.owningKey))
+            return Triple(ptx, arrayListOf(myOldParty.owningKey), listOf(sig))
         }
     }
 

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/VaultFiller.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/VaultFiller.kt
@@ -6,6 +6,8 @@ import net.corda.contracts.Commodity
 import net.corda.contracts.DealState
 import net.corda.contracts.asset.*
 import net.corda.core.contracts.*
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
@@ -19,7 +21,6 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.testing.CHARLIE
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.DUMMY_NOTARY_KEY
-import java.security.KeyPair
 import java.security.PublicKey
 import java.time.Duration
 import java.time.Instant
@@ -28,17 +29,18 @@ import java.util.*
 
 @JvmOverloads
 fun ServiceHub.fillWithSomeTestDeals(dealIds: List<String>,
-                                     participants: List<AbstractParty> = emptyList()) : Vault<DealState> {
+                                     participants: List<AbstractParty> = emptyList(),
+                                     notary: Party = DUMMY_NOTARY) : Vault<DealState> {
     val myKey: PublicKey = myInfo.legalIdentity.owningKey
     val me = AnonymousParty(myKey)
 
     val transactions: List<SignedTransaction> = dealIds.map {
         // Issue a deal state
-        val dummyIssue = TransactionBuilder(notary = DUMMY_NOTARY).apply {
+        val dummyIssue = TransactionBuilder(notary = notary).apply {
             addOutputState(DummyDealContract.State(ref = it, participants = participants.plus(me)))
-            signWith(DUMMY_NOTARY_KEY)
         }
-        return@map signInitialTransaction(dummyIssue)
+        val stx = signInitialTransaction(dummyIssue)
+        return@map addSignature(stx, notary.owningKey)
     }
 
     recordTransactions(transactions)
@@ -61,6 +63,8 @@ fun ServiceHub.fillWithSomeTestLinearStates(numberToCreate: Int,
                                             linearTimestamp: Instant = now()) : Vault<LinearState> {
     val myKey: PublicKey = myInfo.legalIdentity.owningKey
     val me = AnonymousParty(myKey)
+    val issuerKey = DUMMY_NOTARY_KEY
+    val signatureMetadata = SignatureMetadata(myInfo.platformVersion, Crypto.findSignatureScheme(issuerKey.public).schemeNumberID)
 
     val transactions: List<SignedTransaction> = (1..numberToCreate).map {
         // Issue a Linear state
@@ -72,10 +76,9 @@ fun ServiceHub.fillWithSomeTestLinearStates(numberToCreate: Int,
                     linearNumber = linearNumber,
                     linearBoolean = linearBoolean,
                     linearTimestamp = linearTimestamp))
-            signWith(DUMMY_NOTARY_KEY)
         }
 
-        return@map signInitialTransaction(dummyIssue)
+        return@map signInitialTransaction(dummyIssue).withAdditionalSignature(issuerKey, signatureMetadata)
     }
 
     recordTransactions(transactions)
@@ -95,18 +98,19 @@ fun ServiceHub.fillWithSomeTestLinearStates(numberToCreate: Int,
  *
  * The service hub needs to provide at least a key management service and a storage service.
  *
+ * @param issuerServices service hub of the issuer node, which will be used to sign the transaction.
  * @param outputNotary the notary to use for output states. The transaction is NOT signed by this notary.
  * @return a vault object that represents the generated states (it will NOT be the full vault from the service hub!).
  */
 fun ServiceHub.fillWithSomeTestCash(howMuch: Amount<Currency>,
+                                    issuerServices: ServiceHub = this,
                                     outputNotary: Party = DUMMY_NOTARY,
                                     atLeastThisManyStates: Int = 3,
                                     atMostThisManyStates: Int = 10,
                                     rng: Random = Random(),
                                     ref: OpaqueBytes = OpaqueBytes(ByteArray(1, { 1 })),
                                     ownedBy: AbstractParty? = null,
-                                    issuedBy: PartyAndReference = DUMMY_CASH_ISSUER,
-                                    issuerKey: KeyPair = DUMMY_CASH_ISSUER_KEY): Vault<Cash.State> {
+                                    issuedBy: PartyAndReference = DUMMY_CASH_ISSUER): Vault<Cash.State> {
     val amounts = calculateRandomlySizedAmounts(howMuch, atLeastThisManyStates, atMostThisManyStates, rng)
 
     val myKey: PublicKey = ownedBy?.owningKey ?: myInfo.legalIdentity.owningKey
@@ -117,9 +121,8 @@ fun ServiceHub.fillWithSomeTestCash(howMuch: Amount<Currency>,
     val transactions: List<SignedTransaction> = amounts.map { pennies ->
         val issuance = TransactionBuilder(null as Party?)
         cash.generateIssue(issuance, Amount(pennies, Issued(issuedBy.copy(reference = ref), howMuch.token)), me, outputNotary)
-        issuance.signWith(issuerKey)
 
-        return@map issuance.toSignedTransaction(true)
+        return@map issuerServices.signInitialTransaction(issuance, issuedBy.party.owningKey)
     }
 
     recordTransactions(transactions)
@@ -132,21 +135,26 @@ fun ServiceHub.fillWithSomeTestCash(howMuch: Amount<Currency>,
     return Vault(states)
 }
 
+/**
+ *
+ * @param issuerServices service hub of the issuer node, which will be used to sign the transaction.
+ * @param outputNotary the notary to use for output states. The transaction is NOT signed by this notary.
+ * @return a vault object that represents the generated states (it will NOT be the full vault from the service hub!).
+ */
 // TODO: need to make all FungibleAsset commands (issue, move, exit) generic
 fun ServiceHub.fillWithSomeTestCommodity(amount: Amount<Commodity>,
+                                         issuerServices: ServiceHub = this,
                                          outputNotary: Party = DUMMY_NOTARY,
                                          ref: OpaqueBytes = OpaqueBytes(ByteArray(1, { 1 })),
                                          ownedBy: AbstractParty? = null,
-                                         issuedBy: PartyAndReference = DUMMY_OBLIGATION_ISSUER.ref(1),
-                                         issuerKey: KeyPair = DUMMY_OBLIGATION_ISSUER_KEY): Vault<CommodityContract.State> {
+                                         issuedBy: PartyAndReference = DUMMY_OBLIGATION_ISSUER.ref(1)): Vault<CommodityContract.State> {
     val myKey: PublicKey = ownedBy?.owningKey ?: myInfo.legalIdentity.owningKey
     val me = AnonymousParty(myKey)
 
     val commodity = CommodityContract()
     val issuance = TransactionBuilder(null as Party?)
     commodity.generateIssue(issuance, Amount(amount.quantity, Issued(issuedBy.copy(reference = ref), amount.token)), me, outputNotary)
-    issuance.signWith(issuerKey)
-    val transaction = issuance.toSignedTransaction(true)
+    val transaction = issuerServices.signInitialTransaction(issuance, issuedBy.party.owningKey)
 
     recordTransactions(transaction)
 
@@ -181,62 +189,62 @@ fun calculateRandomlySizedAmounts(howMuch: Amount<Currency>, min: Int, max: Int,
     return amounts
 }
 
-fun <T : LinearState> ServiceHub.consume(states: List<StateAndRef<T>>) {
+fun <T : LinearState> ServiceHub.consume(states: List<StateAndRef<T>>, notary: Party) {
     // Create a txn consuming different contract types
     states.forEach {
-        val consumedTx = TransactionBuilder(notary = DUMMY_NOTARY).apply {
+        val builder =  TransactionBuilder(notary = notary).apply {
             addInputState(it)
-            signWith(DUMMY_NOTARY_KEY)
-        }.toSignedTransaction()
+        }
+        val consumedTx = signInitialTransaction(builder, notary.owningKey)
 
         recordTransactions(consumedTx)
     }
 }
 
-fun <T : LinearState> ServiceHub.consumeAndProduce(stateAndRef: StateAndRef<T>): StateAndRef<T> {
+fun <T : LinearState> ServiceHub.consumeAndProduce(stateAndRef: StateAndRef<T>, notary: Party): StateAndRef<T> {
     // Create a txn consuming different contract types
-    val consumedTx = TransactionBuilder(notary = DUMMY_NOTARY).apply {
+    var builder = TransactionBuilder(notary = notary).apply {
         addInputState(stateAndRef)
-        signWith(DUMMY_NOTARY_KEY)
-    }.toSignedTransaction()
+    }
+    val consumedTx = signInitialTransaction(builder, notary.owningKey)
 
     recordTransactions(consumedTx)
 
     // Create a txn consuming different contract types
-    val producedTx = TransactionBuilder(notary = DUMMY_NOTARY).apply {
+    builder = TransactionBuilder(notary = notary).apply {
         addOutputState(DummyLinearContract.State(linearId = stateAndRef.state.data.linearId,
                 participants = stateAndRef.state.data.participants))
-        signWith(DUMMY_NOTARY_KEY)
-    }.toSignedTransaction()
+    }
+    val producedTx = signInitialTransaction(builder, notary.owningKey)
 
     recordTransactions(producedTx)
 
     return producedTx.tx.outRef<T>(0)
 }
 
-fun <T : LinearState> ServiceHub.consumeAndProduce(states: List<StateAndRef<T>>) {
+fun <T : LinearState> ServiceHub.consumeAndProduce(states: List<StateAndRef<T>>, notary: Party) {
     states.forEach {
-        consumeAndProduce(it)
+        consumeAndProduce(it, notary)
     }
 }
 
-fun ServiceHub.consumeDeals(dealStates: List<StateAndRef<DealState>>) = consume(dealStates)
-fun ServiceHub.consumeLinearStates(linearStates: List<StateAndRef<LinearState>>) = consume(linearStates)
-fun ServiceHub.evolveLinearStates(linearStates: List<StateAndRef<LinearState>>) = consumeAndProduce(linearStates)
-fun ServiceHub.evolveLinearState(linearState: StateAndRef<LinearState>) : StateAndRef<LinearState> = consumeAndProduce(linearState)
+fun ServiceHub.consumeDeals(dealStates: List<StateAndRef<DealState>>, notary: Party) = consume(dealStates, notary)
+fun ServiceHub.consumeLinearStates(linearStates: List<StateAndRef<LinearState>>, notary: Party) = consume(linearStates, notary)
+fun ServiceHub.evolveLinearStates(linearStates: List<StateAndRef<LinearState>>, notary: Party) = consumeAndProduce(linearStates, notary)
+fun ServiceHub.evolveLinearState(linearState: StateAndRef<LinearState>, notary: Party) : StateAndRef<LinearState> = consumeAndProduce(linearState, notary)
 
 @JvmOverloads
-fun ServiceHub.consumeCash(amount: Amount<Currency>, to: Party = CHARLIE): Vault.Update<ContractState> {
+fun ServiceHub.consumeCash(amount: Amount<Currency>, to: Party = CHARLIE, notary: Party): Vault.Update<ContractState> {
     val update =  vaultService.rawUpdates.toFuture()
     val services = this
 
     // A tx that spends our money.
-    val spendTX = TransactionBuilder(DUMMY_NOTARY).apply {
+    val builder = TransactionBuilder(notary).apply {
         Cash.generateSpend(services, this, amount, to)
-        signWith(DUMMY_NOTARY_KEY)
-    }.toSignedTransaction(checkSufficientSignatures = false)
+    }
+    val spendTx = signInitialTransaction(builder, notary.owningKey)
 
-    recordTransactions(spendTX)
+    recordTransactions(spendTx)
 
     return update.getOrThrow(Duration.ofSeconds(3))
 }


### PR DESCRIPTION
Remove deprecated signing functions from `TransactionBuilder`, introducing replacement functions where needed for specific cases (i.e. signatures provided by a third party node or unit tests).
