### PR TITLE
fix .rst, enumerations must have a blank line at the end

### DIFF
--- a/docs/source/running-the-demos.rst
+++ b/docs/source/running-the-demos.rst
@@ -34,6 +34,7 @@ To run from the command line in Unix:
 2. Run ``./samples/trader-demo/build/nodes/runnodes`` to open up four new terminals with the four nodes
 3. Run ``./gradlew samples:trader-demo:runBank`` to instruct the bank node to issue cash and commercial paper to the buyer and seller nodes respectively.
 4. Run ``./gradlew samples:trader-demo:runSeller`` to trigger the transaction. If you entered ``flow watch``
+      
 you can see flows running on both sides of transaction. Additionally you should see final trade information displayed
 to your terminal.
 
@@ -43,6 +44,7 @@ To run from the command line in Windows:
 2. Run ``samples\trader-demo\build\nodes\runnodes`` to open up four new terminals with the four nodes
 3. Run ``gradlew samples:trader-demo:runBank`` to instruct the buyer node to request issuance of some cash from the Bank of Corda node
 4. Run ``gradlew samples:trader-demo:runSeller`` to trigger the transaction. If you entered ``flow watch``
+      
 you can see flows running on both sides of transaction. Additionally you should see final trade information displayed
 to your terminal.
 


### PR DESCRIPTION
Fix the indent of the last bulletpoints in the lists under:
https://docs.corda.net/running-the-demos.html#trader-demo