### PR TITLE
Helper SignedTransaction.buildFilteredTransaction(filtering)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -72,7 +72,7 @@ object NotaryFlow {
                     val tx: Any = if (stx.isNotaryChangeTransaction()) {
                         stx.notaryChangeTx
                     } else {
-                        stx.tx.buildFilteredTransaction(Predicate { it is StateRef || it is TimeWindow })
+                        stx.buildFilteredTransaction(Predicate { it is StateRef || it is TimeWindow })
                     }
                     sendAndReceiveWithRetry(notaryParty, tx)
                 }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -14,6 +14,7 @@ import java.security.KeyPair
 import java.security.PublicKey
 import java.security.SignatureException
 import java.util.*
+import java.util.function.Predicate
 
 /**
  * SignedTransaction wraps a serialized WireTransaction. It contains one or more signatures, each one for
@@ -50,11 +51,17 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     /** The id of the contained [WireTransaction]. */
     override val id: SecureHash get() = transaction.id
 
-    /** Returns the contained [WireTransaction], or throws if this is a notary change transaction */
+    /** Returns the contained [WireTransaction], or throws if this is a notary change transaction. */
     val tx: WireTransaction get() = transaction as WireTransaction
 
-    /** Returns the contained [NotaryChangeWireTransaction], or throws if this is a normal transaction */
+    /** Returns the contained [NotaryChangeWireTransaction], or throws if this is a normal transaction. */
     val notaryChangeTx: NotaryChangeWireTransaction get() = transaction as NotaryChangeWireTransaction
+
+    /**
+     * Helper function to directly build a [FilteredTransaction] using provided filtering functions,
+     * without first accessing the [WireTransaction] [tx].
+     */
+    fun buildFilteredTransaction(filtering: Predicate<Any>) = tx.buildFilteredTransaction(filtering)
 
     /** Helper to access the inputs of the contained transaction */
     val inputs: List<StateRef> get() = transaction.inputs

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -114,6 +114,10 @@ UNRELEASED
   ``createSignature(filteredTransaction: FilteredTransaction, publicKey: PublicKey)`` and
   ``createSignature(filteredTransaction: FilteredTransaction)`` to sign with the legal identity key.
 
+* A new helper method ``buildFilteredTransaction(filtering: Predicate<Any>)`` is added to ``SignedTransaction`` to
+  directly build a ``FilteredTransaction`` using provided filtering functions, without first accessing the
+  ``tx: WireTransaction``.
+
 Milestone 14
 ------------
 


### PR DESCRIPTION
Required to bypass the wire transaction `tx`. Our aim is to minimise access to `WireTransaction`. I used the same method name for consistency.