### PR TITLE
Set title for node explorer windows

### DIFF
--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/GuiUtilities.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/GuiUtilities.kt
@@ -19,6 +19,8 @@ import net.corda.finance.contracts.asset.Cash
 import tornadofx.*
 import java.security.PublicKey
 
+const val WINDOW_TITLE = "Corda Node Explorer"
+
 /**
  *  Helper method to reduce boiler plate code
  */

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/LoginView.kt
@@ -10,7 +10,7 @@ import org.controlsfx.dialog.ExceptionDialog
 import tornadofx.*
 import kotlin.system.exitProcess
 
-class LoginView : View() {
+class LoginView : View(WINDOW_TITLE) {
     override val root by fxml<DialogPane>()
 
     private val hostTextField by fxid<TextField>()

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/MainView.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/MainView.kt
@@ -30,7 +30,7 @@ import tornadofx.*
 /**
  * The root view embeds the [Shell] and provides support for the status bar, and modal dialogs.
  */
-class MainView : View() {
+class MainView : View(WINDOW_TITLE) {
     override val root by fxml<Parent>()
 
     // Inject components.


### PR DESCRIPTION
minor UI tweak: make the Node explorer dialog have a non empty title.

That will show more nicely in application bars and lists 