### PR TITLE
Remove notaryIdentityKey from ServiceHub

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -122,8 +122,8 @@ class NotaryFlow {
             val (id, inputs, timeWindow, notary) = receiveAndVerifyTx()
             checkNotary(notary)
             service.validateTimeWindow(timeWindow)
-            service.commitInputStates(inputs, id, otherSide, notary!!.owningKey)
-            signAndSendResponse(id, notary)
+            service.commitInputStates(inputs, id, otherSide)
+            signAndSendResponse(id)
             return null
         }
 
@@ -134,15 +134,16 @@ class NotaryFlow {
         @Suspendable
         abstract fun receiveAndVerifyTx(): TransactionParts
 
+        // Check if transaction is intended to be signed by this notary.
         @Suspendable
-        private fun checkNotary(notary: Party?) {
+        protected fun checkNotary(notary: Party?) {
             if (notary == null || notary !in serviceHub.myInfo.legalIdentities)
                 throw NotaryException(NotaryError.WrongNotary)
         }
 
         @Suspendable
-        private fun signAndSendResponse(txId: SecureHash, notary: Party) {
-            val signature = service.sign(txId, notary.owningKey)
+        private fun signAndSendResponse(txId: SecureHash) {
+            val signature = service.sign(txId)
             send(otherSide, listOf(signature))
         }
     }

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -137,7 +137,7 @@ class NotaryFlow {
         // Check if transaction is intended to be signed by this notary.
         @Suspendable
         protected fun checkNotary(notary: Party?) {
-            if (notary == null || notary !in serviceHub.myInfo.legalIdentities)
+            if (notary !in serviceHub.myInfo.legalIdentities)
                 throw NotaryException(NotaryError.WrongNotary)
         }
 

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -133,20 +133,6 @@ interface ServiceHub : ServicesForResolution {
 
     private val legalIdentityKey: PublicKey get() = this.myInfo.legalIdentitiesAndCerts.first().owningKey
 
-    /**
-     * Helper property to shorten code for fetching the the [PublicKey] portion of the
-     * Node's Notary signing identity. It is required that the Node hosts a notary service,
-     * otherwise an [IllegalArgumentException] will be thrown.
-     * Typical use is during signing in flows and for unit test signing.
-     * When this [PublicKey] is passed into the signing methods below, or on the KeyManagementService
-     * the matching [java.security.PrivateKey] will be looked up internally and used to sign.
-     * If the key is actually a [net.corda.core.crypto.CompositeKey], the first leaf key hosted on this node
-     * will be used to create the signature.
-     */
-    // TODO Remove that from ServiceHub, we could take that information from a transaction notary field and figure out what key to use from that.
-    //  But, it's separate PR.
-    val notaryIdentityKey: PublicKey
-
     // Helper method to construct an initial partially signed transaction from a [TransactionBuilder].
     private fun signInitialTransaction(builder: TransactionBuilder, publicKey: PublicKey, signatureMetadata: SignatureMetadata): SignedTransaction {
         return builder.toSignedTransaction(keyManagementService, publicKey, signatureMetadata)

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomNotaryTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomNotaryTutorial.kt
@@ -10,11 +10,12 @@ import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.core.transactions.SignedTransaction
 import net.corda.node.services.transactions.PersistentUniquenessProvider
+import java.security.PublicKey
 import java.security.SignatureException
 
 // START 1
 @CordaService
-class MyCustomValidatingNotaryService(override val services: ServiceHub) : TrustedAuthorityNotaryService() {
+class MyCustomValidatingNotaryService(override val services: ServiceHub, override val notaryIdentityKey: PublicKey) : TrustedAuthorityNotaryService() {
     override val timeWindowChecker = TimeWindowChecker(services.clock)
     override val uniquenessProvider = PersistentUniquenessProvider()
 
@@ -50,7 +51,7 @@ class MyValidatingNotaryFlow(otherSide: Party, service: MyCustomValidatingNotary
 
     private fun checkSignatures(stx: SignedTransaction) {
         try {
-            stx.verifySignaturesExcept(stx.notary!!.owningKey)
+            stx.verifySignaturesExcept(service.notaryIdentityKey)
         } catch (e: SignatureException) {
             throw NotaryException(NotaryError.TransactionInvalid(e))
         }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -569,12 +569,13 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     }
 
     open protected fun makeCoreNotaryService(type: ServiceType): NotaryService? {
+        check(myNotaryIdentity != null) { "No notary identity initialized when creating a notary service" }
         return when (type) {
-            SimpleNotaryService.type -> SimpleNotaryService(services)
-            ValidatingNotaryService.type -> ValidatingNotaryService(services)
-            RaftNonValidatingNotaryService.type -> RaftNonValidatingNotaryService(services)
-            RaftValidatingNotaryService.type -> RaftValidatingNotaryService(services)
-            BFTNonValidatingNotaryService.type -> BFTNonValidatingNotaryService(services)
+            SimpleNotaryService.type -> SimpleNotaryService(services, myNotaryIdentity!!.owningKey)
+            ValidatingNotaryService.type -> ValidatingNotaryService(services, myNotaryIdentity!!.owningKey)
+            RaftNonValidatingNotaryService.type -> RaftNonValidatingNotaryService(services, myNotaryIdentity!!.owningKey)
+            RaftValidatingNotaryService.type -> RaftValidatingNotaryService(services, myNotaryIdentity!!.owningKey)
+            BFTNonValidatingNotaryService.type -> BFTNonValidatingNotaryService(services, myNotaryIdentity!!.owningKey)
             else -> null
         }
     }
@@ -735,7 +736,6 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         override val myInfo: NodeInfo get() = info
         override val database: CordaPersistence get() = this@AbstractNode.database
         override val configuration: NodeConfiguration get() = this@AbstractNode.configuration
-        override val notaryIdentityKey: PublicKey get() = myNotaryIdentity?.owningKey ?: throw IllegalArgumentException("Node doesn't have notary identity key")
 
         override fun <T : SerializeAsToken> cordaService(type: Class<T>): T {
             require(type.isAnnotationPresent(CordaService::class.java)) { "${type.name} is not a Corda service" }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
@@ -144,9 +144,9 @@ class BFTNonValidatingNotaryService(override val services: ServiceHubInternal,
             return try {
                 val id = ftx.id
                 val inputs = ftx.inputs
-                val notary = ftx.filteredLeaves.notary
+                val notary = ftx.notary
                 validateTimeWindow(ftx.timeWindow)
-                if (notary == null || notary !in services.myInfo.legalIdentities) throw NotaryException(NotaryError.WrongNotary)
+                if (notary !in services.myInfo.legalIdentities) throw NotaryException(NotaryError.WrongNotary)
                 commitInputStates(inputs, id, callerIdentity)
                 log.debug { "Inputs committed successfully, signing $id" }
                 BFTSMaRt.ReplicaResponse.Signature(sign(ftx))

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
@@ -21,6 +21,7 @@ import net.corda.core.utilities.*
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.node.utilities.NODE_DATABASE_PREFIX
+import java.security.PublicKey
 import javax.persistence.Entity
 import kotlin.concurrent.thread
 
@@ -29,7 +30,9 @@ import kotlin.concurrent.thread
  *
  * A transaction is notarised when the consensus is reached by the cluster on its uniqueness, and time-window validity.
  */
-class BFTNonValidatingNotaryService(override val services: ServiceHubInternal, cluster: BFTSMaRt.Cluster = distributedCluster) : NotaryService() {
+class BFTNonValidatingNotaryService(override val services: ServiceHubInternal,
+                                    override val notaryIdentityKey: PublicKey,
+                                    cluster: BFTSMaRt.Cluster = distributedCluster) : NotaryService() {
     companion object {
         val type = SimpleNotaryService.type.getSubType("bft")
         private val log = loggerFor<BFTNonValidatingNotaryService>()
@@ -52,7 +55,7 @@ class BFTNonValidatingNotaryService(override val services: ServiceHubInternal, c
             thread(name = "BFT SMaRt replica $replicaId init", isDaemon = true) {
                 configHandle.use {
                     val timeWindowChecker = TimeWindowChecker(services.clock)
-                    val replica = Replica(it, replicaId, { createMap() }, services, timeWindowChecker)
+                    val replica = Replica(it, replicaId, { createMap() }, services, notaryIdentityKey, timeWindowChecker)
                     replicaHolder.set(replica)
                     log.info("BFT SMaRt replica $replicaId is running.")
                 }
@@ -101,8 +104,8 @@ class BFTNonValidatingNotaryService(override val services: ServiceHubInternal, c
                     toPersistentEntityKey = { PersistentStateRef(it.txhash.toString(), it.index) },
                     fromPersistentEntity = {
                         //TODO null check will become obsolete after making DB/JPA columns not nullable
-                        var txId = it.id.txId ?: throw IllegalStateException("DB returned null SecureHash transactionId")
-                        var index = it.id.index ?: throw IllegalStateException("DB returned null SecureHash index")
+                        val txId = it.id.txId ?: throw IllegalStateException("DB returned null SecureHash transactionId")
+                        val index = it.id.index ?: throw IllegalStateException("DB returned null SecureHash index")
                         Pair(StateRef(txhash = SecureHash.parse(txId), index = index),
                             UniquenessProvider.ConsumingTx(
                                     id = SecureHash.parse(it.consumingTxHash),
@@ -127,7 +130,8 @@ class BFTNonValidatingNotaryService(override val services: ServiceHubInternal, c
                           replicaId: Int,
                           createMap: () -> AppendOnlyPersistentMap<StateRef, UniquenessProvider.ConsumingTx, PersistedCommittedState, PersistentStateRef>,
                           services: ServiceHubInternal,
-                          timeWindowChecker: TimeWindowChecker) : BFTSMaRt.Replica(config, replicaId, createMap, services, timeWindowChecker) {
+                          notaryIdentityKey: PublicKey,
+                          timeWindowChecker: TimeWindowChecker) : BFTSMaRt.Replica(config, replicaId, createMap, services, notaryIdentityKey, timeWindowChecker) {
 
         override fun executeCommand(command: ByteArray): ByteArray {
             val request = command.deserialize<BFTSMaRt.CommitRequest>()
@@ -141,10 +145,9 @@ class BFTNonValidatingNotaryService(override val services: ServiceHubInternal, c
                 val id = ftx.id
                 val inputs = ftx.inputs
                 val notary = ftx.filteredLeaves.notary
-
                 validateTimeWindow(ftx.timeWindow)
                 if (notary == null || notary !in services.myInfo.legalIdentities) throw NotaryException(NotaryError.WrongNotary)
-                commitInputStates(inputs, id, callerIdentity, notary.owningKey)
+                commitInputStates(inputs, id, callerIdentity)
                 log.debug { "Inputs committed successfully, signing $id" }
                 BFTSMaRt.ReplicaResponse.Signature(sign(ftx))
             } catch (e: NotaryException) {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTSMaRt.kt
@@ -254,7 +254,7 @@ object BFTSMaRt {
         }
 
         protected fun sign(filteredTransaction: FilteredTransaction): TransactionSignature {
-            return services.database.transaction { services.createSignature(filteredTransaction, filteredTransaction.filteredLeaves.notary!!.owningKey) }
+            return services.database.transaction { services.createSignature(filteredTransaction, notaryIdentityKey) }
         }
 
         // TODO:

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -27,8 +27,8 @@ class NonValidatingNotaryFlow(otherSide: Party, service: TrustedAuthorityNotaryS
                     it.verify()
                     it.checkAllComponentsVisible(ComponentGroupEnum.INPUTS_GROUP)
                     it.checkAllComponentsVisible(ComponentGroupEnum.TIMEWINDOW_GROUP)
-                    val notary = it.filteredLeaves.notary
-                    TransactionParts(it.id, it.filteredLeaves.inputs, it.filteredLeaves.timeWindow, notary)
+                    val notary = it.notary
+                    TransactionParts(it.id, it.inputs, it.timeWindow, notary)
                 }
                 is NotaryChangeWireTransaction -> TransactionParts(it.id, it.inputs, null, it.notary)
                 else -> {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -27,9 +27,10 @@ class NonValidatingNotaryFlow(otherSide: Party, service: TrustedAuthorityNotaryS
                     it.verify()
                     it.checkAllComponentsVisible(ComponentGroupEnum.INPUTS_GROUP)
                     it.checkAllComponentsVisible(ComponentGroupEnum.TIMEWINDOW_GROUP)
-                    TransactionParts(it.id, it.inputs, it.timeWindow)
+                    val notary = it.filteredLeaves.notary
+                    TransactionParts(it.id, it.filteredLeaves.inputs, it.filteredLeaves.timeWindow, notary)
                 }
-                is NotaryChangeWireTransaction -> TransactionParts(it.id, it.inputs, null)
+                is NotaryChangeWireTransaction -> TransactionParts(it.id, it.inputs, null, it.notary)
                 else -> {
                     throw IllegalArgumentException("Received unexpected transaction type: ${it::class.java.simpleName}," +
                             "expected either ${FilteredTransaction::class.java.simpleName} or ${NotaryChangeWireTransaction::class.java.simpleName}")

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftNonValidatingNotaryService.kt
@@ -5,9 +5,10 @@ import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.node.services.api.ServiceHubInternal
+import java.security.PublicKey
 
 /** A non-validating notary service operated by a group of mutually trusting parties, uses the Raft algorithm to achieve consensus. */
-class RaftNonValidatingNotaryService(override val services: ServiceHubInternal) : TrustedAuthorityNotaryService() {
+class RaftNonValidatingNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : TrustedAuthorityNotaryService() {
     companion object {
         val type = SimpleNotaryService.type.getSubType("raft")
     }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftValidatingNotaryService.kt
@@ -5,9 +5,10 @@ import net.corda.core.identity.Party
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.node.services.api.ServiceHubInternal
+import java.security.PublicKey
 
 /** A validating notary service operated by a group of mutually trusting parties, uses the Raft algorithm to achieve consensus. */
-class RaftValidatingNotaryService(override val services: ServiceHubInternal) : TrustedAuthorityNotaryService() {
+class RaftValidatingNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : TrustedAuthorityNotaryService() {
     companion object {
         val type = ValidatingNotaryService.type.getSubType("raft")
     }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/SimpleNotaryService.kt
@@ -6,9 +6,10 @@ import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.nodeapi.ServiceType
 import net.corda.node.services.api.ServiceHubInternal
+import java.security.PublicKey
 
 /** A simple Notary service that does not perform transaction validation */
-class SimpleNotaryService(override val services: ServiceHubInternal) : TrustedAuthorityNotaryService() {
+class SimpleNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : TrustedAuthorityNotaryService() {
     companion object {
         val type = ServiceType.notary.getSubType("simple")
     }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
@@ -40,7 +40,7 @@ class ValidatingNotaryFlow(otherSide: Party, service: TrustedAuthorityNotaryServ
 
     private fun checkSignatures(stx: SignedTransaction) {
         try {
-            stx.verifySignaturesExcept(stx.notary!!.owningKey)
+            stx.verifySignaturesExcept(service.notaryIdentityKey)
         } catch(e: SignatureException) {
             throw NotaryException(NotaryError.TransactionInvalid(e))
         }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
@@ -24,9 +24,11 @@ class ValidatingNotaryFlow(otherSide: Party, service: TrustedAuthorityNotaryServ
     override fun receiveAndVerifyTx(): TransactionParts {
         try {
             val stx = subFlow(ReceiveTransactionFlow(otherSide, checkSufficientSignatures = false))
+            val notary = stx.notary
+            checkNotary(notary)
             checkSignatures(stx)
             val wtx = stx.tx
-            return TransactionParts(wtx.id, wtx.inputs, wtx.timeWindow)
+            return TransactionParts(wtx.id, wtx.inputs, wtx.timeWindow, notary!!)
         } catch (e: Exception) {
             throw when (e) {
                 is TransactionVerificationException,
@@ -38,7 +40,7 @@ class ValidatingNotaryFlow(otherSide: Party, service: TrustedAuthorityNotaryServ
 
     private fun checkSignatures(stx: SignedTransaction) {
         try {
-            stx.verifySignaturesExcept(serviceHub.notaryIdentityKey)
+            stx.verifySignaturesExcept(stx.notary!!.owningKey)
         } catch(e: SignatureException) {
             throw NotaryException(NotaryError.TransactionInvalid(e))
         }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryService.kt
@@ -6,9 +6,10 @@ import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.TrustedAuthorityNotaryService
 import net.corda.nodeapi.ServiceType
 import net.corda.node.services.api.ServiceHubInternal
+import java.security.PublicKey
 
 /** A Notary service that validates the transaction chain of the submitted transaction before committing it */
-class ValidatingNotaryService(override val services: ServiceHubInternal) : TrustedAuthorityNotaryService() {
+class ValidatingNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : TrustedAuthorityNotaryService() {
     companion object {
         val type = ServiceType.notary.getSubType("validating")
     }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -646,7 +646,7 @@ class TwoPartyTradeFlowTests {
             val sigs = mutableListOf<TransactionSignature>()
             val nodeKey = node.info.chooseIdentity().owningKey
             sigs.add(node.services.keyManagementService.sign(SignableData(id, SignatureMetadata(1, Crypto.findSignatureScheme(nodeKey).schemeNumberID)), nodeKey))
-            sigs.add(notaryNode.services.keyManagementService.sign(SignableData(id, SignatureMetadata(1, Crypto.findSignatureScheme(notaryNode.services.notaryIdentityKey).schemeNumberID)), notaryNode.services.notaryIdentityKey))
+            sigs.add(notaryNode.services.keyManagementService.sign(SignableData(id, SignatureMetadata(1, Crypto.findSignatureScheme(notaryNode.info.notaryIdentity.owningKey).schemeNumberID)), notaryNode.info.notaryIdentity.owningKey))
             extraSigningNodes.forEach { currentNode ->
                 sigs.add(currentNode.services.keyManagementService.sign(
                         SignableData(id, SignatureMetadata(1, Crypto.findSignatureScheme(currentNode.info.chooseIdentity().owningKey).schemeNumberID)),

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -646,7 +646,8 @@ class TwoPartyTradeFlowTests {
             val sigs = mutableListOf<TransactionSignature>()
             val nodeKey = node.info.chooseIdentity().owningKey
             sigs.add(node.services.keyManagementService.sign(SignableData(id, SignatureMetadata(1, Crypto.findSignatureScheme(nodeKey).schemeNumberID)), nodeKey))
-            sigs.add(notaryNode.services.keyManagementService.sign(SignableData(id, SignatureMetadata(1, Crypto.findSignatureScheme(notaryNode.info.notaryIdentity.owningKey).schemeNumberID)), notaryNode.info.notaryIdentity.owningKey))
+            sigs.add(notaryNode.services.keyManagementService.sign(SignableData(id, SignatureMetadata(1,
+                    Crypto.findSignatureScheme(notaryNode.info.legalIdentities[1].owningKey).schemeNumberID)), notaryNode.info.legalIdentities[1].owningKey))
             extraSigningNodes.forEach { currentNode ->
                 sigs.add(currentNode.services.keyManagementService.sign(
                         SignableData(id, SignatureMetadata(1, Crypto.findSignatureScheme(currentNode.info.chooseIdentity().owningKey).schemeNumberID)),

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -161,7 +161,7 @@ class NotaryServiceTests {
     fun issueState(node: StartedNode<*>): StateAndRef<*> {
         val tx = DummyContract.generateInitial(Random().nextInt(), notary, node.info.chooseIdentity().ref(0))
         val signedByNode = node.services.signInitialTransaction(tx)
-        val stx = notaryNode.services.addSignature(signedByNode, notaryNode.info.notaryIdentity.owningKey)
+        val stx = notaryNode.services.addSignature(signedByNode, notary.owningKey)
         node.services.recordTransactions(stx)
         return StateAndRef(tx.outputStates().first(), StateRef(stx.id, 0))
     }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -161,7 +161,7 @@ class NotaryServiceTests {
     fun issueState(node: StartedNode<*>): StateAndRef<*> {
         val tx = DummyContract.generateInitial(Random().nextInt(), notary, node.info.chooseIdentity().ref(0))
         val signedByNode = node.services.signInitialTransaction(tx)
-        val stx = notaryNode.services.addSignature(signedByNode, notaryNode.services.notaryIdentityKey)
+        val stx = notaryNode.services.addSignature(signedByNode, notaryNode.info.notaryIdentity.owningKey)
         node.services.recordTransactions(stx)
         return StateAndRef(tx.outputStates().first(), StateRef(stx.id, 0))
     }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -104,7 +104,7 @@ class ValidatingNotaryServiceTests {
     fun issueState(node: StartedNode<*>): StateAndRef<*> {
         val tx = DummyContract.generateInitial(Random().nextInt(), notary, node.info.chooseIdentity().ref(0))
         val signedByNode = node.services.signInitialTransaction(tx)
-        val stx = notaryNode.services.addSignature(signedByNode, notaryNode.services.notaryIdentityKey)
+        val stx = notaryNode.services.addSignature(signedByNode, notaryNode.info.notaryIdentity.owningKey)
         node.services.recordTransactions(stx)
         return StateAndRef(tx.outputStates().first(), StateRef(stx.id, 0))
     }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -104,7 +104,7 @@ class ValidatingNotaryServiceTests {
     fun issueState(node: StartedNode<*>): StateAndRef<*> {
         val tx = DummyContract.generateInitial(Random().nextInt(), notary, node.info.chooseIdentity().ref(0))
         val signedByNode = node.services.signInitialTransaction(tx)
-        val stx = notaryNode.services.addSignature(signedByNode, notaryNode.info.notaryIdentity.owningKey)
+        val stx = notaryNode.services.addSignature(signedByNode, notary.owningKey)
         node.services.recordTransactions(stx)
         return StateAndRef(tx.outputStates().first(), StateRef(stx.id, 0))
     }

--- a/testing/node-driver/src/main/kotlin/net/corda/node/testing/MockServiceHubInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/node/testing/MockServiceHubInternal.kt
@@ -68,8 +68,6 @@ open class MockServiceHubInternal(
         get() = overrideClock ?: throw UnsupportedOperationException()
     override val myInfo: NodeInfo
         get() = NodeInfo(listOf(MOCK_HOST_AND_PORT), listOf(DUMMY_IDENTITY_1), 1, serial = 1L) // Required to get a dummy platformVersion when required for tests.
-    override val notaryIdentityKey: PublicKey
-        get() = throw IllegalStateException("No notary identity in MockServiceHubInternal")
     override val monitoringService: MonitoringService = MonitoringService(MetricRegistry())
     override val rpcFlows: List<Class<out FlowLogic<*>>>
         get() = throw UnsupportedOperationException()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -257,11 +257,9 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
 
         override fun makeCoreNotaryService(type: ServiceType): NotaryService? {
             if (type != BFTNonValidatingNotaryService.type) return super.makeCoreNotaryService(type)
-            return BFTNonValidatingNotaryService(services, object : BFTSMaRt.Cluster {
-                override fun waitUntilAllReplicasHaveInitialized() {
-                    val clusterNodes = mockNet.nodes.filter { node ->
-                        services.myInfo.legalIdentities.any { it.owningKey in node.started!!.info.serviceIdentities(BFTNonValidatingNotaryService.type).map { it.owningKey } }
-                    }
+            return BFTNonValidatingNotaryService(services, myNotaryIdentity!!.owningKey, object : BFTSMaRt.Cluster {
+                override fun waitUntilAllReplicasHaveInitialized() { // TODO check
+                    val clusterNodes = mockNet.nodes.filter { myNotaryIdentity!!.owningKey in it.started!!.info.legalIdentities.map { it.owningKey } }
                     if (clusterNodes.size != configuration.notaryClusterAddresses.size) {
                         throw IllegalStateException("Unable to enumerate all nodes in BFT cluster.")
                     }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -259,8 +259,8 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
             if (type != BFTNonValidatingNotaryService.type) return super.makeCoreNotaryService(type)
             return BFTNonValidatingNotaryService(services, object : BFTSMaRt.Cluster {
                 override fun waitUntilAllReplicasHaveInitialized() {
-                    val clusterNodes = mockNet.nodes.filter {
-                        services.notaryIdentityKey in it.info.legalIdentitiesAndCerts.map { it.owningKey }
+                    val clusterNodes = mockNet.nodes.filter { node ->
+                        services.myInfo.legalIdentities.any { it.owningKey in node.started!!.info.serviceIdentities(BFTNonValidatingNotaryService.type).map { it.owningKey } }
                     }
                     if (clusterNodes.size != configuration.notaryClusterAddresses.size) {
                         throw IllegalStateException("Unable to enumerate all nodes in BFT cluster.")

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -258,7 +258,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
         override fun makeCoreNotaryService(type: ServiceType): NotaryService? {
             if (type != BFTNonValidatingNotaryService.type) return super.makeCoreNotaryService(type)
             return BFTNonValidatingNotaryService(services, myNotaryIdentity!!.owningKey, object : BFTSMaRt.Cluster {
-                override fun waitUntilAllReplicasHaveInitialized() { // TODO check
+                override fun waitUntilAllReplicasHaveInitialized() {
                     val clusterNodes = mockNet.nodes.filter { myNotaryIdentity!!.owningKey in it.started!!.info.legalIdentities.map { it.owningKey } }
                     if (clusterNodes.size != configuration.notaryClusterAddresses.size) {
                         throw IllegalStateException("Unable to enumerate all nodes in BFT cluster.")

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -156,7 +156,6 @@ open class MockServices(vararg val keys: KeyPair) : ServiceHub {
         val identity = getTestPartyAndCertificate(MEGA_CORP.name, key.public)
         return NodeInfo(emptyList(), listOf(identity), 1,  serial = 1L)
     }
-    override val notaryIdentityKey: PublicKey get()  = throw UnsupportedOperationException()
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
 
     lateinit var hibernatePersister: HibernateObserver


### PR DESCRIPTION
It was redundant, as we have notary field on a transaction. Notaries can
use this field to check if the transaction was meant for them and then
use that information while choosing a key to sign a transaction.
