### PR TITLE
Move useTestClock conditional to Node constructor

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -24,6 +24,7 @@ import net.corda.node.services.messaging.MessagingService
 import net.corda.node.services.messaging.NodeMessagingClient
 import net.corda.node.utilities.AddressUtils
 import net.corda.node.utilities.AffinityExecutor
+import net.corda.node.utilities.TestClock
 import net.corda.nodeapi.ArtemisMessagingComponent
 import net.corda.nodeapi.ArtemisMessagingComponent.Companion.IP_REQUEST_PREFIX
 import net.corda.nodeapi.ArtemisMessagingComponent.Companion.PEER_USER
@@ -58,8 +59,8 @@ import kotlin.system.exitProcess
 open class Node(override val configuration: FullNodeConfiguration,
                 advertisedServices: Set<ServiceInfo>,
                 val versionInfo: VersionInfo,
-                clock: Clock = NodeClock(),
-                val initialiseSerialization: Boolean = true) : AbstractNode(configuration, advertisedServices, clock) {
+                val initialiseSerialization: Boolean = true
+) : AbstractNode(configuration, advertisedServices, createClock(configuration)) {
     companion object {
         private val logger = loggerFor<Node>()
         var renderBasicInfoToConsole = true
@@ -75,6 +76,10 @@ open class Node(override val configuration: FullNodeConfiguration,
             println(message)
             println("Corda will now exit...")
             exitProcess(1)
+        }
+
+        private fun createClock(configuration: FullNodeConfiguration): Clock {
+            return if (configuration.useTestClock) TestClock() else NodeClock()
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -93,7 +93,7 @@ open class NodeStartup(val args: Array<String>) {
     open protected fun preNetworkRegistration(conf: FullNodeConfiguration) = Unit
 
     open protected fun createNode(conf: FullNodeConfiguration, versionInfo: VersionInfo, services: Set<ServiceInfo>): Node {
-        return Node(conf, services, versionInfo, if (conf.useTestClock) TestClock() else NodeClock())
+        return Node(conf, services, versionInfo)
     }
 
     open protected fun startNode(conf: FullNodeConfiguration, versionInfo: VersionInfo, startTime: Long, cmdlineOptions: CmdLineOptions) {

--- a/test-utils/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -772,9 +772,8 @@ class DriverDSL(
                 log.info("Starting in-process Node ${nodeConf.myLegalName.commonName}")
                 // Write node.conf
                 writeConfig(nodeConf.baseDirectory, "node.conf", config)
-                val clock: Clock = if (nodeConf.useTestClock) TestClock() else NodeClock()
                 // TODO pass the version in?
-                val node = Node(nodeConf, nodeConf.calculateServices(), MOCK_VERSION_INFO, clock, initialiseSerialization = false)
+                val node = Node(nodeConf, nodeConf.calculateServices(), MOCK_VERSION_INFO, initialiseSerialization = false)
                 node.start()
                 val nodeThread = thread(name = nodeConf.myLegalName.commonName) {
                     node.run()

--- a/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -164,7 +164,7 @@ abstract class NodeBasedTest : TestDependencyInjectionBase() {
 
         val parsedConfig = config.parseAs<FullNodeConfiguration>()
         val node = Node(parsedConfig, parsedConfig.calculateServices(), MOCK_VERSION_INFO.copy(platformVersion = platformVersion),
-                if (parsedConfig.useTestClock) TestClock() else NodeClock(), initialiseSerialization = false)
+                initialiseSerialization = false)
         node.start()
         nodes += node
         thread(name = legalName.commonName) {


### PR DESCRIPTION
This PR moves the `if (useTestClock)` conditional into the Node's constructor. I also included a change to the IRS demo test so it uses proper logging.

This is a result of a debugging session in the enterprise repo, but this changeset should be in open source