### PR TITLE
[CORDA-460]: Removed usages of deprecated APIs in the codebase.

### DIFF
--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -205,7 +205,7 @@ class TwoPartyTradeFlowTests {
             val allNodes = listOf(notaryNode, aliceNode, bobNode, bankNode)
             allNodes.forEach { node ->
                 node.database.transaction {
-                    allNodes.map { it.services.myInfo.legalIdentityAndCert }.forEach { identity -> node.services.identityService.registerIdentity(identity) }
+                    allNodes.map { it.services.myInfo.legalIdentityAndCert }.forEach { identity -> node.services.identityService.verifyAndRegisterIdentity(identity) }
                 }
             }
 
@@ -619,7 +619,7 @@ class TwoPartyTradeFlowTests {
         val allNodes = listOf(notaryNode, aliceNode, bobNode, bankNode)
         allNodes.forEach { node ->
             node.database.transaction {
-                allNodes.map { it.services.myInfo.legalIdentityAndCert }.forEach { identity -> node.services.identityService.registerIdentity(identity) }
+                allNodes.map { it.services.myInfo.legalIdentityAndCert }.forEach { identity -> node.services.identityService.verifyAndRegisterIdentity(identity) }
             }
         }
 


### PR DESCRIPTION
[CORDA-460]: Removed usages of deprecated APIs in the codebase. `CordaRPCOps.internalVerifiedTransactionsFeed(): DataFeed<List<SignedTransaction>, SignedTransaction>` could not be removed at this stage. Not sure why it's already deprecated.