### PR TITLE
Add support for separate issue and pay

### DIFF
--- a/docs/source/running-the-demos.rst
+++ b/docs/source/running-the-demos.rst
@@ -179,16 +179,16 @@ To run from the command line in Unix:
 
 1. Run ``./gradlew samples:bank-of-corda-demo:deployNodes`` to create a set of configs and installs under ``samples/bank-of-corda-demo/build/nodes``
 2. Run ``./samples/bank-of-corda-demo/build/nodes/runnodes`` to open up three new terminal tabs/windows with the three nodes
-3. Run ``./gradlew samples:bank-of-corda-demo:runRPCCashIssue`` to trigger a cash issuance request
-4. Run ``./gradlew samples:bank-of-corda-demo:runWebCashIssue`` to trigger another cash issuance request.
+3. Run ``./gradlew samples:bank-of-corda-demo:runRPCCashIssueAndPay`` to trigger a cash issuance and payment request
+4. Run ``./gradlew samples:bank-of-corda-demo:runWebCashIssueAndPay`` to trigger another cash issuance and payment request.
    Now look at your terminal tab/window to see the output of the demo
 
 To run from the command line in Windows:
 
 1. Run ``gradlew samples:bank-of-corda-demo:deployNodes`` to create a set of configs and installs under ``samples\bank-of-corda-demo\build\nodes``
 2. Run ``samples\bank-of-corda-demo\build\nodes\runnodes`` to open up three new terminal tabs/windows with the three nodes
-3. Run ``gradlew samples:bank-of-corda-demo:runRPCCashIssue`` to trigger a cash issuance request
-4. Run ``gradlew samples:bank-of-corda-demo:runWebCashIssue`` to trigger another cash issuance request.
+3. Run ``gradlew samples:bank-of-corda-demo:runRPCCashIssueAndPay`` to trigger a cash issuance and payment request
+4. Run ``gradlew samples:bank-of-corda-demo:runWebCashIssueAndPay`` to trigger another cash issuance and payment request.
    Now look at the your terminal tab/window to see the output of the demo
 
 .. note:: To verify that the Bank of Corda node is alive and running, navigate to the following URL:
@@ -199,7 +199,7 @@ To run from the command line in Windows:
           This allows for 3rd party applications to perform actions based on Node Type.
           For example, the Explorer tool only allows nodes of this type to issue and exit cash.
 
-In the window you run the command you should see (in case of Web, RPC is simmilar):
+In the window you run the command you should see (in case of Web, RPC is similar):
 
 - Requesting Cash via Web ...
 - Successfully processed Cash Issue request
@@ -217,6 +217,9 @@ Using the following login details:
 - For the Big Corporation node: localhost / port 10009 / username bigCorpUser / password test
 
 See https://docs.corda.net/node-explorer.html for further details on usage.
+
+The Bank of Corda sample also supports issuance and payment as separate actions for testing
+purposes, using the Gradle tasks "runRPCCashIssue" and "runRPCCashPay" respectively.
 
 .. _simm-demo:
 

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -3,7 +3,6 @@ package net.corda.finance.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.Command
-import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.InsufficientBalanceException
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.flows.SwapIdentitiesFlow
@@ -58,6 +57,7 @@ open class CashPaymentFlow(
         } catch (e: InsufficientBalanceException) {
             throw CashException("Insufficient cash for spend: ${e.message}", e)
         }
+
         progressTracker.currentStep = SIGNING_TX
         val tx = serviceHub.signInitialTransaction(spendTX, keysForSigning)
 

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -2,6 +2,8 @@ package net.corda.finance.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.InsufficientBalanceException
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.flows.SwapIdentitiesFlow
@@ -56,9 +58,14 @@ open class CashPaymentFlow(
         } catch (e: InsufficientBalanceException) {
             throw CashException("Insufficient cash for spend: ${e.message}", e)
         }
-
         progressTracker.currentStep = SIGNING_TX
         val tx = serviceHub.signInitialTransaction(spendTX, keysForSigning)
+
+        // This just exists to validate the identity service is working, as part of testing
+        val previousTx = serviceHub.validatedTransactions.getTransaction(tx.inputs.first().txhash)!!
+        val signers = previousTx.tx.commands.flatMap(Command<*>::signers).toSet()
+        val signingParties = signers.map(serviceHub.identityService::partyFromKey).requireNoNulls()
+        require(signers == signingParties.map(Party::owningKey).toSet())
 
         progressTracker.currentStep = FINALISING_TX
         finaliseTx(setOf(recipient), tx, "Unable to notarise spend")

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -69,6 +69,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
                 ['username'   : "bankUser",
                  'password'   : "test",
                  'permissions': ["StartFlow.net.corda.finance.flows.CashPaymentFlow",
+                                 "StartFlow.net.corda.finance.flows.CashIssueFlow",
                                  "StartFlow.net.corda.finance.flows.CashExitFlow",
                                  "StartFlow.net.corda.finance.flows.CashIssueAndPaymentFlow"]]
         ]
@@ -125,16 +126,38 @@ task runRPCCashIssue(type: JavaExec) {
     args '--role'
     args 'ISSUE_CASH_RPC'
     args '--quantity'
+    args 25000
+    args '--currency'
+    args 'USD'
+}
+
+task runRPCCashIssueAndPay(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'net.corda.bank.BankOfCordaDriverKt'
+    args '--role'
+    args 'ISSUE_PAY_CASH_RPC'
+    args '--quantity'
     args 20000
     args '--currency'
     args 'USD'
 }
 
