### PR TITLE
Simple deserialisation fixes.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -39,7 +39,7 @@ interface SerializationContext {
     /**
      * When serializing, use the format this header sequence represents.
      */
-    val preferedSerializationVersion: ByteSequence
+    val preferredSerializationVersion: ByteSequence
     /**
      * The class loader to use for deserialization.
      */

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AMQPSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AMQPSerializationScheme.kt
@@ -11,7 +11,7 @@ import net.corda.nodeapi.internal.serialization.amqp.SerializationOutput
 import net.corda.nodeapi.internal.serialization.amqp.SerializerFactory
 import java.util.concurrent.ConcurrentHashMap
 
-internal val AMQP_ENABLED get() = SerializationDefaults.P2P_CONTEXT.preferedSerializationVersion == AmqpHeaderV1_0
+internal val AMQP_ENABLED get() = SerializationDefaults.P2P_CONTEXT.preferredSerializationVersion == AmqpHeaderV1_0
 
 abstract class AbstractAMQPSerializationScheme : SerializationScheme {
     internal companion object {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/DefaultKryoCustomizer.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/DefaultKryoCustomizer.kt
@@ -6,11 +6,11 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer
 import com.esotericsoftware.kryo.serializers.FieldSerializer
-import com.esotericsoftware.kryo.util.MapReferenceResolver
 import de.javakaffee.kryoserializers.ArraysAsListSerializer
 import de.javakaffee.kryoserializers.BitSetSerializer
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer
 import de.javakaffee.kryoserializers.guava.*
+import net.corda.core.contracts.PrivacySalt
 import net.corda.core.crypto.composite.CompositeKey
 import net.corda.core.node.CordaPluginRegistry
 import net.corda.core.serialization.SerializeAsToken
@@ -122,6 +122,9 @@ object DefaultKryoCustomizer {
 
             register(NotaryChangeWireTransaction::class.java, NotaryChangeWireTransactionSerializer)
 
+            // Don't deserialize PrivacySalt via its default constructor.
+            register(PrivacySalt::class.java, PrivacySaltSerializer)
+
             val customization = KryoSerializationCustomization(this)
             pluginRegistries.forEach { it.customizeSerialization(customization) }
         }
@@ -154,6 +157,20 @@ object DefaultKryoCustomizer {
                 list += kryo.readClassAndObject(input)
             }
             return list.toNonEmptySet()
+        }
+    }
+
+    /*
+     * Avoid deserialising PrivacySalt via its default constructor
+     * because the random number generator may not be available.
+     */
+    private object PrivacySaltSerializer : Serializer<PrivacySalt>() {
+        override fun write(kryo: Kryo, output: Output, obj: PrivacySalt) {
+            output.writeBytesWithLength(obj.bytes)
+        }
+
+        override fun read(kryo: Kryo, input: Input, type: Class<PrivacySalt>): PrivacySalt {
+            return PrivacySalt(input.readBytesWithLength())
         }
     }
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
@@ -28,7 +28,7 @@ object NotSupportedSeralizationScheme : SerializationScheme {
     override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> = doThrow()
 }
 
-data class SerializationContextImpl(override val preferedSerializationVersion: ByteSequence,
+data class SerializationContextImpl(override val preferredSerializationVersion: ByteSequence,
                                     override val deserializationClassLoader: ClassLoader,
                                     override val whitelist: ClassWhitelist,
                                     override val properties: Map<Any, Any>,
@@ -52,7 +52,7 @@ data class SerializationContextImpl(override val preferedSerializationVersion: B
         })
     }
 
-    override fun withPreferredSerializationVersion(versionHeader: ByteSequence) = copy(preferedSerializationVersion = versionHeader)
+    override fun withPreferredSerializationVersion(versionHeader: ByteSequence) = copy(preferredSerializationVersion = versionHeader)
 }
 
 private const val HEADER_SIZE: Int = 8
@@ -81,7 +81,7 @@ open class SerializationFactoryImpl : SerializationFactory {
     override fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: SerializationContext): T = schemeFor(byteSequence, context.useCase).deserialize(byteSequence, clazz, context)
 
     override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {
-        return schemeFor(context.preferedSerializationVersion, context.useCase).serialize(obj, context)
+        return schemeFor(context.preferredSerializationVersion, context.useCase).serialize(obj, context)
     }
 
     fun registerScheme(scheme: SerializationScheme) {

--- a/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
@@ -111,8 +111,8 @@ class TestSerializationContext : SerializationContext {
 
     override fun toString(): String = stackTrace?.joinToString("\n") ?: "null"
 
-    override val preferedSerializationVersion: ByteSequence
-        get() = delegate!!.preferedSerializationVersion
+    override val preferredSerializationVersion: ByteSequence
+        get() = delegate!!.preferredSerializationVersion
     override val deserializationClassLoader: ClassLoader
         get() = delegate!!.deserializationClassLoader
     override val whitelist: ClassWhitelist

--- a/verifier/src/main/kotlin/net/corda/verifier/Verifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/Verifier.kt
@@ -1,6 +1,5 @@
 package net.corda.verifier
 
-import com.esotericsoftware.kryo.pool.KryoPool
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
@@ -98,15 +97,10 @@ class Verifier {
 
     class KryoVerifierSerializationScheme(serializationFactory: SerializationFactory) : AbstractKryoSerializationScheme(serializationFactory) {
         override fun canDeserializeVersion(byteSequence: ByteSequence, target: SerializationContext.UseCase): Boolean {
-            return byteSequence.equals(KryoHeaderV0_1) && target == SerializationContext.UseCase.P2P
+            return byteSequence == KryoHeaderV0_1 && target == SerializationContext.UseCase.P2P
         }
 
-        override fun rpcClientKryoPool(context: SerializationContext): KryoPool {
-            throw UnsupportedOperationException()
-        }
-
-        override fun rpcServerKryoPool(context: SerializationContext): KryoPool {
-            throw UnsupportedOperationException()
-        }
+        override fun rpcClientKryoPool(context: SerializationContext) = throw UnsupportedOperationException()
+        override fun rpcServerKryoPool(context: SerializationContext) = throw UnsupportedOperationException()
     }
 }


### PR DESCRIPTION
The main one is the custom serialiser for `PrivacySalt` so that we can deserialise it without incidentally invoking the default constructor. (Because a dummy RNG would then try to initialise the object with a constraint-violating all-zero array before replacing the array with the proper values.)

There's also a spelling fix and minor tidy of the `KryoVerifierSerializationScheme` class.