### PR TITLE
CORDA-539 - Integrate enum carpentry into serializer factory

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumSerializer.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumSerializer.kt
@@ -11,7 +11,7 @@ import java.lang.reflect.Type
  */
 class EnumSerializer(declaredType: Type, declaredClass: Class<*>, factory: SerializerFactory) : AMQPSerializer<Any> {
     override val type: Type = declaredType
-    override val typeDescriptor = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${fingerprintForType(type, factory)}")
+    override val typeDescriptor = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${fingerprintForType(type, factory)}")!!
     private val typeNotation: TypeNotation
 
     init {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/AMQPSchemaExtensions.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/AMQPSchemaExtensions.kt
@@ -1,11 +1,12 @@
 package net.corda.nodeapi.internal.serialization.carpenter
 
 import net.corda.nodeapi.internal.serialization.amqp.CompositeType
+import net.corda.nodeapi.internal.serialization.amqp.RestrictedType
 import net.corda.nodeapi.internal.serialization.amqp.Field as AMQPField
 import net.corda.nodeapi.internal.serialization.amqp.Schema as AMQPSchema
 
-fun AMQPSchema.carpenterSchema(classloader: ClassLoader) : CarpenterSchemas {
-    val rtn = CarpenterSchemas.newInstance()
+fun AMQPSchema.carpenterSchema(classloader: ClassLoader) : CarpenterMetaSchema {
+    val rtn = CarpenterMetaSchema.newInstance()
 
     types.filterIsInstance<CompositeType>().forEach {
         it.carpenterSchema(classloader, carpenterSchemas = rtn)
@@ -25,6 +26,7 @@ private fun CompositeType.validatePropertyTypes(classloader: ClassLoader) {
 
 fun AMQPField.typeAsString() = if (type == "*") requires[0] else type
 
+
 /**
  * based upon this AMQP schema either
  *  a) add the corresponding carpenter schema to the [carpenterSchemas] param
@@ -38,7 +40,7 @@ fun AMQPField.typeAsString() = if (type == "*") requires[0] else type
  *  on the class path. For testing purposes schema generation can be forced
  */
 fun CompositeType.carpenterSchema(classloader: ClassLoader,
-                                  carpenterSchemas: CarpenterSchemas,
+                                  carpenterSchemas: CarpenterMetaSchema,
                                   force: Boolean = false) {
     if (classloader.exists(name)) {
         validatePropertyTypes(classloader)
@@ -81,6 +83,18 @@ fun CompositeType.carpenterSchema(classloader: ClassLoader,
                 interfaces = providesList,
                 isInterface = isInterface))
     }
+}
+
+// this is potentially problematic as we're assuming the only type of restriction we will be
+// carpenting is an enum, but actually trying to split out RestrictedType into something
+// more polymorphic is hard. Additionally, to conform to AMQP we're really serialising
+// this as a list so...
+fun RestrictedType.carpenterSchema(carpenterSchemas: CarpenterMetaSchema) {
+    val m: MutableMap<String, Field> = mutableMapOf()
+
+    choices.forEach { m[it.name] = EnumField() }
+
+    carpenterSchemas.carpenterSchemas.add(EnumSchema(name = name, fields = m))
 }
 
 // map a pair of (typename, mandatory) to the corresponding class type

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/AMQPSchemaExtensions.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/AMQPSchemaExtensions.kt
@@ -26,7 +26,6 @@ private fun CompositeType.validatePropertyTypes(classloader: ClassLoader) {
 
 fun AMQPField.typeAsString() = if (type == "*") requires[0] else type
 
-
 /**
  * based upon this AMQP schema either
  *  a) add the corresponding carpenter schema to the [carpenterSchemas] param
@@ -85,8 +84,8 @@ fun CompositeType.carpenterSchema(classloader: ClassLoader,
     }
 }
 
-// this is potentially problematic as we're assuming the only type of restriction we will be
-// carpenting is an enum, but actually trying to split out RestrictedType into something
+// This is potentially problematic as we're assuming the only type of restriction we will be
+// carpenting for, an enum, but actually trying to split out RestrictedType into something
 // more polymorphic is hard. Additionally, to conform to AMQP we're really serialising
 // this as a list so...
 fun RestrictedType.carpenterSchema(carpenterSchemas: CarpenterMetaSchema) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/MetaCarpenter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/MetaCarpenter.kt
@@ -44,9 +44,9 @@ data class CarpenterMetaSchema(
     fun isEmpty() = carpenterSchemas.isEmpty()
     fun isNotEmpty() = carpenterSchemas.isNotEmpty()
 
-    // we could make this an abstract method on TypeNotation but hat
+    // We could make this an abstract method on TypeNotation but that
     // would mean the amqp package being "more" infected with carpenter
-    // specific bits
+    // specific bits.
     fun buildFor(target: TypeNotation, cl: ClassLoader) = when (target) {
         is RestrictedType -> target.carpenterSchema(this)
         is CompositeType -> target.carpenterSchema(cl, this, false)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/SchemaFields.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/SchemaFields.kt
@@ -134,5 +134,4 @@ class EnumField : Field(Enum::class.java) {
 object FieldFactory {
     fun newInstance(mandatory: Boolean, name: String, field: Class<out Any?>) =
             if (mandatory) NonNullableField(name, field) else NullableField(name, field)
-
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt
@@ -1,0 +1,109 @@
+package net.corda.nodeapi.internal.serialization.amqp
+
+import org.junit.Test
+import kotlin.test.*
+import net.corda.nodeapi.internal.serialization.carpenter.*
+
+class DeserializeNeedingCarpentryOfEnumsTest : AmqpCarpenterBase() {
+    companion object {
+        /**
+         * If you want to see the schema encoded into the envelope after serialisation change this to true
+         */
+        private const val VERBOSE = false
+    }
+
+    @Test
+    fun singleEnum() {
+        //
+        // Setup the test
+        //
+        val setupFactory = testDefaultFactory()
+
+        val enumConstants = listOf("AAA", "BBB", "CCC", "DDD", "EEE", "FFF",
+                "GGG", "HHH", "III", "JJJ").associateBy({ it }, { EnumField() })
+
+        // create the enum
+        val testEnumType = setupFactory.classCarpenter.build(EnumSchema("test.testEnumType", enumConstants))
+
+        // create the class that has that enum as an element
+        val testClassType = setupFactory.classCarpenter.build(ClassSchema("test.testClassType",
+                mapOf("a" to NonNullableField(testEnumType))))
+
+        // create an instance of the class we can then serialise
+        val testInstance = testClassType.constructors[0].newInstance(testEnumType.getMethod(
+                "valueOf", String::class.java).invoke(null, "BBB"))
+
+        // serialise the object
+        val serialisedBytes = TestSerializationOutput(VERBOSE, setupFactory).serialize(testInstance)
+
+        //
+        // Test setup done, now on with the actual test
+        //
+
+        // need a second factory to ensure a second carpenter is used and thus the class we're attempting
+        // to de-serialise isn't in the factories class loader
+        val testFactory = testDefaultFactoryWithWhitelist()
+
+        val deserializedObj = DeserializationInput(testFactory).deserialize(serialisedBytes)
+
+        assertTrue(deserializedObj::class.java.getMethod("getA").invoke(deserializedObj)::class.java.isEnum)
+        assertEquals("BBB",
+                (deserializedObj::class.java.getMethod("getA").invoke(deserializedObj) as Enum<*>).name)
+    }
+
+    @Test
+    fun compositeIncludingEnums() {
+        //
+        // Setup the test
+        //
+        val setupFactory = testDefaultFactory()
+
+        val enumConstants = listOf("AAA", "BBB", "CCC", "DDD", "EEE", "FFF",
+                "GGG", "HHH", "III", "JJJ").associateBy({ it }, { EnumField() })
+
+        // create the enum
+        val testEnumType1 = setupFactory.classCarpenter.build(EnumSchema("test.testEnumType1", enumConstants))
+        val testEnumType2 = setupFactory.classCarpenter.build(EnumSchema("test.testEnumType2", enumConstants))
+
+        // create the class that has that enum as an element
+        val testClassType = setupFactory.classCarpenter.build(ClassSchema("test.testClassType",
+                mapOf(
+                        "a" to NonNullableField(testEnumType1),
+                        "b" to NonNullableField(testEnumType2),
+                        "c" to NullableField(testEnumType1),
+                        "d" to NullableField(String::class.java))))
+
+        val vOf1 = testEnumType1.getMethod("valueOf", String::class.java)
+        val vOf2 = testEnumType2.getMethod("valueOf", String::class.java)
+        val testStr = "so many things [Ø Þ]"
+
+        // create an instance of the class we can then serialise
+        val testInstance = testClassType.constructors[0].newInstance(
+                vOf1.invoke(null, "CCC"),
+                vOf2.invoke(null, "EEE"),
+                null,
+                testStr)
+
+        // serialise the object
+        val serialisedBytes = TestSerializationOutput(VERBOSE, setupFactory).serialize(testInstance)
+
+        //
+        // Test setup done, now on with the actual test
+        //
+
+        // need a second factory to ensure a second carpenter is used and thus the class we're attempting
+        // to de-serialise isn't in the factories class loader
+        val testFactory = testDefaultFactoryWithWhitelist()
+
+        val deserializedObj = DeserializationInput(testFactory).deserialize(serialisedBytes)
+
+        assertTrue(deserializedObj::class.java.getMethod("getA").invoke(deserializedObj)::class.java.isEnum)
+        assertEquals("CCC",
+                (deserializedObj::class.java.getMethod("getA").invoke(deserializedObj) as Enum<*>).name)
+        assertTrue(deserializedObj::class.java.getMethod("getB").invoke(deserializedObj)::class.java.isEnum)
+        assertEquals("EEE",
+                (deserializedObj::class.java.getMethod("getB").invoke(deserializedObj) as Enum<*>).name)
+        assertNull(deserializedObj::class.java.getMethod("getC").invoke(deserializedObj))
+        assertEquals(testStr, deserializedObj::class.java.getMethod("getD").invoke(deserializedObj))
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt
@@ -16,8 +16,8 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase() {
         private const val VERBOSE = false
     }
 
-    val sf  = testDefaultFactory()
-    val sf2 = testDefaultFactory()
+    private val sf  = testDefaultFactory()
+    private val sf2 = testDefaultFactory()
 
     @Test
     fun singleInt() {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
@@ -35,7 +35,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assertEquals("b", amqpSchema.fields[1].name)
         assertEquals("int", amqpSchema.fields[1].type)
 
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,
@@ -79,7 +79,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assertEquals("b", amqpSchema.fields[1].name)
         assertEquals("string", amqpSchema.fields[1].type)
 
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt
@@ -29,7 +29,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assertEquals("a", amqpSchema.fields[0].name)
         assertEquals("int", amqpSchema.fields[0].type)
 
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,
@@ -60,7 +60,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assert(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,
@@ -95,7 +95,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assertEquals("a", amqpSchema.fields[0].name)
         assertEquals("long", amqpSchema.fields[0].type)
 
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,
@@ -130,7 +130,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assertEquals("a", amqpSchema.fields[0].name)
         assertEquals("short", amqpSchema.fields[0].type)
 
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,
@@ -165,7 +165,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assertEquals("a", amqpSchema.fields[0].name)
         assertEquals("double", amqpSchema.fields[0].type)
 
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,
@@ -200,7 +200,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase() {
         assertEquals("a", amqpSchema.fields[0].name)
         assertEquals("float", amqpSchema.fields[0].type)
 
-        val carpenterSchema = CarpenterSchemas.newInstance()
+        val carpenterSchema = CarpenterMetaSchema.newInstance()
         amqpSchema.carpenterSchema(
                 classloader = ClassLoader.getSystemClassLoader(),
                 carpenterSchemas = carpenterSchema,


### PR DESCRIPTION
Final piece to integrate enums and the serialiser, given we can currently carpent them and serialise them, add the capability to generate enum schemas in the serialiser when a type is missing