### PR TITLE
Filter for Open Source and Enterprise modules.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.16.3
+gradlePluginsVersion=0.16.4
 kotlinVersion=1.1.4
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
@@ -70,8 +70,8 @@ class Cordformation implements Plugin<Project> {
             // We want to filter out anything Corda related or provided by Corda, like kotlin-stdlib and quasar
             def filteredDeps = directDeps.findAll { excludes.collect { exclude -> (exclude.group == it.group) && (exclude.name == it.name) }.findAll { it }.isEmpty() }
             filteredDeps.each {
-                // net.corda may be a core dependency which shouldn't be included in this cordapp so give a warning
-                if(it.group && it.group.contains('net.corda.')) {
+                // net.corda or com.r3.corda.enterprise may be a core dependency which shouldn't be included in this cordapp so give a warning
+                if (it.group && (it.group.startsWith('net.corda.') || it.group.startsWith('com.r3.corda.enterprise.'))) {
                     logger.warn("You appear to have included a Corda platform component ($it) using a 'compile' or 'runtime' dependency." +
                                 "This can cause node stability problems. Please use 'corda' instead." +
                                 "See http://docs.corda.net/cordapp-build-systems.html")


### PR DESCRIPTION
Open Source modules are `net.corda`, whereas Enterprise modules are `com.r3.corda.enterprise`. We don't want CorDapps to contain either.