### PR TITLE
Restructure concurrent packages

### DIFF
--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -3,8 +3,8 @@
 package net.corda.core
 
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.concurrent.openFuture
+import net.corda.core.concurrent.thenMatch
 import rx.Observable
 import rx.Observer
 

--- a/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt
@@ -1,8 +1,8 @@
+@file:JvmName("ConcurrencyUtils")
 package net.corda.core.concurrent
 
-import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.utilities.getOrThrow
 import net.corda.core.internal.VisibleForTesting
+import net.corda.core.utilities.getOrThrow
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.Future

--- a/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureImpl.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureImpl.kt
@@ -1,0 +1,45 @@
+package net.corda.core.concurrent
+
+import net.corda.core.internal.VisibleForTesting
+import net.corda.core.concurrent.CordaFuture
+import net.corda.core.concurrent.match
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.loggerFor
+import org.slf4j.Logger
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
+/** Unless you really want this particular implementation, use [openFuture] to make one. */
+@VisibleForTesting
+internal class CordaFutureImpl<V>(private val impl: CompletableFuture<V> = CompletableFuture()) : Future<V> by impl, OpenFuture<V> {
+    companion object {
+        private val defaultLog = loggerFor<CordaFutureImpl<*>>()
+        internal val listenerFailedMessage = "Future listener failed:"
+    }
+
+    override fun set(value: V) = impl.complete(value)
+    override fun setException(t: Throwable) = impl.completeExceptionally(t)
+    override fun <W> then(callback: (CordaFuture<V>) -> W) = thenImpl(defaultLog, callback)
+    /** For testing only. */
+    internal fun <W> thenImpl(log: Logger, callback: (CordaFuture<V>) -> W) {
+        impl.whenComplete { _, _ ->
+            try {
+                callback(this)
+            } catch (t: Throwable) {
+                log.error(listenerFailedMessage, t)
+            }
+        }
+    }
+
+    // We don't simply return impl so that the caller can't interfere with it.
+    override fun toCompletableFuture() = CompletableFuture<V>().also { completable ->
+        thenMatch({
+            completable.complete(it)
+        }, {
+            completable.completeExceptionally(it)
+        })
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureImpl.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureImpl.kt
@@ -1,16 +1,10 @@
 package net.corda.core.concurrent
 
 import net.corda.core.internal.VisibleForTesting
-import net.corda.core.concurrent.CordaFuture
-import net.corda.core.concurrent.match
-import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
 import org.slf4j.Logger
-import java.time.Duration
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executor
 import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
 
 /** Unless you really want this particular implementation, use [openFuture] to make one. */
 @VisibleForTesting

--- a/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureUtils.kt
@@ -83,25 +83,4 @@ fun <V> Collection<CordaFuture<out V>>.transpose(): CordaFuture<List<V>> {
     return transpose
 }
 
-/** The contravariant members of [OpenFuture]. */
-interface ValueOrException<in V> {
-    /** @return whether this future actually changed. */
-    fun set(value: V): Boolean
-
-    /** @return whether this future actually changed. */
-    fun setException(t: Throwable): Boolean
-
-    /** When the given future has an outcome, make this future have the same outcome. */
-    fun captureLater(f: CordaFuture<out V>) = f.then { capture { f.getOrThrow() } }
-
-    /** Run the given block (in the foreground) and set this future to its outcome. */
-    fun capture(block: () -> V): Boolean {
-        return set(try {
-            block()
-        } catch (t: Throwable) {
-            return setException(t)
-        })
-    }
-}
-
 internal fun <V> Future<V>.get(timeout: Duration? = null): V = if (timeout == null) get() else get(timeout.toNanos(), TimeUnit.NANOSECONDS)

--- a/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureUtils.kt
@@ -1,4 +1,5 @@
-package net.corda.core.internal.concurrent
+@file:JvmName("CordaFutureUtils")
+package net.corda.core.concurrent
 
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.concurrent.CordaFuture
@@ -110,37 +111,5 @@ interface ValueOrException<in V> {
 
 /** A [CordaFuture] with additional methods to complete it with a value, exception or the outcome of another future. */
 interface OpenFuture<V> : ValueOrException<V>, CordaFuture<V>
-
-/** Unless you really want this particular implementation, use [openFuture] to make one. */
-@VisibleForTesting
-internal class CordaFutureImpl<V>(private val impl: CompletableFuture<V> = CompletableFuture()) : Future<V> by impl, OpenFuture<V> {
-    companion object {
-        private val defaultLog = loggerFor<CordaFutureImpl<*>>()
-        internal val listenerFailedMessage = "Future listener failed:"
-    }
-
-    override fun set(value: V) = impl.complete(value)
-    override fun setException(t: Throwable) = impl.completeExceptionally(t)
-    override fun <W> then(callback: (CordaFuture<V>) -> W) = thenImpl(defaultLog, callback)
-    /** For testing only. */
-    internal fun <W> thenImpl(log: Logger, callback: (CordaFuture<V>) -> W) {
-        impl.whenComplete { _, _ ->
-            try {
-                callback(this)
-            } catch (t: Throwable) {
-                log.error(listenerFailedMessage, t)
-            }
-        }
-    }
-
-    // We don't simply return impl so that the caller can't interfere with it.
-    override fun toCompletableFuture() = CompletableFuture<V>().also { completable ->
-        thenMatch({
-            completable.complete(it)
-        }, {
-            completable.completeExceptionally(it)
-        })
-    }
-}
 
 internal fun <V> Future<V>.get(timeout: Duration? = null): V = if (timeout == null) get() else get(timeout.toNanos(), TimeUnit.NANOSECONDS)

--- a/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/CordaFutureUtils.kt
@@ -1,14 +1,9 @@
 @file:JvmName("CordaFutureUtils")
 package net.corda.core.concurrent
 
-import net.corda.core.internal.VisibleForTesting
-import net.corda.core.concurrent.CordaFuture
-import net.corda.core.concurrent.match
 import net.corda.core.utilities.getOrThrow
-import net.corda.core.utilities.loggerFor
 import org.slf4j.Logger
 import java.time.Duration
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -108,8 +103,5 @@ interface ValueOrException<in V> {
         })
     }
 }
