### PR TITLE
FIX - Modify generateSpend() to send change to a fresh confidential identity

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
@@ -331,7 +331,7 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
             // Generate a new identity that change will be sent to for confidentiality purposes. This means that a
             // third party with a copy of the transaction (such as the notary) cannot identify who the change was
             // sent to
-            val changeIdentity = services.keyManagementService.freshKeyAndCert(services.myInfo.legalIdentityAndCert, revocationEnabled)
+            val changeIdentity = services.keyManagementService.freshKeyAndCert(services.myInfo.legalIdentitiesAndCerts.first(), revocationEnabled)
             return OnLedgerAsset.generateSpend(tx, payments, acceptableCoins,
                     changeIdentity.party.anonymise(),
                     { state, quantity, owner -> deriveState(state, quantity, owner) },

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
@@ -327,7 +327,11 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
             val totalAmount = payments.map { it.amount }.sumOrThrow()
             val cashSelection = CashSelection.getInstance({ services.jdbcSession().metaData })
             val acceptableCoins = cashSelection.unconsumedCashStatesForSpending(services, totalAmount, onlyFromParties, tx.notary, tx.lockId)
-            val changeIdentity = services.keyManagementService.freshKeyAndCert(services.myInfo.legalIdentityAndCert, revocationEnabled = false)
+            val revocationEnabled = false // Revocation is currently unsupported
+            // Generate a new identity that change will be sent to for confidentiality purposes. This means that a
+            // third party with a copy of the transaction (such as the notary) cannot identify who the change was
+            // sent to
+            val changeIdentity = services.keyManagementService.freshKeyAndCert(services.myInfo.legalIdentityAndCert, revocationEnabled)
             return OnLedgerAsset.generateSpend(tx, payments, acceptableCoins,
                     changeIdentity.party.anonymise(),
                     { state, quantity, owner -> deriveState(state, quantity, owner) },

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
@@ -327,7 +327,9 @@ class Cash : OnLedgerAsset<Currency, Cash.Commands, Cash.State>() {
             val totalAmount = payments.map { it.amount }.sumOrThrow()
             val cashSelection = CashSelection.getInstance({ services.jdbcSession().metaData })
             val acceptableCoins = cashSelection.unconsumedCashStatesForSpending(services, totalAmount, onlyFromParties, tx.notary, tx.lockId)
+            val changeIdentity = services.keyManagementService.freshKeyAndCert(services.myInfo.legalIdentityAndCert, revocationEnabled = false)
             return OnLedgerAsset.generateSpend(tx, payments, acceptableCoins,
+                    changeIdentity.party.anonymise(),
                     { state, quantity, owner -> deriveState(state, quantity, owner) },
                     { Cash().generateMoveCommand() })
         }

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt
@@ -79,7 +79,7 @@ abstract class OnLedgerAsset<T : Any, C : CommandData, S : FungibleAsset<T>> : C
          * @param to a key of the recipient.
          * @param acceptableStates a list of acceptable input states to use.
          * @param payChangeTo party to pay any change to; this is normally a confidential identity of the calling
-         * party.
+         * party. We use a new confidential identity here so that the recipient is not identifiable.
          * @param deriveState a function to derive an output state based on an input state, amount for the output
          * and public key to pay to.
          * @param T A type representing a token


### PR DESCRIPTION
[Modify generateSpend() to send change to a fresh confidential identity](https://github.com/corda/corda/pull/1522) was merged to master following successful Unit and Integration test completion, but nevertheless broke the master build with a compilation error (possible cause is a time delay between build and merge to master - in which other PRs were merged to master, but did not trigger an auto-build of this one.) 

This PR fixes the compilation error.