### PR TITLE
Enable RPC start of Flows that return nothing (eg. Void).

### DIFF
--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -194,14 +194,14 @@ interface CordaRPCOps : RPCOps {
      * Start the given flow with the given arguments. [logicType] must be annotated with [net.corda.core.flows.StartableByRPC].
      */
     @RPCReturnsObservables
-    fun <T : Any> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
+    fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T>
 
     /**
      * Start the given flow with the given arguments, returning an [Observable] with a single observation of the
      * result of running the flow. [logicType] must be annotated with [net.corda.core.flows.StartableByRPC].
      */
     @RPCReturnsObservables
-    fun <T : Any> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T>
+    fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T>
 
     /**
      * Returns Node's identity, assuming this will not change while the node is running.
@@ -327,25 +327,25 @@ inline fun <reified T : ContractState> CordaRPCOps.vaultTrackBy(criteria: QueryC
  * Note that the passed in constructor function is only used for unification of other type parameters and reification of
  * the Class instance of the flow. This could be changed to use the constructor function directly.
  */
-inline fun <T : Any, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+inline fun <T, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         @Suppress("UNUSED_PARAMETER")
         flowConstructor: () -> R
 ): FlowHandle<T> = startFlowDynamic(R::class.java)
 
-inline fun <T : Any, A, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+inline fun <T, A, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         @Suppress("UNUSED_PARAMETER")
         flowConstructor: (A) -> R,
         arg0: A
 ): FlowHandle<T> = startFlowDynamic(R::class.java, arg0)
 
-inline fun <T : Any, A, B, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+inline fun <T, A, B, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         @Suppress("UNUSED_PARAMETER")
         flowConstructor: (A, B) -> R,
         arg0: A,
         arg1: B
 ): FlowHandle<T> = startFlowDynamic(R::class.java, arg0, arg1)
 
-inline fun <T : Any, A, B, C, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+inline fun <T, A, B, C, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         @Suppress("UNUSED_PARAMETER")
         flowConstructor: (A, B, C) -> R,
         arg0: A,
@@ -353,7 +353,7 @@ inline fun <T : Any, A, B, C, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         arg2: C
 ): FlowHandle<T> = startFlowDynamic(R::class.java, arg0, arg1, arg2)
 
-inline fun <T : Any, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+inline fun <T, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         @Suppress("UNUSED_PARAMETER")
         flowConstructor: (A, B, C, D) -> R,
         arg0: A,
@@ -362,7 +362,7 @@ inline fun <T : Any, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startFlow
         arg3: D
 ): FlowHandle<T> = startFlowDynamic(R::class.java, arg0, arg1, arg2, arg3)
 
-inline fun <T : Any, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+inline fun <T, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         @Suppress("UNUSED_PARAMETER")
         flowConstructor: (A, B, C, D, E) -> R,
         arg0: A,
@@ -372,7 +372,7 @@ inline fun <T : Any, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startF
         arg4: E
 ): FlowHandle<T> = startFlowDynamic(R::class.java, arg0, arg1, arg2, arg3, arg4)
 
-inline fun <T : Any, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
+inline fun <T, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.startFlow(
         @Suppress("UNUSED_PARAMETER")
         flowConstructor: (A, B, C, D, E, F) -> R,
         arg0: A,
@@ -387,20 +387,20 @@ inline fun <T : Any, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.sta
  * Same again, except this time with progress-tracking enabled.
  */
 @Suppress("unused")
-inline fun <T : Any, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
+inline fun <T, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
         @Suppress("unused_parameter")
         flowConstructor: () -> R
 ): FlowProgressHandle<T> = startTrackedFlowDynamic(R::class.java)
 
 @Suppress("unused")
-inline fun <T : Any, A, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
+inline fun <T, A, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
         @Suppress("unused_parameter")
         flowConstructor: (A) -> R,
         arg0: A
 ): FlowProgressHandle<T> = startTrackedFlowDynamic(R::class.java, arg0)
 
 @Suppress("unused")
-inline fun <T : Any, A, B, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
+inline fun <T, A, B, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
         @Suppress("unused_parameter")
         flowConstructor: (A, B) -> R,
         arg0: A,
@@ -408,7 +408,7 @@ inline fun <T : Any, A, B, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlo
 ): FlowProgressHandle<T> = startTrackedFlowDynamic(R::class.java, arg0, arg1)
 
 @Suppress("unused")
-inline fun <T : Any, A, B, C, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
+inline fun <T, A, B, C, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
         @Suppress("unused_parameter")
         flowConstructor: (A, B, C) -> R,
         arg0: A,
@@ -417,7 +417,7 @@ inline fun <T : Any, A, B, C, reified R : FlowLogic<T>> CordaRPCOps.startTracked
 ): FlowProgressHandle<T> = startTrackedFlowDynamic(R::class.java, arg0, arg1, arg2)
 
 @Suppress("unused")
-inline fun <T : Any, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
+inline fun <T, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
         @Suppress("unused_parameter")
         flowConstructor: (A, B, C, D) -> R,
         arg0: A,
@@ -427,7 +427,7 @@ inline fun <T : Any, A, B, C, D, reified R : FlowLogic<T>> CordaRPCOps.startTrac
 ): FlowProgressHandle<T> = startTrackedFlowDynamic(R::class.java, arg0, arg1, arg2, arg3)
 
 @Suppress("unused")
-inline fun <T : Any, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
+inline fun <T, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
         @Suppress("unused_parameter")
         flowConstructor: (A, B, C, D, E) -> R,
         arg0: A,
