### PR TITLE
Add missing finance CorDapp depdendency to example code

### DIFF
--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     cordaCompile project(path: ":webserver:webcapsule", configuration: 'runtimeArtifacts')
 
     // Corda Plugins: dependent flows and services
-    cordapp project(':samples:bank-of-corda-demo')
+    cordapp project(':finance')
 }
 
 mainClassName = "net.corda.docs.ClientRpcTutorialKt"

--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
     cordaCompile project(path: ":node:capsule", configuration: 'runtimeArtifacts')
     cordaCompile project(path: ":webserver:webcapsule", configuration: 'runtimeArtifacts')
+
+    // Corda Plugins: dependent flows and services
+    cordapp project(':samples:bank-of-corda-demo')
 }
 
 mainClassName = "net.corda.docs.ClientRpcTutorialKt"


### PR DESCRIPTION
The example code uses cash flows and contracts, but doesn't depend on the finance CorDapp. This happens to work at the moment but breaks other changes currently in progress.
