### PR TITLE
Change to using X500Principal in Cordform classes

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.16.2
+gradlePluginsVersion=0.16.3
 kotlinVersion=1.1.4
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
@@ -9,6 +9,7 @@ import org.bouncycastle.asn1.x500.AttributeTypeAndValue
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x500.X500NameBuilder
 import org.bouncycastle.asn1.x500.style.BCStyle
+import javax.security.auth.x500.X500Principal
 
 /**
  * X.500 distinguished name data type customised to how Corda uses names. This restricts the attributes to those Corda
@@ -100,6 +101,8 @@ data class CordaX500Name(val commonName: String?,
             return CordaX500Name(CN, OU, O, L, ST, C)
         }
         @JvmStatic
+        fun build(x500Principal: X500Principal) = build(X500Name.getInstance(x500Principal.encoded))
+        @JvmStatic
         fun parse(name: String) : CordaX500Name = build(X500Name(name))
     }
 
@@ -125,5 +128,10 @@ data class CordaX500Name(val commonName: String?,
                 }.build()
             }
             return x500Cache!!
+        }
+
+    val x500Principal: X500Principal
+        get() {
+            return X500Principal(x500Name.encoded)
         }
 }

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformContext.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformContext.java
@@ -1,13 +1,8 @@
 package net.corda.cordform;
 
-import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.asn1.x500.X500Name;
 import java.nio.file.Path;
 
 public interface CordformContext {
-    /**
-     * Resolve the base directory of a node.
-     *
-     * @param nodeName distinguished name of the node.
-     */
     Path baseDirectory(String nodeName);
 }

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformContext.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformContext.java
@@ -4,5 +4,10 @@ import javax.security.auth.x500.X500Principal;
 import java.nio.file.Path;
 
 public interface CordformContext {
-    Path baseDirectory(X500Principal nodeName);
+    /**
+     * Resolve the base directory of a node.
+     *
+     * @param nodeName distinguished name of the node.
+     */
+    Path baseDirectory(String nodeName);
 }

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformContext.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformContext.java
@@ -1,8 +1,8 @@
 package net.corda.cordform;
 
-import org.bouncycastle.asn1.x500.X500Name;
+import javax.security.auth.x500.X500Principal;
 import java.nio.file.Path;
 
 public interface CordformContext {
-    Path baseDirectory(X500Name nodeName);
+    Path baseDirectory(X500Principal nodeName);
 }

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformDefinition.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformDefinition.java
@@ -1,6 +1,5 @@
 package net.corda.cordform;
 
