### PR TITLE
Fixing demobench freeze on terminal command 'bye'

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -113,11 +113,16 @@ class RPCClient<I : RPCOps>(
 
         /**
          * Closes this client without notifying the server.
+         * The server will eventually clear out the RPC message queue and disconnect subscribed observers,
+         * but this may take longer than desired, so to conserve resources you should normally use [notifyServerAndClose].
+         * This method is helpful when the node may be shutting down or
+         * have already shut down and you don't want to block waiting for it to come back.
          */
         fun forceClose()
 
         /**
-         * Closes this client gracefully by sending a notification to the server.
+         * Closes this client gracefully by sending a notification to the server, so it can immediately clean up resources.
+         * If the server is not available this method may block for a short period until it's clear the server is not coming back.
          */
         fun notifyServerAndClose()
     }

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -110,6 +110,8 @@ class RPCClient<I : RPCOps>(
         val proxy: I
         /** The RPC protocol version reported by the server */
         val serverProtocolVersion: Int
+
+        fun close(gracefully: Boolean = true)
     }
 
     /**
@@ -168,9 +170,13 @@ class RPCClient<I : RPCOps>(
                 object : RPCConnection<I> {
                     override val proxy = ops
                     override val serverProtocolVersion = serverProtocolVersion
-                    override fun close() {
-                        proxyHandler.close()
+                    override fun close(gracefully: Boolean) {
+                        proxyHandler.close(gracefully)
                         serverLocator.close()
+                    }
+
+                    override fun close() {
+                        close(true)
                     }
                 }
             } catch (exception: Throwable) {

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -272,13 +272,17 @@ class RPCClientProxyHandler(
 
     /**
      * Closes this handler without notifying observables.
+     * This method clears up only local resources and as such does not block on any network resources.
      */
     fun forceClose() {
         close(false)
     }
 
     /**
-     * Closes this handler and sends notifications to all observables.
+     * Closes this handler and sends notifications to all observables, so it can immediately clean up resources.
+     * Notifications sent to observables are to be acknowledged, therefore this call blocks until all acknowledgements are received.
+     * If this is not convenient see the [forceClose] method.
+     * If an observable is not accessible this method may block for a duration of the message broker timeout.
      */
     fun notifyServerAndClose() {
         close(true)
@@ -286,6 +290,9 @@ class RPCClientProxyHandler(
 
     /**
      * Closes the RPC proxy. Reaps all observables, shuts down the reaper, closes all sessions and executors.
+     * When observables are to be notified (i.e. the [notify] parameter is true),
+     * the method blocks until all the messages are acknowledged by the observables.
+     * Note: If any of the observables is inaccessible, the method blocks for the duration of the timeout set on the message broker.
      *
      * @param notify whether to notify observables or not.
      */

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -271,13 +271,29 @@ class RPCClientProxyHandler(
     }
 
     /**
-     * Closes the RPC proxy. Reaps all observables, shuts down the reaper, closes all sessions and executors.
+     * Closes this handler without notifying observables.
      */
-    fun close(gracefully: Boolean = true) {
+    fun forceClose() {
+        close(false)
+    }
+
+    /**
+     * Closes this handler and sends notifications to all observables.
+     */
+    fun notifyServerAndClose() {
+        close(true)
+    }
+
+    /**
+     * Closes the RPC proxy. Reaps all observables, shuts down the reaper, closes all sessions and executors.
+     *
+     * @param notify whether to notify observables or not.
+     */
+    private fun close(notify: Boolean = true) {
         sessionAndConsumer?.sessionFactory?.close()
         reaperScheduledFuture?.cancel(false)
         observableContext.observableMap.invalidateAll()
-        reapObservables(gracefully)
+        reapObservables(notify)
         reaperExecutor?.shutdownNow()
         sessionAndProducerPool.close().forEach {
             it.sessionFactory.close()

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
@@ -58,8 +58,6 @@ class R3Pty(val name: X500Name, settings: SettingsProvider, dimension: Dimension
         executor.submit {
             val exitValue = connector.waitFor()
             log.info("Terminal has exited (value={})", exitValue)
-            // TODO: Remove this arbitrary sleep when https://github.com/corda/corda/issues/689 is fixed.
-            try { Thread.sleep(SECONDS.toMillis(2)) } catch (e: InterruptedException) {}
             onExit(exitValue)
         }
 

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
@@ -54,7 +54,7 @@ class NodeRPC(config: NodeConfig, start: (NodeConfig, CordaRPCOps) -> Unit, invo
     override fun close() {
         timer.cancel()
         try {
-            rpcConnection?.close(false)
+            rpcConnection?.forceClose()
         } catch (e: Exception) {
             log.error("Failed to close RPC connection (Error: {})", e.message)
         }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/rpc/NodeRPC.kt
@@ -54,7 +54,7 @@ class NodeRPC(config: NodeConfig, start: (NodeConfig, CordaRPCOps) -> Unit, invo
     override fun close() {
         timer.cancel()
         try {
-            rpcConnection?.close()
+            rpcConnection?.close(false)
         } catch (e: Exception) {
             log.error("Failed to close RPC connection (Error: {})", e.message)
         }


### PR DESCRIPTION
This fixes the demobench UI freeze issue.
The proposed solution is to extend the `close` function (on the `RPCConnection` and `RPCClientProxyHandler`) with a possibility to choose either to notify the counterparty via the AMQP messaging or to skip this step. Previously, the close function was always notifying the counterpart. This caused accessing the Artemis message queue (in order to send the `close` message), which was unable to deliver the message to the other side. The timeout for this process was blocking the UI. 
As a remedy an overload for the aforementioned `close` function has been added and from the DemoBench project it is called with a parameter requesting the skipping of the counterpart notification.

