### PR TITLE
Add signature exchange to transaction key flow

### DIFF
--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -65,9 +65,8 @@ class SwapIdentitiesFlow(private val otherParty: Party,
                 throw SwapIdentitiesException("Certificate subject must match counterparty's well known identity.")
             }
             val signature = DigitalSignature.WithKey(anonymousOtherSide.owningKey, sigBytes.bytes)
-            val sigWithKey = DigitalSignature.WithKey(anonymousOtherSide.owningKey, signature.bytes)
             try {
-                sigWithKey.verify(buildDataToSign(anonymousOtherSideBytes, ourNonce, theirNonce))
+                signature.verify(buildDataToSign(anonymousOtherSideBytes, ourNonce, theirNonce))
             } catch(ex: SignatureException) {
                 throw SwapIdentitiesException("Signature does not match the given identity and nonce.", ex)
             }

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -4,12 +4,17 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.StartableByRPC
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.secureRandomBytes
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.serialize
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
+import java.io.ByteArrayOutputStream
 
 /**
  * Very basic flow which generates new confidential identities for parties in a transaction and exchanges the transaction
@@ -25,10 +30,20 @@ class SwapIdentitiesFlow(private val otherParty: Party,
 
     companion object {
         object AWAITING_KEY : ProgressTracker.Step("Awaiting key")
+        val NONCE_SIZE_BYTES = 16
 
         fun tracker() = ProgressTracker(AWAITING_KEY)
-        fun validateAndRegisterIdentity(identityService: IdentityService, otherSide: Party, anonymousOtherSide: PartyAndCertificate): PartyAndCertificate {
+        fun buildDataToSign(identity: PartyAndCertificate, nonce: ByteArray): ByteArray {
+            val buffer = ByteArrayOutputStream(1024)
+            buffer.write(identity.serialize().bytes)
+            buffer.write(nonce)
+            return buffer.toByteArray()
+        }
+
+        fun validateAndRegisterIdentity(identityService: IdentityService, otherSide: Party, anonymousOtherSide: PartyAndCertificate, nonce: ByteArray, signature: DigitalSignature): PartyAndCertificate {
             require(anonymousOtherSide.name == otherSide.name)
+            val sigWithKey = DigitalSignature.WithKey(anonymousOtherSide.owningKey, signature.bytes)
+            require(sigWithKey.verify(buildDataToSign(anonymousOtherSide, nonce)))
             // Validate then store their identity so that we can prove the key in the transaction is owned by the
             // counterparty.
             identityService.verifyAndRegisterIdentity(anonymousOtherSide)
@@ -47,8 +62,16 @@ class SwapIdentitiesFlow(private val otherParty: Party,
             identities.put(otherParty, legalIdentityAnonymous.party.anonymise())
         } else {
             val otherSession = initiateFlow(otherParty)
-            val anonymousOtherSide = otherSession.sendAndReceive<PartyAndCertificate>(legalIdentityAnonymous).unwrap { confidentialIdentity ->
-                validateAndRegisterIdentity(serviceHub.identityService, otherSession.counterparty, confidentialIdentity)
+            val ourNonce = secureRandomBytes(NONCE_SIZE_BYTES)
+            val theirNonce = otherSession.sendAndReceive<ByteArray>(ourNonce).unwrap { nonce ->
+                require(nonce.size == NONCE_SIZE_BYTES)
+                nonce
+            }
+            val data = buildDataToSign(legalIdentityAnonymous, theirNonce)
+            val ourSig: DigitalSignature = serviceHub.keyManagementService.sign(data, legalIdentityAnonymous.owningKey)
+            val anonymousOtherSide = otherSession.sendAndReceive<IdentityWithSignature>(IdentityWithSignature(legalIdentityAnonymous, ourSig.bytes)).unwrap { (confidentialIdentity, theirSigBytes) ->
+                val theirSig = DigitalSignature.WithKey(confidentialIdentity.owningKey, theirSigBytes)
+                validateAndRegisterIdentity(serviceHub.identityService, otherParty, confidentialIdentity, ourNonce, theirSig)
             }
             identities.put(ourIdentity, legalIdentityAnonymous.party.anonymise())
             identities.put(otherSession.counterparty, anonymousOtherSide.party.anonymise())
@@ -56,4 +79,6 @@ class SwapIdentitiesFlow(private val otherParty: Party,
         return identities
     }
 
+    @CordaSerializable
+    data class IdentityWithSignature(val identity: PartyAndCertificate, val signature: ByteArray)
 }

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -99,10 +99,12 @@ class SwapIdentitiesFlow(private val otherParty: Party,
 
     object NonceVerifier : UntrustworthyData.Validator<ByteArray, ByteArray> {
         override fun validate(data: ByteArray): ByteArray {
-            if (data.size == NONCE_SIZE_BYTES)
-                return data
-            else
+            if (data.size != NONCE_SIZE_BYTES)
                 throw SwapIdentitiesException("Nonce must be $NONCE_SIZE_BYTES bytes.")
+            val zeroByte = 0.toByte()
+            if (data.all { it == zeroByte })
+                throw SwapIdentitiesException("Nonce must not be all zeroes.")
+            return data
         }
     }
 }

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -20,6 +20,7 @@ import net.corda.core.utilities.UntrustworthyData
 import net.corda.core.utilities.unwrap
 import java.io.ByteArrayOutputStream
 import java.security.SignatureException
+import kotlin.experimental.xor
 
 /**
  * Very basic flow which generates new confidential identities for parties in a transaction and exchanges the transaction
@@ -39,10 +40,16 @@ class SwapIdentitiesFlow(private val otherParty: Party,
         val NONCE_SIZE_BYTES = 16
 
         fun tracker() = ProgressTracker(AWAITING_KEY)
-        fun buildDataToSign(identity: SerializedBytes<PartyAndCertificate>, nonce: ByteArray): ByteArray {
+        fun buildDataToSign(identity: SerializedBytes<PartyAndCertificate>,
+                            ourNonce: ByteArray,
+                            theirNonce: ByteArray): ByteArray {
+            val xoredNonce = ByteArray(NONCE_SIZE_BYTES)
+            for (idx in 0..(NONCE_SIZE_BYTES - 1)) {
+                xoredNonce[idx] = ourNonce[idx] xor theirNonce[idx]
+            }
             val buffer = ByteArrayOutputStream(1024)
             buffer.write(identity.bytes)
-            buffer.write(nonce)
+            buffer.write(xoredNonce)
             return buffer.toByteArray()
         }
 
@@ -50,7 +57,8 @@ class SwapIdentitiesFlow(private val otherParty: Party,
         fun validateAndRegisterIdentity(identityService: IdentityService,
                                         otherSide: Party,
                                         anonymousOtherSideBytes: SerializedBytes<PartyAndCertificate>,
-                                        nonce: ByteArray,
+                                        ourNonce: ByteArray,
+                                        theirNonce: ByteArray,
                                         sigBytes: DigitalSignature): PartyAndCertificate {
             val anonymousOtherSide: PartyAndCertificate = anonymousOtherSideBytes.deserialize()
             if (anonymousOtherSide.name != otherSide.name) {
@@ -59,8 +67,8 @@ class SwapIdentitiesFlow(private val otherParty: Party,
             val signature = DigitalSignature.WithKey(anonymousOtherSide.owningKey, sigBytes.bytes)
             val sigWithKey = DigitalSignature.WithKey(anonymousOtherSide.owningKey, signature.bytes)
             try {
-                sigWithKey.verify(buildDataToSign(anonymousOtherSideBytes, nonce))
-            } catch (ex: SignatureException) {
+                sigWithKey.verify(buildDataToSign(anonymousOtherSideBytes, ourNonce, theirNonce))
+            } catch(ex: SignatureException) {
                 throw SwapIdentitiesException("Signature does not match the given identity and nonce.", ex)
             }
             // Validate then store their identity so that we can prove the key in the transaction is owned by the
@@ -84,12 +92,12 @@ class SwapIdentitiesFlow(private val otherParty: Party,
             val otherSession = initiateFlow(otherParty)
             val ourNonce = secureRandomBytes(NONCE_SIZE_BYTES)
             val theirNonce = otherSession.sendAndReceive<ByteArray>(ourNonce).unwrap(NonceVerifier)
-            val data = buildDataToSign(serializedIdentity, theirNonce)
+            val data = buildDataToSign(serializedIdentity, ourNonce, theirNonce)
             val ourSig: DigitalSignature.WithKey = serviceHub.keyManagementService.sign(data, legalIdentityAnonymous.owningKey)
             val ourIdentWithSig = IdentityWithSignature(serializedIdentity, ourSig.withoutKey())
             val anonymousOtherSide = otherSession.sendAndReceive<IdentityWithSignature>(ourIdentWithSig)
                     .unwrap { (confidentialIdentityBytes, theirSigBytes) ->
-                        validateAndRegisterIdentity(serviceHub.identityService, otherParty, confidentialIdentityBytes, ourNonce, theirSigBytes)
+                        validateAndRegisterIdentity(serviceHub.identityService, otherParty, confidentialIdentityBytes, ourNonce, theirNonce, theirSigBytes)
                     }
             identities.put(ourIdentity, legalIdentityAnonymous.party.anonymise())
             identities.put(otherParty, anonymousOtherSide.party.anonymise())

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -44,7 +44,7 @@ class SwapIdentitiesFlow(private val otherParty: Party,
                             ourNonce: ByteArray,
                             theirNonce: ByteArray): ByteArray {
             val xoredNonce = ByteArray(NONCE_SIZE_BYTES)
-            for (idx in 0..(NONCE_SIZE_BYTES - 1)) {
+            for (idx in 0 until NONCE_SIZE_BYTES) {
                 xoredNonce[idx] = ourNonce[idx] xor theirNonce[idx]
             }
             val buffer = ByteArrayOutputStream(1024)

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -47,12 +47,12 @@ class SwapIdentitiesFlow(private val otherParty: Party,
         /**
          * Generate the determinstic data blob the confidential identity's key holder signs to indicate they want to
          * represent the subject named in the X.509 certificate. Note that this is never actually sent between nodes,
-         * but only the signature is sent. The blob is built independently and the received signature verified against
-         * the expected blob.
+         * but only the signature is sent. The blob is built independently on each node and the received signature
+         * verified against the expected blob, rather than exchanging the blob.
          */
         fun buildDataToSign(confidentialIdentity: PartyAndCertificate): ByteArray {
-            val certReqInfo = CertificateOwnershipAssertion(confidentialIdentity.name, confidentialIdentity.owningKey)
-            return certReqInfo.serialize().bytes
+            val certOwnerAssert = CertificateOwnershipAssertion(confidentialIdentity.name, confidentialIdentity.owningKey)
+            return certOwnerAssert.serialize().bytes
         }
 
         @Throws(SwapIdentitiesException::class)
