### PR TITLE
Refactor serialisation contexts into separate classes, according to their use-cases.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AMQPSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AMQPSerializationScheme.kt
@@ -99,9 +99,3 @@ val AMQP_P2P_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
         emptyMap(),
         true,
         SerializationContext.UseCase.P2P)
-val AMQP_STORAGE_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
-        SerializationDefaults.javaClass.classLoader,
-        AllButBlacklisted,
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.Storage)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ClientContexts.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ClientContexts.kt
@@ -1,0 +1,15 @@
+@file:JvmName("ClientContexts")
+package net.corda.nodeapi.internal.serialization
+
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationDefaults
+
+/*
+ * Serialisation contexts for the client.
+ */
+val KRYO_RPC_CLIENT_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
+        SerializationDefaults.javaClass.classLoader,
+        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.RPCClient)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
@@ -218,34 +218,6 @@ val KRYO_P2P_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
         emptyMap(),
         true,
         SerializationContext.UseCase.P2P)
-val KRYO_RPC_SERVER_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
-        SerializationDefaults.javaClass.classLoader,
-        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.RPCServer)
-val KRYO_RPC_CLIENT_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
-        SerializationDefaults.javaClass.classLoader,
-        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.RPCClient)
-val KRYO_STORAGE_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
-        SerializationDefaults.javaClass.classLoader,
-        AllButBlacklisted,
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.Storage)
-val KRYO_CHECKPOINT_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
-        SerializationDefaults.javaClass.classLoader,
-        QuasarWhitelist,
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.Checkpoint)
-
-object QuasarWhitelist : ClassWhitelist {
-    override fun hasListed(type: Class<*>): Boolean = true
-}
 
 interface SerializationScheme {
     // byteSequence expected to just be the 8 bytes necessary for versioning

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
@@ -1,0 +1,32 @@
+@file:JvmName("ServerContexts")
+package net.corda.nodeapi.internal.serialization
+
+import net.corda.core.serialization.ClassWhitelist
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationDefaults
+
+/*
+ * Serialisation contexts for the server.
+ */
+val KRYO_RPC_SERVER_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
+        SerializationDefaults.javaClass.classLoader,
+        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.RPCServer)
+val KRYO_STORAGE_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
+        SerializationDefaults.javaClass.classLoader,
+        AllButBlacklisted,
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.Storage)
+val KRYO_CHECKPOINT_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
+        SerializationDefaults.javaClass.classLoader,
+        QuasarWhitelist,
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.Checkpoint)
+
+object QuasarWhitelist : ClassWhitelist {
+    override fun hasListed(type: Class<*>): Boolean = true
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
@@ -4,6 +4,7 @@ package net.corda.nodeapi.internal.serialization
 import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationDefaults
+import net.corda.nodeapi.internal.serialization.amqp.AmqpHeaderV1_0
 
 /*
  * Serialisation contexts for the server.
@@ -30,3 +31,10 @@ val KRYO_CHECKPOINT_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
 object QuasarWhitelist : ClassWhitelist {
     override fun hasListed(type: Class<*>): Boolean = true
 }
+
+val AMQP_STORAGE_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
+        SerializationDefaults.javaClass.classLoader,
+        AllButBlacklisted,
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.Storage)


### PR DESCRIPTION
Prevent Kotlin from trying to instantiate every context, in all cases. Specifically, the `AllButBlacklisted` whitelist _cannot_ be instantiated in some circumstances.