### PR TITLE
Updated vault query api documentation.

### DIFF
--- a/docs/source/api-persistence.rst
+++ b/docs/source/api-persistence.rst
@@ -100,6 +100,8 @@ processed to ensure only the ``X500Name`` of the identity is persisted where an 
 value is stored in the associated column. To preserve privacy, identity keys are never persisted. Developers should use
 the ``IdentityService`` to resolve keys from well know X500 identity names.
 
+.. _jdbc_session_ref:
+
 JDBC session
 ------------
 Apps may also interact directly with the underlying Node's database by using a standard

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -108,7 +108,7 @@ An example of a custom query in Java is illustrated here:
     :start-after: DOCSTART VaultJavaQueryExample3
     :end-before: DOCEND VaultJavaQueryExample3
 
-.. note:: Queries by ``Party`` specify the ``AbstractParty`` which may be concrete or anonymous. In the later case, where an anonymous party does not have an associated X500Name, no query results will ever be produced. For performance reasons, queries do not use PublicKey as search criteria.
+.. note:: Queries by ``Party`` specify the ``AbstractParty`` which may be concrete or anonymous. In the later case, where an anonymous party does not resolve to an X500Name via the IdentityService, no query results will ever be produced. For performance reasons, queries do not use PublicKey as search criteria.
 
 Pagination
 ----------

--- a/node/src/test/kotlin/net/corda/node/services/database/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/database/HibernateConfigurationTest.kt
@@ -870,7 +870,7 @@ class HibernateConfigurationTest : TestDependencyInjectionBase() {
         val nativeQuery = "SELECT v.transaction_id, v.output_index FROM vault_states v WHERE v.state_status = 0"
 
         database.transaction {
-            val jdbcSession = database.createSession()
+            val jdbcSession = services.jdbcSession()
             val prepStatement = jdbcSession.prepareStatement(nativeQuery)
             val rs = prepStatement.executeQuery()
         // DOCEND JdbcSession

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -182,6 +182,7 @@ class ScheduledFlowTests {
      * @return states ordered by the transaction ID.
      */
     private fun queryStatesWithPaging(vaultQueryService: VaultQueryService): List<StateAndRef<ScheduledState>> {
+        // DOCSTART VaultQueryExamplePaging
         var pageNumber = DEFAULT_PAGE_NUM
         val states = mutableListOf<StateAndRef<ScheduledState>>()
         do {
@@ -190,6 +191,7 @@ class ScheduledFlowTests {
             states.addAll(results.states)
             pageNumber++
         } while ((pageSpec.pageSize * (pageNumber)) <= results.totalStatesAvailable)
+        // DOCEND VaultQueryExamplePaging
         return states.toList()
     }
 }


### PR DESCRIPTION
Removed redundant deprecated query examples.
Updated old references (party query).
Add extra sample showing paging iteration.
Added additional references to ServiceHub jdbcSession()
Fixed incorrect code in jdbcSession() code snippet example.