### PR TITLE
Non-validating notaries can see all inputs

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt
@@ -129,7 +129,7 @@ class PartialMerkleTree(val root: PartialTree) {
      */
     fun verify(merkleRootHash: SecureHash, hashesToCheck: List<SecureHash>): Boolean {
         val usedHashes = ArrayList<SecureHash>()
-        val verifyRoot = verify(root, usedHashes)
+        val verifyRoot = rootAndUsedHashes(root, usedHashes)
         // It means that we obtained more/fewer hashes than needed or different sets of hashes.
         if (hashesToCheck.groupBy { it } != usedHashes.groupBy { it })
             return false
@@ -140,7 +140,7 @@ class PartialMerkleTree(val root: PartialTree) {
      * Recursive calculation of root of this partial tree.
      * Modifies usedHashes to later check for inclusion with hashes provided.
      */
-    private fun verify(node: PartialTree, usedHashes: MutableList<SecureHash>): SecureHash {
+    fun rootAndUsedHashes(node: PartialTree, usedHashes: MutableList<SecureHash>): SecureHash {
         return when (node) {
             is PartialTree.IncludedLeaf -> {
                 usedHashes.add(node.hash)
@@ -148,8 +148,8 @@ class PartialMerkleTree(val root: PartialTree) {
             }
             is PartialTree.Leaf -> node.hash
             is PartialTree.Node -> {
-                val leftHash = verify(node.left, usedHashes)
-                val rightHash = verify(node.right, usedHashes)
+                val leftHash = rootAndUsedHashes(node.left, usedHashes)
+                val rightHash = rootAndUsedHashes(node.right, usedHashes)
                 return leftHash.hashConcat(rightHash)
             }
         }

--- a/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/PartialMerkleTree.kt
@@ -133,7 +133,7 @@ class PartialMerkleTree(val root: PartialTree) {
         // It means that we obtained more/fewer hashes than needed or different sets of hashes.
         // We exclude the special oneHash from calculations, as it's only required for input state full visibility
         // in non-validating notaries. For more info, see TODO in FilteredTransaction.buildMerkleTransaction.
-        if (hashesToCheck.filter { it != SecureHash.oneHash }.groupBy { it } != usedHashes.filter { it != SecureHash.oneHash }.groupBy { it })
+        if (hashesToCheck.groupBy { it } != usedHashes.filter { it != SecureHash.oneHash }.groupBy { it })
             return false
         return (verifyRoot == merkleRootHash)
     }

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -40,6 +40,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
 
         @JvmStatic fun randomSHA256() = sha256(newSecureRandom().generateSeed(32))
         val zeroHash = SecureHash.SHA256(ByteArray(32, { 0.toByte() }))
+        val oneHash = SecureHash.SHA256(ByteArray(32, { 255.toByte() })) // Required for input state visibility purposes. See WireTransaction.fullMerkleTree().
     }
 
     // In future, maybe SHA3, truncated hashes etc.

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -171,8 +171,10 @@ class FilteredTransaction private constructor(
             } else if (!wtx.inputs.isEmpty()) {
                 PartialMerkleTree.build(merkleTree, filteredLeaves.availableComponentHashes)
             } else {
-                // TODO: Consider adding oneHash only when sending to non-validating notaries (but for instance not to Oracles).
-                //      To achieve the above, we might require a new boolean input to this function.
+                // TODO: Consider adding oneHash only when sending to non-validating notaries (but not to Oracles or
+                //      other entities that do not require full input state visibility).
+                //      To achieve the above, we might introduce a new boolean input to this function, to decide
+                //      if oneHash should be included in partial tree build.
                 PartialMerkleTree.build(merkleTree, listOf(SecureHash.oneHash) + filteredLeaves.availableComponentHashes)
             }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -101,7 +101,28 @@ data class WireTransaction(
     /**
      * Builds whole Merkle tree for a transaction.
      */
-    val merkleTree: MerkleTree by lazy { MerkleTree.getMerkleTree(availableComponentHashes) }
+    val merkleTree: MerkleTree by lazy { fullMerkleTree() }
+
+    /**
+     * Builds the input states sub Merkle tree.
+     */
+    val inputsMerkleTree: MerkleTree? by lazy { inputsMerkleTree() }
+
+    private fun fullMerkleTree(): MerkleTree {
+        return if (!inputs.isEmpty()) {
+            MerkleTree.getMerkleTree(availableComponentHashes)
+        } else {
+            MerkleTree.getMerkleTree(listOf(inputsMerkleTree!!.hash) + availableComponentHashes.subList(inputs.size, availableComponentHashes.size))
+        }
+    }
+
+    private fun inputsMerkleTree(): MerkleTree? {
+        return if (!inputs.isEmpty()) {
+            MerkleTree.getMerkleTree(availableComponentHashes.subList(0, inputs.size))
+        } else {
+            null
+        }
+    }
 
     /**
      * Construction of partial transaction from WireTransaction based on filtering.

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -115,11 +115,14 @@ data class WireTransaction(
             // Use the root hash of the inputs sub Merkle Tree as first leaf in the whole Merkle tree.
             MerkleTree.getMerkleTree(listOf(inputsMerkleTree!!.hash) + availableComponentHashes.subList(inputs.size, availableComponentHashes.size))
         } else {
-            MerkleTree.getMerkleTree(availableComponentHashes)
+            // If there are no input states, add the oneHash as the leftmost leaf to avoid a certain security issue,
+            // where one can trick the non-validating notary by hiding all input states.
+            // OneHash was used instead of zeroHash to avoid confusion
+            MerkleTree.getMerkleTree(listOf(SecureHash.oneHash) + availableComponentHashes)
         }
     }
 
-    // Compute the input states sub Merkle Tree, as
+    // Compute the input states sub Merkle Tree.
     private fun inputStatesMerkleTree(): MerkleTree? {
         return if (!inputs.isEmpty()) {
             MerkleTree.getMerkleTree(availableComponentHashes.subList(0, inputs.size))

--- a/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
@@ -203,7 +203,7 @@ class PartialMerkleTreeTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `verify Partial Merkle Tree - too little leaves failure`() {
+    fun `verify Partial Merkle Tree - less leaves failure`() {
         val inclHashes = arrayListOf(hashed[3], hashed[5], hashed[0])
         val pmt = PartialMerkleTree.build(merkleTree, inclHashes)
         inclHashes.remove(hashed[0])
@@ -327,8 +327,6 @@ class PartialMerkleTreeTest : TestDependencyInjectionBase() {
         assertTrue { nonValidatingFilteredTx.verifyAndAllInputsVisible() }
         assertFalse { someInputsFilteredTx.verifyAndAllInputsVisible() }
         assertFalse { oneInputFilteredTx.verifyAndAllInputsVisible() }
-        // TODO: the test below fails because you can trick the notary to believe there are no inputs at all.
-        //      Consider always using a Zero Hash as the first leaf.
-        // assertFalse { noInputsFilteredTx.verifyAndAllInputsVisible() }
+        assertFalse { noInputsFilteredTx.verifyAndAllInputsVisible() }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -23,7 +23,7 @@ class NonValidatingNotaryFlow(otherSide: Party, service: TrustedAuthorityNotaryS
         val parts = receive<Any>(otherSide).unwrap {
             when (it) {
                 is FilteredTransaction -> {
-                    it.verify()
+                    it.verifyAndAllInputsVisible()
                     TransactionParts(it.rootHash, it.filteredLeaves.inputs, it.filteredLeaves.timeWindow)
                 }
                 is NotaryChangeWireTransaction -> TransactionParts(it.id, it.inputs, null)


### PR DESCRIPTION
In order to make sure non-validating notaries can verify they see all inputs, a model with a sub Merkle tree for inputs states is implemented. There was a security issue to be handled, according to which one could hide all inputs from a filtered tx, and thus the sub Merkle tree was not enough (actually not visible at all). To circumvent the aforementioned problem, we always set the leftmost leaf in the Merkle tree to be `oneHash` (similar to `zeroHash`, but all bits are set to one) if no input states exist in the wtx.
![inputssubmerkletree](https://user-images.githubusercontent.com/25659162/29608526-4dcfdf6e-87ec-11e7-8790-f4d2ec06d83d.jpg)

Here is a visual partial tree representation for a filtered tx sent to a non-validating notary.
![non-validatingnotariesseeallinputs](https://user-images.githubusercontent.com/25659162/29608948-94b5d590-87ed-11e7-9a2c-362b30be6ddf.jpeg)

Bare in mind that the sub Merkle tree model has been selected between 3 candidate approaches, after various discussions as the most elegant solution:
[AWG-Numberofinputsvisibletonon-validatingnotaries-230817-1020.pdf](https://github.com/corda/corda/files/1244840/AWG-Numberofinputsvisibletonon-validatingnotaries-230817-1020.pdf)
