### PR TITLE
deployNodes Gradle task appends properties from an optional file to node.conf

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=2.0.0
+gradlePluginsVersion=2.0.1
 kotlinVersion=1.1.50
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -281,6 +281,8 @@ Release 1.0
   on the node's keystore.
 
 .. _changelog_m14:
+* Cordformation node building DSL can have an additional parameter `configFile` with the path to a properties file
+  to be appended to node.conf.
 
 Milestone 14
 ------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -33,6 +33,9 @@ UNRELEASED
 * Gradle task ``deployNodes`` can have an additional parameter `configFile` with the path to a properties file
   to be appended to node.conf.
 
+* Cordformation node building DSL can have an additional parameter `configFile` with the path to a properties file
+  to be appended to node.conf.
+
 .. _changelog_v1:
 
 Release 1.0
@@ -281,8 +284,6 @@ Release 1.0
   on the node's keystore.
 
 .. _changelog_m14:
-* Cordformation node building DSL can have an additional parameter `configFile` with the path to a properties file
-  to be appended to node.conf.
 
 Milestone 14
 ------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,7 +10,7 @@ UNRELEASED
 
 * The ``Cordformation`` gradle plugin has been split into ``cordformation`` and ``cordapp``. The former builds and
   deploys nodes for development and testing, the latter turns a project into a cordapp project that generates JARs in
-  the standard CorDapp format.   
+  the standard CorDapp format.
 
 * ``Cordform`` and node identity generation
   * Cordform may not specify a value for ``NetworkMap``, when that happens, during the task execution the following happens:
@@ -29,6 +29,9 @@ UNRELEASED
   services. The remaining use of this config was for notaries, the configuring of which has been cleaned up and simplified.
   ``notaryNodeAddress``, ``notaryClusterAddresses`` and ``bftSMaRt`` have also been removed and replaced by a single
   ``notary`` config object. See :doc:`corda-configuration-file` for more details.
+
+* Gradle task ``deployNodes`` can have an additional parameter `configFile` with the path to a properties file
+  to be appended to node.conf.
 
 .. _changelog_v1:
 

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -77,4 +77,30 @@ public class CordformNode implements NodeDefinition {
     public void rpcPort(Integer rpcPort) {
         config = config.withValue("rpcAddress", ConfigValueFactory.fromAnyRef(DEFAULT_HOST + ':' + rpcPort));
     }
+
+    /**
+     * Set the port which to bind the Copycat (Raft) node to.
+     *
+     * @param notaryPort The Raft port.
+     */
+    public void notaryNodePort(Integer notaryPort) {
+        config = config.withValue("notaryNodeAddress", ConfigValueFactory.fromAnyRef(DEFAULT_HOST + ':' + notaryPort));
+    }
+
+    /**
+     * @param id The (0-based) BFT replica ID.
+     */
+    public void bftReplicaId(Integer id) {
+        config = config.withValue("bftSMaRt", ConfigValueFactory.fromMap(Collections.singletonMap("replicaId", id)));
+    }
+
+    /**
+     * Set the path to a file with optional properties, which are appended to the generated node.conf file.
+     *
+     * @param configFile The file path.
+     */
+    public void configFile(String configFile) {
+        config = config.withValue("configFile", ConfigValueFactory.fromAnyRef(configFile));
+    }
+
 }

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -79,22 +79,6 @@ public class CordformNode implements NodeDefinition {
     }
 
     /**
-     * Set the port which to bind the Copycat (Raft) node to.
-     *
-     * @param notaryPort The Raft port.
-     */
-    public void notaryNodePort(Integer notaryPort) {
-        config = config.withValue("notaryNodeAddress", ConfigValueFactory.fromAnyRef(DEFAULT_HOST + ':' + notaryPort));
-    }
-
-    /**
-     * @param id The (0-based) BFT replica ID.
-     */
-    public void bftReplicaId(Integer id) {
-        config = config.withValue("bftSMaRt", ConfigValueFactory.fromMap(Collections.singletonMap("replicaId", id)));
-    }
-
-    /**
      * Set the path to a file with optional properties, which are appended to the generated node.conf file.
      *
      * @param configFile The file path.
@@ -102,5 +86,4 @@ public class CordformNode implements NodeDefinition {
     public void configFile(String configFile) {
         config = config.withValue("configFile", ConfigValueFactory.fromAnyRef(configFile));
     }
-
 }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
@@ -107,7 +107,7 @@ class Node extends CordformNode {
         installBuiltPlugin()
         installCordapps()
         installConfig()
-        appendExtraConfig()
+        appendOptionalConfig()
     }
 
     /**
@@ -195,20 +195,20 @@ class Node extends CordformNode {
     /**
      * Appends installed config file with properties from an optional file.
      */
