### PR TITLE
Rewrite ExchangeRate to use BigDecimal

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
@@ -5,23 +5,24 @@ import javafx.beans.value.ObservableValue
 import net.corda.core.contracts.Amount
 import java.util.*
 
-
-interface ExchangeRate {
-    fun rate(from: Currency, to: Currency): Double
-}
-
-fun ExchangeRate.exchangeAmount(amount: Amount<Currency>, to: Currency) =
-        Amount(exchangeDouble(amount, to).toLong(), to)
-
-fun ExchangeRate.exchangeDouble(amount: Amount<Currency>, to: Currency) =
-        rate(amount.token, to) * amount.quantity
-
 /**
  * This model provides an exchange rate from arbitrary currency to arbitrary currency.
- * TODO hook up an actual oracle
  */
+abstract class ExchangeRate {
+    fun exchangeAmount(amount: Amount<Currency>, to: Currency) =
+            Amount(exchangeDouble(amount, to).toLong(), to)
+
+    fun exchangeDouble(amount: Amount<Currency>, to: Currency) =
+            rate(amount.token, to) * amount.quantity
+    abstract fun rate(from: Currency, to: Currency): Double
+}
+
+/**
+ * Default implementation of an exchange rate model, which uses a fixed exchange rate.
+ */
+// TODO hook up an actual oracle
 class ExchangeRateModel {
-    val exchangeRate: ObservableValue<ExchangeRate> = SimpleObjectProperty<ExchangeRate>(object : ExchangeRate {
+    val exchangeRate: ObservableValue<ExchangeRate> = SimpleObjectProperty<ExchangeRate>(object : ExchangeRate() {
         override fun rate(from: Currency, to: Currency) = 1.0
     })
 }

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
@@ -3,18 +3,17 @@ package net.corda.client.jfx.model
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.value.ObservableValue
 import net.corda.core.contracts.Amount
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.util.*
 
 /**
  * This model provides an exchange rate from arbitrary currency to arbitrary currency.
  */
 abstract class ExchangeRate {
-    fun exchangeAmount(amount: Amount<Currency>, to: Currency) =
-            Amount(exchangeDouble(amount, to).toLong(), to)
-
-    fun exchangeDouble(amount: Amount<Currency>, to: Currency) =
-            rate(amount.token, to) * amount.quantity
-    abstract fun rate(from: Currency, to: Currency): Double
+    fun exchangeAmount(amount: Amount<Currency>, to: Currency, roundingMode: RoundingMode = RoundingMode.HALF_UP) =
+            amount.multiply(rate(amount.token, to), roundingMode)
+    abstract fun rate(from: Currency, to: Currency): BigDecimal
 }
 
 /**
@@ -23,6 +22,6 @@ abstract class ExchangeRate {
 // TODO hook up an actual oracle
 class ExchangeRateModel {
     val exchangeRate: ObservableValue<ExchangeRate> = SimpleObjectProperty<ExchangeRate>(object : ExchangeRate() {
-        override fun rate(from: Currency, to: Currency) = 1.0
+        override fun rate(from: Currency, to: Currency) = BigDecimal.ONE
     })
 }

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
@@ -11,8 +11,14 @@ import java.util.*
  * This model provides an exchange rate from arbitrary currency to arbitrary currency.
  */
 abstract class ExchangeRate {
-    fun exchangeAmount(amount: Amount<Currency>, to: Currency, roundingMode: RoundingMode = RoundingMode.HALF_UP) =
-            amount.multiply(rate(amount.token, to), roundingMode)
+    /**
+     * Convert the given amount of a currency into the target currency. Rounding/precision correction of the resulting
+     * quantity of the target currency is the responsibility of the calling code.
+     *
+     * @return the original amount converted to a quantity of the target currency.
+     */
+    fun exchangeAmount(amount: Amount<Currency>, to: Currency) = BigDecimal.valueOf(amount.quantity).multiply(rate(amount.token, to))
+
     abstract fun rate(from: Currency, to: Currency): BigDecimal
 }
 

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ExchangeRateModel.kt
@@ -12,12 +12,11 @@ import java.util.*
  */
 abstract class ExchangeRate {
     /**
-     * Convert the given amount of a currency into the target currency. Rounding/precision correction of the resulting
-     * quantity of the target currency is the responsibility of the calling code.
+     * Convert the given amount of a currency into the target currency.
      *
-     * @return the original amount converted to a quantity of the target currency.
+     * @return the original amount converted to an amount in the target currency.
      */
-    fun exchangeAmount(amount: Amount<Currency>, to: Currency) = BigDecimal.valueOf(amount.quantity).multiply(rate(amount.token, to))
+    fun exchangeAmount(amount: Amount<Currency>, to: Currency) = Amount.fromDecimal(amount.toDecimal().multiply(rate(amount.token, to)), to)
 
     abstract fun rate(from: Currency, to: Currency): BigDecimal
 }

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
@@ -29,7 +29,7 @@ object AmountBindings {
         return EasyBind.combine(observableCurrency, observableExchangeRate) { currency, exchangeRate ->
             Pair<Currency, (Amount<Currency>) -> Long>(
                     currency,
-                    { amount -> exchangeRate.exchangeAmount(amount, currency).quantity }
+                    { amount -> exchangeRate.exchangeAmount(amount, currency).toLong() }
             )
         }
     }

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
@@ -29,7 +29,7 @@ object AmountBindings {
         return EasyBind.combine(observableCurrency, observableExchangeRate) { currency, exchangeRate ->
             Pair<Currency, (Amount<Currency>) -> Long>(
                     currency,
-                    { amount -> exchangeRate.exchangeAmount(amount, currency).toLong() }
+                    { amount -> exchangeRate.exchangeAmount(amount, currency).quantity }
             )
         }
     }

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/AmountBindings.kt
@@ -29,7 +29,7 @@ object AmountBindings {
         return EasyBind.combine(observableCurrency, observableExchangeRate) { currency, exchangeRate ->
             Pair<Currency, (Amount<Currency>) -> Long>(
                     currency,
-                    { (quantity, _, token) -> (exchangeRate.rate(token, currency) * quantity).toLong() }
+                    { amount -> exchangeRate.exchangeAmount(amount, currency).quantity }
             )
         }
     }

--- a/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
@@ -5,8 +5,6 @@ import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.exactAdd
 import java.math.BigDecimal
-import java.math.BigInteger
-import java.math.MathContext
 import java.math.RoundingMode
 import java.util.*
 

--- a/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
@@ -234,11 +234,6 @@ data class Amount<T : Any>(val quantity: Long, val displayTokenSize: BigDecimal,
      */
     operator fun times(other: Int): Amount<T> = Amount(Math.multiplyExact(quantity, other.toLong()), displayTokenSize, token)
 
-    fun multiply(other: BigDecimal, roundingMode: RoundingMode): Amount<T> {
-        val newQuantity: BigDecimal = BigDecimal.valueOf(quantity).multiply(other).setScale(0, roundingMode)
-        return Amount(newQuantity.toLong(), token)
-    }
-
     /**
      * This method provides a token conserving divide mechanism.
      * @param partitions the number of amounts to divide the current quantity into.

--- a/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
@@ -5,6 +5,8 @@ import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.exactAdd
 import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.MathContext
 import java.math.RoundingMode
 import java.util.*
 
@@ -231,6 +233,11 @@ data class Amount<T : Any>(val quantity: Long, val displayTokenSize: BigDecimal,
      * N.B. Division is not supported as fractional tokens are not representable by an Amount.
      */
     operator fun times(other: Int): Amount<T> = Amount(Math.multiplyExact(quantity, other.toLong()), displayTokenSize, token)
+
+    fun multiply(other: BigDecimal, roundingMode: RoundingMode): Amount<T> {
+        val newQuantity: BigDecimal = BigDecimal.valueOf(quantity).multiply(other).setScale(0, roundingMode)
+        return Amount(newQuantity.toLong(), token)
+    }
 
     /**
      * This method provides a token conserving divide mechanism.


### PR DESCRIPTION
Rewrite `ExchangeRate` to use `BigDecimal` for the quantity multiplication, to ensure that there is no loss of precision during the conversion process.

Also extends `Amount` to provide a multiplication function with rounding mode specified.