### PR TITLE
In preparation for the removal of advertised services, @CordaService …

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/CordaService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/CordaService.kt
@@ -1,19 +1,20 @@
 package net.corda.core.node.services
 
+import net.corda.core.node.PluginServiceHub
+import net.corda.core.node.ServiceHub
+import net.corda.core.serialization.SerializeAsToken
+import net.corda.core.serialization.SingletonSerializeAsToken
 import kotlin.annotation.AnnotationTarget.CLASS
 
 /**
  * Annotate any class that needs to be a long-lived service within the node, such as an oracle, with this annotation.
- * Such a class needs to have a constructor with a single parameter of type [net.corda.core.node.PluginServiceHub]. This
- * construtor will be invoked during node start to initialise the service. The service hub provided can be used to get
- * information about the node that may be necessary for the service. Corda services are created as singletons within
- * the node and are available to flows via [net.corda.core.node.ServiceHub.cordaService].
+ * Such a class needs to have a constructor with a single parameter of type [PluginServiceHub]. This construtor will be
+ * invoked during node start to initialise the service. The service hub provided can be used to get information about the
+ * node that may be necessary for the service. Corda services are created as singletons within the node and are available
+ * to flows via [ServiceHub.cordaService].
  *
- * The service class has to implement [net.corda.core.serialization.SerializeAsToken] to ensure correct usage within flows.
- * (If possible extend [net.corda.core.serialization.SingletonSerializeAsToken] instead as it removes the boilerplate.)
- *
- * The annotated class should expose its [ServiceType] via a public static field named `type`, so that the service is
- * only loaded in nodes that declare the type in their advertisedServices.
+ * The service class has to implement [SerializeAsToken] to ensure correct usage within flows. (If possible extend
+ * [SingletonSerializeAsToken] instead as it removes the boilerplate.)
  */
 // TODO Handle the singleton serialisation of Corda services automatically, removing the need to implement SerializeAsToken
 // TODO Perhaps this should be an interface or abstract class due to the need for it to implement SerializeAsToken and

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomNotaryTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomNotaryTutorial.kt
@@ -10,16 +10,11 @@ import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.core.transactions.SignedTransaction
 import net.corda.node.services.transactions.PersistentUniquenessProvider
