### PR TITLE
Applied contract type filtering to ALL Query Criteria types 

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -79,8 +79,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
     }
 
     private fun deriveContractTypes(contractStateTypes: Set<Class<out ContractState>>? = null): List<String> {
-        val combinedContractTypeTypes = contractStateTypes?.plus(contractType) ?: setOf(contractType)
-        combinedContractTypeTypes.filter { it.name != ContractState::class.java.name }.let {
+        val combinedContractStateTypes = contractStateTypes?.plus(contractType) ?: setOf(contractType)
+        combinedContractStateTypes.filter { it.name != ContractState::class.java.name }.let {
             val interfaces = it.flatMap { contractTypeMappings[it.name] ?: emptyList() }
             val concrete = it.filter { !it.isInterface }.map { it.name }
             return interfaces.plus(concrete)

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -221,7 +221,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         predicateSet.add(joinPredicate)
 
         // contract State Types
-        predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(deriveContractTypes())))
+        val contractTypes = deriveContractTypes()
+        if (contractTypes.isNotEmpty())
+            predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(contractTypes)))
 
         // owner
         criteria.owner?.let {
@@ -273,7 +275,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         joinPredicates.add(joinPredicate)
 
         // contract State Types
-        predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(deriveContractTypes())))
+        val contractTypes = deriveContractTypes()
+        if (contractTypes.isNotEmpty())
+            predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(contractTypes)))
 
         // linear ids
         criteria.linearId?.let {
@@ -315,7 +319,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
             joinPredicates.add(joinPredicate)
 
             // contract State Types
-            predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(deriveContractTypes())))
+            val contractTypes = deriveContractTypes()
+            if (contractTypes.isNotEmpty())
+                predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(contractTypes)))
 
             // resolve general criteria expressions
             parseExpression(entityRoot, criteria.expression, predicateSet)

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -43,14 +43,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         val predicateSet = mutableSetOf<Predicate>()
 
         // contract State Types
-        val combinedContractTypeTypes = criteria.contractStateTypes?.plus(contractType) ?: setOf(contractType)
-        combinedContractTypeTypes.filter { it.name != ContractState::class.java.name }.let {
-            val interfaces = it.flatMap { contractTypeMappings[it.name] ?: emptyList() }
-            val concrete = it.filter { !it.isInterface }.map { it.name }
-            val all = interfaces.plus(concrete)
-            if (all.isNotEmpty())
-                predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(all)))
-        }
+        val contractTypes = deriveContractTypes(criteria.contractStateTypes)
+        if (contractTypes.isNotEmpty())
+            predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(contractTypes)))
 
         // soft locking
         if (!criteria.includeSoftlockedStates)
@@ -81,6 +76,15 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
             predicateSet.add(parseExpression(vaultStates, expression) as Predicate)
         }
         return predicateSet
+    }
+
+    private fun  deriveContractTypes(contractStateTypes: Set<Class<out ContractState>>? = null): List<String> {
+        val combinedContractTypeTypes = contractStateTypes?.plus(contractType) ?: setOf(contractType)
+        combinedContractTypeTypes.filter { it.name != ContractState::class.java.name }.let {
+            val interfaces = it.flatMap { contractTypeMappings[it.name] ?: emptyList() }
+            val concrete = it.filter { !it.isInterface }.map { it.name }
+            return interfaces.plus(concrete)
+        }
     }
 
     private fun columnPredicateToPredicate(column: Path<out Any?>, columnPredicate: ColumnPredicate<*>): Predicate {
@@ -216,6 +220,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), vaultFungibleStates.get<PersistentStateRef>("stateRef"))
         predicateSet.add(joinPredicate)
 
+        // contract State Types
+        predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(deriveContractTypes())))
+
         // owner
         criteria.owner?.let {
             val ownerKeys = criteria.owner as List<AbstractParty>
@@ -265,6 +272,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), vaultLinearStates.get<PersistentStateRef>("stateRef"))
         joinPredicates.add(joinPredicate)
 
+        // contract State Types
+        predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(deriveContractTypes())))
+
         // linear ids
         criteria.linearId?.let {
             val uniqueIdentifiers = criteria.linearId as List<UniqueIdentifier>
@@ -303,6 +313,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
 
             val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
             joinPredicates.add(joinPredicate)
+
+            // contract State Types
+            predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(deriveContractTypes())))
 
             // resolve general criteria expressions
             parseExpression(entityRoot, criteria.expression, predicateSet)

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -78,7 +78,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         return predicateSet
     }
 
-    private fun  deriveContractTypes(contractStateTypes: Set<Class<out ContractState>>? = null): List<String> {
+    private fun deriveContractTypes(contractStateTypes: Set<Class<out ContractState>>? = null): List<String> {
         val combinedContractTypeTypes = contractStateTypes?.plus(contractType) ?: setOf(contractType)
         combinedContractTypeTypes.filter { it.name != ContractState::class.java.name }.let {
             val interfaces = it.flatMap { contractTypeMappings[it.name] ?: emptyList() }


### PR DESCRIPTION
Bug surfaced in TraderDemo integration test where assertions use vault custom query aggregate function to count number of states of a given contract type (commercial paper, cash). 

This PR ensures the contract type filter is applied to all 4 types of VaultQueryCriteria:
```
VaultQueryCriteria
LinearStateQueryCriteria
FungibleAssetQueryCriteria
VaultCustomQueryCriteria
```