-task runWebCashIssue(type: JavaExec) {
+task runRPCCashPay(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'net.corda.bank.BankOfCordaDriverKt'
     args '--role'
-    args 'ISSUE_CASH_WEB'
+    args 'PAY_CASH_RPC'
+    args '--quantity'
+    args 997
+    args '--currency'
+    args 'USD'
+}
+
+task runWebCashIssueAndPay(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'net.corda.bank.BankOfCordaDriverKt'
+    args '--role'
+    args 'ISSUE_PAY_CASH_WEB'
     args '--quantity'
     args 30000
     args '--currency'

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
@@ -1,7 +1,7 @@
 package net.corda.bank
 
 import net.corda.bank.api.BankOfCordaClientApi
-import net.corda.bank.api.BankOfCordaWebApi.IssueRequestParams
+import net.corda.bank.api.IssueAndPaymentRequestParams
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.transactions.SimpleNotaryService
@@ -18,7 +18,7 @@ class BankOfCordaHttpAPITest {
             val nodeBankOfCordaFuture = startNode(providedName = BOC.name, advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type)))
             val (nodeBankOfCorda) = listOf(nodeBankOfCordaFuture, bigCorpNodeFuture).map { it.getOrThrow() }
             val nodeBankOfCordaApiAddr = startWebserver(nodeBankOfCorda).getOrThrow().listenAddress
-            assertTrue(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssue(IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name, BOC.name)))
+            assertTrue(BankOfCordaClientApi(nodeBankOfCordaApiAddr).requestWebIssueAndPayment(IssueAndPaymentRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name, BOC.name)))
         }, isDebug = true)
     }
 }

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
@@ -17,10 +17,6 @@ import javax.ws.rs.core.Response
 // API is accessible from /api/bank. All paths specified below are relative to it.
 @Path("bank")
 class BankOfCordaWebApi(val rpc: CordaRPCOps) {
-    data class IssueRequestParams(val amount: Long, val currency: String,
-                                  val issueToPartyName: CordaX500Name, val issuerBankPartyRef: String,
-                                  val issuerBankName: CordaX500Name,
-                                  val notaryName: CordaX500Name)
 
     private companion object {
         val logger = loggerFor<BankOfCordaWebApi>()
@@ -39,10 +35,10 @@ class BankOfCordaWebApi(val rpc: CordaRPCOps) {
     @POST
     @Path("issue-asset-request")
     @Consumes(MediaType.APPLICATION_JSON)
-    fun issueAssetRequest(params: IssueRequestParams): Response {
+    fun issueAssetRequest(params: IssueAndPaymentRequest): Response {
         // Resolve parties via RPC
-        val issueToParty = rpc.partyFromX500Name(params.issueToPartyName)
-                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issueToPartyName} in identity service").build()
+        val issueToParty = rpc.partyFromX500Name(params.payToPartyName)
+                ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.payToPartyName} in identity service").build()
         rpc.partyFromX500Name(params.issuerBankName) ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issuerBankName} in identity service").build()
         val notaryParty = rpc.partyFromX500Name(params.notaryName)
                 ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.notaryName} in identity service").build()

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/IssueAndPaymentRequest.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/IssueAndPaymentRequest.kt
@@ -1,0 +1,12 @@
+package net.corda.bank.api
+
+import net.corda.core.identity.CordaX500Name
+
+interface IssueAndPaymentRequest : IssueRequest, PaymentRequest
+
+data class IssueAndPaymentRequestParams(override val amount: Long,
+                                        override val currency: String,
+                                        override val payToPartyName: CordaX500Name,
+                                        override val issuerBankPartyRef: String,
+                                        override val issuerBankName: CordaX500Name,
+                                        override val notaryName: CordaX500Name) : IssueAndPaymentRequest

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/IssueRequest.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/IssueRequest.kt
@@ -1,0 +1,17 @@
+package net.corda.bank.api
+
+import net.corda.core.identity.CordaX500Name
+
+interface IssueRequest {
+    val amount: Long
+    val currency: String
+    val issuerBankPartyRef: String
+    val issuerBankName: CordaX500Name
+    val notaryName: CordaX500Name
+}
+
+data class IssueRequestParams(override val amount: Long,
+                              override val currency: String,
+                              override val issuerBankPartyRef: String,
+                              override val issuerBankName: CordaX500Name,
+                              override val notaryName: CordaX500Name) : IssueRequest

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/PaymentRequest.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/PaymentRequest.kt
@@ -1,0 +1,13 @@
+package net.corda.bank.api
+
+import net.corda.core.identity.CordaX500Name
+
+interface PaymentRequest {
+    val amount: Long
+    val currency: String
+    val payToPartyName: CordaX500Name
+}
+
+data class PaymentRequestParams(override val amount: Long,
+                                override val currency: String,
+                                override val payToPartyName: CordaX500Name) : PaymentRequest


### PR DESCRIPTION
Add support for separate issue and pay actions in Bank of Corda demo to help with identifying persistence issues, by enabling the issue transaction to be generated, a full node shutdown/startup run, then the payment transaction generated to confirm that everything is loaded correctly on startup.

Release 1.1 equivalent of #1538
