### PR TITLE
Redefine VaultSchema attribute of serialized Contract state to LOB 

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -39,8 +39,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var contractStateClassName: String,
 
             /** refers to serialized transaction Contract State */
-            // TODO: define contract state size maximum size and adjust length accordingly
-            @Column(name = "contract_state", length = 100000)
+            @Lob
+            @Column(name = "contract_state")
             var contractState: ByteArray,
 
             /** state lifecycle: unconsumed, consumed */


### PR DESCRIPTION
This change also removes the 100,000 hard size constraint.

This change is aligned with other schema changes to map all Kotlin `ByteArray` types to explicit Hibernate `Lob` annotations.