### PR TITLE
Removed is relevant from LinearState.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -219,11 +219,6 @@ interface LinearState : ContractState {
      * except at issuance/termination.
      */
     val linearId: UniqueIdentifier
-
-    /**
-     * True if this should be tracked by our vault(s).
-     */
-    fun isRelevant(ourKeys: Set<PublicKey>): Boolean
 }
 // DOCEND 2
 

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -395,4 +395,4 @@ The Corda Tutorials provide examples satisfying these additional Use Cases:
  .. _JPQL: http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql
  .. _JPA: https://docs.spring.io/spring-data/jpa/docs/current/reference/html
 
- 
+

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -34,7 +34,6 @@ UNRELEASED
   must use ``SendTransactionFlow`` at the correct place. There is also ``ReceiveStateAndRefFlow`` and ``SendStateAndRefFlow`` for
   dealing with ``StateAndRef``s.
 
-
 * Vault query soft locking enhancements and deprecations
   * removed original ``VaultService`` ``softLockedStates` query mechanism.
   * introduced improved ``SoftLockingCondition`` filterable attribute in ``VaultQueryCriteria`` to enable specification
@@ -67,6 +66,9 @@ UNRELEASED
 
 * Moved ``:finance`` gradle project files into a ``net.corda.finance`` package namespace.
   This may require adjusting imports of Cash flow references and also of ``StartFlow`` permission in ``gradle.build`` files.
+
+* Removed the concept of relevancy from ``LinearState``. The ``ContractState``'s relevancy to the vault can be determined
+  by the flow context, the vault will process any transaction from a flow which is not derived from transaction resolution verification.
 
 Milestone 14
 ------------

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
@@ -3,7 +3,6 @@ package net.corda.docs
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.crypto.TransactionSignature
-import net.corda.core.crypto.containsAny
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
@@ -18,7 +17,6 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.seconds
 import net.corda.core.utilities.unwrap
-import java.security.PublicKey
 
 // Minimal state model of a manual approval process
 @CordaSerializable
@@ -51,10 +49,6 @@ data class TradeApprovalContract(private val blank: Void? = null) : Contract {
 
         val parties: List<Party> get() = listOf(source, counterparty)
         override val participants: List<AbstractParty> get() = parties
-
-        override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return participants.any { it.owningKey.containsAny(ourKeys) }
-        }
     }
 
     /**

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -58,10 +58,6 @@ class ScheduledFlowTests {
         }
 
         override val participants: List<AbstractParty> = listOf(source, destination)
-
-        override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return participants.any { it.owningKey.containsAny(ourKeys) }
-        }
     }
 
     class InsertInitialStateFlow(val destination: Party) : FlowLogic<Unit>() {

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -476,15 +476,18 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
         val service = (services.vaultService as NodeVaultService)
         val amount = Amount(1000, Issued(BOC.ref(1), GBP))
         val wellKnownCash = Cash.State(amount, services.myInfo.legalIdentity)
-        assertTrue { service.isRelevant(wellKnownCash, services.keyManagementService.keys) }
+        val myKeys = services.keyManagementService.filterMyKeys(listOf(wellKnownCash.owner.owningKey))
+        assertTrue { service.isRelevant(wellKnownCash, myKeys.toSet()) }
 
         val anonymousIdentity = services.keyManagementService.freshKeyAndCert(services.myInfo.legalIdentityAndCert, false)
         val anonymousCash = Cash.State(amount, anonymousIdentity.party)
-        assertTrue { service.isRelevant(anonymousCash, services.keyManagementService.keys) }
+        val anonymousKeys = services.keyManagementService.filterMyKeys(listOf(anonymousCash.owner.owningKey))
+        assertTrue { service.isRelevant(anonymousCash, anonymousKeys.toSet()) }
 
         val thirdPartyIdentity = AnonymousParty(generateKeyPair().public)
         val thirdPartyCash = Cash.State(amount, thirdPartyIdentity)
-        assertFalse { service.isRelevant(thirdPartyCash, services.keyManagementService.keys) }
+        val thirdPartyKeys = services.keyManagementService.filterMyKeys(listOf(thirdPartyCash.owner.owningKey))
+        assertFalse { service.isRelevant(thirdPartyCash, thirdPartyKeys.toSet()) }
     }
 
     // TODO: Unit test linear state relevancy checks

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
@@ -618,10 +618,6 @@ class InterestRateSwap : Contract {
         override val participants: List<AbstractParty>
             get() = listOf(fixedLeg.fixedRatePayer, floatingLeg.floatingRatePayer)
 
-        override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return fixedLeg.fixedRatePayer.owningKey.containsAny(ourKeys) || floatingLeg.floatingRatePayer.owningKey.containsAny(ourKeys)
-        }
-
         override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
             val nextFixingOf = nextFixingOf() ?: return null
 

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/IRSState.kt
@@ -22,10 +22,6 @@ data class IRSState(val swap: SwapData,
     val ref: String get() = linearId.externalId!! // Same as the constructor for UniqueIdentified
     override val participants: List<AbstractParty> get() = listOf(buyer, seller)
 
-    override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-        return participants.flatMap { it.owningKey.keys }.intersect(ourKeys).isNotEmpty()
-    }
-
     override fun generateAgreement(notary: Party): TransactionBuilder {
         val state = IRSState(swap, buyer, seller, OGTrade())
         return TransactionBuilder(notary).withItems(state, Command(OGTrade.Commands.Agree(), participants.map { it.owningKey }))

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/contracts/PortfolioState.kt
@@ -37,10 +37,6 @@ data class PortfolioState(val portfolio: List<StateRef>,
         return ScheduledActivity(flow, LocalDate.now().plus(1, ChronoUnit.DAYS).atStartOfDay().toInstant(ZoneOffset.UTC))
     }
 
-    override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-        return participants.flatMap { it.owningKey.keys }.intersect(ourKeys).isNotEmpty()
-    }
-
     override fun generateAgreement(notary: Party): TransactionBuilder {
         return TransactionBuilder(notary).withItems(copy(), Command(PortfolioSwap.Commands.Agree(), participants.map { it.owningKey }))
     }

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyDealContract.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyDealContract.kt
@@ -26,10 +26,6 @@ class DummyDealContract : Contract {
                     participants: List<AbstractParty> = listOf(),
                     ref: String) : this(contract, participants, UniqueIdentifier(ref))
 
-        override fun isRelevant(ourKeys: Set<PublicKey>): Boolean {
-            return participants.any { it.owningKey.containsAny(ourKeys) }
-        }
-
         override fun generateAgreement(notary: Party): TransactionBuilder {
             throw UnsupportedOperationException("not implemented")
         }

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyLinearContract.kt
@@ -39,10 +39,6 @@ class DummyLinearContract : Contract {
             val linearBoolean: Boolean = true,
             val nonce: SecureHash = SecureHash.randomSHA256()) : LinearState, QueryableState {
 
-        override fun isRelevant(ourKeys: Set<java.security.PublicKey>): Boolean {
-            return participants.any { it.owningKey.containsAny(ourKeys) }
-        }
-
         override fun supportedSchemas(): Iterable<MappedSchema> = listOf(DummyLinearStateSchemaV1, DummyLinearStateSchemaV2)
 
         override fun generateMappedObject(schema: MappedSchema): PersistentState {


### PR DESCRIPTION
* added a flag in the config file to allow storing of irrelevant states in the vault.
* added relevancy to CommonQueryCriteria for querying irrelevant states.