### PR TITLE
[CORDA-442] Make cordformation serialize NodeInfos to disk during deployment.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=1.0.1
+gradlePluginsVersion=1.0.0
 kotlinVersion=1.1.50
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=1.0.0
+gradlePluginsVersion=1.1.0
 kotlinVersion=1.1.50
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -55,7 +55,7 @@ Release 1.0
 
 * ``Cordformation`` and node identity generation
   * Cordform may not specify a ``NetworkMapNode``, when that happens during ``DeployNodes`` the following happens:
-    1. Each node is started and its signed serialized NodeInfo is written to disk in the node folder.
+    1. Each node is started and its signed serialized NodeInfo is written to disk in the node base directory.
     2. Every serialized ``NodeInfo`` above is copied in every other node "additional-node-info" folder under the NodeInfo folder.
   * Nodes read all the nodes stored in ``additional-node-info`` when the ``NetworkMapService`` starts up.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -249,11 +249,17 @@ Milestone 14
 
 * Changes in ``NodeInfo``:
 
-   * ``PhysicalLocation`` was renamed to ``WorldMapLocation`` to emphasise that it doesn't need to map to a truly physical
+  * ``PhysicalLocation`` was renamed to ``WorldMapLocation`` to emphasise that it doesn't need to map to a truly physical
      location of the node server.
-   * Slots for multiple IP addresses and ``legalIdentitiesAndCert``s were introduced. Addresses are no longer of type
-     ``SingleMessageRecipient``, but of ``NetworkHostAndPort``.
+  * Slots for multiple IP addresses and ``legalIdentitiesAndCert``s were introduced. Addresses are no longer of type
+   ``SingleMessageRecipient``, but of ``NetworkHostAndPort`` .
 
+* Cordformation and node identity generation
+  * Cordform may not specify a NetworkMapNode, when that happens during DeployNodes the following happens:
+    1. each node is started and its signed serialized NodeInfo is written to disk in the node folder
+    2. every serialized NodeInfo above is copied in every other node "additional-node-info" folder under the NodeInfo folder
+  * Node read all the nodes stored in "additional-node-info" when the NetworkMapService starts up.
+      
 * ``ServiceHub.storageService`` has been removed. ``attachments`` and ``validatedTransactions`` are now direct members of
   ``ServiceHub``.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -53,8 +53,8 @@ Release 1.0
    was introduced. Other special nodes parties like Oracles or Regulators need to be specified directly in CorDapp or flow.
   * Moved ``ServiceType`` and ``ServiceInfo`` to ``net.corda.nodeapi`` package as services are only required on node startup.
 
-* ``Cordformation`` and node identity generation
-  * Cordform may not specify a ``NetworkMapNode``, when that happens during ``DeployNodes`` the following happens:
+* ``Cordform`` and node identity generation
+  * Cordform may not specify a value for ``NetworkMap``, when that happens, during the task execution the following happens:
     1. Each node is started and its signed serialized NodeInfo is written to disk in the node base directory.
     2. Every serialized ``NodeInfo`` above is copied in every other node "additional-node-info" folder under the NodeInfo folder.
   * Nodes read all the nodes stored in ``additional-node-info`` when the ``NetworkMapService`` starts up.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -51,7 +51,13 @@ Release 1.0
    * In preparation for ``NetworkMapService`` redesign and distributing notaries through ``NetworkParameters`` we added
    ``NetworkMapCache::notaryIdentities`` list to enable to lookup for notary parties known to the network. Related ``CordaRPCOps::notaryIdentities``
    was introduced. Other special nodes parties like Oracles or Regulators need to be specified directly in CorDapp or flow.
-   * Moved ``ServiceType`` and ``ServiceInfo`` to ``net.corda.nodeapi`` package as services are only required on node startup.
+  * Moved ``ServiceType`` and ``ServiceInfo`` to ``net.corda.nodeapi`` package as services are only required on node startup.
+
+* ``Cordformation`` and node identity generation
+  * Cordform may not specify a ``NetworkMapNode``, when that happens during ``DeployNodes`` the following happens:
+    1. Each node is started and its signed serialized NodeInfo is written to disk in the node folder.
+    2. Every serialized ``NodeInfo`` above is copied in every other node "additional-node-info" folder under the NodeInfo folder.
+  * Nodes read all the nodes stored in ``additional-node-info`` when the ``NetworkMapService`` starts up.
 
 * Adding enum support to the class carpenter
 
@@ -253,12 +259,6 @@ Milestone 14
      location of the node server.
   * Slots for multiple IP addresses and ``legalIdentitiesAndCert``s were introduced. Addresses are no longer of type
    ``SingleMessageRecipient``, but of ``NetworkHostAndPort`` .
-
-* Cordformation and node identity generation
-  * Cordform may not specify a NetworkMapNode, when that happens during DeployNodes the following happens:
-    1. each node is started and its signed serialized NodeInfo is written to disk in the node folder
-    2. every serialized NodeInfo above is copied in every other node "additional-node-info" folder under the NodeInfo folder
-  * Node read all the nodes stored in "additional-node-info" when the NetworkMapService starts up.
       
 * ``ServiceHub.storageService`` has been removed. ``attachments`` and ``validatedTransactions`` are now direct members of
   ``ServiceHub``.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -57,7 +57,7 @@ Release 1.0
    * In preparation for ``NetworkMapService`` redesign and distributing notaries through ``NetworkParameters`` we added
    ``NetworkMapCache::notaryIdentities`` list to enable to lookup for notary parties known to the network. Related ``CordaRPCOps::notaryIdentities``
    was introduced. Other special nodes parties like Oracles or Regulators need to be specified directly in CorDapp or flow.
-  * Moved ``ServiceType`` and ``ServiceInfo`` to ``net.corda.nodeapi`` package as services are only required on node startup.
+   * Moved ``ServiceType`` and ``ServiceInfo`` to ``net.corda.nodeapi`` package as services are only required on node startup.
 
 * Adding enum support to the class carpenter
 
@@ -255,11 +255,11 @@ Milestone 14
 
 * Changes in ``NodeInfo``:
 
-  * ``PhysicalLocation`` was renamed to ``WorldMapLocation`` to emphasise that it doesn't need to map to a truly physical
+   * ``PhysicalLocation`` was renamed to ``WorldMapLocation`` to emphasise that it doesn't need to map to a truly physical
      location of the node server.
-  * Slots for multiple IP addresses and ``legalIdentitiesAndCert``s were introduced. Addresses are no longer of type
-   ``SingleMessageRecipient``, but of ``NetworkHostAndPort`` .
-      
+   * Slots for multiple IP addresses and ``legalIdentitiesAndCert``s were introduced. Addresses are no longer of type
+     ``SingleMessageRecipient``, but of ``NetworkHostAndPort``.
+
 * ``ServiceHub.storageService`` has been removed. ``attachments`` and ``validatedTransactions`` are now direct members of
   ``ServiceHub``.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,12 @@ from the previous milestone release.
 UNRELEASED
 ----------
 
