### PR TITLE
Specify correct use of Hibernate SQL statement debug output

### DIFF
--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -350,6 +350,15 @@ Track unconsumed deal states or linear states (with snapshot including specifica
     :start-after: DOCSTART VaultJavaQueryExample4
     :end-before: DOCEND VaultJavaQueryExample4
 
+Troubleshooting
+---------------
+If the results your were expecting do not match actual returned query results we recommend you add an entry to your
+``log4j2.xml`` configuration file to enable display of executed SQL statements::
+
+        <Logger name="org.hibernate.SQL" level="debug" additivity="false"> 
+            <AppenderRef ref="Console-Appender"/> 
+        </Logger>
+
 Behavioural notes
 -----------------
 1. **TrackBy** updates do not take into account the full criteria specification due to different and more restrictive syntax

--- a/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
@@ -18,9 +18,7 @@ import java.sql.Connection
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
-class HibernateConfiguration(val schemaService: SchemaService, val useDefaultLogging: Boolean = false, val databaseProperties: Properties) {
-    constructor(schemaService: SchemaService, databaseProperties: Properties) : this(schemaService, false, databaseProperties)
-
+class HibernateConfiguration(val schemaService: SchemaService, val databaseProperties: Properties) {
     companion object {
         val logger = loggerFor<HibernateConfiguration>()
     }
@@ -59,8 +57,7 @@ class HibernateConfiguration(val schemaService: SchemaService, val useDefaultLog
         // TODO: replace auto schema generation as it isn't intended for production use, according to Hibernate docs.
         val config = Configuration(metadataSources).setProperty("hibernate.connection.provider_class", HibernateConfiguration.NodeDatabaseConnectionProvider::class.java.name)
                 .setProperty("hibernate.hbm2ddl.auto", if (databaseProperties.getProperty("initDatabase","true") == "true") "update" else "validate")
-                .setProperty("hibernate.show_sql", "$useDefaultLogging")
-                .setProperty("hibernate.format_sql", "$useDefaultLogging")
+                .setProperty("hibernate.format_sql", "true")
         schemas.forEach { schema ->
             // TODO: require mechanism to set schemaOptions (databaseSchema, tablePrefix) which are not global to session
             schema.mappedTypes.forEach { config.addAnnotatedClass(it) }

--- a/test-common/src/main/resources/log4j2-test.xml
+++ b/test-common/src/main/resources/log4j2-test.xml
@@ -5,7 +5,7 @@
     </Properties>
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%-5level] %date{HH:mm:ss,SSS} [%t] %c{2}.%method - %msg%n" />
+            <PatternLayout pattern="[%-5level] %date{HH:mm:ss,SSS} [%t] (%F:%L) %c{2}.%method - %msg%n" />
         </Console>
         <!-- Required for printBasicInfo -->
         <Console name="Console-Appender-Println" target="SYSTEM_OUT">
@@ -21,6 +21,9 @@
         </Logger>
         <Logger name="BasicInfo" additivity="false">
             <AppenderRef ref="Console-Appender-Println"/>
+        </Logger>
+        <Logger name="org.hibernate.SQL" level="debug" additivity="false"> 
+            <AppenderRef ref="Console-Appender"/> 
         </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Was previously setting Hibernate SQL statement debug logging by explicitly setting a boolean flag in code.
This PR removes the unnecessary debug variable and delegates configuration to equivalent log4j2.xml.