### PR TITLE
Fixing trader demo docs. After recent refactoring they've become out …

### DIFF
--- a/docs/source/running-the-demos.rst
+++ b/docs/source/running-the-demos.rst
@@ -41,7 +41,7 @@ To run from the command line in Windows:
 
 1. Run ``gradlew samples:trader-demo:deployNodes`` to create a set of configs and installs under ``samples\trader-demo\build\nodes``
 2. Run ``samples\trader-demo\build\nodes\runnodes`` to open up four new terminals with the four nodes
-3. Run ``gradlew samples:trader-demo:runBuyer`` to instruct the buyer node to request issuance of some cash from the Bank of Corda node
+3. Run ``gradlew samples:trader-demo:runBank`` to instruct the buyer node to request issuance of some cash from the Bank of Corda node
 4. Run ``gradlew samples:trader-demo:runSeller`` to trigger the transaction. If you entered ``flow watch``
 you can see flows running on both sides of transaction. Additionally you should see final trade information displayed
 to your terminal.


### PR DESCRIPTION
Ross, could you double check if this is correct? I've tried to run the trader demo locally and failed following the documentation. I think the reason is this small rename of the gradle task.