### PR TITLE
Refactoring the CordaFuture - adding docs, and removing Kt Java class

### DIFF
--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
@@ -1,9 +1,9 @@
 package net.corda.client.rpc
 
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.doneFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.messaging.getRpcContext
@@ -58,6 +58,8 @@ class ClientRPCInfrastructureTests : AbstractRPCTest() {
 
     inner class TestOpsImpl : TestOps {
         override val protocolVersion = 1
+        // Do not remove the return type of the following method as the generated corresponding Java counterpart will have
+        // 2 methods (1 returning Void and the other returning void). In result this test suit will fail.
         override fun barf(): Unit = throw IllegalArgumentException("Barf!")
         override fun void() {}
         override fun someCalculation(str: String, num: Int) = "$str $num"
@@ -65,6 +67,8 @@ class ClientRPCInfrastructureTests : AbstractRPCTest() {
         override fun makeListenableFuture() = doneFuture(1)
         override fun makeComplicatedObservable() = complicatedObservable
         override fun makeComplicatedListenableFuture() = complicatedListenableFuturee
+        // Do not remove the return type of the following method as the generated corresponding Java counterpart will have
+        // 2 methods (1 returning Void and the other returning void). In result this test suit will fail.
         override fun addedLater(): Unit = throw IllegalStateException()
         override fun captureUser(): String = getRpcContext().currentUser.username
     }
@@ -160,9 +164,9 @@ class ClientRPCInfrastructureTests : AbstractRPCTest() {
             val clientQuotes = LinkedBlockingQueue<String>()
             val clientFuture = proxy.makeComplicatedListenableFuture()
 
-            clientFuture.thenMatch({
+            thenMatch(clientFuture, {
                 val name = it.first
-                it.second.thenMatch({
+                thenMatch(it.second, {
                     clientQuotes += "Quote by $name: $it"
                 }, {})
             }, {})

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
@@ -4,7 +4,7 @@ import net.corda.client.rpc.internal.RPCClientConfiguration
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.millis
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.fork
+import net.corda.core.internal.concurrent.CordaFutures.Companion.fork
 import net.corda.core.serialization.CordaSerializable
 import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.testing.RPCDriverExposedDSLInterface
@@ -69,7 +69,7 @@ class RPCConcurrencyTests : AbstractRPCTest() {
                 Observable.empty<ObservableRose<Int>>()
             } else {
                 val publish = UnicastSubject.create<ObservableRose<Int>>()
-                ForkJoinPool.commonPool().fork {
+                fork(ForkJoinPool.commonPool()) {
                     (1..branchingFactor).toList().parallelStream().forEach {
                         publish.onNext(getParallelObservableTree(depth - 1, branchingFactor))
                     }
@@ -106,7 +106,7 @@ class RPCConcurrencyTests : AbstractRPCTest() {
             val done = CountDownLatch(numberOfBlockedCalls)
             // Start a couple of blocking RPC calls
             (1..numberOfBlockedCalls).forEach {
-                ForkJoinPool.commonPool().fork {
+                fork(ForkJoinPool.commonPool()) {
                     proxy.ops.waitLatch(id)
                     done.countDown()
                 }

--- a/core/src/main/kotlin/net/corda/core/Utils.kt
+++ b/core/src/main/kotlin/net/corda/core/Utils.kt
@@ -3,8 +3,8 @@
 package net.corda.core
 
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import rx.Observable
 import rx.Observer
 
@@ -12,7 +12,7 @@ import rx.Observer
 
 fun <A> CordaFuture<out A>.toObservable(): Observable<A> {
     return Observable.create { subscriber ->
-        thenMatch({
+        thenMatch(this, {
             subscriber.onNext(it)
             subscriber.onCompleted()
         }, {

--- a/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt
@@ -1,6 +1,6 @@
 package net.corda.core.concurrent
 
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.internal.VisibleForTesting
 import org.slf4j.Logger

--- a/core/src/main/kotlin/net/corda/core/internal/concurrent/CordaFutureImpl.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/concurrent/CordaFutureImpl.kt
@@ -1,8 +1,10 @@
 package net.corda.core.internal.concurrent
 
-import net.corda.core.internal.VisibleForTesting
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.concurrent.match
+import net.corda.core.internal.VisibleForTesting
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
 import org.slf4j.Logger
@@ -11,81 +13,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
-
-/** @return a fresh [OpenFuture]. */
-fun <V> openFuture(): OpenFuture<V> = CordaFutureImpl()
-
-/** @return a done future with the given value as its outcome. */
-fun <V> doneFuture(value: V): CordaFuture<V> = CordaFutureImpl<V>().apply { set(value) }
-
-/** @return a future that will have the same outcome as the given block, when this executor has finished running it. */
-fun <V> Executor.fork(block: () -> V): CordaFuture<V> = CordaFutureImpl<V>().also { execute { it.capture(block) } }
-
-/** When this future is done, do [match]. */
-fun <V, W, X> CordaFuture<out V>.thenMatch(success: (V) -> W, failure: (Throwable) -> X) = then { match(success, failure) }
-
-/** When this future is done and the outcome is failure, log the throwable. */
-fun CordaFuture<*>.andForget(log: Logger) = thenMatch({}, { log.error("Background task failed:", it) })
-
-/**
- * Returns a future that will have an outcome of applying the given transform to this future's value.
- * But if this future fails, the transform is not invoked and the returned future becomes done with the same throwable.
- */
-fun <V, W> CordaFuture<out V>.map(transform: (V) -> W): CordaFuture<W> = CordaFutureImpl<W>().also { result ->
-    thenMatch({
-        result.capture { transform(it) }
-    }, {
-        result.setException(it)
-    })
-}
-
-/**
- * Returns a future that will have the same outcome as the future returned by the given transform.
- * But if this future or the transform fails, the returned future's outcome is the same throwable.
- * In the case where this future fails, the transform is not invoked.
- */
-fun <V, W> CordaFuture<out V>.flatMap(transform: (V) -> CordaFuture<out W>): CordaFuture<W> = CordaFutureImpl<W>().also { result ->
-    thenMatch(success@ {
-        result.captureLater(try {
-            transform(it)
-        } catch (t: Throwable) {
-            result.setException(t)
-            return@success
-        })
-    }, {
-        result.setException(it)
-    })
-}
-
-/**
- * If all of the given futures succeed, the returned future's outcome is a list of all their values.
- * The values are in the same order as the futures in the collection, not the order of completion.
- * If at least one given future fails, the returned future's outcome is the first throwable that was thrown.
- * Any subsequent throwables are added to the first one as suppressed throwables, in the order they are thrown.
- * If no futures were given, the returned future has an immediate outcome of empty list.
- * Otherwise the returned future does not have an outcome until all given futures have an outcome.
- * Unlike Guava's Futures.allAsList, this method never hides failures/hangs subsequent to the first failure.
- */
-fun <V> Collection<CordaFuture<out V>>.transpose(): CordaFuture<List<V>> {
-    if (isEmpty()) return doneFuture(emptyList())
-    val transpose = CordaFutureImpl<List<V>>()
-    val stateLock = Any()
-    var failure: Throwable? = null
-    var remaining = size
-    forEach {
-        it.then { doneFuture ->
-            synchronized(stateLock) {
-                doneFuture.match({}, { throwable ->
-                    if (failure == null) failure = throwable else failure!!.addSuppressed(throwable)
-                })
-                if (--remaining == 0) {
-                    if (failure == null) transpose.set(map { it.getOrThrow() }) else transpose.setException(failure!!)
-                }
-            }
-        }
-    }
-    return transpose
-}
 
 /** The contravariant members of [OpenFuture]. */
 interface ValueOrException<in V> {
@@ -105,6 +32,136 @@ interface ValueOrException<in V> {
         } catch (t: Throwable) {
             return setException(t)
         })
+    }
+}
+
+/**
+ * A convenience class providing utility functions around the CordaFuture class.
+ */
+class CordaFutures {
+    companion object {
+        /**
+         * Creates an instance of [OpenFuture].
+         *
+         * @param V a future value type.
+         * @return a fresh [OpenFuture].
+         */
+        @JvmStatic
+        fun <V> openFuture(): OpenFuture<V> = CordaFutureImpl()
+
+        /**
+         * Creates an instance of [CordaFuture] being already completed with a given value.
+         *
+         * @param V a future value type.
+         * @param value an outcome of the created future.
+         * @return a done future with the given value as its outcome.
+         */
+        @JvmStatic
+        fun <V> doneFuture(value: V): CordaFuture<V> = CordaFutureImpl<V>().apply { set(value) }
+
+        /**
+         * Creates an instance of [CordaFuture], which value will be the outcome of the lambda, executed by the [executor].
+         *
+         * @param V a future value type.
+         * @param executor to execute the given lambda.
+         * @param block a lambda, which result will be the future outcome.
+         * @return a future that will have the same outcome as the given block, when this executor has finished running it.
+         */
+        @JvmStatic
+        fun <V> fork(executor: Executor, block: () -> V): CordaFuture<V> = CordaFutureImpl<V>().also { executor.execute { it.capture(block) } }
+
+        /** Once the given future is done, it matches (@see [match]) its result against the [success] and [failure].
+         *
+         * @param future a future, which outcome is to be matched.
+         * @param success invoked when the future finished successfully. The outcome of the future is passed as input.
+         * @param failure invoked when the future finished with an exception. The exception is passed as input.
+         */
+        @JvmStatic
+        fun <V, W, X> thenMatch(future: CordaFuture<out V>, success: (V) -> W, failure: (Throwable) -> X) = future.then { future.match(success, failure) }
+
+        /**
+         * When the future is done and the outcome is failure, log the throwable.
+         *
+         * @param future which outcome is matched.
+         * @param log logger to be used for logging the error in case of future failure.
+         */
+        @JvmStatic
+        fun andForget(future: CordaFuture<*>, log: Logger) = thenMatch(future, {}, { log.error("Background task failed:", it) })
+
+        /**
+         * Applies the [transform] function to the outcome of the [future] and returns new  future with the result
+         * of that transformation as the outcome. If the original future fails, the transform is not invoked and
+         * the returned future becomes done with the same throwable.
+         *
+         * @param future future which value is to be transformed.
+         * @param transform transformation to be applied.
+         * @return a future holding either the result of the transformation or the original future failure cause.
+         *
+         */
+        @JvmStatic
+        fun <V, W> map(future: CordaFuture<out V>, transform: (V) -> W): CordaFuture<W> = CordaFutureImpl<W>().also { result ->
+            thenMatch(future, {
+                result.capture { transform(it) }
+            }, {
+                result.setException(it)
+            })
+        }
+
+        /**
+         * Calls transform on the outcome of the given [future] and returns a future that will have the same outcome
+         * as the future returned by the transform function. If the future (passed as a parameter)
+         * or the transform fails the returned future's outcome is the same throwable and the transform is not invoked.
+         *
+         * @param future future which value is to be transformed.
+         * @param transform transformation to be applied.
+         * @return a future holding either the same result as the future given by the transformation or the original future failure cause.
+         */
+        @JvmStatic
+        fun <V, W> flatMap(future: CordaFuture<out V>, transform: (V) -> CordaFuture<out W>): CordaFuture<W> = CordaFutureImpl<W>().also { result ->
+            thenMatch(future, success@ {
+                result.captureLater(try {
+                    transform(it)
+                } catch (t: Throwable) {
+                    result.setException(t)
+                    return@success
+                })
+            }, {
+                result.setException(it)
+            })
+        }
+
+        /**
+         * If all of the given futures succeed, the returned future's outcome is a list of all their values.
+         * The values are in the same order as the futures in the collection and not in the order of their completion.
+         * If at least one given future fails, the returned future's outcome is the first throwable that was thrown.
+         * Any subsequent throwables are added to the first one as suppressed throwables, in the order they are thrown.
+         * If no futures were given, the returned future has an immediate outcome of empty list.
+         * Otherwise the returned future does not have an outcome until all given futures have an outcome.
+         * Unlike Guava's Futures.allAsList, this method never hides failures/hangs subsequent to the first failure.
+         *
+         * @param futures a collection of futures to be transposed.
+         */
+        @JvmStatic
+        fun <V> transpose(futures: Collection<CordaFuture<out V>>): CordaFuture<List<V>> {
+            if (futures.isEmpty()) return doneFuture(emptyList())
+            val transpose = CordaFutureImpl<List<V>>()
+            val stateLock = Any()
+            var failure: Throwable? = null
+            var remaining = futures.size
+            futures.forEach {
+                it.then { doneFuture ->
+                    synchronized(stateLock) {
+                        doneFuture.match({}, { throwable ->
+                            if (failure == null) failure = throwable else failure!!.addSuppressed(throwable)
+                        })
+                        if (--remaining == 0) {
+                            if (failure == null) transpose.set(futures.map { it.getOrThrow() }) else transpose.setException(failure!!)
+                        }
+                    }
+                }
+            }
+            return transpose
+        }
     }
 }
 
@@ -135,7 +192,7 @@ internal class CordaFutureImpl<V>(private val impl: CompletableFuture<V> = Compl
 
     // We don't simply return impl so that the caller can't interfere with it.
     override fun toCompletableFuture() = CompletableFuture<V>().also { completable ->
-        thenMatch({
+        thenMatch(this, {
             completable.complete(it)
         }, {
             completable.completeExceptionally(it)

--- a/core/src/test/java/net/corda/core/concurrent/CordaFutureInJavaTest.java
+++ b/core/src/test/java/net/corda/core/concurrent/CordaFutureInJavaTest.java
@@ -10,8 +10,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static net.corda.core.internal.concurrent.CordaFutureImplKt.doneFuture;
-import static net.corda.core.internal.concurrent.CordaFutureImplKt.openFuture;
+import static net.corda.core.internal.concurrent.CordaFutures.doneFuture;
+import static net.corda.core.internal.concurrent.CordaFutures.openFuture;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/concurrent/ConcurrencyUtilsTest.kt
@@ -1,7 +1,7 @@
 package net.corda.core.concurrent
 
 import com.nhaarman.mockito_kotlin.*
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.utilities.getOrThrow
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test

--- a/docs/source/tutorial-contract.rst
+++ b/docs/source/tutorial-contract.rst
@@ -329,8 +329,8 @@ simultaneously. But it gets complicated when you want to issue or exit one state
 Things get harder still once you want to split and merge states. We say states are *fungible* if they are
 treated identically to each other by the recipient, despite the fact that they aren't quite identical. Dollar bills are
 fungible because even though one may be worn/a bit dirty and another may be crisp and new, they are still both worth
-exactly $1. Likewise, ten $1 bills are almost exactly equivalent to one $10 bill. On the other hand, $10 and ?10 are not
-fungible: if you tried to pay for something that cost ?20 with $10+?10 notes your trade would not be accepted.
+exactly $1. Likewise, ten $1 bills are almost exactly equivalent to one $10 bill. On the other hand, $10 and £10 are not
+fungible: if you tried to pay for something that cost £20 with $10+£10 notes your trade would not be accepted.
 
 To make all this easier the contract API provides a notion of groups. A group is a set of input states and output states
 that should be checked for validity together.
@@ -339,11 +339,11 @@ Consider the following simplified currency trade transaction:
 
 * **Input**:  $12,000 owned by Alice   (A)
 * **Input**:   $3,000 owned by Alice   (A)
-* **Input**:  ?10,000 owned by Bob     (B)
-* **Output**: ?10,000 owned by Alice   (B)
+* **Input**:  £10,000 owned by Bob     (B)
+* **Output**: £10,000 owned by Alice   (B)
 * **Output**: $15,000 owned by Bob     (A)
 
-In this transaction Alice and Bob are trading $15,000 for ?10,000. Alice has her money in the form of two different
+In this transaction Alice and Bob are trading $15,000 for £10,000. Alice has her money in the form of two different
 inputs e.g. because she received the dollars in two payments. The input and output amounts do balance correctly, but
 the cash smart contract must consider the pounds and the dollars separately because they are not fungible: they cannot
 be merged together. So we have two groups: A and B.

--- a/docs/source/tutorial-contract.rst
+++ b/docs/source/tutorial-contract.rst
@@ -329,8 +329,8 @@ simultaneously. But it gets complicated when you want to issue or exit one state
 Things get harder still once you want to split and merge states. We say states are *fungible* if they are
 treated identically to each other by the recipient, despite the fact that they aren't quite identical. Dollar bills are
 fungible because even though one may be worn/a bit dirty and another may be crisp and new, they are still both worth
-exactly $1. Likewise, ten $1 bills are almost exactly equivalent to one $10 bill. On the other hand, $10 and £10 are not
-fungible: if you tried to pay for something that cost £20 with $10+£10 notes your trade would not be accepted.
+exactly $1. Likewise, ten $1 bills are almost exactly equivalent to one $10 bill. On the other hand, $10 and ?10 are not
+fungible: if you tried to pay for something that cost ?20 with $10+?10 notes your trade would not be accepted.
 
 To make all this easier the contract API provides a notion of groups. A group is a set of input states and output states
 that should be checked for validity together.
@@ -339,11 +339,11 @@ Consider the following simplified currency trade transaction:
 
 * **Input**:  $12,000 owned by Alice   (A)
 * **Input**:   $3,000 owned by Alice   (A)
-* **Input**:  £10,000 owned by Bob     (B)
-* **Output**: £10,000 owned by Alice   (B)
+* **Input**:  ?10,000 owned by Bob     (B)
+* **Output**: ?10,000 owned by Alice   (B)
 * **Output**: $15,000 owned by Bob     (A)
 
-In this transaction Alice and Bob are trading $15,000 for £10,000. Alice has her money in the form of two different
+In this transaction Alice and Bob are trading $15,000 for ?10,000. Alice has her money in the form of two different
 inputs e.g. because she received the dollars in two payments. The input and output amounts do balance correctly, but
 the cash smart contract must consider the pounds and the dollars separately because they are not fungible: they cannot
 be merged together. So we have two groups: A and B.
@@ -469,34 +469,47 @@ logic.
 
    .. sourcecode:: java
 
-      Timestamp time = tx.getTimestamp();   // Can be null/missing.
-      for (InOutGroup<State> group : groups) {
-          List<State> inputs = group.getInputs();
-          List<State> outputs = group.getOutputs();
+      final TimeWindow timeWindow = tx.getTimeWindow();
+              for (final InOutGroup<State, State> group : groups) {
+                  final List<State> inputs = group.getInputs();
+                  final List<State> outputs = group.getOutputs();
 
-          // For now do not allow multiple pieces of CP to trade in a single transaction. Study this more!
-          State input = single(filterIsInstance(inputs, State.class));
+                  if (command.getValue() instanceof Commands.Move) {
+                      final AuthenticatedObject<Commands.Move> cmd = requireSingleCommand(tx.getCommands(), Commands.Move.class);
 
-          checkState(cmd.getSigners().contains(input.getOwner()), "the transaction is signed by the owner of the CP");
+                      // There should be only a single input due to aggregation above
+                      final State input = Iterables.getOnlyElement(inputs);
+                      if (!cmd.getSigners().contains(input.getOwner().getOwningKey()))
+                          throw new IllegalStateException("Failed requirement: the transaction is signed by the owner of the CP");
 
-          if (cmd.getValue() instanceof JavaCommercialPaper.Commands.Move) {
-              checkState(outputs.size() == 1, "the state is propagated");
-              // Don't need to check anything else, as if outputs.size == 1 then the output is equal to
-              // the input ignoring the owner field due to the grouping.
-          } else if (cmd.getValue() instanceof JavaCommercialPaper.Commands.Redeem) {
-              TimeWindow timeWindow = tx.getTimeWindow();
-              Instant time = null == timeWindow
-                       ? null
-                       : timeWindow.getUntilTime();
-              Amount<Issued<Currency>> received = CashKt.sumCashBy(tx.getOutputs(), input.getOwner());
+                      // Check the output CP state is the same as the input state, ignoring the owner field.
+                      if (outputs.size() != 1) {
+                          throw new IllegalStateException("the state is propagated");
+                      }
+                  } else if (command.getValue() instanceof Commands.Redeem) {
+                      final AuthenticatedObject<Commands.Redeem> cmd = requireSingleCommand(tx.getCommands(), Commands.Redeem.class);
 
-              checkState(received.equals(input.getFaceValue()), "received amount equals the face value");
-              checkState(time != null && !time.isBefore(input.getMaturityDate(), "the paper must have matured");
-              checkState(outputs.isEmpty(), "the paper must be destroyed");
-          } else if (cmd.getValue() instanceof JavaCommercialPaper.Commands.Issue) {
-              // .. etc .. (see Kotlin for full definition)
-          }
-      }
+                      // There should be only a single input due to aggregation above
+                      final State input = Iterables.getOnlyElement(inputs);
+
+                      if (!cmd.getSigners().contains(input.getOwner().getOwningKey()))
+                          throw new IllegalStateException("Failed requirement: the transaction is signed by the owner of the CP");
+
+                      final Instant time = null == timeWindow ? null : timeWindow.getUntilTime();
+                      final Amount<Issued<Currency>> received = StateSumming.sumCashBy(tx.getOutputStates(), input.getOwner());
+
+                      requireThat(require -> {
+                          require.using("must be timestamped", timeWindow != null);
+                          require.using("received amount equals the face value: "
+                                  + received + " vs " + input.getFaceValue(), received.equals(input.getFaceValue()));
+                          require.using("the paper must have matured", time != null && !time.isBefore(input.getMaturityDate()));
+                          require.using("the received amount equals the face value", input.getFaceValue().equals(received));
+                          require.using("the paper must be destroyed", outputs.isEmpty());
+                          return Unit.INSTANCE;
+                      });
+                  } else if (command.getValue() instanceof Commands.Issue) {
+                      // .. etc .. (see Kotlin for full definition)
+                  }
 
 This loop is the core logic of the contract.
 

--- a/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
@@ -6,7 +6,7 @@ import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.ALICE
@@ -24,9 +24,9 @@ class CordappScanningDriverTest {
         val user = User("u", "p", setOf(startFlowPermission<ReceiveFlow>()))
         // The driver will automatically pick up the annotated flows below
         driver {
-            val (alice, bob) = listOf(
+            val (alice, bob) = transpose(listOf(
                     startNode(ALICE.name, rpcUsers = listOf(user)),
-                    startNode(BOB.name)).transpose().getOrThrow()
+                    startNode(BOB.name))).getOrThrow()
             val initiatedFlowClass = alice.rpcClientToNode()
                     .start(user.username, user.password)
                     .proxy

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import com.google.common.base.Stopwatch
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.OpaqueBytes
@@ -113,7 +113,7 @@ class NodePerformanceTests {
                 val doneFutures = (1..100).toList().parallelStream().map {
                     connection.proxy.startFlow(::CashIssueFlow, 1.DOLLARS, OpaqueBytes.of(0), a.nodeInfo.notaryIdentity).returnValue
                 }.toList()
-                doneFutures.transpose().get()
+                transpose(doneFutures).get()
                 println("STARTING PAYMENT")
                 startPublishingFixedRateInjector(metricRegistry, 8, 5.minutes, 100L / TimeUnit.SECONDS) {
                     connection.proxy.startFlow(::CashPaymentFlow, 1.DOLLARS, a.nodeInfo.legalIdentity).returnValue.get()

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -8,8 +8,8 @@ import net.corda.testing.DUMMY_BANK_A
 import net.corda.core.flows.NotaryError
 import net.corda.core.flows.NotaryException
 import net.corda.core.flows.NotaryFlow
-import net.corda.core.internal.concurrent.map
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.map
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.node.internal.AbstractNode
@@ -25,10 +25,10 @@ class RaftNotaryServiceTests : NodeBasedTest() {
 
     @Test
     fun `detect double spend`() {
-        val (bankA) = listOf(
+        val (bankA) = transpose(listOf(
                 startNode(DUMMY_BANK_A.name),
-                startNotaryCluster(notaryName, 3).map { it.first() }
-        ).transpose().getOrThrow()
+                map(startNotaryCluster(notaryName, 3)) { it.first() }
+        )).getOrThrow()
 
         val notaryParty = bankA.services.networkMapCache.getNotary(notaryName)!!
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
 import net.corda.testing.ALICE
@@ -16,9 +16,9 @@ import org.junit.Test
 class FlowVersioningTest : NodeBasedTest() {
     @Test
     fun `getFlowContext returns the platform version for core flows`() {
-        val (alice, bob) = listOf(
+        val (alice, bob) = transpose(listOf(
                 startNode(ALICE.name, platformVersion = 2),
-                startNode(BOB.name, platformVersion = 3)).transpose().getOrThrow()
+                startNode(BOB.name, platformVersion = 3))).getOrThrow()
         bob.installCoreFlow(PretendInitiatingCoreFlow::class, ::PretendInitiatedCoreFlow)
         val (alicePlatformVersionAccordingToBob, bobPlatformVersionAccordingToAlice) = alice.services.startFlow(
                 PretendInitiatingCoreFlow(bob.info.legalIdentity)).resultFuture.getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
@@ -2,7 +2,7 @@ package net.corda.services.messaging
 
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.internal.elapsedTime
 import net.corda.core.internal.times
 import net.corda.core.messaging.MessageRecipients
@@ -38,7 +38,7 @@ class P2PMessagingTest : NodeBasedTest() {
     @Test
     fun `network map will work after restart`() {
         val identities = listOf(DUMMY_BANK_A, DUMMY_BANK_B, DUMMY_NOTARY)
-        fun startNodes() = identities.map { startNode(it.name) }.transpose()
+        fun startNodes() = transpose(identities.map { startNode(it.name) })
 
         val startUpDuration = elapsedTime { startNodes().getOrThrow() }
         // Start the network map a second time - this will restore message queues from the journal.
@@ -74,7 +74,7 @@ class P2PMessagingTest : NodeBasedTest() {
                 DUMMY_MAP.name,
                 advertisedServices = setOf(distributedService),
                 configOverrides = mapOf("notaryNodeAddress" to notaryClusterAddress.toString()))
-        val (serviceNode2, alice) = listOf(
+        val (serviceNode2, alice) = transpose(listOf(
                 startNode(
                         SERVICE_2_NAME,
                         advertisedServices = setOf(distributedService),
@@ -82,7 +82,7 @@ class P2PMessagingTest : NodeBasedTest() {
                                 "notaryNodeAddress" to freeLocalHostAndPort().toString(),
                                 "notaryClusterAddresses" to listOf(notaryClusterAddress.toString()))),
                 startNode(ALICE.name)
-        ).transpose().getOrThrow()
+        )).getOrThrow()
 
         assertAllNodesAreUsed(listOf(networkMapNode, serviceNode2), DISTRIBUTED_SERVICE_NAME, alice)
     }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1,7 +1,6 @@
 package net.corda.node.internal
 
 import com.codahale.metrics.MetricRegistry
-import net.corda.core.internal.VisibleForTesting
 import com.google.common.collect.Lists
 import com.google.common.collect.MutableClassToInstanceMap
 import com.google.common.util.concurrent.MoreExecutors
@@ -13,8 +12,8 @@ import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.*
-import net.corda.core.internal.concurrent.flatMap
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.flatMap
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.RPCOps
 import net.corda.core.messaging.SingleMessageRecipient
@@ -34,7 +33,6 @@ import net.corda.node.services.TransactionKeyHandler
 import net.corda.node.services.api.*
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.configureWithDevSSLCertificate
-import net.corda.node.services.database.HibernateConfiguration
 import net.corda.node.services.events.NodeSchedulerService
 import net.corda.node.services.events.ScheduledActivityObserver
 import net.corda.node.services.identity.InMemoryIdentityService
@@ -597,7 +595,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         val address: SingleMessageRecipient = networkMapAddress ?:
                 network.getAddressOfParty(PartyInfo.Node(info)) as SingleMessageRecipient
         // Register for updates, even if we're the one running the network map.
-        return sendNetworkMapRegistration(address).flatMap { (error) ->
+        return flatMap(sendNetworkMapRegistration(address)) { (error) ->
             check(error == null) { "Unable to register with the network map service: $error" }
             // The future returned addMapService will complete on the same executor as sendNetworkMapRegistration, namely the one used by net
             services.networkMapCache.addMapService(network, address, true, null)

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -3,10 +3,10 @@ package net.corda.node.internal
 import com.codahale.metrics.JmxReporter
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.concurrent.flatMap
-import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.doneFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.flatMap
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.messaging.RPCOps
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.ServiceInfo
@@ -259,7 +259,7 @@ open class Node(override val configuration: FullNodeConfiguration,
      */
     override fun registerWithNetworkMap(): CordaFuture<Unit> {
         val networkMapConnection = messageBroker?.networkMapConnectionFuture ?: doneFuture(Unit)
-        return networkMapConnection.flatMap { super.registerWithNetworkMap() }
+        return flatMap(networkMapConnection) { super.registerWithNetworkMap() }
     }
 
     override fun myAddresses(): List<NetworkHostAndPort> {
@@ -306,7 +306,7 @@ open class Node(override val configuration: FullNodeConfiguration,
         }
         super.start()
 
-        networkMapRegistrationFuture.thenMatch({
+        thenMatch(networkMapRegistrationFuture, {
             serverThread.execute {
                 // Begin exporting our own metrics via JMX. These can be monitored using any agent, e.g. Jolokia:
                 //

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -8,7 +8,7 @@ import net.corda.core.crypto.newSecureRandom
 import net.corda.core.crypto.parsePublicKeyBase58
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.ThreadBox
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.internal.div
 import net.corda.core.internal.noneOrSingle
 import net.corda.core.internal.toX509CertHolder

--- a/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
@@ -2,7 +2,7 @@ package net.corda.node.services.messaging
 
 import com.google.common.util.concurrent.ListenableFuture
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.services.PartyInfo

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
@@ -2,8 +2,8 @@ package net.corda.node.services.messaging
 
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.concurrent.andForget
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.andForget
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.internal.ThreadBox
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.MessageRecipients
@@ -232,7 +232,7 @@ class NodeMessagingClient(override val config: NodeConfiguration,
 
             // Create a queue, consumer and producer for handling P2P network messages.
             p2pConsumer = makeP2PConsumer(session, true)
-            networkMapRegistrationFuture.thenMatch({
+            thenMatch(networkMapRegistrationFuture, {
                 state.locked {
                     log.info("Network map is complete, so removing filter from P2P consumer.")
                     try {
@@ -334,7 +334,7 @@ class NodeMessagingClient(override val config: NodeConfiguration,
         while (!networkMapRegistrationFuture.isDone && processMessage(consumer)) {
         }
         with(networkMapRegistrationFuture) {
-            if (isDone) getOrThrow() else andForget(log) // Trigger node shutdown here to avoid deadlock in shutdown hooks.
+            if (isDone) getOrThrow() else andForget(this, log) // Trigger node shutdown here to avoid deadlock in shutdown hooks.
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -12,7 +12,7 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.abbreviate
 import net.corda.core.internal.concurrent.OpenFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.internal.staticField
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.*
@@ -173,7 +173,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
             receiveInternal<SessionData>(newSession, receiveType)
         } else {
             val sendData = createSessionData(session, payload)
-            sendAndReceiveInternal<SessionData>(session, sendData, receiveType)
+            sendAndReceiveInternal(session, sendData, receiveType)
         }
         logger.debug { "Received ${sessionData.message.payload.toString().abbreviate(300)}" }
         return sessionData.checkPayloadIs(receiveType)
@@ -242,7 +242,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
     }
 
     // TODO Dummy implementation of access to application specific audit logging
-    override fun recordAuditEvent(eventType: String, comment: String, extraAuditData: Map<String, String>): Unit {
+    override fun recordAuditEvent(eventType: String, comment: String, extraAuditData: Map<String, String>) {
         val flowAuditEvent = FlowAppAuditEvent(
                 serviceHub.clock.instant(),
                 flowInitiator,

--- a/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/InMemoryTransactionVerifierService.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.transactions
 
 import com.google.common.util.concurrent.MoreExecutors
-import net.corda.core.internal.concurrent.fork
+import net.corda.core.internal.concurrent.CordaFutures.Companion.fork
 import net.corda.core.node.services.TransactionVerifierService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.LedgerTransaction
@@ -10,5 +10,5 @@ import java.util.concurrent.Executors
 class InMemoryTransactionVerifierService(numberOfWorkers: Int) : SingletonSerializeAsToken(), TransactionVerifierService {
     private val workerPool = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numberOfWorkers))
 
-    override fun verify(transaction: LedgerTransaction) = workerPool.fork(transaction::verify)
+    override fun verify(transaction: LedgerTransaction) = fork(workerPool, transaction::verify)
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt
@@ -7,7 +7,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.node.services.TransactionVerifierService
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.concurrent.OpenFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.loggerFor

--- a/node/src/main/kotlin/net/corda/node/shell/FlowWatchPrintingSubscriber.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/FlowWatchPrintingSubscriber.kt
@@ -3,7 +3,7 @@ package net.corda.node.shell
 import net.corda.core.crypto.commonName
 import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.StateMachineRunId
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.StateMachineUpdate.Added
 import net.corda.core.messaging.StateMachineUpdate.Removed

--- a/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
@@ -13,7 +13,7 @@ import net.corda.core.flows.FlowInitiator
 import net.corda.core.flows.FlowLogic
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.concurrent.OpenFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.internal.write

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -12,7 +12,7 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.concurrent.map
+import net.corda.core.internal.concurrent.CordaFutures.Companion.map
 import net.corda.core.internal.rootCause
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.SingleMessageRecipient
@@ -534,7 +534,7 @@ class TwoPartyTradeFlowTests {
             serviceHub.keyManagementService.freshKeyAndCert(serviceHub.myInfo.legalIdentityAndCert, false)
         }.party.anonymise()
         val buyerFlows: Observable<BuyerAcceptor> = buyerNode.registerInitiatedFlow(BuyerAcceptor::class.java)
-        val firstBuyerFiber = buyerFlows.toFuture().map { it.stateMachine }
+        val firstBuyerFiber = map(buyerFlows.toFuture()) { it.stateMachine }
         val seller = SellerInitiator(buyerNode.info.legalIdentity, notaryNode.info, assetToSell, 1000.DOLLARS, anonymousSeller)
         val sellerResult = sellerNode.services.startFlow(seller).resultFuture
         return RunResult(firstBuyerFiber, sellerResult, seller.stateMachine.id)

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -3,8 +3,8 @@ package net.corda.node.services.messaging
 import com.codahale.metrics.MetricRegistry
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.doneFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.services.RPCUserService
@@ -41,23 +41,23 @@ import kotlin.test.assertNull
 class ArtemisMessagingTests : TestDependencyInjectionBase() {
     @Rule @JvmField val temporaryFolder = TemporaryFolder()
 
-    val serverPort = freePort()
-    val rpcPort = freePort()
-    val topic = "platform.self"
-    val identity = generateKeyPair()
+    private val serverPort = freePort()
+    private val rpcPort = freePort()
+    private val topic = "platform.self"
+    private val identity = generateKeyPair()
 
-    lateinit var config: NodeConfiguration
-    lateinit var database: CordaPersistence
-    lateinit var userService: RPCUserService
-    lateinit var networkMapRegistrationFuture: CordaFuture<Unit>
+    private lateinit var config: NodeConfiguration
+    private lateinit var database: CordaPersistence
+    private lateinit var userService: RPCUserService
+    private lateinit var networkMapRegistrationFuture: CordaFuture<Unit>
 
-    var messagingClient: NodeMessagingClient? = null
-    var messagingServer: ArtemisMessagingServer? = null
+    private var messagingClient: NodeMessagingClient? = null
+    private var messagingServer: ArtemisMessagingServer? = null
 
     // TODO: We should have a dummy service hub rather than change behaviour in tests
-    val networkMapCache = InMemoryNetworkMapCache(serviceHub = null)
+    private val networkMapCache = InMemoryNetworkMapCache(serviceHub = null)
 
-    val rpcOps = object : RPCOps {
+    private val rpcOps = object : RPCOps {
         override val protocolVersion: Int get() = throw UnsupportedOperationException()
     }
 

--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -1,7 +1,7 @@
 package net.corda.attachmentdemo
 
 import net.corda.core.node.services.ServiceInfo
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
@@ -19,11 +19,11 @@ class AttachmentDemoTest {
         val numOfExpectedBytes = 10_000_000
         driver(dsl = {
             val demoUser = listOf(User("demo", "demo", setOf(startFlowPermission<AttachmentDemoFlow>())))
-            val (nodeA, nodeB) = listOf(
+            val (nodeA, nodeB) = transpose(listOf(
                     startNode(DUMMY_BANK_A.name, rpcUsers = demoUser),
                     startNode(DUMMY_BANK_B.name, rpcUsers = demoUser),
                     startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type)))
-            ).transpose().getOrThrow()
+            )).getOrThrow()
 
             val senderThread = CompletableFuture.supplyAsync {
                 nodeA.rpcClientToNode().start(demoUser[0].username, demoUser[0].password).use {

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
@@ -3,7 +3,7 @@ package net.corda.bank
 import net.corda.bank.api.BankOfCordaClientApi
 import net.corda.bank.api.BankOfCordaWebApi.IssueRequestParams
 import net.corda.core.node.services.ServiceInfo
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.driver.driver
 import net.corda.node.services.transactions.SimpleNotaryService
@@ -15,10 +15,10 @@ class BankOfCordaHttpAPITest {
     @Test
     fun `issuer flow via Http`() {
         driver(dsl = {
-            val (nodeBankOfCorda) = listOf(
+            val (nodeBankOfCorda) = transpose(listOf(
                     startNode(BOC.name, setOf(ServiceInfo(SimpleNotaryService.type))),
                     startNode(BIGCORP_LEGAL_NAME)
-            ).transpose().getOrThrow()
+            )).getOrThrow()
             val anonymous = false
             val nodeBankOfCordaApiAddr = startWebserver(nodeBankOfCorda).getOrThrow().listenAddress
             assertTrue(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name, BOC.name, anonymous)))

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -1,6 +1,6 @@
 package net.corda.bank
 
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.Vault
@@ -23,10 +23,10 @@ class BankOfCordaRPCClientTest {
             val bocManager = User("bocManager", "password1", permissions = setOf(
                     startFlowPermission<CashIssueAndPaymentFlow>()))
             val bigCorpCFO = User("bigCorpCFO", "password2", permissions = emptySet())
-            val (nodeBankOfCorda, nodeBigCorporation) = listOf(
+            val (nodeBankOfCorda, nodeBigCorporation) = transpose(listOf(
                     startNode(BOC.name, setOf(ServiceInfo(SimpleNotaryService.type)), listOf(bocManager)),
                     startNode(BIGCORP_LEGAL_NAME, rpcUsers = listOf(bigCorpCFO))
-            ).transpose().getOrThrow()
+            )).getOrThrow()
 
             // Bank of Corda RPC Client
             val bocClient = nodeBankOfCorda.rpcClientToNode()

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -1,7 +1,7 @@
 package net.corda.irs
 
 import net.corda.client.rpc.CordaRPCClient
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.messaging.vaultTrackBy
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.toFuture
@@ -44,19 +44,19 @@ class IRSDemoTest : IntegrationTestCategory {
     @Test
     fun `runs IRS demo`() {
         driver(useTestClock = true, isDebug = true) {
-            val (controller, nodeA, nodeB) = listOf(
+            val (controller, nodeA, nodeB) = transpose(listOf(
                     startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type), ServiceInfo(NodeInterestRates.Oracle.type))),
                     startNode(DUMMY_BANK_A.name, rpcUsers = listOf(rpcUser)),
                     startNode(DUMMY_BANK_B.name)
-            ).transpose().getOrThrow()
+            )).getOrThrow()
 
             log.info("All nodes started")
 
-            val (controllerAddr, nodeAAddr, nodeBAddr) = listOf(
+            val (controllerAddr, nodeAAddr, nodeBAddr) = transpose(listOf(
                     startWebserver(controller),
                     startWebserver(nodeA),
                     startWebserver(nodeB)
-            ).transpose().getOrThrow().map { it.listenAddress }
+            )).getOrThrow().map { it.listenAddress }
 
             log.info("All webservers started")
 

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/Main.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/Main.kt
@@ -1,6 +1,6 @@
 package net.corda.irs
 
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.DUMMY_BANK_A
@@ -16,11 +16,11 @@ import net.corda.testing.driver.driver
  */
 fun main(args: Array<String>) {
     driver(dsl = {
-        val (controller, nodeA, nodeB) = listOf(
+        val (controller, nodeA, nodeB) = transpose(listOf(
                 startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type), ServiceInfo(NodeInterestRates.Oracle.type))),
                 startNode(DUMMY_BANK_A.name),
                 startNode(DUMMY_BANK_B.name)
-        ).transpose().getOrThrow()
+        )).getOrThrow()
 
         startWebserver(controller)
         startWebserver(nodeA)

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
@@ -8,9 +8,9 @@ import net.corda.core.node.CityDatabase
 import net.corda.core.node.WorldMapLocation
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.containsType
-import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.concurrent.flatMap
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.flatMap
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.doneFuture
 import net.corda.testing.DUMMY_MAP
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.DUMMY_REGULATOR
@@ -261,12 +261,12 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
         }
     }
 
-    val networkInitialisationFinished = mockNet.nodes.map { it.networkMapRegistrationFuture }.transpose()
+    val networkInitialisationFinished = transpose(mockNet.nodes.map { it.networkMapRegistrationFuture })
 
     fun start(): CordaFuture<Unit> {
         mockNet.startNodes()
         // Wait for all the nodes to have finished registering with the network map service.
-        return networkInitialisationFinished.flatMap { startMainSimulation() }
+        return flatMap(networkInitialisationFinished) { startMainSimulation() }
     }
 
     /**

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -2,7 +2,7 @@ package net.corda.vega
 
 import com.opengamma.strata.product.common.BuySell
 import net.corda.core.node.services.ServiceInfo
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
@@ -34,8 +34,8 @@ class SimmValuationTest : IntegrationTestCategory {
     fun `runs SIMM valuation demo`() {
         driver(isDebug = true) {
             startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type))).getOrThrow()
-            val (nodeA, nodeB) = listOf(startNode(nodeALegalName), startNode(nodeBLegalName)).transpose().getOrThrow()
-            val (nodeAApi, nodeBApi) = listOf(startWebserver(nodeA), startWebserver(nodeB)).transpose()
+            val (nodeA, nodeB) = transpose(listOf(startNode(nodeALegalName), startNode(nodeBLegalName))).getOrThrow()
+            val (nodeAApi, nodeBApi) = transpose(listOf(startWebserver(nodeA), startWebserver(nodeB)))
                     .getOrThrow()
                     .map { HttpApi.fromHostAndPort(it.listenAddress, "api/simmvaluationdemo") }
             val nodeBParty = getPartyWithName(nodeAApi, nodeBLegalName)

--- a/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
+++ b/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
@@ -1,6 +1,6 @@
 package net.corda.vega
 
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.DUMMY_BANK_A
@@ -18,11 +18,11 @@ import net.corda.testing.driver.driver
 fun main(args: Array<String>) {
     driver(dsl = {
         startNode(DUMMY_NOTARY.name, setOf(ServiceInfo(SimpleNotaryService.type)))
-        val (nodeA, nodeB, nodeC) = listOf(
+        val (nodeA, nodeB, nodeC) = transpose(listOf(
                 startNode(DUMMY_BANK_A.name),
                 startNode(DUMMY_BANK_B.name),
                 startNode(DUMMY_BANK_C.name)
-        ).transpose().getOrThrow()
+        )).getOrThrow()
 
         startWebserver(nodeA)
         startWebserver(nodeB)

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -1,7 +1,7 @@
 package net.corda.traderdemo
 
 import net.corda.client.rpc.CordaRPCClient
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
@@ -32,12 +32,12 @@ class TraderDemoTest : NodeBasedTest() {
                 startFlowPermission<CashIssueFlow>(),
                 startFlowPermission<CashPaymentFlow>(),
                 startFlowPermission<CommercialPaperIssueFlow>()))
-        val (nodeA, nodeB, bankNode) = listOf(
+        val (nodeA, nodeB, bankNode) = transpose(listOf(
                 startNode(DUMMY_BANK_A.name, rpcUsers = listOf(demoUser)),
                 startNode(DUMMY_BANK_B.name, rpcUsers = listOf(demoUser)),
                 startNode(BOC.name, rpcUsers = listOf(bankUser)),
                 startNode(DUMMY_NOTARY.name, advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)))
-        ).transpose().getOrThrow()
+        )).getOrThrow()
 
         nodeA.registerInitiatedFlow(BuyerFlow::class.java)
 

--- a/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
@@ -9,7 +9,7 @@ import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.concurrent.CordaFutures.Companion.transpose
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.services.ServiceInfo
 import net.corda.node.services.transactions.ValidatingNotaryService
@@ -126,6 +126,6 @@ fun DriverDSLExposedInterface.aliceBobAndNotary(): List<PredefinedTestNode> {
     val alice = alice()
     val bob = bob()
     val notary = notary()
-    listOf(alice.nodeFuture, bob.nodeFuture, notary.nodeFuture).transpose().get()
+    transpose(listOf(alice.nodeFuture, bob.nodeFuture, notary.nodeFuture)).get()
     return listOf(alice, bob, notary)
 }

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -8,7 +8,7 @@ import net.corda.core.crypto.cert
 import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.concurrent.doneFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.doneFuture
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.createDirectory
 import net.corda.core.messaging.MessageRecipients

--- a/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/SimpleNode.kt
@@ -3,7 +3,7 @@ package net.corda.testing.node
 import com.codahale.metrics.MetricRegistry
 import net.corda.core.crypto.commonName
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.messaging.RPCOps
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.KeyManagementService

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/web/WebServer.kt
@@ -3,7 +3,7 @@ package net.corda.demobench.web
 import com.google.common.util.concurrent.RateLimiter
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.utilities.minutes
-import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.concurrent.CordaFutures.Companion.openFuture
 import net.corda.core.internal.until
 import net.corda.core.utilities.loggerFor
 import net.corda.demobench.model.NodeConfig

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -8,7 +8,7 @@ import net.corda.client.mock.pickOne
 import net.corda.client.rpc.CordaRPCConnection
 import net.corda.core.contracts.Amount
 import net.corda.core.identity.Party
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.startFlow
@@ -138,7 +138,7 @@ class ExplorerSimulation(val options: OptionSet) {
         // Log to logger when flow finish.
         fun FlowHandle<AbstractCashFlow.Result>.log(seq: Int, name: String) {
             val out = "[$seq] $name $id :"
-            returnValue.thenMatch({ (stx) ->
+            thenMatch(returnValue, { (stx) ->
                 Main.log.info("$out ${stx.id} ${(stx.tx.outputs.first().data as Cash.State).amount}")
             }, {
                 Main.log.info("$out ${it.message}")

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/NodeConnection.kt
@@ -5,7 +5,7 @@ import com.jcraft.jsch.Session
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.client.rpc.CordaRPCConnection
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.internal.concurrent.fork
+import net.corda.core.internal.concurrent.CordaFutures.Companion.fork
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort
@@ -88,7 +88,7 @@ class NodeConnection(val remoteNode: RemoteNode, private val jSchSession: Sessio
 
     private fun runShellCommand(command: String, stdout: OutputStream, stderr: OutputStream): CordaFuture<Int> {
         log.info("Running '$command' on ${remoteNode.hostname}")
-        return ForkJoinPool.commonPool().fork {
+        return fork(ForkJoinPool.commonPool()) {
             val (exitCode, _) = withChannelExec(command) { channel ->
                 channel.outputStream = stdout
                 channel.setErrStream(stderr)

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/CrossCashTest.kt
@@ -5,7 +5,7 @@ import net.corda.client.mock.pickN
 import net.corda.core.contracts.Issued
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.identity.AbstractParty
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.messaging.startFlow
 import net.corda.core.messaging.vaultQueryBy
 import net.corda.core.utilities.OpaqueBytes
@@ -220,7 +220,7 @@ val crossCashTest = LoadTest<CrossCashCommand, CrossCashState>(
                 is ExitRequest -> command.node.proxy.startFlow(::CashExitFlow, request).returnValue
                 else -> throw IllegalArgumentException("Unexpected request type: $request")
             }
-            result.thenMatch({
+            thenMatch(result, {
                 log.info("Success[$command]: $result")
             }, {
                 log.error("Failure[$command]", it)

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/NotaryTest.kt
@@ -6,7 +6,7 @@ import net.corda.client.mock.pickOne
 import net.corda.client.mock.replicate
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowException
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.messaging.startFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.finance.contracts.asset.DUMMY_CASH_ISSUER
@@ -42,7 +42,7 @@ val dummyNotarisationTest = LoadTest<NotariseCommand, Unit>(
             try {
                 val proxy = node.proxy
                 val issueFlow = proxy.startFlow(::FinalityFlow, issueTx)
-                issueFlow.returnValue.thenMatch({
+                thenMatch(issueFlow.returnValue, {
                     proxy.startFlow(::FinalityFlow, moveTx)
                 }, {})
             } catch (e: FlowException) {

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/StabilityTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/StabilityTest.kt
@@ -3,7 +3,7 @@ package net.corda.loadtest.tests
 import net.corda.client.mock.Generator
 import net.corda.core.contracts.Amount
 import net.corda.core.flows.FlowException
-import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.concurrent.CordaFutures.Companion.thenMatch
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
@@ -37,7 +37,7 @@ object StabilityTest {
                     is ExitRequest -> command.node.proxy.startFlow(::CashExitFlow, request).returnValue
                     else -> throw IllegalArgumentException("Unexpected request type: $request")
                 }
-                result.thenMatch({
+                thenMatch(result, {
                     log.info("Success[$command]: $result")
                 }, {
                     log.error("Failure[$command]", it)


### PR DESCRIPTION
This refactor and doc improvement is only for the CordaFutureImpl.kt and in particular removal of the CordaFutureKt Java class.

Even though this PR looks big, the main changes are in the `core/src/main/kotlin/net/corda/core/internal/concurrent/CordaFutureImpl.kt`.
The rest are mainly changes in the classes referencing the CordaFuture.
There are also few changes that go to some IntelliJ warnings fixes and one public docs (a tutorial section) fix.

I suggest to start with CordaFutureImpl.kt.