@@ -113,6 +113,7 @@ class SwapIdentitiesFlow(private val otherParty: Party,
  * the key represents the named entity), but protects against a certificate authority incorrectly claiming others'
  * keys.
  */
+@CordaSerializable
 data class CertificateOwnershipAssertion(val x500Name: CordaX500Name,
                                          val publicKey: PublicKey)
 

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -39,8 +39,6 @@ class SwapIdentitiesFlow(private val otherParty: Party,
 
     companion object {
         object AWAITING_KEY : ProgressTracker.Step("Awaiting key")
-        val ASSERTION_PREFIX: ByteArray = "Assertion of identity ownership ".toByteArray(Charset.forName("US-ASCII"))
-        val ASSERTION_POSTFIX: ByteArray = "Identity assertion ends".toByteArray(Charset.forName("US-ASCII"))
 
         fun tracker() = ProgressTracker(AWAITING_KEY)
         /**
@@ -55,13 +53,7 @@ class SwapIdentitiesFlow(private val otherParty: Party,
             // actual certificate signing requests as these could theoretically be resubmitted to a signing service.
             val cert = confidentialIdentity.certificate.toX509CertHolder()
             val certReqInfo = CertificationRequestInfo(cert.subject, cert.subjectPublicKeyInfo, DERSet())
-            val data = ByteArrayOutputStream(1024).use { out ->
-                out.write(ASSERTION_PREFIX)
-                out.write(certReqInfo.encoded)
-                out.write(ASSERTION_POSTFIX)
-                out.toByteArray()
-            }
-            return data
+            return certReqInfo.encoded
         }
 
         @Throws(SwapIdentitiesException::class)

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
@@ -30,9 +30,10 @@ class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEna
         val legalIdentityAnonymous = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, revocationEnabled)
         val serializedIdentity = SerializedBytes<PartyAndCertificate>(legalIdentityAnonymous.serialize().bytes)
         val data = SwapIdentitiesFlow.buildDataToSign(serializedIdentity, theirNonce)
-        val ourSig: DigitalSignature = serviceHub.keyManagementService.sign(data, legalIdentityAnonymous.owningKey)
-        otherSideSession.sendAndReceive<SwapIdentitiesFlow.IdentityWithSignature>(SwapIdentitiesFlow.IdentityWithSignature(serializedIdentity, ourSig.bytes)).unwrap { (confidentialIdentity, theirSigBytes) ->
-            SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, confidentialIdentity, ourNonce, theirSigBytes)
-        }
+        val ourSig = serviceHub.keyManagementService.sign(data, legalIdentityAnonymous.owningKey)
+        otherSideSession.sendAndReceive<SwapIdentitiesFlow.IdentityWithSignature>(SwapIdentitiesFlow.IdentityWithSignature(serializedIdentity, ourSig.withoutKey()))
+                .unwrap { (confidentialIdentity, theirSigBytes) ->
+                    SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, confidentialIdentity, ourNonce, theirSigBytes)
+                }
     }
 }

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
@@ -25,10 +25,7 @@ class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEna
     override fun call() {
         val revocationEnabled = false
         val ourNonce = secureRandomBytes(SwapIdentitiesFlow.NONCE_SIZE_BYTES)
-        val theirNonce = otherSideSession.sendAndReceive<ByteArray>(ourNonce).unwrap { nonce ->
-            require(nonce.size == SwapIdentitiesFlow.NONCE_SIZE_BYTES)
-            nonce
-        }
+        val theirNonce = otherSideSession.sendAndReceive<ByteArray>(ourNonce).unwrap(SwapIdentitiesFlow.NonceVerifier)
         progressTracker.currentStep = SENDING_KEY
         val legalIdentityAnonymous = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, revocationEnabled)
         val serializedIdentity = SerializedBytes<PartyAndCertificate>(legalIdentityAnonymous.serialize().bytes)

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
@@ -1,8 +1,11 @@
 package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.DigitalSignature
+import net.corda.core.crypto.secureRandomBytes
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
+import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
@@ -19,10 +22,18 @@ class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEna
     @Suspendable
     override fun call() {
         val revocationEnabled = false
+        val ourNonce = secureRandomBytes(SwapIdentitiesFlow.NONCE_SIZE_BYTES)
+        val theirNonce = otherSideSession.sendAndReceive<ByteArray>(ourNonce).unwrap { nonce ->
+            require(nonce.size == SwapIdentitiesFlow.NONCE_SIZE_BYTES)
+            nonce
+        }
         progressTracker.currentStep = SENDING_KEY
         val legalIdentityAnonymous = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, revocationEnabled)
-        otherSideSession.sendAndReceive<PartyAndCertificate>(legalIdentityAnonymous).unwrap { confidentialIdentity ->
-            SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, confidentialIdentity)
+        val data = SwapIdentitiesFlow.buildDataToSign(legalIdentityAnonymous, theirNonce)
+        val ourSig: DigitalSignature = serviceHub.keyManagementService.sign(data, legalIdentityAnonymous.owningKey)
+        otherSideSession.sendAndReceive<SwapIdentitiesFlow.IdentityWithSignature>(SwapIdentitiesFlow.IdentityWithSignature(legalIdentityAnonymous, ourSig.bytes)).unwrap { (confidentialIdentity, theirSigBytes) ->
+            val theirSig = DigitalSignature.WithKey(confidentialIdentity.owningKey, theirSigBytes)
+            SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, confidentialIdentity, ourNonce, theirSig)
         }
     }
 }

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
@@ -1,16 +1,15 @@
 package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.secureRandomBytes
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
-import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
+import java.util.*
 
 class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEnabled: Boolean) : FlowLogic<Unit>() {
     constructor(otherSideSession: FlowSession) : this(otherSideSession, false)
@@ -25,15 +24,19 @@ class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEna
     override fun call() {
         val ourNonce = secureRandomBytes(SwapIdentitiesFlow.NONCE_SIZE_BYTES)
         val theirNonce = otherSideSession.sendAndReceive<ByteArray>(ourNonce).unwrap(SwapIdentitiesFlow.NonceVerifier)
+        val nonces = TreeSet(SwapIdentitiesFlow.ArrayComparator).apply {
+            add(ourNonce)
+            add(theirNonce)
+        }
         val revocationEnabled = false
         progressTracker.currentStep = SENDING_KEY
         val legalIdentityAnonymous = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, revocationEnabled)
         val serializedIdentity = SerializedBytes<PartyAndCertificate>(legalIdentityAnonymous.serialize().bytes)
-        val data = SwapIdentitiesFlow.buildDataToSign(serializedIdentity, ourNonce, theirNonce)
+        val data = SwapIdentitiesFlow.buildDataToSign(serializedIdentity, nonces)
         val ourSig = serviceHub.keyManagementService.sign(data, legalIdentityAnonymous.owningKey)
         otherSideSession.sendAndReceive<SwapIdentitiesFlow.IdentityWithSignature>(SwapIdentitiesFlow.IdentityWithSignature(serializedIdentity, ourSig.withoutKey()))
                 .unwrap { (confidentialIdentity, theirSigBytes) ->
-                    SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, confidentialIdentity, ourNonce, theirNonce, theirSigBytes)
+                    SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, confidentialIdentity, nonces, theirSigBytes)
                 }
     }
 }

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
@@ -1,15 +1,14 @@
 package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.crypto.secureRandomBytes
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.SerializedBytes
+import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
-import java.util.*
 
 class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEnabled: Boolean) : FlowLogic<Unit>() {
     constructor(otherSideSession: FlowSession) : this(otherSideSession, false)
@@ -24,13 +23,14 @@ class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEna
     override fun call() {
         val revocationEnabled = false
         progressTracker.currentStep = SENDING_KEY
-        val legalIdentityAnonymous = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, revocationEnabled)
-        val serializedIdentity = SerializedBytes<PartyAndCertificate>(legalIdentityAnonymous.serialize().bytes)
-        val data = SwapIdentitiesFlow.buildDataToSign(serializedIdentity)
-        val ourSig = serviceHub.keyManagementService.sign(data, legalIdentityAnonymous.owningKey)
+        val ourConfidentialIdentity = serviceHub.keyManagementService.freshKeyAndCert(ourIdentityAndCert, revocationEnabled)
+        val serializedIdentity = SerializedBytes<PartyAndCertificate>(ourConfidentialIdentity.serialize().bytes)
+        val data = SwapIdentitiesFlow.buildDataToSign(ourConfidentialIdentity)
+        val ourSig = serviceHub.keyManagementService.sign(data, ourConfidentialIdentity.owningKey)
         otherSideSession.sendAndReceive<SwapIdentitiesFlow.IdentityWithSignature>(SwapIdentitiesFlow.IdentityWithSignature(serializedIdentity, ourSig.withoutKey()))
-                .unwrap { (confidentialIdentity, theirSigBytes) ->
-                    SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, confidentialIdentity, theirSigBytes)
+                .unwrap { (theirConfidentialIdentityBytes, theirSigBytes) ->
+                    val theirConfidentialIdentity = theirConfidentialIdentityBytes.deserialize()
+                    SwapIdentitiesFlow.validateAndRegisterIdentity(serviceHub.identityService, otherSideSession.counterparty, theirConfidentialIdentity, theirSigBytes)
                 }
     }
 }

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -75,7 +75,7 @@ class SwapIdentitiesFlowTests {
         val sigData = SwapIdentitiesFlow.buildDataToSign(notBobBytes, nonce)
         val signature = notaryNode.services.keyManagementService.sign(sigData, notBob.owningKey)
         assertFailsWith<SwapIdentitiesException>("Certificate subject must match counterparty's well known identity.") {
-            SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, nonce, signature.bytes)
+            SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, nonce, signature.withoutKey())
         }
 
         mockNet.stopNodes()
@@ -105,7 +105,7 @@ class SwapIdentitiesFlowTests {
             val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousBobBytes, wrongNonce)
             val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.bytes)
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.withoutKey())
             }
         }
         // Check that the wrong signature with the correct nonce is rejected
@@ -116,7 +116,7 @@ class SwapIdentitiesFlowTests {
             val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousNotaryBytes, nonce)
             val signature = notaryNode.services.keyManagementService.sign(sigData, anonymousNotary.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousNotaryBytes, nonce, signature.bytes)
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousNotaryBytes, nonce, signature.withoutKey())
             }
         }
         // Check that the right signing key, right nonce but wrong identity is rejected
@@ -131,7 +131,7 @@ class SwapIdentitiesFlowTests {
             val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousAliceBytes, nonce)
             val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.bytes)
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.withoutKey())
             }
         }
 

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -13,6 +13,7 @@ import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.chooseIdentity
 import net.corda.testing.node.MockNetwork
 import org.junit.Test
+import java.util.*
 import kotlin.test.*
 
 class SwapIdentitiesFlowTests {
@@ -89,12 +90,13 @@ class SwapIdentitiesFlowTests {
         val mockNet = MockNetwork(false, true)
 
         // Set up values we'll need
+        val fixedRand = Random(20170914L)
         val notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
         val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
         val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
         val bob: Party = bobNode.services.myInfo.legalIdentity
-        val nonce = ByteArray(1) { 0 }
-        val wrongNonce = ByteArray(1) { Byte.MAX_VALUE }
+        val nonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
+        val wrongNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
         // Check that the right signing key but the wrong nonce is rejected
         bobNode.database.transaction {
             bobNode.services.keyManagementService.freshKeyAndCert(bobNode.services.myInfo.legalIdentityAndCert, false)

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -76,6 +76,8 @@ class SwapIdentitiesFlowTests {
         assertFailsWith<IllegalArgumentException>("Certificate subject must match counterparty's well known identity") {
             SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, nonce, signature.bytes)
         }
+
+        mockNet.stopNodes()
     }
 
     /**
@@ -130,5 +132,7 @@ class SwapIdentitiesFlowTests {
                 SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.bytes)
             }
         }
+
+        mockNet.stopNodes()
     }
 }

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -7,10 +7,14 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.getOrThrow
+<<<<<<< 569d542154a9ef3376a24fd048174641e6b57cf3:confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
 import net.corda.testing.ALICE
 import net.corda.testing.BOB
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.chooseIdentity
+=======
+import net.corda.testing.*
+>>>>>>> Add nonce XOR:core/src/test/kotlin/net/corda/core/flows/SwapIdentitiesFlowTests.kt
 import net.corda.testing.node.MockNetwork
 import org.junit.Test
 import java.util.*
@@ -54,6 +58,35 @@ class SwapIdentitiesFlowTests {
         mockNet.stopNodes()
     }
 
+    @Test
+    fun `data to sign must not be defined by counterparty`() {
+        val fixedRand = Random(20170914L)
+        val identity = SerializedBytes<PartyAndCertificate>(ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes))
+        val aliceNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
+        val bobNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
+        val sigData = SwapIdentitiesFlow.buildDataToSign(identity, aliceNonce, bobNonce)
+        assertTrue { arrayContains(sigData, identity.bytes) }
+        assertFalse { arrayContains(sigData, aliceNonce) }
+        assertFalse { arrayContains(sigData, bobNonce) }
+    }
+
+    private fun arrayContains(outerArray: ByteArray, innerArray: ByteArray): Boolean {
+        val searchSpace = outerArray.size - innerArray.size
+        if (searchSpace >= 0) {
+            for (outerIdx in 0..(searchSpace - 1)) {
+                var matchedIdx = 0
+                for (innerIdx in 0..(innerArray.size - 1)) {
+                    if (outerArray[outerIdx + innerIdx] != innerArray[innerIdx])
+                        break
+                    matchedIdx = innerIdx
+                }
+                if (matchedIdx == innerArray.size - 1)
+                    return true
+            }
+        }
+        return false
+    }
+
     /**
      * Check that flow is actually validating the name on the certificate presented by the counterparty.
      */
@@ -63,19 +96,21 @@ class SwapIdentitiesFlowTests {
         val mockNet = MockNetwork(false, true)
 
         // Set up values we'll need
+        val fixedRand = Random(20170914L)
         val notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
         val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
         val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
         val bob: Party = bobNode.services.myInfo.legalIdentity
-        val nonce = ByteArray(1) { 0 }
+        val aliceNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
+        val bobNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
         val notBob = notaryNode.database.transaction {
             notaryNode.services.keyManagementService.freshKeyAndCert(notaryNode.services.myInfo.legalIdentityAndCert, false)
         }
         val notBobBytes = SerializedBytes<PartyAndCertificate>(notBob.serialize().bytes)
-        val sigData = SwapIdentitiesFlow.buildDataToSign(notBobBytes, nonce)
+        val sigData = SwapIdentitiesFlow.buildDataToSign(notBobBytes, aliceNonce, bobNonce)
         val signature = notaryNode.services.keyManagementService.sign(sigData, notBob.owningKey)
         assertFailsWith<SwapIdentitiesException>("Certificate subject must match counterparty's well known identity.") {
-            SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, nonce, signature.withoutKey())
+            SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, aliceNonce, bobNonce, signature.withoutKey())
         }
 
         mockNet.stopNodes()
@@ -95,17 +130,18 @@ class SwapIdentitiesFlowTests {
         val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
         val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
         val bob: Party = bobNode.services.myInfo.legalIdentity
-        val nonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
+        val aliceNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
+        val bobNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
         val wrongNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
         // Check that the right signing key but the wrong nonce is rejected
         bobNode.database.transaction {
             bobNode.services.keyManagementService.freshKeyAndCert(bobNode.services.myInfo.legalIdentityAndCert, false)
         }.let { anonymousBob ->
             val anonymousBobBytes = SerializedBytes<PartyAndCertificate>(anonymousBob.serialize().bytes)
-            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousBobBytes, wrongNonce)
+            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousBobBytes, aliceNonce, wrongNonce)
             val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.withoutKey())
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, aliceNonce, bobNonce, signature.withoutKey())
             }
         }
         // Check that the wrong signature with the correct nonce is rejected
