### PR TITLE
Add warning to notary demo Cordform extensions

### DIFF
--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
@@ -21,6 +21,8 @@ fun main(args: Array<String>) = BFTNotaryCordform.runNodes()
 private val clusterSize = 4 // Minimum size that tolerates a faulty replica.
 private val notaryNames = createNotaryNames(clusterSize)
 
+// This is not the intended final design for how to use CordformDefinition, please treat this as experimental and DO
+// NOT use this as a design to copy.
 object BFTNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].toString()) {
     private val clusterName = CordaX500Name(organisation = "BFT", locality = "Zurich", country = "CH")
     private val advertisedService = ServiceInfo(BFTNonValidatingNotaryService.type, clusterName)

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
@@ -19,6 +19,8 @@ internal fun createNotaryNames(clusterSize: Int) = (0 until clusterSize).map { C
 
 private val notaryNames = createNotaryNames(3)
 
+// This is not the intended final design for how to use CordformDefinition, please treat this as experimental and DO
+// NOT use this as a design to copy.
 object RaftNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].toString()) {
     private val clusterName = CordaX500Name(organisation = "Raft", locality = "Zurich", country = "CH")
     private val advertisedService = ServiceInfo(RaftValidatingNotaryService.type, clusterName)

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
@@ -18,6 +18,8 @@ fun main(args: Array<String>) = SingleNotaryCordform.runNodes()
 
 val notaryDemoUser = User("demou", "demop", setOf(startFlowPermission<DummyIssueAndMove>(), startFlowPermission<RPCStartableNotaryFlowClient>()))
 
+// This is not the intended final design for how to use CordformDefinition, please treat this as experimental and DO
+// NOT use this as a design to copy.
 object SingleNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", DUMMY_NOTARY.name.toString()) {
     init {
         node {


### PR DESCRIPTION
Add warning to not use the notary demo Cordform extension pattern, as it's experimental and should be replaced later on.
