### PR TITLE
JPA Hibernate AbstractParty converter

### DIFF
--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
@@ -1,0 +1,30 @@
+package net.corda.core.schemas.converters
+
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.identity.Party
+import net.corda.core.node.services.IdentityService
+import javax.persistence.AttributeConverter
+import javax.persistence.Converter
+
+@Converter
+class AbstractPartyConverter(val identitySvc: IdentityService) : AttributeConverter<AbstractParty, String> {
+
+    override fun convertToDatabaseColumn(party: AbstractParty?): String {
+        val partyName =
+            when (party) {
+                is AnonymousParty -> identitySvc.partyFromAnonymous(party).toString()
+                is Party -> party.nameOrNull().toString()
+                else -> ""
+        }
+        return partyName
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): AbstractParty {
+        dbData?.let {
+            val party = identitySvc.partyFromName(dbData)
+            return party as AbstractParty
+        }
+        throw IdentityService.UnknownAnonymousPartyException("")
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
@@ -8,7 +8,7 @@ import org.bouncycastle.asn1.x500.X500Name
 import javax.persistence.AttributeConverter
 import javax.persistence.Converter
 
-@Converter
+@Converter(autoApply = true)
 class AbstractPartyConverter(val identitySvc: IdentityService) : AttributeConverter<AbstractParty, String> {
 
     override fun convertToDatabaseColumn(party: AbstractParty?): String {

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
@@ -6,6 +6,10 @@ import org.bouncycastle.asn1.x500.X500Name
 import javax.persistence.AttributeConverter
 import javax.persistence.Converter
 
+/**
+ * Converter to persist a party as its's well known identity (where resolvable)
+ * Completely anonymous parties are stored as null (to preserve privacy)
+ */
 @Converter(autoApply = true)
 class AbstractPartyConverter(val identitySvc: IdentityService) : AttributeConverter<AbstractParty, String> {
 

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
@@ -1,8 +1,6 @@
 package net.corda.core.schemas.converters
 
 import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.AnonymousParty
-import net.corda.core.identity.Party
 import net.corda.core.node.services.IdentityService
 import org.bouncycastle.asn1.x500.X500Name
 import javax.persistence.AttributeConverter
@@ -12,13 +10,10 @@ import javax.persistence.Converter
 class AbstractPartyConverter(val identitySvc: IdentityService) : AttributeConverter<AbstractParty, String> {
 
     override fun convertToDatabaseColumn(party: AbstractParty?): String? {
-        val partyName =
-            when (party) {
-                is AnonymousParty -> identitySvc.partyFromAnonymous(party)?.toString()
-                is Party -> party.nameOrNull().toString()
-                else -> null // non resolvable anonymous parties
+        party?.let {
+            return identitySvc.partyFromAnonymous(party)?.toString()
         }
-        return partyName
+        return null // non resolvable anonymous parties
     }
 
     override fun convertToEntityAttribute(dbData: String?): AbstractParty? {

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
@@ -4,6 +4,7 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.node.services.IdentityService
+import org.bouncycastle.asn1.x500.X500Name
 import javax.persistence.AttributeConverter
 import javax.persistence.Converter
 
@@ -15,16 +16,16 @@ class AbstractPartyConverter(val identitySvc: IdentityService) : AttributeConver
             when (party) {
                 is AnonymousParty -> identitySvc.partyFromAnonymous(party).toString()
                 is Party -> party.nameOrNull().toString()
-                else -> ""
+                else -> throw IdentityService.UnknownAnonymousPartyException("Unable to resolve identity: $party")
         }
         return partyName
     }
 
     override fun convertToEntityAttribute(dbData: String?): AbstractParty {
         dbData?.let {
-            val party = identitySvc.partyFromName(dbData)
+            val party = identitySvc.partyFromX500Name(X500Name(dbData))
             return party as AbstractParty
         }
-        throw IdentityService.UnknownAnonymousPartyException("")
+        throw IdentityService.UnknownAnonymousPartyException("Unable to resolve identity: $dbData")
     }
 }

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyConverter.kt
@@ -11,21 +11,21 @@ import javax.persistence.Converter
 @Converter(autoApply = true)
 class AbstractPartyConverter(val identitySvc: IdentityService) : AttributeConverter<AbstractParty, String> {
 
-    override fun convertToDatabaseColumn(party: AbstractParty?): String {
+    override fun convertToDatabaseColumn(party: AbstractParty?): String? {
         val partyName =
             when (party) {
-                is AnonymousParty -> identitySvc.partyFromAnonymous(party).toString()
+                is AnonymousParty -> identitySvc.partyFromAnonymous(party)?.toString()
                 is Party -> party.nameOrNull().toString()
-                else -> throw IdentityService.UnknownAnonymousPartyException("Unable to resolve identity: $party")
+                else -> null // non resolvable anonymous parties
         }
         return partyName
     }
 
-    override fun convertToEntityAttribute(dbData: String?): AbstractParty {
+    override fun convertToEntityAttribute(dbData: String?): AbstractParty? {
         dbData?.let {
             val party = identitySvc.partyFromX500Name(X500Name(dbData))
             return party as AbstractParty
         }
-        throw IdentityService.UnknownAnonymousPartyException("Unable to resolve identity: $dbData")
+        return null // non resolvable anonymous parties are stored as nulls
     }
 }

--- a/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyToX500NameAsStringConverter.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/converters/AbstractPartyToX500NameAsStringConverter.kt
@@ -11,7 +11,7 @@ import javax.persistence.Converter
  * Completely anonymous parties are stored as null (to preserve privacy)
  */
 @Converter(autoApply = true)
-class AbstractPartyConverter(val identitySvc: IdentityService) : AttributeConverter<AbstractParty, String> {
+class AbstractPartyToX500NameAsStringConverter(val identitySvc: IdentityService) : AttributeConverter<AbstractParty, String> {
 
     override fun convertToDatabaseColumn(party: AbstractParty?): String? {
         party?.let {

--- a/docs/source/api-persistence.rst
+++ b/docs/source/api-persistence.rst
@@ -93,6 +93,13 @@ Several examples of entities and mappings are provided in the codebase, includin
 .. literalinclude:: ../../finance/src/main/kotlin/net/corda/schemas/CashSchemaV1.kt
     :language: kotlin
 
+Identity mapping
+----------------
+Schema entity attributes defined by identity types (``AbstractParty``, ``Party``, ``AnonymousParty``) are automatically
+processed to ensure only the ``X500Name`` of the identity is persisted where an identity is well known, otherwise a null
+value is stored in the associated column. To preserve privacy, identity keys are never persisted. Developers should use
+the ``IdentityService`` to resolve keys from well know X500 identity names.
+
 JDBC session
 ------------
 Apps may also interact directly with the underlying Node's database by using a standard

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -91,6 +91,9 @@ UNRELEASED
     of different soft locking retrieval behaviours (exclusive of soft locked states, soft locked states only, specified
     by set of lock ids)
 
+* Added JPA ``AbstractPartyConverter`` to ensure identity schema attributes are persisted securely according to type
+  (well known party, resolvable anonymous party, completely anonymous party).
+
 Milestone 13
 ------------
 

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -54,7 +54,6 @@ class CashTests : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(NodeVaultService::class)
-        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MINI_CORP_KEY, MEGA_CORP_KEY, OUR_KEY))
         database = databaseAndServices.first
         miniCorpServices = databaseAndServices.second

--- a/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/contracts/asset/CashTests.kt
@@ -6,11 +6,17 @@ import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
+import net.corda.core.node.services.IdentityService
+import net.corda.core.node.services.VaultQueryService
 import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.queryBy
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes
+import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.identity.InMemoryIdentityService
+import net.corda.node.services.schema.NodeSchemaService
+import net.corda.node.services.vault.HibernateVaultQueryImpl
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.CordaPersistence
 import net.corda.testing.*
@@ -48,6 +54,7 @@ class CashTests : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(NodeVaultService::class)
+        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MINI_CORP_KEY, MEGA_CORP_KEY, OUR_KEY))
         database = databaseAndServices.first
         miniCorpServices = databaseAndServices.second

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -479,7 +479,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     private fun makeVaultObservers() {
         VaultSoftLockManager(services.vaultService, smm)
         ScheduledActivityObserver(services)
-        HibernateObserver(services.vaultService.rawUpdates, HibernateConfiguration(services.schemaService, configuration.database ?: Properties()))
+        HibernateObserver(services.vaultService.rawUpdates, HibernateConfiguration(services.schemaService, configuration.database ?: Properties(), services.identityService))
     }
 
     private fun makeInfo(): NodeInfo {
@@ -766,7 +766,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         override val networkMapCache by lazy { InMemoryNetworkMapCache(this) }
         override val vaultService by lazy { NodeVaultService(this, configuration.dataSourceProperties, configuration.database) }
         override val vaultQueryService by lazy {
-            HibernateVaultQueryImpl(HibernateConfiguration(schemaService, configuration.database ?: Properties()), vaultService.updatesPublisher)
+            HibernateVaultQueryImpl(HibernateConfiguration(schemaService, configuration.database ?: Properties(), identityService), vaultService.updatesPublisher)
         }
         // Place the long term identity key in the KMS. Eventually, this is likely going to be separated again because
         // the KMS is meant for derived temporary keys used in transactions, and we're not supposed to sign things with

--- a/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
@@ -3,7 +3,7 @@ package net.corda.node.services.database
 import net.corda.core.internal.castIfPossible
 import net.corda.core.node.services.IdentityService
 import net.corda.core.schemas.MappedSchema
-import net.corda.core.schemas.converters.AbstractPartyConverter
+import net.corda.core.schemas.converters.AbstractPartyToX500NameAsStringConverter
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.api.SchemaService
 import net.corda.node.utilities.DatabaseTransactionManager
@@ -80,7 +80,7 @@ class HibernateConfiguration(val schemaService: SchemaService, val databasePrope
                 }
             })
             // register custom converters
-            applyAttributeConverter(AbstractPartyConverter(identitySvc))
+            applyAttributeConverter(AbstractPartyToX500NameAsStringConverter(identitySvc))
 
             build()
         }

--- a/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
@@ -60,8 +60,6 @@ class HibernateConfiguration(val schemaService: SchemaService, val databasePrope
         val config = Configuration(metadataSources).setProperty("hibernate.connection.provider_class", HibernateConfiguration.NodeDatabaseConnectionProvider::class.java.name)
                 .setProperty("hibernate.hbm2ddl.auto", if (databaseProperties.getProperty("initDatabase","true") == "true") "update" else "validate")
                 .setProperty("hibernate.format_sql", "true")
-        // add custom converters
-        config.addAttributeConverter(AbstractPartyConverter(identitySvc))
 
         schemas.forEach { schema ->
             // TODO: require mechanism to set schemaOptions (databaseSchema, tablePrefix) which are not global to session
@@ -81,6 +79,9 @@ class HibernateConfiguration(val schemaService: SchemaService, val databasePrope
                     return Identifier.toIdentifier(tablePrefix + default.text, default.isQuoted)
                 }
             })
+            // register custom converters
+            applyAttributeConverter(AbstractPartyConverter(identitySvc))
+
             build()
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/database/HibernateConfiguration.kt
@@ -60,9 +60,9 @@ class HibernateConfiguration(val schemaService: SchemaService, val databasePrope
         val config = Configuration(metadataSources).setProperty("hibernate.connection.provider_class", HibernateConfiguration.NodeDatabaseConnectionProvider::class.java.name)
                 .setProperty("hibernate.hbm2ddl.auto", if (databaseProperties.getProperty("initDatabase","true") == "true") "update" else "validate")
                 .setProperty("hibernate.format_sql", "true")
-
         // add custom converters
         config.addAttributeConverter(AbstractPartyConverter(identitySvc))
+
         schemas.forEach { schema ->
             // TODO: require mechanism to set schemaOptions (databaseSchema, tablePrefix) which are not global to session
             schema.mappedTypes.forEach { config.addAnnotatedClass(it) }

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -107,7 +107,6 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** [OwnableState] attributes */
             @Column(name = "owner_id")
-            @Convert(converter = AbstractPartyConverter::class)
             var owner: AbstractParty,
 
             /** [FungibleAsset] attributes

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -107,6 +107,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** [OwnableState] attributes */
             @Column(name = "owner_id")
+            @Convert(converter = AbstractPartyConverter::class)
             var owner: AbstractParty,
 
             /** [FungibleAsset] attributes

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -133,27 +133,4 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
                      issuerRef = _issuerRef.bytes,
                      participants =  _participants.map { CommonSchemaV1.Party(it) }.toSet())
     }
-
-    @Converter(autoApply = true)
-//    class BooleanToIntegerConverter(debug: Boolean) : AttributeConverter<Boolean, Int> {
-    class BooleanToIntegerConverter : AttributeConverter<Boolean, Int> {
-        override fun convertToDatabaseColumn(attribute: Boolean?): Int {
-            attribute?.let {
-                when (attribute) {
-                    true -> return 1
-                    false -> return 0
-                }
-            }
-            return -1
-        }
-        override fun convertToEntityAttribute(dbData: Int?): Boolean {
-            dbData?.let {
-                when (dbData) {
-                    1 -> return true
-                    else -> return false
-                }
-            }
-            return false
-        }
-    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -107,7 +107,6 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** [OwnableState] attributes */
             @Column(name = "owner_id")
-            @Convert(converter = AbstractPartyConverter::class)
             var owner: AbstractParty,
 
             /** [FungibleAsset] attributes
@@ -133,5 +132,28 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
                      issuerParty = CommonSchemaV1.Party(_issuerParty),
                      issuerRef = _issuerRef.bytes,
                      participants =  _participants.map { CommonSchemaV1.Party(it) }.toSet())
+    }
+
+    @Converter(autoApply = true)
+//    class BooleanToIntegerConverter(debug: Boolean) : AttributeConverter<Boolean, Int> {
+    class BooleanToIntegerConverter : AttributeConverter<Boolean, Int> {
+        override fun convertToDatabaseColumn(attribute: Boolean?): Int {
+            attribute?.let {
+                when (attribute) {
+                    true -> return 1
+                    false -> return 0
+                }
+            }
+            return -1
+        }
+        override fun convertToEntityAttribute(dbData: Int?): Boolean {
+            dbData?.let {
+                when (dbData) {
+                    1 -> return true
+                    else -> return false
+                }
+            }
+            return false
+        }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -6,6 +6,7 @@ import net.corda.core.node.services.Vault
 import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
+import net.corda.core.schemas.converters.AbstractPartyConverter
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
 import java.time.Instant
@@ -105,8 +106,9 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var participants: Set<CommonSchemaV1.Party>,
 
             /** [OwnableState] attributes */
-            @OneToOne(cascade = arrayOf(CascadeType.ALL))
-            var owner: CommonSchemaV1.Party,
+            @Column(name = "owner_id")
+            @Convert(converter = AbstractPartyConverter::class)
+            var owner: AbstractParty,
 
             /** [FungibleAsset] attributes
              *
@@ -126,7 +128,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var issuerRef: ByteArray
     ) : PersistentState() {
         constructor(_owner: AbstractParty, _quantity: Long, _issuerParty: AbstractParty, _issuerRef: OpaqueBytes, _participants: List<AbstractParty>) :
-                this(owner = CommonSchemaV1.Party(_owner),
+                this(owner = _owner,
                      quantity = _quantity,
                      issuerParty = CommonSchemaV1.Party(_issuerParty),
                      issuerRef = _issuerRef.bytes,

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -6,7 +6,6 @@ import net.corda.core.node.services.Vault
 import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
-import net.corda.core.schemas.converters.AbstractPartyConverter
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
 import java.time.Instant

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -18,6 +18,7 @@ import net.corda.core.node.services.vault.QueryCriteria.VaultCustomQueryCriteria
 import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria;
 import net.corda.core.utilities.OpaqueBytes;
 import net.corda.node.utilities.CordaPersistence;
+import net.corda.node.services.identity.*;
 import net.corda.schemas.CashSchemaV1;
 import net.corda.testing.TestConstants;
 import net.corda.testing.TestDependencyInjectionBase;
@@ -44,6 +45,7 @@ import static net.corda.core.node.services.vault.QueryCriteriaUtils.MAX_PAGE_SIZ
 import static net.corda.core.utilities.ByteArrays.toHexString;
 import static net.corda.testing.CoreTestUtils.*;
 import static net.corda.testing.node.MockServicesKt.makeTestDatabaseAndMockServices;
+import static net.corda.testing.TestConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class VaultQueryJavaTests extends TestDependencyInjectionBase {
@@ -57,6 +59,7 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
     public void setUp() {
         ArrayList<KeyPair> keys = new ArrayList<>();
         keys.add(getMEGA_CORP_KEY());
+        InMemoryIdentityService identityService = new InMemoryIdentityService(getMOCK_IDENTITIES(), Collections.emptyMap(), getDUMMY_CA().getCertificate());
         Pair<CordaPersistence, MockServices> databaseAndServices = makeTestDatabaseAndMockServices(Collections.EMPTY_SET, keys);
         database = databaseAndServices.getFirst();
         services = databaseAndServices.getSecond();

--- a/node/src/test/kotlin/net/corda/node/services/database/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/HibernateConfigurationTest.kt
@@ -14,6 +14,7 @@ import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.serialization.deserialize
 import net.corda.core.transactions.SignedTransaction
+import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.schema.HibernateObserver
 import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.services.vault.HibernateVaultQueryImpl
@@ -71,7 +72,8 @@ class HibernateConfigurationTest : TestDependencyInjectionBase() {
         database = configureDatabase(dataSourceProps, defaultDatabaseProperties)
         val customSchemas = setOf(VaultSchemaV1, CashSchemaV1, SampleCashSchemaV2, SampleCashSchemaV3)
         database.transaction {
-            hibernateConfig = HibernateConfiguration(NodeSchemaService(customSchemas), makeTestDatabaseProperties())
+            val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
+            hibernateConfig = HibernateConfiguration(NodeSchemaService(customSchemas), makeTestDatabaseProperties(), identityService)
             services = object : MockServices(BOB_KEY) {
                 override val vaultService: VaultService = makeVaultService(dataSourceProps, hibernateConfig)
 

--- a/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/schema/HibernateObserverTests.kt
@@ -10,9 +10,12 @@ import net.corda.core.schemas.QueryableState
 import net.corda.testing.LogHelper
 import net.corda.node.services.api.SchemaService
 import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.utilities.CordaPersistence
 import net.corda.node.utilities.configureDatabase
+import net.corda.testing.DUMMY_CA
 import net.corda.testing.MEGA_CORP
+import net.corda.testing.MOCK_IDENTITIES
 import net.corda.testing.node.makeTestDataSourceProperties
 import net.corda.testing.node.makeTestDatabaseProperties
 import org.hibernate.annotations.Cascade
@@ -102,7 +105,8 @@ class HibernateObserverTests {
         }
 
         @Suppress("UNUSED_VARIABLE")
-        val observer = HibernateObserver(rawUpdatesPublisher, HibernateConfiguration(schemaService, makeTestDatabaseProperties()))
+        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
+        val observer = HibernateObserver(rawUpdatesPublisher, HibernateConfiguration(schemaService, makeTestDatabaseProperties(), identityService))
         database.transaction {
             rawUpdatesPublisher.onNext(Vault.Update(emptySet(), setOf(StateAndRef(TransactionState(TestState(), MEGA_CORP), StateRef(SecureHash.sha256("dummy"), 0)))))
             val parentRowCountResult = TransactionManager.current().connection.prepareStatement("select count(*) from Parents").executeQuery()

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -54,7 +54,6 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(NodeVaultService::class)
-        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices()
         database = databaseAndServices.first
         services = databaseAndServices.second

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -23,6 +23,9 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.NonEmptySet
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.toNonEmptySet
+import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.identity.InMemoryIdentityService
+import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.utilities.CordaPersistence
 import net.corda.testing.*
 import net.corda.testing.contracts.fillWithSomeTestCash
@@ -51,6 +54,7 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(NodeVaultService::class)
+        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices()
         database = databaseAndServices.first
         services = databaseAndServices.second

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -13,6 +13,14 @@ import net.corda.core.identity.Party
 import net.corda.core.node.services.*
 import net.corda.core.node.services.vault.*
 import net.corda.core.node.services.vault.QueryCriteria.*
+import net.corda.core.utilities.seconds
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.NonEmptySet
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.toHexString
+import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.identity.InMemoryIdentityService
+import net.corda.node.services.schema.NodeSchemaService
 import net.corda.core.utilities.*
 import net.corda.node.utilities.CordaPersistence
 import net.corda.node.utilities.configureDatabase
@@ -50,6 +58,7 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
     @Before
     fun setUp() {
+        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MEGA_CORP_KEY))
         database = databaseAndServices.first
         services = databaseAndServices.second

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -58,7 +58,6 @@ class VaultQueryTests : TestDependencyInjectionBase() {
 
     @Before
     fun setUp() {
-        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MEGA_CORP_KEY))
         database = databaseAndServices.first
         services = databaseAndServices.second

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -12,6 +12,9 @@ import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.identity.InMemoryIdentityService
+import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.utilities.CordaPersistence
 import net.corda.testing.*
 import net.corda.testing.contracts.*
@@ -39,6 +42,7 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(VaultWithCashTest::class)
+        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices()
         database = databaseAndServices.first
         services = databaseAndServices.second

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -42,7 +42,6 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(VaultWithCashTest::class)
-        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
         val databaseAndServices = makeTestDatabaseAndMockServices()
         database = databaseAndServices.first
         services = databaseAndServices.second

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -88,7 +88,7 @@ open class MockServices(vararg val keys: KeyPair) : ServiceHub {
 
     lateinit var hibernatePersister: HibernateObserver
 
-    fun makeVaultService(dataSourceProps: Properties, hibernateConfig: HibernateConfiguration = HibernateConfiguration(NodeSchemaService(), makeTestDatabaseProperties())): VaultService {
+    fun makeVaultService(dataSourceProps: Properties, hibernateConfig: HibernateConfiguration = HibernateConfiguration(NodeSchemaService(), makeTestDatabaseProperties(), identityService)): VaultService {
         val vaultService = NodeVaultService(this, dataSourceProps, makeTestDatabaseProperties())
         hibernatePersister = HibernateObserver(vaultService.rawUpdates, hibernateConfig)
         return vaultService

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -221,7 +221,8 @@ fun makeTestDatabaseAndMockServices(customSchemas: Set<MappedSchema> = setOf(Com
     val databaseProperties = makeTestDatabaseProperties()
     val database = configureDatabase(dataSourceProps, databaseProperties)
     val mockService = database.transaction {
-        val hibernateConfig = HibernateConfiguration(NodeSchemaService(customSchemas), databaseProperties)
+        val identityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DUMMY_CA.certificate)
+        val hibernateConfig = HibernateConfiguration(NodeSchemaService(customSchemas), databaseProperties, identityService)
         object : MockServices(*(keys.toTypedArray())) {
             override val vaultService: VaultService = makeVaultService(dataSourceProps, hibernateConfig)
 


### PR DESCRIPTION
Schema entity attributes with an `AbstractParty` type will be stored according to the following rules:
- (concrete) Party -> store string'ified X500Name
- Anonymous Party -> if resolvable to legal identity (using identityService), store string'ified X500Name of resolved identity
- Anonymous Party -> if not resolvable (eg. legal identity not owner) then store `null` value