### PR TITLE
Sync notary demo fixes from M14

### DIFF
--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt
@@ -1,8 +1,8 @@
 package net.corda.notarydemo.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.Contract
-import net.corda.core.contracts.ContractState
+import net.corda.contracts.asset.Cash
+import net.corda.core.contracts.*
 import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
@@ -26,16 +26,16 @@ class DummyIssueAndMove(private val notary: Party, private val counterpartyNode:
     @Suspendable
     override fun call() = serviceHub.run {
         // Self issue an asset
-        val state = State(listOf(myInfo.legalIdentity), discriminator)
-        val issueTx = signInitialTransaction(TransactionBuilder(notary).apply {
-            addOutputState(state)
-        })
-        recordTransactions(issueTx)
+        val amount = Amount(1000000, Issued(myInfo.legalIdentity.ref(0), GBP))
+        val issueTxBuilder = TransactionBuilder(notary = notary)
+        val signers = Cash().generateIssue(issueTxBuilder, amount, serviceHub.myInfo.legalIdentity, notary)
+        val issueTx = serviceHub.signInitialTransaction(issueTxBuilder, signers)
+        serviceHub.recordTransactions(issueTx)
         // Move ownership of the asset to the counterparty
+        val moveTxBuilder = TransactionBuilder(notary = notary)
+
+        val (_, keys) = vaultService.generateSpend(moveTxBuilder, Amount(amount.quantity, GBP), counterpartyNode)
         // We don't check signatures because we know that the notary's signature is missing
-        signInitialTransaction(TransactionBuilder(notary).apply {
-            addInputState(issueTx.tx.outRef<ContractState>(0))
-            addOutputState(state.copy(participants = listOf(counterpartyNode)))
-        })
+        signInitialTransaction(moveTxBuilder, keys)
     }
 }


### PR DESCRIPTION
* Use Cash contract instead of DummyContract in notary demo to remove dependency on test utils
* Check transactions to be recorded before filtering rather than after, as currently if the entire
list of transactions is already recorded, it's mis-reported as an empty input.