### PR TITLE
Fix notary demo

### DIFF
--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/flows/DummyIssueAndMove.kt
@@ -1,10 +1,9 @@
 package net.corda.notarydemo.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.Amount
+import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractState
-import net.corda.core.contracts.Issued
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.AbstractParty
@@ -12,8 +11,6 @@ import net.corda.core.identity.Party
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.finance.GBP
-import net.corda.finance.contracts.asset.Cash
 
 @StartableByRPC
 class DummyIssueAndMove(private val notary: Party, private val counterpartyNode: Party, private val discriminator: Int) : FlowLogic<SignedTransaction>() {
@@ -21,23 +18,27 @@ class DummyIssueAndMove(private val notary: Party, private val counterpartyNode:
         override fun verify(tx: LedgerTransaction) {}
     }
 
+    data class DummyCommand(val dummy: Int = 0): CommandData
+
     data class State(override val participants: List<AbstractParty>, private val discriminator: Int) : ContractState {
         override val contract = DoNothingContract
     }
 
     @Suspendable
-    override fun call() = serviceHub.run {
+    override fun call(): SignedTransaction {
         // Self issue an asset
-        val amount = Amount(1000000, Issued(myInfo.legalIdentity.ref(0), GBP))
-        val issueTxBuilder = TransactionBuilder(notary = notary)
-        val signers = Cash().generateIssue(issueTxBuilder, amount, serviceHub.myInfo.legalIdentity, notary)
-        val issueTx = serviceHub.signInitialTransaction(issueTxBuilder, signers)
+        val state = State(listOf(serviceHub.myInfo.legalIdentity), discriminator)
+        val issueTx = serviceHub.signInitialTransaction(TransactionBuilder(notary).apply {
+            addOutputState(state)
+            addCommand(DummyCommand(),listOf(serviceHub.myInfo.legalIdentity.owningKey))
+        })
         serviceHub.recordTransactions(issueTx)
         // Move ownership of the asset to the counterparty
-        val moveTxBuilder = TransactionBuilder(notary = notary)
-
-        val (_, keys) = Cash.generateSpend(serviceHub, moveTxBuilder, Amount(amount.quantity, GBP), counterpartyNode)
         // We don't check signatures because we know that the notary's signature is missing
-        signInitialTransaction(moveTxBuilder, keys)
+        return serviceHub.signInitialTransaction(TransactionBuilder(notary).apply {
+            addInputState(issueTx.tx.outRef<ContractState>(0))
+            addOutputState(state.copy(participants = listOf(counterpartyNode)))
+            addCommand(DummyCommand(),listOf(serviceHub.myInfo.legalIdentity.owningKey))
+        })
     }
 }


### PR DESCRIPTION
The notary demo got reverted to a cash version that didn't work, due to incorrect use of soft-locking.
This reverts to a simple custom state suitable for showing notary logic.