### PR TITLE
Remove grouping from FungibleAsset (Issue and Move)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt
@@ -3,8 +3,6 @@ package net.corda.core.contracts
 import net.corda.core.flows.FlowException
 import net.corda.core.identity.AbstractParty
 import java.security.PublicKey
-import net.corda.core.contracts.Amount.Companion.sumOrNull
-import net.corda.core.contracts.Amount.Companion.sumOrZero
 
 class InsufficientBalanceException(val amountMissing: Amount<*>) : FlowException("Insufficient balance, missing $amountMissing")
 
@@ -16,25 +14,28 @@ class InsufficientBalanceException(val amountMissing: Amount<*>) : FlowException
  * crude are fungible and countable (oil from two small containers can be poured into one large
  * container), shares of the same class in a specific company are fungible and countable, and so on.
  *
- * See [Cash] for an example contract that implements currency using state objects that implement
+ * An example usage would be a cash transaction contract that implements currency using state objects that implement
  * this interface.
  *
  * @param T a type that represents the asset in question. This should describe the basic type of the asset
  * (GBP, USD, oil, shares in company <X>, etc.) and any additional metadata (issuer, grade, class, etc.).
  */
 interface FungibleAsset<T : Any> : OwnableState {
+    /**
+     * Amount represents a positive quantity of some issued product which can be cash, tokens, assets, or generally
+     * anything else that's quantifiable with integer quantities. See [Issued] and [Amount] for more details.
+     */
     val amount: Amount<Issued<T>>
+
     /**
      * There must be an ExitCommand signed by these keys to destroy the amount. While all states require their
      * owner to sign, some (i.e. cash) also require the issuer.
      */
     val exitKeys: Collection<PublicKey>
-    /** There must be a MoveCommand signed by this key to claim the amount */
-    override val owner: AbstractParty
 
-    fun move(newAmount: Amount<Issued<T>>, newOwner: AbstractParty): FungibleAsset<T>
-
-    interface ExitCommand<T : Any>: CommandData {
-        val amount: Amount<Issued<T>>
-    }
+    /**
+     * Copies the underlying data structure, replacing the amount and owner fields with the new values and leaving the
+     * rest (exitKeys) alone.
+     */
+    fun withNewOwnerAndAmount(newAmount: Amount<Issued<T>>, newOwner: AbstractParty): FungibleAsset<T>
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/FungibleAsset.kt
@@ -34,22 +34,7 @@ interface FungibleAsset<T : Any> : OwnableState {
 
     fun move(newAmount: Amount<Issued<T>>, newOwner: AbstractParty): FungibleAsset<T>
 
-    // Just for grouping
-    interface Commands : CommandData {
-        interface Move : MoveCommand, Commands
-
-        /**
-         * Allows new asset states to be issued into existence: the nonce ("number used once") ensures the transaction
-         * has a unique ID even when there are no inputs.
-         */
-        interface Issue : IssueCommand, Commands
-
-        /**
-         * A command stating that money has been withdrawn from the shared ledger and is now accounted for
-         * in some other way.
-         */
-        interface Exit<T : Any> : Commands {
-            val amount: Amount<Issued<T>>
-        }
+    interface ExitCommand<T : Any>: CommandData {
+        val amount: Amount<Issued<T>>
     }
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -156,15 +156,15 @@ data class CommandAndState(val command: CommandData, val ownableState: OwnableSt
  * A contract state that can have a single owner.
  */
 interface OwnableState : ContractState {
-    /** There must be a MoveCommand signed by this key to claim the amount */
+    /** There must be a MoveCommand signed by this key to claim the amount. */
     val owner: AbstractParty
 
-    /** Copies the underlying data structure, replacing the owner field with this new value and leaving the rest alone */
+    /** Copies the underlying data structure, replacing the owner field with this new value and leaving the rest alone. */
     fun withNewOwner(newOwner: AbstractParty): CommandAndState
 }
 // DOCEND 3
 
-/** Something which is scheduled to happen at a point in time */
+/** Something which is scheduled to happen at a point in time. */
 interface Scheduled {
     val scheduledAt: Instant
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -284,12 +284,6 @@ data class Command<T : CommandData>(val value: T, val signers: List<PublicKey>) 
     override fun toString() = "${commandDataToString()} with pubkeys ${signers.joinToString()}"
 }
 
-/** A common issue command, to enforce that issue commands have a nonce value. */
-// TODO: Revisit use of nonce values - should this be part of the TX rather than the command perhaps?
-interface IssueCommand : CommandData {
-    val nonce: Long
-}
-
 /** A common move command for contract states which can change owner. */
 interface MoveCommand : CommandData {
     /**

--- a/core/src/test/kotlin/net/corda/core/contracts/LedgerTransactionQueryTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/LedgerTransactionQueryTests.kt
@@ -187,7 +187,7 @@ class LedgerTransactionQueryTests : TestDependencyInjectionBase() {
         val intCmd2 = ltx.commandsOfType<Commands.Cmd2>()
         assertEquals(5, intCmd2.size)
         assertEquals(listOf(0, 1, 2, 3, 4), intCmd2.map { it.value.id })
-        val notPresentQuery = ltx.commandsOfType(FungibleAsset.Commands.Exit::class.java)
+        val notPresentQuery = ltx.commandsOfType(FungibleAsset.ExitCommand::class.java)
         assertEquals(emptyList(), notPresentQuery)
     }
 

--- a/core/src/test/kotlin/net/corda/core/contracts/LedgerTransactionQueryTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/LedgerTransactionQueryTests.kt
@@ -28,6 +28,7 @@ class LedgerTransactionQueryTests : TestDependencyInjectionBase() {
     interface Commands {
         data class Cmd1(val id: Int) : CommandData, Commands
         data class Cmd2(val id: Int) : CommandData, Commands
+        data class Cmd3(val id: Int) : CommandData, Commands // Unused command, required for command not-present checks.
     }
 
 
@@ -187,7 +188,7 @@ class LedgerTransactionQueryTests : TestDependencyInjectionBase() {
         val intCmd2 = ltx.commandsOfType<Commands.Cmd2>()
         assertEquals(5, intCmd2.size)
         assertEquals(listOf(0, 1, 2, 3, 4), intCmd2.map { it.value.id })
-        val notPresentQuery = ltx.commandsOfType(FungibleAsset.ExitCommand::class.java)
+        val notPresentQuery = ltx.commandsOfType(Commands.Cmd3::class.java)
         assertEquals(emptyList(), notPresentQuery)
     }
 

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -5,13 +5,13 @@ import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
+import net.corda.core.internal.Emoji
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.queryBy
-import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
-import net.corda.core.internal.Emoji
+import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.USD
 import net.corda.finance.`issued by`

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -203,7 +203,7 @@ class ContractUpgradeFlowTest {
             override val contract = CashV2()
             override val participants = owners
 
-            override fun move(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty) = copy(amount = amount.copy(newAmount.quantity), owners = listOf(newOwner))
+            override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty) = copy(amount = amount.copy(newAmount.quantity), owners = listOf(newOwner))
             override fun toString() = "${Emoji.bagOfCash}New Cash($amount at ${amount.token.issuer} owned by $owner)"
             override fun withNewOwner(newOwner: AbstractParty) = CommandAndState(Cash.Commands.Move(), copy(owners = listOf(newOwner)))
         }

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -280,7 +280,7 @@ public class FlowCookbookJava {
             TypeOnlyCommandData typeOnlyCommandData = new DummyContract.Commands.Create();
             // 2. Include additional data which can be used by the contract
             //    during verification, alongside fulfilling the roles above
-            CommandData commandDataWithData = new Cash.Commands.Issue(12345678);
+            CommandData commandDataWithData = new Cash.Commands.Issue();
 
             // Attachments are identified by their hash.
             // The attachment with the corresponding hash must have been

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
@@ -262,8 +262,8 @@ object FlowCookbook {
             //    fork the contract's verification logic.
             val typeOnlyCommandData: TypeOnlyCommandData = DummyContract.Commands.Create()
             // 2. Include additional data which can be used by the contract
-            //    during verification, alongside fulfilling the roles above
-            val commandDataWithData: CommandData = Cash.Commands.Issue(nonce = 12345678)
+            //    during verification, alongside fulfilling the roles above.
+            val commandDataWithData: CommandData = Cash.Commands.Issue()
 
             // Attachments are identified by their hash.
             // The attachment with the corresponding hash must have been

--- a/docs/source/using-a-notary.rst
+++ b/docs/source/using-a-notary.rst
@@ -87,9 +87,9 @@ we just use a helper that handles it for us. We also assume that we already have
 .. sourcecode:: kotlin
 
     val inputState = StateAndRef(sate, stateRef)
-    val moveTransactionBuilder = DummyContract.move(inputState, newOwner = aliceParty.owningKey)
+    val moveTransactionBuilder = DummyContract.withNewOwnerAndAmount(inputState, newOwner = aliceParty.owningKey)
 
-The ``DummyContract.move()`` method will a new transaction builder with our old state as the input, a new state
+The ``DummyContract.withNewOwnerAndAmount()`` method will a new transaction builder with our old state as the input, a new state
 with Alice as the owner, and a relevant contract command for "move".
 
 Again we sign the transaction, and build it:

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
@@ -76,7 +76,7 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
         override val contract = CASH_PROGRAM_ID
         override val participants = listOf(owner)
 
-        override fun move(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty): FungibleAsset<Currency>
+        override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty): FungibleAsset<Currency>
                 = copy(amount = amount.copy(newAmount.quantity), owner = newOwner)
 
         override fun toString() = "${Emoji.bagOfCash}Cash($amount at ${amount.token.issuer} owned by $owner)"
@@ -128,7 +128,7 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
          * A command stating that money has been withdrawn from the shared ledger and is now accounted for
          * in some other way.
          */
-        data class Exit(override val amount: Amount<Issued<Currency>>) : FungibleAsset.ExitCommand<Currency>
+        data class Exit(val amount: Amount<Issued<Currency>>) : CommandData
     }
 
     /**

--- a/finance/src/main/kotlin/net/corda/contracts/asset/CommodityContract.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/CommodityContract.kt
@@ -2,18 +2,17 @@ package net.corda.contracts.asset
 
 import net.corda.contracts.Commodity
 import net.corda.core.contracts.*
-import net.corda.core.crypto.newSecureRandom
-import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
-import java.security.PublicKey
 import net.corda.finance.utils.sumCommodities
 import net.corda.finance.utils.sumCommoditiesOrNull
 import net.corda.finance.utils.sumCommoditiesOrZero
+import java.security.PublicKey
 import java.util.*
+
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -168,15 +167,3 @@ class CommodityContract : OnLedgerAsset<Commodity, CommodityContract.Commands, C
     override fun generateExitCommand(amount: Amount<Issued<Commodity>>) = Commands.Exit(amount)
     override fun generateMoveCommand() = Commands.Move()
 }
-
-/**
- * Sums the cash states in the list, throwing an exception if there are none, or if any of the cash
- * states cannot be added together (i.e. are different currencies).
- */
-fun Iterable<ContractState>.sumCommodities() = filterIsInstance<CommodityContract.State>().map { it.amount }.sumOrThrow()
-
-/** Sums the cash states in the list, returning null if there are none. */
-@Suppress("unused") fun Iterable<ContractState>.sumCommoditiesOrNull() = filterIsInstance<CommodityContract.State>().map { it.amount }.sumOrNull()
-
-/** Sums the cash states in the list, returning zero of the given currency if there are none. */
-fun Iterable<ContractState>.sumCommoditiesOrZero(currency: Issued<Commodity>) = filterIsInstance<CommodityContract.State>().map { it.amount }.sumOrZero(currency)

--- a/finance/src/main/kotlin/net/corda/contracts/asset/CommodityContract.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/CommodityContract.kt
@@ -48,7 +48,7 @@ class CommodityContract : OnLedgerAsset<Commodity, CommodityContract.Commands, C
         override val exitKeys: Set<PublicKey> = Collections.singleton(owner.owningKey)
         override val participants = listOf(owner)
 
-        override fun move(newAmount: Amount<Issued<Commodity>>, newOwner: AbstractParty): FungibleAsset<Commodity>
+        override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Commodity>>, newOwner: AbstractParty): FungibleAsset<Commodity>
                 = copy(amount = amount.copy(newAmount.quantity), owner = newOwner)
 
         override fun toString() = "Commodity($amount at ${amount.token.issuer} owned by $owner)"
@@ -77,7 +77,7 @@ class CommodityContract : OnLedgerAsset<Commodity, CommodityContract.Commands, C
          * A command stating that money has been withdrawn from the shared ledger and is now accounted for
          * in some other way.
          */
-        data class Exit(override val amount: Amount<Issued<Commodity>>) : FungibleAsset.ExitCommand<Commodity>
+        data class Exit(val amount: Amount<Issued<Commodity>>) : CommandData
     }
 
     override fun verify(tx: LedgerTransaction) {

--- a/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
@@ -244,7 +244,7 @@ abstract class OnLedgerAsset<T : Any, C : CommandData, S : FungibleAsset<T>> : C
         )
     }
 
-    abstract fun generateExitCommand(amount: Amount<Issued<T>>): FungibleAsset.ExitCommand<T>
+    abstract fun generateExitCommand(amount: Amount<Issued<T>>): CommandData
     abstract fun generateMoveCommand(): MoveCommand
 
     /**

--- a/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/OnLedgerAsset.kt
@@ -244,9 +244,8 @@ abstract class OnLedgerAsset<T : Any, C : CommandData, S : FungibleAsset<T>> : C
         )
     }
 
-    abstract fun generateExitCommand(amount: Amount<Issued<T>>): FungibleAsset.Commands.Exit<T>
-    abstract fun generateIssueCommand(): FungibleAsset.Commands.Issue
-    abstract fun generateMoveCommand(): FungibleAsset.Commands.Move
+    abstract fun generateExitCommand(amount: Amount<Issued<T>>): FungibleAsset.ExitCommand<T>
+    abstract fun generateMoveCommand(): MoveCommand
 
     /**
      * Derive a new transaction state based on the given example, with amount and owner modified. This allows concrete

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -8,7 +8,6 @@ import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.queryBy
-import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes
@@ -17,10 +16,6 @@ import net.corda.finance.utils.sumCash
 import net.corda.finance.utils.sumCashBy
 import net.corda.finance.utils.sumCashOrNull
 import net.corda.finance.utils.sumCashOrZero
-import net.corda.core.utilities.OpaqueBytes
-import net.corda.node.services.database.HibernateConfiguration
-import net.corda.node.services.schema.NodeSchemaService
-import net.corda.node.services.vault.HibernateVaultQueryImpl
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.CordaPersistence
 import net.corda.testing.*

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -8,6 +8,7 @@ import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.queryBy
+import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes
@@ -16,6 +17,10 @@ import net.corda.finance.utils.sumCash
 import net.corda.finance.utils.sumCashBy
 import net.corda.finance.utils.sumCashOrNull
 import net.corda.finance.utils.sumCashOrZero
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.schema.NodeSchemaService
+import net.corda.node.services.vault.HibernateVaultQueryImpl
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.CordaPersistence
 import net.corda.testing.*
@@ -141,10 +146,6 @@ class CashTests : TestDependencyInjectionBase() {
                         amount = 1000.DOLLARS `issued by` MINI_CORP.ref(12, 34),
                         owner = AnonymousParty(ALICE_PUBKEY)
                 )
-            }
-            tweak {
-                command(MINI_CORP_PUBKEY) { Cash.Commands.Issue(0) }
-                this `fails with` "has a nonce"
             }
             command(MINI_CORP_PUBKEY) { Cash.Commands.Issue() }
             this.verifies()

--- a/finance/src/test/kotlin/net/corda/contracts/asset/DummyFungibleContract.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/DummyFungibleContract.kt
@@ -1,8 +1,6 @@
 package net.corda.contracts.asset
 
 import net.corda.core.contracts.*
-import net.corda.core.crypto.newSecureRandom
-import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.toBase58String
 import net.corda.core.identity.AbstractParty
 import net.corda.core.internal.Emoji
@@ -10,7 +8,6 @@ import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.QueryableState
 import net.corda.core.transactions.LedgerTransaction
-import net.corda.core.transactions.TransactionBuilder
 import net.corda.finance.utils.sumCash
 import net.corda.finance.utils.sumCashOrNull
 import net.corda.finance.utils.sumCashOrZero
@@ -36,7 +33,7 @@ class DummyFungibleContract : OnLedgerAsset<Currency, DummyFungibleContract.Comm
         override val contract = CASH_PROGRAM_ID
         override val participants = listOf(owner)
 
-        override fun move(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty): FungibleAsset<Currency>
+        override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty): FungibleAsset<Currency>
                 = copy(amount = amount.copy(newAmount.quantity), owner = newOwner)
 
         override fun toString() = "${Emoji.bagOfCash}Cash($amount at ${amount.token.issuer} owned by $owner)"
@@ -83,7 +80,7 @@ class DummyFungibleContract : OnLedgerAsset<Currency, DummyFungibleContract.Comm
 
         class Issue : TypeOnlyCommandData()
 
-        data class Exit(override val amount: Amount<Issued<Currency>>) : FungibleAsset.ExitCommand<Currency>
+        data class Exit(val amount: Amount<Issued<Currency>>) : CommandData
     }
 
     override fun deriveState(txState: TransactionState<State>, amount: Amount<Issued<Currency>>, owner: AbstractParty)

--- a/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
@@ -129,10 +129,6 @@ class ObligationTests {
                         template = megaCorpDollarSettlement
                 )
             }
-            tweak {
-                command(MINI_CORP_PUBKEY) { Obligation.Commands.Issue(0) }
-                this `fails with` "has a nonce"
-            }
             command(MINI_CORP_PUBKEY) { Obligation.Commands.Issue() }
             this.verifies()
         }
@@ -189,7 +185,7 @@ class ObligationTests {
             this `fails with` ""
         }
 
-        // Can't have any other commands if we have an issue command (because the issue command overrules them)
+        // Can't have any other commands if we have an issue command (because the issue command overrules them).
         transaction {
             input { inState }
             output { inState.copy(quantity = inState.amount.quantity * 2) }


### PR DESCRIPTION
This is part of the [finance CorDapp improvements](https://discourse.corda.net/t/various-things-to-improve-in-the-finance-cordapp/1386)
IssueCommand is also totally removed as no nonce is required anymore and all Issues can be `TypeOnlyCommandData`