### PR TITLE
Revert `linearId` (UniqueIdentifier) Vault Query search attribute

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -65,11 +65,15 @@ sealed class QueryCriteria {
      * LinearStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultLinearState]
      */
     data class LinearStateQueryCriteria @JvmOverloads constructor(val participants: List<AbstractParty>? = null,
-                                                                  val linearId: List<UniqueIdentifier>? = null,
                                                                   val uuid: List<UUID>? = null,
                                                                   val externalId: List<String>? = null,
                                                                   override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
                                                                   override val contractStateTypes: Set<Class<out ContractState>>? = null) : CommonQueryCriteria() {
+            constructor(participants: List<AbstractParty>? = null,
+                        linearId: List<UniqueIdentifier>? = null,
+                        status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
+                        contractStateTypes: Set<Class<out ContractState>>? = null) : this(participants, linearId?.map { it.id }, linearId?.mapNotNull { it.externalId }, status, contractStateTypes)
+
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
             return parser.parseCriteria(this)

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -4,12 +4,12 @@ package net.corda.core.node.services.vault
 
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.Vault
 import net.corda.core.schemas.PersistentState
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
-import org.bouncycastle.asn1.x500.X500Name
 import java.time.Instant
 import java.util.*
 import javax.persistence.criteria.Predicate
@@ -65,6 +65,7 @@ sealed class QueryCriteria {
      * LinearStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultLinearState]
      */
     data class LinearStateQueryCriteria @JvmOverloads constructor(val participants: List<AbstractParty>? = null,
+                                                                  val linearId: List<UniqueIdentifier>? = null,
                                                                   val uuid: List<UUID>? = null,
                                                                   val externalId: List<String>? = null,
                                                                   override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -2,7 +2,6 @@ package net.corda.node.services.vault
 
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultQueryException
@@ -278,13 +277,6 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
 
         val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), vaultLinearStates.get<PersistentStateRef>("stateRef"))
         joinPredicates.add(joinPredicate)
-
-        // linear ids
-        criteria.linearId?.let {
-            // WARNING: UniqueIdentifier equality test only uses UUID
-            val uniqueIdentifiers = criteria.linearId as List<UniqueIdentifier>
-            predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<UUID>("uuid").`in`(uniqueIdentifiers.map { it.id })))
-        }
 
         // linear ids UUID
         criteria.uuid?.let {

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -287,7 +287,8 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
         // linear ids externalId
         criteria.externalId?.let {
             val externalIds = criteria.externalId as List<String>
-            predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<String>("externalId").`in`(externalIds)))
+            if (externalIds.isNotEmpty())
+                predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<String>("externalId").`in`(externalIds)))
         }
 
         // deal participants

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.vault
 
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultQueryException
@@ -277,6 +278,13 @@ class HibernateQueryCriteriaParser(val contractType: Class<out ContractState>,
 
         val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), vaultLinearStates.get<PersistentStateRef>("stateRef"))
         joinPredicates.add(joinPredicate)
