### PR TITLE
Ensure transactions in tests have commands

### DIFF
--- a/core/src/test/kotlin/net/corda/core/contracts/LedgerTransactionQueryTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/LedgerTransactionQueryTests.kt
@@ -7,6 +7,7 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.TestDependencyInjectionBase
 import net.corda.testing.contracts.DummyContract
+import net.corda.testing.dummyCommand
 import net.corda.testing.node.MockServices
 import org.junit.Before
 import org.junit.Test
@@ -50,7 +51,11 @@ class LedgerTransactionQueryTests : TestDependencyInjectionBase() {
 
     private fun makeDummyStateAndRef(data: Any): StateAndRef<*> {
         val dummyState = makeDummyState(data)
-        val fakeIssueTx = services.signInitialTransaction(TransactionBuilder(notary = DUMMY_NOTARY).addOutputState(dummyState))
+        val fakeIssueTx = services.signInitialTransaction(
+                TransactionBuilder(notary = DUMMY_NOTARY)
+                        .addOutputState(dummyState)
+                        .addCommand(dummyCommand())
+        )
         services.recordTransactions(fakeIssueTx)
         val dummyStateRef = StateRef(fakeIssueTx.id, 0)
         return StateAndRef(TransactionState(dummyState, DUMMY_NOTARY, null), dummyStateRef)

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionGraphSearchTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionGraphSearchTests.kt
@@ -34,14 +34,15 @@ class TransactionGraphSearchTests : TestDependencyInjectionBase() {
         val notaryServices = MockServices(DUMMY_NOTARY_KEY)
 
         val originBuilder = TransactionBuilder(DUMMY_NOTARY)
-        originBuilder.addOutputState(DummyState(random31BitValue()))
-        originBuilder.addCommand(command, MEGA_CORP_PUBKEY)
+                .addOutputState(DummyState(random31BitValue()))
+                .addCommand(command, MEGA_CORP_PUBKEY)
 
         val originPtx = megaCorpServices.signInitialTransaction(originBuilder)
         val originTx = notaryServices.addSignature(originPtx)
 
         val inputBuilder = TransactionBuilder(DUMMY_NOTARY)
-        inputBuilder.addInputState(originTx.tx.outRef<DummyState>(0))
+                .addInputState(originTx.tx.outRef<DummyState>(0))
+                .addCommand(dummyCommand(MEGA_CORP_PUBKEY))
 
         val inputPtx = megaCorpServices.signInitialTransaction(inputBuilder)
         val inputTx = megaCorpServices.addSignature(inputPtx)

--- a/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
@@ -227,10 +227,10 @@ class ObligationTests {
         initialiseTestSerialization()
         val obligationAliceToBob = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(ALICE, BOB))
         val obligationBobToAlice = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(BOB, ALICE))
-        val txBuilder = TransactionBuilder(DUMMY_NOTARY).apply {
+        val tx = TransactionBuilder(DUMMY_NOTARY).apply {
             Obligation<Currency>().generateCloseOutNetting(this, ALICE, obligationAliceToBob, obligationBobToAlice)
-        }
-        assertEquals(0, txBuilder.outputStates().size)
+        }.toWireTransaction()
+        assertEquals(0, tx.outputs.size)
     }
 
     /** Test generating a transaction to net two obligations of the different sizes, and confirm the balance is correct. */

--- a/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/ObligationTests.kt
@@ -68,15 +68,16 @@ class ObligationTests {
     fun trivial() {
         transaction {
             input { inState }
-            this `fails with` "the amounts balance"
 
             tweak {
                 output { outState.copy(quantity = 2000.DOLLARS.quantity) }
+                command(CHARLIE.owningKey) { Obligation.Commands.Move() }
                 this `fails with` "the amounts balance"
             }
             tweak {
                 output { outState }
-                // No command arguments
+                command(CHARLIE.owningKey) { DummyCommandData }
+                // Invalid command
                 this `fails with` "required net.corda.contracts.asset.Obligation.Commands.Move command"
             }
             tweak {
@@ -224,20 +225,20 @@ class ObligationTests {
     @Test
     fun `generate close-out net transaction`() {
         initialiseTestSerialization()
-        val obligationAliceToBob = oneMillionDollars.OBLIGATION between Pair(ALICE, BOB)
-        val obligationBobToAlice = oneMillionDollars.OBLIGATION between Pair(BOB, ALICE)
-        val tx = TransactionBuilder(DUMMY_NOTARY).apply {
+        val obligationAliceToBob = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(ALICE, BOB))
+        val obligationBobToAlice = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(BOB, ALICE))
+        val txBuilder = TransactionBuilder(DUMMY_NOTARY).apply {
             Obligation<Currency>().generateCloseOutNetting(this, ALICE, obligationAliceToBob, obligationBobToAlice)
-        }.toWireTransaction()
-        assertEquals(0, tx.outputs.size)
+        }
+        assertEquals(0, txBuilder.outputStates().size)
     }
 
     /** Test generating a transaction to net two obligations of the different sizes, and confirm the balance is correct. */
     @Test
     fun `generate close-out net transaction with remainder`() {
         initialiseTestSerialization()
-        val obligationAliceToBob = (2000000.DOLLARS `issued by` defaultIssuer).OBLIGATION between Pair(ALICE, BOB)
-        val obligationBobToAlice = oneMillionDollars.OBLIGATION between Pair(BOB, ALICE)
+        val obligationAliceToBob = getStateAndRef((2000000.DOLLARS `issued by` defaultIssuer).OBLIGATION between Pair(ALICE, BOB))
+        val obligationBobToAlice = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(BOB, ALICE))
         val tx = TransactionBuilder(DUMMY_NOTARY).apply {
             Obligation<Currency>().generateCloseOutNetting(this, ALICE, obligationAliceToBob, obligationBobToAlice)
         }.toWireTransaction()
@@ -251,10 +252,10 @@ class ObligationTests {
     @Test
     fun `generate payment net transaction`() {
         initialiseTestSerialization()
-        val obligationAliceToBob = oneMillionDollars.OBLIGATION between Pair(ALICE, BOB)
-        val obligationBobToAlice = oneMillionDollars.OBLIGATION between Pair(BOB, ALICE)
+        val obligationAliceToBob = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(ALICE, BOB))
+        val obligationBobToAlice = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(BOB, ALICE))
         val tx = TransactionBuilder(DUMMY_NOTARY).apply {
-            Obligation<Currency>().generatePaymentNetting(this, obligationAliceToBob.amount.token, DUMMY_NOTARY, obligationAliceToBob, obligationBobToAlice)
+            Obligation<Currency>().generatePaymentNetting(this, obligationAliceToBob.state.data.amount.token, DUMMY_NOTARY, obligationAliceToBob, obligationBobToAlice)
         }.toWireTransaction()
         assertEquals(0, tx.outputs.size)
     }
@@ -263,15 +264,23 @@ class ObligationTests {
     @Test
     fun `generate payment net transaction with remainder`() {
         initialiseTestSerialization()
-        val obligationAliceToBob = oneMillionDollars.OBLIGATION between Pair(ALICE, BOB)
-        val obligationBobToAlice = (2000000.DOLLARS `issued by` defaultIssuer).OBLIGATION between Pair(BOB, ALICE)
-        val tx = TransactionBuilder(null).apply {
-            Obligation<Currency>().generatePaymentNetting(this, obligationAliceToBob.amount.token, DUMMY_NOTARY, obligationAliceToBob, obligationBobToAlice)
+        val obligationAliceToBob = getStateAndRef(oneMillionDollars.OBLIGATION between Pair(ALICE, BOB))
+        val obligationAliceToBobState = obligationAliceToBob.state.data
+        val obligationBobToAlice = getStateAndRef((2000000.DOLLARS `issued by` defaultIssuer).OBLIGATION between Pair(BOB, ALICE))
+        val obligationBobToAliceState = obligationBobToAlice.state.data
+        val tx = TransactionBuilder(DUMMY_NOTARY).apply {
+            Obligation<Currency>().generatePaymentNetting(this, obligationAliceToBobState.amount.token, DUMMY_NOTARY, obligationAliceToBob, obligationBobToAlice)
         }.toWireTransaction()
         assertEquals(1, tx.outputs.size)
-        val expected = obligationBobToAlice.copy(quantity = obligationBobToAlice.quantity - obligationAliceToBob.quantity)
+        val expected = obligationBobToAliceState.copy(quantity = obligationBobToAliceState.quantity - obligationAliceToBobState.quantity)
         val actual = tx.getOutput(0)
         assertEquals(expected, actual)
+    }
+
+    private inline fun <reified T: ContractState> getStateAndRef(state: T): StateAndRef<T> {
+        val txState = TransactionState(state, DUMMY_NOTARY)
+        return StateAndRef(txState, StateRef(SecureHash.randomSHA256(), 0))
+
     }
 
     /** Test generating a transaction to mark outputs as having defaulted. */
@@ -596,15 +605,20 @@ class ObligationTests {
     @Test
     fun zeroSizedValues() {
         transaction {
-            input { inState }
-            input { inState.copy(quantity = 0L) }
-            this `fails with` "zero sized inputs"
-        }
-        transaction {
-            input { inState }
-            output { inState }
-            output { inState.copy(quantity = 0L) }
-            this `fails with` "zero sized outputs"
+            command(CHARLIE.owningKey) { Obligation.Commands.Move() }
+            tweak {
+                input { inState }
+                input { inState.copy(quantity = 0L) }
+
+                this `fails with` "zero sized inputs"
+            }
+            tweak {
+                input { inState }
+                output { inState }
+                output { inState.copy(quantity = 0L) }
+
+                this `fails with` "zero sized outputs"
+            }
         }
     }
 
@@ -614,6 +628,7 @@ class ObligationTests {
         transaction {
             input { inState }
             output { outState `issued by` MINI_CORP }
+            command(MINI_CORP_PUBKEY) { Obligation.Commands.Move() }
             this `fails with` "the amounts balance"
         }
         // Can't mix currencies.
@@ -621,6 +636,7 @@ class ObligationTests {
             input { inState }
             output { outState.copy(quantity = 80000, template = megaCorpDollarSettlement) }
             output { outState.copy(quantity = 20000, template = megaCorpPoundSettlement) }
+            command(MINI_CORP_PUBKEY) { Obligation.Commands.Move() }
             this `fails with` "the amounts balance"
         }
         transaction {
@@ -633,6 +649,7 @@ class ObligationTests {
                 )
             }
             output { outState.copy(quantity = 115000) }
+            command(MINI_CORP_PUBKEY) { Obligation.Commands.Move() }
             this `fails with` "the amounts balance"
         }
         // Can't have superfluous input states from different issuers.
@@ -703,12 +720,14 @@ class ObligationTests {
             // Can't merge them together.
             tweak {
                 output { inState.copy(beneficiary = AnonymousParty(BOB_PUBKEY), quantity = 200000L) }
+                command(CHARLIE.owningKey) { Obligation.Commands.Move() }
                 this `fails with` "the amounts balance"
             }
             // Missing MiniCorp deposit
             tweak {
                 output { inState.copy(beneficiary = AnonymousParty(BOB_PUBKEY)) }
                 output { inState.copy(beneficiary = AnonymousParty(BOB_PUBKEY)) }
+                command(CHARLIE.owningKey) { Obligation.Commands.Move() }
                 this `fails with` "the amounts balance"
             }
 

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -15,6 +15,7 @@ import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.contracts.DummyContract
+import net.corda.testing.dummyCommand
 import net.corda.testing.getTestPartyAndCertificate
 import net.corda.testing.node.MockNetwork
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -168,7 +169,7 @@ fun issueState(node: AbstractNode, notaryNode: AbstractNode): StateAndRef<*> {
 fun issueMultiPartyState(nodeA: AbstractNode, nodeB: AbstractNode, notaryNode: AbstractNode): StateAndRef<DummyContract.MultiOwnerState> {
     val state = TransactionState(DummyContract.MultiOwnerState(0,
             listOf(nodeA.info.legalIdentity, nodeB.info.legalIdentity)), notaryNode.info.notaryIdentity)
-    val tx = TransactionBuilder(notary = notaryNode.info.notaryIdentity).withItems(state)
+    val tx = TransactionBuilder(notary = notaryNode.info.notaryIdentity).withItems(state, dummyCommand())
     val signedByA = nodeA.services.signInitialTransaction(tx)
     val signedByAB = nodeB.services.addSignature(signedByA)
     val stx = notaryNode.services.addSignature(signedByAB, notaryNode.services.notaryIdentityKey)

--- a/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/RequeryConfigurationTest.kt
@@ -19,6 +19,7 @@ import net.corda.node.utilities.CordaPersistence
 import net.corda.node.utilities.configureDatabase
 import net.corda.testing.*
 import net.corda.testing.contracts.DummyContract
+import net.corda.testing.dummyCommand
 import net.corda.testing.node.makeTestDataSourceProperties
 import net.corda.testing.node.makeTestDatabaseProperties
 import net.corda.testing.node.makeTestIdentityService
@@ -204,7 +205,7 @@ class RequeryConfigurationTest : TestDependencyInjectionBase() {
                 inputs = listOf(StateRef(SecureHash.randomSHA256(), index)),
                 attachments = emptyList(),
                 outputs = emptyList(),
-                commands = emptyList(),
+                commands = listOf(dummyCommand()),
                 notary = DUMMY_NOTARY,
                 timeWindow = null
         )

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -22,6 +22,7 @@ import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.node.services.transactions.ValidatingNotaryService
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.contracts.DummyContract
+import net.corda.testing.dummyCommand
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -71,7 +72,8 @@ class ScheduledFlowTests {
 
             val notary = serviceHub.networkMapCache.getAnyNotary()
             val builder = TransactionBuilder(notary)
-            builder.withItems(scheduledState)
+                    .addOutputState(scheduledState)
+                    .addCommand(dummyCommand(serviceHub.legalIdentityKey))
             val tx = serviceHub.signInitialTransaction(builder)
             subFlow(FinalityFlow(tx, setOf(serviceHub.myInfo.legalIdentity)))
         }
@@ -91,7 +93,8 @@ class ScheduledFlowTests {
             val notary = state.state.notary
             val newStateOutput = scheduledState.copy(processed = true)
             val builder = TransactionBuilder(notary)
-            builder.withItems(state, newStateOutput)
+                    .addOutputState(newStateOutput)
+                    .addCommand(dummyCommand(serviceHub.legalIdentityKey))
             val tx = serviceHub.signInitialTransaction(builder)
             subFlow(FinalityFlow(tx, setOf(scheduledState.source, scheduledState.destination)))
         }

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -93,6 +93,7 @@ class ScheduledFlowTests {
             val notary = state.state.notary
             val newStateOutput = scheduledState.copy(processed = true)
             val builder = TransactionBuilder(notary)
+                    .addInputState(state)
                     .addOutputState(newStateOutput)
                     .addCommand(dummyCommand(serviceHub.legalIdentityKey))
             val tx = serviceHub.signInitialTransaction(builder)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -4,8 +4,8 @@ import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignatureMetadata
-import net.corda.core.node.services.VaultService
 import net.corda.core.crypto.TransactionSignature
+import net.corda.core.node.services.VaultService
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.toFuture
 import net.corda.core.transactions.SignedTransaction
@@ -220,7 +220,7 @@ class DBTransactionStorageTests : TestDependencyInjectionBase() {
                 inputs = listOf(StateRef(SecureHash.randomSHA256(), 0)),
                 attachments = emptyList(),
                 outputs = emptyList(),
-                commands = emptyList(),
+                commands = listOf(dummyCommand()),
                 notary = DUMMY_NOTARY,
                 timeWindow = null
         )

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -595,7 +595,8 @@ class FlowFrameworkTests {
     @Test
     fun `wait for transaction`() {
         val ptx = TransactionBuilder(notary = notary1.info.notaryIdentity)
-        ptx.addOutputState(DummyState())
+                .addOutputState(DummyState())
+                .addCommand(dummyCommand(node1.services.legalIdentityKey))
         val stx = node1.services.signInitialTransaction(ptx)
 
         val committerFiber = node1.registerFlowFactory(WaitingFlows.Waiter::class) {
@@ -609,7 +610,8 @@ class FlowFrameworkTests {
     @Test
     fun `committer throws exception before calling the finality flow`() {
         val ptx = TransactionBuilder(notary = notary1.info.notaryIdentity)
-        ptx.addOutputState(DummyState())
+                .addOutputState(DummyState())
+                .addCommand(dummyCommand())
         val stx = node1.services.signInitialTransaction(ptx)
 
         node1.registerFlowFactory(WaitingFlows.Waiter::class) {
@@ -625,7 +627,8 @@ class FlowFrameworkTests {
     @Test
     fun `verify vault query service is tokenizable by force checkpointing within a flow`() {
         val ptx = TransactionBuilder(notary = notary1.info.notaryIdentity)
-        ptx.addOutputState(DummyState())
+                .addOutputState(DummyState())
+                .addCommand(dummyCommand(node1.services.legalIdentityKey))
         val stx = node1.services.signInitialTransaction(ptx)
 
         node1.registerFlowFactory(VaultQueryFlow::class) {

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -18,6 +18,7 @@ import net.corda.node.services.network.NetworkMapService
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.MEGA_CORP_KEY
 import net.corda.testing.contracts.DummyContract
+import net.corda.testing.dummyCommand
 import net.corda.testing.node.MockNetwork
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -52,7 +53,9 @@ class ValidatingNotaryServiceTests {
     fun `should report error for invalid transaction dependency`() {
         val stx = run {
             val inputState = issueInvalidState(clientNode, notaryNode.info.notaryIdentity)
-            val tx = TransactionBuilder(notaryNode.info.notaryIdentity).withItems(inputState)
+            val tx = TransactionBuilder(notaryNode.info.notaryIdentity)
+                    .addInputState(inputState)
+                    .addCommand(dummyCommand(clientNode.services.legalIdentityKey))
             clientNode.services.signInitialTransaction(tx)
         }
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -219,6 +219,7 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
             val dummyIssueBuilder = TransactionBuilder(notary = DUMMY_NOTARY).apply {
                 addOutputState(DummyLinearContract.State(linearId = linearId, participants = listOf(freshIdentity)))
                 addOutputState(DummyLinearContract.State(linearId = linearId, participants = listOf(freshIdentity)))
+                addCommand(dummyCommand(notaryServices.legalIdentityKey))
             }
             val dummyIssue = notaryServices.signInitialTransaction(dummyIssueBuilder)
 
@@ -238,7 +239,8 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
 
             // Issue a linear state
             val dummyIssueBuilder = TransactionBuilder(notary = DUMMY_NOTARY)
-            dummyIssueBuilder.addOutputState(DummyLinearContract.State(linearId = linearId, participants = listOf(freshIdentity)))
+                    .addOutputState(DummyLinearContract.State(linearId = linearId, participants = listOf(freshIdentity)))
+                    .addCommand(dummyCommand(notaryServices.legalIdentityKey))
             val dummyIssuePtx = notaryServices.signInitialTransaction(dummyIssueBuilder)
             val dummyIssue = services.addSignature(dummyIssuePtx)
 
@@ -248,10 +250,10 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
             assertThat(vaultQuery.queryBy<DummyLinearContract.State>().states).hasSize(1)
 
             // Move the same state
-            val dummyMoveBuilder = TransactionBuilder(notary = DUMMY_NOTARY).apply {
-                addOutputState(DummyLinearContract.State(linearId = linearId, participants = listOf(freshIdentity)))
-                addInputState(dummyIssue.tx.outRef<LinearState>(0))
-            }
+            val dummyMoveBuilder = TransactionBuilder(notary = DUMMY_NOTARY)
+                    .addOutputState(DummyLinearContract.State(linearId = linearId, participants = listOf(freshIdentity)))
+                    .addInputState(dummyIssue.tx.outRef<LinearState>(0))
+                    .addCommand(dummyCommand(notaryServices.legalIdentityKey))
 
             val dummyMove = notaryServices.signInitialTransaction(dummyMoveBuilder)
 
@@ -315,6 +317,7 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
                 addOutputState(DummyDealContract.State(ref = "999", participants = listOf(freshIdentity)))
                 addInputState(linearStates.first())
                 addInputState(deals.first())
+                addCommand(dummyCommand(notaryServices.legalIdentityKey))
             }
 
             val dummyMove = notaryServices.signInitialTransaction(dummyMoveBuilder)

--- a/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
@@ -74,7 +74,9 @@ val DUMMY_CA: CertificateAndKeyPair by lazy {
     CertificateAndKeyPair(cert, DUMMY_CA_KEY)
 }
 
-fun dummyCommand(vararg signers: PublicKey) = Command<TypeOnlyCommandData>(object : TypeOnlyCommandData() {}, signers.toList())
+fun dummyCommand(vararg signers: PublicKey = arrayOf(generateKeyPair().public) ) = Command<TypeOnlyCommandData>(DummyCommandData, signers.toList())
+
+object DummyCommandData : TypeOnlyCommandData()
 
 val DUMMY_IDENTITY_1: PartyAndCertificate get() = getTestPartyAndCertificate(DUMMY_PARTY)
 val DUMMY_PARTY: Party get() = Party(X500Name("CN=Dummy,O=Dummy,L=Madrid,C=ES"), DUMMY_KEY_1.public)


### PR DESCRIPTION
Transaction validity rules dictate that every tx must have at least one command (the actual check will be enforced in a subsequent PR)