@@ -113,10 +149,10 @@ class SwapIdentitiesFlowTests {
             notaryNode.services.keyManagementService.freshKeyAndCert(notaryNode.services.myInfo.legalIdentityAndCert, false)
         }.let { anonymousNotary ->
             val anonymousNotaryBytes = SerializedBytes<PartyAndCertificate>(anonymousNotary.serialize().bytes)
-            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousNotaryBytes, nonce)
+            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousNotaryBytes, aliceNonce, bobNonce)
             val signature = notaryNode.services.keyManagementService.sign(sigData, anonymousNotary.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousNotaryBytes, nonce, signature.withoutKey())
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousNotaryBytes, aliceNonce, bobNonce, signature.withoutKey())
             }
         }
         // Check that the right signing key, right nonce but wrong identity is rejected
@@ -128,10 +164,10 @@ class SwapIdentitiesFlowTests {
         }.let { anonymousBob ->
             val anonymousAliceBytes = SerializedBytes<PartyAndCertificate>(anonymousAlice.serialize().bytes)
             val anonymousBobBytes = SerializedBytes<PartyAndCertificate>(anonymousBob.serialize().bytes)
-            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousAliceBytes, nonce)
+            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousAliceBytes, aliceNonce, bobNonce)
             val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.withoutKey())
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, aliceNonce, bobNonce, signature.withoutKey())
             }
         }
 

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -73,7 +73,7 @@ class SwapIdentitiesFlowTests {
         val notBobBytes = SerializedBytes<PartyAndCertificate>(notBob.serialize().bytes)
         val sigData = SwapIdentitiesFlow.buildDataToSign(notBobBytes, nonce)
         val signature = notaryNode.services.keyManagementService.sign(sigData, notBob.owningKey)
-        assertFailsWith<IllegalArgumentException>("Certificate subject must match counterparty's well known identity") {
+        assertFailsWith<SwapIdentitiesException>("Certificate subject must match counterparty's well known identity.") {
             SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, nonce, signature.bytes)
         }
 
@@ -102,7 +102,7 @@ class SwapIdentitiesFlowTests {
             val anonymousBobBytes = SerializedBytes<PartyAndCertificate>(anonymousBob.serialize().bytes)
             val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousBobBytes, wrongNonce)
             val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
-            assertFailsWith<IllegalArgumentException>("Signature does not match the given identity and nonce") {
+            assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
                 SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.bytes)
             }
         }