+
+        // linear ids
+        criteria.linearId?.let {
+            // WARNING: UniqueIdentifier equality test only uses UUID
+            val uniqueIdentifiers = criteria.linearId as List<UniqueIdentifier>
+            predicateSet.add(criteriaBuilder.and(vaultLinearStates.get<UUID>("uuid").`in`(uniqueIdentifiers.map { it.id })))
+        }
 
         // linear ids UUID
         criteria.uuid?.let {

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -192,8 +192,8 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
             QueryCriteria vaultCriteria = new VaultQueryCriteria(status, contractStateTypes);
 
             List<UniqueIdentifier> linearIds = Collections.singletonList(ids.getSecond());
-            QueryCriteria linearCriteriaAll = new LinearStateQueryCriteria(null, linearIds);
-            QueryCriteria dealCriteriaAll = new LinearStateQueryCriteria(null, null, null, dealIds);
+            QueryCriteria linearCriteriaAll = new LinearStateQueryCriteria(null, linearIds, Vault.StateStatus.UNCONSUMED, null);
+            QueryCriteria dealCriteriaAll = new LinearStateQueryCriteria(null, null, dealIds);
 
             QueryCriteria compositeCriteria1 = dealCriteriaAll.or(linearCriteriaAll);
             QueryCriteria compositeCriteria2 = compositeCriteria1.and(vaultCriteria);
@@ -309,8 +309,8 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
 
             List<UniqueIdentifier> linearIds = Collections.singletonList(uid);
             List<AbstractParty> dealParty = Collections.singletonList(getMEGA_CORP());
-            QueryCriteria dealCriteria = new LinearStateQueryCriteria(dealParty, null, null, dealIds);
-            QueryCriteria linearCriteria = new LinearStateQueryCriteria(dealParty, linearIds);
+            QueryCriteria dealCriteria = new LinearStateQueryCriteria(dealParty, null, dealIds);
+            QueryCriteria linearCriteria = new LinearStateQueryCriteria(dealParty, linearIds, Vault.StateStatus.UNCONSUMED, null);
             QueryCriteria dealOrLinearIdCriteria = dealCriteria.or(linearCriteria);
             QueryCriteria compositeCriteria = dealOrLinearIdCriteria.and(vaultCriteria);
 

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -191,12 +191,12 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
 
             QueryCriteria vaultCriteria = new VaultQueryCriteria(status, contractStateTypes);
 
-            List<UUID> linearIds = Collections.singletonList(ids.getSecond().getId());
-            QueryCriteria linearCriteriaAll = new LinearStateQueryCriteria(null, linearIds, null, status);
-            QueryCriteria dealCriteriaAll = new LinearStateQueryCriteria(null, null, dealIds, status);
+            List<UniqueIdentifier> linearIds = Collections.singletonList(ids.getSecond());
+            QueryCriteria linearCriteriaAll = new LinearStateQueryCriteria(null, linearIds);
+            QueryCriteria dealCriteriaAll = new LinearStateQueryCriteria(null, null, null, dealIds);
 
             QueryCriteria compositeCriteria1 = dealCriteriaAll.or(linearCriteriaAll);
-            QueryCriteria compositeCriteria2 = vaultCriteria.and(compositeCriteria1);
+            QueryCriteria compositeCriteria2 = compositeCriteria1.and(vaultCriteria);
 
             PageSpecification pageSpec = new PageSpecification(DEFAULT_PAGE_NUM, MAX_PAGE_SIZE);
             Sort.SortColumn sortByUid = new Sort.SortColumn(new SortAttribute.Standard(Sort.LinearStateAttribute.UUID), Sort.Direction.DESC);
@@ -307,10 +307,10 @@ public class VaultQueryJavaTests extends TestDependencyInjectionBase {
             Set<Class<ContractState>> contractStateTypes = new HashSet(Arrays.asList(DealState.class, LinearState.class));
             QueryCriteria vaultCriteria = new VaultQueryCriteria(Vault.StateStatus.UNCONSUMED, contractStateTypes);
 
-            List<UUID> linearIds = Collections.singletonList(uid.getId());
+            List<UniqueIdentifier> linearIds = Collections.singletonList(uid);
             List<AbstractParty> dealParty = Collections.singletonList(getMEGA_CORP());
-            QueryCriteria dealCriteria = new LinearStateQueryCriteria(dealParty, null, dealIds);
-            QueryCriteria linearCriteria = new LinearStateQueryCriteria(dealParty, linearIds, null);
+            QueryCriteria dealCriteria = new LinearStateQueryCriteria(dealParty, null, null, dealIds);
+            QueryCriteria linearCriteria = new LinearStateQueryCriteria(dealParty, linearIds);
             QueryCriteria dealOrLinearIdCriteria = dealCriteria.or(linearCriteria);
             QueryCriteria compositeCriteria = dealOrLinearIdCriteria.and(vaultCriteria);
 


### PR DESCRIPTION
Re-introduce the `linearId: List<UniqueIdentifier>` Vault Query search attribute on `LinearStateQueryCriteria` for CorDapp developer convenience and ease of use.

This was removed in [PR#1237](https://github.com/corda/corda/pull/1237) as part of a refactoring exercise.

Note: the same assumptions still apply (ie. equality on `UniqueIdentifier` only takes into account the `UUID` field, and **not** the optional `externalId`). Should this equality check change in future, the Vault Query criteria implementation will be modified accordingly but the API will remain consistent.