### PR TITLE
Upgrade DemoBench to TornadoFX 1.7.10

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.tornadofx_version = '1.7.3'
+    ext.tornadofx_version = '1.7.10'
     ext.jna_version = '4.1.0'
     ext.purejavacomm_version = '0.0.18'
     ext.controlsfx_version = '8.40.12'


### PR DESCRIPTION
Upgrade to TornadoFX 1.7.10 now that we've upgraded to Kotlin 1.1.4.