-import net.corda.node.services.transactions.ValidatingNotaryService
 import java.security.SignatureException
 
 // START 1
 @CordaService
 class MyCustomValidatingNotaryService(override val services: PluginServiceHub) : TrustedAuthorityNotaryService() {
-    companion object {
-        val type = ValidatingNotaryService.type.getSubType("mycustom")
-    }
-
     override val timeWindowChecker = TimeWindowChecker(services.clock)
     override val uniquenessProvider = PersistentUniquenessProvider()
 

--- a/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt
@@ -13,7 +13,6 @@ import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.TokenizableAssetInfo
 import net.corda.core.identity.Party
-import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.finance.contracts.asset.CommodityContract
@@ -416,7 +415,7 @@ interface FixableDealState : DealState {
     /**
      * What oracle service to use for the fixing
      */
-    val oracleType: ServiceType
+    val oracle: Party
 
     /**
      * Generate a fixing command for this deal and fix.

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/Cordapp.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/Cordapp.kt
@@ -2,12 +2,8 @@ package net.corda.node.internal.cordapp
 
 import net.corda.core.flows.FlowLogic
 import net.corda.core.node.CordaPluginRegistry
-import net.corda.core.node.NodeInfo
-import net.corda.core.node.services.ServiceType
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.serialization.SerializeAsToken
-import net.corda.core.utilities.debug
-import net.corda.core.utilities.loggerFor
 import java.net.URL
 
 /**
@@ -27,32 +23,4 @@ data class Cordapp(
         val services: List<Class<out SerializeAsToken>>,
         val plugins: List<CordaPluginRegistry>,
         val customSchemas: Set<MappedSchema>,
-        val jarPath: URL) {
-    companion object {
-        private val logger = loggerFor<Cordapp>()
-    }
-
-    fun filterEnabledServices(info: NodeInfo): List<Class<out SerializeAsToken>> {
-        return services.filter {
-            val serviceType = getServiceType(it)
-            if (serviceType != null && info.serviceIdentities(serviceType).isEmpty()) {
-                logger.debug {
-                    "Ignoring ${it.name} as a Corda service since $serviceType is not one of our " +
-                            "advertised services"
-                }
-                false
-            } else {
-                true
-            }
-        }
-    }
-
-    private fun getServiceType(clazz: Class<*>): ServiceType? {
-        return try {
-            clazz.getField("type").get(null) as ServiceType
-        } catch (e: NoSuchFieldException) {
-            logger.warn("${clazz.name} does not have a type field, optimistically proceeding with install.")
-            null
-        }
-    }
-}
+        val jarPath: URL)

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
@@ -2,7 +2,8 @@ package net.corda.irs.api
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Command
-import net.corda.core.crypto.*
+import net.corda.core.crypto.MerkleTreeException
+import net.corda.core.crypto.TransactionSignature
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
@@ -10,9 +11,7 @@ import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.internal.ThreadBox
 import net.corda.core.node.PluginServiceHub
-import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.CordaService
-import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.FilteredTransaction
 import net.corda.core.utilities.ProgressTracker
@@ -27,7 +26,6 @@ import net.corda.finance.contracts.math.InterpolatorFactory
 import net.corda.irs.flows.RatesFixFlow
 import org.apache.commons.io.IOUtils
 import java.math.BigDecimal
-import java.security.PublicKey
 import java.time.LocalDate
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
@@ -48,7 +46,7 @@ import kotlin.collections.set
 object NodeInterestRates {
     // DOCSTART 2
     @InitiatedBy(RatesFixFlow.FixSignFlow::class)
-    class FixSignHandler(val otherParty: Party) : FlowLogic<Unit>() {
+    class FixSignHandler(private val otherParty: Party) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
             val request = receive<RatesFixFlow.SignRequest>(otherParty).unwrap { it }
@@ -58,14 +56,14 @@ object NodeInterestRates {
     }
 
     @InitiatedBy(RatesFixFlow.FixQueryFlow::class)
-    class FixQueryHandler(val otherParty: Party) : FlowLogic<Unit>() {
+    class FixQueryHandler(private val otherParty: Party) : FlowLogic<Unit>() {
         object RECEIVED : ProgressTracker.Step("Received fix request")
         object SENDING : ProgressTracker.Step("Sending fix response")
 
         override val progressTracker = ProgressTracker(RECEIVED, SENDING)
 
         @Suspendable
-        override fun call(): Unit {
+        override fun call() {
             val request = receive<RatesFixFlow.QueryRequest>(otherParty).unwrap { it }
             progressTracker.currentStep = RECEIVED
             val oracle = serviceHub.cordaService(Oracle::class.java)
@@ -84,12 +82,10 @@ object NodeInterestRates {
     @ThreadSafe
     // DOCSTART 3
     @CordaService
-    class Oracle(val identity: Party, private val signingKey: PublicKey, val services: ServiceHub) : SingletonSerializeAsToken() {
-        constructor(services: PluginServiceHub) : this(
-            services.myInfo.serviceIdentities(type).first(),
-            services.myInfo.serviceIdentities(type).first().owningKey.keys.first { services.keyManagementService.keys.contains(it) },
-            services
-        ) {
+    class Oracle(private val services: PluginServiceHub) : SingletonSerializeAsToken() {
+        private val mutex = ThreadBox(InnerState())
+
+        init {
             // Set some default fixes to the Oracle, so we can smoothly run the IRS Demo without uploading fixes.
             // This is required to avoid a situation where the runnodes version of the demo isn't in a good state
             // upon startup.
@@ -97,18 +93,11 @@ object NodeInterestRates {
         }
         // DOCEND 3
 
-        companion object {
-            @JvmField
-            val type = ServiceType.corda.getSubType("interest_rates")
-        }
-
         private class InnerState {
             // TODO Update this to use a database once we have an database API
             val fixes = HashSet<Fix>()
             var container: FixContainer = FixContainer(fixes)
         }
-
-        private val mutex = ThreadBox(InnerState())
 
         var knownFixes: FixContainer
             set(value) {
@@ -120,11 +109,6 @@ object NodeInterestRates {
                 }
             }
             get() = mutex.locked { container }
-
-        // Make this the last bit of initialisation logic so fully constructed when entered into instances map
-        init {
-            require(signingKey in identity.owningKey.keys)
-        }
 
         @Suspendable
         fun query(queries: List<FixOf>): List<Fix> {
@@ -150,8 +134,9 @@ object NodeInterestRates {
             }
             // Performing validation of obtained FilteredLeaves.
             fun commandValidator(elem: Command<*>): Boolean {
-                if (!(identity.owningKey in elem.signers && elem.value is Fix))
-                    throw IllegalArgumentException("Oracle received unknown command (not in signers or not Fix).")
+                require(services.myInfo.legalIdentity.owningKey in elem.signers && elem.value is Fix) {
+                    "Oracle received unknown command (not in signers or not Fix)."
+                }
                 val fix = elem.value as Fix
                 val known = knownFixes[fix.of]
                 if (known == null || known != fix)
@@ -167,15 +152,14 @@ object NodeInterestRates {
             }
 
             val leaves = ftx.filteredLeaves
-            if (!leaves.checkWithFun(::check))
-                throw IllegalArgumentException()
+            require(leaves.checkWithFun(::check))
 
             // It all checks out, so we can return a signature.
             //
             // Note that we will happily sign an invalid transaction, as we are only being presented with a filtered
             // version so we can't resolve or check it ourselves. However, that doesn't matter much, as if we sign
             // an invalid transaction the signature is worthless.
-            return services.createSignature(ftx, signingKey)
+            return services.createSignature(ftx, services.myInfo.legalIdentity.owningKey)
         }
         // DOCEND 1
 
@@ -212,7 +196,7 @@ object NodeInterestRates {
         private fun buildContainer(fixes: Set<Fix>): Map<Pair<String, LocalDate>, InterpolatingRateMap> {
             val tempContainer = HashMap<Pair<String, LocalDate>, HashMap<Tenor, BigDecimal>>()
             for ((fixOf, value) in fixes) {
-                val rates = tempContainer.getOrPut(fixOf.name to fixOf.forDay) { HashMap<Tenor, BigDecimal>() }
+                val rates = tempContainer.getOrPut(fixOf.name to fixOf.forDay) { HashMap() }
                 rates[fixOf.ofTenor] = value
             }
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -3,22 +3,16 @@ package net.corda.irs.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.crypto.TransactionSignature
-import net.corda.core.utilities.toBase58String
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.flows.SchedulableFlow
-import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
-import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.utilities.ProgressTracker
-import net.corda.core.utilities.seconds
-import net.corda.core.utilities.trace
-import net.corda.core.utilities.transient
+import net.corda.core.utilities.*
 import net.corda.finance.contracts.Fix
 import net.corda.finance.contracts.FixableDealState
 import net.corda.finance.flows.TwoPartyDealFlow
@@ -65,11 +59,8 @@ object FixingFlow {
 
             val ptx = TransactionBuilder(txState.notary)
 
-            val oracle = serviceHub.networkMapCache.getNodesWithService(handshake.payload.oracleType).first()
-            val oracleParty = oracle.serviceIdentities(handshake.payload.oracleType).first()
-
             // DOCSTART 1
-            val addFixing = object : RatesFixFlow(ptx, oracleParty, fixOf, BigDecimal.ZERO, BigDecimal.ONE) {
+            val addFixing = object : RatesFixFlow(ptx, handshake.payload.oracle, fixOf, BigDecimal.ZERO, BigDecimal.ONE) {
                 @Suspendable
                 override fun beforeSigning(fix: Fix) {
                     newDeal.generateFix(ptx, StateAndRef(txState, handshake.payload.ref), fix)
@@ -82,7 +73,7 @@ object FixingFlow {
                 @Suspendable
                 override fun filtering(elem: Any): Boolean {
                     return when (elem) {
-                        is Command<*> -> oracleParty.owningKey in elem.signers && elem.value is Fix
+                        is Command<*> -> handshake.payload.oracle.owningKey in elem.signers && elem.value is Fix
                         else -> false
                     }
                 }
@@ -104,7 +95,7 @@ object FixingFlow {
                   override val payload: FixingSession,
                   override val progressTracker: ProgressTracker = TwoPartyDealFlow.Primary.tracker()) : TwoPartyDealFlow.Primary() {
         @Suppress("UNCHECKED_CAST")
-        internal val dealToFix: StateAndRef<FixableDealState> by transient {
+        private val dealToFix: StateAndRef<FixableDealState> by transient {
             val state = serviceHub.loadState(payload.ref) as TransactionState<FixableDealState>
             StateAndRef(state, payload.ref)
         }
@@ -121,7 +112,7 @@ object FixingFlow {
 
     /** Used to set up the session between [Floater] and [Fixer] */
     @CordaSerializable
-    data class FixingSession(val ref: StateRef, val oracleType: ServiceType)
+    data class FixingSession(val ref: StateRef, val oracle: Party)
 
     /**
      * This flow looks at the deal and decides whether to be the Fixer or Floater role in agreeing a fixing.
@@ -142,14 +133,14 @@ object FixingFlow {
         }
 
         @Suspendable
-        override fun call(): Unit {
+        override fun call() {
             progressTracker.nextStep()
             val dealToFix = serviceHub.loadState(ref)
             val fixableDeal = (dealToFix.data as FixableDealState)
             val parties = fixableDeal.participants.sortedBy { it.owningKey.toBase58String() }
             val myKey = serviceHub.myInfo.legalIdentity.owningKey
             if (parties[0].owningKey == myKey) {
-                val fixing = FixingSession(ref, fixableDeal.oracleType)
+                val fixing = FixingSession(ref, fixableDeal.oracle)
                 val counterparty = serviceHub.identityService.partyFromAnonymous(parties[1]) ?: throw IllegalStateException("Cannot resolve floater party")
                 // Start the Floater which will then kick-off the Fixer
                 subFlow(Floater(counterparty, fixing))

--- a/samples/irs-demo/src/main/resources/irsweb/js/Deal.js
+++ b/samples/irs-demo/src/main/resources/irsweb/js/Deal.js
@@ -69,7 +69,8 @@ define(['viewmodel/FixedRate'], (fixedRateViewModel) => {
                 fixedLeg: fixedLeg,
                 floatingLeg: floatingLeg,
                 calculation: calculationModel,
-                common: common
+                common: common,
+                oracle: dealViewModel.oracle
             };
 
             return json;

--- a/samples/irs-demo/src/main/resources/irsweb/js/viewmodel/Deal.js
+++ b/samples/irs-demo/src/main/resources/irsweb/js/viewmodel/Deal.js
@@ -4,6 +4,7 @@ define(['viewmodel/FixedLeg', 'viewmodel/FloatingLeg', 'viewmodel/Common'], (fix
     return {
         fixedLeg: fixedLeg,
         floatingLeg: floatingLeg,
-        common: common
+        common: common,
+        oracle: "O=Notary Service,L=Zurich,C=CH"
     };
 });

--- a/samples/irs-demo/src/main/resources/net/corda/irs/simulation/example-irs-trade.json
+++ b/samples/irs-demo/src/main/resources/net/corda/irs/simulation/example-irs-trade.json
@@ -81,5 +81,6 @@
     "dailyInterestAmount": "(CashAmount * InterestRate ) / (fixedLeg.notional.token.currencyCode.equals('GBP')) ? 365 : 360",
     "tradeID": "tradeXXX",
     "hashLegalDocs": "put hash here"
-  }
+  },
+  "oracle": "oracleXXX"
 }

--- a/samples/irs-demo/src/main/resources/net/corda/irs/simulation/trade.json
+++ b/samples/irs-demo/src/main/resources/net/corda/irs/simulation/trade.json
@@ -84,5 +84,6 @@
     "dailyInterestAmount": "(CashAmount * InterestRate ) / (fixedLeg.notional.token.currencyCode.equals('GBP')) ? 365 : 360",
     "tradeID": "tradeXXX",
     "hashLegalDocs": "put hash here"
-  }
+  },
+  "oracle": "oracleXXX"
 }

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/IRSDemo.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/IRSDemo.kt
@@ -3,6 +3,7 @@
 package net.corda.irs
 
 import joptsimple.OptionParser
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.NetworkHostAndPort
 import kotlin.system.exitProcess
 
@@ -30,7 +31,7 @@ fun main(args: Array<String>) {
     val value = options.valueOf(valueArg)
     when (role) {
         Role.UploadRates -> IRSDemoClientApi(NetworkHostAndPort("localhost", 10004)).runUploadRates()
-        Role.Trade -> IRSDemoClientApi(NetworkHostAndPort("localhost", 10007)).runTrade(value)
+        Role.Trade -> IRSDemoClientApi(NetworkHostAndPort("localhost", 10007)).runTrade(value, CordaX500Name.parse("O=Notary Service,L=Zurich,C=CH"))
         Role.Date -> IRSDemoClientApi(NetworkHostAndPort("localhost", 10010)).runDateChange(value)
     }
 }

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/IrsDemoClientApi.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/IrsDemoClientApi.kt
@@ -1,5 +1,6 @@
 package net.corda.irs
 
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.irs.utilities.uploadFile
 import net.corda.testing.http.HttpApi
@@ -12,9 +13,9 @@ import java.net.URL
 class IRSDemoClientApi(private val hostAndPort: NetworkHostAndPort) {
     private val api = HttpApi.fromHostAndPort(hostAndPort, apiRoot)
 
-    fun runTrade(tradeId: String): Boolean {
+    fun runTrade(tradeId: String, oracleName: CordaX500Name): Boolean {
         val fileContents = IOUtils.toString(javaClass.classLoader.getResourceAsStream("net/corda/irs/simulation/example-irs-trade.json"), Charsets.UTF_8.name())
-        val tradeFile = fileContents.replace("tradeXXX", tradeId)
+        val tradeFile = fileContents.replace("tradeXXX", tradeId).replace("oracleXXX", oracleName.toString())
         return api.postJson("deals", tradeFile)
     }
 

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/Main.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/Main.kt
@@ -2,11 +2,10 @@ package net.corda.irs
 
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
 import net.corda.testing.DUMMY_NOTARY
-import net.corda.irs.api.NodeInterestRates
-import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.testing.driver.driver
 
 /**
@@ -15,12 +14,13 @@ import net.corda.testing.driver.driver
  */
 fun main(args: Array<String>) {
     driver(dsl = {
-        val controllerFuture = startNode(
-                providedName = DUMMY_NOTARY.name,
-                advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type), ServiceInfo(NodeInterestRates.Oracle.type)))
-        val nodeAFuture = startNode(providedName = DUMMY_BANK_A.name)
-        val nodeBFuture = startNode(providedName = DUMMY_BANK_B.name)
-        val (controller, nodeA, nodeB) = listOf(controllerFuture, nodeAFuture, nodeBFuture).map { it.getOrThrow() }
+        val (controller, nodeA, nodeB) = listOf(
+                startNode(
+                        providedName = DUMMY_NOTARY.name,
+                        advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type))),
+                startNode(providedName = DUMMY_BANK_A.name),
+                startNode(providedName = DUMMY_BANK_B.name))
+                .map { it.getOrThrow() }
 
         startWebserver(controller)
         startWebserver(nodeA)

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
@@ -3,6 +3,7 @@ package net.corda.netmap.simulation
 import co.paralleluniverse.fibers.Suspendable
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import net.corda.client.jackson.JacksonSupport
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatedBy
@@ -18,12 +19,10 @@ import net.corda.finance.flows.TwoPartyDealFlow.Instigator
 import net.corda.finance.plugin.registerFinanceJSONMappers
 import net.corda.irs.contract.InterestRateSwap
 import net.corda.irs.flows.FixingFlow
-import net.corda.client.jackson.JacksonSupport
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.testing.DUMMY_CA
 import net.corda.testing.node.InMemoryMessagingNetwork
 import rx.Observable
-import java.security.PublicKey
 import java.time.LocalDate
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -43,7 +42,7 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
     private val executeOnNextIteration = Collections.synchronizedList(LinkedList<() -> Unit>())
 
     override fun startMainSimulation(): CompletableFuture<Unit> {
-        om = JacksonSupport.createInMemoryMapper(InMemoryIdentityService((banks + regulators + networkMap).map { it.info.legalIdentityAndCert }, trustRoot = DUMMY_CA.certificate))
+        om = JacksonSupport.createInMemoryMapper(InMemoryIdentityService((banks + regulators + networkMap + ratesOracle).map { it.info.legalIdentityAndCert }, trustRoot = DUMMY_CA.certificate))
         registerFinanceJSONMappers(om)
 
         return startIRSDealBetween(0, 1).thenCompose {
@@ -127,7 +126,11 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
         // We load the IRS afresh each time because the leg parts of the structure aren't data classes so they don't
         // have the convenient copy() method that'd let us make small adjustments. Instead they're partly mutable.
         // TODO: We should revisit this in post-Excalibur cleanup and fix, e.g. by introducing an interface.
-        val irs = om.readValue<InterestRateSwap.State>(javaClass.classLoader.getResource("net/corda/irs/simulation/trade.json"))
+
+        val irs = om.readValue<InterestRateSwap.State>(javaClass.classLoader.getResourceAsStream("net/corda/irs/simulation/trade.json")
+                .reader()
+                .readText()
+                .replace("oracleXXX", RatesOracleFactory.RATES_SERVICE_NAME.toString()))
         irs.fixedLeg.fixedRatePayer = node1.info.legalIdentity
         irs.floatingLeg.floatingRatePayer = node2.info.legalIdentity
 

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
@@ -116,7 +116,6 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
         override fun create(config: NodeConfiguration, network: MockNetwork, networkMapAddr: SingleMessageRecipient?,
                             advertisedServices: Set<ServiceInfo>, id: Int, overrideServices: Map<ServiceInfo, KeyPair>?,
                             entropyRoot: BigInteger): SimulatedNode {
-            require(advertisedServices.containsType(NodeInterestRates.Oracle.type))
             val cfg = testNodeConfiguration(
                     baseDirectory = config.baseDirectory,
                     myLegalName = RATES_SERVICE_NAME)
@@ -155,7 +154,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
     val networkMap = mockNet.createNode(nodeFactory = NetworkMapNodeFactory, advertisedServices = ServiceInfo(NetworkMapService.type))
     val notary = mockNet.createNode(networkMap.network.myAddress, nodeFactory = NotaryNodeFactory, advertisedServices = ServiceInfo(SimpleNotaryService.type))
     val regulators = listOf(mockNet.createNode(networkMap.network.myAddress, start = false, nodeFactory = RegulatorFactory))
-    val ratesOracle = mockNet.createNode(networkMap.network.myAddress, start = false, nodeFactory = RatesOracleFactory, advertisedServices = ServiceInfo(NodeInterestRates.Oracle.type))
+    val ratesOracle = mockNet.createNode(networkMap.network.myAddress, start = false, nodeFactory = RatesOracleFactory)
 
     // All nodes must be in one of these two lists for the purposes of the visualiser tool.
     val serviceProviders: List<SimulatedNode> = listOf(notary, ratesOracle, networkMap)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -5,7 +5,7 @@ import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.DataFeed
 import net.corda.core.node.NodeInfo
-import net.corda.core.node.ServiceHub
+import net.corda.core.node.PluginServiceHub
 import net.corda.core.node.services.*
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.serialization.SerializeAsToken
@@ -45,7 +45,7 @@ import java.util.*
  * A singleton utility that only provides a mock identity, key and storage service. However, this is sufficient for
  * building chains of transactions and verifying them. It isn't sufficient for testing flows however.
  */
-open class MockServices(vararg val keys: KeyPair) : ServiceHub {
+open class MockServices(vararg val keys: KeyPair) : PluginServiceHub {
 
     companion object {
 


### PR DESCRIPTION
…no longer expects a static "type" field for the ServiceType.

Instead @CordaServices will use the main identity of the node.

