### PR TITLE
Demote quasar-core to a runtime dependency.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.15.1
+gradlePluginsVersion=0.15.2
 kotlinVersion=1.1.4
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
+    // Quasar, for suspendable fibres.
+    compileOnly "co.paralleluniverse:quasar-core:$quasar_version:jdk8"
+
     // Thread safety annotations
     compile "com.google.code.findbugs:jsr305:3.0.1"
 

--- a/gradle-plugins/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/gradle-plugins/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -14,7 +14,7 @@ class QuasarPlugin implements Plugin<Project> {
 //        To add a local .jar dependency:
 //        project.dependencies.add("quasar", project.files("${project.rootProject.projectDir}/lib/quasar.jar"))
         project.dependencies.add("quasar", "co.paralleluniverse:quasar-core:${project.rootProject.ext.quasar_version}:jdk8@jar")
-        project.dependencies.add("compile", project.configurations.getByName("quasar"))
+        project.dependencies.add("runtime", project.configurations.getByName("quasar"))
 
         project.tasks.withType(Test) {
             jvmArgs "-javaagent:${project.configurations.quasar.singleFile}"

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -30,8 +30,10 @@ class FlowVersioningTest : NodeBasedTest() {
     private class PretendInitiatingCoreFlow(val initiatedParty: Party) : FlowLogic<Pair<Int, Int>>() {
         @Suspendable
         override fun call(): Pair<Int, Int> {
+            // Execute receive() outside of the Pair constructor to avoid Kotlin/Quasar instrumentation bug.
+            val alicePlatformVersionAccordingToBob = receive<Int>(initiatedParty).unwrap { it }
             return Pair(
-                    receive<Int>(initiatedParty).unwrap { it },
+                    alicePlatformVersionAccordingToBob,
                     getFlowContext(initiatedParty).flowVersion
             )
         }

--- a/samples/network-visualiser/build.gradle
+++ b/samples/network-visualiser/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     // Cordapp dependencies
     // GraphStream: For visualisation
-    compile 'co.paralleluniverse:capsule:1.0.3'
+    compileOnly "co.paralleluniverse:capsule:$capsule_version"
     compile "org.graphstream:gs-core:1.3"
     compile "org.graphstream:gs-ui:1.3"
 }

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 task standaloneJar(type: Jar) {
     // Create a fat jar by packing all deps into the output
     from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
     }
     with jar
     exclude("META-INF/*.DSA")


### PR DESCRIPTION
We want `quasar-core` as a runtime dependency rather than a compile dependency so that we are still able to exclude it from any "fat jars" that we build. The `QuasarPlugin` only installs `quasar-core` as a Java agent, and runtime scope is fine for that.
Add `quasar-core` to `:core` as a non-transitive "compileOnly" dependency so that we still have access to the `@Suspendable` annotation.

This change also flushed a (known) Quasar/Kotlin instrumentation bug in `FlowVersioningTest`, which @exFalso helped me fix.

And I've corrected the use of `capsule` in `network-visualiser` too, for good measure.