### PR TITLE
Eliminate generated `Kt` classes

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/CommercialPaper.kt
@@ -40,10 +40,11 @@ import java.util.*
  *    which may need to be tracked. That, in turn, requires validation logic (there is a bean validator that knows how
  *    to do this in the Apache BVal project).
  */
-val CP_PROGRAM_ID = CommercialPaper()
-
 // TODO: Generalise the notion of an owned instrument into a superclass/supercontract. Consider composition vs inheritance.
 class CommercialPaper : Contract {
+    companion object {
+        val CP_PROGRAM_ID = CommercialPaper()
+    }
     data class State(
             val issuance: PartyAndReference,
             override val owner: AbstractParty,

--- a/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt
@@ -209,6 +209,7 @@ open class BusinessCalendar (val holidayDates: List<LocalDate>) {
             it to BusinessCalendar::class.java.getResourceAsStream("${it}HolidayCalendar.txt").bufferedReader().readText()
         }.toMap()
 
+        @JvmStatic
         fun calculateDaysBetween(startDate: LocalDate,
                                  endDate: LocalDate,
                                  dcbYear: DayCountBasisYear,
@@ -223,9 +224,11 @@ open class BusinessCalendar (val holidayDates: List<LocalDate>) {
         }
 
         /** Parses a date of the form YYYY-MM-DD, like 2016-01-10 for 10th Jan. */
+        @JvmStatic
         fun parseDateFromString(it: String): LocalDate = LocalDate.parse(it, DateTimeFormatter.ISO_LOCAL_DATE)
 
         /** Returns a business calendar that combines all the named holiday calendars into one list of holiday dates. */
+        @JvmStatic
         fun getInstance(vararg calname: String) = BusinessCalendar(
                 calname.flatMap { (TEST_CALENDAR_DATA[it] ?: throw UnknownCalendar(it)).split(",") }.
                         toSet().
@@ -234,6 +237,7 @@ open class BusinessCalendar (val holidayDates: List<LocalDate>) {
         )
 
         /** Calculates an event schedule that moves events around to ensure they fall on working days. */
+        @JvmStatic
         fun createGenericSchedule(startDate: LocalDate,
                                   period: Frequency,
                                   calendar: BusinessCalendar = getInstance(),
@@ -257,9 +261,11 @@ open class BusinessCalendar (val holidayDates: List<LocalDate>) {
             return ret
         }
 
-        /** Calculates the date from @startDate moving forward @steps of time size @period. Does not apply calendar
+        /**
+         * Calculates the date from @startDate moving forward 'steps' of time size 'period'. Does not apply calendar
          * logic / roll conventions.
          */
+        @JvmStatic
         fun getOffsetDate(startDate: LocalDate, period: Frequency, steps: Int = 1): LocalDate {
             if (steps == 0) return startDate
             return period.offset(startDate, steps.toLong())

--- a/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt
@@ -190,10 +190,6 @@ enum class Frequency(val annualCompoundCount: Int, val offset: LocalDate.(Long) 
     Daily(365, { plusDays(1 * it) });
 }
 
-
-@Suppress("unused") // This utility may be useful in future. TODO: Review before API stability guarantees in place.
-fun LocalDate.isWorkingDay(accordingToCalendar: BusinessCalendar): Boolean = accordingToCalendar.isWorkingDay(this)
-
 // TODO: Make Calendar data come from an oracle
 
 /**

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/CommodityContract.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/CommodityContract.kt
@@ -19,9 +19,6 @@ import java.util.*
 // Commodity
 //
 
-// Just a fake program identifier for now. In a real system it could be, for instance, the hash of the program bytecode.
-val COMMODITY_PROGRAM_ID = CommodityContract()
-
 /**
  * A commodity contract represents an amount of some commodity, tracked on a distributed ledger. The design of this
  * contract is intentionally similar to the [Cash] contract, and the same commands (issue, move, exit) apply, the
@@ -34,6 +31,11 @@ val COMMODITY_PROGRAM_ID = CommodityContract()
  */
 // TODO: Need to think about expiry of commodities, how to require payment of storage costs, etc.
 class CommodityContract : OnLedgerAsset<Commodity, CommodityContract.Commands, CommodityContract.State>() {
+    companion object {
+        // Just a fake program identifier for now. In a real system it could be, for instance, the hash of the program bytecode.
+        val COMMODITY_PROGRAM_ID = CommodityContract()
+    }
+
     /** A state representing a commodity claim against some party */
     data class State(
             override val amount: Amount<Issued<Commodity>>,

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/contract/IRS.kt
@@ -2,7 +2,6 @@ package net.corda.irs.contract
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import net.corda.core.contracts.*
-import net.corda.core.crypto.containsAny
 import net.corda.core.flows.FlowLogicRefFactory
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
@@ -18,7 +17,6 @@ import org.apache.commons.jexl3.JexlBuilder
 import org.apache.commons.jexl3.MapContext
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.security.PublicKey
 import java.time.LocalDate
 import java.util.*
 
@@ -76,7 +74,7 @@ abstract class RatePaymentEvent(date: LocalDate,
 
     abstract val flow: Amount<Currency>
 
-    val days: Int get() = calculateDaysBetween(accrualStartDate, accrualEndDate, dayCountBasisYear, dayCountBasisDay)
+    val days: Int get() = BusinessCalendar.calculateDaysBetween(accrualStartDate, accrualEndDate, dayCountBasisYear, dayCountBasisDay)
 
     // TODO : Fix below (use daycount convention for division, not hardcoded 360 etc)
     val dayCountFactor: BigDecimal get() = (BigDecimal(days).divide(BigDecimal(360.0), 8, RoundingMode.HALF_UP)).setScale(4, RoundingMode.HALF_UP)


### PR DESCRIPTION
Eliminate generated `...Kt` classes, to make Java API cleaner

Part of https://r3-cev.atlassian.net/browse/CORDA-499