-
-/** A [CordaFuture] with additional methods to complete it with a value, exception or the outcome of another future. */
-interface OpenFuture<V> : ValueOrException<V>, CordaFuture<V>
 
 internal fun <V> Future<V>.get(timeout: Duration? = null): V = if (timeout == null) get() else get(timeout.toNanos(), TimeUnit.NANOSECONDS)

--- a/core/src/main/kotlin/net/corda/core/concurrent/OpenFuture.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/OpenFuture.kt
@@ -1,4 +1,27 @@
 package net.corda.core.concurrent
 
-/** A [CordaFuture] with additional methods to complete it with a value, exception or the outcome of another future. */
-interface OpenFuture<V> : ValueOrException<V>, CordaFuture<V>
+import net.corda.core.utilities.getOrThrow
+
+/** A future with additional methods to complete it with a value, exception or the outcome of another future. This
+ * is separate to [CordaFuture] such that under normal usage futures cannot be set where they're meant to be used as
+ * read-only.
+ */
+interface OpenFuture<V> : CordaFuture<V> {
+    /** @return whether this future actually changed. */
+    fun set(value: V): Boolean
+
+    /** @return whether this future actually changed. */
+    fun setException(t: Throwable): Boolean
+
+    /** When the given future has an outcome, make this future have the same outcome. */
+    fun captureLater(f: CordaFuture<out V>) = f.then { capture { f.getOrThrow() } }
+
+    /** Run the given block (in the foreground) and set this future to its outcome. */
+    fun capture(block: () -> V): Boolean {
+        return set(try {
+            block()
+        } catch (t: Throwable) {
+            return setException(t)
+        })
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/concurrent/OpenFuture.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/OpenFuture.kt
@@ -1,0 +1,4 @@
+package net.corda.core.concurrent
+
+/** A [CordaFuture] with additional methods to complete it with a value, exception or the outcome of another future. */
+interface OpenFuture<V> : ValueOrException<V>, CordaFuture<V>

--- a/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
@@ -1,6 +1,6 @@
 package net.corda.core.utilities
 
-import net.corda.core.internal.concurrent.get
+import net.corda.core.concurrent.get
 import net.corda.core.serialization.CordaSerializable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/core/src/test/java/net/corda/core/concurrent/CordaFutureInJavaTest.java
+++ b/core/src/test/java/net/corda/core/concurrent/CordaFutureInJavaTest.java
@@ -1,6 +1,6 @@
 package net.corda.core.concurrent;
 
-import net.corda.core.internal.concurrent.OpenFuture;
+import net.corda.core.concurrent.OpenFuture;
 import org.junit.Test;
 
 import java.io.EOFException;

--- a/core/src/test/java/net/corda/core/concurrent/CordaFutureInJavaTest.java
+++ b/core/src/test/java/net/corda/core/concurrent/CordaFutureInJavaTest.java
@@ -1,6 +1,5 @@
 package net.corda.core.concurrent;
 
-import net.corda.core.concurrent.OpenFuture;
 import org.junit.Test;
 
 import java.io.EOFException;
@@ -10,8 +9,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static net.corda.core.internal.concurrent.CordaFutureImplKt.doneFuture;
-import static net.corda.core.internal.concurrent.CordaFutureImplKt.openFuture;
+import static net.corda.core.concurrent.CordaFutureUtils.doneFuture;
+import static net.corda.core.concurrent.CordaFutureUtils.openFuture;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt
@@ -1,7 +1,7 @@
 package net.corda.core.concurrent
 
 import com.nhaarman.mockito_kotlin.*
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.utilities.getOrThrow
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test

--- a/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
@@ -6,7 +6,7 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.concurrent.transpose
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.ALICE

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import com.google.common.base.Stopwatch
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.concurrent.transpose
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.OpaqueBytes

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -8,8 +8,8 @@ import net.corda.testing.DUMMY_BANK_A
 import net.corda.core.flows.NotaryError
 import net.corda.core.flows.NotaryException
 import net.corda.core.flows.NotaryFlow
-import net.corda.core.internal.concurrent.map
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.concurrent.map
+import net.corda.core.concurrent.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.node.internal.AbstractNode

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.concurrent.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
 import net.corda.testing.ALICE

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
@@ -2,7 +2,7 @@ package net.corda.services.messaging
 
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.concurrent.transpose
 import net.corda.core.internal.elapsedTime
 import net.corda.core.internal.times
 import net.corda.core.messaging.MessageRecipients

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -13,8 +13,8 @@ import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.*
-import net.corda.core.internal.concurrent.flatMap
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.flatMap
+import net.corda.core.concurrent.openFuture
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.RPCOps
 import net.corda.core.messaging.SingleMessageRecipient

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -1,12 +1,8 @@
 package net.corda.node.internal
 
 import com.codahale.metrics.JmxReporter
-import net.corda.core.concurrent.CordaFuture
+import net.corda.core.concurrent.*
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.concurrent.flatMap
-import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.messaging.RPCOps
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.ServiceInfo

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -5,7 +5,7 @@ import com.typesafe.config.ConfigException
 import joptsimple.OptionException
 import net.corda.core.crypto.commonName
 import net.corda.core.crypto.orgName
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.concurrent.thenMatch
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.internal.*

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -8,7 +8,7 @@ import net.corda.core.crypto.newSecureRandom
 import net.corda.core.crypto.parsePublicKeyBase58
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.ThreadBox
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.internal.div
 import net.corda.core.internal.noneOrSingle
 import net.corda.core.internal.toX509CertHolder

--- a/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
@@ -2,7 +2,7 @@ package net.corda.node.services.messaging
 
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.services.PartyInfo

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
@@ -2,8 +2,8 @@ package net.corda.node.services.messaging
 
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.andForget
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.concurrent.andForget
+import net.corda.core.concurrent.thenMatch
 import net.corda.core.internal.ThreadBox
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.MessageRecipients

--- a/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/InMemoryNetworkMapCache.kt
@@ -5,8 +5,8 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.internal.concurrent.map
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.map
+import net.corda.core.concurrent.openFuture
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -11,8 +11,8 @@ import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.abbreviate
-import net.corda.core.internal.concurrent.OpenFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.OpenFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.internal.staticField
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.*

--- a/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.transactions
 
 import com.google.common.util.concurrent.MoreExecutors
-import net.corda.core.internal.concurrent.fork
+import net.corda.core.concurrent.fork
 import net.corda.core.node.services.TransactionVerifierService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.LedgerTransaction

--- a/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt
@@ -6,8 +6,8 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.SecureHash
 import net.corda.core.node.services.TransactionVerifierService
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.OpenFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.OpenFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.loggerFor

--- a/node/src/main/kotlin/net/corda/node/shell/FlowWatchPrintingSubscriber.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/FlowWatchPrintingSubscriber.kt
@@ -3,7 +3,7 @@ package net.corda.node.shell
 import net.corda.core.crypto.commonName
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.StateMachineRunId
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.StateMachineUpdate.Added
 import net.corda.core.messaging.StateMachineUpdate.Removed

--- a/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
@@ -12,8 +12,8 @@ import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
 import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.concurrent.OpenFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.OpenFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.internal.write

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -12,7 +12,7 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.concurrent.map
+import net.corda.core.concurrent.map
 import net.corda.core.internal.rootCause
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.SingleMessageRecipient

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -3,8 +3,8 @@ package net.corda.node.services.messaging
 import com.codahale.metrics.MetricRegistry
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.doneFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.services.RPCUserService

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -10,8 +10,8 @@ import net.corda.core.crypto.generateKeyPair
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.internal.concurrent.flatMap
-import net.corda.core.internal.concurrent.map
+import net.corda.core.concurrent.flatMap
+import net.corda.core.concurrent.map
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.node.services.PartyInfo
 import net.corda.core.node.services.ServiceInfo

--- a/test-utils/src/main/kotlin/net/corda/testing/RPCDriver.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/RPCDriver.kt
@@ -9,8 +9,8 @@ import net.corda.client.rpc.internal.RPCClient
 import net.corda.client.rpc.internal.RPCClientConfiguration
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.fork
-import net.corda.core.internal.concurrent.map
+import net.corda.core.concurrent.fork
+import net.corda.core.concurrent.map
 import net.corda.core.internal.div
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.NetworkHostAndPort

--- a/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
@@ -9,7 +9,7 @@ import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.concurrent.transpose
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.services.ServiceInfo
 import net.corda.node.services.transactions.ValidatingNotaryService

--- a/test-utils/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -16,7 +16,7 @@ import net.corda.core.crypto.commonName
 import net.corda.core.crypto.getX509Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.ThreadBox
-import net.corda.core.internal.concurrent.*
+import net.corda.core.concurrent.*
 import net.corda.core.internal.div
 import net.corda.core.internal.times
 import net.corda.core.messaging.CordaRPCOps

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -8,7 +8,7 @@ import net.corda.core.crypto.cert
 import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.concurrent.doneFuture
+import net.corda.core.concurrent.doneFuture
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.createDirectory
 import net.corda.core.messaging.MessageRecipients

--- a/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -1,13 +1,9 @@
 package net.corda.testing.node
 
-import net.corda.core.concurrent.CordaFuture
+import net.corda.core.concurrent.*
 import net.corda.core.crypto.appendToCommonName
 import net.corda.core.crypto.commonName
 import net.corda.core.crypto.getX509Name
-import net.corda.core.internal.concurrent.flatMap
-import net.corda.core.internal.concurrent.fork
-import net.corda.core.internal.concurrent.map
-import net.corda.core.internal.concurrent.transpose
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.node.services.ServiceInfo

--- a/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
@@ -3,7 +3,7 @@ package net.corda.testing.node
 import com.codahale.metrics.MetricRegistry
 import net.corda.core.crypto.commonName
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.concurrent.openFuture
 import net.corda.core.messaging.RPCOps
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -2,10 +2,9 @@ package net.corda.verifier
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import net.corda.core.concurrent.CordaFuture
+import net.corda.core.concurrent.*
 import net.corda.core.crypto.commonName
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.*
 import net.corda.core.internal.div
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.NetworkHostAndPort

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
@@ -1,8 +1,8 @@
 package net.corda.verifier
 
 import net.corda.client.mock.generateOrFail
-import net.corda.core.internal.concurrent.map
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.concurrent.map
+import net.corda.core.concurrent.transpose
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.transactions.LedgerTransaction


### PR DESCRIPTION
Restructure concurrent packages to make it easier to find classes; this does mean the implementation class is visible, however I don't think this is likely to be an issue.

Add Java class names to Kotlin functions to make resulting classes more sensibly named, and remove merge ValueOrException into OpenFuture.