+* ``Cordform`` and node identity generation
+  * Cordform may not specify a value for ``NetworkMap``, when that happens, during the task execution the following happens:
+    1. Each node is started and its signed serialized NodeInfo is written to disk in the node base directory.
+    2. Every serialized ``NodeInfo`` above is copied in every other node "additional-node-info" folder under the NodeInfo folder.
+  * Nodes read all the nodes stored in ``additional-node-info`` when the ``NetworkMapService`` starts up.
+
 * ``Cordapp`` now has a name field for identifying CorDapps and all CorDapp names are printed to console at startup.
 
 * Enums now respsect the whitelist applied to the Serializer factory serializing / deserializing them. If the enum isn't
@@ -52,12 +58,6 @@ Release 1.0
    ``NetworkMapCache::notaryIdentities`` list to enable to lookup for notary parties known to the network. Related ``CordaRPCOps::notaryIdentities``
    was introduced. Other special nodes parties like Oracles or Regulators need to be specified directly in CorDapp or flow.
   * Moved ``ServiceType`` and ``ServiceInfo`` to ``net.corda.nodeapi`` package as services are only required on node startup.
-
-* ``Cordform`` and node identity generation
-  * Cordform may not specify a value for ``NetworkMap``, when that happens, during the task execution the following happens:
-    1. Each node is started and its signed serialized NodeInfo is written to disk in the node base directory.
-    2. Every serialized ``NodeInfo`` above is copied in every other node "additional-node-info" folder under the NodeInfo folder.
-  * Nodes read all the nodes stored in ``additional-node-info`` when the ``NetworkMapService`` starts up.
 
 * Adding enum support to the class carpenter
 

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -9,6 +9,11 @@ import java.util.List;
 import java.util.Map;
 
 public class CordformNode implements NodeDefinition {
+    /**
+     * Path relative to the running node where the serialized NodeInfos are stored.
+     */
+    public static final String NODE_INFO_FOLDER = "additional-node-infos";
+
     protected static final String DEFAULT_HOST = "localhost";
 
     /**

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -12,7 +12,7 @@ public class CordformNode implements NodeDefinition {
     /**
      * Path relative to the running node where the serialized NodeInfos are stored.
      */
-    public static final String NODE_INFO_FOLDER = "additional-node-infos";
+    public static final String NODE_INFO_DIRECTORY = "additional-node-infos";
 
     protected static final String DEFAULT_HOST = "localhost";
 

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -11,9 +11,6 @@ import org.gradle.api.tasks.TaskAction
 import java.nio.file.Path
 import java.nio.file.Paths
 
-// Keep this in sync with the value in NodeInfoSerializer.kt
-final NODE_INFO_PATH = "additional-node-infos"
-
 
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
@@ -21,6 +18,9 @@ final NODE_INFO_PATH = "additional-node-infos"
  * See documentation for examples.
  */
 class Cordform extends DefaultTask {
+    // Keep this in sync with the value in NodeInfoSerializer.kt
+    final NODE_INFO_PATH = "additional-node-infos"
+
     /**
      * Optionally the name of a CordformDefinition subclass to which all configuration will be delegated.
      */

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.TaskAction
 import java.nio.file.Path
 import java.nio.file.Paths
 
-
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
  *

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -158,18 +158,20 @@ class Cordform extends DefaultTask {
 
     void generateNodeInfos() {
         nodes.each { Node node ->
-            def process = new ProcessBuilder("java", "-Dcorda.NodeInfoQuit=1" , "-jar", Node.NODEJAR_NAME)
+            def process = new ProcessBuilder("java", "-jar", Node.NODEJAR_NAME, "--just-generate-node-info")
                     .directory(fullNodePath(node).toFile())
                     .redirectErrorStream(true)
                     .start()
                     .waitFor()
         }
         for (source in nodes) {
-            for (destination in nodes) if (source.nodeDir != destination.nodeDir) {
-                project.copy {
-                    from fullNodePath(source).toString()
-                    include 'nodeInfo-*'
-                    into fullNodePath(destination).resolve(NODE_INFO_PATH).toString()
+            for (destination in nodes) {
+                if (source.nodeDir != destination.nodeDir) {
+                    project.copy {
+                        from fullNodePath(source).toString()
+                        include 'nodeInfo-*'
+                        into fullNodePath(destination).resolve(NODE_INFO_PATH).toString()
+                    }
                 }
             }
         }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -159,7 +159,7 @@ class Cordform extends DefaultTask {
                     .directory(fullNodePath(node).toFile())
                     .redirectErrorStream(true)
                     .start()
-            process.inputStream.eachLine {println it}
+                    .waitFor()
         }
         for (source in nodes) {
             for (destination in nodes) if (source.nodeDir != destination.nodeDir) {

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -11,6 +11,10 @@ import org.gradle.api.tasks.TaskAction
 import java.nio.file.Path
 import java.nio.file.Paths
 
+// Keep this in sync with the value in NodeInfoSerializer.kt
+final NODE_INFO_PATH = "additional-node-infos"
+
+
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
  *
@@ -166,7 +170,7 @@ class Cordform extends DefaultTask {
                 project.copy {
                     from fullNodePath(source).toString()
                     include 'nodeInfo-*'
-                    into fullNodePath(destination).resolve("additional-node-infos").toString()
+                    into fullNodePath(destination).resolve(NODE_INFO_PATH).toString()
                 }
             }
         }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -141,8 +141,7 @@ class Cordform extends DefaultTask {
                 it.build()
             }
             generateNodeInfos()
-
-            println "Starting without networkMapNode, this an experimental feature"
+            logger.info("Starting without networkMapNode, this an experimental feature")
         } else {
             nodes.each {
                 if (it != networkMapNode) {

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -167,7 +167,7 @@ class Cordform extends DefaultTask {
                     project.copy {
                         from fullNodePath(source).toString()
                         include 'nodeInfo-*'
-                        into fullNodePath(destination).resolve(Node.NODE_INFO_FOLDER).toString()
+                        into fullNodePath(destination).resolve(Node.NODE_INFO_DIRECTORY).toString()
                     }
                 }
             }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -3,6 +3,7 @@ package net.corda.plugins
 import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import net.corda.cordform.CordformContext
 import net.corda.cordform.CordformDefinition
+import net.corda.cordform.CordformNode
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.bouncycastle.asn1.x500.X500Name
 import org.gradle.api.DefaultTask
@@ -18,9 +19,6 @@ import java.nio.file.Paths
  * See documentation for examples.
  */
 class Cordform extends DefaultTask {
-    // Keep this in sync with the value in NodeInfoSerializer.kt
-    final NODE_INFO_PATH = "additional-node-infos"
-
     /**
      * Optionally the name of a CordformDefinition subclass to which all configuration will be delegated.
      */
@@ -170,7 +168,7 @@ class Cordform extends DefaultTask {
                     project.copy {
                         from fullNodePath(source).toString()
                         include 'nodeInfo-*'
-                        into fullNodePath(destination).resolve(NODE_INFO_PATH).toString()
+                        into fullNodePath(destination).resolve(CordformNode.NODE_INFO_PATH).toString()
                     }
                 }
             }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -136,7 +136,7 @@ class Cordform extends DefaultTask {
         }
         installRunScript()
         def networkMapNode = getNodeByName(networkMapNodeName)
-        if (networkMapNode == null){
+        if (networkMapNode == null) {
             nodes.each {
                 it.build()
             }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -167,7 +167,7 @@ class Cordform extends DefaultTask {
                     project.copy {
                         from fullNodePath(source).toString()
                         include 'nodeInfo-*'
-                        into fullNodePath(destination).resolve(CordformNode.NODE_INFO_PATH).toString()
+                        into fullNodePath(destination).resolve(Node.NODE_INFO_FOLDER).toString()
                     }
                 }
             }

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.TaskAction
 import java.nio.file.Path
 import java.nio.file.Paths
 
+
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
  *

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -12,7 +12,6 @@ import org.gradle.api.tasks.TaskAction
 import java.nio.file.Path
 import java.nio.file.Paths
 
-
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
  *

--- a/node/src/main/kotlin/net/corda/node/ArgsParser.kt
+++ b/node/src/main/kotlin/net/corda/node/ArgsParser.kt
@@ -34,6 +34,8 @@ class ArgsParser {
     private val noLocalShellArg = optionParser.accepts("no-local-shell", "Do not start the embedded shell locally.")
     private val isRegistrationArg = optionParser.accepts("initial-registration", "Start initial node registration with Corda network to obtain certificate from the permissioning server.")
     private val isVersionArg = optionParser.accepts("version", "Print the version and exit")
+    private val justGenerateNodeInfoArg = optionParser.accepts("just-generate-node-info",
+            "Perform the node start-up task necessary to generate the nodeInfo, save it to disk, then quit")
     private val helpArg = optionParser.accepts("help").forHelp()
 
     fun parse(vararg args: String): CmdLineOptions {
@@ -50,7 +52,9 @@ class ArgsParser {
         val isVersion = optionSet.has(isVersionArg)
         val noLocalShell = optionSet.has(noLocalShellArg)
         val sshdServer = optionSet.has(sshdServerArg)
-        return CmdLineOptions(baseDirectory, configFile, help, loggingLevel, logToConsole, isRegistration, isVersion, noLocalShell, sshdServer)
+        val justGenerateNodeInfo = optionSet.has(justGenerateNodeInfoArg)
+        return CmdLineOptions(baseDirectory, configFile, help, loggingLevel, logToConsole, isRegistration, isVersion,
+                noLocalShell, sshdServer, justGenerateNodeInfo)
     }
 
     fun printHelp(sink: PrintStream) = optionParser.printHelpOn(sink)
@@ -64,7 +68,8 @@ data class CmdLineOptions(val baseDirectory: Path,
                           val isRegistration: Boolean,
                           val isVersion: Boolean,
                           val noLocalShell: Boolean,
-                          val sshdServer: Boolean) {
+                          val sshdServer: Boolean,
+                          val justGenerateNodeInfo : Boolean) {
     fun loadConfig() = ConfigHelper
                 .loadConfig(baseDirectory, configFile)
                 .parseAs<FullNodeConfiguration>()

--- a/node/src/main/kotlin/net/corda/node/ArgsParser.kt
+++ b/node/src/main/kotlin/net/corda/node/ArgsParser.kt
@@ -35,7 +35,7 @@ class ArgsParser {
     private val isRegistrationArg = optionParser.accepts("initial-registration", "Start initial node registration with Corda network to obtain certificate from the permissioning server.")
     private val isVersionArg = optionParser.accepts("version", "Print the version and exit")
     private val justGenerateNodeInfoArg = optionParser.accepts("just-generate-node-info",
-            "Perform the node start-up task necessary to generate the nodeInfo, save it to disk, then quit")
+            "Perform the node start-up task necessary to generate its nodeInfo, save it to disk, then quit")
     private val helpArg = optionParser.accepts("help").forHelp()
 
     fun parse(vararg args: String): CmdLineOptions {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -391,6 +391,11 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
                 services.transactionVerifierService, services.validatedTransactions, services.contractUpgradeService,
                 services, cordappProvider, this)
         makeNetworkServices(tokenizableServices)
+        System.getProperty("corda.NodeInfoQuit")?.let {
+            NodeInfoSerializer.saveToFile(this)
+            log.info("Peacefully quitting after having written my NodeInfo to disk")
+            System.exit(0)
+        }
         return tokenizableServices
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -182,7 +182,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     }
 
     open fun generateNodeInfo() {
-        require(started == null) { "Node has already been started" }
+        check(started == null) { "Node has already been started" }
 
         initCertificate()
 
@@ -195,7 +195,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
     }
 
     open fun start(): StartedNode<AbstractNode> {
-        require(started == null) { "Node has already been started" }
+        check(started == null) { "Node has already been started" }
 
         initCertificate()
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -392,7 +392,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
                 services, cordappProvider, this)
         makeNetworkServices(tokenizableServices)
         // Property corda.NodeInfoQuit is defined when we want the node to generate its identity and then
-        // write it to disk. This is used the the deployment scripts and Cordformation.
+        // write it to disk. This is used in the deployment scripts and Cordformation.
         System.getProperty("corda.NodeInfoQuit")?.let {
             NodeInfoSerializer().saveToFile(configuration.baseDirectory, info, services.keyManagementService)
             log.info("Peacefully quitting after having written my NodeInfo to disk")

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -391,8 +391,10 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
                 services.transactionVerifierService, services.validatedTransactions, services.contractUpgradeService,
                 services, cordappProvider, this)
         makeNetworkServices(tokenizableServices)
+        // Property corda.NodeInfoQuit is defined when we want the node to generate its identity and then
+        // write it to disk. This is used the the deployment scripts and Cordformation.
         System.getProperty("corda.NodeInfoQuit")?.let {
-            NodeInfoSerializer.saveToFile(configuration.baseDirectory, info, services.keyManagementService)
+            NodeInfoSerializer().saveToFile(configuration.baseDirectory, info, services.keyManagementService)
             log.info("Peacefully quitting after having written my NodeInfo to disk")
             System.exit(0)
         }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -183,30 +183,22 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
 
     open fun generateNodeInfo() {
         check(started == null) { "Node has already been started" }
-
         initCertificate()
-
         log.info("Generating nodeInfo ...")
-
         initialiseDatabasePersistence {
-            val tokenizableServices = makeServices()
+            makeServices()
             saveOwnNodeInfo()
         }
     }
 
     open fun start(): StartedNode<AbstractNode> {
         check(started == null) { "Node has already been started" }
-
         initCertificate()
-
         log.info("Node starting up ...")
-
         // Do all of this in a database transaction so anything that might need a connection has one.
         val startedImpl = initialiseDatabasePersistence {
             val tokenizableServices = makeServices()
-
             saveOwnNodeInfo()
-
             smm = StateMachineManager(services,
                     checkpointStorage,
                     serverThread,

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -392,7 +392,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
                 services, cordappProvider, this)
         makeNetworkServices(tokenizableServices)
         System.getProperty("corda.NodeInfoQuit")?.let {
-            NodeInfoSerializer.saveToFile(this)
+            NodeInfoSerializer.saveToFile(configuration.baseDirectory, info, services.keyManagementService)
             log.info("Peacefully quitting after having written my NodeInfo to disk")
             System.exit(0)
         }

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -310,6 +310,11 @@ open class Node(override val configuration: FullNodeConfiguration,
     private val _startupComplete = openFuture<Unit>()
     val startupComplete: CordaFuture<Unit> get() = _startupComplete
 
+    override fun generateNodeInfo() {
+        initialiseSerialization()
+        super.generateNodeInfo()
+    }
+
     override fun start(): StartedNode<Node> {
         if (initialiseSerialization) {
             initialiseSerialization()

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -92,18 +92,24 @@ open class NodeStartup(val args: Array<String>) {
 
     open protected fun startNode(conf: FullNodeConfiguration, versionInfo: VersionInfo, startTime: Long, cmdlineOptions: CmdLineOptions) {
         val advertisedServices = conf.calculateServices()
-        val node = createNode(conf, versionInfo, advertisedServices).start()
-        printPluginsAndServices(node.internals)
-        node.internals.nodeReadyFuture.thenMatch({
+        val node = createNode(conf, versionInfo, advertisedServices)
+        if (cmdlineOptions.justGenerateNodeInfo) {
+            // Perform the the minimum required start-up logic to be able to write a nodeInfo to disk
+            node.generateNodeInfo()
+            return
+        }
+        val startedNode = node.start()
+        printPluginsAndServices(startedNode.internals)
+        startedNode.internals.nodeReadyFuture.thenMatch({
             val elapsed = (System.currentTimeMillis() - startTime) / 10 / 100.0
-            val name = node.info.legalIdentitiesAndCerts.first().name.organisation
+            val name = startedNode.info.legalIdentitiesAndCerts.first().name.organisation
             Node.printBasicNodeInfo("Node for \"$name\" started up and registered in $elapsed sec")
 
             // Don't start the shell if there's no console attached.
             val runShell = !cmdlineOptions.noLocalShell && System.console() != null
-            node.internals.startupComplete.then {
+            startedNode.internals.startupComplete.then {
                 try {
-                    InteractiveShell.startShell(cmdlineOptions.baseDirectory, runShell, cmdlineOptions.sshdServer, node)
+                    InteractiveShell.startShell(cmdlineOptions.baseDirectory, runShell, cmdlineOptions.sshdServer, startedNode)
                 } catch(e: Throwable) {
                     logger.error("Shell failed to start", e)
                 }
@@ -112,7 +118,7 @@ open class NodeStartup(val args: Array<String>) {
         {
             th -> logger.error("Unexpected exception during registration", th)
         })
-        node.internals.run()
+        startedNode.internals.run()
     }
 
     open protected fun logStartupInfo(versionInfo: VersionInfo, cmdlineOptions: CmdLineOptions, conf: FullNodeConfiguration) {

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -94,7 +94,7 @@ open class NodeStartup(val args: Array<String>) {
         val advertisedServices = conf.calculateServices()
         val node = createNode(conf, versionInfo, advertisedServices)
         if (cmdlineOptions.justGenerateNodeInfo) {
-            // Perform the the minimum required start-up logic to be able to write a nodeInfo to disk
+            // Perform the minimum required start-up logic to be able to write a nodeInfo to disk
             node.generateNodeInfo()
             return
         }

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -33,11 +33,11 @@ class NodeInfoSerializer {
      * Saves the given [NodeInfo] to a path.
      * The node is 'encoded' as a SignedData<NodeInfo>, signed with the owning key of its first identity.
      * The name of the written file will be "nodeInfo-" followed by the hash of the content. The hash in the filename
-     * is used so that one can freely copy these files without fearing to overwrite a another one.
+     * is used so that one can freely copy these files without fearing to overwrite another one.
      *
-     * @param path the path where to write the file, if non-existant it will be created.
-     * @param nodeInfo the nodeInfo to serialize
-     * @param keyManager a KeyManagementService used to sign the node
+     * @param path the path where to write the file, if non-existaent it will be created.
+     * @param nodeInfo the NodeInfo to serialize.
+     * @param keyManager a KeyManagementService used to sign the NodeInfo data.
      */
     fun saveToFile(path: Path, nodeInfo: NodeInfo, keyManager: KeyManagementService) {
         path.toFile().mkdirs()
@@ -49,7 +49,7 @@ class NodeInfoSerializer {
     }
 
     /**
-     * Loads all the files contained in a given path and returns the deserialized [NodeInfo]s
+     * Loads all the files contained in a given path and returns the deserialized [NodeInfo]s.
      * Signatures are checked before returning a value.
      *
      * @param nodePath the node base path. NodeInfo files are searched for in nodePath/[NODE_INFO_FOLDER]

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -21,7 +21,7 @@ class NodeInfoSerializer {
 
     companion object {
         /**
-         * Path relative to the running node where to look for serialized NodeInfos.
+         * Path relative to the running node where the serialized NodeInfos are stored.
          * Keep this in sync with the value in Cordform.groovy.
          */
         const val NODE_INFO_FOLDER = "additional-node-infos"
@@ -44,7 +44,7 @@ class NodeInfoSerializer {
         val serializedBytes: SerializedBytes<NodeInfo> = nodeInfo.serialize()
         val regSig = keyManager.sign(serializedBytes.bytes, nodeInfo.legalIdentities.first().owningKey)
         val signedData: SignedData<NodeInfo> = SignedData(serializedBytes, regSig)
-        val file: File = (path / ("nodeInfo-" + signedData.hashCode().toString())).toFile()
+        val file: File = (path / ("nodeInfo-" + serializedBytes.hashCode().toString())).toFile()
         file.writeBytes(signedData.serialize().bytes)
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -2,35 +2,84 @@ package net.corda.node.services.network
 
 import net.corda.core.crypto.SignedData
 import net.corda.core.internal.div
+import net.corda.core.internal.isDirectory
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.KeyManagementService
+import net.corda.core.serialization.SerializationFactory
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.ByteSequence
-import net.corda.node.internal.AbstractNode
-import net.corda.node.internal.Node
+import net.corda.core.utilities.loggerFor
 import java.io.File
 import java.nio.file.Path
-import java.security.PublicKey
 
-object NodeInfoSerializer {
+/**
+ * Class containing the logic to serialize and de-serialize a [NodeInfo] to disk and reading them back.
+ */
+class NodeInfoSerializer {
 
-    const val NODE_INFO_FOLDER = "additional-node-infos"
+    companion object {
+        /**
+         * Path relative to the running node where to look for serialized NodeInfos.
+         * Keep this in sync with the value in Cordform.groovy.
+         */
+        const val NODE_INFO_FOLDER = "additional-node-infos"
 
-    fun loadFromFile(file: File): NodeInfo {
+        val logger = loggerFor<NodeInfoSerializer>()
+    }
+
+    /**
+     * Saves the given [NodeInfo] to a path.
+     * The node is 'encoded' as a SignedData<NodeInfo>, signed with the owning key of its first identity.
+     * The name of the written file will be "nodeInfo-" followed by the hash of the content. The hash in the filename
+     * is used so that one can freely copy these files without fearing to overwrite a another one.
+     *
+     * @param path the path where to write the file, if non-existant it will be created.
+     * @param nodeInfo the nodeInfo to serialize
+     * @param keyManager a KeyManagementService used to sign the node
+     */
+    fun saveToFile(path: Path, nodeInfo: NodeInfo, keyManager: KeyManagementService) {
+        path.toFile().mkdirs()
+        val serializedBytes: SerializedBytes<NodeInfo> = nodeInfo.serialize()
+        val regSig = keyManager.sign(serializedBytes.bytes, nodeInfo.legalIdentities.first().owningKey)
+        val signedData: SignedData<NodeInfo> = SignedData(serializedBytes, regSig)
+        val file: File = (path / ("nodeInfo-" + signedData.hashCode().toString())).toFile()
+        file.writeBytes(signedData.serialize().bytes)
+    }
+
+    /**
+     * Loads all the files contained in a given path and returns the deserialized [NodeInfo]s
+     * Signatures are checked before returning a value.
+     *
+     * @param nodePath the node base path. NodeInfo files are searched for in nodePath/[NODE_INFO_FOLDER]
+     * @return a list of [NodeInfo]s
+     */
+    fun loadFromDirectory(nodePath: Path): List<NodeInfo> {
+        val result = mutableListOf<NodeInfo>()
+        val nodeInfoDirectory = nodePath / NodeInfoSerializer.NODE_INFO_FOLDER
+        if (!nodeInfoDirectory.isDirectory()) {
+            logger.info("$nodeInfoDirectory isn't a Directory, not loading NodeInfo from files")
+            return result
+        }
+        var readFiles = 0
+        for (file in nodeInfoDirectory.toFile().walk().maxDepth(1)) if (file.isFile) {
+            try {
+                logger.info("Reading NodeInfo from file: $file")
+                val nodeInfo = loadFromFile(file)
+                result.add(nodeInfo)
+                readFiles++
+            } catch (e: Exception) {
+                logger.error("Exception parsing NodeInfo from file. $file: " + e)
+                e.printStackTrace()
+            }
+        }
+        logger.info("Succesfully read $readFiles NodeInfo files.")
+        return result
+    }
+
+    private fun loadFromFile(file: File): NodeInfo {
         val signedData: SignedData<NodeInfo> = ByteSequence.of(file.readBytes()).deserialize()
         return signedData.verified()
     }
-
-    fun saveToFile(path: Path, nodeInfo: NodeInfo, keyManager: KeyManagementService) {
-        path.toFile().mkdirs()
-        val sb: SerializedBytes<NodeInfo> = nodeInfo.serialize()
-        val regSig = keyManager.sign(sb.bytes, nodeInfo.legalIdentities.first().owningKey)
-        val sd: SignedData<NodeInfo> = SignedData(sb, regSig)
-        //nodeInfo.
-        val file: File = (path / ("nodeInfo-" + sd.hashCode().toString())).toFile()
-        file.writeBytes(sd.serialize().bytes)
-    }
-
 }

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.network
 
+import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
 import net.corda.core.internal.div
 import net.corda.core.internal.isDirectory
@@ -44,7 +45,7 @@ class NodeInfoSerializer {
         val serializedBytes: SerializedBytes<NodeInfo> = nodeInfo.serialize()
         val regSig = keyManager.sign(serializedBytes.bytes, nodeInfo.legalIdentities.first().owningKey)
         val signedData: SignedData<NodeInfo> = SignedData(serializedBytes, regSig)
-        val file: File = (path / ("nodeInfo-" + serializedBytes.hashCode().toString())).toFile()
+        val file: File = (path / ("nodeInfo-" + SecureHash.sha256(serializedBytes.bytes).toString())).toFile()
         file.writeBytes(signedData.serialize().bytes)
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -23,18 +23,14 @@ object NodeInfoSerializer {
         return signedData.verified()
     }
 
-    fun saveToFile(path: Path, nodeInfo: NodeInfo, keyManager: KeyManagementService, publicKey: PublicKey) {
+    fun saveToFile(path: Path, nodeInfo: NodeInfo, keyManager: KeyManagementService) {
         path.toFile().mkdirs()
         val sb: SerializedBytes<NodeInfo> = nodeInfo.serialize()
-        val regSig = keyManager.sign(sb.bytes, publicKey)
+        val regSig = keyManager.sign(sb.bytes, nodeInfo.legalIdentities.first().owningKey)
         val sd: SignedData<NodeInfo> = SignedData(sb, regSig)
         //nodeInfo.
         val file: File = (path / ("nodeInfo-" + sd.hashCode().toString())).toFile()
         file.writeBytes(sd.serialize().bytes)
     }
 
-    fun saveToFile(node: AbstractNode) {
-        saveToFile(node.configuration.baseDirectory, node.info,
-                node.services.keyManagementService, node.services.legalIdentityKey)
-    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -57,7 +57,7 @@ class NodeInfoSerializer {
      */
     fun loadFromDirectory(nodePath: Path): List<NodeInfo> {
         val result = mutableListOf<NodeInfo>()
-        val nodeInfoDirectory = nodePath / CordformNode.NODE_INFO_FOLDER
+        val nodeInfoDirectory = nodePath / CordformNode.NODE_INFO_DIRECTORY
         if (!nodeInfoDirectory.isDirectory()) {
             logger.info("$nodeInfoDirectory isn't a Directory, not loading NodeInfo from files")
             return result
@@ -70,7 +70,7 @@ class NodeInfoSerializer {
                     val nodeInfo = loadFromFile(file)
                     result.add(nodeInfo)
                 } catch (e: Exception) {
-                    logger.error("Exception parsing NodeInfo from file. $file: " + e)
+                    logger.error("Exception parsing NodeInfo from file. $file" , e)
                 }
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -6,7 +6,6 @@ import net.corda.core.internal.div
 import net.corda.core.internal.isDirectory
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.KeyManagementService
-import net.corda.core.serialization.SerializationFactory
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
@@ -16,7 +15,7 @@ import java.io.File
 import java.nio.file.Path
 
 /**
- * Class containing the logic to serialize and de-serialize a [NodeInfo] to disk and reading them back.
+ * Class containing the logic to serialize and de-serialize a [NodeInfo] to disk and reading it back.
  */
 class NodeInfoSerializer {
 
@@ -63,19 +62,18 @@ class NodeInfoSerializer {
             logger.info("$nodeInfoDirectory isn't a Directory, not loading NodeInfo from files")
             return result
         }
-        var readFiles = 0
-        for (file in nodeInfoDirectory.toFile().walk().maxDepth(1)) if (file.isFile) {
-            try {
-                logger.info("Reading NodeInfo from file: $file")
-                val nodeInfo = loadFromFile(file)
-                result.add(nodeInfo)
-                readFiles++
-            } catch (e: Exception) {
-                logger.error("Exception parsing NodeInfo from file. $file: " + e)
-                e.printStackTrace()
+        for (file in nodeInfoDirectory.toFile().walk().maxDepth(1))
+            if (file.isFile) {
+                try {
+                    logger.info("Reading NodeInfo from file: $file")
+                    val nodeInfo = loadFromFile(file)
+                    result.add(nodeInfo)
+                } catch (e: Exception) {
+                    logger.error("Exception parsing NodeInfo from file. $file: " + e)
+                    e.printStackTrace()
+                }
             }
-        }
-        logger.info("Succesfully read $readFiles NodeInfo files.")
+        logger.info("Succesfully read ${result.size} NodeInfo files.")
         return result
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -1,0 +1,40 @@
+package net.corda.node.services.network
+
+import net.corda.core.crypto.SignedData
+import net.corda.core.internal.div
+import net.corda.core.node.NodeInfo
+import net.corda.core.node.services.KeyManagementService
+import net.corda.core.serialization.SerializedBytes
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
+import net.corda.core.utilities.ByteSequence
+import net.corda.node.internal.AbstractNode
+import net.corda.node.internal.Node
+import java.io.File
+import java.nio.file.Path
+import java.security.PublicKey
+
+object NodeInfoSerializer {
+
+    const val NODE_INFO_FOLDER = "additional-node-infos"
+
+    fun loadFromFile(file: File): NodeInfo {
+        val signedData: SignedData<NodeInfo> = ByteSequence.of(file.readBytes()).deserialize()
+        return signedData.verified()
+    }
+
+    fun saveToFile(path: Path, nodeInfo: NodeInfo, keyManager: KeyManagementService, publicKey: PublicKey) {
+        path.toFile().mkdirs()
+        val sb: SerializedBytes<NodeInfo> = nodeInfo.serialize()
+        val regSig = keyManager.sign(sb.bytes, publicKey)
+        val sd: SignedData<NodeInfo> = SignedData(sb, regSig)
+        //nodeInfo.
+        val file: File = (path / ("nodeInfo-" + sd.hashCode().toString())).toFile()
+        file.writeBytes(sd.serialize().bytes)
+    }
+
+    fun saveToFile(node: AbstractNode) {
+        saveToFile(node.configuration.baseDirectory, node.info,
+                node.services.keyManagementService, node.services.legalIdentityKey)
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoSerializer.kt
@@ -40,12 +40,16 @@ class NodeInfoSerializer {
      * @param keyManager a KeyManagementService used to sign the NodeInfo data.
      */
     fun saveToFile(path: Path, nodeInfo: NodeInfo, keyManager: KeyManagementService) {
-        path.toFile().mkdirs()
-        val serializedBytes: SerializedBytes<NodeInfo> = nodeInfo.serialize()
-        val regSig = keyManager.sign(serializedBytes.bytes, nodeInfo.legalIdentities.first().owningKey)
-        val signedData: SignedData<NodeInfo> = SignedData(serializedBytes, regSig)
-        val file: File = (path / ("nodeInfo-" + SecureHash.sha256(serializedBytes.bytes).toString())).toFile()
-        file.writeBytes(signedData.serialize().bytes)
+        try {
+            path.toFile().mkdirs()
+            val serializedBytes: SerializedBytes<NodeInfo> = nodeInfo.serialize()
+            val regSig = keyManager.sign(serializedBytes.bytes, nodeInfo.legalIdentities.first().owningKey)
+            val signedData: SignedData<NodeInfo> = SignedData(serializedBytes, regSig)
+            val file: File = (path / ("nodeInfo-" + SecureHash.sha256(serializedBytes.bytes).toString())).toFile()
+            file.writeBytes(signedData.serialize().bytes)
+        } catch (e : Exception) {
+            logger.warn("Couldn't write node info to file: ${e.toString()}")
+        }
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -33,7 +33,6 @@ import net.corda.node.utilities.AddOrRemove
 import net.corda.node.utilities.DatabaseTransactionManager
 import net.corda.node.utilities.bufferUntilDatabaseCommit
 import net.corda.node.utilities.wrapWithDatabaseTransaction
-
 import org.hibernate.Session
 import rx.Observable
 import rx.subjects.PublishSubject

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -94,31 +94,29 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
         serviceHub.database.transaction { loadFromDB() }
     }
 
-
     private fun loadFromFiles() {
         logger.info("Loading network map from files..")
         val configuration = serviceHub.configuration
 
         val nodeInfoDirectory = configuration.baseDirectory / NodeInfoSerializer.NODE_INFO_FOLDER
         if (!nodeInfoDirectory.isDirectory()) {
-            logger.info("{$nodeInfoDirectory} isn't a Directory, not loading NodeInfo from files")
+            logger.info("$nodeInfoDirectory isn't a Directory, not loading NodeInfo from files")
             return
         }
         var readFiles = 0
         for (file in nodeInfoDirectory.toFile().walk().maxDepth(1)) if (file.isFile) {
             try {
-                logger.info("Reading NodeInfo from file: ${file}")
+                logger.info("Reading NodeInfo from file: $file")
                 val nodeInfo = NodeInfoSerializer.loadFromFile(file)
                 addNode(nodeInfo)
                 readFiles++
             } catch (e: Exception) {
-                logger.error("Exception parsing NodeInfo from file. ${file}: " + e)
+                logger.error("Exception parsing NodeInfo from file. $file: " + e)
                 e.printStackTrace()
             }
         }
-        logger.info("Succesfully read and loaded {$readFiles} NodeInfo files.")
+        logger.info("Succesfully read and loaded $readFiles NodeInfo files.")
     }
-
 
     override fun getPartyInfo(party: Party): PartyInfo? {
         val nodes = serviceHub.database.transaction { queryByIdentityKey(party.owningKey) }

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services.network
 
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -169,7 +169,7 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
         synchronized(_changed) {
             registeredNodes[node.legalIdentities.first().owningKey]?.let {
                 if (it.serial > node.serial) {
-                    logger.info("Discarding nodeInfo for ${node.legalIdentities.first().name} with an older timestamp")
+                    logger.info("Discarding older nodeInfo for ${node.legalIdentities.first().name}")
                     return
                 }
             }

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -94,12 +94,31 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
         serviceHub.database.transaction { loadFromDB() }
     }
 
+
     private fun loadFromFiles() {
         logger.info("Loading network map from files..")
-        for (node in NodeInfoSerializer().loadFromDirectory(serviceHub.configuration.baseDirectory)) {
-            addNode(node)
+        val configuration = serviceHub.configuration
+
+        val nodeInfoDirectory = configuration.baseDirectory / NodeInfoSerializer.NODE_INFO_FOLDER
+        if (!nodeInfoDirectory.isDirectory()) {
+            logger.info("{$nodeInfoDirectory} isn't a Directory, not loading NodeInfo from files")
+            return
         }
+        var readFiles = 0
+        for (file in nodeInfoDirectory.toFile().walk().maxDepth(1)) if (file.isFile) {
+            try {
+                logger.info("Reading NodeInfo from file: ${file}")
+                val nodeInfo = NodeInfoSerializer.loadFromFile(file)
+                addNode(nodeInfo)
+                readFiles++
+            } catch (e: Exception) {
+                logger.error("Exception parsing NodeInfo from file. ${file}: " + e)
+                e.printStackTrace()
+            }
+        }
+        logger.info("Succesfully read and loaded {$readFiles} NodeInfo files.")
     }
+
 
     override fun getPartyInfo(party: Party): PartyInfo? {
         val nodes = serviceHub.database.transaction { queryByIdentityKey(party.owningKey) }

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services.network
 
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -1,10 +1,7 @@
 package net.corda.node.services.network
 
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.crypto.cert
 import net.corda.core.internal.bufferUntilSubscribed
-import net.corda.core.crypto.parsePublicKeyBase58
-import net.corda.core.crypto.toBase58String
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
@@ -97,31 +94,29 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
         serviceHub.database.transaction { loadFromDB() }
     }
 
-
     private fun loadFromFiles() {
         logger.info("Loading network map from files..")
         val configuration = serviceHub.configuration
 
         val nodeInfoDirectory = configuration.baseDirectory / NodeInfoSerializer.NODE_INFO_FOLDER
         if (!nodeInfoDirectory.isDirectory()) {
-            logger.info("{$nodeInfoDirectory} isn't a Directory, not loading NodeInfo from files")
+            logger.info("$nodeInfoDirectory isn't a Directory, not loading NodeInfo from files")
             return
         }
         var readFiles = 0
         for (file in nodeInfoDirectory.toFile().walk().maxDepth(1)) if (file.isFile) {
             try {
-                logger.info("Reading NodeInfo from file: ${file}")
+                logger.info("Reading NodeInfo from file: $file")
                 val nodeInfo = NodeInfoSerializer.loadFromFile(file)
                 addNode(nodeInfo)
                 readFiles++
             } catch (e: Exception) {
-                logger.error("Exception parsing NodeInfo from file. ${file}: " + e)
+                logger.error("Exception parsing NodeInfo from file. $file: " + e)
                 e.printStackTrace()
             }
         }
-        logger.info("Succesfully read and loaded {$readFiles} NodeInfo files.")
+        logger.info("Succesfully read and loaded $readFiles NodeInfo files.")
     }
-
 
     override fun getPartyInfo(party: Party): PartyInfo? {
         val nodes = serviceHub.database.transaction { queryByIdentityKey(party.owningKey) }

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -96,26 +96,9 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
 
     private fun loadFromFiles() {
         logger.info("Loading network map from files..")
-        val configuration = serviceHub.configuration
-
-        val nodeInfoDirectory = configuration.baseDirectory / NodeInfoSerializer.NODE_INFO_FOLDER
-        if (!nodeInfoDirectory.isDirectory()) {
-            logger.info("$nodeInfoDirectory isn't a Directory, not loading NodeInfo from files")
-            return
+        for (node in NodeInfoSerializer().loadFromDirectory(serviceHub.configuration.baseDirectory)) {
+            addNode(node)
         }
-        var readFiles = 0
-        for (file in nodeInfoDirectory.toFile().walk().maxDepth(1)) if (file.isFile) {
-            try {
-                logger.info("Reading NodeInfo from file: $file")
-                val nodeInfo = NodeInfoSerializer.loadFromFile(file)
-                addNode(nodeInfo)
-                readFiles++
-            } catch (e: Exception) {
-                logger.error("Exception parsing NodeInfo from file. $file: " + e)
-                e.printStackTrace()
-            }
-        }
-        logger.info("Succesfully read and loaded $readFiles NodeInfo files.")
     }
 
     override fun getPartyInfo(party: Party): PartyInfo? {

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -6,11 +6,8 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.VisibleForTesting
-import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.div
-import net.corda.core.internal.isDirectory
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.node.NodeInfo
@@ -32,14 +29,16 @@ import net.corda.node.services.messaging.createMessage
 import net.corda.node.services.messaging.sendRequest
 import net.corda.node.services.network.NetworkMapService.FetchMapResponse
 import net.corda.node.services.network.NetworkMapService.SubscribeResponse
-import net.corda.node.utilities.*
-import org.bouncycastle.asn1.x500.X500Name
+import net.corda.node.utilities.AddOrRemove
+import net.corda.node.utilities.DatabaseTransactionManager
+import net.corda.node.utilities.bufferUntilDatabaseCommit
+import net.corda.node.utilities.wrapWithDatabaseTransaction
+
 import org.hibernate.Session
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.security.PublicKey
 import java.security.SignatureException
-import java.security.cert.TrustAnchor
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
 

--- a/node/src/test/kotlin/net/corda/node/ArgsParserTest.kt
+++ b/node/src/test/kotlin/net/corda/node/ArgsParserTest.kt
@@ -23,7 +23,8 @@ class ArgsParserTest {
                 isRegistration = false,
                 isVersion = false,
                 noLocalShell = false,
-                sshdServer = false))
+                sshdServer = false,
+                justGenerateNodeInfo = false))
     }
 
     @Test
@@ -116,5 +117,11 @@ class ArgsParserTest {
     fun version() {
         val cmdLineOptions = parser.parse("--version")
         assertThat(cmdLineOptions.isVersion).isTrue()
+    }
+
+    @Test
+    fun `generate node infos`() {
+        val cmdLineOptions = parser.parse("--just-generate-node-info")
+        assertThat(cmdLineOptions.justGenerateNodeInfo).isTrue()
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
@@ -11,7 +11,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-
 import java.nio.charset.Charset
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -64,6 +63,3 @@ class NodeInfoSerializerTest : NodeBasedTest() {
         assertEquals(nodeInfo, nodeInfos.first())
     }
 }
-
-
-

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
@@ -57,7 +57,7 @@ class NodeInfoSerializerTest : NodeBasedTest() {
 
     @Test
     fun `load a non empty Directory`() {
-        val nodeInfoFolder = folder.newFolder(CordformNode.NODE_INFO_FOLDER)
+        val nodeInfoFolder = folder.newFolder(CordformNode.NODE_INFO_DIRECTORY)
         nodeInfoSerializer.saveToFile(nodeInfoFolder.toPath(), nodeInfo, keyManagementService)
         val nodeInfos = nodeInfoSerializer.loadFromDirectory(folder.root.toPath())
 

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
@@ -1,0 +1,69 @@
+package net.corda.node.services.network
+
+import net.corda.core.internal.div
+import net.corda.core.node.NodeInfo
+import net.corda.core.node.services.KeyManagementService
+import net.corda.node.services.identity.InMemoryIdentityService
+import net.corda.testing.*
+import net.corda.testing.node.MockKeyManagementService
+import net.corda.testing.node.NodeBasedTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import java.nio.charset.Charset
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class NodeInfoSerializerTest : NodeBasedTest() {
+
+    @Rule @JvmField var folder = TemporaryFolder()
+
+    lateinit var keyManagementService: KeyManagementService
+
+    // Object under test
+    val nodeInfoSerializer = NodeInfoSerializer()
+
+    companion object {
+        val nodeInfoFileRegex = Regex("nodeInfo\\-\\d*")
+        val nodeInfo = NodeInfo(listOf(), listOf(getTestPartyAndCertificate(ALICE)), 0, listOf(), 0)
+    }
+
+    @Before
+    fun start() {
+        val identityService = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
+        keyManagementService = MockKeyManagementService(identityService, ALICE_KEY)
+    }
+
+    @Test
+    fun `save a NodeInfo`() {
+        nodeInfoSerializer.saveToFile(folder.root.toPath(), nodeInfo, keyManagementService)
+
+        assertEquals(1, folder.root.list().size)
+        val fileName = folder.root.list()[0]
+        assertTrue(fileName.matches(nodeInfoFileRegex))
+        val fileContent = (folder.root.path / fileName).toFile().readBytes().toString(Charset.defaultCharset())
+        // Just check that something is written, another tests verifies that the written value can be read back.
+        assertTrue { !fileContent.isEmpty() }
+    }
+
+    @Test
+    fun `load an empty Folder`() {
+        assertEquals(0, nodeInfoSerializer.loadFromDirectory(folder.root.toPath()).size)
+    }
+
+    @Test
+    fun `load a non empty Folder`() {
+        val nodeInfoFolder = folder.newFolder(NodeInfoSerializer.NODE_INFO_FOLDER)
+        nodeInfoSerializer.saveToFile(nodeInfoFolder.toPath(), nodeInfo, keyManagementService)
+        val nodeInfos = nodeInfoSerializer.loadFromDirectory(folder.root.toPath())
+
+        assertEquals(1, nodeInfos.size)
+        assertEquals(nodeInfo, nodeInfos.first())
+    }
+}
+
+
+

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
@@ -27,7 +27,7 @@ class NodeInfoSerializerTest : NodeBasedTest() {
     val nodeInfoSerializer = NodeInfoSerializer()
 
     companion object {
-        val nodeInfoFileRegex = Regex("nodeInfo\\-\\d*")
+        val nodeInfoFileRegex = Regex("nodeInfo\\-.*")
         val nodeInfo = NodeInfo(listOf(), listOf(getTestPartyAndCertificate(ALICE)), 0, 0)
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.network
 
+import net.corda.cordform.CordformNode
 import net.corda.core.internal.div
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.KeyManagementService
@@ -14,7 +15,8 @@ import org.junit.rules.TemporaryFolder
 import java.nio.charset.Charset
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.contentOf
 
 class NodeInfoSerializerTest : NodeBasedTest() {
 
@@ -43,19 +45,19 @@ class NodeInfoSerializerTest : NodeBasedTest() {
         assertEquals(1, folder.root.list().size)
         val fileName = folder.root.list()[0]
         assertTrue(fileName.matches(nodeInfoFileRegex))
-        val fileContent = (folder.root.path / fileName).toFile().readBytes().toString(Charset.defaultCharset())
+        val file = (folder.root.path / fileName).toFile()
         // Just check that something is written, another tests verifies that the written value can be read back.
-        assertTrue { !fileContent.isEmpty() }
+        assertThat(contentOf(file)).isNotEmpty()
     }
 
     @Test
-    fun `load an empty Folder`() {
+    fun `load an empty Directory`() {
         assertEquals(0, nodeInfoSerializer.loadFromDirectory(folder.root.toPath()).size)
     }
 
     @Test
-    fun `load a non empty Folder`() {
-        val nodeInfoFolder = folder.newFolder(NodeInfoSerializer.NODE_INFO_FOLDER)
+    fun `load a non empty Directory`() {
+        val nodeInfoFolder = folder.newFolder(CordformNode.NODE_INFO_FOLDER)
         nodeInfoSerializer.saveToFile(nodeInfoFolder.toPath(), nodeInfo, keyManagementService)
         val nodeInfos = nodeInfoSerializer.loadFromDirectory(folder.root.toPath())
 

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoSerializerTest.kt
@@ -28,7 +28,7 @@ class NodeInfoSerializerTest : NodeBasedTest() {
 
     companion object {
         val nodeInfoFileRegex = Regex("nodeInfo\\-\\d*")
-        val nodeInfo = NodeInfo(listOf(), listOf(getTestPartyAndCertificate(ALICE)), 0, listOf(), 0)
+        val nodeInfo = NodeInfo(listOf(), listOf(getTestPartyAndCertificate(ALICE)), 0, 0)
     }
 
     @Before

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -51,7 +51,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     directory "./build/nodes"
     // This name "Notary" is hard-coded into TraderDemoClientApi so if you change it here, change it there too.
     // In this demo the node that runs a standalone notary also acts as the network map server.
-    networkMap "O=Notary Service,L=Zurich,C=CH"
+    //networkMap "O=Notary Service,L=Zurich,C=CH"
     node {
         name "O=Notary Service,L=Zurich,C=CH"
         advertisedServices = ["corda.notary.validating"]

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -51,7 +51,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     directory "./build/nodes"
     // This name "Notary" is hard-coded into TraderDemoClientApi so if you change it here, change it there too.
     // In this demo the node that runs a standalone notary also acts as the network map server.
-    //networkMap "O=Notary Service,L=Zurich,C=CH"
+    networkMap "O=Notary Service,L=Zurich,C=CH"
     node {
         name "O=Notary Service,L=Zurich,C=CH"
         advertisedServices = ["corda.notary.validating"]


### PR DESCRIPTION
Initial PR for https://r3-cev.atlassian.net/projects/CORDA/issues/CORDA-442

Allow for cordformation not to specify which node is network map.
When that happens Cordformation will start each node and make it serialize its NodeInfo to disk.
This make 'depolyNodes' slower. On my machine for the traderDemo it's ~25s

PersistentNetworkMapCache will load files from disk at startup.
Additionally nodeinfos are loaded in the networkMapCache only if they're newer than the currently known version.

