### PR TITLE
Add support for serialisation of Linked Hash Maps

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/MapSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/MapSerializer.kt
@@ -5,6 +5,7 @@ import java.io.NotSerializableException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.util.*
+import kotlin.collections.LinkedHashMap
 import kotlin.collections.Map
 import kotlin.collections.iterator
 import kotlin.collections.map
@@ -20,7 +21,11 @@ class MapSerializer(val declaredType: ParameterizedType, factory: SerializerFact
         private val supportedTypes: Map<Class<out Map<*, *>>, (Map<*, *>) -> Map<*, *>> = mapOf(
                 Map::class.java to { map -> Collections.unmodifiableMap(map) },
                 SortedMap::class.java to { map -> Collections.unmodifiableSortedMap(TreeMap(map)) },
-                NavigableMap::class.java to { map -> Collections.unmodifiableNavigableMap(TreeMap(map)) }
+                NavigableMap::class.java to { map -> Collections.unmodifiableNavigableMap(TreeMap(map)) },
+                // Collections doesn't have any representation of a linked hash map but our recommendation
+                // for anyone trying to use a hash map is to use a linked one to ensure stable iteration
+                // hence this exception
+                LinkedHashMap::class.java to { map -> LinkedHashMap(map) }
         )
 
         private fun findConcreteType(clazz: Class<*>): (Map<*, *>) -> Map<*, *> {

--- a/core/src/main/kotlin/net/corda/core/serialization/amqp/ObjectSerializer.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/amqp/ObjectSerializer.kt
@@ -71,7 +71,6 @@ class ObjectSerializer(val clazz: Type, factory: SerializerFactory) : AMQPSerial
         return interfaces.map { nameForType(it) }
     }
 
-
     fun construct(properties: List<Any?>): Any {
         if (javaConstructor == null) {
             throw NotSerializableException("Attempt to deserialize an interface: $clazz. Serialized form is invalid.")

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/AMQPTestUtils.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/AMQPTestUtils.kt
@@ -1,0 +1,14 @@
+package net.corda.core.serialization.amqp
+
+import org.apache.qpid.proton.codec.Data
+
+class TestSerializationOutput(
+        private val verbose: Boolean,
+        serializerFactory: SerializerFactory = SerializerFactory()) : SerializationOutput(serializerFactory) {
+
+    override fun writeSchema(schema: Schema, data: Data) {
+        if (verbose) println(schema)
+        super.writeSchema(schema, data)
+    }
+}
+

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeCollectionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeCollectionTests.kt
@@ -1,0 +1,75 @@
+package net.corda.core.serialization.amqp
+
+import org.junit.Test
+import java.util.*
+
+class DeserializeCollectionTests {
+
+    companion object {
+        /**
+         * If you want to see the schema encoded into the envelope after serialisation change this to true
+         */
+        private const val VERBOSE = false
+    }
+
+    val sf = SerializerFactory()
+
+    @Test
+    fun mapTest() {
+        data class C(val c: Map<String, Int>)
+        val c = C (mapOf("A" to 1, "B" to 2))
+
+        val serialisedBytes = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        DeserializationInput(sf).deserialize(serialisedBytes)
+    }
+
+    @Test
+    fun sortedMapTest() {
+        data class C(val c: SortedMap<String, Int>)
+        val c = C(sortedMapOf ("A" to 1, "B" to 2))
+        val serialisedBytes = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        DeserializationInput(sf).deserialize(serialisedBytes)
+    }
+
+    @Test
+    fun treeMapTest() {
+        data class C(val c: NavigableMap<String, Int>)
+        val c = C(TreeMap (mapOf("A" to 1, "B" to 3)))
+
+        val serialisedBytes = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        DeserializationInput(sf).deserialize(serialisedBytes)
+    }
+
+    @Test
+    fun navigableMapTest() {
+        data class C(val c: NavigableMap<String, Int>)
+        val c = C(TreeMap (mapOf("A" to 1, "B" to 3)).descendingMap())
+
+        val serialisedBytes = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        DeserializationInput(sf).deserialize(serialisedBytes)
+    }
+
+    @Test(expected=java.lang.IllegalArgumentException::class)
+    fun HashMapTest() {
+        data class C(val c : HashMap<String, Int>)
+        val c = C (HashMap (mapOf("A" to 1, "B" to 2)))
+
+        // expect this to throw
+        TestSerializationOutput(VERBOSE, sf).serialize(c)
+    }
+
+    // unlike the above as a linked hash map is stable under iteration we should be able to
+    // serialise it
+    @Test
+    fun linkedHashMapTest() {
+        data class C(val c : LinkedHashMap<String, Int>)
+        val c = C (LinkedHashMap (mapOf("A" to 1, "B" to 2)))
+
+        val serialisedBytes = TestSerializationOutput(VERBOSE, sf).serialize(c)
+        val deserializedObj = DeserializationInput(sf).deserialize(serialisedBytes)
+    }
+
+
+
+
+}

--- a/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -1,6 +1,5 @@
 package net.corda.core.serialization.amqp
 
-import org.apache.qpid.proton.codec.Data
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -9,15 +8,6 @@ import kotlin.test.assertEquals
 // char property of the class would've been treated as an Integer and given to the constructor
 // as such
 class DeserializeSimpleTypesTests {
-    class TestSerializationOutput(
-            private val verbose: Boolean,
-            serializerFactory: SerializerFactory = SerializerFactory()) : SerializationOutput(serializerFactory) {
-
-        override fun writeSchema(schema: Schema, data: Data) {
-            if (verbose) println(schema)
-            super.writeSchema(schema, data)
-        }
-    }
 
     companion object {
         /**


### PR DESCRIPTION
Currently our advice for anyone trying to serialise a hash map as a
member of a class is to use a linked hash map instead. However, we can't
actually serialise one as it's not set as a serialisable type.

The problem is the generic collections interface we're using doesn't
recognise linked hash maps as a concept so this requires a special case
to handle properly