### PR TITLE
CORDA-499: Rename CurrencyUtils to Currencies

### DIFF
--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -29,12 +29,13 @@ import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static kotlin.test.AssertionsKt.assertEquals;
 import static net.corda.client.rpc.CordaRPCClientConfiguration.getDefault;
-import static net.corda.finance.CurrencyUtils.DOLLARS;
+import static net.corda.finance.Currencies.DOLLARS;
 import static net.corda.finance.contracts.GetBalances.getCashBalance;
 import static net.corda.node.services.FlowPermissions.startFlowPermission;
 import static net.corda.testing.TestConstants.getALICE;
 
-public class CordaRPCJavaClientTest extends NodeBasedTest {
+public class
+CordaRPCJavaClientTest extends NodeBasedTest {
     private List<String> perms = Arrays.asList(startFlowPermission(CashPaymentFlow.class), startFlowPermission(CashIssueFlow.class));
     private Set<String> permSet = new HashSet<>(perms);
     private User rpcUser = new User("user1", "test", permSet);

--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -34,8 +34,7 @@ import static net.corda.finance.contracts.GetBalances.getCashBalance;
 import static net.corda.node.services.FlowPermissions.startFlowPermission;
 import static net.corda.testing.TestConstants.getALICE;
 
-public class
-CordaRPCJavaClientTest extends NodeBasedTest {
+public class CordaRPCJavaClientTest extends NodeBasedTest {
     private List<String> perms = Arrays.asList(startFlowPermission(CashPaymentFlow.class), startFlowPermission(CashIssueFlow.class));
     private Set<String> permSet = new HashSet<>(perms);
     private User rpcUser = new User("user1", "test", permSet);

--- a/finance/src/main/kotlin/net/corda/finance/Currencies.kt
+++ b/finance/src/main/kotlin/net/corda/finance/Currencies.kt
@@ -1,4 +1,4 @@
-@file:JvmName("CurrencyUtils")
+@file:JvmName("Currencies")
 
 package net.corda.finance
 

--- a/finance/src/test/java/net/corda/finance/contracts/asset/CashTestsJava.java
+++ b/finance/src/test/java/net/corda/finance/contracts/asset/CashTestsJava.java
@@ -6,8 +6,8 @@ import net.corda.core.utilities.OpaqueBytes;
 import net.corda.testing.DummyCommandData;
 import org.junit.Test;
 
-import static net.corda.finance.CurrencyUtils.DOLLARS;
-import static net.corda.finance.CurrencyUtils.issuedBy;
+import static net.corda.finance.Currencies.DOLLARS;
+import static net.corda.finance.Currencies.issuedBy;
 import static net.corda.testing.CoreTestUtils.*;
 import static net.corda.testing.NodeTestUtils.*;
 

--- a/finance/src/test/kotlin/net/corda/finance/CurrenciesTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/CurrenciesTests.kt
@@ -4,7 +4,7 @@ import net.corda.core.contracts.Amount
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class CurrencyUtilsTest {
+class CurrenciesTests {
     @Test
     fun `basic currency`() {
         val expected = 1000L


### PR DESCRIPTION
Rename CurrencyUtils to Currencies to explain why it's not in the finance utils package. Replaces #1403
