### PR TITLE
CORDA-540: Correctly mark AttachmentConstraint to be CordaSerializable

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
@@ -3,13 +3,13 @@ package net.corda.core.contracts
 import net.corda.core.serialization.CordaSerializable
 
 /** Constrain which contract-code-containing attachments can be used with a [ContractState]. */
+@CordaSerializable
 interface AttachmentConstraint {
     /** Returns whether the given contract attachments can be used with the [ContractState] associated with this constraint object. */
     fun isSatisfiedBy(attachments: List<Attachment>): Boolean
 }
 
 /** An [AttachmentConstraint] where [isSatisfiedBy] always returns true. */
-@CordaSerializable
 object AlwaysAcceptAttachmentConstraint : AttachmentConstraint {
     override fun isSatisfiedBy(attachments: List<Attachment>) = true
 }


### PR DESCRIPTION
Or else many core/contract unit tests failing in AMQP mode