### PR TITLE
Add alt serialise method that returns the schema and the bytes

### DIFF
--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPTestUtils.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPTestUtils.kt
@@ -1,8 +1,11 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
+import net.corda.core.serialization.SerializedBytes
 import org.apache.qpid.proton.codec.Data
 import net.corda.nodeapi.internal.serialization.AllWhitelist
 import net.corda.nodeapi.internal.serialization.EmptyWhitelist
+import java.io.NotSerializableException
+
 
 fun testDefaultFactory() = SerializerFactory(AllWhitelist, ClassLoader.getSystemClassLoader())
 fun testDefaultFactoryWithWhitelist() = SerializerFactory(EmptyWhitelist, ClassLoader.getSystemClassLoader())
@@ -15,5 +18,20 @@ class TestSerializationOutput(
     override fun writeSchema(schema: Schema, data: Data) {
         if (verbose) println(schema)
         super.writeSchema(schema, data)
+    }
+}
+
+fun testName(): String = Thread.currentThread().stackTrace[2].methodName
+
+data class BytesAndSchema<T : Any>(val obj: SerializedBytes<T>, val schema: Schema)
+
+// Extension for the serialize routine that returns the scheme encoded into the
+// bytes as well as the bytes for simple testing
+@Throws(NotSerializableException::class)
+fun <T : Any> SerializationOutput.serializeRtnSchema(obj: T): BytesAndSchema<T> {
+    try {
+        return BytesAndSchema(_serialize(obj), Schema(schemaHistory.toList()))
+    } finally {
+        andFinally()
     }
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPTestUtils.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPTestUtils.kt
@@ -28,7 +28,7 @@ data class BytesAndSchema<T : Any>(val obj: SerializedBytes<T>, val schema: Sche
 // Extension for the serialize routine that returns the scheme encoded into the
 // bytes as well as the bytes for simple testing
 @Throws(NotSerializableException::class)
-fun <T : Any> SerializationOutput.serializeRtnSchema(obj: T): BytesAndSchema<T> {
+fun <T : Any> SerializationOutput.serializeAndReturnSchema(obj: T): BytesAndSchema<T> {
     try {
         return BytesAndSchema(_serialize(obj), Schema(schemaHistory.toList()))
     } finally {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeAndReturnEnvelopeTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeAndReturnEnvelopeTests.kt
@@ -7,11 +7,9 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class DeserializeAndReturnEnvelopeTests {
-
-    fun testName(): String = Thread.currentThread().stackTrace[2].methodName
-
+    // the 'this' reference means we can't just move this to the common test utils
     @Suppress("NOTHING_TO_INLINE")
-    inline fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
+    inline private fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
 
     @Test
     fun oneType() {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializeAndReturnSchemaTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializeAndReturnSchemaTest.kt
@@ -1,0 +1,34 @@
+package net.corda.nodeapi.internal.serialization.amqp
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SerializeAndReturnSchemaTest {
+    // the 'this' reference means we can't just move this to the common test utils
+    @Suppress("NOTHING_TO_INLINE")
+    inline private fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
+
+    val factory = testDefaultFactory()
+
+    // just a simple test to verify the internal test extension for serialize does
+    // indeed give us the correct schema back. This is more useful in support of other
+    // tests rather than by itself but for those to be reliable this also needs
+    // testing
+    @Test
+    fun getSchema() {
+        data class C(val a: Int, val b: Int)
+        val a = 1
+        val b = 2
+
+        val sc = SerializationOutput(factory).serializeRtnSchema(C(a, b))
+
+        assertEquals(1, sc.schema.types.size)
+        assertEquals(classTestName("C"), sc.schema.types.first().name)
+        assertTrue(sc.schema.types.first() is CompositeType)
+        assertEquals(2, (sc.schema.types.first() as CompositeType).fields.size)
+        assertNotNull((sc.schema.types.first() as CompositeType).fields.find { it.name == "a" })
+        assertNotNull((sc.schema.types.first() as CompositeType).fields.find { it.name == "b" })
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializeAndReturnSchemaTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializeAndReturnSchemaTest.kt
@@ -22,7 +22,7 @@ class SerializeAndReturnSchemaTest {
         val a = 1
         val b = 2
 
-        val sc = SerializationOutput(factory).serializeRtnSchema(C(a, b))
+        val sc = SerializationOutput(factory).serializeAndReturnSchema(C(a, b))
 
         assertEquals(1, sc.schema.types.size)
         assertEquals(classTestName("C"), sc.schema.types.first().name)


### PR DESCRIPTION
For future testing it would be nice, post serialisation, to have easy
access to the serialised objects schema so we can check how it was
serialised. Adding a helper function to return a data class that does
this in the same way we can for deserialize