### PR TITLE
Throw a diagnostic exception if your FlowLogic.call method is not marked as @Suspendable.

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.events
 
+import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowLogicRef
@@ -133,6 +134,7 @@ class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
     }
 
     class TestFlowLogic(val increment: Int = 1) : FlowLogic<Unit>() {
+        @Suspendable
         override fun call() {
             (serviceHub as TestReference).testReference.calls += increment
             (serviceHub as TestReference).testReference.countDown.countDown()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -912,6 +912,7 @@ class FlowFrameworkTests {
         override val progressTracker: ProgressTracker = ProgressTracker(START_STEP)
         lateinit var exceptionThrown: E
 
+        @Suspendable
         override fun call(): Nothing {
             progressTracker.currentStep = START_STEP
             exceptionThrown = exception()

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt
@@ -23,6 +23,7 @@ object UpdateBusinessDayFlow {
 
     @InitiatedBy(Broadcast::class)
     private class UpdateBusinessDayHandler(val otherParty: Party) : FlowLogic<Unit>() {
+        @Suspendable
         override fun call() {
             val message = receive<UpdateBusinessDayMessage>(otherParty).unwrap { it }
             (serviceHub.clock as TestClock).updateDate(message.date)


### PR DESCRIPTION
This catches a bunch of unit tests where it's missing and also resolves an issue I saw Roger hit the other day.

Additionally, adds a missing exception logging path.