### PR TITLE
Additional transaction validation rules

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -289,7 +289,7 @@ abstract class TypeOnlyCommandData : CommandData {
 data class Command<T : CommandData>(val value: T, val signers: List<PublicKey>) {
     // TODO Introduce NonEmptyList?
     init {
-        require(signers.isNotEmpty())
+        require(signers.isNotEmpty()) { "The list of signers cannot be empty" }
     }
 
     constructor(data: T, key: PublicKey) : this(data, listOf(key))

--- a/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/BaseTransaction.kt
@@ -27,8 +27,8 @@ abstract class BaseTransaction : NamedByHash {
     }
 
     private fun checkNotarySetIfInputsPresent() {
-        if (notary == null) {
-            check(inputs.isEmpty()) { "The notary must be specified explicitly for any transaction that has inputs" }
+        if (inputs.isNotEmpty()) {
+            check(notary != null) { "The notary must be specified explicitly for any transaction that has inputs" }
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -33,8 +33,9 @@ data class WireTransaction(
 ) : CoreTransaction(), TraversableTransaction {
     init {
         checkBaseInvariants()
+        check(inputs.isNotEmpty() || outputs.isNotEmpty()) { "A transaction must contain at least one input or output state" }
+        check(commands.isNotEmpty()) { "A transaction must contain at least one command" }
         if (timeWindow != null) check(notary != null) { "Transactions with time-windows must be notarised" }
-        check(availableComponents.isNotEmpty()) { "A WireTransaction cannot be empty" }
     }
 
     /** The transaction id is represented by the root hash of Merkle tree over the transaction components. */

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt
@@ -169,8 +169,6 @@ class Cap {
             output { stateInitial }
             timeWindow(TEST_TX_TIME_1)
 
-            this `fails with` "transaction has a single command"
-
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }
                 this `fails with` "the transaction is signed by all liable parties"

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Caplet.kt
@@ -56,8 +56,6 @@ class Caplet {
             output { stateStart }
             timeWindow(TEST_TX_TIME_1)
 
-            this `fails with` "transaction has a single command"
-
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }
                 this `fails with` "the transaction is signed by all liable parties"

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXFwdTimeOption.kt
@@ -53,8 +53,6 @@ class FXFwdTimeOption
             output { inState }
             timeWindow(TEST_TX_TIME_1)
 
-            this `fails with` "transaction has a single command"
-
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }
                 this `fails with` "the transaction is signed by all liable parties"

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/FXSwap.kt
@@ -45,8 +45,6 @@ class FXSwap {
             output { inState }
             timeWindow(TEST_TX_TIME_1)
 
-            this `fails with` "transaction has a single command"
-
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }
                 this `fails with` "the transaction is signed by all liable parties"

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/IRS.kt
@@ -136,8 +136,6 @@ class IRS {
             output { stateInitial }
             timeWindow(TEST_TX_TIME_1)
 
-            this `fails with` "transaction has a single command"
-
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }
                 this `fails with` "the transaction is signed by all liable parties"

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/RollOutTests.kt
@@ -145,8 +145,6 @@ class RollOutTests {
             output { stateStart }
             timeWindow(TEST_TX_TIME_1)
 
-            this `fails with` "transaction has a single command"
-
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }
                 this `fails with` "the transaction is signed by all liable parties"

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Swaption.kt
@@ -62,8 +62,6 @@ class Swaption {
             output { stateInitial }
             timeWindow(TEST_TX_TIME_1)
 
-            this `fails with` "transaction has a single command"
-
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }
                 this `fails with` "the transaction is signed by all liable parties"

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ZeroCouponBond.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/ZeroCouponBond.kt
@@ -48,11 +48,8 @@ class ZeroCouponBond {
 
     @Test
     fun `issue - signature`() {
-
         transaction {
             output { inState }
-
-            this `fails with` "transaction has a single command"
 
             tweak {
                 command(acmeCorp.owningKey) { UniversalContract.Commands.Issue() }

--- a/finance/src/test/java/net/corda/finance/contracts/asset/CashTestsJava.java
+++ b/finance/src/test/java/net/corda/finance/contracts/asset/CashTestsJava.java
@@ -4,6 +4,7 @@ import kotlin.Unit;
 import net.corda.core.contracts.PartyAndReference;
 import net.corda.core.identity.AnonymousParty;
 import net.corda.core.utilities.OpaqueBytes;
+import net.corda.testing.DummyCommandData;
 import org.junit.Test;
 
 import static net.corda.finance.CurrencyUtils.DOLLARS;
@@ -24,16 +25,17 @@ public class CashTestsJava {
         ledger(lg -> {
             lg.transaction(tx -> {
                 tx.input(inState);
-                tx.failsWith("the amounts balance");
 
                 tx.tweak(tw -> {
                     tw.output(new Cash.State(issuedBy(DOLLARS(2000), defaultIssuer), new AnonymousParty(getMINI_CORP_PUBKEY())));
+                    tw.command(getMEGA_CORP_PUBKEY(), new Cash.Commands.Move());
                     return tw.failsWith("the amounts balance");
                 });
 
                 tx.tweak(tw -> {
                     tw.output(outState);
-                    // No command arguments
+                    tw.command(getMEGA_CORP_PUBKEY(), DummyCommandData.INSTANCE);
+                    // Invalid command
                     return tw.failsWith("required net.corda.finance.contracts.asset.Cash.Commands.Move command");
                 });
                 tx.tweak(tw -> {

--- a/finance/src/test/java/net/corda/finance/contracts/asset/CashTestsJava.java
+++ b/finance/src/test/java/net/corda/finance/contracts/asset/CashTestsJava.java
@@ -1,6 +1,5 @@
 package net.corda.finance.contracts.asset;
 
-import kotlin.Unit;
 import net.corda.core.contracts.PartyAndReference;
 import net.corda.core.identity.AnonymousParty;
 import net.corda.core.utilities.OpaqueBytes;
@@ -22,44 +21,41 @@ public class CashTestsJava {
 
     @Test
     public void trivial() {
-        ledger(lg -> {
-            lg.transaction(tx -> {
-                tx.input(inState);
+        transaction(tx -> {
+            tx.input(inState);
 
-                tx.tweak(tw -> {
-                    tw.output(new Cash.State(issuedBy(DOLLARS(2000), defaultIssuer), new AnonymousParty(getMINI_CORP_PUBKEY())));
-                    tw.command(getMEGA_CORP_PUBKEY(), new Cash.Commands.Move());
-                    return tw.failsWith("the amounts balance");
-                });
-
-                tx.tweak(tw -> {
-                    tw.output(outState);
-                    tw.command(getMEGA_CORP_PUBKEY(), DummyCommandData.INSTANCE);
-                    // Invalid command
-                    return tw.failsWith("required net.corda.finance.contracts.asset.Cash.Commands.Move command");
-                });
-                tx.tweak(tw -> {
-                    tw.output(outState);
-                    tw.command(getMINI_CORP_PUBKEY(), new Cash.Commands.Move());
-                    return tw.failsWith("the owning keys are a subset of the signing keys");
-                });
-                tx.tweak(tw -> {
-                    tw.output(outState);
-                    // issuedBy() can't be directly imported because it conflicts with other identically named functions
-                    // with different overloads (for some reason).
-                    tw.output(outState.issuedBy(getMINI_CORP()));
-                    tw.command(getMEGA_CORP_PUBKEY(), new Cash.Commands.Move());
-                    return tw.failsWith("at least one cash input");
-                });
-
-                // Simple reallocation works.
-                return tx.tweak(tw -> {
-                    tw.output(outState);
-                    tw.command(getMEGA_CORP_PUBKEY(), new Cash.Commands.Move());
-                    return tw.verifies();
-                });
+            tx.tweak(tw -> {
+                tw.output(new Cash.State(issuedBy(DOLLARS(2000), defaultIssuer), new AnonymousParty(getMINI_CORP_PUBKEY())));
+                tw.command(getMEGA_CORP_PUBKEY(), new Cash.Commands.Move());
+                return tw.failsWith("the amounts balance");
             });
-            return Unit.INSTANCE;
+
+            tx.tweak(tw -> {
+                tw.output(outState);
+                tw.command(getMEGA_CORP_PUBKEY(), DummyCommandData.INSTANCE);
+                // Invalid command
+                return tw.failsWith("required net.corda.finance.contracts.asset.Cash.Commands.Move command");
+            });
+            tx.tweak(tw -> {
+                tw.output(outState);
+                tw.command(getMINI_CORP_PUBKEY(), new Cash.Commands.Move());
+                return tw.failsWith("the owning keys are a subset of the signing keys");
+            });
+            tx.tweak(tw -> {
+                tw.output(outState);
+                // issuedBy() can't be directly imported because it conflicts with other identically named functions
+                // with different overloads (for some reason).
+                tw.output(outState.issuedBy(getMINI_CORP()));
+                tw.command(getMEGA_CORP_PUBKEY(), new Cash.Commands.Move());
+                return tw.failsWith("at least one cash input");
+            });
+
+            // Simple reallocation works.
+            return tx.tweak(tw -> {
+                tw.output(outState);
+                tw.command(getMEGA_CORP_PUBKEY(), new Cash.Commands.Move());
+                return tw.verifies();
+            });
         });
     }
 }

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -84,15 +84,16 @@ class CashTests : TestDependencyInjectionBase() {
     fun trivial() {
         transaction {
             input { inState }
-            this `fails with` "the amounts balance"
 
             tweak {
                 output { outState.copy(amount = 2000.DOLLARS `issued by` defaultIssuer) }
+                command(ALICE_PUBKEY) { Cash.Commands.Move() }
                 this `fails with` "the amounts balance"
             }
             tweak {
                 output { outState }
-                // No command arguments
+                command(ALICE_PUBKEY) { DummyCommandData }
+                // Invalid command
                 this `fails with` "required net.corda.finance.contracts.asset.Cash.Commands.Move command"
             }
             tweak {
@@ -278,12 +279,14 @@ class CashTests : TestDependencyInjectionBase() {
         transaction {
             input { inState }
             input { inState.copy(amount = 0.DOLLARS `issued by` defaultIssuer) }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this `fails with` "zero sized inputs"
         }
         transaction {
             input { inState }
             output { inState }
             output { inState.copy(amount = 0.DOLLARS `issued by` defaultIssuer) }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this `fails with` "zero sized outputs"
         }
     }
@@ -294,6 +297,7 @@ class CashTests : TestDependencyInjectionBase() {
         transaction {
             input { inState }
             output { outState `issued by` MINI_CORP }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this `fails with` "the amounts balance"
         }
         // Can't change deposit reference when splitting.
@@ -301,6 +305,7 @@ class CashTests : TestDependencyInjectionBase() {
             val splits2 = inState.amount.splitEvenly(2)
             input { inState }
             for (i in 0..1) output { outState.copy(amount = splits2[i]).editDepositRef(i.toByte()) }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this `fails with` "the amounts balance"
         }
         // Can't mix currencies.
@@ -308,6 +313,7 @@ class CashTests : TestDependencyInjectionBase() {
             input { inState }
             output { outState.copy(amount = 800.DOLLARS `issued by` defaultIssuer) }
             output { outState.copy(amount = 200.POUNDS `issued by` defaultIssuer) }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this `fails with` "the amounts balance"
         }
         transaction {
@@ -319,6 +325,7 @@ class CashTests : TestDependencyInjectionBase() {
                 )
             }
             output { outState.copy(amount = 1150.DOLLARS `issued by` defaultIssuer) }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this `fails with` "the amounts balance"
         }
         // Can't have superfluous input states from different issuers.
@@ -334,6 +341,7 @@ class CashTests : TestDependencyInjectionBase() {
             input { inState }
             input { inState.editDepositRef(3) }
             output { outState.copy(amount = inState.amount * 2).editDepositRef(3) }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this `fails with` "for reference [01]"
         }
     }
@@ -403,6 +411,7 @@ class CashTests : TestDependencyInjectionBase() {
             // Gather 2000 dollars from two different issuers.
             input { inState }
             input { inState `issued by` MINI_CORP }
+            command(ALICE_PUBKEY) { Cash.Commands.Move() }
 
             // Can't merge them together.
             tweak {
@@ -419,7 +428,6 @@ class CashTests : TestDependencyInjectionBase() {
             // This works.
             output { inState.copy(owner = AnonymousParty(BOB_PUBKEY)) }
             output { inState.copy(owner = AnonymousParty(BOB_PUBKEY)) `issued by` MINI_CORP }
-            command(ALICE_PUBKEY) { Cash.Commands.Move() }
             this.verifies()
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -2,17 +2,18 @@ package net.corda.node.services
 
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
-import net.corda.testing.contracts.DummyContract
-import net.corda.core.identity.Party
-import net.corda.testing.DUMMY_BANK_A
 import net.corda.core.flows.NotaryError
 import net.corda.core.flows.NotaryException
 import net.corda.core.flows.NotaryFlow
+import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.concurrent.transpose
-import net.corda.core.utilities.getOrThrow
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.AbstractNode
+import net.corda.testing.DUMMY_BANK_A
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.dummyCommand
 import net.corda.testing.node.NodeBasedTest
 import org.bouncycastle.asn1.x500.X500Name
 import org.junit.Test
@@ -34,7 +35,9 @@ class RaftNotaryServiceTests : NodeBasedTest() {
 
         val inputState = issueState(bankA, notaryParty)
 
-        val firstTxBuilder = TransactionBuilder(notaryParty).withItems(inputState)
+        val firstTxBuilder = TransactionBuilder(notaryParty)
+                .addInputState(inputState)
+                .addCommand(dummyCommand(bankA.services.legalIdentityKey))
         val firstSpendTx = bankA.services.signInitialTransaction(firstTxBuilder)
 
         val firstSpend = bankA.services.startFlow(NotaryFlow.Client(firstSpendTx))
@@ -43,6 +46,7 @@ class RaftNotaryServiceTests : NodeBasedTest() {
         val secondSpendBuilder = TransactionBuilder(notaryParty).withItems(inputState).run {
             val dummyState = DummyContract.SingleOwnerState(0, bankA.info.legalIdentity)
             addOutputState(dummyState)
+            addCommand(dummyCommand(bankA.services.legalIdentityKey))
             this
         }
         val secondSpendTx = bankA.services.signInitialTransaction(secondSpendBuilder)

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -1,19 +1,18 @@
 package net.corda.node.services.statemachine
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.internal.InputStreamAndHash
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
+import net.corda.core.internal.InputStreamAndHash
 import net.corda.core.messaging.startFlow
-import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.utilities.unwrap
 import net.corda.testing.BOB
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.aliceBobAndNotary
 import net.corda.testing.contracts.DummyState
 import net.corda.testing.driver.driver
+import net.corda.testing.dummyCommand
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -28,6 +27,7 @@ class LargeTransactionsTest {
         override fun call() {
             val tx = TransactionBuilder(notary = DUMMY_NOTARY)
                     .addOutputState(DummyState())
+                    .addCommand(dummyCommand(serviceHub.legalIdentityKey))
                     .addAttachment(hash1)
                     .addAttachment(hash2)
                     .addAttachment(hash3)

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -6,6 +6,7 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
@@ -115,8 +116,9 @@ class AttachmentDemoFlow(val otherSide: Party, val notary: Party, val hash: Secu
     override fun call(): SignedTransaction {
         // Create a trivial transaction with an output that describes the attachment, and the attachment itself
         val ptx = TransactionBuilder(notary)
-        ptx.addOutputState(AttachmentContract.State(hash))
-        ptx.addAttachment(hash)
+                .addOutputState(AttachmentContract.State(hash))
+                .addCommand(AttachmentContract.Command, serviceHub.legalIdentityKey)
+                .addAttachment(hash)
 
         progressTracker.currentStep = SIGNING
 
@@ -182,6 +184,8 @@ class AttachmentContract : Contract {
         val attachment = tx.attachments.single()
         require(state.hash == attachment.id)
     }
+
+    object Command : TypeOnlyCommandData()
 
     data class State(val hash: SecureHash.SHA256) : ContractState {
         override val contract: Contract = AttachmentContract()

--- a/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -155,7 +155,9 @@ fun getFreeLocalPorts(hostName: String, numberToAlloc: Int): List<NetworkHostAnd
         transactionBuilder: TransactionBuilder = TransactionBuilder(notary = DUMMY_NOTARY),
         initialiseSerialization: Boolean = true,
         dsl: TransactionDSL<TransactionDSLInterpreter>.() -> EnforceVerifyOrFail
-) = ledger(initialiseSerialization = initialiseSerialization) { this.transaction(transactionLabel, transactionBuilder, dsl) }
+) = ledger(initialiseSerialization = initialiseSerialization) {
+    dsl(TransactionDSL(TestTransactionDSLInterpreter(this.interpreter, transactionBuilder)))
+}
 
 fun testNodeConfiguration(
         baseDirectory: Path,

--- a/test-utils/src/main/kotlin/net/corda/testing/TransactionDSLInterpreter.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TransactionDSLInterpreter.kt
@@ -78,9 +78,6 @@ class TransactionDSL<out T : TransactionDSLInterpreter>(val interpreter: T) : Tr
     fun input(state: ContractState) {
         val transaction = ledgerInterpreter._unverifiedTransaction(null, TransactionBuilder(notary = DUMMY_NOTARY)) {
             output { state }
-            // Add a dummy randomised output so that the transaction id differs when issuing the same state multiple times
-            val nonceState = DummyContract.SingleOwnerState(Random().nextInt(), DUMMY_NOTARY)
-            output { nonceState }
         }
         input(transaction.outRef<ContractState>(0).ref)
     }


### PR DESCRIPTION
As per https://r3-cev.atlassian.net/browse/CORDA-485 we decided to disallow transactions that have no commands, and transactions with no input and output states.