### PR TITLE
Move Jackson client support into net.corda.client.jackson package

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -1,4 +1,4 @@
-package net.corda.jackson
+package net.corda.client.jackson
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/StringToMethodCallParser.kt
@@ -1,11 +1,11 @@
-package net.corda.jackson
+package net.corda.client.jackson
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.google.common.collect.HashMultimap
 import com.google.common.collect.Multimap
-import net.corda.jackson.StringToMethodCallParser.ParsedMethodCall
+import net.corda.client.jackson.StringToMethodCallParser.ParsedMethodCall
 import org.slf4j.LoggerFactory
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -1,4 +1,4 @@
-package net.corda.jackson
+package net.corda.client.jackson
 
 import com.fasterxml.jackson.databind.SerializationFeature
 import net.corda.core.contracts.Amount

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/StringToMethodCallParserTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/StringToMethodCallParserTest.kt
@@ -1,4 +1,4 @@
-package net.corda.jackson
+package net.corda.client.jackson
 
 import net.corda.core.crypto.SecureHash
 import org.junit.Assert.assertArrayEquals

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,3 +1,8 @@
 # Package net.corda.finance.utils
 
 A collection of utilities for summing financial states, for example, summing obligations to get total debts.
+
+# Package net.corda.client.jackson
+
+Utilities and serialisers for working with JSON representations of basic types. This adds Jackson support for
+the java.time API, some core types, and Kotlin data classes.

--- a/node/src/main/java/net/corda/node/shell/RunShellCommand.java
+++ b/node/src/main/java/net/corda/node/shell/RunShellCommand.java
@@ -1,7 +1,7 @@
 package net.corda.node.shell;
 
 import net.corda.core.messaging.*;
-import net.corda.jackson.*;
+import net.corda.client.jackson.*;
 import org.crsh.cli.*;
 import org.crsh.command.*;
 

--- a/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/InteractiveShell.kt
@@ -21,8 +21,8 @@ import net.corda.core.internal.*
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.utilities.loggerFor
-import net.corda.jackson.JacksonSupport
-import net.corda.jackson.StringToMethodCallParser
+import net.corda.client.jackson.JacksonSupport
+import net.corda.client.jackson.StringToMethodCallParser
 import net.corda.node.internal.Node
 import net.corda.node.services.messaging.CURRENT_RPC_CONTEXT
 import net.corda.node.services.messaging.RpcContext

--- a/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
+++ b/node/src/test/kotlin/net/corda/node/InteractiveShellTest.kt
@@ -10,7 +10,7 @@ import net.corda.core.internal.FlowStateMachine
 import net.corda.core.node.ServiceHub
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.UntrustworthyData
-import net.corda.jackson.JacksonSupport
+import net.corda.client.jackson.JacksonSupport
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.shell.InteractiveShell
 import net.corda.testing.DUMMY_CA

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -61,7 +61,7 @@ class IRSDemoTest : IntegrationTestCategory {
             log.info("All webservers started")
 
             val (_, nodeAApi, nodeBApi) = listOf(controller, nodeA, nodeB).zip(listOf(controllerAddr, nodeAAddr, nodeBAddr)).map {
-                val mapper = net.corda.jackson.JacksonSupport.createDefaultMapper(it.first.rpc)
+                val mapper = net.corda.client.jackson.JacksonSupport.createDefaultMapper(it.first.rpc)
                 registerFinanceJSONMappers(mapper)
                 HttpApi.fromHostAndPort(it.second, "api/irs", mapper = mapper)
             }

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
@@ -20,7 +20,7 @@ import net.corda.finance.flows.TwoPartyDealFlow.Instigator
 import net.corda.finance.plugin.registerFinanceJSONMappers
 import net.corda.irs.contract.InterestRateSwap
 import net.corda.irs.flows.FixingFlow
-import net.corda.jackson.JacksonSupport
+import net.corda.client.jackson.JacksonSupport
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.testing.DUMMY_CA
 import net.corda.testing.node.InMemoryMessagingNetwork

--- a/test-utils/src/integration-test/kotlin/net/corda/testing/FlowStackSnapshotTest.kt
+++ b/test-utils/src/integration-test/kotlin/net/corda/testing/FlowStackSnapshotTest.kt
@@ -1,6 +1,7 @@
 package net.corda.testing
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.client.jackson.JacksonSupport
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowStackSnapshot
 import net.corda.core.flows.StartableByRPC
@@ -10,7 +11,6 @@ import net.corda.core.internal.list
 import net.corda.core.internal.read
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.CordaSerializable
-import net.corda.jackson.JacksonSupport
 import net.corda.node.services.FlowPermissions.Companion.startFlowPermission
 import net.corda.nodeapi.User
 import net.corda.testing.driver.driver

--- a/test-utils/src/main/kotlin/net/corda/testing/FlowStackSnapshot.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/FlowStackSnapshot.kt
@@ -15,7 +15,7 @@ import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.div
 import net.corda.core.internal.write
 import net.corda.core.serialization.SerializeAsToken
-import net.corda.jackson.JacksonSupport
+import net.corda.client.jackson.JacksonSupport
 import net.corda.node.services.statemachine.FlowStackSnapshotFactory
 import java.nio.file.Path
 import java.time.Instant

--- a/test-utils/src/main/kotlin/net/corda/testing/http/HttpApi.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/http/HttpApi.kt
@@ -30,7 +30,7 @@ class HttpApi(val root: URL, val mapper: ObjectMapper = defaultMapper) {
         fun fromHostAndPort(hostAndPort: NetworkHostAndPort, base: String, protocol: String = "http", mapper: ObjectMapper = defaultMapper): HttpApi
                 = HttpApi(URL("$protocol://$hostAndPort/$base/"), mapper)
         private val defaultMapper: ObjectMapper by lazy {
-            net.corda.jackson.JacksonSupport.createNonRpcMapper()
+            net.corda.client.jackson.JacksonSupport.createNonRpcMapper()
         }
     }
 }

--- a/test-utils/src/main/kotlin/net/corda/testing/http/HttpUtils.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/http/HttpUtils.kt
@@ -22,7 +22,7 @@ object HttpUtils {
                 .readTimeout(60, TimeUnit.SECONDS).build()
     }
     val defaultMapper: ObjectMapper by lazy {
-        net.corda.jackson.JacksonSupport.createNonRpcMapper()
+        net.corda.client.jackson.JacksonSupport.createNonRpcMapper()
     }
 
     fun putJson(url: URL, data: String): Boolean {

--- a/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
@@ -1,10 +1,10 @@
 package net.corda.webserver.internal
 
 import com.google.common.html.HtmlEscapers.htmlEscaper
+import net.corda.client.jackson.JacksonSupport
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.loggerFor
-import net.corda.jackson.JacksonSupport
 import net.corda.nodeapi.ArtemisMessagingComponent
 import net.corda.webserver.WebServerConfig
 import net.corda.webserver.services.WebServerPluginRegistry


### PR DESCRIPTION
Move Jackson client support into net.corda.client.jackson package to match naming scheme used elsewhere