@@ -113,7 +113,7 @@ class SwapIdentitiesFlowTests {
             val anonymousNotaryBytes = SerializedBytes<PartyAndCertificate>(anonymousNotary.serialize().bytes)
             val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousNotaryBytes, nonce)
             val signature = notaryNode.services.keyManagementService.sign(sigData, anonymousNotary.owningKey)
-            assertFailsWith<IllegalArgumentException>("Signature does not match the given identity and nonce") {
+            assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce") {
                 SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousNotaryBytes, nonce, signature.bytes)
             }
         }
@@ -128,7 +128,7 @@ class SwapIdentitiesFlowTests {
             val anonymousBobBytes = SerializedBytes<PartyAndCertificate>(anonymousBob.serialize().bytes)
             val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousAliceBytes, nonce)
             val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
-            assertFailsWith<IllegalArgumentException>("Signature does not match the given identity and nonce") {
+            assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
                 SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, nonce, signature.bytes)
             }
         }

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -7,14 +7,9 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.getOrThrow
-import net.corda.testing.ALICE
-import net.corda.testing.BOB
-import net.corda.testing.DUMMY_NOTARY
-import net.corda.testing.chooseIdentity
 import net.corda.testing.*
 import net.corda.testing.node.MockNetwork
 import org.junit.Test
