### PR TITLE
Remove DealState dependency inside Vault

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -4,7 +4,6 @@ package net.corda.core.node.services.vault
 
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.Vault
 import net.corda.core.schemas.PersistentState
@@ -64,8 +63,8 @@ sealed class QueryCriteria {
      * LinearStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultLinearState]
      */
     data class LinearStateQueryCriteria @JvmOverloads constructor(val participants: List<AbstractParty>? = null,
-                                                                  val linearId: List<UniqueIdentifier>? = null,
-                                                                  val dealRef: List<String>? = null,
+                                                                  val uuid: List<UUID>? = null,
+                                                                  val externalId: List<String>? = null,
                                                                   override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this as CommonQueryCriteria).plus(parser.parseCriteria(this))

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -162,8 +162,7 @@ data class Sort(val columns: Collection<SortColumn>) {
     enum class LinearStateAttribute(val attributeName: String) : Attribute {
         /** Vault Linear States */
         UUID("uuid"),
-        EXTERNAL_ID("externalId"),
-        DEAL_REFERENCE("dealReference")
+        EXTERNAL_ID("externalId")
     }
 
     enum class FungibleStateAttribute(val attributeName: String) : Attribute {

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
@@ -5,15 +5,14 @@ import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.ServiceInfo
-import net.corda.core.node.services.Vault
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.toFuture
 import net.corda.core.utilities.getOrThrow
-import net.corda.testing.DUMMY_NOTARY
-import net.corda.testing.DUMMY_NOTARY_KEY
 import net.corda.node.services.network.NetworkMapService
 import net.corda.node.services.transactions.ValidatingNotaryService
+import net.corda.testing.DUMMY_NOTARY
+import net.corda.testing.DUMMY_NOTARY_KEY
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -28,7 +27,7 @@ class WorkflowTransactionBuildTutorialTest {
 
     // Helper method to locate the latest Vault version of a LinearState
     private inline fun <reified T : LinearState> ServiceHub.latest(ref: UniqueIdentifier): StateAndRef<T> {
-        val linearHeads = vaultQueryService.queryBy<T>(QueryCriteria.LinearStateQueryCriteria(linearId = listOf(ref)))
+        val linearHeads = vaultQueryService.queryBy<T>(QueryCriteria.LinearStateQueryCriteria(uuid = listOf(ref.id)))
         return linearHeads.states.single()
     }
 

--- a/finance/src/main/kotlin/net/corda/contracts/FinanceTypes.kt
+++ b/finance/src/main/kotlin/net/corda/contracts/FinanceTypes.kt
@@ -13,9 +13,8 @@ import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.TokenizableAssetInfo
-import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.node.services.*
+import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
 import java.math.BigDecimal
@@ -391,9 +390,6 @@ data class Commodity(val commodityCode: String,
  * implementation of general flows that manipulate many agreement types.
  */
 interface DealState : LinearState {
-    /** Human readable well known reference (e.g. trade reference) */
-    val ref: String
-
     /**
      * Generate a partial transaction representing an agreement (command) to this deal, allowing a general
      * deal/agreement flow to generate the necessary transaction for potential implementations.

--- a/finance/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
+++ b/finance/src/main/kotlin/net/corda/flows/TwoPartyDealFlow.kt
@@ -174,7 +174,7 @@ object TwoPartyDealFlow {
             // What is the seller trying to sell us?
             val autoOffer = handshake.payload
             val deal = autoOffer.dealBeingOffered
-            logger.trace { "Got deal request for: ${deal.ref}" }
+            logger.trace { "Got deal request for: ${deal.linearId.externalId!!}" }
             return handshake.copy(payload = autoOffer.copy(dealBeingOffered = deal))
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
@@ -1,15 +1,14 @@
 package net.corda.node.services.schema
 
-import net.corda.contracts.DealState
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.FungibleAsset
 import net.corda.core.contracts.LinearState
+import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.QueryableState
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.node.services.api.SchemaService
-import net.corda.core.schemas.CommonSchemaV1
 import net.corda.node.services.keys.PersistentKeyManagementService
 import net.corda.node.services.persistence.DBCheckpointStorage
 import net.corda.node.services.persistence.DBTransactionMappingStorage
@@ -59,9 +58,6 @@ class NodeSchemaService(customSchemas: Set<MappedSchema> = emptySet()) : SchemaS
             schemas += state.supportedSchemas()
         if (state is LinearState)
             schemas += VaultSchemaV1   // VaultLinearStates
-        // TODO: DealState to be deprecated (collapsed into LinearState)
-        if (state is DealState)
-            schemas += VaultSchemaV1   // VaultLinearStates
         if (state is FungibleAsset<*>)
             schemas += VaultSchemaV1   // VaultFungibleStates
 
@@ -70,11 +66,8 @@ class NodeSchemaService(customSchemas: Set<MappedSchema> = emptySet()) : SchemaS
 
     // Because schema is always one supported by the state, just delegate.
     override fun generateMappedObject(state: ContractState, schema: MappedSchema): PersistentState {
-        // TODO: DealState to be deprecated (collapsed into LinearState)
-        if ((schema is VaultSchemaV1) && (state is DealState))
-            return VaultSchemaV1.VaultLinearStates(state.linearId, state.ref, state.participants)
         if ((schema is VaultSchemaV1) && (state is LinearState))
-            return VaultSchemaV1.VaultLinearStates(state.linearId, "", state.participants)
+            return VaultSchemaV1.VaultLinearStates(state.linearId, state.participants)
         if ((schema is VaultSchemaV1) && (state is FungibleAsset<*>))
             return VaultSchemaV1.VaultFungibleStates(state.owner, state.amount.quantity, state.amount.token.issuer.party, state.amount.token.issuer.reference, state.participants)
         return (state as QueryableState).generateMappedObject(schema)

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -2,7 +2,6 @@ package net.corda.node.services.vault
 
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultQueryException
@@ -229,7 +228,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
     override fun parseCriteria(criteria: QueryCriteria.FungibleAssetQueryCriteria) : Collection<Predicate> {
         log.trace { "Parsing FungibleAssetQueryCriteria: $criteria" }
 
-        var predicateSet = mutableSetOf<Predicate>()
+        val predicateSet = mutableSetOf<Predicate>()
 
         val vaultFungibleStates = criteriaQuery.from(VaultSchemaV1.VaultFungibleStates::class.java)
         rootEntities.putIfAbsent(VaultSchemaV1.VaultFungibleStates::class.java, vaultFungibleStates)
@@ -296,19 +295,16 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         if (contractTypes.isNotEmpty())
             predicateSet.add(criteriaBuilder.and(vaultStates.get<String>("contractStateClassName").`in`(contractTypes)))
 
-        // linear ids
-        criteria.linearId?.let {
-            val uniqueIdentifiers = criteria.linearId as List<UniqueIdentifier>
-            val externalIds = uniqueIdentifiers.mapNotNull { it.externalId }
-            if (externalIds.isNotEmpty())
-                predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<String>("externalId").`in`(externalIds)))
-            predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<UUID>("uuid").`in`(uniqueIdentifiers.map { it.id })))
+        // linear ids UUID
+        criteria.uuid?.let {
+            val uuids = criteria.uuid as List<UUID>
+            predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<UUID>("uuid").`in`(uuids)))
         }
 
-        // deal refs
-        criteria.dealRef?.let {
-            val dealRefs = criteria.dealRef as List<String>
-            predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<String>("dealReference").`in`(dealRefs)))
+        // linear ids externalId
+        criteria.externalId?.let {
+            val externalIds = criteria.externalId as List<String>
+            predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<String>("externalId").`in`(externalIds)))
         }
 
         // deal participants
@@ -359,7 +355,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
     override fun parseOr(left: QueryCriteria, right: QueryCriteria): Collection<Predicate> {
         log.trace { "Parsing OR QueryCriteria composition: $left OR $right" }
 
-        var predicateSet = mutableSetOf<Predicate>()
+        val predicateSet = mutableSetOf<Predicate>()
         val leftPredicates = parse(left)
         val rightPredicates = parse(right)
 
@@ -372,7 +368,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
     override fun parseAnd(left: QueryCriteria, right: QueryCriteria): Collection<Predicate> {
         log.trace { "Parsing AND QueryCriteria composition: $left AND $right" }
 
-        var predicateSet = mutableSetOf<Predicate>()
+        val predicateSet = mutableSetOf<Predicate>()
         val leftPredicates = parse(left)
         val rightPredicates = parse(right)
 
@@ -417,7 +413,7 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
     private fun parse(sorting: Sort) {
         log.trace { "Parsing sorting specification: $sorting" }
 
-        var orderCriteria = mutableListOf<Order>()
+        val orderCriteria = mutableListOf<Order>()
 
         sorting.columns.map { (sortAttribute, direction) ->
             val (entityStateClass, entityStateAttributeParent, entityStateAttributeChild) =

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -5,9 +5,7 @@ import co.paralleluniverse.strands.Strand
 import com.google.common.annotations.VisibleForTesting
 import io.requery.PersistenceException
 import io.requery.kotlin.eq
-import io.requery.kotlin.notNull
 import io.requery.query.RowExpression
-import net.corda.contracts.asset.Cash
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.containsAny

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -68,8 +68,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
     @Entity
     @Table(name = "vault_linear_states",
             indexes = arrayOf(Index(name = "external_id_index", columnList = "external_id"),
-                              Index(name = "uuid_index", columnList = "uuid"),
-                              Index(name = "deal_reference_index", columnList = "deal_reference")))
+                    Index(name = "uuid_index", columnList = "uuid")))
     class VaultLinearStates(
             /** [ContractState] attributes */
             @OneToMany(cascade = arrayOf(CascadeType.ALL))
@@ -82,18 +81,11 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var externalId: String?,
 
             @Column(name = "uuid", nullable = false)
-            var uuid: UUID,
-
-            // TODO: DealState to be deprecated (collapsed into LinearState)
-
-            /** Deal State attributes **/
-            @Column(name = "deal_reference")
-            var dealReference: String
+            var uuid: UUID
     ) : PersistentState() {
-        constructor(uid: UniqueIdentifier, _dealReference: String, _participants: List<AbstractParty>) :
+        constructor(uid: UniqueIdentifier, _participants: List<AbstractParty>) :
                 this(externalId = uid.externalId,
                      uuid = uid.id,
-                     dealReference = _dealReference,
                      participants = _participants.map{ CommonSchemaV1.Party(it) }.toSet() )
     }
 

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -171,7 +171,7 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
 
             QueryCriteria vaultCriteria = new VaultQueryCriteria(status, contractStateTypes);
 
-            List<UniqueIdentifier> linearIds = Collections.singletonList(uid);
+            List<UUID> linearIds = Collections.singletonList(uid.getId());
             QueryCriteria linearCriteriaAll = new LinearStateQueryCriteria(null, linearIds);
             QueryCriteria dealCriteriaAll = new LinearStateQueryCriteria(null, null, dealIds);
 
@@ -281,7 +281,7 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
             Set<Class<ContractState>> contractStateTypes = new HashSet(Arrays.asList(DealState.class, LinearState.class));
             QueryCriteria vaultCriteria = new VaultQueryCriteria(Vault.StateStatus.UNCONSUMED, contractStateTypes);
 
-            List<UniqueIdentifier> linearIds = Collections.singletonList(uid);
+            List<UUID> linearIds = Collections.singletonList(uid.getId());
             List<AbstractParty> dealParty = Collections.singletonList(getMEGA_CORP());
             QueryCriteria dealCriteria = new LinearStateQueryCriteria(dealParty, null, dealIds);
             QueryCriteria linearCriteria = new LinearStateQueryCriteria(dealParty, linearIds, null);

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -13,9 +13,6 @@ import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.node.services.database.HibernateConfiguration
-import net.corda.node.services.identity.InMemoryIdentityService
-import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.utilities.CordaPersistence
 import net.corda.testing.*
 import net.corda.testing.contracts.*
@@ -278,7 +275,7 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
 
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
             val deals = vaultQuery.queryBy<DummyDealContract.State>().states
-            deals.forEach { println(it.state.data.ref) }
+            deals.forEach { println(it.state.data.linearId.externalId!!) }
         }
 
         database.transaction {
@@ -306,7 +303,7 @@ class VaultWithCashTest : TestDependencyInjectionBase() {
 
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
             val deals = vaultQuery.queryBy<DummyDealContract.State>().states
-            deals.forEach { println(it.state.data.ref) }
+            deals.forEach { println(it.state.data.linearId.externalId!!) }
 
             services.fillWithSomeTestLinearStates(3)
             val linearStates = vaultQuery.queryBy<DummyLinearContract.State>().states

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/InterestRateSwapAPI.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/InterestRateSwapAPI.kt
@@ -3,8 +3,8 @@ package net.corda.irs.api
 import net.corda.core.contracts.filterStatesOfType
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
-import net.corda.core.utilities.getOrThrow
 import net.corda.core.messaging.vaultQueryBy
+import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
 import net.corda.irs.contract.InterestRateSwap
 import net.corda.irs.flows.AutoOfferFlow
@@ -37,7 +37,7 @@ class InterestRateSwapAPI(val rpc: CordaRPCOps) {
 
     private fun getDealByRef(ref: String): InterestRateSwap.State? {
         val vault = rpc.vaultQueryBy<InterestRateSwap.State>().states
-        val states = vault.filterStatesOfType<InterestRateSwap.State>().filter { it.state.data.ref == ref }
+        val states = vault.filterStatesOfType<InterestRateSwap.State>().filter { it.state.data.linearId.externalId == ref }
         return if (states.isEmpty()) null else {
             val deals = states.map { it.state.data }
             return if (deals.isEmpty()) null else deals[0]

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
@@ -567,7 +567,7 @@ class InterestRateSwap : Contract {
         requireNotNull(tx.timeWindow) { "must be have a time-window)" }
         val groups: List<LedgerTransaction.InOutGroup<State, UniqueIdentifier>> = tx.groupStates { state -> state.linearId }
         var atLeastOneCommandProcessed = false
-        for ((inputs, outputs, key) in groups) {
+        for ((inputs, outputs, _) in groups) {
             val agreeCommand = tx.commands.select<Commands.Agree>().firstOrNull()
             if (agreeCommand != null) {
                 verifyAgreeCommand(inputs, outputs)
@@ -616,7 +616,7 @@ class InterestRateSwap : Contract {
         override val oracleType: ServiceType
             get() = NodeInterestRates.Oracle.type
 
-        override val ref = common.tradeID
+        val ref: String get() = linearId.externalId ?: ""
 
         override val participants: List<AbstractParty>
             get() = listOf(fixedLeg.fixedRatePayer, floatingLeg.floatingRatePayer)

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
@@ -19,7 +19,7 @@ data class IRSState(val swap: SwapData,
                     val seller: AbstractParty,
                     override val contract: OGTrade,
                     override val linearId: UniqueIdentifier = UniqueIdentifier(swap.id.first + swap.id.second)) : DealState {
-    override val ref: String = linearId.externalId!! // Same as the constructor for UniqueIdentified
+    val ref: String get() = linearId.externalId!! // Same as the constructor for UniqueIdentified
     override val participants: List<AbstractParty> get() = listOf(buyer, seller)
 
     override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
@@ -29,7 +29,7 @@ data class PortfolioState(val portfolio: List<StateRef>,
     data class Update(val portfolio: List<StateRef>? = null, val valuation: PortfolioValuation? = null)
 
     override val participants: List<AbstractParty> get() = _parties.toList()
-    override val ref: String = linearId.toString()
+    val ref: String get() = linearId.toString()
     val valuer: AbstractParty get() = participants[0]
 
     override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity {

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyDealContract.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyDealContract.kt
@@ -21,11 +21,14 @@ class DummyDealContract : Contract {
     override fun verify(tx: LedgerTransaction) {}
 
     data class State(
-            override val contract: Contract = DummyDealContract(),
-            override val participants: List<AbstractParty> = listOf(),
-            override val linearId: UniqueIdentifier = UniqueIdentifier(),
-            override val ref: String) : DealState, QueryableState
+            override val contract: Contract,
+            override val participants: List<AbstractParty>,
+            override val linearId: UniqueIdentifier) : DealState, QueryableState
     {
+        constructor(contract: Contract = DummyDealContract(),
+                    participants: List<AbstractParty> = listOf(),
+                    ref: String) : this(contract, participants, UniqueIdentifier(ref))
+
         override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
             return participants.any { it.owningKey.containsAny(ourKeys) }
         }
@@ -39,8 +42,7 @@ class DummyDealContract : Contract {
         override fun generateMappedObject(schema: MappedSchema): PersistentState {
             return when (schema) {
                 is DummyDealStateSchemaV1 -> DummyDealStateSchemaV1.PersistentDummyDealState(
-                        uid = linearId,
-                        dealReference = ref
+                        uid = linearId
                 )
                 else -> throw IllegalArgumentException("Unrecognised schema $schema")
             }

--- a/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyDealStateSchemaV1.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/schemas/DummyDealStateSchemaV1.kt
@@ -3,7 +3,6 @@ package net.corda.testing.schemas
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
-import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Table
 import javax.persistence.Transient
@@ -21,10 +20,6 @@ object DummyDealStateSchemaV1 : MappedSchema(schemaFamily = DummyDealStateSchema
     @Entity
     @Table(name = "dummy_deal_states")
     class PersistentDummyDealState(
-
-            @Column(name = "deal_reference")
-            var dealReference: String,
-
             /** parent attributes */
             @Transient
             val uid: UniqueIdentifier


### PR DESCRIPTION
One of the lingering finance dependencies inside the NodeSchemaService is the DealState, because we allow filters against the ref field. However, we always allowed the equivalent data inside the linearId as this has an externalId field. Also, the query by linearId isn't quite the same as the equality function on the UniqueIdentifier class, which is by UUID only.
Therefore I have moved to make the usages all point at linearid component and allowed separate queries for the two components of the linearId.