### PR TITLE
Make OpaqueBytesSubSequence AMQP serializable

### DIFF
--- a/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
@@ -139,7 +139,10 @@ fun ByteArray.sequence(offset: Int = 0, size: Int = this.size) = ByteSequence.of
 fun ByteArray.toHexString(): String = DatatypeConverter.printHexBinary(this)
 fun String.parseAsHex(): ByteArray = DatatypeConverter.parseHexBinary(this)
 
-private class OpaqueBytesSubSequence(override val bytes: ByteArray, override val offset: Int, override val size: Int) : ByteSequence() {
+/**
+ * Class is public for serialization purposes
+ */
+class OpaqueBytesSubSequence(override val bytes: ByteArray, override val offset: Int, override val size: Int) : ByteSequence() {
     init {
         require(offset >= 0 && offset < bytes.size)
         require(size >= 0 && size <= bytes.size)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AMQPSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AMQPSerializationScheme.kt
@@ -23,6 +23,7 @@ abstract class AbstractAMQPSerializationScheme : SerializationScheme {
                 register(net.corda.nodeapi.internal.serialization.amqp.custom.BigDecimalSerializer)
                 register(net.corda.nodeapi.internal.serialization.amqp.custom.CurrencySerializer)
                 register(net.corda.nodeapi.internal.serialization.amqp.custom.InstantSerializer(this))
+                register(net.corda.nodeapi.internal.serialization.amqp.custom.OpaqueBytesSubSequenceSerializer(this))
             }
         }
     }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/custom/OpaqueBytesSubSequenceSerializer.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/custom/OpaqueBytesSubSequenceSerializer.kt
@@ -1,0 +1,20 @@
+package net.corda.nodeapi.internal.serialization.amqp.custom
+
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.OpaqueBytesSubSequence
+import net.corda.nodeapi.internal.serialization.amqp.CustomSerializer
+import net.corda.nodeapi.internal.serialization.amqp.SerializerFactory
+
+/**
+ * A serializer for [OpaqueBytesSubSequence] that uses a proxy object to write out only content included into sequence
+ * to save on network bandwidth
+ * Uses [OpaqueBytes] as a proxy
+ */
+class OpaqueBytesSubSequenceSerializer(factory: SerializerFactory) :
+        CustomSerializer.Proxy<OpaqueBytesSubSequence, OpaqueBytes>(OpaqueBytesSubSequence::class.java, OpaqueBytes::class.java, factory) {
+    override val additionalSerializers: Iterable<CustomSerializer<out Any>> = emptyList()
+
+    override fun toProxy(obj: OpaqueBytesSubSequence): OpaqueBytes = obj.copy() as OpaqueBytes
+
+    override fun fromProxy(proxy: OpaqueBytes): OpaqueBytesSubSequence = OpaqueBytesSubSequence(proxy.bytes, proxy.offset, proxy.size)
+}


### PR DESCRIPTION
As discussed with @rick-r3 - limit amount of data we sent over the wire in case when OpaqueBytesSubSequence only point to a smaller section of the referenced ByteArray