-import java.util.*
 import kotlin.test.*
 
 class SwapIdentitiesFlowTests {
@@ -55,39 +50,6 @@ class SwapIdentitiesFlowTests {
         mockNet.stopNodes()
     }
 
-    @Test
-    fun `data to sign must not be defined by counterparty`() {
-        val fixedRand = Random(20170914L)
-        val identity = SerializedBytes<PartyAndCertificate>(ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes))
-        val aliceNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
-        val bobNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
-        val validNonces = TreeSet(SwapIdentitiesFlow.ArrayComparator).apply {
-            add(aliceNonce)
-            add(bobNonce)
-        }
-        val sigData = SwapIdentitiesFlow.buildDataToSign(identity, validNonces)
-        assertTrue { arrayContains(sigData, identity.bytes) }
-        assertFalse { arrayContains(sigData, aliceNonce) }
-        assertFalse { arrayContains(sigData, bobNonce) }
-    }
-
-    private fun arrayContains(outerArray: ByteArray, innerArray: ByteArray): Boolean {
-        val searchSpace = outerArray.size - innerArray.size
-        if (searchSpace >= 0) {
-            for (outerIdx in 0 until searchSpace) {
-                var matchedIdx = 0
-                for (innerIdx in 0 until innerArray.size) {
-                    if (outerArray[outerIdx + innerIdx] != innerArray[innerIdx])
-                        break
-                    matchedIdx = innerIdx
-                }
-                if (matchedIdx == innerArray.size - 1)
-                    return true
-            }
-        }
-        return false
-    }
-
     /**
      * Check that flow is actually validating the name on the certificate presented by the counterparty.
      */