@@ -438,7 +438,7 @@ inline fun <T : Any, A, B, C, D, E, reified R : FlowLogic<T>> CordaRPCOps.startT
 ): FlowProgressHandle<T> = startTrackedFlowDynamic(R::class.java, arg0, arg1, arg2, arg3, arg4)
 
 @Suppress("unused")
-inline fun <T : Any, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
+inline fun <T, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.startTrackedFlow(
         @Suppress("unused_parameter")
         flowConstructor: (A, B, C, D, E, F) -> R,
         arg0: A,

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -127,7 +127,7 @@ class CordaRPCOpsImpl(
         }
     }
 
-    override fun <T : Any> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
+    override fun <T> startTrackedFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowProgressHandle<T> {
         val stateMachine = startFlow(logicType, args)
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
@@ -136,12 +136,12 @@ class CordaRPCOpsImpl(
         )
     }
 
-    override fun <T : Any> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
+    override fun <T> startFlowDynamic(logicType: Class<out FlowLogic<T>>, vararg args: Any?): FlowHandle<T> {
         val stateMachine = startFlow(logicType, args)
         return FlowHandleImpl(id = stateMachine.id, returnValue = stateMachine.resultFuture)
     }
 
-    private fun <T : Any> startFlow(logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachineImpl<T> {
+    private fun <T> startFlow(logicType: Class<out FlowLogic<T>>, args: Array<out Any?>): FlowStateMachineImpl<T> {
         require(logicType.isAnnotationPresent(StartableByRPC::class.java)) { "${logicType.name} was not designed for RPC" }
         val rpcContext = getRpcContext()
         rpcContext.requirePermission(startFlowPermission(logicType))

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -126,7 +126,7 @@ interface ServiceHubInternal : PluginServiceHub {
      * @throws net.corda.core.flows.IllegalFlowLogicException or IllegalArgumentException if there are problems with the
      * [logicType] or [args].
      */
-    fun <T : Any> invokeFlowAsync(
+    fun <T> invokeFlowAsync(
             logicType: Class<out FlowLogic<T>>,
             flowInitiator: FlowInitiator,
             vararg args: Any?): FlowStateMachineImpl<T> {

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.contracts.Issued
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.crypto.keys
 import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.messaging.*
 import net.corda.core.node.services.ServiceInfo
@@ -44,6 +45,7 @@ import rx.Observable
 import java.io.ByteArrayOutputStream
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CordaRPCOpsImplTest {
@@ -248,4 +250,19 @@ class CordaRPCOpsImplTest {
         @Suspendable
         override fun call() = Unit
     }
+
+    @Test
+    fun `attempt to start RPC flow with void return`() {
+        CURRENT_RPC_CONTEXT.set(RpcContext(User("user", "pwd", permissions = setOf(
+                startFlowPermission<VoidRPCFlow>()
+        ))))
+        assertNull(rpc.startFlow(::VoidRPCFlow).returnValue.getOrThrow())
+    }
+
+    @StartableByRPC
+    class VoidRPCFlow : FlowLogic<Void?>() {
+        @Suspendable
+        override fun call() : Void? = null
+    }
+
 }

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -73,12 +73,6 @@ class CordaRPCOpsImplTest {
                 startFlowPermission<CashIssueFlow>(),
                 startFlowPermission<CashPaymentFlow>()
         ))))
-
-        aliceNode.database.transaction {
-            stateMachineUpdates = rpc.stateMachinesFeed().updates
-            transactions = rpc.verifiedTransactionsFeed().updates
-            vaultTrackCash = rpc.vaultTrackBy<Cash.State>().updates
-        }
     }
 
     @After
@@ -88,6 +82,11 @@ class CordaRPCOpsImplTest {
 
     @Test
     fun `cash issue accepted`() {
+        aliceNode.database.transaction {
+            stateMachineUpdates = rpc.stateMachinesFeed().updates
+            vaultTrackCash = rpc.vaultTrackBy<Cash.State>().updates
+        }
+
         val quantity = 1000L
         val ref = OpaqueBytes(ByteArray(1) { 1 })
 
@@ -133,6 +132,12 @@ class CordaRPCOpsImplTest {
 
     @Test
     fun `issue and move`() {
+        aliceNode.database.transaction {
+            stateMachineUpdates = rpc.stateMachinesFeed().updates
+            transactions = rpc.verifiedTransactionsFeed().updates
+            vaultTrackCash = rpc.vaultTrackBy<Cash.State>().updates
+        }
+
         val anonymous = false
         val result = rpc.startFlow(::CashIssueFlow,
                 100.DOLLARS,
@@ -256,7 +261,9 @@ class CordaRPCOpsImplTest {
         CURRENT_RPC_CONTEXT.set(RpcContext(User("user", "pwd", permissions = setOf(
                 startFlowPermission<VoidRPCFlow>()
         ))))
-        assertNull(rpc.startFlow(::VoidRPCFlow).returnValue.getOrThrow())
+        val result = rpc.startFlow(::VoidRPCFlow)
+        mockNet.runNetwork()
+        assertNull(result.returnValue.getOrThrow())
     }
 
     @StartableByRPC
@@ -264,5 +271,4 @@ class CordaRPCOpsImplTest {
         @Suspendable
         override fun call() : Void? = null
     }
-
 }


### PR DESCRIPTION
Usage of `<T: Any>` in RPC calls to `startFlow*()` prevents calling Flows which return nothing (eg. Void). Compiler is unable to resolve the typed parameter for Void (as this is not a subtype of Any).