### PR TITLE
Re-re-move Java test to the correct location, fix compile issue

### DIFF
--- a/node-api/src/test/java/net/corda/nodeapi/internal/serialization/amqp/JavaSerializationOutputTests.java
+++ b/node-api/src/test/java/net/corda/nodeapi/internal/serialization/amqp/JavaSerializationOutputTests.java
@@ -168,8 +168,9 @@ public class JavaSerializationOutputTests {
     }
 
     private Object serdes(Object obj) throws NotSerializableException {
-        SerializerFactory factory = new SerializerFactory(AllWhitelist.INSTANCE, ClassLoader.getSystemClassLoader());
-        SerializationOutput ser = new SerializationOutput(factory);
+        SerializerFactory factory1 = new SerializerFactory(AllWhitelist.INSTANCE, ClassLoader.getSystemClassLoader());
+        SerializerFactory factory2 = new SerializerFactory(AllWhitelist.INSTANCE, ClassLoader.getSystemClassLoader());
+        SerializationOutput ser = new SerializationOutput(factory1);
         SerializedBytes<Object> bytes = ser.serialize(obj);
 
         DecoderImpl decoder = new DecoderImpl();
@@ -187,13 +188,13 @@ public class JavaSerializationOutputTests {
         Envelope result = (Envelope) decoder.readObject();
         assertTrue(result != null);
 
-        DeserializationInput des = new DeserializationInput();
+        DeserializationInput des = new DeserializationInput(factory2);
         Object desObj = des.deserialize(bytes, Object.class);
         assertTrue(Objects.deepEquals(obj, desObj));
 
         // Now repeat with a re-used factory
-        SerializationOutput ser2 = new SerializationOutput(factory);
-        DeserializationInput des2 = new DeserializationInput(factory);
+        SerializationOutput ser2 = new SerializationOutput(factory1);
+        DeserializationInput des2 = new DeserializationInput(factory1);
         Object desObj2 = des2.deserialize(ser2.serialize(obj), Object.class);
         assertTrue(Objects.deepEquals(obj, desObj2));
         // TODO: check schema is as expected


### PR DESCRIPTION
Somehow this slipped past Gradle that I hadn't changed the serializer
factory here to take the needed argument now it's no longer defaulted