### PR TITLE
Composite Signature OID fix and crypto comments clean up

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -12,7 +12,7 @@ import java.util.*
 
 /**
  * A tree data structure that enables the representation of composite public keys.
- * Notice that with that implementation CompositeKey extends PublicKey. Leaves are represented by single public keys.
+ * Notice that with that implementation CompositeKey extends [PublicKey]. Leaves are represented by single public keys.
  *
  * For complex scenarios, such as *"Both Alice and Bob need to sign to consume a state S"*, we can represent
  * the requirement by creating a tree with a root [CompositeKey], and Alice and Bob as children.
@@ -159,7 +159,7 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
     }
 
     /**
-     * Takes single PublicKey and checks if CompositeKey requirements hold for that key.
+     * Takes single [PublicKey] and checks if [CompositeKey] requirements hold for that key.
      */
     fun isFulfilledBy(key: PublicKey) = isFulfilledBy(setOf(key))
 
@@ -205,7 +205,7 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
     }
 
     /**
-     * Set of all leaf keys of that CompositeKey.
+     * Set of all leaf keys of that [CompositeKey].
      */
     val leafKeys: Set<PublicKey>
         get() = children.flatMap { it.node.keys }.toSet() // Uses PublicKey.keys extension.

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKeyFactory.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKeyFactory.kt
@@ -26,7 +26,7 @@ class CompositeKeyFactory : KeyFactorySpi() {
 
     @Throws(InvalidKeySpecException::class)
     override fun <T : KeySpec> engineGetKeySpec(key: Key, keySpec: Class<T>): T {
-        // Only support [X509EncodedKeySpec].
+        // Only support X509EncodedKeySpec.
         throw InvalidKeySpecException("Not implemented yet $key $keySpec")
     }
 

--- a/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
@@ -21,14 +21,16 @@ class CordaSecurityProvider : Provider(PROVIDER_NAME, 0.1, "$PROVIDER_NAME secur
         val compositeKeyOID = CordaObjectIdentifier.COMPOSITE_KEY.id
         put("Alg.Alias.KeyFactory.$compositeKeyOID", CompositeKey.KEY_ALGORITHM)
         put("Alg.Alias.KeyFactory.OID.$compositeKeyOID", CompositeKey.KEY_ALGORITHM)
-        put("Alg.Alias.Signature.$compositeKeyOID", CompositeSignature.SIGNATURE_ALGORITHM)
-        put("Alg.Alias.Signature.OID.$compositeKeyOID", CompositeSignature.SIGNATURE_ALGORITHM)
+
+        val compositeSignatureOID = CordaObjectIdentifier.COMPOSITE_SIGNATURE.id
+        put("Alg.Alias.Signature.$compositeSignatureOID", CompositeSignature.SIGNATURE_ALGORITHM)
+        put("Alg.Alias.Signature.OID.$compositeSignatureOID", CompositeSignature.SIGNATURE_ALGORITHM)
     }
 }
 
 object CordaObjectIdentifier {
-    // UUID-based OID
-    // TODO: Register for an OID space and issue our own shorter OID
+    // UUID-based OID.
+    // TODO: Register for an OID space and issue our own shorter OID.
     @JvmField val COMPOSITE_KEY = ASN1ObjectIdentifier("2.25.30086077608615255153862931087626791002")
     @JvmField val COMPOSITE_SIGNATURE = ASN1ObjectIdentifier("2.25.30086077608615255153862931087626791003")
 }

