### PR TITLE
CORDA-499: Add testing classes to Dokka

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -9,7 +9,7 @@ dokka {
     moduleName = 'corda'
     outputDirectory = file("${rootProject.rootDir}/docs/build/html/api/kotlin")
     processConfigurations = ['compile']
-    sourceDirs = files('../core/src/main/kotlin', '../client/jfx/src/main/kotlin', '../client/mock/src/main/kotlin', '../client/rpc/src/main/kotlin', '../node-api/src/main/kotlin', '../finance/src/main/kotlin', '../client/jackson/src/main/kotlin')
+    sourceDirs = files('../core/src/main/kotlin', '../client/jfx/src/main/kotlin', '../client/mock/src/main/kotlin', '../client/rpc/src/main/kotlin', '../node-api/src/main/kotlin', '../finance/src/main/kotlin', '../client/jackson/src/main/kotlin', '../testing/node-driver/src/main/kotlin', '../testing/test-utils/src/main/kotlin')
     jdkVersion = 8
 
     externalDocumentationLink {
@@ -28,7 +28,7 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
     outputFormat = "javadoc"
     outputDirectory = file("${rootProject.rootDir}/docs/build/html/api/javadoc")
     processConfigurations = ['compile']
-    sourceDirs = files('../core/src/main/kotlin', '../client/jfx/src/main/kotlin', '../client/mock/src/main/kotlin', '../client/rpc/src/main/kotlin', '../node-api/src/main/kotlin', '../finance/src/main/kotlin', '../client/jackson/src/main/kotlin')
+    sourceDirs = files('../core/src/main/kotlin', '../client/jfx/src/main/kotlin', '../client/mock/src/main/kotlin', '../client/rpc/src/main/kotlin', '../node-api/src/main/kotlin', '../finance/src/main/kotlin', '../client/jackson/src/main/kotlin', '../testing/node-driver/src/main/kotlin', '../testing/test-utils/src/main/kotlin')
     includes = ['packages.md']
     jdkVersion = 8
 


### PR DESCRIPTION
This adds the `node-driver` and `test-utils` testing modules to Dokka.
