### PR TITLE
Eliminate explicit Kryo configuration to allow flexibility for AMQP

### DIFF
--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SerializationTokenTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SerializationTokenTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.*
 import net.corda.core.utilities.OpaqueBytes
-import net.corda.node.serialization.KryoServerSerializationScheme
 import net.corda.testing.TestDependencyInjectionBase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -21,13 +20,8 @@ class SerializationTokenTest  : TestDependencyInjectionBase() {
 
     @Before
     fun setup() {
-        factory = SerializationFactoryImpl().apply { registerScheme(KryoServerSerializationScheme(this)) }
-        context = SerializationContextImpl(KryoHeaderV0_1,
-                javaClass.classLoader,
-                AllWhitelist,
-                emptyMap(),
-                true,
-                SerializationContext.UseCase.P2P)
+        factory = SerializationDefaults.SERIALIZATION_FACTORY
+        context = SerializationDefaults.CHECKPOINT_CONTEXT.withWhitelisted(SingletonSerializationToken::class.java)
     }
 
     // Large tokenizable object so we can tell from the smaller number of serialized bytes it was actually tokenized


### PR DESCRIPTION
The test still needs a bit more work as some private classes cannot be serialized with AMQP, e.g.:
java.io.NotSerializableException: Unexpected throwable: Class net.corda.nodeapi.internal.serialization.amqp.ObjectSerializer can not access a member of class net.corda.nodeapi.internal.serialization.SerializationTokenTest$LargeTokenizable with modifiers "public" java.lang.IllegalAccessException: Class net.corda.nodeapi.internal.serialization.amqp.ObjectSerializer can not access a member of class net.corda.nodeapi.internal.serialization.SerializationTokenTest$LargeTokenizable with modifiers "public"
	at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:102)
	at java.lang.reflect.AccessibleObject.slowCheckMemberAccess(AccessibleObject.java:296)
	at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:288)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:413)
	at net.corda.nodeapi.internal.serialization.amqp.ObjectSerializer.construct(ObjectSerializer.kt:79)
	at net.corda.nodeapi.internal.serialization.amqp.ObjectSerializer.readObject(ObjectSerializer.kt:62)
	at net.corda.nodeapi.internal.serialization.amqp.DeserializationInput.readObject$node_api_main(DeserializationInput.kt:124)
	at net.corda.nodeapi.internal.serialization.amqp.DeserializationInput.readObjectOrNull$node_api_main(DeserializationInput.kt:114)
	at net.corda.nodeapi.internal.serialization.amqp.DeserializationInput$deserialize$1.invoke(DeserializationInput.kt:100)
	at net.corda.nodeapi.internal.serialization.amqp.DeserializationInput.des(DeserializationInput.kt:81)
	at net.corda.nodeapi.internal.serialization.amqp.DeserializationInput.deserialize(DeserializationInput.kt:98)
	at net.corda.nodeapi.internal.serialization.AbstractAMQPSerializationScheme.deserialize(AMQPSerializationScheme.kt:51)
	at net.corda.nodeapi.internal.serialization.SerializationFactoryImpl.deserialize(SerializationScheme.kt:81)
	at net.corda.testing.TestSerializationFactory.deserialize(SerializationTestHelpers.kt:96)
	at net.corda.nodeapi.internal.serialization.SerializationTokenTest.write token and read tokenizable(SerializationTokenTest.kt:123)