### PR TITLE
Move flows into net.corda.core.node.flows package

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/flows/BroadcastTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/BroadcastTransactionFlow.kt
@@ -1,6 +1,8 @@
-package net.corda.core.flows
+package net.corda.core.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.NonEmptySet

--- a/core/src/main/kotlin/net/corda/core/node/flows/DataVendingFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/DataVendingFlow.kt
@@ -1,35 +1,11 @@
-package net.corda.core.flows
+package net.corda.core.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.StateAndRef
 import net.corda.core.identity.Party
 import net.corda.core.internal.FetchDataFlow
-import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
 
-/**
- * The [SendTransactionFlow] should be used to send a transaction to another peer that wishes to verify that transaction's
- * integrity by resolving and checking the dependencies as well. The other side should invoke [ReceiveTransactionFlow] at
- * the right point in the conversation to receive the sent transaction and perform the resolution back-and-forth required
- * to check the dependencies and download any missing attachments.
- *
- * @param otherSide the target party.
- * @param stx the [SignedTransaction] being sent to the [otherSide].
- */
-open class SendTransactionFlow(otherSide: Party, stx: SignedTransaction) : DataVendingFlow(otherSide, stx)
-
-/**
- * The [SendStateAndRefFlow] should be used to send a list of input [StateAndRef] to another peer that wishes to verify
- * the input's integrity by resolving and checking the dependencies as well. The other side should invoke [ReceiveStateAndRefFlow]
- * at the right point in the conversation to receive the input state and ref and perform the resolution back-and-forth
- * required to check the dependencies.
- *
- * @param otherSide the target party.
- * @param stateAndRefs the list of [StateAndRef] being sent to the [otherSide].
- */
-open class SendStateAndRefFlow(otherSide: Party, stateAndRefs: List<StateAndRef<*>>) : DataVendingFlow(otherSide, stateAndRefs)
-
-sealed class DataVendingFlow(val otherSide: Party, val payload: Any) : FlowLogic<Void?>() {
+open class DataVendingFlow(val otherSide: Party, val payload: Any) : net.corda.core.flows.FlowLogic<Void?>() {
     @Suspendable
     protected open fun sendPayloadAndReceiveDataRequest(otherSide: Party, payload: Any) = sendAndReceive<FetchDataFlow.Request>(otherSide, payload)
 

--- a/core/src/main/kotlin/net/corda/core/node/flows/DataVendingFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/DataVendingFlow.kt
@@ -2,7 +2,6 @@ package net.corda.core.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.identity.Party
-import net.corda.core.internal.FetchDataFlow
 import net.corda.core.utilities.unwrap
 
 open class DataVendingFlow(val otherSide: Party, val payload: Any) : net.corda.core.flows.FlowLogic<Void?>() {

--- a/core/src/main/kotlin/net/corda/core/node/flows/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/FetchDataFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.core.internal
+package net.corda.core.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.AbstractAttachment
@@ -9,8 +9,8 @@ import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.internal.FetchDataFlow.DownloadedVsRequestedDataMismatch
-import net.corda.core.internal.FetchDataFlow.HashNotFound
+import net.corda.core.node.flows.FetchDataFlow.DownloadedVsRequestedDataMismatch
+import net.corda.core.node.flows.FetchDataFlow.HashNotFound
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationToken
 import net.corda.core.serialization.SerializeAsToken

--- a/core/src/main/kotlin/net/corda/core/node/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/FinalityFlow.kt
@@ -7,7 +7,6 @@ import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker

--- a/core/src/main/kotlin/net/corda/core/node/flows/ManualFinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/ManualFinalityFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.core.flows
+package net.corda.core.node.flows
 
 import net.corda.core.identity.Party
 import net.corda.core.transactions.LedgerTransaction
@@ -13,8 +13,8 @@ import net.corda.core.utilities.ProgressTracker
  * @param extraRecipients A list of additional participants to inform of the transaction.
  */
 class ManualFinalityFlow(transactions: Iterable<SignedTransaction>,
-                   recipients: Set<Party>,
-                   progressTracker: ProgressTracker) : FinalityFlow(transactions, recipients, progressTracker) {
-    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(listOf(transaction), extraParticipants, tracker())
-    override fun lookupParties(ltx: LedgerTransaction): Set<Participant> = emptySet()
+                         recipients: Set<Party>,
+                         progressTracker: ProgressTracker) : FinalityFlow(transactions, recipients, progressTracker) {
+    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(listOf(transaction), extraParticipants, FinalityFlow.Companion.tracker())
+    override fun lookupParties(ltx: LedgerTransaction): Set<FinalityFlow.Participant> = emptySet()
 }

--- a/core/src/main/kotlin/net/corda/core/node/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/NotaryFlow.kt
@@ -11,7 +11,6 @@ import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
-import net.corda.core.internal.FetchDataFlow
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.serialization.CordaSerializable

--- a/core/src/main/kotlin/net/corda/core/node/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/NotaryFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.core.flows
+package net.corda.core.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.StateRef
@@ -7,16 +7,17 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.keys
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
 import net.corda.core.internal.FetchDataFlow
-import net.corda.core.node.services.NotaryService
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
-import java.security.SignatureException
 import java.util.function.Predicate
 
 object NotaryFlow {
@@ -33,7 +34,7 @@ object NotaryFlow {
     @InitiatingFlow
     open class Client(private val stx: SignedTransaction,
                       override val progressTracker: ProgressTracker) : FlowLogic<List<TransactionSignature>>() {
-        constructor(stx: SignedTransaction) : this(stx, tracker())
+        constructor(stx: SignedTransaction) : this(stx, NotaryFlow.Client.Companion.tracker())
 
         companion object {
             object REQUESTING : ProgressTracker.Step("Requesting signature by Notary service")
@@ -47,7 +48,7 @@ object NotaryFlow {
         @Suspendable
         @Throws(NotaryException::class)
         override fun call(): List<TransactionSignature> {
-            progressTracker.currentStep = REQUESTING
+            progressTracker.currentStep = NotaryFlow.Client.Companion.REQUESTING
 
             notaryParty = stx.notary ?: throw IllegalStateException("Transaction does not specify a Notary")
             check(stx.inputs.all { stateRef -> serviceHub.loadState(stateRef).notary == notaryParty }) {
@@ -60,7 +61,7 @@ object NotaryFlow {
                 } else {
                     stx.verifySignaturesExcept(notaryParty.owningKey)
                 }
-            } catch (ex: SignatureException) {
+            } catch (ex: java.security.SignatureException) {
                 throw NotaryException(NotaryError.TransactionInvalid(ex))
             }
 

--- a/core/src/main/kotlin/net/corda/core/node/flows/ReceiveStateAndRefFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/ReceiveStateAndRefFlow.kt
@@ -1,0 +1,27 @@
+package net.corda.core.node.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.Party
+import net.corda.core.internal.ResolveTransactionsFlow
+import net.corda.core.utilities.unwrap
+
+/**
+ * The [ReceiveStateAndRefFlow] should be called in response to the [SendStateAndRefFlow].
+ *
+ * This flow is a combination of [receive] and resolve. This flow will receive a list of [StateAndRef]
+ * and perform the resolution back-and-forth required to check the dependencies.
+ * The flow will return the list of [StateAndRef] after it is resolved.
+ */
+// @JvmSuppressWildcards is used to suppress wildcards in return type when calling `subFlow(new ReceiveStateAndRef<T>(otherParty))` in java.
+class ReceiveStateAndRefFlow<out T : ContractState>(private val otherParty: Party) : FlowLogic<@JvmSuppressWildcards List<StateAndRef<T>>>() {
+    @Suspendable
+    override fun call(): List<StateAndRef<T>> {
+        return receive<List<StateAndRef<T>>>(otherParty).unwrap {
+            subFlow(ResolveTransactionsFlow(it.map { it.ref.txhash }.toSet(), otherParty))
+            it
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/node/flows/ReceiveStateAndRefFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/ReceiveStateAndRefFlow.kt
@@ -5,7 +5,6 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.utilities.unwrap
 
 /**

--- a/core/src/main/kotlin/net/corda/core/node/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/ReceiveTransactionFlow.kt
@@ -1,9 +1,11 @@
-package net.corda.core.flows
+package net.corda.core.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.*
+import net.corda.core.contracts.AttachmentResolutionException
+import net.corda.core.contracts.TransactionResolutionException
+import net.corda.core.contracts.TransactionVerificationException
+import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
 import java.security.SignatureException
@@ -22,27 +24,10 @@ constructor(private val otherParty: Party, private val checkSufficientSignatures
     @Throws(SignatureException::class, AttachmentResolutionException::class, TransactionResolutionException::class, TransactionVerificationException::class)
     override fun call(): SignedTransaction {
         return receive<SignedTransaction>(otherParty).unwrap {
-            subFlow(ResolveTransactionsFlow(it, otherParty))
+            subFlow(net.corda.core.internal.ResolveTransactionsFlow(it, otherParty))
             it.verify(serviceHub, checkSufficientSignatures)
             it
         }
     }
 }
 
-/**
- * The [ReceiveStateAndRefFlow] should be called in response to the [SendStateAndRefFlow].
- *
- * This flow is a combination of [receive] and resolve. This flow will receive a list of [StateAndRef]
- * and perform the resolution back-and-forth required to check the dependencies.
- * The flow will return the list of [StateAndRef] after it is resolved.
- */
-// @JvmSuppressWildcards is used to suppress wildcards in return type when calling `subFlow(new ReceiveStateAndRef<T>(otherParty))` in java.
-class ReceiveStateAndRefFlow<out T : ContractState>(private val otherParty: Party) : FlowLogic<@JvmSuppressWildcards List<StateAndRef<T>>>() {
-    @Suspendable
-    override fun call(): List<StateAndRef<T>> {
-        return receive<List<StateAndRef<T>>>(otherParty).unwrap {
-            subFlow(ResolveTransactionsFlow(it.map { it.ref.txhash }.toSet(), otherParty))
-            it
-        }
-    }
-}

--- a/core/src/main/kotlin/net/corda/core/node/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/ReceiveTransactionFlow.kt
@@ -24,7 +24,7 @@ constructor(private val otherParty: Party, private val checkSufficientSignatures
     @Throws(SignatureException::class, AttachmentResolutionException::class, TransactionResolutionException::class, TransactionVerificationException::class)
     override fun call(): SignedTransaction {
         return receive<SignedTransaction>(otherParty).unwrap {
-            subFlow(net.corda.core.internal.ResolveTransactionsFlow(it, otherParty))
+            subFlow(ResolveTransactionsFlow(it, otherParty))
             it.verify(serviceHub, checkSufficientSignatures)
             it
         }

--- a/core/src/main/kotlin/net/corda/core/node/flows/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/ResolveTransactionsFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.core.internal
+package net.corda.core.node.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.SecureHash

--- a/core/src/main/kotlin/net/corda/core/node/flows/SendStateAndRefFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/SendStateAndRefFlow.kt
@@ -1,0 +1,15 @@
+package net.corda.core.node.flows
+
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.identity.Party
+
+/**
+ * The [SendStateAndRefFlow] should be used to send a list of input [StateAndRef] to another peer that wishes to verify
+ * the input's integrity by resolving and checking the dependencies as well. The other side should invoke [ReceiveStateAndRefFlow]
+ * at the right point in the conversation to receive the input state and ref and perform the resolution back-and-forth
+ * required to check the dependencies.
+ *
+ * @param otherSide the target party.
+ * @param stateAndRefs the list of [StateAndRef] being sent to the [otherSide].
+ */
+open class SendStateAndRefFlow(otherSide: Party, stateAndRefs: List<StateAndRef<*>>) : DataVendingFlow(otherSide, stateAndRefs)

--- a/core/src/main/kotlin/net/corda/core/node/flows/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/SendTransactionFlow.kt
@@ -1,0 +1,15 @@
+package net.corda.core.node.flows
+
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+
+/**
+ * The [SendTransactionFlow] should be used to send a transaction to another peer that wishes to verify that transaction's
+ * integrity by resolving and checking the dependencies as well. The other side should invoke [ReceiveTransactionFlow] at
+ * the right point in the conversation to receive the sent transaction and perform the resolution back-and-forth required
+ * to check the dependencies and download any missing attachments.
+ *
+ * @param otherSide the target party.
+ * @param stx the [SignedTransaction] being sent to the [otherSide].
+ */
+open class SendTransactionFlow(otherSide: Party, stx: SignedTransaction) : DataVendingFlow(otherSide, stx)

--- a/core/src/main/kotlin/net/corda/core/node/flows/StateReplacementException.kt
+++ b/core/src/main/kotlin/net/corda/core/node/flows/StateReplacementException.kt
@@ -1,0 +1,6 @@
+package net.corda.core.node.flows
+
+import net.corda.core.flows.FlowException
+
+open class StateReplacementException @JvmOverloads constructor(message: String? = null, cause: Throwable? = null)
+    : FlowException(message, cause)

--- a/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
@@ -4,9 +4,9 @@ import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.*
 import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.NotaryError
-import net.corda.core.flows.NotaryException
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryError
+import net.corda.core.node.flows.NotaryException
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.identity.Party
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SingletonSerializeAsToken

--- a/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
@@ -5,8 +5,8 @@ import net.corda.core.contracts.Attachment
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
 import net.corda.core.identity.Party
-import net.corda.core.internal.FetchAttachmentsFlow
-import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.flows.FetchAttachmentsFlow
+import net.corda.core.node.flows.FetchDataFlow
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.getOrThrow

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -7,6 +7,7 @@ import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.node.flows.CollectSignaturesFlow
 import net.corda.core.node.flows.FinalityFlow
+import net.corda.core.node.flows.SignTransactionFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -5,6 +5,8 @@ import net.corda.core.contracts.Command
 import net.corda.core.contracts.requireThat
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.CollectSignaturesFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -7,6 +7,8 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.Emoji
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
+import net.corda.core.node.flows.ContractUpgradeFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.node.services.queryBy
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction

--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -3,6 +3,7 @@ package net.corda.core.flows
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.Issued
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.GBP

--- a/core/src/test/kotlin/net/corda/core/flows/ManualFinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ManualFinalityFlowTests.kt
@@ -3,6 +3,7 @@ package net.corda.core.flows
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.Issued
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.ManualFinalityFlow
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.GBP

--- a/core/src/test/kotlin/net/corda/core/flows/TestDataVendingFlow.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/TestDataVendingFlow.kt
@@ -3,6 +3,7 @@ package net.corda.core.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.identity.Party
 import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.flows.SendStateAndRefFlow
 import net.corda.core.utilities.UntrustworthyData
 
 // Flow to start data vending without sending transaction. For testing only.

--- a/core/src/test/kotlin/net/corda/core/flows/TestDataVendingFlow.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/TestDataVendingFlow.kt
@@ -2,7 +2,7 @@ package net.corda.core.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.identity.Party
-import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.flows.FetchDataFlow
 import net.corda.core.node.flows.SendStateAndRefFlow
 import net.corda.core.utilities.UntrustworthyData
 

--- a/core/src/test/kotlin/net/corda/core/flows/TransactionKeyFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/TransactionKeyFlowTests.kt
@@ -3,6 +3,7 @@ package net.corda.core.flows
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.TransactionKeyFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.ALICE
 import net.corda.testing.BOB

--- a/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.TestDataVendingFlow
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.ResolveTransactionsFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.sequence

--- a/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
@@ -7,8 +7,8 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.TestDataVendingFlow
 import net.corda.core.identity.Party
-import net.corda.core.internal.FetchAttachmentsFlow
-import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.flows.FetchAttachmentsFlow
+import net.corda.core.node.flows.FetchDataFlow
 import net.corda.core.messaging.RPCOps
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.services.ServiceInfo

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -8,7 +8,7 @@ import net.corda.core.crypto.SecureHash;
 import net.corda.core.crypto.TransactionSignature;
 import net.corda.core.flows.*;
 import net.corda.core.identity.Party;
-import net.corda.core.internal.FetchDataFlow;
+import net.corda.core.node.flows.FetchDataFlow;
 import net.corda.core.node.flows.*;
 import net.corda.core.node.services.ServiceType;
 import net.corda.core.node.services.Vault;

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -9,6 +9,7 @@ import net.corda.core.crypto.TransactionSignature;
 import net.corda.core.flows.*;
 import net.corda.core.identity.Party;
 import net.corda.core.internal.FetchDataFlow;
+import net.corda.core.node.flows.*;
 import net.corda.core.node.services.ServiceType;
 import net.corda.core.node.services.Vault;
 import net.corda.core.node.services.Vault.Page;

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomNotaryTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomNotaryTutorial.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.node.PluginServiceHub
+import net.corda.core.node.flows.*
 import net.corda.core.node.services.CordaService
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
@@ -9,6 +9,7 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.flows.*
 import net.corda.core.node.services.ServiceType
 import net.corda.core.node.services.Vault.Page
 import net.corda.core.node.services.queryBy
@@ -389,7 +390,7 @@ object FlowCookbook {
             subFlow(SendTransactionFlow(counterparty, twiceSignedTx))
 
             // Optional request verification to further restrict data access.
-            subFlow(object :SendTransactionFlow(counterparty, twiceSignedTx){
+            subFlow(object : SendTransactionFlow(counterparty, twiceSignedTx){
                 override fun verifyDataRequest(dataRequest: FetchDataFlow.Request.Data) {
                     // Extra request verification.
                 }

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
@@ -8,7 +8,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.flows.FetchDataFlow
 import net.corda.core.node.flows.*
 import net.corda.core.node.services.ServiceType
 import net.corda.core.node.services.Vault.Page

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -11,6 +11,7 @@ import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.ServiceHub
+import net.corda.core.node.flows.*
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.builder
 import net.corda.core.serialization.CordaSerializable

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.containsAny
-import net.corda.core.flows.FinalityFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow

--- a/finance/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt
@@ -2,10 +2,10 @@ package net.corda.finance.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
-import net.corda.core.flows.FinalityFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.NotaryException
+import net.corda.core.node.flows.NotaryException
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
@@ -2,7 +2,7 @@ package net.corda.finance.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
-import net.corda.core.flows.FinalityFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.InsufficientBalanceException
 import net.corda.core.flows.StartableByRPC
-import net.corda.core.flows.TransactionKeyFlow
+import net.corda.core.node.flows.TransactionKeyFlow
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
@@ -4,11 +4,15 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.requireThat
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
-import net.corda.core.flows.*
+import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.flows.CollectSignaturesFlow
+import net.corda.core.node.flows.FinalityFlow
+import net.corda.core.node.flows.SignTransactionFlow
+import net.corda.core.node.flows.TransactionKeyFlow
 import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
@@ -1,15 +1,14 @@
 package net.corda.finance.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.Amount
-import net.corda.core.contracts.OwnableState
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.withoutIssuer
 import net.corda.core.contracts.*
-import net.corda.core.flows.*
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.IdentitySyncFlow
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.flows.*
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder

--- a/finance/src/test/java/net/corda/finance/flows/AbstractStateReplacementFlowTest.java
+++ b/finance/src/test/java/net/corda/finance/flows/AbstractStateReplacementFlowTest.java
@@ -1,6 +1,6 @@
 package net.corda.finance.flows;
 
-import net.corda.core.flows.AbstractStateReplacementFlow;
+import net.corda.core.node.flows.AbstractStateReplacementFlow;
 import net.corda.core.identity.Party;
 import net.corda.core.transactions.SignedTransaction;
 import net.corda.core.utilities.ProgressTracker;

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
@@ -7,7 +7,7 @@ import com.esotericsoftware.kryo.io.Output
 import com.google.common.primitives.Ints
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.crypto.*
-import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.flows.FetchDataFlow
 import net.corda.core.serialization.*
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.sequence

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -4,11 +4,11 @@ import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.composite.CompositeKey
-import net.corda.core.flows.NotaryError
-import net.corda.core.flows.NotaryException
-import net.corda.core.flows.NotaryFlow
 import net.corda.core.identity.Party
 import net.corda.core.internal.div
+import net.corda.core.node.flows.NotaryError
+import net.corda.core.node.flows.NotaryException
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -2,12 +2,12 @@ package net.corda.node.services
 
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
-import net.corda.core.flows.NotaryError
-import net.corda.core.flows.NotaryException
-import net.corda.core.flows.NotaryFlow
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.concurrent.transpose
+import net.corda.core.node.flows.NotaryError
+import net.corda.core.node.flows.NotaryException
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.AbstractNode

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -2,10 +2,15 @@ package net.corda.node.services.statemachine
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.*
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.internal.InputStreamAndHash
 import net.corda.core.messaging.startFlow
+import net.corda.core.node.flows.ReceiveTransactionFlow
+import net.corda.core.node.flows.SendTransactionFlow
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.testing.BOB
 import net.corda.testing.DUMMY_NOTARY

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -19,6 +19,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.RPCOps
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.*
+import net.corda.core.node.flows.*
 import net.corda.core.node.services.*
 import net.corda.core.node.services.NetworkMapCache.MapChange
 import net.corda.core.serialization.SerializeAsToken
@@ -34,7 +35,6 @@ import net.corda.node.services.TransactionKeyHandler
 import net.corda.node.services.api.*
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.configureWithDevSSLCertificate
-import net.corda.node.services.database.HibernateConfiguration
 import net.corda.node.services.events.NodeSchedulerService
 import net.corda.node.services.events.ScheduledActivityObserver
 import net.corda.node.services.identity.InMemoryIdentityService

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -8,6 +8,7 @@ import net.corda.core.contracts.requireThat
 import net.corda.core.flows.*
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.*
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -14,6 +14,7 @@ import net.corda.core.internal.abbreviate
 import net.corda.core.internal.concurrent.OpenFuture
 import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.staticField
+import net.corda.core.flows.InitiatingFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.*
 import net.corda.node.services.api.FlowAppAuditEvent

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
@@ -5,7 +5,7 @@ import com.google.common.util.concurrent.SettableFuture
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.*
 import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.NotaryException
+import net.corda.core.node.flows.NotaryException
 import net.corda.core.identity.Party
 import net.corda.core.node.services.NotaryService
 import net.corda.core.node.services.TimeWindowChecker

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt
@@ -15,8 +15,8 @@ import bftsmart.tom.util.Extractor
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.*
-import net.corda.core.flows.NotaryError
-import net.corda.core.flows.NotaryException
+import net.corda.core.node.flows.NotaryError
+import net.corda.core.node.flows.NotaryException
 import net.corda.core.identity.Party
 import net.corda.core.internal.declaredField
 import net.corda.core.internal.toTypedArray

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -1,8 +1,8 @@
 package net.corda.node.services.transactions
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.NotaryFlow
-import net.corda.core.flows.TransactionParts
+import net.corda.core.node.flows.NotaryFlow
+import net.corda.core.node.flows.TransactionParts
 import net.corda.core.identity.Party
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.core.transactions.FilteredTransaction

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
@@ -1,6 +1,6 @@
 package net.corda.node.services.transactions
 
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt
@@ -1,6 +1,6 @@
 package net.corda.node.services.transactions
 
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService

--- a/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
@@ -1,6 +1,6 @@
 package net.corda.node.services.transactions
 
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.identity.Party
 import net.corda.core.node.services.ServiceType
 import net.corda.core.node.services.TimeWindowChecker

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
@@ -2,8 +2,8 @@ package net.corda.node.services.transactions
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.TransactionVerificationException
-import net.corda.core.flows.*
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.*
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.core.transactions.SignedTransaction
 import java.security.SignatureException

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt
@@ -1,6 +1,6 @@
 package net.corda.node.services.transactions
 
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.identity.Party
 import net.corda.core.node.services.ServiceType
 import net.corda.core.node.services.TimeWindowChecker

--- a/node/src/smoke-test/kotlin/net/corda/node/CordappSmokeTest.kt
+++ b/node/src/smoke-test/kotlin/net/corda/node/CordappSmokeTest.kt
@@ -8,6 +8,7 @@ import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.internal.list
 import net.corda.core.messaging.startFlow
+import net.corda.core.flows.InitiatingFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.nodeapi.User
 import net.corda.smoketesting.NodeConfig

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -2,13 +2,12 @@ package net.corda.node.services
 
 import net.corda.core.contracts.*
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.flows.NotaryChangeFlow
-import net.corda.core.flows.StateReplacementException
+import net.corda.core.node.flows.NotaryChangeFlow
+import net.corda.core.node.flows.StateReplacementException
 import net.corda.core.identity.Party
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
-import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
 import net.corda.node.internal.AbstractNode
 import net.corda.node.services.network.NetworkMapService

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -2,12 +2,13 @@ package net.corda.node.services
 
 import net.corda.core.contracts.*
 import net.corda.core.crypto.generateKeyPair
+import net.corda.core.identity.Party
 import net.corda.core.node.flows.NotaryChangeFlow
 import net.corda.core.node.flows.StateReplacementException
-import net.corda.core.identity.Party
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
 import net.corda.node.internal.AbstractNode
 import net.corda.node.services.network.NetworkMapService

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -7,6 +7,7 @@ import net.corda.core.crypto.containsAny
 import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.VaultQueryService
 import net.corda.core.node.services.queryBy

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DataVendingServiceTests.kt
@@ -6,7 +6,7 @@ import net.corda.core.contracts.Issued
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
-import net.corda.core.flows.SendTransactionFlow
+import net.corda.core.node.flows.SendTransactionFlow
 import net.corda.core.identity.Party
 import net.corda.core.node.services.queryBy
 import net.corda.core.transactions.SignedTransaction

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -13,6 +13,9 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.concurrent.map
 import net.corda.core.messaging.MessageRecipients
+import net.corda.core.node.flows.FinalityFlow
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.node.services.PartyInfo
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.queryBy

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -4,9 +4,9 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.TransactionSignature
-import net.corda.core.flows.NotaryError
-import net.corda.core.flows.NotaryException
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryError
+import net.corda.core.node.flows.NotaryException
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -5,9 +5,9 @@ import net.corda.core.contracts.Command
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.TransactionSignature
-import net.corda.core.flows.NotaryError
-import net.corda.core.flows.NotaryException
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryError
+import net.corda.core.node.flows.NotaryException
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.getOrThrow

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -8,7 +8,7 @@ import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.TypeOnlyCommandData
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.FinalityFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.AbstractParty

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/RPCStartableNotaryFlowClient.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/RPCStartableNotaryFlowClient.kt
@@ -1,6 +1,6 @@
 package net.corda.notarydemo.flows
 
-import net.corda.core.flows.NotaryFlow
+import net.corda.core.node.flows.NotaryFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.transactions.SignedTransaction
 

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
@@ -11,8 +11,10 @@ import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.flows.*
-import net.corda.core.flows.AbstractStateReplacementFlow.Proposal
+import net.corda.core.node.flows.AbstractStateReplacementFlow.Proposal
 import net.corda.core.identity.Party
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.node.flows.StateReplacementException
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria.LinearStateQueryCriteria
 import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/StateRevisionFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/StateRevisionFlow.kt
@@ -2,8 +2,8 @@ package net.corda.vega.flows
 
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateAndRef
-import net.corda.core.flows.AbstractStateReplacementFlow
-import net.corda.core.flows.StateReplacementException
+import net.corda.core.node.flows.AbstractStateReplacementFlow
+import net.corda.core.node.flows.StateReplacementException
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.seconds

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt
@@ -3,7 +3,7 @@ package net.corda.traderdemo.flow
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.FinalityFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party

--- a/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt
@@ -1,7 +1,7 @@
 package net.corda.testing.contracts
 
 import net.corda.core.contracts.*
-import net.corda.core.flows.ContractUpgradeFlow
+import net.corda.core.node.flows.ContractUpgradeFlow
 import net.corda.core.identity.AbstractParty
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt
@@ -4,10 +4,10 @@ import net.corda.client.mock.Generator
 import net.corda.client.mock.int
 import net.corda.client.mock.pickOne
 import net.corda.client.mock.replicate
-import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowException
 import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.messaging.startFlow
+import net.corda.core.node.flows.FinalityFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.finance.contracts.asset.DUMMY_CASH_ISSUER
 import net.corda.finance.contracts.asset.DUMMY_CASH_ISSUER_KEY


### PR DESCRIPTION
Move flows into net.corda.core.node.flows package to structurally match services in net.corda.core.node.services package, and to separate implemented flows from the classes flows are based on.

Part of https://r3-cev.atlassian.net/browse/CORDA-499