### PR TITLE
Use String instead of Class for the flowClass

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FlowStackSnapshot.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowStackSnapshot.kt
@@ -7,7 +7,7 @@ import java.time.Instant
  */
 data class FlowStackSnapshot(
         val time: Instant,
-        val flowClass: Class<out FlowLogic<*>>,
+        val flowClass: String,
         val stackFrames: List<Frame>
 ) {
     data class Frame(

--- a/test-utils/src/main/kotlin/net/corda/testing/FlowStackSnapshot.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/FlowStackSnapshot.kt
@@ -73,7 +73,7 @@ class FlowStackSnapshotFactoryImpl : FlowStackSnapshotFactory {
             }
             Frame(element, stackObjects)
         }
-        return FlowStackSnapshot(Instant.now(), flowClass, frames)
+        return FlowStackSnapshot(Instant.now(), flowClass.name, frames)
     }
 
     private val StackTraceElement.instrumentedAnnotation: Instrumented? get() {


### PR DESCRIPTION
This is a very minor change, that is intended to simplify the FlowStackSnapshot instance serialization/deserialization process.