### PR TITLE
Improvements to Vault Query Service soft locked state querying

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -274,12 +274,6 @@ interface VaultService {
      */
     fun softLockRelease(lockId: UUID, stateRefs: NonEmptySet<StateRef>? = null)
 
-    /**
-     * Retrieve softLockStates for a given [UUID] or return all softLockStates in vault for a given
-     * [ContractState] type
-     */
-    fun <T : ContractState> softLockedStates(lockId: UUID? = null): List<StateAndRef<T>>
-
     // DOCEND SoftLockAPI
 
     /**

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -26,6 +26,18 @@ sealed class QueryCriteria {
     @CordaSerializable
     data class TimeCondition(val type: TimeInstantType, val predicate: ColumnPredicate<Instant>)
 
+    // DOCSTART VaultQuerySoftLockingCriteria
+    @CordaSerializable
+    data class SoftLockingCondition(val type: SoftLockingType, val lockIds: List<UUID> = emptyList())
+
+    @CordaSerializable
+    enum class SoftLockingType {
+        EXCLUSIVE,      // exclusive of soft locked states
+        LOCKED_ONLY,    // only soft locked states
+        SPECIFIED       // only specified soft locked states (specified by lock ids)
+    }
+    // DOCEND VaultQuerySoftLockingCriteria
+
     abstract class CommonQueryCriteria : QueryCriteria() {
         abstract val status: Vault.StateStatus
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
@@ -40,7 +52,7 @@ sealed class QueryCriteria {
                                                              val contractStateTypes: Set<Class<out ContractState>>? = null,
                                                              val stateRefs: List<StateRef>? = null,
                                                              val notaryName: List<X500Name>? = null,
-                                                             val includeSoftlockedStates: Boolean = true,
+                                                             val softLockingCondition: SoftLockingCondition? = null,
                                                              val timeCondition: TimeCondition? = null) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this as CommonQueryCriteria).plus(parser.parseCriteria(this))

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -32,9 +32,9 @@ sealed class QueryCriteria {
 
     @CordaSerializable
     enum class SoftLockingType {
-        EXCLUSIVE,      // exclusive of soft locked states
+        UNLOCKED_ONLY,  // only unlocked states
         LOCKED_ONLY,    // only soft locked states
-        SPECIFIED,       // only those soft locked states specified by lock id(s)
+        SPECIFIED,      // only those soft locked states specified by lock id(s)
         UNLOCKED_AND_SPECIFIED   // all unlocked states plus those soft locked states specified by lock id(s)
     }
     // DOCEND VaultQuerySoftLockingCriteria

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -34,7 +34,8 @@ sealed class QueryCriteria {
     enum class SoftLockingType {
         EXCLUSIVE,      // exclusive of soft locked states
         LOCKED_ONLY,    // only soft locked states
-        SPECIFIED       // only specified soft locked states (specified by lock ids)
+        SPECIFIED,       // only those soft locked states specified by lock id(s)
+        UNLOCKED_AND_SPECIFIED   // all unlocked states plus those soft locked states specified by lock id(s)
     }
     // DOCEND VaultQuerySoftLockingCriteria
 

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -56,7 +56,7 @@ There are four implementations of this interface which can be chained together t
 
 1. ``VaultQueryCriteria`` provides filterable criteria on attributes within the Vault states table: status (UNCONSUMED, CONSUMED), state reference(s), contract state type(s), notaries, soft locked states, timestamps (RECORDED, CONSUMED).
 
-	.. note:: Sensible defaults are defined for frequently used attributes (status = UNCONSUMED, includeSoftlockedStates = true).
+	.. note:: Sensible defaults are defined for frequently used attributes (status = UNCONSUMED, always include soft locked states).
 
 2. ``FungibleAssetQueryCriteria`` provides filterable criteria on attributes defined in the Corda Core ``FungibleAsset`` contract state interface, used to represent assets that are fungible, countable and issued by a specific party (eg. ``Cash.State`` and ``CommodityContract.State`` in the Corda finance module). Filterable attributes include: participants(s), owner(s), quantity, issuer party(s) and issuer reference(s).
 	   

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -79,6 +79,12 @@ UNRELEASED
   dealing with ``StateAndRef``s.
 
 
+* Vault query soft locking enhancements and deprecations
+  * removed original ``VaultService`` ``softLockedStates` query mechanism.
+  * introduced improved ``SoftLockingCondition`` filterable attribute in ``VaultQueryCriteria`` to enable specification
+    of different soft locking retrieval behaviours (exclusive of soft locked states, soft locked states only, specified
+    by set of lock ids)
+
 Milestone 13
 ------------
 

--- a/docs/source/soft-locking.rst
+++ b/docs/source/soft-locking.rst
@@ -22,13 +22,15 @@ query soft locks associated with states as required by their CorDapp application
     :start-after: DOCSTART SoftLockAPI
     :end-before: DOCEND SoftLockAPI
 
-You can also control whether soft locked states are retrieved in general vault queries by setting an optional boolean
-`includeSoftLockedStates` flag (which is set to *true* by default)
+Query
+-----
+By default vault queries will always include locked states in its result sets.
+Custom filterable criteria can be specified using the ``SoftLockingCondition` attribute of ``VaultQueryCriteria``:
 
-.. literalinclude:: ../../core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
-    :language: kotlin
-    :start-after: DOCSTART VaultStatesQuery
-    :end-before: DOCEND VaultStatesQuery
+.. literalinclude:: ../../core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+:language: kotlin
+        :start-after: DOCSTART VaultQuerySoftLockingCriteria
+        :end-before: DOCEND VaultQuerySoftLockingCriteria
 
 Explicit Usage
 --------------

--- a/docs/source/soft-locking.rst
+++ b/docs/source/soft-locking.rst
@@ -25,12 +25,12 @@ query soft locks associated with states as required by their CorDapp application
 Query
 -----
 By default vault queries will always include locked states in its result sets.
-Custom filterable criteria can be specified using the ``SoftLockingCondition` attribute of ``VaultQueryCriteria``:
+Custom filterable criteria can be specified using the ``SoftLockingCondition`` attribute of ``VaultQueryCriteria``:
 
 .. literalinclude:: ../../core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
-:language: kotlin
-        :start-after: DOCSTART VaultQuerySoftLockingCriteria
-        :end-before: DOCEND VaultQuerySoftLockingCriteria
+  :language: kotlin
+  :start-after: DOCSTART VaultQuerySoftLockingCriteria
+  :end-before: DOCEND VaultQuerySoftLockingCriteria
 
 Explicit Usage
 --------------

--- a/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 class HibernateConfiguration(val schemaService: SchemaService, val useDefaultLogging: Boolean = false, val databaseProperties: Properties) {
-    constructor(schemaService: SchemaService, databaseProperties: Properties) : this(schemaService, true, databaseProperties)
+    constructor(schemaService: SchemaService, databaseProperties: Properties) : this(schemaService, false, databaseProperties)
 
     companion object {
         val logger = loggerFor<HibernateConfiguration>()

--- a/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 class HibernateConfiguration(val schemaService: SchemaService, val useDefaultLogging: Boolean = false, val databaseProperties: Properties) {
-    constructor(schemaService: SchemaService, databaseProperties: Properties) : this(schemaService, false, databaseProperties)
+    constructor(schemaService: SchemaService, databaseProperties: Properties) : this(schemaService, true, databaseProperties)
 
     companion object {
         val logger = loggerFor<HibernateConfiguration>()

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -52,16 +52,19 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
             val softLocking = criteria.softLockingCondition
             val type = softLocking!!.type
             when(type) {
-                QueryCriteria.SoftLockingType.EXCLUSIVE ->
+                QueryCriteria.SoftLockingType.UNLOCKED_ONLY ->
                     predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").isNull))
                 QueryCriteria.SoftLockingType.LOCKED_ONLY ->
                     predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").isNotNull))
                 QueryCriteria.SoftLockingType.UNLOCKED_AND_SPECIFIED -> {
+                    require(softLocking.lockIds.isNotEmpty()) { "Must specify one or more lockIds" }
                     predicateSet.add(criteriaBuilder.or(vaultStates.get<String>("lockId").isNull,
                                                         vaultStates.get<String>("lockId").`in`(softLocking.lockIds.map { it.toString() })))
                 }
-                QueryCriteria.SoftLockingType.SPECIFIED ->
+                QueryCriteria.SoftLockingType.SPECIFIED -> {
+                    require(softLocking.lockIds.isNotEmpty()) { "Must specify one or more lockIds" }
                     predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").`in`(softLocking.lockIds.map { it.toString() })))
+                }
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -56,6 +56,10 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
                     predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").isNull))
                 QueryCriteria.SoftLockingType.LOCKED_ONLY ->
                     predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").isNotNull))
+                QueryCriteria.SoftLockingType.UNLOCKED_AND_SPECIFIED -> {
+                    predicateSet.add(criteriaBuilder.or(vaultStates.get<String>("lockId").isNull,
+                                                        vaultStates.get<String>("lockId").`in`(softLocking.lockIds.map { it.toString() })))
+                }
                 QueryCriteria.SoftLockingType.SPECIFIED ->
                     predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").`in`(softLocking.lockIds.map { it.toString() })))
             }

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -48,8 +48,18 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
             predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(contractTypes)))
 
         // soft locking
-        if (!criteria.includeSoftlockedStates)
-            predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").isNull))
+        criteria.softLockingCondition?.let {
+            val softLocking = criteria.softLockingCondition
+            val type = softLocking!!.type
+            when(type) {
+                QueryCriteria.SoftLockingType.EXCLUSIVE ->
+                    predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").isNull))
+                QueryCriteria.SoftLockingType.LOCKED_ONLY ->
+                    predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").isNotNull))
+                QueryCriteria.SoftLockingType.SPECIFIED ->
+                    predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("lockId").`in`(softLocking.lockIds.map { it.toString() })))
+            }
+        }
 
         // notary names
         criteria.notaryName?.let {

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -140,17 +140,17 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
             assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId).states).hasSize(2)
 
             // excluding softlocked states
-            val unlockedStates1 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.EXCLUSIVE))).states
+            val unlockedStates1 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.UNLOCKED_ONLY))).states
             assertThat(unlockedStates1).hasSize(1)
 
             // soft lock release one of the states explicitly
             vaultSvc.softLockRelease(softLockId, NonEmptySet.of(unconsumedStates[1].ref))
-            val unlockedStates2 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.EXCLUSIVE))).states
+            val unlockedStates2 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.UNLOCKED_ONLY))).states
             assertThat(unlockedStates2).hasSize(2)
 
             // soft lock release the rest by id
             vaultSvc.softLockRelease(softLockId)
-            val unlockedStates = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.EXCLUSIVE))).states
+            val unlockedStates = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.UNLOCKED_ONLY))).states
             assertThat(unlockedStates).hasSize(3)
 
             // should be back to original states

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -12,6 +12,7 @@ import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultQueryService
 import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.queryBy
+import net.corda.core.node.services.vault.QueryCriteria.*
 import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria
 import net.corda.core.transactions.NotaryChangeWireTransaction
 import net.corda.core.transactions.SignedTransaction
@@ -132,22 +133,24 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
             vaultSvc.softLockReserve(softLockId, stateRefsToSoftLock)
 
             // all softlocked states
-            assertThat(vaultSvc.softLockedStates<Cash.State>()).hasSize(2)
+            val criteriaLocked = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.LOCKED_ONLY))
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaLocked).states).hasSize(2)
             // my softlocked states
-            assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId)).hasSize(2)
+            val criteriaByLockId = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.SPECIFIED, listOf(softLockId)))
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId).states).hasSize(2)
 
             // excluding softlocked states
-            val unlockedStates1 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(includeSoftlockedStates = false)).states
+            val unlockedStates1 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.EXCLUSIVE))).states
             assertThat(unlockedStates1).hasSize(1)
 
             // soft lock release one of the states explicitly
             vaultSvc.softLockRelease(softLockId, NonEmptySet.of(unconsumedStates[1].ref))
-            val unlockedStates2 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(includeSoftlockedStates = false)).states
+            val unlockedStates2 = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.EXCLUSIVE))).states
             assertThat(unlockedStates2).hasSize(2)
 
             // soft lock release the rest by id
             vaultSvc.softLockRelease(softLockId)
-            val unlockedStates = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(includeSoftlockedStates = false)).states
+            val unlockedStates = vaultQuery.queryBy<Cash.State>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.EXCLUSIVE))).states
             assertThat(unlockedStates).hasSize(3)
 
             // should be back to original states
@@ -157,12 +160,14 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
 
     @Test
     fun `soft locking attempt concurrent reserve`() {
-
         val backgroundExecutor = Executors.newFixedThreadPool(2)
         val countDown = CountDownLatch(2)
 
         val softLockId1 = UUID.randomUUID()
         val softLockId2 = UUID.randomUUID()
+
+        val criteriaByLockId1 = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.SPECIFIED, listOf(softLockId1)))
+        val criteriaByLockId2 = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.SPECIFIED, listOf(softLockId2)))
 
         val vaultStates =
                 database.transaction {
@@ -177,7 +182,7 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
             try {
                 database.transaction {
                     vaultSvc.softLockReserve(softLockId1, stateRefsToSoftLock)
-                    assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId1)).hasSize(3)
+                    assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId1).states).hasSize(3)
                 }
                 println("SOFT LOCK STATES #1 succeeded")
             } catch(e: Throwable) {
@@ -193,7 +198,7 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
                 Thread.sleep(100)   // let 1st thread soft lock them 1st
                 database.transaction {
                     vaultSvc.softLockReserve(softLockId2, stateRefsToSoftLock)
-                    assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId2)).hasSize(3)
+                    assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId2).states).hasSize(3)
                 }
                 println("SOFT LOCK STATES #2 succeeded")
             } catch(e: Throwable) {
@@ -205,10 +210,10 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
 
         countDown.await()
         database.transaction {
-            val lockStatesId1 = vaultSvc.softLockedStates<Cash.State>(softLockId1)
+            val lockStatesId1 = vaultQuery.queryBy<Cash.State>(criteriaByLockId1).states
             println("SOFT LOCK #1 final states: $lockStatesId1")
             assertThat(lockStatesId1.size).isIn(0, 3)
-            val lockStatesId2 = vaultSvc.softLockedStates<Cash.State>(softLockId2)
+            val lockStatesId2 = vaultQuery.queryBy<Cash.State>(criteriaByLockId2).states
             println("SOFT LOCK #2 final states: $lockStatesId2")
             assertThat(lockStatesId2.size).isIn(0, 3)
         }
@@ -216,7 +221,6 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
 
     @Test
     fun `soft locking partial reserve states fails`() {
-
         val softLockId1 = UUID.randomUUID()
         val softLockId2 = UUID.randomUUID()
 
@@ -231,7 +235,8 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
         // lock 1st state with LockId1
         database.transaction {
             vaultSvc.softLockReserve(softLockId1, NonEmptySet.of(stateRefsToSoftLock.first()))
-            assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId1)).hasSize(1)
+            val criteriaByLockId1 = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.SPECIFIED, listOf(softLockId1)))
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId1).states).hasSize(1)
         }
 
         // attempt to lock all 3 states with LockId2
@@ -244,8 +249,8 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
 
     @Test
     fun `attempt to lock states already soft locked by me`() {
-
         val softLockId1 = UUID.randomUUID()
+        val criteriaByLockId1 = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.SPECIFIED, listOf(softLockId1)))
 
         val vaultStates =
                 database.transaction {
@@ -258,13 +263,13 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
         // lock states with LockId1
         database.transaction {
             vaultSvc.softLockReserve(softLockId1, stateRefsToSoftLock)
-            assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId1)).hasSize(3)
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId1).states).hasSize(3)
         }
 
         // attempt to relock same states with LockId1
         database.transaction {
             vaultSvc.softLockReserve(softLockId1, stateRefsToSoftLock)
-            assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId1)).hasSize(3)
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId1).states).hasSize(3)
         }
     }
 
@@ -272,6 +277,7 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
     fun `lock additional states to some already soft locked by me`() {
 
         val softLockId1 = UUID.randomUUID()
+        val criteriaByLockId1 = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.SPECIFIED, listOf(softLockId1)))
 
         val vaultStates =
                 database.transaction {
@@ -284,13 +290,13 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
         // lock states with LockId1
         database.transaction {
             vaultSvc.softLockReserve(softLockId1, NonEmptySet.of(stateRefsToSoftLock.first()))
-            assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId1)).hasSize(1)
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId1).states).hasSize(1)
         }
 
         // attempt to lock all states with LockId1 (including previously already locked one)
         database.transaction {
             vaultSvc.softLockReserve(softLockId1, stateRefsToSoftLock.toNonEmptySet())
-            assertThat(vaultSvc.softLockedStates<Cash.State>(softLockId1)).hasSize(3)
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaByLockId1).states).hasSize(3)
         }
     }
 
@@ -307,7 +313,8 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
             spendableStatesUSD.forEach(::println)
             assertThat(spendableStatesUSD).hasSize(1)
             assertThat(spendableStatesUSD[0].state.data.amount.quantity).isEqualTo(100L * 100)
-            assertThat(vaultSvc.softLockedStates<Cash.State>()).hasSize(1)
+            val criteriaLocked = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.LOCKED_ONLY))
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaLocked).states).hasSize(1)
         }
     }
 
@@ -360,7 +367,8 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
             val spendableStatesUSD = (vaultSvc as NodeVaultService).unconsumedStatesForSpending<Cash.State>(110.DOLLARS, lockId = UUID.randomUUID())
             spendableStatesUSD.forEach(::println)
             assertThat(spendableStatesUSD).hasSize(1)
-            assertThat(vaultSvc.softLockedStates<Cash.State>()).hasSize(0)
+            val criteriaLocked = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.LOCKED_ONLY))
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaLocked).states).hasSize(0)
         }
     }
 
@@ -377,7 +385,8 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
             spendableStatesUSD.forEach(::println)
             assertThat(spendableStatesUSD).hasSize(1)
             assertThat(spendableStatesUSD[0].state.data.amount.quantity).isGreaterThanOrEqualTo(100L)
-            assertThat(vaultSvc.softLockedStates<Cash.State>()).hasSize(1)
+            val criteriaLocked = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.LOCKED_ONLY))
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaLocked).states).hasSize(1)
         }
     }
 
@@ -397,7 +406,8 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
                 spendableStatesUSD.forEach(::println)
             }
             // note only 3 spend attempts succeed with a total of 8 states
-            assertThat(vaultSvc.softLockedStates<Cash.State>()).hasSize(8)
+            val criteriaLocked = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.LOCKED_ONLY))
+            assertThat(vaultQuery.queryBy<Cash.State>(criteriaLocked).states).hasSize(8)
         }
     }
 


### PR DESCRIPTION
Removed deprecated `softLockStates` query method from `VaultService`
Introduced flexible `SoftLockingCondition` filterable attribute in `VaultQueryCriteria`