### PR TITLE
Fix jackson serialization of transaction types. 

### DIFF
--- a/client/jackson/src/test/kotlin/net/corda/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/jackson/JacksonSupportTest.kt
@@ -6,8 +6,16 @@ import com.pholser.junit.quickcheck.Property
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.USD
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SignatureMetadata
+import net.corda.core.crypto.TransactionSignature
 import net.corda.core.testing.PublicKeyGenerator
+import net.corda.core.transactions.SignedTransaction
+import net.corda.testing.ALICE_PUBKEY
+import net.corda.testing.DUMMY_NOTARY
+import net.corda.testing.MINI_CORP
 import net.corda.testing.TestDependencyInjectionBase
+import net.corda.testing.contracts.DummyContract
 import net.i2p.crypto.eddsa.EdDSAPublicKey
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,5 +58,25 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
     fun writeAmount() {
         val writer = mapper.writer().without(SerializationFeature.INDENT_OUTPUT)
         assertEquals("""{"notional":"25000000.00 USD"}""", writer.writeValueAsString(Dummy(Amount.parseCurrency("$25000000"))))
+    }
+
+    @Test
+    fun writeTransaction() {
+        fun makeDummyTx(): SignedTransaction {
+            val wtx = DummyContract.generateInitial(1, DUMMY_NOTARY, MINI_CORP.ref(1)).toWireTransaction()
+            val signatures = TransactionSignature(
+                    ByteArray(1),
+                    ALICE_PUBKEY,
+                    SignatureMetadata(
+                            1,
+                            Crypto.findSignatureScheme(ALICE_PUBKEY).schemeNumberID
+                    )
+            )
+            return SignedTransaction(wtx, listOf(signatures))
+        }
+
+        val writer = mapper.writer()
+        // We don't particularly care about the serialized format, just need to make sure it completes successfully.
+        writer.writeValueAsString(makeDummyTx())
     }
 }


### PR DESCRIPTION
By default it attempts to serialize any property (anything that looks like a _getter_), which causes issues on the SignedTransaction, since it attempts to resolve both a regular and a notary change transaction from the serialized bytes.

@andr3ej discovered it causes an exception on the shell:
```
>>> run verifiedTransactionsFeed
RPC failed: java.lang.ClassCastException: net.corda.core.transactions.WireTransaction cannot be cast to net.corda.core.transactions.NotaryChangeWireTransaction
```