--- a/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
@@ -29,7 +29,7 @@ class CordaSecurityProvider : Provider(PROVIDER_NAME, 0.1, "$PROVIDER_NAME secur
 }
 
 object CordaObjectIdentifier {
-    // UUID-based OID.
+    // UUID-based OID
     // TODO: Register for an OID space and issue our own shorter OID.
     @JvmField val COMPOSITE_KEY = ASN1ObjectIdentifier("2.25.30086077608615255153862931087626791002")
     @JvmField val COMPOSITE_SIGNATURE = ASN1ObjectIdentifier("2.25.30086077608615255153862931087626791003")

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -197,7 +197,7 @@ object Crypto {
     private val providerMap: Map<String, Provider> = mapOf(
             BouncyCastleProvider.PROVIDER_NAME to getBouncyCastleProvider(),
             CordaSecurityProvider.PROVIDER_NAME to CordaSecurityProvider(),
-            "BCPQC" to BouncyCastlePQCProvider()) // unfortunately, provider's name is not final in BouncyCastlePQCProvider, so we explicitly set it.
+            "BCPQC" to BouncyCastlePQCProvider()) // Unfortunately, provider's name is not final in BouncyCastlePQCProvider, so we explicitly set it.
 
     private fun getBouncyCastleProvider() = BouncyCastleProvider().apply {
         putAll(EdDSASecurityProvider())

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -91,7 +91,7 @@ fun PublicKey.containsAny(otherKeys: Iterable<PublicKey>): Boolean {
 /** Returns the set of all [PublicKey]s of the signatures. */
 fun Iterable<TransactionSignature>.byKeys() = map { it.by }.toSet()
 
-// Allow Kotlin destructuring:    val (private, public) = keyPair.
+// Allow Kotlin destructuring:    val (private, public) = keyPair
 operator fun KeyPair.component1(): PrivateKey = this.private
 
 operator fun KeyPair.component2(): PublicKey = this.public

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -91,7 +91,8 @@ fun PublicKey.containsAny(otherKeys: Iterable<PublicKey>): Boolean {
 /** Returns the set of all [PublicKey]s of the signatures. */
 fun Iterable<TransactionSignature>.byKeys() = map { it.by }.toSet()
 
-// Allow Kotlin destructuring:    val (private, public) = keyPair
+// Allow Kotlin destructuring:
+// val (private, public) = keyPair
 operator fun KeyPair.component1(): PrivateKey = this.private
 
 operator fun KeyPair.component2(): PublicKey = this.public

--- a/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt
@@ -6,8 +6,8 @@ import java.security.InvalidKeyException
 import java.security.PublicKey
 import java.security.SignatureException
 
-// TODO: Is there a use-case for bare [DigitalSignature], or is everything a [DigitalSignature.WithKey]? If there's no
-//       actual use-case, we should merge the with key version into the parent class. In that case [CompositeSignatureWithKeys]
+// TODO: Is there a use-case for bare DigitalSignature, or is everything a DigitalSignature.WithKey? If there's no
+//       actual use-case, we should merge the with key version into the parent class. In that case CompositeSignatureWithKeys
 //       should be renamed to match.
 /** A wrapper around a digital signature. */
 @CordaSerializable

--- a/core/src/main/kotlin/net/corda/core/crypto/MerkleTree.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/MerkleTree.kt
@@ -3,7 +3,7 @@ package net.corda.core.crypto
 import java.util.*
 
 /**
- * Creation and verification of a Merkle Tree for a [WireTransaction].
+ * Creation and verification of a Merkle tree for a [WireTransaction].
  *
  * See: https://en.wikipedia.org/wiki/Merkle_tree
  *

--- a/core/src/main/kotlin/net/corda/core/crypto/MerkleTree.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/MerkleTree.kt
@@ -3,7 +3,7 @@ package net.corda.core.crypto
 import java.util.*
 
 /**
- * Creation and verification of a Merkle Tree for a Wire Transaction.
+ * Creation and verification of a Merkle Tree for a [WireTransaction].
  *
  * See: https://en.wikipedia.org/wiki/Merkle_tree
  *
@@ -49,7 +49,7 @@ sealed class MerkleTree {
          */
         private tailrec fun buildMerkleTree(lastNodesList: List<MerkleTree>): MerkleTree {
             if (lastNodesList.size == 1) {
-                return lastNodesList[0] //Root reached.
+                return lastNodesList[0] // Root reached.
             } else {
                 val newLevelHashes: MutableList<MerkleTree> = ArrayList()
                 val n = lastNodesList.size

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -12,7 +12,7 @@ import java.security.MessageDigest
  */
 @CordaSerializable
 sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
-    /** SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes) */
+    /** SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes). */
     class SHA256(bytes: ByteArray) : SecureHash(bytes) {
         init {
             require(bytes.size == 32)

--- a/core/src/main/kotlin/net/corda/core/crypto/SignableData.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SignableData.kt
@@ -11,4 +11,3 @@ import net.corda.core.serialization.CordaSerializable
  */
 @CordaSerializable
 data class SignableData(val txId: SecureHash, val signatureMetadata: SignatureMetadata)
-

--- a/core/src/main/kotlin/net/corda/core/crypto/SignatureScheme.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SignatureScheme.kt
@@ -29,4 +29,5 @@ data class SignatureScheme(
         val signatureName: String,
         val algSpec: AlgorithmParameterSpec?,
         val keySize: Int?,
-        val desc: String)
+        val desc: String
+)

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -230,7 +230,7 @@ class FilteredTransaction private constructor(
     }
 
     /**
-     * Runs verification of Partial Merkle Branch against [id].
+     * Runs verification of partial Merkle branch against [id].
      */
     @Throws(MerkleTreeException::class)
     fun verify(): Boolean {


### PR DESCRIPTION
The `Alg.Alias.Signature.OID` in `CordaSecurityProvider` was still using the keyOID vs signatureOID.
Also did some minor clean up, mainly in comments and api docs references.