### PR TITLE
Remove BOC reference from trader demo client API

### DIFF
--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
@@ -44,7 +44,7 @@ class TraderDemoClientApi(val rpc: CordaRPCOps) {
         return vault.filterStatesOfType<CommercialPaper.State>().size
     }
 
-    fun runBuyer(amount: Amount<Currency> = 30000.DOLLARS, anonymous: Boolean = true) {
+    fun runBuyer(amount: Amount<Currency> = 30000.DOLLARS, anonymous: Boolean = false) {
         val bankOfCordaParty = rpc.partyFromX500Name(BOC.name)
                 ?: throw IllegalStateException("Unable to locate ${BOC.name} in Network Map Service")
         val notaryLegalIdentity = rpc.partyFromX500Name(DUMMY_NOTARY.name)

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
@@ -18,7 +18,7 @@ import net.corda.core.utilities.seconds
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.flows.TwoPartyTradeFlow
-import net.corda.testing.BOC
+import org.bouncycastle.asn1.x500.X500Name
 import java.time.Instant
 import java.util.*
 
@@ -69,7 +69,7 @@ class SellerFlow(val otherParty: Party,
     @Suspendable
     fun selfIssueSomeCommercialPaper(ownedBy: AbstractParty, notaryNode: NodeInfo): StateAndRef<CommercialPaper.State> {
         // Make a fake company that's issued its own paper.
-        val party = Party(BOC.name, serviceHub.legalIdentityKey)
+        val party = Party(X500Name("CN=BankOfCorda,O=R3,L=New York,C=US"), serviceHub.legalIdentityKey)
 
         val issuance: SignedTransaction = run {
             val tx = CommercialPaper().generateIssue(party.ref(1, 2, 3), 1100.DOLLARS `issued by` DUMMY_CASH_ISSUER,


### PR DESCRIPTION
* Remove BOC reference from trader demo client API as it fails at runtime because the test constants are not available.
* Disable anonymisation in the command line trader demo.