### PR TITLE
SSL cert wrong X500Name fix

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -1,8 +1,8 @@
 package net.corda.node.utilities.registration
 
 import net.corda.core.crypto.Crypto
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.*
-import net.corda.core.internal.cert
 import net.corda.core.utilities.seconds
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.utilities.*
@@ -85,7 +85,7 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
             println("Generating SSL certificate for node messaging service.")
             val sslKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
             val caCert = caKeyStore.getX509Certificate(CORDA_CLIENT_CA).toX509CertHolder()
-            val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, CordaX500Name.build(caCert.subject).copy(commonName = null), sslKey.public)
+            val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, CordaX500Name.build(caCert.cert.subjectX500Principal).copy(commonName = null), sslKey.public)
             val sslKeyStore = loadOrCreateKeyStore(config.sslKeystore, keystorePassword)
             sslKeyStore.addOrReplaceKey(CORDA_CLIENT_TLS, sslKey.private, privateKeyPassword.toCharArray(),
                     arrayOf(sslCert.cert, *certificates))

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -85,7 +85,7 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
             println("Generating SSL certificate for node messaging service.")
             val sslKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
             val caCert = caKeyStore.getX509Certificate(CORDA_CLIENT_CA).toX509CertHolder()
-            val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, caCert.subject.withCommonName(null), sslKey.public)
+            val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, CordaX500Name.build(caCert.subject).copy(commonName = null), sslKey.public)
             val sslKeyStore = loadOrCreateKeyStore(config.sslKeystore, keystorePassword)
             sslKeyStore.addOrReplaceKey(CORDA_CLIENT_TLS, sslKey.private, privateKeyPassword.toCharArray(),
                     arrayOf(sslCert.cert, *certificates))

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -85,7 +85,7 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
             println("Generating SSL certificate for node messaging service.")
             val sslKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
             val caCert = caKeyStore.getX509Certificate(CORDA_CLIENT_CA).toX509CertHolder()
-            val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, caCert.subject, sslKey.public)
+            val sslCert = X509Utilities.createCertificate(CertificateType.TLS, caCert, keyPair, caCert.subject.withCommonName(null), sslKey.public)
             val sslKeyStore = loadOrCreateKeyStore(config.sslKeystore, keystorePassword)
             sslKeyStore.addOrReplaceKey(CORDA_CLIENT_TLS, sslKey.private, privateKeyPassword.toCharArray(),
                     arrayOf(sslCert.cert, *certificates))

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
@@ -6,10 +6,7 @@ import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.internal.exists
-import net.corda.core.internal.toTypedArray
-import net.corda.core.internal.toX509CertHolder
-import net.corda.core.internal.cert
+import net.corda.core.internal.*
 import net.corda.node.utilities.X509Utilities
 import net.corda.node.utilities.getX509Certificate
 import net.corda.node.utilities.loadKeyStore
@@ -82,8 +79,10 @@ class NetworkRegistrationHelperTest {
             assertTrue(containsAlias(X509Utilities.CORDA_CLIENT_TLS))
             val certificateChain = getCertificateChain(X509Utilities.CORDA_CLIENT_TLS)
             assertEquals(4, certificateChain.size)
-            assertEquals(listOf(getX500Name(O = "R3 Ltd", L = "London", C = "GB")) + identities, certificateChain.map { it.toX509CertHolder().subject })
-            assertEquals(getX500Name(O = "R3 Ltd", L = "London", C = "GB"), getX509Certificate(X509Utilities.CORDA_CLIENT_TLS).subject)
+            assertEquals(listOf(CordaX500Name(organisation = "R3 Ltd", locality = "London", country = "GB").x500Name) + identities.map { it.x500Name },
+                    certificateChain.map { it.toX509CertHolder().subject })
+            assertEquals(CordaX500Name(organisation = "R3 Ltd", locality = "London", country = "GB").x500Principal,
+                    getX509Certificate(X509Utilities.CORDA_CLIENT_TLS).subjectX500Principal)
         }
 
         trustStore.run {

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
@@ -11,6 +11,7 @@ import net.corda.core.internal.toTypedArray
 import net.corda.core.internal.toX509CertHolder
 import net.corda.core.internal.cert
 import net.corda.node.utilities.X509Utilities
+import net.corda.node.utilities.getX509Certificate
 import net.corda.node.utilities.loadKeyStore
 import net.corda.testing.ALICE
 import net.corda.testing.testNodeConfiguration
@@ -81,7 +82,8 @@ class NetworkRegistrationHelperTest {
             assertTrue(containsAlias(X509Utilities.CORDA_CLIENT_TLS))
             val certificateChain = getCertificateChain(X509Utilities.CORDA_CLIENT_TLS)
             assertEquals(4, certificateChain.size)
-            assertEquals(listOf("CORDA_CLIENT_CA", "CORDA_CLIENT_CA", "CORDA_INTERMEDIATE_CA", "CORDA_ROOT_CA"), certificateChain.map { it.toX509CertHolder().subject.commonName })
+            assertEquals(listOf(getX500Name(O = "R3 Ltd", L = "London", C = "GB")) + identities, certificateChain.map { it.toX509CertHolder().subject })
+            assertEquals(getX500Name(O = "R3 Ltd", L = "London", C = "GB"), getX509Certificate(X509Utilities.CORDA_CLIENT_TLS).subject)
         }
 
         trustStore.run {


### PR DESCRIPTION
fix a bug where network registration helper creates a SSL cert with wrong X500 name
