### PR TITLE
Introduced a property to be able to enable AMQP mode from command line for Gradle run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,11 @@ allprojects {
     tasks.withType(Test) {
         // Prevent the project from creating temporary files outside of the build directory.
         systemProperties['java.io.tmpdir'] = buildDir
+
+        // Ensures that "net.corda.testing.amqp.enable" is passed correctly from Gradle command line
+        // down to JVM executing unit test. It looks like we are running unit tests in the forked mode
+        // and all the "-D" parameters passed to Gradle not making it to unit test level
+        systemProperty("net.corda.testing.amqp.enable", System.getProperty("net.corda.testing.amqp.enable"))
     }
 
     group 'net.corda'

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,9 @@ allprojects {
         // Ensures that "net.corda.testing.amqp.enable" is passed correctly from Gradle command line
         // down to JVM executing unit test. It looks like we are running unit tests in the forked mode
         // and all the "-D" parameters passed to Gradle not making it to unit test level
-        systemProperty("net.corda.testing.amqp.enable", System.getProperty("net.corda.testing.amqp.enable"))
+        // TODO: Remove once we fully switched to AMQP
+        final AMQP_ENABLE_PROP_NAME = "net.corda.testing.amqp.enable"
+        systemProperty(AMQP_ENABLE_PROP_NAME, System.getProperty(AMQP_ENABLE_PROP_NAME))
     }
 
     group 'net.corda'

--- a/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
@@ -66,7 +66,10 @@ fun initialiseTestSerialization() {
         registerScheme(AMQPClientSerializationScheme())
         registerScheme(AMQPServerSerializationScheme())
     }
-    (SerializationDefaults.P2P_CONTEXT as TestSerializationContext).delegate = if (java.lang.Boolean.getBoolean("net.corda.testing.amqp.enable")) {
+
+    val AMQP_ENABLE_PROP_NAME = "net.corda.testing.amqp.enable"
+    // TODO: Remove these "if" conditions once we fully switched to AMQP
+    (SerializationDefaults.P2P_CONTEXT as TestSerializationContext).delegate = if (java.lang.Boolean.getBoolean(AMQP_ENABLE_PROP_NAME)) {
         AMQP_P2P_CONTEXT
     } else {
         KRYO_P2P_CONTEXT

--- a/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
@@ -66,7 +66,11 @@ fun initialiseTestSerialization() {
         registerScheme(AMQPClientSerializationScheme())
         registerScheme(AMQPServerSerializationScheme())
     }
-    (SerializationDefaults.P2P_CONTEXT as TestSerializationContext).delegate = KRYO_P2P_CONTEXT
+    (SerializationDefaults.P2P_CONTEXT as TestSerializationContext).delegate = if (java.lang.Boolean.getBoolean("net.corda.testing.amqp.enable")) {
+        AMQP_P2P_CONTEXT
+    } else {
+        KRYO_P2P_CONTEXT
+    }
     (SerializationDefaults.RPC_SERVER_CONTEXT as TestSerializationContext).delegate = KRYO_RPC_SERVER_CONTEXT
     (SerializationDefaults.RPC_CLIENT_CONTEXT as TestSerializationContext).delegate = KRYO_RPC_CLIENT_CONTEXT
     (SerializationDefaults.STORAGE_CONTEXT as TestSerializationContext).delegate = KRYO_STORAGE_CONTEXT


### PR DESCRIPTION
This can be useful if we decide to create a custom TeamCity configuration that will enable us to independently run *all* tests in AMQP mode to know where we stand.

I have tested that it runs locally from root of Git repo using the following command:
`gradlew -Dnet.corda.testing.amqp.enable=true clean build`