### PR TITLE
Remove the copy of Guava from within the finance module.

### DIFF
--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     // ObjectWeb Asm: a library for synthesising and working with JVM bytecode.
     compile "org.ow2.asm:asm:5.0.4"
 
+    compile "com.google.guava:guava:$guava_version"
+
     testCompile "junit:junit:$junit_version"
     testCompile project(':test-utils')
 }

--- a/finance/build.gradle
+++ b/finance/build.gradle
@@ -15,8 +15,6 @@ dependencies {
     // and CorDapps using :finance features should use 'cordapp' not 'compile' linkage.
     cordaCompile project(':core')
 
-    compile "com.google.guava:guava:$guava_version"
-
     testCompile project(':test-utils')
     testCompile project(path: ':core', configuration: 'testArtifacts')
     testCompile "junit:junit:$junit_version"


### PR DESCRIPTION
Declare Guava as a `cordaCompile` dependency so that we don't bundle it inside the finance module.