-import javax.security.auth.x500.X500Principal;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.function.Consumer;
@@ -8,9 +7,9 @@ import java.util.function.Consumer;
 public abstract class CordformDefinition {
     public final Path driverDirectory;
     public final ArrayList<Consumer<? super CordformNode>> nodeConfigurers = new ArrayList<>();
-    public final X500Principal networkMapNodeName;
+    public final String networkMapNodeName;
 
-    public CordformDefinition(Path driverDirectory, X500Principal networkMapNodeName) {
+    public CordformDefinition(Path driverDirectory, String networkMapNodeName) {
         this.driverDirectory = driverDirectory;
         this.networkMapNodeName = networkMapNodeName;
     }

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformDefinition.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformDefinition.java
@@ -1,6 +1,6 @@
 package net.corda.cordform;
 
-import org.bouncycastle.asn1.x500.X500Name;
+import javax.security.auth.x500.X500Principal;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.function.Consumer;
@@ -8,9 +8,9 @@ import java.util.function.Consumer;
 public abstract class CordformDefinition {
     public final Path driverDirectory;
     public final ArrayList<Consumer<? super CordformNode>> nodeConfigurers = new ArrayList<>();
-    public final X500Name networkMapNodeName;
+    public final X500Principal networkMapNodeName;
 
-    public CordformDefinition(Path driverDirectory, X500Name networkMapNodeName) {
+    public CordformDefinition(Path driverDirectory, X500Principal networkMapNodeName) {
         this.driverDirectory = driverDirectory;
         this.networkMapNodeName = networkMapNodeName;
     }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -120,8 +120,8 @@ class Cordform extends DefaultTask {
                 }
             }
             cd.setup new CordformContext() {
-                Path baseDirectory(X500Principal nodeName) {
-                    project.projectDir.toPath().resolve(getNodeByName(nodeName.toString()).nodeDir.toPath())
+                Path baseDirectory(String nodeName) {
+                    project.projectDir.toPath().resolve(getNodeByName(nodeName).nodeDir.toPath())
                 }
             }
         } else {

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -1,18 +1,15 @@
 package net.corda.plugins
 
+import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import net.corda.cordform.CordformContext
 import net.corda.cordform.CordformDefinition
 import org.apache.tools.ant.filters.FixCrLfFilter
-import org.bouncycastle.asn1.x500.X500Name
 import org.gradle.api.DefaultTask
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.TaskAction
-
 import java.nio.file.Path
 import java.nio.file.Paths
-import javax.security.auth.x500.X500Principal
-
-import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
+import javax.security.auth.x500.X500Principal;
 
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
@@ -124,7 +121,7 @@ class Cordform extends DefaultTask {
             }
             cd.setup new CordformContext() {
                 Path baseDirectory(X500Principal nodeName) {
-                    project.projectDir.toPath().resolve(getNodeByName(X500Name.getInstance(nodeName.getEncoded())).nodeDir.toPath())
+                    project.projectDir.toPath().resolve(getNodeByName(nodeName.toString()).nodeDir.toPath())
                 }
             }
         } else {

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -1,6 +1,5 @@
 package net.corda.plugins
 
-import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import net.corda.cordform.CordformContext
 import net.corda.cordform.CordformDefinition
 import org.apache.tools.ant.filters.FixCrLfFilter
@@ -8,8 +7,12 @@ import org.bouncycastle.asn1.x500.X500Name
 import org.gradle.api.DefaultTask
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.TaskAction
+
 import java.nio.file.Path
 import java.nio.file.Paths
+import javax.security.auth.x500.X500Principal
+
+import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
@@ -120,8 +123,8 @@ class Cordform extends DefaultTask {
                 }
             }
             cd.setup new CordformContext() {
-                Path baseDirectory(X500Name nodeName) {
-                    project.projectDir.toPath().resolve(getNodeByName(nodeName.toString()).nodeDir.toPath())
+                Path baseDirectory(X500Principal nodeName) {
+                    project.projectDir.toPath().resolve(getNodeByName(X500Name.getInstance(nodeName.getEncoded())).nodeDir.toPath())
                 }
             }
         } else {

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -4,12 +4,12 @@ import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import net.corda.cordform.CordformContext
 import net.corda.cordform.CordformDefinition
 import org.apache.tools.ant.filters.FixCrLfFilter
+import org.bouncycastle.asn1.x500.X500Name
 import org.gradle.api.DefaultTask
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.TaskAction
 import java.nio.file.Path
 import java.nio.file.Paths
-import javax.security.auth.x500.X500Principal;
 
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
@@ -64,7 +64,7 @@ class P2PMessagingTest : NodeBasedTest() {
     @Test
     fun `communicating with a distributed service which the network map node is part of`() {
         ServiceIdentityGenerator.generateToDisk(
-                listOf(DUMMY_MAP.name, SERVICE_2_NAME).map { baseDirectory(it.x500Name) },
+                listOf(DUMMY_MAP.name, SERVICE_2_NAME).map { baseDirectory(it) },
                 RaftValidatingNotaryService.type.id,
                 DISTRIBUTED_SERVICE_NAME)
 

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PSecurityTest.kt
@@ -57,7 +57,7 @@ class P2PSecurityTest : NodeBasedTest() {
     private fun startSimpleNode(legalName: CordaX500Name,
                                 trustRoot: X509Certificate): SimpleNode {
         val config = testNodeConfiguration(
-                baseDirectory = baseDirectory(legalName.x500Name),
+                baseDirectory = baseDirectory(legalName),
                 myLegalName = legalName).also {
             whenever(it.networkMapService).thenReturn(NetworkMapInfo(networkMapNode.internals.configuration.p2pAddress, networkMapNode.info.legalIdentity.name))
         }

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
@@ -65,6 +65,6 @@ object BFTNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", not
     }
 
     override fun setup(context: CordformContext) {
-        ServiceIdentityGenerator.generateToDisk(notaryNames.map { context.baseDirectory(it.x500Principal) }, advertisedService.type.id, clusterName, minCorrectReplicas(clusterSize))
+        ServiceIdentityGenerator.generateToDisk(notaryNames.map(CordaX500Name::toString).map(context::baseDirectory), advertisedService.type.id, clusterName, minCorrectReplicas(clusterSize))
     }
 }

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
@@ -22,7 +22,7 @@ fun main(args: Array<String>) = BFTNotaryCordform.runNodes()
 private val clusterSize = 4 // Minimum size that tolerates a faulty replica.
 private val notaryNames = createNotaryNames(clusterSize)
 
-object BFTNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].x500Principal) {
+object BFTNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].toString()) {
     private val clusterName = CordaX500Name(organisation = "BFT", locality = "Zurich", country = "CH")
     private val advertisedService = ServiceInfo(BFTNonValidatingNotaryService.type, clusterName)
 

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
@@ -22,7 +22,7 @@ fun main(args: Array<String>) = BFTNotaryCordform.runNodes()
 private val clusterSize = 4 // Minimum size that tolerates a faulty replica.
 private val notaryNames = createNotaryNames(clusterSize)
 
-object BFTNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].x500Name) {
+object BFTNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].x500Principal) {
     private val clusterName = CordaX500Name(organisation = "BFT", locality = "Zurich", country = "CH")
     private val advertisedService = ServiceInfo(BFTNonValidatingNotaryService.type, clusterName)
 
@@ -65,6 +65,6 @@ object BFTNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", not
     }
 
     override fun setup(context: CordformContext) {
-        ServiceIdentityGenerator.generateToDisk(notaryNames.map { context.baseDirectory(it.x500Name) }, advertisedService.type.id, clusterName, minCorrectReplicas(clusterSize))
+        ServiceIdentityGenerator.generateToDisk(notaryNames.map { context.baseDirectory(it.x500Principal) }, advertisedService.type.id, clusterName, minCorrectReplicas(clusterSize))
     }
 }

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
@@ -20,7 +20,7 @@ internal fun createNotaryNames(clusterSize: Int) = (0 until clusterSize).map { C
 
 private val notaryNames = createNotaryNames(3)
 
-object RaftNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].x500Principal) {
+object RaftNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].toString()) {
     private val clusterName = CordaX500Name(organisation = "Raft", locality = "Zurich", country = "CH")
     private val advertisedService = ServiceInfo(RaftValidatingNotaryService.type, clusterName)
 

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
@@ -20,7 +20,7 @@ internal fun createNotaryNames(clusterSize: Int) = (0 until clusterSize).map { C
 
 private val notaryNames = createNotaryNames(3)
 
-object RaftNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].x500Name) {
+object RaftNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", notaryNames[0].x500Principal) {
     private val clusterName = CordaX500Name(organisation = "Raft", locality = "Zurich", country = "CH")
     private val advertisedService = ServiceInfo(RaftValidatingNotaryService.type, clusterName)
 
@@ -62,6 +62,6 @@ object RaftNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", no
     }
 
     override fun setup(context: CordformContext) {
-        ServiceIdentityGenerator.generateToDisk(notaryNames.map { context.baseDirectory(it.x500Name) }, advertisedService.type.id, clusterName)
+        ServiceIdentityGenerator.generateToDisk(notaryNames.map { context.baseDirectory(it.x500Principal) }, advertisedService.type.id, clusterName)
     }
 }

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
@@ -62,6 +62,6 @@ object RaftNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", no
     }
 
     override fun setup(context: CordformContext) {
-        ServiceIdentityGenerator.generateToDisk(notaryNames.map { context.baseDirectory(it.x500Principal) }, advertisedService.type.id, clusterName)
+        ServiceIdentityGenerator.generateToDisk(notaryNames.map(CordaX500Name::toString).map(context::baseDirectory), advertisedService.type.id, clusterName)
     }
 }

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
@@ -19,7 +19,7 @@ fun main(args: Array<String>) = SingleNotaryCordform.runNodes()
 
 val notaryDemoUser = User("demou", "demop", setOf(startFlowPermission<DummyIssueAndMove>(), startFlowPermission<RPCStartableNotaryFlowClient>()))
 
