### PR TITLE
Exclude kotlin-reflect artifact from any CorDapp.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=0.16.4
+gradlePluginsVersion=0.16.5
 kotlinVersion=1.1.4
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordformation.groovy
@@ -60,6 +60,7 @@ class Cordformation implements Plugin<Project> {
         def excludes = [
                 [group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib'],
                 [group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jre8'],
+                [group: 'org.jetbrains.kotlin', name: 'kotlin-reflect'],
                 [group: 'co.paralleluniverse', name: 'quasar-core']
         ]
 


### PR DESCRIPTION
Ensure that `kotlin-reflect` is not bundled into CorDapps, because this artifact is expected to be imported from the Node.