@@ -97,25 +59,18 @@ class SwapIdentitiesFlowTests {
         val mockNet = MockNetwork(false, true)
 
         // Set up values we'll need
-        val fixedRand = Random(20170914L)
         val notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
         val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
         val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
         val bob: Party = bobNode.services.myInfo.chooseIdentity()
-        val aliceNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
-        val bobNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
-        val validNonces = TreeSet(SwapIdentitiesFlow.ArrayComparator).apply {
-            add(aliceNonce)
-            add(bobNonce)
-        }
         val notBob = notaryNode.database.transaction {
             notaryNode.services.keyManagementService.freshKeyAndCert(notaryNode.services.myInfo.chooseIdentityAndCert(), false)
         }
         val notBobBytes = SerializedBytes<PartyAndCertificate>(notBob.serialize().bytes)
-        val sigData = SwapIdentitiesFlow.buildDataToSign(notBobBytes, validNonces)
+        val sigData = SwapIdentitiesFlow.buildDataToSign(notBobBytes)
         val signature = notaryNode.services.keyManagementService.sign(sigData, notBob.owningKey)
         assertFailsWith<SwapIdentitiesException>("Certificate subject must match counterparty's well known identity.") {
-            SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, validNonces, signature.withoutKey())
+            SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, notBobBytes, signature.withoutKey())
         }
 
         mockNet.stopNodes()
