### PR TITLE
Transform Kotlin's EmptyList, EmptySet and EmptyMap into Java classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.2'
     ext.junit_version = '4.12'
-    ext.mockito_version = '1.10.19'
+    ext.mockito_version = '2.10.0'
     ext.jopt_simple_version = '5.0.2'
     ext.jansi_version = '1.14'
     ext.hibernate_version = '5.2.6.Final'

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/DefaultWhitelist.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/DefaultWhitelist.kt
@@ -19,16 +19,14 @@ class DefaultWhitelist : CordaPluginRegistry() {
                     Notification::class.java,
                     Notification.Kind::class.java,
                     ArrayList::class.java,
-                    listOf<Any>().javaClass, // EmptyList
                     Pair::class.java,
                     ByteArray::class.java,
                     UUID::class.java,
                     LinkedHashSet::class.java,
-                    setOf<Unit>().javaClass, // EmptySet
                     Currency::class.java,
                     listOf(Unit).javaClass, // SingletonList
                     setOf(Unit).javaClass, // SingletonSet
-                    mapOf(Unit to Unit).javaClass, // SingletonSet
+                    mapOf(Unit to Unit).javaClass, // SingletonMap
                     NetworkHostAndPort::class.java,
                     SimpleString::class.java,
                     KryoException::class.java, // TODO: Will be removed when we migrate away from Kryo

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CordaClassResolverTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/CordaClassResolverTests.kt
@@ -214,17 +214,17 @@ class CordaClassResolverTests {
     }
 
     @Test
-    fun `Kotlin EmptyList registers as ArrayList`() {
-        val arrayListClass = arrayListOf<Any>().javaClass
+    fun `Kotlin EmptyList registers as Java emptyList`() {
+        val javaEmptyListClass = Collections.emptyList<Any>().javaClass
         val kryo = mock<Kryo>()
         val resolver = CordaClassResolver(allButBlacklistedContext).apply { setKryo(kryo) }
-        whenever(kryo.getDefaultSerializer(arrayListClass)).thenReturn(DefaultSerializableSerializer())
+        whenever(kryo.getDefaultSerializer(javaEmptyListClass)).thenReturn(DefaultSerializableSerializer())
 
         val registration = resolver.registerImplicit(emptyListClass)
         assertNotNull(registration)
-        assertEquals(arrayListClass, registration.type)
+        assertEquals(javaEmptyListClass, registration.type)
         assertEquals(DefaultClassResolver.NAME.toInt(), registration.id)
-        verify(kryo).getDefaultSerializer(arrayListClass)
+        verify(kryo).getDefaultSerializer(javaEmptyListClass)
         assertEquals(registration, resolver.getRegistration(emptyListClass))
     }
 
@@ -235,17 +235,17 @@ class CordaClassResolverTests {
     }
 
     @Test
-    fun `Kotlin EmptySet registers as LinkedHashSet`() {
-        val linkedSetClass = linkedSetOf<Any>().javaClass
+    fun `Kotlin EmptySet registers as Java emptySet`() {
+        val javaEmptySetClass = Collections.emptySet<Any>().javaClass
         val kryo = mock<Kryo>()
         val resolver = CordaClassResolver(allButBlacklistedContext).apply { setKryo(kryo) }
-        whenever(kryo.getDefaultSerializer(linkedSetClass)).thenReturn(DefaultSerializableSerializer())
+        whenever(kryo.getDefaultSerializer(javaEmptySetClass)).thenReturn(DefaultSerializableSerializer())
 
         val registration = resolver.registerImplicit(emptySetClass)
         assertNotNull(registration)
-        assertEquals(linkedSetClass, registration.type)
+        assertEquals(javaEmptySetClass, registration.type)
         assertEquals(DefaultClassResolver.NAME.toInt(), registration.id)
-        verify(kryo).getDefaultSerializer(linkedSetClass)
+        verify(kryo).getDefaultSerializer(javaEmptySetClass)
         assertEquals(registration, resolver.getRegistration(emptySetClass))
     }
 
@@ -256,17 +256,17 @@ class CordaClassResolverTests {
     }
 
     @Test
-    fun `Kotlin EmptyMap registers as LinkedHashMap`() {
-        val linkedMapClass = linkedMapOf<Any, Any>().javaClass
+    fun `Kotlin EmptyMap registers as Java emptyMap`() {
+        val javaEmptyMapClass = Collections.emptyMap<Any, Any>().javaClass
         val kryo = mock<Kryo>()
         val resolver = CordaClassResolver(allButBlacklistedContext).apply { setKryo(kryo) }
-        whenever(kryo.getDefaultSerializer(linkedMapClass)).thenReturn(DefaultSerializableSerializer())
+        whenever(kryo.getDefaultSerializer(javaEmptyMapClass)).thenReturn(DefaultSerializableSerializer())
 
         val registration = resolver.registerImplicit(emptyMapClass)
         assertNotNull(registration)
-        assertEquals(linkedMapClass, registration.type)
+        assertEquals(javaEmptyMapClass, registration.type)
         assertEquals(DefaultClassResolver.NAME.toInt(), registration.id)
-        verify(kryo).getDefaultSerializer(linkedMapClass)
+        verify(kryo).getDefaultSerializer(javaEmptyMapClass)
         assertEquals(registration, resolver.getRegistration(emptyMapClass))
     }
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
@@ -25,9 +25,7 @@ import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class KryoTests : TestDependencyInjectionBase() {
     private lateinit var factory: SerializationFactory
@@ -111,6 +109,20 @@ class KryoTests : TestDependencyInjectionBase() {
         val serialised = TestSingleton.serialize(factory, context)
         val deserialised = serialised.deserialize(factory, context)
         assertThat(deserialised).isSameAs(TestSingleton)
+    }
+
+    @Test
+    fun `check Kotlin EmptyList can be serialised`() {
+        val deserialisedList: List<Int> = emptyList<Int>().serialize(factory, context).deserialize(factory, context)
+        assertEquals(0, deserialisedList.size)
+        assertEquals<Any>(arrayListOf<Int>().javaClass, deserialisedList.javaClass)
+    }
+
+    @Test
+    fun `check Kotlin EmptySet can be serialised`() {
+        val deserialisedSet: Set<Int> = emptySet<Int>().serialize(factory, context).deserialize(factory, context)
+        assertEquals(0, deserialisedSet.size)
+        assertEquals<Any>(linkedSetOf<Int>().javaClass, deserialisedSet.javaClass)
     }
 
     @Test

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.time.Instant
+import java.util.Collections
 import kotlin.test.*
 
 class KryoTests : TestDependencyInjectionBase() {
@@ -115,14 +116,21 @@ class KryoTests : TestDependencyInjectionBase() {
     fun `check Kotlin EmptyList can be serialised`() {
         val deserialisedList: List<Int> = emptyList<Int>().serialize(factory, context).deserialize(factory, context)
         assertEquals(0, deserialisedList.size)
-        assertEquals<Any>(arrayListOf<Int>().javaClass, deserialisedList.javaClass)
+        assertEquals<Any>(Collections.emptyList<Int>().javaClass, deserialisedList.javaClass)
     }
 
     @Test
     fun `check Kotlin EmptySet can be serialised`() {
         val deserialisedSet: Set<Int> = emptySet<Int>().serialize(factory, context).deserialize(factory, context)
         assertEquals(0, deserialisedSet.size)
-        assertEquals<Any>(linkedSetOf<Int>().javaClass, deserialisedSet.javaClass)
+        assertEquals<Any>(Collections.emptySet<Int>().javaClass, deserialisedSet.javaClass)
+    }
+
+    @Test
+    fun `check Kotlin EmptyMap can be serialised`() {
+        val deserialisedMap: Map<Int, Int> = emptyMap<Int, Int>().serialize(factory, context).deserialize(factory, context)
+        assertEquals(0, deserialisedMap.size)
+        assertEquals<Any>(Collections.emptyMap<Int, Int>().javaClass, deserialisedMap.javaClass)
     }
 
     @Test

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/ListsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/ListsSerializationTest.kt
@@ -12,10 +12,11 @@ import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.io.NotSerializableException
 import java.nio.charset.StandardCharsets.*
+import java.util.*
 
 class ListsSerializationTest : TestDependencyInjectionBase() {
     private companion object {
-        val arrayListClass = arrayListOf<Any>().javaClass
+        val javaEmptyListClass = Collections.emptyList<Any>().javaClass
     }
 
     @Test
@@ -42,16 +43,15 @@ class ListsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check empty list serialises as ArrayList`() {
+    fun `check empty list serialises as Java emptyList`() {
         val nameID = 0
         val serializedForm = emptyList<Int>().serialize()
         val output = ByteArrayOutputStream().apply {
             write(KryoHeaderV0_1.bytes)
             write(DefaultClassResolver.NAME + 2)
             write(nameID)
-            write(arrayListClass.name.toAscii())
+            write(javaEmptyListClass.name.toAscii())
             write(Kryo.NOT_NULL.toInt())
-            write(emptyList<Int>().size)
         }
         assertArrayEquals(output.toByteArray(), serializedForm.bytes)
     }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/MapsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/MapsSerializationTest.kt
@@ -13,13 +13,13 @@ import org.junit.Test
 import org.bouncycastle.asn1.x500.X500Name
 import java.io.ByteArrayOutputStream
 import java.io.NotSerializableException
+import java.util.*
 
 class MapsSerializationTest : TestDependencyInjectionBase() {
     private companion object {
-        val linkedMapClass = linkedMapOf<Any, Any>().javaClass
+        val javaEmptyMapClass = Collections.emptyMap<Any, Any>().javaClass
+        val smallMap = mapOf("foo" to "bar", "buzz" to "bull")
     }
-
-    private val smallMap = mapOf("foo" to "bar", "buzz" to "bull")
 
     @Test
     fun `check EmptyMap serialization`() = amqpSpecific<MapsSerializationTest>("kotlin.collections.EmptyMap is not enabled for Kryo serialization") {
@@ -63,16 +63,15 @@ class MapsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check empty map serialises as LinkedHashMap`() {
+    fun `check empty map serialises as Java emptytMap`() {
         val nameID = 0
         val serializedForm = emptyMap<Int, Int>().serialize()
         val output = ByteArrayOutputStream().apply {
             write(KryoHeaderV0_1.bytes)
             write(DefaultClassResolver.NAME + 2)
             write(nameID)
-            write(linkedMapClass.name.toAscii())
+            write(javaEmptyMapClass.name.toAscii())
             write(Kryo.NOT_NULL.toInt())
-            write(emptyMap<Int, Int>().size)
         }
         assertArrayEquals(output.toByteArray(), serializedForm.bytes)
     }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
@@ -8,10 +8,11 @@ import net.corda.testing.TestDependencyInjectionBase
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.ByteArrayOutputStream
+import java.util.*
 
 class SetsSerializationTest : TestDependencyInjectionBase() {
     private companion object {
-        val linkedSetClass = linkedSetOf<Any>().javaClass
+        val javaEmptySetClass = Collections.emptySet<Any>().javaClass
     }
 
     @Test
@@ -38,16 +39,15 @@ class SetsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check empty set serialises as LinkedHashSet`() {
+    fun `check empty set serialises as Java emptySet`() {
         val nameID = 0
         val serializedForm = emptySet<Int>().serialize()
         val output = ByteArrayOutputStream().apply {
             write(KryoHeaderV0_1.bytes)
             write(DefaultClassResolver.NAME + 2)
             write(nameID)
-            write(linkedSetClass.name.toAscii())
+            write(javaEmptySetClass.name.toAscii())
             write(Kryo.NOT_NULL.toInt())
-            write(emptySet<Int>().size)
         }
         assertArrayEquals(output.toByteArray(), serializedForm.bytes)
     }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
@@ -1,0 +1,54 @@
+package net.corda.nodeapi.internal.serialization
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.util.DefaultClassResolver
+import net.corda.core.serialization.serialize
+import net.corda.node.services.statemachine.SessionData
+import net.corda.testing.TestDependencyInjectionBase
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+class SetsSerializationTest : TestDependencyInjectionBase() {
+    private companion object {
+        val linkedSetClass = linkedSetOf<Any>().javaClass
+    }
+
+    @Test
+    fun `check set can be serialized as root of serialization graph`() {
+        assertEqualAfterRoundTripSerialization(emptySet<Int>())
+        assertEqualAfterRoundTripSerialization(setOf(1))
+        assertEqualAfterRoundTripSerialization(setOf(1, 2))
+    }
+
+    @Test
+    fun `check set can be serialized as part of SessionData`() {
+        run {
+            val sessionData = SessionData(123, setOf(1))
+            assertEqualAfterRoundTripSerialization(sessionData)
+        }
+        run {
+            val sessionData = SessionData(123, setOf(1, 2))
+            assertEqualAfterRoundTripSerialization(sessionData)
+        }
+        run {
+            val sessionData = SessionData(123, emptySet<Int>())
+            assertEqualAfterRoundTripSerialization(sessionData)
+        }
+    }
+
+    @Test
+    fun `check empty set serialises as LinkedHashSet`() {
+        val nameID = 0
+        val serializedForm = emptySet<Int>().serialize()
+        val output = ByteArrayOutputStream().apply {
+            write(KryoHeaderV0_1.bytes)
+            write(DefaultClassResolver.NAME + 2)
+            write(nameID)
+            write(linkedSetClass.name.toAscii())
+            write(Kryo.NOT_NULL.toInt())
+            write(emptySet<Int>().size)
+        }
+        assertArrayEquals(output.toByteArray(), serializedForm.bytes)
+    }
+}


### PR DESCRIPTION
We prefer to replace Kotlin's `EmptyList`, `EmptySet` and `EmptyMap` classes with standard Java classes when serialising.

Fixes #994