### PR TITLE
Fix serialization of ServiceHub

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -387,7 +387,10 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         info = makeInfo(legalIdentity)
 
         val tokenizableServices = mutableListOf(attachments, network, services.vaultService, services.vaultQueryService,
-                services.keyManagementService, services.identityService, platformClock, services.schedulerService)
+                services.keyManagementService, services.identityService, platformClock, services.schedulerService,
+                services.auditService, services.monitoringService, services.networkMapCache, services.schemaService,
+                services.transactionVerifierService, services.validatedTransactions, services.contractUpgradeService,
+                services, this)
         makeAdvertisedServices(tokenizableServices)
         return tokenizableServices
     }

--- a/node/src/main/kotlin/net/corda/node/services/upgrade/ContractUpgradeServiceImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/upgrade/ContractUpgradeServiceImpl.kt
@@ -3,11 +3,15 @@ package net.corda.node.services.upgrade
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.UpgradedContract
 import net.corda.core.node.services.ContractUpgradeService
+import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.node.utilities.NODE_DATABASE_PREFIX
 import net.corda.node.utilities.PersistentMap
-import javax.persistence.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
 
-class ContractUpgradeServiceImpl : ContractUpgradeService {
+class ContractUpgradeServiceImpl : ContractUpgradeService, SingletonSerializeAsToken() {
 
     @Entity
     @Table(name = "${NODE_DATABASE_PREFIX}contract_upgrades")

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -22,6 +22,7 @@ import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.ServiceInfo
 import net.corda.core.node.services.Vault
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.toFuture
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -734,7 +735,7 @@ class TwoPartyTradeFlowTests {
     }
 
 
-    class RecordingTransactionStorage(val database: CordaPersistence, val delegate: WritableTransactionStorage) : WritableTransactionStorage {
+    class RecordingTransactionStorage(val database: CordaPersistence, val delegate: WritableTransactionStorage) : WritableTransactionStorage, SingletonSerializeAsToken() {
         override fun track(): DataFeed<List<SignedTransaction>, SignedTransaction> {
             return database.transaction {
                 delegate.track()


### PR DESCRIPTION
Discovered by accident, on another branch, that if ServiceHub got captured on the stack then it didn't serialize correctly.  Turns out it and many of the services on it were not registered for tokenisation.