@@ -130,45 +85,22 @@ class SwapIdentitiesFlowTests {
         val mockNet = MockNetwork(false, true)
 
         // Set up values we'll need
-        val fixedRand = Random(20170914L)
         val notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
         val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
         val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
         val bob: Party = bobNode.services.myInfo.chooseIdentity()
-        val aliceNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
-        val bobNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
-        val wrongNonce = ByteArray(SwapIdentitiesFlow.NONCE_SIZE_BYTES) { 0 }.apply(fixedRand::nextBytes)
-        val validNonces = TreeSet(SwapIdentitiesFlow.ArrayComparator).apply {
-            add(aliceNonce)
-            add(bobNonce)
-        }
-        val invalidNonces = TreeSet(SwapIdentitiesFlow.ArrayComparator).apply {
-            add(aliceNonce)
-            add(wrongNonce)
-        }
-        // Check that the right signing key but the wrong nonce is rejected
-        bobNode.database.transaction {
-            bobNode.services.keyManagementService.freshKeyAndCert(bobNode.services.myInfo.chooseIdentityAndCert(), false)
-        }.let { anonymousBob ->
-            val anonymousBobBytes = SerializedBytes<PartyAndCertificate>(anonymousBob.serialize().bytes)
-            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousBobBytes, invalidNonces)
-            val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
-            assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, validNonces, signature.withoutKey())
-            }
-        }
-        // Check that the wrong signature with the correct nonce is rejected
+        // Check that the wrong signature is rejected
         notaryNode.database.transaction {
             notaryNode.services.keyManagementService.freshKeyAndCert(notaryNode.services.myInfo.chooseIdentityAndCert(), false)
         }.let { anonymousNotary ->
             val anonymousNotaryBytes = SerializedBytes<PartyAndCertificate>(anonymousNotary.serialize().bytes)
-            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousNotaryBytes, validNonces)
+            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousNotaryBytes)
             val signature = notaryNode.services.keyManagementService.sign(sigData, anonymousNotary.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousNotaryBytes, validNonces, signature.withoutKey())
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousNotaryBytes, signature.withoutKey())
             }
         }
