### PR TITLE
Deprecating verifiedTransactions from the public API

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt
@@ -89,7 +89,7 @@ class NodeMonitorModel {
         vaultUpdates.startWith(initialVaultUpdate).subscribe(vaultUpdatesSubject)
 
         // Transactions
-        val (transactions, newTransactions) = proxy.verifiedTransactionsFeed()
+        val (transactions, newTransactions) = proxy.internalVerifiedTransactionsFeed()
         newTransactions.startWith(transactions).subscribe(transactionsSubject)
 
         // SM -> TX mapping

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -157,15 +157,21 @@ interface CordaRPCOps : RPCOps {
     // DOCEND VaultTrackAPIHelpers
 
     /**
-     * Returns a list of all recorded transactions.
+     * @suppress Returns a list of all recorded transactions.
+     *
+     * TODO This method should be removed once SGX work is finalised and the design of the corresponding API using [FilteredTransaction] can be started
      */
-    fun verifiedTransactionsSnapshot(): List<SignedTransaction>
+    @Deprecated("This method is intended only for internal use and will be removed from the public API soon.")
+    fun internalVerifiedTransactionsSnapshot(): List<SignedTransaction>
 
     /**
-     * Returns a data feed of all recorded transactions and an observable of future recorded ones.
+     * @suppress Returns a data feed of all recorded transactions and an observable of future recorded ones.
+     *
+     * TODO This method should be removed once SGX work is finalised and the design of the corresponding API using [FilteredTransaction] can be started
      */
+    @Deprecated("This method is intended only for internal use and will be removed from the public API soon.")
     @RPCReturnsObservables
-    fun verifiedTransactionsFeed(): DataFeed<List<SignedTransaction>, SignedTransaction>
+    fun internalVerifiedTransactionsFeed(): DataFeed<List<SignedTransaction>, SignedTransaction>
 
     /**
      * Returns a snapshot list of existing state machine id - recorded transaction hash mappings.

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
@@ -63,7 +63,7 @@ fun main(args: Array<String>) {
         // END 2
 
         // START 3
-        val (transactions: List<SignedTransaction>, futureTransactions: Observable<SignedTransaction>) = proxy.verifiedTransactionsFeed()
+        val (transactions: List<SignedTransaction>, futureTransactions: Observable<SignedTransaction>) = proxy.internalVerifiedTransactionsFeed()
         // END 3
 
         // START 4

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -71,13 +71,13 @@ class CordaRPCOpsImpl(
         }
     }
 
-    override fun verifiedTransactionsSnapshot(): List<SignedTransaction> {
-        val (snapshot, updates) = verifiedTransactionsFeed()
+    override fun internalVerifiedTransactionsSnapshot(): List<SignedTransaction> {
+        val (snapshot, updates) = internalVerifiedTransactionsFeed()
         updates.notUsed()
         return snapshot
     }
 
-    override fun verifiedTransactionsFeed(): DataFeed<List<SignedTransaction>, SignedTransaction> {
+    override fun internalVerifiedTransactionsFeed(): DataFeed<List<SignedTransaction>, SignedTransaction> {
         return database.transaction {
             services.validatedTransactions.track()
         }

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -137,7 +137,7 @@ class CordaRPCOpsImplTest {
     fun `issue and move`() {
         aliceNode.database.transaction {
             stateMachineUpdates = rpc.stateMachinesFeed().updates
-            transactions = rpc.verifiedTransactionsFeed().updates
+            transactions = rpc.internalVerifiedTransactionsFeed().updates
             vaultTrackCash = rpc.vaultTrackBy<Cash.State>().updates
         }
 

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -131,7 +131,7 @@ class AttachmentDemoFlow(val otherSide: Party, val notary: Party, val hash: Secu
 
 fun recipient(rpc: CordaRPCOps) {
     println("Waiting to receive transaction ...")
-    val stx = rpc.verifiedTransactionsFeed().updates.toBlocking().first()
+    val stx = rpc.internalVerifiedTransactionsFeed().updates.toBlocking().first()
     val wtx = stx.tx
     if (wtx.attachments.isNotEmpty()) {
         if (wtx.outputs.isNotEmpty()) {

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
@@ -187,7 +187,7 @@ class NodeTerminalView : Fragment() {
 
     private fun initialise(config: NodeConfig, ops: CordaRPCOps) {
         try {
-            val (txInit, txNext) = ops.verifiedTransactionsFeed()
+            val (txInit, txNext) = ops.internalVerifiedTransactionsFeed()
             val (stateInit, stateNext) = ops.vaultTrackBy<ContractState>(paging = pageSpecification)
 
             txCount = txInit.size


### PR DESCRIPTION
Both methods are not included in the JavaDocs anymore.