-object SingleNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", DUMMY_NOTARY.name.x500Name) {
+object SingleNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", DUMMY_NOTARY.name.x500Principal) {
     init {
         node {
             name(ALICE.name)

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
@@ -19,7 +19,7 @@ fun main(args: Array<String>) = SingleNotaryCordform.runNodes()
 
 val notaryDemoUser = User("demou", "demop", setOf(startFlowPermission<DummyIssueAndMove>(), startFlowPermission<RPCStartableNotaryFlowClient>()))
 
-object SingleNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", DUMMY_NOTARY.name.x500Principal) {
+object SingleNotaryCordform : CordformDefinition("build" / "notary-demo-nodes", DUMMY_NOTARY.name.toString()) {
     init {
         node {
             name(ALICE.name)

--- a/testing/node-driver/src/main/kotlin/net/corda/demorun/DemoRunner.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/demorun/DemoRunner.kt
@@ -18,7 +18,7 @@ fun CordformDefinition.clean() {
 fun CordformDefinition.runNodes() = driver(
         isDebug = true,
         driverDirectory = driverDirectory,
-        networkMapStartStrategy = NetworkMapStartStrategy.Nominated(CordaX500Name.build(networkMapNodeName)),
+        networkMapStartStrategy = NetworkMapStartStrategy.Nominated(CordaX500Name.parse(networkMapNodeName)),
         portAllocation = PortAllocation.Incremental(10001)
 ) {
     setup(this)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -38,7 +38,6 @@ import net.corda.testing.*
 import net.corda.testing.node.MockServices.Companion.MOCK_VERSION_INFO
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.bouncycastle.asn1.x500.X500Name
 import org.slf4j.Logger
 import java.io.File
 import java.net.*
@@ -56,7 +55,6 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
-import javax.security.auth.x500.X500Principal
 import kotlin.concurrent.thread
 
 
@@ -682,7 +680,7 @@ class DriverDSL(
             override fun getConfig() = configOf("p2pAddress" to p2pAddress.toString())
         }))
         val config = ConfigHelper.loadConfig(
-                baseDirectory = baseDirectory(name.x500Principal),
+                baseDirectory = baseDirectory(name),
                 allowMissingConfig = true,
                 configOverrides = configOf(
                         "myLegalName" to name.toString(),
@@ -707,7 +705,7 @@ class DriverDSL(
             val name = CordaX500Name.parse(node.name)
 
             val config = ConfigHelper.loadConfig(
-                    baseDirectory = baseDirectory(name.x500Principal),
+                    baseDirectory = baseDirectory(name),
                     allowMissingConfig = true,
                     configOverrides = node.config + mapOf(
                             "extraAdvertisedServiceIds" to node.advertisedServices,
@@ -729,7 +727,7 @@ class DriverDSL(
             startInSameProcess: Boolean?
     ): CordaFuture<Pair<Party, List<NodeHandle>>> {
         val nodeNames = (0 until clusterSize).map { CordaX500Name(organisation = "Notary Service $it", locality = "Zurich", country = "CH") }
-        val paths = nodeNames.map { baseDirectory(it.x500Principal) }
+        val paths = nodeNames.map { baseDirectory(it) }
         ServiceIdentityGenerator.generateToDisk(paths, type.id, notaryName)
         val advertisedServices = setOf(ServiceInfo(type, notaryName))
         val notaryClusterAddress = portAllocation.nextHostAndPort()
@@ -800,13 +798,13 @@ class DriverDSL(
 
     }
 
-    override fun baseDirectory(nodeName: X500Principal): Path = baseDirectory(CordaX500Name.build(X500Name.getInstance(nodeName.encoded)))
+    override fun baseDirectory(nodeName: String): Path = baseDirectory(CordaX500Name.parse(nodeName))
 
     override fun startDedicatedNetworkMapService(startInProcess: Boolean?): CordaFuture<NodeHandle> {
         val webAddress = portAllocation.nextHostAndPort()
         val networkMapLegalName = networkMapStartStrategy.legalName
         val config = ConfigHelper.loadConfig(
-                baseDirectory = baseDirectory(networkMapLegalName.x500Principal),
+                baseDirectory = baseDirectory(networkMapLegalName),
                 allowMissingConfig = true,
                 configOverrides = configOf(
                         "myLegalName" to networkMapLegalName.toString(),

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeBasedTest.kt
@@ -135,7 +135,10 @@ abstract class NodeBasedTest : TestDependencyInjectionBase() {
                            clusterSize: Int,
                            serviceType: ServiceType = RaftValidatingNotaryService.type): CordaFuture<List<StartedNode<Node>>> {
         ServiceIdentityGenerator.generateToDisk(
-                (0 until clusterSize).map { baseDirectory(getX500Name(O = "${notaryName.organisation}-$it", L = notaryName.locality, C = notaryName.country)) },
+                (0 until clusterSize).map {
+                    val clusterNodeName = CordaX500Name(organisation = "${notaryName.organisation}-$it", locality = notaryName.locality, country = notaryName.country)
+                    baseDirectory(clusterNodeName)
+                },
                 serviceType.id,
                 notaryName)
 
@@ -163,7 +166,7 @@ abstract class NodeBasedTest : TestDependencyInjectionBase() {
         }
     }
 
-    protected fun baseDirectory(legalName: X500Name) = tempFolder.root.toPath() / legalName.organisation.replace(WHITESPACE, "")
+    protected fun baseDirectory(legalName: CordaX500Name) = tempFolder.root.toPath() / legalName.organisation.replace(WHITESPACE, "")
 
     private fun startNodeInternal(legalName: CordaX500Name,
                                   platformVersion: Int,
@@ -171,7 +174,7 @@ abstract class NodeBasedTest : TestDependencyInjectionBase() {
                                   rpcUsers: List<User>,
                                   configOverrides: Map<String, Any>,
                                   noNetworkMap: Boolean = false): StartedNode<Node> {
-        val baseDirectory = baseDirectory(legalName.x500Name).createDirectories()
+        val baseDirectory = baseDirectory(legalName).createDirectories()
         val localPort = getFreeLocalPorts("localhost", 2)
         val p2pAddress = configOverrides["p2pAddress"] ?: localPort[0].toString()
         val config = ConfigHelper.loadConfig(


### PR DESCRIPTION
Change to using X500Principal in Cordform classes in preparation for eliminating X500Name from public APIs.