### PR TITLE
Correct notary demo in M14

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -113,8 +113,9 @@ interface ServiceHubInternal : PluginServiceHub {
     val uploaders: List<FileUploader>
 
     override fun recordTransactions(txs: Iterable<SignedTransaction>) {
-        val recordedTransactions = txs.filter { validatedTransactions.addTransaction(it) }
-        require(recordedTransactions.isNotEmpty()) { "No transactions passed in for recording" }
+        val inputTxs = txs.toList()
+        require (inputTxs.isNotEmpty()) { "No transactions passed in for recording" }
+        val recordedTransactions = inputTxs.filter { validatedTransactions.addTransaction(it) }
         val stateMachineRunId = FlowStateMachineImpl.currentStateMachine()?.id
         if (stateMachineRunId != null) {
             recordedTransactions.forEach {

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -113,9 +113,8 @@ interface ServiceHubInternal : PluginServiceHub {
     val uploaders: List<FileUploader>
 
     override fun recordTransactions(txs: Iterable<SignedTransaction>) {
-        val inputTxs = txs.toList()
-        require (inputTxs.isNotEmpty()) { "No transactions passed in for recording" }
-        val recordedTransactions = inputTxs.filter { validatedTransactions.addTransaction(it) }
+        require (txs.any()) { "No transactions passed in for recording" }
+        val recordedTransactions = txs.filter { validatedTransactions.addTransaction(it) }
         val stateMachineRunId = FlowStateMachineImpl.currentStateMachine()?.id
         if (stateMachineRunId != null) {
             recordedTransactions.forEach {

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt
@@ -1,28 +1,33 @@
 package net.corda.notarydemo.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.testing.contracts.DummyContract
+import net.corda.contracts.asset.Cash
+import net.corda.core.contracts.Amount
+import net.corda.core.contracts.GBP
+import net.corda.core.contracts.Issued
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
-import java.util.*
+import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 class DummyIssueAndMove(private val notary: Party, private val counterpartyNode: Party) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call(): SignedTransaction {
-        val random = Random()
         // Self issue an asset
-        val issueTxBuilder = DummyContract.generateInitial(random.nextInt(), notary, serviceHub.myInfo.legalIdentity.ref(0))
-        val issueTx = serviceHub.signInitialTransaction(issueTxBuilder)
+        val amount = Amount(1000000, Issued(serviceHub.myInfo.legalIdentity.ref(0), GBP))
+        val issueTxBuilder = TransactionBuilder(notary = notary)
+        val signers = Cash().generateIssue(issueTxBuilder, amount, serviceHub.myInfo.legalIdentity, notary)
+        val issueTx = serviceHub.signInitialTransaction(issueTxBuilder, signers)
         serviceHub.recordTransactions(issueTx)
         // Move ownership of the asset to the counterparty
         val counterPartyKey = counterpartyNode.owningKey
-        val asset = issueTx.tx.outRef<DummyContract.SingleOwnerState>(0)
-        val moveTxBuilder = DummyContract.move(asset, counterpartyNode)
-        val moveTx = serviceHub.signInitialTransaction(moveTxBuilder)
+        val asset = issueTx.tx.outRef<Cash.State>(0)
+        val moveTxBuilder = TransactionBuilder(notary = notary)
+
+        val (_, keys) = serviceHub.vaultService.generateSpend(moveTxBuilder, Amount(amount.quantity, GBP), counterpartyNode)
         // We don't check signatures because we know that the notary's signature is missing
-        return moveTx
+        return serviceHub.signInitialTransaction(moveTxBuilder, keys)
     }
 }


### PR DESCRIPTION
Shams, I've asked you to review because I've changed a test you added to `ServiceHubInternal`, do let me know if this is an inappropriate solution. Previously however in the RAFT notary case it for some reason double-records transactions, which leads to it throwing an error as after filtering the `recordedTransactions` list is empty.
