### PR TITLE
CORDA-499: Restructure TransactionGraphSearch to be Dokka-friendly

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionGraphSearch.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionGraphSearch.kt
@@ -15,23 +15,22 @@ import java.util.concurrent.Callable
  *
  * In future, this should support restricting the search by time, and other types of useful query.
  *
- * @param transactions map of transaction id to [SignedTransaction].
- * @param startPoints transactions to use as starting points for the search.
- * @param query query to test transactions within the graph for matching.
+ * @property transactions map of transaction id to [SignedTransaction].
+ * @property startPoints transactions to use as starting points for the search.
+ * @property query query to test transactions within the graph for matching.
  */
 class TransactionGraphSearch(private val transactions: TransactionStorage,
                              private val startPoints: List<WireTransaction>,
                              private val query: Query) : Callable<List<WireTransaction>> {
     /**
      * Query criteria to match transactions against.
+     *
+     * @property withCommandOfType contract command class to restrict matches to, or null for no filtering by command. Matches the class or
+     * any subclass.
+     * @property followInputsOfType contract output state class to follow the corresponding inputs to. Matches this exact class only.
      */
     data class Query(
-            /**
-             * Contract command class to restrict matches to, or null for no filtering by command. Matches the class or
-             * any subclass.
-             */
             val withCommandOfType: Class<out CommandData>? = null,
-            /** Contract output state class to follow the corresponding inputs to. Matches this exact class only. */
             val followInputsOfType: Class<out ContractState>? = null
     ) {
         /**

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionGraphSearchTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionGraphSearchTests.kt
@@ -53,8 +53,7 @@ class TransactionGraphSearchTests : TestDependencyInjectionBase() {
     @Test
     fun `return empty from empty`() {
         val storage = buildTransactions(DummyContract.Commands.Create())
-        val search = TransactionGraphSearch(storage, emptyList())
-        search.query = TransactionGraphSearch.Query()
+        val search = TransactionGraphSearch(storage, emptyList(), TransactionGraphSearch.Query())
         val expected = emptyList<WireTransaction>()
         val actual = search.call()
 
@@ -64,8 +63,7 @@ class TransactionGraphSearchTests : TestDependencyInjectionBase() {
     @Test
     fun `return empty from no match`() {
         val storage = buildTransactions(DummyContract.Commands.Create())
-        val search = TransactionGraphSearch(storage, listOf(storage.inputTx.tx))
-        search.query = TransactionGraphSearch.Query()
+        val search = TransactionGraphSearch(storage, listOf(storage.inputTx.tx), TransactionGraphSearch.Query())
         val expected = emptyList<WireTransaction>()
         val actual = search.call()
 
@@ -75,8 +73,7 @@ class TransactionGraphSearchTests : TestDependencyInjectionBase() {
     @Test
     fun `return origin on match`() {
         val storage = buildTransactions(DummyContract.Commands.Create())
-        val search = TransactionGraphSearch(storage, listOf(storage.inputTx.tx))
-        search.query = TransactionGraphSearch.Query(DummyContract.Commands.Create::class.java)
+        val search = TransactionGraphSearch(storage, listOf(storage.inputTx.tx), TransactionGraphSearch.Query(DummyContract.Commands.Create::class.java))
         val expected = listOf(storage.originTx.tx)
         val actual = search.call()
 

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TransactionGraphSearch.kt
@@ -1,5 +1,8 @@
-package net.corda.core.contracts
+package net.corda.traderdemo
 
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
 import net.corda.core.node.services.TransactionStorage
 import net.corda.core.transactions.SignedTransaction

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
@@ -53,9 +53,9 @@ class BuyerFlow(val otherParty: Party) : FlowLogic<Unit>() {
 
     private fun logIssuanceAttachment(tradeTX: SignedTransaction) {
         // Find the original CP issuance.
-        val search = TransactionGraphSearch(serviceHub.validatedTransactions, listOf(tradeTX.tx))
-        search.query = TransactionGraphSearch.Query(withCommandOfType = CommercialPaper.Commands.Issue::class.java,
-                followInputsOfType = CommercialPaper.State::class.java)
+        val search = TransactionGraphSearch(serviceHub.validatedTransactions, listOf(tradeTX.tx),
+                TransactionGraphSearch.Query(withCommandOfType = CommercialPaper.Commands.Issue::class.java,
+                    followInputsOfType = CommercialPaper.State::class.java))
         val cpIssuance = search.call().single()
 
         // Buyer will fetch the attachment from the seller automatically when it resolves the transaction.

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/BuyerFlow.kt
@@ -2,7 +2,6 @@ package net.corda.traderdemo.flow
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
-import net.corda.core.contracts.TransactionGraphSearch
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.identity.Party
@@ -14,6 +13,7 @@ import net.corda.core.utilities.unwrap
 import net.corda.finance.contracts.CommercialPaper
 import net.corda.finance.contracts.getCashBalances
 import net.corda.finance.flows.TwoPartyTradeFlow
+import net.corda.traderdemo.TransactionGraphSearch
 import java.util.*
 
 @InitiatedBy(SellerFlow::class)
@@ -53,6 +53,9 @@ class BuyerFlow(val otherParty: Party) : FlowLogic<Unit>() {
 
     private fun logIssuanceAttachment(tradeTX: SignedTransaction) {
         // Find the original CP issuance.
+        // TODO: This is potentially very expensive, and requires transaction details we may no longer have once
+        //       SGX is enabled. Should be replaced with including the attachment on all transactions involving
+        //       the state.
         val search = TransactionGraphSearch(serviceHub.validatedTransactions, listOf(tradeTX.tx),
                 TransactionGraphSearch.Query(withCommandOfType = CommercialPaper.Commands.Issue::class.java,
                     followInputsOfType = CommercialPaper.State::class.java))

--- a/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt
+++ b/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt
@@ -1,5 +1,6 @@
-package net.corda.core.contracts
+package net.corda.traderdemo
 
+import net.corda.core.contracts.CommandData
 import net.corda.core.crypto.newSecureRandom
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder


### PR DESCRIPTION
* Remove internal state of TransactionGraphSearch from being publicly visible.
* Add Dokka comments for TransactionGraphSearch.Query values.
* Move query into TransactionGraphSearch constructor as it should always be set except for test cases.