### PR TITLE
Fixed a crash in cordformation 

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.15.2
+gradlePluginsVersion=0.16.0
 kotlinVersion=1.1.4
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
@@ -71,7 +71,7 @@ class Cordformation implements Plugin<Project> {
             def filteredDeps = directDeps.findAll { excludes.collect { exclude -> (exclude.group == it.group) && (exclude.name == it.name) }.findAll { it }.isEmpty() }
             filteredDeps.each {
                 // net.corda may be a core dependency which shouldn't be included in this cordapp so give a warning
-                if(it.group.contains('net.corda.')) {
+                if(it.group && it.group.contains('net.corda.')) {
                     logger.warn("You appear to have included a Corda platform component ($it) using a 'compile' or 'runtime' dependency." +
                                 "This can cause node stability problems. Please use 'corda' instead." +
                                 "See http://docs.corda.net/cordapp-build-systems.html")


### PR DESCRIPTION
when trying to build nodes for a project with a file as a dependency and any other dependencies without a group

This will need to be backported to M14 as well.

It fixes the issue described in this SO post; https://stackoverflow.com/questions/46004915/getting-an-error-when-adding-a-3rd-party-jar-file