### PR TITLE
Move HibernateConfiguration into net.corda.node.services.persistence

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1,7 +1,6 @@
 package net.corda.node.internal
 
 import com.codahale.metrics.MetricRegistry
-import net.corda.core.internal.VisibleForTesting
 import com.google.common.collect.Lists
 import com.google.common.collect.MutableClassToInstanceMap
 import com.google.common.util.concurrent.MoreExecutors
@@ -34,7 +33,6 @@ import net.corda.node.services.TransactionKeyHandler
 import net.corda.node.services.api.*
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.configureWithDevSSLCertificate
-import net.corda.node.services.database.HibernateConfiguration
 import net.corda.node.services.events.NodeSchedulerService
 import net.corda.node.services.events.ScheduledActivityObserver
 import net.corda.node.services.identity.InMemoryIdentityService

--- a/node/src/main/kotlin/net/corda/node/services/persistence/HibernateConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/HibernateConfiguration.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.database
+package net.corda.node.services.persistence
 
 import net.corda.core.internal.castIfPossible
 import net.corda.core.node.services.IdentityService
@@ -62,7 +62,7 @@ class HibernateConfiguration(createSchemaService: () -> SchemaService, private v
         // We set a connection provider as the auto schema generation requires it.  The auto schema generation will not
         // necessarily remain and would likely be replaced by something like Liquibase.  For now it is very convenient though.
         // TODO: replace auto schema generation as it isn't intended for production use, according to Hibernate docs.
-        val config = Configuration(metadataSources).setProperty("hibernate.connection.provider_class", HibernateConfiguration.NodeDatabaseConnectionProvider::class.java.name)
+        val config = Configuration(metadataSources).setProperty("hibernate.connection.provider_class", NodeDatabaseConnectionProvider::class.java.name)
                 .setProperty("hibernate.hbm2ddl.auto", if (databaseProperties.getProperty("initDatabase","true") == "true") "update" else "validate")
                 .setProperty("hibernate.format_sql", "true")
                 .setProperty("hibernate.connection.isolation", transactionIsolationLevel.toString())

--- a/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
@@ -8,7 +8,7 @@ import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
-import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.persistence.HibernateConfiguration
 import net.corda.node.utilities.DatabaseTransactionManager
 import org.hibernate.FlushMode
 import rx.Observable

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateVaultQueryImpl.kt
@@ -1,11 +1,11 @@
 package net.corda.node.services.vault
 
-import net.corda.core.internal.ThreadBox
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.SecureHash
+import net.corda.core.internal.ThreadBox
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.messaging.DataFeed
 import net.corda.core.node.services.Vault
@@ -20,7 +20,7 @@ import net.corda.core.serialization.deserialize
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.trace
-import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.persistence.HibernateConfiguration
 import net.corda.node.utilities.DatabaseTransactionManager
 import org.hibernate.Session
 import rx.Observable

--- a/node/src/main/kotlin/net/corda/node/utilities/CordaPersistence.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/CordaPersistence.kt
@@ -4,7 +4,7 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import net.corda.core.node.services.IdentityService
 import net.corda.node.services.api.SchemaService
-import net.corda.node.services.database.HibernateConfiguration
+import net.corda.node.services.persistence.HibernateConfiguration
 import net.corda.node.services.schema.NodeSchemaService
 import org.hibernate.SessionFactory
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -13,7 +13,6 @@ import net.corda.core.transactions.WireTransaction
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.finance.schemas.SampleCashSchemaV2
 import net.corda.finance.schemas.SampleCashSchemaV3
-import net.corda.node.services.database.HibernateConfiguration
 import net.corda.node.services.schema.HibernateObserver
 import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.services.transactions.PersistentUniquenessProvider

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.database
+package net.corda.node.services.persistence
 
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef

--- a/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/test-utils/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -18,10 +18,10 @@ import net.corda.finance.schemas.CommercialPaperSchemaV1
 import net.corda.node.VersionInfo
 import net.corda.node.services.api.StateMachineRecordedTransactionMappingStorage
 import net.corda.node.services.api.WritableTransactionStorage
-import net.corda.node.services.database.HibernateConfiguration
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.keys.freshCertificate
 import net.corda.node.services.keys.getSigner
+import net.corda.node.services.persistence.HibernateConfiguration
 import net.corda.node.services.persistence.InMemoryStateMachineRecordedTransactionMappingStorage
 import net.corda.node.services.schema.HibernateObserver
 import net.corda.node.services.schema.NodeSchemaService


### PR DESCRIPTION
Move `HibernateConfiguration` into `net.corda.node.services.persistence` as having a single-class package that's differentiated from the persistence package seems excessive.
