### PR TITLE
Correct exceptions thrown from checkSignaturesAreValid()

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -5,6 +5,7 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.transactions.SignedTransaction.SignaturesMissingException
 import net.corda.core.utilities.toNonEmptySet
+import java.security.InvalidKeyException
 import java.security.PublicKey
 import java.security.SignatureException
 
@@ -52,9 +53,10 @@ interface TransactionWithSignatures : NamedByHash {
      * corrupt. If you use this function directly you'll need to do the other checks yourself. Probably you
      * want [verifySignatures] instead.
      *
+     * @throws InvalidKeyException if the key on a signature is invalid.
      * @throws SignatureException if a signature fails to verify.
      */
-    @Throws(SignatureException::class)
+    @Throws(InvalidKeyException::class, SignatureException::class)
     fun checkSignaturesAreValid() {
         for (sig in sigs) {
             sig.verify(id)

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -26,6 +26,7 @@ import net.corda.testing.contracts.DummyState;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.jetbrains.annotations.NotNull;
 
+import java.security.GeneralSecurityException;
 import java.security.PublicKey;
 import java.security.SignatureException;
 import java.time.Duration;
@@ -506,7 +507,7 @@ public class FlowCookbookJava {
                 twiceSignedTx.checkSignaturesAreValid();
                 // DOCEND 37
 
-            } catch (SignatureException e) {
+            } catch (GeneralSecurityException e) {
                 // Handle this as required.
             }
 


### PR DESCRIPTION
`checkSignaturesAreValid()` calls `TransactionSignature.verify()`, which throws `InvalidKeyException` but `checkSignaturesAreValid()` did not indicate it could throw `InvalidKeyException`.