### PR TITLE
Enable autorecovery in RAFT Copycat client

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt
@@ -10,6 +10,7 @@ import io.atomix.catalyst.transport.netty.NettyTransport
 import io.atomix.catalyst.transport.netty.SslProtocol
 import io.atomix.copycat.client.ConnectionStrategies
 import io.atomix.copycat.client.CopycatClient
+import io.atomix.copycat.client.RecoveryStrategies
 import io.atomix.copycat.server.CopycatServer
 import io.atomix.copycat.server.storage.Storage
 import io.atomix.copycat.server.storage.StorageLevel
@@ -118,6 +119,7 @@ class RaftUniquenessProvider(services: ServiceHubInternal) : UniquenessProvider,
                 .withTransport(transport) // TODO: use local transport for client-server communications
                 .withConnectionStrategy(ConnectionStrategies.EXPONENTIAL_BACKOFF)
                 .withSerializer(serializer)
+                .withRecoveryStrategy(RecoveryStrategies.RECOVER)
                 .build()
         _clientFuture = serverFuture.thenCompose { client.connect(address) }
     }


### PR DESCRIPTION
Without this setting of the Copycat library, it will make no attept to reconnect after intermittent network failure or other cases and it starts throwing exceptions about event executor being shut down.