-    private void appendExtraConfig() {
+    private void appendOptionalConfig() {
         final configFileProperty = "configFile"
-        File additionalConfig
+        File optionalConfig
         if (project.findProperty(configFileProperty)) { //provided by -PconfigFile command line property when running Gradle task
-            additionalConfig = new File(project.findProperty(configFileProperty))
+            optionalConfig = new File(project.findProperty(configFileProperty))
         } else if (config.hasPath(configFileProperty)) {
-            additionalConfig = new File(config.getString(configFileProperty))
+            optionalConfig = new File(config.getString(configFileProperty))
         }
-        if (additionalConfig) {
-            if (!additionalConfig.exists()) {
-               println "$configFileProperty '$additionalConfig' not found"
+        if (optionalConfig) {
+            if (!optionalConfig.exists()) {
+               println "$configFileProperty '$optionalConfig' not found"
             } else {
                 def confFile = new File(project.buildDir.getPath() + "/../" + nodeDir, 'node.conf')
-                additionalConfig.withInputStream {
+                optionalConfig.withInputStream {
                     input -> confFile << input
                 }
             }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
@@ -190,7 +190,7 @@ class Node extends CordformNode {
         }
         if (additionalConfig) {
             if (!additionalConfig.exists()) {
-                println "File additionalConfigFile '" + additionalConfig + "' not exist"
+               println "$configFileProperty '$additionalConfig' not found"
             } else {
                 additionalConfig.eachLine {
                     line -> configFileText << line

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
@@ -107,6 +107,7 @@ class Node extends CordformNode {
         installBuiltPlugin()
         installCordapps()
         installConfig()
+        appendExtraConfig()
     }
 
     /**
@@ -180,7 +181,21 @@ class Node extends CordformNode {
     private void installConfig() {
         def configFileText = config.root().render(new ConfigRenderOptions(false, false, true, false)).split("\n").toList()
 
-        // Appending properties from an optional file
+        // Need to write a temporary file first to use the project.copy, which resolves directories correctly.
+        def tmpDir = new File(project.buildDir, "tmp")
+        def tmpConfFile = new File(tmpDir, 'node.conf')
+        Files.write(tmpConfFile.toPath(), configFileText, StandardCharsets.UTF_8)
+
+        project.copy {
+            from tmpConfFile
+            into nodeDir
+        }
+    }
+
+    /**
+     * Appends installed config file with properties from an optional file.
+     */
+    private void appendExtraConfig() {
         final configFileProperty = "configFile"
         File additionalConfig
         if (project.findProperty(configFileProperty)) { //provided by -PconfigFile command line property when running Gradle task
@@ -192,20 +207,11 @@ class Node extends CordformNode {
             if (!additionalConfig.exists()) {
                println "$configFileProperty '$additionalConfig' not found"
             } else {
-                additionalConfig.eachLine {
-                    line -> configFileText << line
+                def confFile = new File(project.buildDir.getPath() + "/../" + nodeDir, 'node.conf')
+                additionalConfig.withInputStream {
+                    input -> confFile << input
                 }
             }
-        }
-
-        // Need to write a temporary file first to use the project.copy, which resolves directories correctly.
-        def tmpDir = new File(project.buildDir, "tmp")
-        def tmpConfFile = new File(tmpDir, 'node.conf')
-        Files.write(tmpConfFile.toPath(), configFileText, StandardCharsets.UTF_8)
-
-        project.copy {
-            from tmpConfFile
-            into nodeDir
         }
     }
 

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Node.groovy
@@ -180,6 +180,24 @@ class Node extends CordformNode {
     private void installConfig() {
         def configFileText = config.root().render(new ConfigRenderOptions(false, false, true, false)).split("\n").toList()
 
+        // Appending properties from an optional file
+        final configFileProperty = "configFile"
+        File additionalConfig
+        if (project.findProperty(configFileProperty)) { //provided by -PconfigFile command line property when running Gradle task
+            additionalConfig = new File(project.findProperty(configFileProperty))
+        } else if (config.hasPath(configFileProperty)) {
+            additionalConfig = new File(config.getString(configFileProperty))
+        }
+        if (additionalConfig) {
+            if (!additionalConfig.exists()) {
+                println "File additionalConfigFile '" + additionalConfig + "' not exist"
+            } else {
+                additionalConfig.eachLine {
+                    line -> configFileText << line
+                }
+            }
+        }
+
         // Need to write a temporary file first to use the project.copy, which resolves directories correctly.
         def tmpDir = new File(project.buildDir, "tmp")
         def tmpConfFile = new File(tmpDir, 'node.conf')


### PR DESCRIPTION
Appending properties from an optional file when deploying node is useful when e.g. testing against different databases.