### PR TITLE
Made SwapIdentitiesFlow internal until we make it into an inlined flow

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/SwapIdentitiesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/SwapIdentitiesFlow.kt
@@ -1,9 +1,12 @@
-package net.corda.core.flows
+package net.corda.core.internal
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.AnonymousParty
-import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.identity.Party
+import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.IdentityService
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap

--- a/core/src/test/kotlin/net/corda/core/internal/SwapIdentitiesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/SwapIdentitiesFlowTests.kt
@@ -1,4 +1,4 @@
-package net.corda.core.flows
+package net.corda.core.internal
 
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.InsufficientBalanceException
 import net.corda.core.flows.StartableByRPC
-import net.corda.core.flows.SwapIdentitiesFlow
+import net.corda.core.internal.SwapIdentitiesFlow
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
@@ -8,6 +8,7 @@ import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
+import net.corda.core.internal.SwapIdentitiesFlow
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceType
 import net.corda.core.serialization.CordaSerializable

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.*
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.identity.Party
+import net.corda.core.internal.SwapIdentitiesFlow
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap


### PR DESCRIPTION
There's strong indication that SwapIdentitiesFlow is not ready in it's current state of v1.0. For example it's not inline, which something myself and Mike believe it should be. But doing so has knock on effects to calling flows and how they're designed. I suggest we move this into internal until we resolve these issues. Currently it's only used in `finance` and so shouldn't be a problem.