-        // Check that the right signing key, right nonce but wrong identity is rejected
+        // Check that the right signing key, but wrong identity is rejected
         val anonymousAlice = aliceNode.database.transaction {
             aliceNode.services.keyManagementService.freshKeyAndCert(aliceNode.services.myInfo.chooseIdentityAndCert(), false)
         }
@@ -177,10 +109,10 @@ class SwapIdentitiesFlowTests {
         }.let { anonymousBob ->
             val anonymousAliceBytes = SerializedBytes<PartyAndCertificate>(anonymousAlice.serialize().bytes)
             val anonymousBobBytes = SerializedBytes<PartyAndCertificate>(anonymousBob.serialize().bytes)
-            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousAliceBytes, validNonces)
+            val sigData = SwapIdentitiesFlow.buildDataToSign(anonymousAliceBytes)
             val signature = bobNode.services.keyManagementService.sign(sigData, anonymousBob.owningKey)
             assertFailsWith<SwapIdentitiesException>("Signature does not match the given identity and nonce.") {
-                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, validNonces, signature.withoutKey())
+                SwapIdentitiesFlow.validateAndRegisterIdentity(aliceNode.services.identityService, bob, anonymousBobBytes, signature.withoutKey())
             }
         }
 

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -74,9 +74,9 @@ class SwapIdentitiesFlowTests {
     private fun arrayContains(outerArray: ByteArray, innerArray: ByteArray): Boolean {
         val searchSpace = outerArray.size - innerArray.size
         if (searchSpace >= 0) {
-            for (outerIdx in 0..(searchSpace - 1)) {
+            for (outerIdx in 0 until searchSpace) {
                 var matchedIdx = 0
-                for (innerIdx in 0..(innerArray.size - 1)) {
+                for (innerIdx in 0 until innerArray.size) {
                     if (outerArray[outerIdx + innerIdx] != innerArray[innerIdx])
                         break
                     matchedIdx = innerIdx

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -56,9 +56,9 @@ class SwapIdentitiesFlowTests {
         val mockNet = MockNetwork(false, true)
 
         // Set up values we'll need
-        val notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
-        val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
-        val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
+        val notaryNode = mockNet.createNotaryNode(DUMMY_NOTARY.name)
+        val aliceNode = mockNet.createPartyNode(ALICE.name)
+        val bobNode = mockNet.createPartyNode(BOB.name)
         val bob: Party = bobNode.services.myInfo.chooseIdentity()
         val notBob = notaryNode.database.transaction {
             notaryNode.services.keyManagementService.freshKeyAndCert(notaryNode.services.myInfo.chooseIdentityAndCert(), false)
@@ -81,9 +81,9 @@ class SwapIdentitiesFlowTests {
         val mockNet = MockNetwork(false, true)
 
         // Set up values we'll need
-        val notaryNode = mockNet.createNotaryNode(null, DUMMY_NOTARY.name)
-        val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
-        val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
+        val notaryNode = mockNet.createNotaryNode(DUMMY_NOTARY.name)
+        val aliceNode = mockNet.createPartyNode(ALICE.name)
+        val bobNode = mockNet.createPartyNode(BOB.name)
         val bob: Party = bobNode.services.myInfo.chooseIdentity()
         // Check that the wrong signature is rejected
         notaryNode.database.transaction {

--- a/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/DigitalSignature.kt
@@ -46,5 +46,6 @@ open class DigitalSignature(bytes: ByteArray) : OpaqueBytes(bytes) {
          */
         @Throws(InvalidKeyException::class, SignatureException::class)
         fun isValid(content: ByteArray) = by.isValid(content, this)
+        fun withoutKey() : DigitalSignature = DigitalSignature(this.bytes)
     }
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -196,7 +196,6 @@ fun <T : Any> T.serialize(serializationFactory: SerializationFactory = Serializa
  * A type safe wrapper around a byte array that contains a serialised object. You can call [SerializedBytes.deserialize]
  * to get the original object back.
  */
-@Suppress("unused") // Type parameter is just for documentation purposes.
 class SerializedBytes<T : Any>(bytes: ByteArray) : OpaqueBytes(bytes) {
     // It's OK to use lazy here because SerializedBytes is configured to use the ImmutableClassSerializer.
     val hash: SecureHash by lazy { bytes.sha256() }


### PR DESCRIPTION
Add signature exchange to transaction key flow to verify that the counterparty actually owns the key they claim to.

