### PR TITLE
Vault identity cleanup

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -136,7 +136,6 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
                              val consumedTime: Instant?,
                              val status: Vault.StateStatus,
                              val notaryName: String,
-                             val notaryKey: String,
                              val lockId: String?,
                              val lockUpdateTime: Instant?)
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -5,6 +5,7 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowException
+import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.toFuture
@@ -135,7 +136,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
                              val recordedTime: Instant,
                              val consumedTime: Instant?,
                              val status: Vault.StateStatus,
-                             val notaryName: String,
+                             val notary: AbstractParty?,
                              val lockId: String?,
                              val lockUpdateTime: Instant?)
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -51,7 +51,7 @@ sealed class QueryCriteria {
     data class VaultQueryCriteria @JvmOverloads constructor (override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
                                                              val contractStateTypes: Set<Class<out ContractState>>? = null,
                                                              val stateRefs: List<StateRef>? = null,
-                                                             val notaryName: List<AbstractParty>? = null,
+                                                             val notary: List<AbstractParty>? = null,
                                                              val softLockingCondition: SoftLockingCondition? = null,
                                                              val timeCondition: TimeCondition? = null) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
@@ -81,7 +81,7 @@ sealed class QueryCriteria {
     data class FungibleAssetQueryCriteria @JvmOverloads constructor(val participants: List<AbstractParty>? = null,
                                                                     val owner: List<AbstractParty>? = null,
                                                                     val quantity: ColumnPredicate<Long>? = null,
-                                                                    val issuerPartyName: List<AbstractParty>? = null,
+                                                                    val issuer: List<AbstractParty>? = null,
                                                                     val issuerRef: List<OpaqueBytes>? = null,
                                                                     override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED) : CommonQueryCriteria() {
        override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -51,7 +51,7 @@ sealed class QueryCriteria {
     data class VaultQueryCriteria @JvmOverloads constructor (override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
                                                              val contractStateTypes: Set<Class<out ContractState>>? = null,
                                                              val stateRefs: List<StateRef>? = null,
-                                                             val notaryName: List<X500Name>? = null,
+                                                             val notaryName: List<AbstractParty>? = null,
                                                              val softLockingCondition: SoftLockingCondition? = null,
                                                              val timeCondition: TimeCondition? = null) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -151,7 +151,7 @@ data class Sort(val columns: Collection<SortColumn>) {
 
     enum class VaultStateAttribute(val attributeName: String) : Attribute {
         /** Vault States */
-        NOTARY_NAME("notaryName"),
+        NOTARY_NAME("notary"),
         CONTRACT_TYPE("contractStateClassName"),
         STATE_STATUS("stateStatus"),
         RECORDED_TIME("recordedTime"),

--- a/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
@@ -17,10 +17,16 @@ object CommonSchema
 /**
  * First version of the Vault ORM schema
  */
-object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, version = 1, mappedTypes = listOf(Party::class.java)) {
+object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, version = 1, mappedTypes = emptyList()) {
 
     @MappedSuperclass
     open class LinearState(
+            /** [ContractState] attributes */
+
+            /** X500Name of participant parties **/
+            @ElementCollection
+            var participants: Set<String>,
+
             /**
              *  Represents a [LinearState] [UniqueIdentifier]
              */
@@ -31,18 +37,24 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
             var uuid: UUID
 
     ) : PersistentState() {
-        constructor(uid: UniqueIdentifier) : this(externalId = uid.externalId, uuid = uid.id)
+        constructor(uid: UniqueIdentifier, _participants: Set<AbstractParty>)
+            : this(participants = _participants.map { it.nameOrNull().toString() }.toSet(),
+                   externalId = uid.externalId,
+                   uuid = uid.id)
     }
 
     @MappedSuperclass
     open class FungibleState(
             /** [ContractState] attributes */
-            @OneToMany(cascade = arrayOf(CascadeType.ALL))
-            var participants: Set<CommonSchemaV1.Party>,
+
+            /** X500Name of participant parties **/
+            @ElementCollection
+            var participants: Set<String>,
 
             /** [OwnableState] attributes */
-            @OneToOne(cascade = arrayOf(CascadeType.ALL))
-            var ownerKey: CommonSchemaV1.Party,
+
+            /** X500Name of anonymous owner party (after resolution by the IdentityService) **/
+            var owner: String,
 
             /** [FungibleAsset] attributes
              *
@@ -55,42 +67,18 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
             var quantity: Long,
 
             /** Issuer attributes */
-            @OneToOne(cascade = arrayOf(CascadeType.ALL))
-            var issuerParty: CommonSchemaV1.Party,
+
+            /** X500Name of issuer party **/
+            var issuer: String,
 
             @Column(name = "issuer_reference")
             var issuerRef: ByteArray
     ) : PersistentState() {
-        constructor(_participants: Set<AbstractParty>, _ownerKey: AbstractParty, _quantity: Long, _issuerParty: AbstractParty, _issuerRef: ByteArray)
-                : this(participants = _participants.map { CommonSchemaV1.Party(it) }.toSet(),
-                       ownerKey = CommonSchemaV1.Party(_ownerKey),
+        constructor(_participants: Set<AbstractParty>, _owner: AbstractParty, _quantity: Long, _issuerParty: AbstractParty, _issuerRef: ByteArray)
+                : this(participants = _participants.map { it.nameOrNull().toString() }.toSet(),
+                       owner = _owner.nameOrNull().toString(),
                        quantity = _quantity,
-                       issuerParty = CommonSchemaV1.Party(_issuerParty),
+                       issuer = _issuerParty.nameOrNull().toString(),
                        issuerRef = _issuerRef)
-    }
-
-    /**
-     *  Party entity (to be replaced by referencing final Identity Schema)
-     */
-    @Entity
-    @Table(name = "vault_party",
-            indexes = arrayOf(Index(name = "party_name_idx", columnList = "party_name")))
-    class Party(
-            @Id
-            @GeneratedValue
-            @Column(name = "party_id")
-            var id: Int,
-
-            /**
-             * [Party] attributes
-             */
-            @Column(name = "party_name")
-            var name: String,
-
-            @Column(name = "party_key", length = 65535) // TODO What is the upper limit on size of CompositeKey?)
-            var key: String
-    ) {
-        constructor(party: AbstractParty)
-                : this(0, party.nameOrNull()?.toString() ?: party.toString(), party.owningKey.toBase58String())
     }
 }

--- a/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
@@ -25,7 +25,8 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<AbstractParty>,
+            @Column(name = "participants")
+            var participants: MutableSet<AbstractParty>? = null,
 
             /**
              *  Represents a [LinearState] [UniqueIdentifier]
@@ -38,7 +39,7 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
 
     ) : PersistentState() {
         constructor(uid: UniqueIdentifier, _participants: Set<AbstractParty>)
-            : this(participants = _participants.toSet(),
+            : this(participants = _participants.toMutableSet(),
                    externalId = uid.externalId,
                    uuid = uid.id)
     }
@@ -49,7 +50,8 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<AbstractParty>,
+            @Column(name = "participants")
+            var participants: MutableSet<AbstractParty>? = null,
 
             /** [OwnableState] attributes */
 
@@ -69,6 +71,7 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
             /** Issuer attributes */
 
             /** X500Name of issuer party **/
+            @Column(name = "issuer_name")
             var issuer: AbstractParty,
 
             @Column(name = "issuer_reference")

--- a/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
@@ -55,7 +55,8 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
 
             /** [OwnableState] attributes */
 
-            /** X500Name of anonymous owner party (after resolution by the IdentityService) **/
+            /** X500Name of owner party **/
+            @Column(name = "owner_name")
             var owner: AbstractParty,
 
             /** [FungibleAsset] attributes

--- a/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/CommonSchema.kt
@@ -25,7 +25,7 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<String>,
+            var participants: Set<AbstractParty>,
 
             /**
              *  Represents a [LinearState] [UniqueIdentifier]
@@ -38,7 +38,7 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
 
     ) : PersistentState() {
         constructor(uid: UniqueIdentifier, _participants: Set<AbstractParty>)
-            : this(participants = _participants.map { it.nameOrNull().toString() }.toSet(),
+            : this(participants = _participants.toSet(),
                    externalId = uid.externalId,
                    uuid = uid.id)
     }
@@ -49,12 +49,12 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<String>,
+            var participants: Set<AbstractParty>,
 
             /** [OwnableState] attributes */
 
             /** X500Name of anonymous owner party (after resolution by the IdentityService) **/
-            var owner: String,
+            var owner: AbstractParty,
 
             /** [FungibleAsset] attributes
              *
@@ -69,16 +69,9 @@ object CommonSchemaV1 : MappedSchema(schemaFamily = CommonSchema.javaClass, vers
             /** Issuer attributes */
 
             /** X500Name of issuer party **/
-            var issuer: String,
+            var issuer: AbstractParty,
 
             @Column(name = "issuer_reference")
             var issuerRef: ByteArray
-    ) : PersistentState() {
-        constructor(_participants: Set<AbstractParty>, _owner: AbstractParty, _quantity: Long, _issuerParty: AbstractParty, _issuerRef: ByteArray)
-                : this(participants = _participants.map { it.nameOrNull().toString() }.toSet(),
-                       owner = _owner.nameOrNull().toString(),
-                       quantity = _quantity,
-                       issuer = _issuerParty.nameOrNull().toString(),
-                       issuerRef = _issuerRef)
-    }
+    ) : PersistentState()
 }

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyToX500NameAsStringConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyToX500NameAsStringConverter.kt
@@ -24,7 +24,9 @@ class AbstractPartyToX500NameAsStringConverter(identitySvc: () -> IdentityServic
 
     override fun convertToDatabaseColumn(party: AbstractParty?): String? {
         party?.let {
-            return identityService.partyFromAnonymous(party)?.toString()
+            val partyName = identityService.partyFromAnonymous(party)?.toString()
+            if (partyName != null) return partyName
+            else log.warn ("Identity service unable to resolve AbstractParty: $party")
         }
         return null // non resolvable anonymous parties
     }

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyToX500NameAsStringConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyToX500NameAsStringConverter.kt
@@ -2,6 +2,7 @@ package net.corda.core.schemas.converters
 
 import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.IdentityService
+import net.corda.core.utilities.loggerFor
 import org.bouncycastle.asn1.x500.X500Name
 import javax.persistence.AttributeConverter
 import javax.persistence.Converter
@@ -17,6 +18,10 @@ class AbstractPartyToX500NameAsStringConverter(identitySvc: () -> IdentityServic
         identitySvc()
     }
 
+    companion object {
+        val log = loggerFor<AbstractPartyToX500NameAsStringConverter>()
+    }
+
     override fun convertToDatabaseColumn(party: AbstractParty?): String? {
         party?.let {
             return identityService.partyFromAnonymous(party)?.toString()
@@ -27,7 +32,8 @@ class AbstractPartyToX500NameAsStringConverter(identitySvc: () -> IdentityServic
     override fun convertToEntityAttribute(dbData: String?): AbstractParty? {
         dbData?.let {
             val party = identityService.partyFromX500Name(X500Name(dbData))
-            return party as AbstractParty
+            if (party != null) return party
+            else log.warn ("Identity service unable to resolve X500name: $dbData")
         }
         return null // non resolvable anonymous parties are stored as nulls
     }

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -42,11 +42,14 @@ class ContractUpgradeFlowTest {
     @Before
     fun setup() {
         mockNet = MockNetwork()
-        val nodes = mockNet.createSomeNodes()
+        val nodes = mockNet.createSomeNodes(notaryKeyPair = null) // prevent generation of notary override
         a = nodes.partyNodes[0]
         b = nodes.partyNodes[1]
         notary = nodes.notaryNode.info.notaryIdentity
-        mockNet.runNetwork()
+
+        val nodeIdentity = nodes.notaryNode.info.legalIdentitiesAndCerts.single { it.party == nodes.notaryNode.info.notaryIdentity }
+        a.services.identityService.registerIdentity(nodeIdentity)
+        b.services.identityService.registerIdentity(nodeIdentity)
     }
 
     @After

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -43,8 +43,8 @@ private fun gatherOurInputs(serviceHub: ServiceHub,
     val ourParties = ourKeys.map { serviceHub.identityService.partyFromKey(it) ?: throw IllegalStateException("Unable to resolve party from key") }
     val fungibleCriteria = QueryCriteria.FungibleAssetQueryCriteria(owner = ourParties)
 
-    val notary = notary ?: serviceHub.networkMapCache.getAnyNotary()
-    val vaultCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notary = listOf(notary as AbstractParty))
+    val notaries = notary ?: serviceHub.networkMapCache.getAnyNotary()
+    val vaultCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notary = listOf(notaries as AbstractParty))
 
     val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.equal(amountRequired.token.product.currencyCode) }
     val cashCriteria = QueryCriteria.VaultCustomQueryCriteria(logicalExpression)

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -44,7 +44,7 @@ private fun gatherOurInputs(serviceHub: ServiceHub,
     val fungibleCriteria = QueryCriteria.FungibleAssetQueryCriteria(owner = ourParties)
 
     val notary = notary ?: serviceHub.networkMapCache.getAnyNotary()
-    val vaultCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notaryName = listOf(notary as AbstractParty))
+    val vaultCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notary = listOf(notary as AbstractParty))
 
     val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.equal(amountRequired.token.product.currencyCode) }
     val cashCriteria = QueryCriteria.VaultCustomQueryCriteria(logicalExpression)

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -12,6 +12,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.*
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.vault.QueryCriteria
@@ -42,8 +43,8 @@ private fun gatherOurInputs(serviceHub: ServiceHub,
     val ourParties = ourKeys.map { serviceHub.identityService.partyFromKey(it) ?: throw IllegalStateException("Unable to resolve party from key") }
     val fungibleCriteria = QueryCriteria.FungibleAssetQueryCriteria(owner = ourParties)
 
-    val notaryName = if (notary != null) notary.name else serviceHub.networkMapCache.getAnyNotary()!!.name
-    val vaultCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notaryName = listOf(notaryName))
+    val notary = notary ?: serviceHub.networkMapCache.getAnyNotary()
+    val vaultCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notaryName = listOf(notary as AbstractParty))
 
     val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.equal(amountRequired.token.product.currencyCode) }
     val cashCriteria = QueryCriteria.VaultCustomQueryCriteria(logicalExpression)

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
@@ -10,6 +10,7 @@ import net.corda.core.crypto.testing.NULL_PARTY
 import net.corda.core.crypto.toBase58String
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
+import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.Emoji
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.StatesNotAvailableException

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
@@ -99,7 +99,7 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
         override fun generateMappedObject(schema: MappedSchema): PersistentState {
             return when (schema) {
                 is CashSchemaV1 -> CashSchemaV1.PersistentCashState(
-                        owner = this.owner.owningKey.toBase58String(),
+                        owner = this.owner,
                         pennies = this.amount.quantity,
                         currency = this.amount.token.product.currencyCode,
                         issuerParty = this.amount.token.issuer.party.owningKey.toBase58String(),

--- a/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/asset/Cash.kt
@@ -323,7 +323,7 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
                         AND (vs.lock_id = '$lockId' OR vs.lock_id is null)
                         """ +
                                 (if (notary != null)
-                                    " AND vs.notary_key = '${notary.owningKey.toBase58String()}'" else "") +
+                                    " AND vs.notary_name = '${notary.name}'" else "") +
                                 (if (onlyFromIssuerParties.isNotEmpty())
                                     " AND ccs.issuer_key IN ($issuerKeysStr)" else "") +
                                 (if (withIssuerRefs.isNotEmpty())

--- a/finance/src/main/kotlin/net/corda/schemas/CashSchemaV1.kt
+++ b/finance/src/main/kotlin/net/corda/schemas/CashSchemaV1.kt
@@ -1,5 +1,6 @@
 package net.corda.schemas
 
+import net.corda.core.identity.AbstractParty
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.serialization.CordaSerializable
@@ -21,8 +22,9 @@ object CashSchemaV1 : MappedSchema(schemaFamily = CashSchema.javaClass, version 
            indexes = arrayOf(Index(name = "ccy_code_idx", columnList = "ccy_code"),
                              Index(name = "pennies_idx", columnList = "pennies")))
     class PersistentCashState(
-            @Column(name = "owner_key")
-            var owner: String,
+            /** X500Name of owner party **/
+            @Column(name = "owner_name")
+            var owner: AbstractParty,
 
             @Column(name = "pennies")
             var pennies: Long,

--- a/finance/src/test/kotlin/net/corda/contracts/DummyFungibleContract.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/DummyFungibleContract.kt
@@ -54,7 +54,7 @@ class DummyFungibleContract : OnLedgerAsset<Currency, DummyFungibleContract.Comm
                         issuerRef = this.amount.token.issuer.reference.bytes
                 )
                 is SampleCashSchemaV2 -> SampleCashSchemaV2.PersistentCashState(
-                        _participants = this.participants.toSet(),
+                        _participants = this.participants.toMutableSet(),
                         _owner = this.owner,
                         _quantity = this.amount.quantity,
                         currency = this.amount.token.product.currencyCode,
@@ -62,12 +62,12 @@ class DummyFungibleContract : OnLedgerAsset<Currency, DummyFungibleContract.Comm
                         _issuerRef = this.amount.token.issuer.reference.bytes
                 )
                 is SampleCashSchemaV3 -> SampleCashSchemaV3.PersistentCashState(
-                        _participants = this.participants.toSet(),
-                        _owner = this.owner,
-                        _quantity = this.amount.quantity,
-                        _currency = this.amount.token.product.currencyCode,
-                        _issuerParty = this.amount.token.issuer.party,
-                        _issuerRef = this.amount.token.issuer.reference.bytes
+                        participants = this.participants.toMutableSet(),
+                        owner = this.owner,
+                        pennies = this.amount.quantity,
+                        currency = this.amount.token.product.currencyCode,
+                        issuer = this.amount.token.issuer.party,
+                        issuerRef = this.amount.token.issuer.reference.bytes
                 )
                 else -> throw IllegalArgumentException("Unrecognised schema $schema")
             }

--- a/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV2.kt
+++ b/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV2.kt
@@ -13,7 +13,7 @@ import javax.persistence.Table
  * [VaultFungibleState] abstract schema
  */
 object SampleCashSchemaV2 : MappedSchema(schemaFamily = CashSchema.javaClass, version = 2,
-                                   mappedTypes = listOf(PersistentCashState::class.java, CommonSchemaV1.Party::class.java)) {
+                                   mappedTypes = listOf(PersistentCashState::class.java)) {
     @Entity
     @Table(name = "cash_states_v2",
            indexes = arrayOf(Index(name = "ccy_code_idx2", columnList = "ccy_code")))

--- a/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV2.kt
+++ b/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV2.kt
@@ -33,5 +33,5 @@ object SampleCashSchemaV2 : MappedSchema(schemaFamily = CashSchema.javaClass, ve
         val _issuerParty: AbstractParty,
         @Transient
         val _issuerRef: ByteArray
-    ) : CommonSchemaV1.FungibleState(_participants, _owner, _quantity, _issuerParty, _issuerRef)
+    ) : CommonSchemaV1.FungibleState(_participants.toMutableSet(), _owner, _quantity, _issuerParty, _issuerRef)
 }

--- a/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV3.kt
+++ b/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV3.kt
@@ -19,10 +19,11 @@ object SampleCashSchemaV3 : MappedSchema(schemaFamily = CashSchema.javaClass, ve
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<String>,
+            var participants: MutableSet<AbstractParty>? = null,
 
-            /** X500Name of anonymous owner party (after resolution by the IdentityService) **/
-            var owner: String,
+            /** X500Name of owner party **/
+            @Column(name = "owner_name")
+            var owner: AbstractParty,
 
             @Column(name = "pennies")
             var pennies: Long,
@@ -31,17 +32,10 @@ object SampleCashSchemaV3 : MappedSchema(schemaFamily = CashSchema.javaClass, ve
             var currency: String,
 
             /** X500Name of issuer party **/
-            var issuer: String,
+            @Column(name = "issuer_name")
+            var issuer: AbstractParty,
 
             @Column(name = "issuer_ref")
             var issuerRef: ByteArray
-    ) : PersistentState() {
-        constructor(_participants: Set<AbstractParty>, _owner: AbstractParty, _quantity: Long, _currency: String, _issuerParty: AbstractParty, _issuerRef: ByteArray)
-                : this(participants = _participants.map { it.nameOrNull().toString() }.toSet(),
-                        owner = _owner.nameOrNull().toString(),
-                        pennies = _quantity,
-                        currency = _currency,
-                        issuer = _issuerParty.nameOrNull().toString(),
-                        issuerRef = _issuerRef)
-    }
+    ) : PersistentState()
 }

--- a/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV3.kt
+++ b/finance/src/test/kotlin/net/corda/schemas/SampleCashSchemaV3.kt
@@ -11,16 +11,18 @@ import javax.persistence.*
  * at the time of writing.
  */
 object SampleCashSchemaV3 : MappedSchema(schemaFamily = CashSchema.javaClass, version = 3,
-                                   mappedTypes = listOf(PersistentCashState::class.java, CommonSchemaV1.Party::class.java)) {
+                                         mappedTypes = listOf(PersistentCashState::class.java)) {
     @Entity
     @Table(name = "cash_states_v3")
     class PersistentCashState(
             /** [ContractState] attributes */
-            @OneToMany(cascade = arrayOf(CascadeType.ALL))
-            var participants: Set<CommonSchemaV1.Party>,
 
-            @OneToOne(cascade = arrayOf(CascadeType.ALL))
-            var owner: CommonSchemaV1.Party,
+            /** X500Name of participant parties **/
+            @ElementCollection
+            var participants: Set<String>,
+
+            /** X500Name of anonymous owner party (after resolution by the IdentityService) **/
+            var owner: String,
 
             @Column(name = "pennies")
             var pennies: Long,
@@ -28,18 +30,18 @@ object SampleCashSchemaV3 : MappedSchema(schemaFamily = CashSchema.javaClass, ve
             @Column(name = "ccy_code", length = 3)
             var currency: String,
 
-            @OneToOne(cascade = arrayOf(CascadeType.ALL))
-            var issuerParty: CommonSchemaV1.Party,
+            /** X500Name of issuer party **/
+            var issuer: String,
 
             @Column(name = "issuer_ref")
             var issuerRef: ByteArray
     ) : PersistentState() {
         constructor(_participants: Set<AbstractParty>, _owner: AbstractParty, _quantity: Long, _currency: String, _issuerParty: AbstractParty, _issuerRef: ByteArray)
-                : this(participants = _participants.map { CommonSchemaV1.Party(it) }.toSet(),
-                        owner = CommonSchemaV1.Party(_owner),
+                : this(participants = _participants.map { it.nameOrNull().toString() }.toSet(),
+                        owner = _owner.nameOrNull().toString(),
                         pennies = _quantity,
                         currency = _currency,
-                        issuerParty = CommonSchemaV1.Party(_issuerParty),
+                        issuer = _issuerParty.nameOrNull().toString(),
                         issuerRef = _issuerRef)
     }
 }

--- a/finance/src/test/kotlin/net/corda/schemas/SampleCommercialPaperSchemaV2.kt
+++ b/finance/src/test/kotlin/net/corda/schemas/SampleCommercialPaperSchemaV2.kt
@@ -44,5 +44,5 @@ object SampleCommercialPaperSchemaV2 : MappedSchema(schemaFamily = CommercialPap
             val _issuerParty: AbstractParty,
             @Transient
             val _issuerRef: ByteArray
-    ) : CommonSchemaV1.FungibleState(_participants, _owner, _quantity, _issuerParty, _issuerRef)
+    ) : CommonSchemaV1.FungibleState(_participants.toMutableSet(), _owner, _quantity, _issuerParty, _issuerRef)
 }

--- a/finance/src/test/kotlin/net/corda/schemas/SampleCommercialPaperSchemaV2.kt
+++ b/finance/src/test/kotlin/net/corda/schemas/SampleCommercialPaperSchemaV2.kt
@@ -14,7 +14,7 @@ import javax.persistence.Table
  * [VaultFungibleState] abstract schema
  */
 object SampleCommercialPaperSchemaV2 : MappedSchema(schemaFamily = CommercialPaperSchema.javaClass, version = 1,
-                                              mappedTypes = listOf(PersistentCommercialPaperState::class.java, CommonSchemaV1.Party::class.java)) {
+                                                    mappedTypes = listOf(PersistentCommercialPaperState::class.java)) {
     @Entity
     @Table(name = "cp_states_v2",
            indexes = arrayOf(Index(name = "ccy_code_index2", columnList = "ccy_code"),

--- a/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/requery/VaultSchema.kt
+++ b/node-schemas/src/main/kotlin/net/corda/node/services/vault/schemas/requery/VaultSchema.kt
@@ -41,9 +41,6 @@ object VaultSchema {
         @get:Column(name = "notary_name")
         var notaryName: String
 
-        @get:Column(name = "notary_key", length = 65535) // TODO What is the upper limit on size of CompositeKey?
-        var notaryKey: String
-
         /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */
         @get:Column(name = "contract_state_class_name")
         var contractStateClassName: String

--- a/node-schemas/src/test/kotlin/net/corda/node/services/vault/schemas/VaultSchemaTest.kt
+++ b/node-schemas/src/test/kotlin/net/corda/node/services/vault/schemas/VaultSchemaTest.kt
@@ -314,7 +314,6 @@ class VaultSchemaTest : TestDependencyInjectionBase() {
             contractStateClassName = state.data.javaClass.name
             contractState = state.serialize().bytes
             notaryName = state.notary.name.toString()
-            notaryKey = state.notary.owningKey.toBase58String()
             recordedTime = Instant.now()
         }
     }
@@ -655,15 +654,12 @@ class VaultSchemaTest : TestDependencyInjectionBase() {
 
     @Test
     fun insertWithBigCompositeKey() {
-        val keys = (1..314).map { generateKeyPair().public }
-        val bigNotaryKey = CompositeKey.Builder().addKeys(keys).build()
         val vaultStEntity = VaultStatesEntity().apply {
             txId = SecureHash.randomSHA256().toString()
             index = 314
             stateStatus = Vault.StateStatus.UNCONSUMED
             contractStateClassName = VaultNoopContract.VaultNoopState::class.java.name
             notaryName = "Huge distributed notary"
-            notaryKey = bigNotaryKey.toBase58String()
             recordedTime = Instant.now()
         }
         data.insert(vaultStEntity)

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -244,9 +244,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // owner
         criteria.owner?.let {
             val ownerKeys = criteria.owner as List<AbstractParty>
-            val joinFungibleStateToParty = vaultFungibleStates.join<VaultSchemaV1.VaultFungibleStates, CommonSchemaV1.Party>("issuerParty")
-            val owners = ownerKeys.map { it.nameOrNull()?.toString() ?: it.toString()}
-            predicateSet.add(criteriaBuilder.and(joinFungibleStateToParty.get<CommonSchemaV1.Party>("name").`in`(owners)))
+            val owners = ownerKeys.map { it.nameOrNull().toString() }
+            predicateSet.add(criteriaBuilder.and(vaultFungibleStates.get<String>("owner").`in`(owners)))
         }
 
         // quantity
@@ -257,9 +256,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // issuer party
         criteria.issuerPartyName?.let {
             val issuerParties = criteria.issuerPartyName as List<AbstractParty>
-            val joinFungibleStateToParty = vaultFungibleStates.join<VaultSchemaV1.VaultFungibleStates, CommonSchemaV1.Party>("issuerParty")
             val issuerPartyNames = issuerParties.map { it.nameOrNull().toString() }
-            predicateSet.add(criteriaBuilder.and(joinFungibleStateToParty.get<CommonSchemaV1.Party>("name").`in`(issuerPartyNames)))
+            predicateSet.add(criteriaBuilder.and(vaultFungibleStates.get<String>("issuer").`in`(issuerPartyNames)))
         }
 
         // issuer reference
@@ -271,9 +269,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // participants
         criteria.participants?.let {
             val participants = criteria.participants as List<AbstractParty>
-            val joinFungibleStateToParty = vaultFungibleStates.join<VaultSchemaV1.VaultFungibleStates, CommonSchemaV1.Party>("participants")
             val participantKeys = participants.map { it.nameOrNull().toString() }
-            predicateSet.add(criteriaBuilder.and(joinFungibleStateToParty.get<CommonSchemaV1.Party>("name").`in`(participantKeys)))
+            val joinLinearStateToParty = vaultFungibleStates.joinSet<VaultSchemaV1.VaultLinearStates, String>("participants")
+            predicateSet.add(criteriaBuilder.and(joinLinearStateToParty.`in`(participantKeys)))
             criteriaQuery.distinct(true)
         }
         return predicateSet
@@ -310,9 +308,9 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // deal participants
         criteria.participants?.let {
             val participants = criteria.participants as List<AbstractParty>
-            val joinLinearStateToParty = vaultLinearStates.join<VaultSchemaV1.VaultLinearStates, CommonSchemaV1.Party>("participants")
             val participantKeys = participants.map { it.nameOrNull().toString() }
-            predicateSet.add(criteriaBuilder.and(joinLinearStateToParty.get<CommonSchemaV1.Party>("name").`in`(participantKeys)))
+            val joinLinearStateToParty = vaultLinearStates.joinSet<VaultSchemaV1.VaultLinearStates, String>("participants")
+            predicateSet.add(criteriaBuilder.and(joinLinearStateToParty.`in`(participantKeys)))
             criteriaQuery.distinct(true)
         }
         return predicateSet

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -69,8 +69,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
 
         // notary names
         criteria.notaryName?.let {
-            val notaryNames = (criteria.notaryName as List<X500Name>).map { it.toString() }
-            predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("notaryName").`in`(notaryNames)))
+            predicateSet.add(criteriaBuilder.and(vaultStates.get<AbstractParty>("notaryName").`in`(criteria.notaryName)))
         }
 
         // state references
@@ -243,9 +242,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
 
         // owner
         criteria.owner?.let {
-            val ownerKeys = criteria.owner as List<AbstractParty>
-            val owners = ownerKeys.map { it.nameOrNull().toString() }
-            predicateSet.add(criteriaBuilder.and(vaultFungibleStates.get<String>("owner").`in`(owners)))
+            val owners = criteria.owner as List<AbstractParty>
+            predicateSet.add(criteriaBuilder.and(vaultFungibleStates.get<AbstractParty>("owner").`in`(owners)))
         }
 
         // quantity
@@ -256,8 +254,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // issuer party
         criteria.issuerPartyName?.let {
             val issuerParties = criteria.issuerPartyName as List<AbstractParty>
-            val issuerPartyNames = issuerParties.map { it.nameOrNull().toString() }
-            predicateSet.add(criteriaBuilder.and(vaultFungibleStates.get<String>("issuer").`in`(issuerPartyNames)))
+            predicateSet.add(criteriaBuilder.and(vaultFungibleStates.get<AbstractParty>("issuer").`in`(issuerParties)))
         }
 
         // issuer reference
@@ -269,9 +266,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // participants
         criteria.participants?.let {
             val participants = criteria.participants as List<AbstractParty>
-            val participantKeys = participants.map { it.nameOrNull().toString() }
-            val joinLinearStateToParty = vaultFungibleStates.joinSet<VaultSchemaV1.VaultLinearStates, String>("participants")
-            predicateSet.add(criteriaBuilder.and(joinLinearStateToParty.`in`(participantKeys)))
+            val joinLinearStateToParty = vaultFungibleStates.joinSet<VaultSchemaV1.VaultLinearStates, AbstractParty>("participants")
+            predicateSet.add(criteriaBuilder.and(joinLinearStateToParty.`in`(participants)))
             criteriaQuery.distinct(true)
         }
         return predicateSet
@@ -308,9 +304,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // deal participants
         criteria.participants?.let {
             val participants = criteria.participants as List<AbstractParty>
-            val participantKeys = participants.map { it.nameOrNull().toString() }
-            val joinLinearStateToParty = vaultLinearStates.joinSet<VaultSchemaV1.VaultLinearStates, String>("participants")
-            predicateSet.add(criteriaBuilder.and(joinLinearStateToParty.`in`(participantKeys)))
+            val joinLinearStateToParty = vaultLinearStates.joinSet<VaultSchemaV1.VaultLinearStates, AbstractParty>("participants")
+            predicateSet.add(criteriaBuilder.and(joinLinearStateToParty.`in`(participants)))
             criteriaQuery.distinct(true)
         }
         return predicateSet

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -7,14 +7,12 @@ import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultQueryException
 import net.corda.core.node.services.vault.*
 import net.corda.core.node.services.vault.QueryCriteria.CommonQueryCriteria
-import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.toHexString
 import net.corda.core.utilities.trace
-import org.bouncycastle.asn1.x500.X500Name
 import java.util.*
 import javax.persistence.Tuple
 import javax.persistence.criteria.*
@@ -68,8 +66,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         }
 
         // notary names
-        criteria.notaryName?.let {
-            predicateSet.add(criteriaBuilder.and(vaultStates.get<AbstractParty>("notaryName").`in`(criteria.notaryName)))
+        criteria.notary?.let {
+            predicateSet.add(criteriaBuilder.and(vaultStates.get<AbstractParty>("notary").`in`(criteria.notary)))
         }
 
         // state references
@@ -252,8 +250,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         }
 
         // issuer party
-        criteria.issuerPartyName?.let {
-            val issuerParties = criteria.issuerPartyName as List<AbstractParty>
+        criteria.issuer?.let {
+            val issuerParties = criteria.issuer as List<AbstractParty>
             predicateSet.add(criteriaBuilder.and(vaultFungibleStates.get<AbstractParty>("issuer").`in`(issuerParties)))
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -98,7 +98,7 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                                 val vaultState = result[0] as VaultSchemaV1.VaultStates
                                 val stateRef = StateRef(SecureHash.parse(vaultState.stateRef!!.txId!!), vaultState.stateRef!!.index!!)
                                 val state = vaultState.contractState.deserialize<TransactionState<T>>(context = STORAGE_CONTEXT)
-                                statesMeta.add(Vault.StateMetadata(stateRef, vaultState.contractStateClassName, vaultState.recordedTime, vaultState.consumedTime, vaultState.stateStatus, vaultState.notaryName, vaultState.lockId, vaultState.lockUpdateTime))
+                                statesMeta.add(Vault.StateMetadata(stateRef, vaultState.contractStateClassName, vaultState.recordedTime, vaultState.consumedTime, vaultState.stateStatus, vaultState.notaryName.nameOrNull().toString(), vaultState.lockId, vaultState.lockUpdateTime))
                                 statesAndRefs.add(StateAndRef(state, stateRef))
                             }
                             else {

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -98,7 +98,14 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                                 val vaultState = result[0] as VaultSchemaV1.VaultStates
                                 val stateRef = StateRef(SecureHash.parse(vaultState.stateRef!!.txId!!), vaultState.stateRef!!.index!!)
                                 val state = vaultState.contractState.deserialize<TransactionState<T>>(context = STORAGE_CONTEXT)
-                                statesMeta.add(Vault.StateMetadata(stateRef, vaultState.contractStateClassName, vaultState.recordedTime, vaultState.consumedTime, vaultState.stateStatus, vaultState.notaryName.nameOrNull().toString(), vaultState.lockId, vaultState.lockUpdateTime))
+                                statesMeta.add(Vault.StateMetadata(stateRef,
+                                                                   vaultState.contractStateClassName,
+                                                                   vaultState.recordedTime,
+                                                                   vaultState.consumedTime,
+                                                                   vaultState.stateStatus,
+                                                                   vaultState.notaryName?.nameOrNull()?.toString() ?: "",
+                                                                   vaultState.lockId,
+                                                                   vaultState.lockUpdateTime))
                                 statesAndRefs.add(StateAndRef(state, stateRef))
                             }
                             else {

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -98,7 +98,7 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                                 val vaultState = result[0] as VaultSchemaV1.VaultStates
                                 val stateRef = StateRef(SecureHash.parse(vaultState.stateRef!!.txId!!), vaultState.stateRef!!.index!!)
                                 val state = vaultState.contractState.deserialize<TransactionState<T>>(context = STORAGE_CONTEXT)
-                                statesMeta.add(Vault.StateMetadata(stateRef, vaultState.contractStateClassName, vaultState.recordedTime, vaultState.consumedTime, vaultState.stateStatus, vaultState.notaryName, vaultState.notaryKey, vaultState.lockId, vaultState.lockUpdateTime))
+                                statesMeta.add(Vault.StateMetadata(stateRef, vaultState.contractStateClassName, vaultState.recordedTime, vaultState.consumedTime, vaultState.stateStatus, vaultState.notaryName, vaultState.lockId, vaultState.lockUpdateTime))
                                 statesAndRefs.add(StateAndRef(state, stateRef))
                             }
                             else {

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -103,7 +103,7 @@ class HibernateVaultQueryImpl(hibernateConfig: HibernateConfiguration,
                                                                    vaultState.recordedTime,
                                                                    vaultState.consumedTime,
                                                                    vaultState.stateStatus,
-                                                                   vaultState.notaryName?.nameOrNull()?.toString() ?: "",
+                                                                   vaultState.notary,
                                                                    vaultState.lockId,
                                                                    vaultState.lockUpdateTime))
                                 statesAndRefs.add(StateAndRef(state, stateRef))

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -98,7 +98,6 @@ class NodeVaultService(private val services: ServiceHub, dataSourceProperties: P
                         contractStateClassName = it.value.state.data.javaClass.name
                         contractState = it.value.state.serialize(context = STORAGE_CONTEXT).bytes
                         notaryName = it.value.state.notary.name.toString()
-                        notaryKey = it.value.state.notary.owningKey.toBase58String()
                         recordedTime = services.clock.instant()
                     }
                     insert(state)

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -27,12 +27,9 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
     @Table(name = "vault_states",
             indexes = arrayOf(Index(name = "state_status_idx", columnList = "state_status")))
     class VaultStates(
-            /** refers to the notary a state is attached to */
+            /** refers to the X500Name of the notary a state is attached to */
             @Column(name = "notary_name")
             var notaryName: String,
-
-            @Column(name = "notary_key", length = 65535) // TODO What is the upper limit on size of CompositeKey?
-            var notaryKey: String,
 
             /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */
             @Column(name = "contract_state_class_name")

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -102,7 +102,9 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var participants: MutableSet<AbstractParty>? = null,
 
             /** [OwnableState] attributes */
-            @Column(name = "owner_id")
+
+            /** X500Name of owner party **/
+            @Column(name = "owner_name")
             var owner: AbstractParty,
 
             /** [FungibleAsset] attributes

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -29,7 +29,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
     class VaultStates(
             /** refers to the X500Name of the notary a state is attached to */
             @Column(name = "notary_name")
-            var notaryName: String,
+            var notaryName: AbstractParty,
 
             /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */
             @Column(name = "contract_state_class_name")
@@ -71,7 +71,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<String>,
+            var participants: Set<AbstractParty>,
 
             /**
              *  Represents a [LinearState] [UniqueIdentifier]
@@ -85,7 +85,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
         constructor(uid: UniqueIdentifier, _participants: List<AbstractParty>) :
                 this(externalId = uid.externalId,
                      uuid = uid.id,
-                     participants = _participants.map{ it.nameOrNull().toString() }.toSet() )
+                     participants = _participants.toSet())
     }
 
     @Entity
@@ -95,7 +95,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<String>,
+            var participants: Set<AbstractParty>,
 
             /** [OwnableState] attributes */
             @Column(name = "owner_id")
@@ -114,7 +114,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             /** Issuer attributes */
 
             /** X500Name of issuer party **/
-            var issuer: String,
+            var issuer: AbstractParty,
 
             @Column(name = "issuer_reference")
             var issuerRef: ByteArray
@@ -122,8 +122,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
         constructor(_owner: AbstractParty, _quantity: Long, _issuerParty: AbstractParty, _issuerRef: OpaqueBytes, _participants: List<AbstractParty>) :
                 this(owner = _owner,
                      quantity = _quantity,
-                     issuer = _issuerParty.nameOrNull().toString(),
+                     issuer = _issuerParty,
                      issuerRef = _issuerRef.bytes,
-                     participants =  _participants.map { it.nameOrNull().toString() }.toSet())
+                     participants =  _participants.toSet())
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -67,9 +67,9 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             indexes = arrayOf(Index(name = "external_id_index", columnList = "external_id"),
                     Index(name = "uuid_index", columnList = "uuid")))
     class VaultLinearStates(
-            /** [ContractState] attributes */
-            @OneToMany(cascade = arrayOf(CascadeType.ALL))
-            var participants: Set<CommonSchemaV1.Party>,
+            /** X500Name of participant parties **/
+            @ElementCollection
+            var participants: Set<String>,
 
             /**
              *  Represents a [LinearState] [UniqueIdentifier]
@@ -83,15 +83,15 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
         constructor(uid: UniqueIdentifier, _participants: List<AbstractParty>) :
                 this(externalId = uid.externalId,
                      uuid = uid.id,
-                     participants = _participants.map{ CommonSchemaV1.Party(it) }.toSet() )
+                     participants = _participants.map{ it.nameOrNull().toString() }.toSet() )
     }
 
     @Entity
     @Table(name = "vault_fungible_states")
     class VaultFungibleStates(
-            /** [ContractState] attributes */
-            @OneToMany(cascade = arrayOf(CascadeType.ALL))
-            var participants: Set<CommonSchemaV1.Party>,
+            /** X500Name of participant parties **/
+            @ElementCollection
+            var participants: Set<String>,
 
             /** [OwnableState] attributes */
             @Column(name = "owner_id")
@@ -108,8 +108,9 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var quantity: Long,
 
             /** Issuer attributes */
-            @OneToOne(cascade = arrayOf(CascadeType.ALL))
-            var issuerParty: CommonSchemaV1.Party,
+
+            /** X500Name of issuer party **/
+            var issuer: String,
 
             @Column(name = "issuer_reference")
             var issuerRef: ByteArray
@@ -117,8 +118,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
         constructor(_owner: AbstractParty, _quantity: Long, _issuerParty: AbstractParty, _issuerRef: OpaqueBytes, _participants: List<AbstractParty>) :
                 this(owner = _owner,
                      quantity = _quantity,
-                     issuerParty = CommonSchemaV1.Party(_issuerParty),
+                     issuer = _issuerParty.nameOrNull().toString(),
                      issuerRef = _issuerRef.bytes,
-                     participants =  _participants.map { CommonSchemaV1.Party(it) }.toSet())
+                     participants =  _participants.map { it.nameOrNull().toString() }.toSet())
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -71,7 +71,10 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<AbstractParty>,
+            @Column(name = "participants")
+            var participants: MutableSet<AbstractParty>? = null,
+            // Reason for not using Set is described here:
+            // https://stackoverflow.com/questions/44213074/kotlin-collection-has-neither-generic-type-or-onetomany-targetentity
 
             /**
              *  Represents a [LinearState] [UniqueIdentifier]
@@ -85,7 +88,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
         constructor(uid: UniqueIdentifier, _participants: List<AbstractParty>) :
                 this(externalId = uid.externalId,
                      uuid = uid.id,
-                     participants = _participants.toSet())
+                     participants = _participants.toMutableSet())
     }
 
     @Entity
@@ -95,7 +98,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<AbstractParty>,
+            @Column(name = "participants")
+            var participants: MutableSet<AbstractParty>? = null,
 
             /** [OwnableState] attributes */
             @Column(name = "owner_id")
@@ -114,6 +118,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             /** Issuer attributes */
 
             /** X500Name of issuer party **/
+            @Column(name = "issuer_name")
             var issuer: AbstractParty,
 
             @Column(name = "issuer_reference")
@@ -124,6 +129,6 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
                      quantity = _quantity,
                      issuer = _issuerParty,
                      issuerRef = _issuerRef.bytes,
-                     participants =  _participants.toSet())
+                     participants = _participants.toMutableSet())
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -29,7 +29,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
     class VaultStates(
             /** refers to the X500Name of the notary a state is attached to */
             @Column(name = "notary_name")
-            var notaryName: AbstractParty,
+            var notary: AbstractParty,
 
             /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */
             @Column(name = "contract_state_class_name")

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -1,9 +1,9 @@
 package net.corda.node.services.vault
 
+import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.Vault
-import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.serialization.CordaSerializable
@@ -22,7 +22,7 @@ object VaultSchema
  */
 @CordaSerializable
 object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, version = 1,
-                                    mappedTypes = listOf(VaultStates::class.java, VaultLinearStates::class.java, VaultFungibleStates::class.java,  CommonSchemaV1.Party::class.java)) {
+                                    mappedTypes = listOf(VaultStates::class.java, VaultLinearStates::class.java, VaultFungibleStates::class.java)) {
     @Entity
     @Table(name = "vault_states",
             indexes = arrayOf(Index(name = "state_status_idx", columnList = "state_status")))
@@ -67,6 +67,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             indexes = arrayOf(Index(name = "external_id_index", columnList = "external_id"),
                     Index(name = "uuid_index", columnList = "uuid")))
     class VaultLinearStates(
+            /** [ContractState] attributes */
+
             /** X500Name of participant parties **/
             @ElementCollection
             var participants: Set<String>,
@@ -89,6 +91,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
     @Entity
     @Table(name = "vault_fungible_states")
     class VaultFungibleStates(
+            /** [ContractState] attributes */
+
             /** X500Name of participant parties **/
             @ElementCollection
             var participants: Set<String>,

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -8,9 +8,7 @@ import net.corda.core.contracts.*;
 import net.corda.core.crypto.EncodingUtils;
 import net.corda.core.identity.AbstractParty;
 import net.corda.core.messaging.DataFeed;
-import net.corda.core.node.services.Vault;
-import net.corda.core.node.services.VaultQueryException;
-import net.corda.core.node.services.VaultQueryService;
+import net.corda.core.node.services.*;
 import net.corda.core.node.services.vault.*;
 import net.corda.core.node.services.vault.QueryCriteria.LinearStateQueryCriteria;
 import net.corda.core.node.services.vault.QueryCriteria.VaultCustomQueryCriteria;
@@ -44,6 +42,7 @@ import static net.corda.core.utilities.ByteArrays.toHexString;
 import static net.corda.testing.CoreTestUtils.*;
 import static net.corda.testing.TestConstants.*;
 import static net.corda.testing.node.MockServicesKt.makeTestDatabaseAndMockServices;
+import static net.corda.testing.node.MockServicesKt.makeTestIdentityService;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class VaultQueryJavaTests extends TestDependencyInjectionBase {
@@ -58,7 +57,9 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
         ArrayList<KeyPair> keys = new ArrayList<>();
         keys.add(getMEGA_CORP_KEY());
         keys.add(getDUMMY_NOTARY_KEY());
-        Pair<CordaPersistence, MockServices> databaseAndServices = makeTestDatabaseAndMockServices(Collections.EMPTY_SET, keys);
+
+        IdentityService identitySvc = makeTestIdentityService();
+        Pair<CordaPersistence, MockServices> databaseAndServices = makeTestDatabaseAndMockServices(Collections.EMPTY_SET, keys, () -> identitySvc);
         issuerServices = new MockServices(getDUMMY_CASH_ISSUER_KEY(), getBOC_KEY());
         database = databaseAndServices.getFirst();
         services = databaseAndServices.getSecond();

--- a/node/src/test/kotlin/net/corda/node/services/database/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/HibernateConfigurationTest.kt
@@ -638,9 +638,8 @@ class HibernateConfigurationTest : TestDependencyInjectionBase() {
         // search predicate
         val cashStatesSchema = criteriaQuery.from(SampleCashSchemaV3.PersistentCashState::class.java)
 
-        val joinCashToParty = cashStatesSchema.join<SampleCashSchemaV3.PersistentCashState, CommonSchemaV1.Party>("owner")
-        val queryOwnerKey = BOB_PUBKEY.toBase58String()
-        criteriaQuery.where(criteriaBuilder.equal(joinCashToParty.get<CommonSchemaV1.Party>("key"), queryOwnerKey))
+        val queryOwner = BOB.name.toString()
+        criteriaQuery.where(criteriaBuilder.equal(cashStatesSchema.get<String>("owner"), queryOwner))
 
         val joinVaultStatesToCash = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), cashStatesSchema.get<PersistentStateRef>("stateRef"))
         criteriaQuery.where(joinVaultStatesToCash)
@@ -723,9 +722,9 @@ class HibernateConfigurationTest : TestDependencyInjectionBase() {
         // search predicate
         val cashStatesSchema = criteriaQuery.from(SampleCashSchemaV3.PersistentCashState::class.java)
 
-        val joinCashToParty = cashStatesSchema.join<SampleCashSchemaV3.PersistentCashState, CommonSchemaV1.Party>("participants")
-        val queryParticipantKeys = firstCashState.state.data.participants.map { it.owningKey.toBase58String() }
-        criteriaQuery.where(criteriaBuilder.equal(joinCashToParty.get<CommonSchemaV1.Party>("key"), queryParticipantKeys))
+        val queryParticipants = firstCashState.state.data.participants.map { it.nameOrNull().toString() }
+        val joinCashStateToParty = cashStatesSchema.joinSet<SampleCashSchemaV3.PersistentCashState, String>("participants")
+        criteriaQuery.where(criteriaBuilder.and(joinCashStateToParty.`in`(queryParticipants)))
 
         val joinVaultStatesToCash = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), cashStatesSchema.get<PersistentStateRef>("stateRef"))
         criteriaQuery.where(joinVaultStatesToCash)

--- a/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
@@ -173,7 +173,6 @@ class RequeryConfigurationTest : TestDependencyInjectionBase() {
             contractStateClassName = DummyContract.SingleOwnerState::class.java.name
             contractState = DummyContract.SingleOwnerState(owner = AnonymousParty(MEGA_CORP_PUBKEY)).serialize().bytes
             notaryName = txn.tx.notary!!.name.toString()
-            notaryKey = txn.tx.notary!!.owningKey.toBase58String()
             recordedTime = Instant.now()
         }
         return state

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -68,8 +68,8 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
                                                              lockId: UUID = UUID.randomUUID(),
                                                              withIssuerRefs: Set<OpaqueBytes>? = null): List<StateAndRef<Cash.State>> {
 
-        val notary = if (notary != null) listOf(notary) else null
-        var baseCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notary = notary)
+        val notaries = if (notary != null) listOf(notary) else null
+        var baseCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notary = notaries)
         if (onlyFromIssuerParties != null || withIssuerRefs != null) {
             baseCriteria = baseCriteria.and(QueryCriteria.FungibleAssetQueryCriteria(
                     issuer = onlyFromIssuerParties?.toList(),

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -68,11 +68,11 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
                                                              lockId: UUID = UUID.randomUUID(),
                                                              withIssuerRefs: Set<OpaqueBytes>? = null): List<StateAndRef<Cash.State>> {
 
-        val notaryName = if (notary != null) listOf(notary) else null
-        var baseCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notaryName = notaryName)
+        val notary = if (notary != null) listOf(notary) else null
+        var baseCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notary = notary)
         if (onlyFromIssuerParties != null || withIssuerRefs != null) {
             baseCriteria = baseCriteria.and(QueryCriteria.FungibleAssetQueryCriteria(
-                    issuerPartyName = onlyFromIssuerParties?.toList(),
+                    issuer = onlyFromIssuerParties?.toList(),
                     issuerRef = withIssuerRefs?.toList()))
         }
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -68,7 +68,7 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
                                                              lockId: UUID = UUID.randomUUID(),
                                                              withIssuerRefs: Set<OpaqueBytes>? = null): List<StateAndRef<Cash.State>> {
 
-        val notaryName = if (notary != null) listOf(notary.name) else null
+        val notaryName = if (notary != null) listOf(notary) else null
         var baseCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(notaryName = notaryName)
         if (onlyFromIssuerParties != null || withIssuerRefs != null) {
             baseCriteria = baseCriteria.and(QueryCriteria.FungibleAssetQueryCriteria(

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -64,7 +64,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         database = databaseAndServices.first
         services = databaseAndServices.second
         // register additional identities
-        identitySvc.registerIdentity(CASH_NOTARY_IDENTITY)
+        identitySvc.verifyAndRegisterIdentity(CASH_NOTARY_IDENTITY)
         notaryServices = MockServices(DUMMY_NOTARY_KEY, DUMMY_CASH_ISSUER_KEY, BOC_KEY, MEGA_CORP_KEY)
     }
 
@@ -423,7 +423,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed linear states for single participant`() {
         database.transaction {
-            identitySvc.registerIdentity(BIG_CORP_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(BIG_CORP_IDENTITY)
 
             services.fillWithSomeTestLinearStates(2, "TEST", participants = listOf(MEGA_CORP, MINI_CORP))
             services.fillWithSomeTestDeals(listOf("456"), participants = listOf(MEGA_CORP, BIG_CORP))
@@ -439,7 +439,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed linear states for two participants`() {
         database.transaction {
-            identitySvc.registerIdentity(BIG_CORP_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(BIG_CORP_IDENTITY)
 
             services.fillWithSomeTestLinearStates(2, "TEST", participants = listOf(MEGA_CORP, MINI_CORP))
             services.fillWithSomeTestDeals(listOf("456"), participants = listOf(MEGA_CORP, BIG_CORP))
@@ -800,7 +800,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `aggregate functions sum by issuer and currency and sort by aggregate sum`() {
         database.transaction {
-            identitySvc.registerIdentity(BOC_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(BOC_IDENTITY)
 
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
             services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L), issuedBy = BOC.ref(1))
@@ -1403,7 +1403,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed fungible assets for specific issuer party and refs`() {
         database.transaction {
-            identitySvc.registerIdentity(BOC_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(BOC_IDENTITY)
 
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)), ref = OpaqueBytes.of(1))
@@ -1433,9 +1433,6 @@ class VaultQueryTests : TestDependencyInjectionBase() {
         val chfCashIssuerServices = MockServices(chfCashIssuerKey)
 
         database.transaction {
-//            identitySvc.registerIdentity(GBP_CASH_IDENTITY)
-//            identitySvc.registerIdentity(USD_CASH_IDENTITY)
-//            identitySvc.registerIdentity(CHF_CASH_IDENTITY)
 
             services.fillWithSomeTestCash(100.POUNDS, gbpCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (gbpCashIssuer))
             services.fillWithSomeTestCash(100.DOLLARS, usdCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (usdCashIssuer))
@@ -1567,7 +1564,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed fungible assets for issuer party`() {
         database.transaction {
-            identitySvc.registerIdentity(BOC_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(BOC_IDENTITY)
 
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)))
@@ -1839,7 +1836,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed linear heads for single participant`() {
         database.transaction {
-            identitySvc.registerIdentity(ALICE_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(ALICE_IDENTITY)
             services.fillWithSomeTestLinearStates(1, "TEST1", listOf(ALICE))
             services.fillWithSomeTestLinearStates(1)
             services.fillWithSomeTestLinearStates(1, "TEST3")
@@ -1855,9 +1852,9 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Test
     fun `unconsumed linear heads for multiple participants`() {
         database.transaction {
-            identitySvc.registerIdentity(ALICE_IDENTITY)
-            identitySvc.registerIdentity(BOB_IDENTITY)
-            identitySvc.registerIdentity(CHARLIE_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(ALICE_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(BOB_IDENTITY)
+            identitySvc.verifyAndRegisterIdentity(CHARLIE_IDENTITY)
 
             services.fillWithSomeTestLinearStates(1, "TEST1", listOf(ALICE,BOB,CHARLIE))
             services.fillWithSomeTestLinearStates(1)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -50,7 +50,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     lateinit var notaryServices: MockServices
     val vaultSvc: VaultService get() = services.vaultService
     val vaultQuerySvc: VaultQueryService get() = services.vaultQueryService
-    val identitySvc: IdentityService get() = services.identityService
+    val identitySvc: IdentityService = makeTestIdentityService()
     lateinit var database: CordaPersistence
 
     // test cash notary
@@ -60,11 +60,12 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
     @Before
     fun setUp() {
-        val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MEGA_CORP_KEY, DUMMY_NOTARY_KEY))
-        database = databaseAndServices.first
-        services = databaseAndServices.second
         // register additional identities
         identitySvc.verifyAndRegisterIdentity(CASH_NOTARY_IDENTITY)
+        identitySvc.verifyAndRegisterIdentity(BOC_IDENTITY)
+        val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MEGA_CORP_KEY, DUMMY_NOTARY_KEY), identitySvc = { identitySvc })
+        database = databaseAndServices.first
+        services = databaseAndServices.second
         notaryServices = MockServices(DUMMY_NOTARY_KEY, DUMMY_CASH_ISSUER_KEY, BOC_KEY, MEGA_CORP_KEY)
     }
 
@@ -79,7 +80,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
     @Ignore
     @Test
     fun createPersistentTestDb() {
-        val database = configureDatabase(makePersistentDataSourceProperties(), makeTestDatabaseProperties(), identitySvc = ::makeTestIdentityService)
+        val database = configureDatabase(makePersistentDataSourceProperties(), makeTestDatabaseProperties(), identitySvc = { identitySvc })
 
         setUpDb(database, 5000)
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -413,7 +413,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
 
             // DOCSTART VaultQueryExample4
-            val criteria = VaultQueryCriteria(notaryName = listOf(CASH_NOTARY))
+            val criteria = VaultQueryCriteria(notary = listOf(CASH_NOTARY))
             val results = vaultQuerySvc.queryBy<ContractState>(criteria)
             // DOCEND VaultQueryExample4
             assertThat(results.states).hasSize(3)
@@ -1410,7 +1410,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(2)), ref = OpaqueBytes.of(2))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(3)), ref = OpaqueBytes.of(3))
 
-            val criteria = FungibleAssetQueryCriteria(issuerPartyName = listOf(BOC),
+            val criteria = FungibleAssetQueryCriteria(issuer = listOf(BOC),
                     issuerRef = listOf(BOC.ref(1).reference, BOC.ref(2).reference))
             val results = vaultQuerySvc.queryBy<FungibleAsset<*>>(criteria)
             assertThat(results.states).hasSize(2)
@@ -1441,7 +1441,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             services.fillWithSomeTestCash(100.DOLLARS, usdCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (usdCashIssuer))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, chfCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (chfCashIssuer))
 
-            val criteria = FungibleAssetQueryCriteria(issuerPartyName = listOf(gbpCashIssuer.party, usdCashIssuer.party))
+            val criteria = FungibleAssetQueryCriteria(issuer = listOf(gbpCashIssuer.party, usdCashIssuer.party))
             val results = vaultQuerySvc.queryBy<FungibleAsset<*>>(criteria)
             assertThat(results.states).hasSize(2)
         }
@@ -1573,7 +1573,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)))
 
             // DOCSTART VaultQueryExample14
-            val criteria = FungibleAssetQueryCriteria(issuerPartyName = listOf(BOC))
+            val criteria = FungibleAssetQueryCriteria(issuer = listOf(BOC))
             val results = vaultQuerySvc.queryBy<FungibleAsset<*>>(criteria)
             // DOCEND VaultQueryExample14
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -1035,6 +1035,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 100, 100, Random(0L))
 
+            @Suppress("OVERFLOW_EXPECTED")
             val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE + 1)  // overflow = -2147483648
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultQuerySvc.queryBy<ContractState>(criteria, paging = pagingSpec)

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -5,6 +5,7 @@ package net.corda.testing
 
 import com.nhaarman.mockito_kotlin.spy
 import com.nhaarman.mockito_kotlin.whenever
+import net.corda.contracts.asset.DUMMY_CASH_ISSUER
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.*
 import net.corda.core.identity.Party
@@ -88,7 +89,9 @@ val BIG_CORP_PARTY_REF = BIG_CORP.ref(OpaqueBytes.of(1)).reference
 
 val ALL_TEST_KEYS: List<KeyPair> get() = listOf(MEGA_CORP_KEY, MINI_CORP_KEY, ALICE_KEY, BOB_KEY, DUMMY_NOTARY_KEY)
 
-val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_NOTARY_IDENTITY)
+val DUMMY_CASH_ISSUER_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(DUMMY_CASH_ISSUER.party as Party)
+
+val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)
 val MOCK_IDENTITY_SERVICE: IdentityService get() = InMemoryIdentityService(MOCK_IDENTITIES, emptySet(), DUMMY_CA.certificate.cert)
 
 val MOCK_HOST_AND_PORT = NetworkHostAndPort("mockHost", 30000)

--- a/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
@@ -61,6 +61,7 @@ val BOB: Party get() = Party(X500Name("CN=Bob Plc,O=Bob Plc,L=Rome,C=IT"), BOB_K
 
 val CHARLIE_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(90)) }
 /** Dummy individual identity for tests and simulations */
+val CHARLIE_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(CHARLIE)
 val CHARLIE: Party get() = Party(X500Name("CN=Charlie Ltd,O=Charlie Ltd,L=Athens,C=GR"), CHARLIE_KEY.public)
 
 val DUMMY_REGULATOR_KEY: KeyPair by lazy { entropyToKeyPair(BigInteger.valueOf(100)) }

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyDealContract.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyDealContract.kt
@@ -42,6 +42,7 @@ class DummyDealContract : Contract {
         override fun generateMappedObject(schema: MappedSchema): PersistentState {
             return when (schema) {
                 is DummyDealStateSchemaV1 -> DummyDealStateSchemaV1.PersistentDummyDealState(
+                        _participants = participants.toSet(),
                         uid = linearId
                 )
                 else -> throw IllegalArgumentException("Unrecognised schema $schema")

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
@@ -50,7 +50,7 @@ class DummyLinearContract : Contract {
         override fun generateMappedObject(schema: MappedSchema): PersistentState {
             return when (schema) {
                 is DummyLinearStateSchemaV1 -> DummyLinearStateSchemaV1.PersistentDummyLinearState(
-                        participants = participants.toSet(),
+                        participants = participants.toMutableSet(),
                         externalId = linearId.externalId,
                         uuid = linearId.id,
                         linearString = linearString,

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
@@ -50,7 +50,7 @@ class DummyLinearContract : Contract {
         override fun generateMappedObject(schema: MappedSchema): PersistentState {
             return when (schema) {
                 is DummyLinearStateSchemaV1 -> DummyLinearStateSchemaV1.PersistentDummyLinearState(
-                        participants = participants.map { it.nameOrNull().toString() }.toSet(),
+                        participants = participants.toSet(),
                         externalId = linearId.externalId,
                         uuid = linearId.id,
                         linearString = linearString,

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
@@ -50,6 +50,7 @@ class DummyLinearContract : Contract {
         override fun generateMappedObject(schema: MappedSchema): PersistentState {
             return when (schema) {
                 is DummyLinearStateSchemaV1 -> DummyLinearStateSchemaV1.PersistentDummyLinearState(
+                        participants = participants.map { it.nameOrNull().toString() }.toSet(),
                         externalId = linearId.externalId,
                         uuid = linearId.id,
                         linearString = linearString,
@@ -58,6 +59,7 @@ class DummyLinearContract : Contract {
                         linearBoolean = linearBoolean
                 )
                 is DummyLinearStateSchemaV2 -> DummyLinearStateSchemaV2.PersistentDummyLinearState(
+                        _participants = participants.toSet(),
                         uid = linearId,
                         linearString = linearString,
                         linearNumber = linearNumber,

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/VaultFiller.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/VaultFiller.kt
@@ -115,12 +115,15 @@ fun ServiceHub.fillWithSomeTestCash(howMuch: Amount<Currency>,
 
     val myKey: PublicKey = ownedBy?.owningKey ?: myInfo.legalIdentity.owningKey
     val me = AnonymousParty(myKey)
+    // TODO: remove legalParty
+    val legalParty = this.identityService.partyFromAnonymous(me)
 
     // We will allocate one state to one transaction, for simplicities sake.
     val cash = Cash()
     val transactions: List<SignedTransaction> = amounts.map { pennies ->
         val issuance = TransactionBuilder(null as Party?)
-        cash.generateIssue(issuance, Amount(pennies, Issued(issuedBy.copy(reference = ref), howMuch.token)), me, outputNotary)
+        // TODO: use anonymous party as owner (awaiting PR that persists resolved anonymous party identities using Hibernate Custom BasicType)
+        cash.generateIssue(issuance, Amount(pennies, Issued(issuedBy.copy(reference = ref), howMuch.token)), legalParty!!, outputNotary)
 
         return@map issuerServices.signInitialTransaction(issuance, issuedBy.party.owningKey)
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/VaultFiller.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/VaultFiller.kt
@@ -115,14 +115,12 @@ fun ServiceHub.fillWithSomeTestCash(howMuch: Amount<Currency>,
 
     val myKey = ownedBy?.owningKey ?: myInfo.legalIdentity.owningKey
     val anonParty = AnonymousParty(myKey)
-    val legalParty = this.identityService.partyFromAnonymous(anonParty)
 
     // We will allocate one state to one transaction, for simplicities sake.
     val cash = Cash()
     val transactions: List<SignedTransaction> = amounts.map { pennies ->
         val issuance = TransactionBuilder(null as Party?)
-        // TODO: always use anonymous party as owner (awaiting PR that persists resolved anonymous party identities using Hibernate Custom BasicType)
-        cash.generateIssue(issuance, Amount(pennies, Issued(issuedBy.copy(reference = ref), howMuch.token)), (legalParty?: anonParty), outputNotary)
+        cash.generateIssue(issuance, Amount(pennies, Issued(issuedBy.copy(reference = ref), howMuch.token)), anonParty, outputNotary)
 
         return@map issuerServices.signInitialTransaction(issuance, issuedBy.party.owningKey)
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -217,13 +217,15 @@ fun makeTestDatabaseProperties(): Properties {
 
 fun makeTestIdentityService() = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
 
-fun makeTestDatabaseAndMockServices(customSchemas: Set<MappedSchema> = setOf(CommercialPaperSchemaV1, DummyLinearStateSchemaV1, CashSchemaV1), keys: List<KeyPair> = listOf(MEGA_CORP_KEY)): Pair<CordaPersistence, MockServices> {
+fun makeTestDatabaseAndMockServices(customSchemas: Set<MappedSchema> = setOf(CommercialPaperSchemaV1, DummyLinearStateSchemaV1, CashSchemaV1),
+                                    keys: List<KeyPair> = listOf(MEGA_CORP_KEY),
+                                    identitySvc: ()-> IdentityService = { makeTestIdentityService() }): Pair<CordaPersistence, MockServices> {
     val dataSourceProps = makeTestDataSourceProperties()
     val databaseProperties = makeTestDatabaseProperties()
 
-    val database = configureDatabase(dataSourceProps, databaseProperties, identitySvc = ::makeTestIdentityService)
+    val database = configureDatabase(dataSourceProps, databaseProperties, identitySvc = identitySvc)
     val mockService = database.transaction {
-        val hibernateConfig = HibernateConfiguration(NodeSchemaService(customSchemas), databaseProperties,  identitySvc = ::makeTestIdentityService)
+        val hibernateConfig = HibernateConfiguration(NodeSchemaService(customSchemas), databaseProperties,  identitySvc = identitySvc)
         object : MockServices(*(keys.toTypedArray())) {
             override val vaultService: VaultService = makeVaultService(dataSourceProps, hibernateConfig)
 

--- a/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyDealStateSchemaV1.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyDealStateSchemaV1.kt
@@ -1,6 +1,7 @@
 package net.corda.testing.schemas
 
 import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.AbstractParty
 import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import javax.persistence.Entity
@@ -22,7 +23,10 @@ object DummyDealStateSchemaV1 : MappedSchema(schemaFamily = DummyDealStateSchema
     class PersistentDummyDealState(
             /** parent attributes */
             @Transient
+            val _participants: Set<AbstractParty>,
+
+            @Transient
             val uid: UniqueIdentifier
 
-    ) : CommonSchemaV1.LinearState(uid = uid)
+    ) : CommonSchemaV1.LinearState(uid, _participants)
 }

--- a/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV1.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV1.kt
@@ -1,6 +1,7 @@
 package net.corda.testing.schemas
 
 import net.corda.core.contracts.ContractState
+import net.corda.core.identity.AbstractParty
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import java.time.Instant
@@ -26,7 +27,7 @@ object DummyLinearStateSchemaV1 : MappedSchema(schemaFamily = DummyLinearStateSc
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<String>,
+            var participants: Set<AbstractParty>,
 
             /**
              * UniqueIdentifier

--- a/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV1.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV1.kt
@@ -1,13 +1,11 @@
 package net.corda.testing.schemas
 
+import net.corda.core.contracts.ContractState
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import java.time.Instant
 import java.util.*
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.Index
-import javax.persistence.Table
+import javax.persistence.*
 
 /**
  * An object used to fully qualify the [DummyLinearStateSchema] family name (i.e. independent of version).
@@ -24,6 +22,12 @@ object DummyLinearStateSchemaV1 : MappedSchema(schemaFamily = DummyLinearStateSc
            indexes = arrayOf(Index(name = "external_id_idx", columnList = "external_id"),
                              Index(name = "uuid_idx", columnList = "uuid")))
     class PersistentDummyLinearState(
+            /** [ContractState] attributes */
+
+            /** X500Name of participant parties **/
+            @ElementCollection
+            var participants: Set<String>,
+
             /**
              * UniqueIdentifier
              */

--- a/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV1.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV1.kt
@@ -27,7 +27,7 @@ object DummyLinearStateSchemaV1 : MappedSchema(schemaFamily = DummyLinearStateSc
 
             /** X500Name of participant parties **/
             @ElementCollection
-            var participants: Set<AbstractParty>,
+            var participants: MutableSet<AbstractParty>,
 
             /**
              * UniqueIdentifier

--- a/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV2.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyLinearStateSchemaV2.kt
@@ -1,6 +1,7 @@
 package net.corda.testing.schemas
 
 import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.AbstractParty
 import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import javax.persistence.Column
@@ -26,6 +27,9 @@ object DummyLinearStateSchemaV2 : MappedSchema(schemaFamily = DummyLinearStateSc
 
             /** parent attributes */
             @Transient
+            val _participants: Set<AbstractParty>,
+
+            @Transient
             val uid: UniqueIdentifier
-    ) : CommonSchemaV1.LinearState(uid = uid)
+    ) : CommonSchemaV1.LinearState(uid, _participants)
 }


### PR DESCRIPTION
Remove `CommonSchemaV1.Party` schema table (holding Key and X500Name) and all schema entity references to this table  (in favour of stringified X500Name only). 
Remove references to Keys stored in vault tables. Keys should be resolved using the `identityService.partyFromX500Name()` or `identityService.partyFromAnonymous()`
Uses new JPA schema type converter `AbstractPartyConverter` to correctly persist and resolve identities.