### PR TITLE
Docs: Stop the API pages being orphaned without a menu

### DIFF
--- a/docs/source/api-index.rst
+++ b/docs/source/api-index.rst
@@ -3,13 +3,16 @@ API
 
 This section describes the APIs that are available for the development of CorDapps:
 
-* :doc:`api-states`
-* :doc:`api-persistence`
-* :doc:`api-contracts`
-* :doc:`api-vault-query`
-* :doc:`api-transactions`
-* :doc:`api-flows`
-* :doc:`api-core-types`
+.. toctree::
+   :maxdepth: 1
+
+   api-states
+   api-persistence
+   api-contracts
+   api-vault-query
+   api-transactions
+   api-flows
+   api-core-types
 
 Before reading this page, you should be familiar with the :doc:`key concepts of Corda <key-concepts>`.
 


### PR DESCRIPTION
Just a very small change to the Sphinx docs as I was getting annoyed that the API pages don't have links in the TOC. The "API: blah" pages now show up in the TOC and also each "API: blah" page has the menu so you don't need to go back to the main "API" page to get to the page for each "API: blah" page.

Before (as it currently is):
<img width="1092" alt="screen shot 2017-08-02 at 10 44 45" src="https://user-images.githubusercontent.com/1138061/28867920-aab686fc-776f-11e7-8e28-bef8c15157f9.png">
After (this PR):
<img width="1096" alt="screen shot 2017-08-02 at 10 43 32" src="https://user-images.githubusercontent.com/1138061/28867930-afd7c6e6-776f-11e7-997f-6b745a0421bc.png">