### PR TITLE
Add deprecated flows

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/AbstractStateReplacementFlow.kt
@@ -1,0 +1,220 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.isFulfilledBy
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.UntrustworthyData
+import net.corda.core.utilities.unwrap
+import java.security.PublicKey
+
+/**
+ * Abstract flow to be used for replacing one state with another, for example when changing the notary of a state.
+ * Notably this requires a one to one replacement of states, states cannot be split, merged or issued as part of these
+ * flows.
+ */
+@Deprecated("Use net.corda.core.flows.AbstractStateReplacementFlow")
+abstract class AbstractStateReplacementFlow {
+    /**
+     * The [Proposal] contains the details of proposed state modification.
+     * This is the message sent by the [Instigator] to all participants([Acceptor]) during the state replacement process.
+     *
+     * @param M the type of a class representing proposed modification by the instigator.
+     */
+    @CordaSerializable
+    data class Proposal<out M>(val stateRef: StateRef, val modification: M)
+
+    /**
+     * The assembled transaction for upgrading a contract.
+     *
+     * @param stx signed transaction to do the upgrade.
+     * @param participants the parties involved in the upgrade transaction.
+     * @param myKey key
+     */
+    data class UpgradeTx(val stx: SignedTransaction, val participants: Iterable<PublicKey>, val myKey: PublicKey)
+
+    /**
+     * The [Instigator] assembles the transaction for state replacement and sends out change proposals to all participants
+     * ([Acceptor]) of that state. If participants agree to the proposed change, they each sign the transaction.
+     * Finally, [Instigator] sends the transaction containing all participants' signatures to the notary for signature, and
+     * then back to each participant so they can record it and use the new updated state for future transactions.
+     *
+     * @param S the input contract state type
+     * @param T the output contract state type, this can be different from [S]. For example, in contract upgrade, the output state type can be different from the input state type after the upgrade process.
+     * @param M the type of a class representing proposed modification by the instigator.
+     */
+    @Deprecated("Use net.corda.core.flows.Instigator")
+    abstract class Instigator<out S : ContractState, out T : ContractState, out M>(
+            val originalState: StateAndRef<S>,
+            val modification: M,
+            override val progressTracker: ProgressTracker = tracker()) : FlowLogic<StateAndRef<T>>() {
+        companion object {
+            object SIGNING : ProgressTracker.Step("Requesting signatures from other parties")
+            object NOTARY : ProgressTracker.Step("Requesting notary signature")
+
+            fun tracker() = ProgressTracker(SIGNING, NOTARY)
+        }
+
+        @Suspendable
+        @Throws(StateReplacementException::class)
+        override fun call(): StateAndRef<T> {
+            val (stx, participantKeys, myKey) = assembleTx()
+
+            progressTracker.currentStep = SIGNING
+
+            val signatures = if (participantKeys.singleOrNull() == myKey) {
+                getNotarySignatures(stx)
+            } else {
+                collectSignatures(participantKeys - myKey, stx)
+            }
+
+            val finalTx = stx + signatures
+            serviceHub.recordTransactions(finalTx)
+
+            val newOutput = run {
+                if (stx.isNotaryChangeTransaction()) {
+                    stx.resolveNotaryChangeTransaction(serviceHub).outRef<T>(0)
+                } else {
+                    stx.tx.outRef<T>(0)
+                }
+            }
+
+            return newOutput
+        }
+
+        /**
+         * Build the upgrade transaction.
+         *
+         * @return a triple of the transaction, the public keys of all participants, and the participating public key of
+         * this node.
+         */
+        abstract protected fun assembleTx(): UpgradeTx
+
+        @Suspendable
+        private fun collectSignatures(participants: Iterable<PublicKey>, stx: SignedTransaction): List<TransactionSignature> {
+            // In identity service we record all identities we know about from network map.
+            val parties = participants.map {
+                serviceHub.identityService.partyFromKey(it) ?:
+                        throw IllegalStateException("Participant $it to state $originalState not found on the network")
+            }
+
+            val participantSignatures = parties.map { getParticipantSignature(it, stx) }
+
+            val allPartySignedTx = stx + participantSignatures
+
+            val allSignatures = participantSignatures + getNotarySignatures(allPartySignedTx)
+            parties.forEach { send(it, allSignatures) }
+
+            return allSignatures
+        }
+
+        @Suspendable
+        private fun getParticipantSignature(party: Party, stx: SignedTransaction): TransactionSignature {
+            val proposal = Proposal(originalState.ref, modification)
+            subFlow(SendTransactionFlow(party, stx))
+            return sendAndReceive<TransactionSignature>(party, proposal).unwrap {
+                check(party.owningKey.isFulfilledBy(it.by)) { "Not signed by the required participant" }
+                it.verify(stx.id)
+                it
+            }
+        }
+
+        @Suspendable
+        private fun getNotarySignatures(stx: SignedTransaction): List<TransactionSignature> {
+            progressTracker.currentStep = NOTARY
+            try {
+                return subFlow(NotaryFlow.Client(stx))
+            } catch (e: NotaryException) {
+                throw StateReplacementException("Unable to notarise state change", e)
+            }
+        }
+    }
+
+    // Type parameter should ideally be Unit but that prevents Java code from subclassing it (https://youtrack.jetbrains.com/issue/KT-15964).
+    // We use Void? instead of Unit? as that's what you'd use in Java.
+    @Deprecated("Use net.corda.core.flows.Acceptor")
+    abstract class Acceptor<in T>(val otherSide: Party,
+                                  override val progressTracker: ProgressTracker = tracker()) : FlowLogic<Void?>() {
+            constructor(otherSide: Party) : this(otherSide, tracker())
+        companion object {
+            object VERIFYING : ProgressTracker.Step("Verifying state replacement proposal")
+            object APPROVING : ProgressTracker.Step("State replacement approved")
+
+            fun tracker() = ProgressTracker(VERIFYING, APPROVING)
+        }
+
+        @Suspendable
+        @Throws(StateReplacementException::class)
+        override fun call(): Void? {
+            progressTracker.currentStep = VERIFYING
+            // We expect stx to have insufficient signatures here
+            val stx = subFlow(ReceiveTransactionFlow(otherSide, checkSufficientSignatures = false))
+            checkMySignatureRequired(stx)
+            val maybeProposal: UntrustworthyData<Proposal<T>> = receive(otherSide)
+            maybeProposal.unwrap {
+                verifyProposal(stx, it)
+            }
+            approve(stx)
+            return null
+        }
+
+        @Suspendable
+        private fun approve(stx: SignedTransaction) {
+            progressTracker.currentStep = APPROVING
+
+            val mySignature = sign(stx)
+            val swapSignatures = sendAndReceive<List<TransactionSignature>>(otherSide, mySignature)
+
+            // TODO: This step should not be necessary, as signatures are re-checked in verifyRequiredSignatures.
+            val allSignatures = swapSignatures.unwrap { signatures ->
+                signatures.forEach { it.verify(stx.id) }
+                signatures
+            }
+
+            val finalTx = stx + allSignatures
+            if (finalTx.isNotaryChangeTransaction()) {
+                finalTx.resolveNotaryChangeTransaction(serviceHub).verifyRequiredSignatures()
+            } else {
+                finalTx.verifyRequiredSignatures()
+            }
+            serviceHub.recordTransactions(finalTx)
+        }
+
+        /**
+         * Check the state change proposal and the signed transaction to confirm that it's acceptable to this node.
+         * Rules for verification depend on the change proposed, and may further depend on the node itself (for example configuration).
+         * The proposal is returned if acceptable, otherwise a [StateReplacementException] is thrown.
+         */
+        @Throws(StateReplacementException::class)
+        abstract protected fun verifyProposal(stx: SignedTransaction, proposal: Proposal<T>)
+
+        private fun checkMySignatureRequired(stx: SignedTransaction) {
+            // TODO: use keys from the keyManagementService instead
+            // TODO Check the set of multiple identities?
+            val myKey = ourIdentity.owningKey
+
+            val requiredKeys = if (stx.isNotaryChangeTransaction()) {
+                stx.resolveNotaryChangeTransaction(serviceHub).requiredSigningKeys
+            } else {
+                stx.tx.requiredSigningKeys
+            }
+
+            require(myKey in requiredKeys) { "Party is not a participant for any of the input states of transaction ${stx.id}" }
+        }
+
+        private fun sign(stx: SignedTransaction): TransactionSignature {
+            return serviceHub.createSignature(stx)
+        }
+    }
+}
+
+open class StateReplacementException @JvmOverloads constructor(message: String? = null, cause: Throwable? = null)
+    : FlowException(message, cause)

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/BroadcastTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/BroadcastTransactionFlow.kt
@@ -1,0 +1,31 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.NonEmptySet
+
+/**
+ * Notify the specified parties about a transaction. The remote peers will download this transaction and its
+ * dependency graph, verifying them all. The flow returns when all peers have acknowledged the transactions
+ * as valid. Normally you wouldn't use this directly, it would be called via [FinalityFlow].
+ *
+ * @param notarisedTransaction transaction which has been notarised (if needed) and is ready to notify nodes about.
+ * @param participants a list of participants involved in the transaction.
+ * @return a list of participants who were successfully notified of the transaction.
+ */
+@InitiatingFlow
+@Deprecated("Use net.corda.core.flows.BroadcastTransactionFlow instead")
+class BroadcastTransactionFlow(val notarisedTransaction: SignedTransaction,
+                               val participants: NonEmptySet<Party>) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        // TODO: Messaging layer should handle this broadcast for us
+        participants.filter { !serviceHub.myInfo.isLegalIdentity(it) }.forEach { participant ->
+            // SendTransactionFlow allows otherParty to access our data to resolve the transaction.
+            subFlow(SendTransactionFlow(participant, notarisedTransaction))
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/CollectSignaturesFlow.kt
@@ -1,0 +1,278 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.isFulfilledBy
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.utilities.toBase58String
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.identity.Party
+import net.corda.core.node.ServiceHub
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.unwrap
+import java.security.PublicKey
+
+/**
+ * The [CollectSignaturesFlow] is used to automate the collection of counter-party signatures for a given transaction.
+ *
+ * You would typically use this flow after you have built a transaction with the TransactionBuilder and signed it with
+ * your key pair. If there are additional signatures to collect then they can be collected using this flow. Signatures
+ * are collected based upon the [WireTransaction.requiredSigningKeys] property which contains the union of all the PublicKeys
+ * listed in the transaction's commands as well as a notary's public key, if required. This flow returns a
+ * [SignedTransaction] which can then be passed to the [FinalityFlow] for notarisation. The other side of this flow is
+ * the [SignTransactionFlow].
+ *
+ * **WARNING**: This flow ONLY works with [ServiceHub.legalIdentityKey]s and WILL break if used with randomly generated
+ * keys by the [ServiceHub.keyManagementService].
+ *
+ * Usage:
+ *
+ * - Call the [CollectSignaturesFlow] flow as a [subFlow] and pass it a [SignedTransaction] which has at least been
+ *   signed by the transaction creator (and possibly an oracle, if required)
+ * - The flow expects that the calling node has signed the provided transaction, if not the flow will fail
+ * - The flow will also fail if:
+ *   1. The provided transaction is invalid
+ *   2. Any of the required signing parties cannot be found in the [ServiceHub.networkMapCache] of the initiator
+ *   3. If the wrong key has been used by a counterparty to sign the transaction
+ *   4. The counterparty rejects the provided transaction
+ * - The flow will return a [SignedTransaction] with all the counter-party signatures (but not the notary's!)
+ * - If the provided transaction has already been signed by all counter-parties then this flow simply returns the
+ *   provided transaction without contacting any counter-parties
+ * - Call the [FinalityFlow] with the return value of this flow
+ *
+ * Example - issuing a multi-lateral agreement which requires N signatures:
+ *
+ *     val builder = TransactionBuilder(notaryRef)
+ *     val issueCommand = Command(Agreement.Commands.Issue(), state.participants)
+ *
+ *     builder.withItems(state, issueCommand)
+ *     builder.toWireTransaction().toLedgerTransaction(serviceHub).verify()
+ *
+ *     // Transaction creator signs transaction.
+ *     val ptx = serviceHub.signInitialTransaction(builder)
+ *
+ *     // Call to CollectSignaturesFlow.
+ *     // The returned signed transaction will have all signatures appended apart from the notary's.
+ *     val stx = subFlow(CollectSignaturesFlow(ptx))
+ *
+ * @param partiallySignedTx Transaction to collect the remaining signatures for
+ * @param myOptionalKeys set of keys in the transaction which are owned by this node. This includes keys used on commands, not
+ * just in the states. If null, the default well known identity of the node is used.
+ */
+// TODO: AbstractStateReplacementFlow needs updating to use this flow.
+@Deprecated("Use net.corda.core.flows.CollectSignaturesFlow instead")
+class CollectSignaturesFlow @JvmOverloads constructor (val partiallySignedTx: SignedTransaction,
+                                                       val myOptionalKeys: Iterable<PublicKey>?,
+                                                       override val progressTracker: ProgressTracker = tracker()) : FlowLogic<SignedTransaction>() {
+    @JvmOverloads constructor(partiallySignedTx: SignedTransaction, progressTracker: ProgressTracker = tracker()) : this(partiallySignedTx, null, progressTracker)
+    companion object {
+        object COLLECTING : ProgressTracker.Step("Collecting signatures from counter-parties.")
+        object VERIFYING : ProgressTracker.Step("Verifying collected signatures.")
+
+        fun tracker() = ProgressTracker(COLLECTING, VERIFYING)
+
+        // TODO: Make the progress tracker adapt to the number of counter-parties to collect from.
+    }
+
+    @Suspendable override fun call(): SignedTransaction {
+        // Check the signatures which have already been provided and that the transaction is valid.
+        // Usually just the Initiator and possibly an oracle would have signed at this point.
+        val myKeys: Iterable<PublicKey> = myOptionalKeys ?: listOf(ourIdentity.owningKey)
+        val signed = partiallySignedTx.sigs.map { it.by }
+        val notSigned = partiallySignedTx.tx.requiredSigningKeys - signed
+
+        // One of the signatures collected so far MUST be from the initiator of this flow.
+        require(partiallySignedTx.sigs.any { it.by in myKeys }) {
+            "The Initiator of CollectSignaturesFlow must have signed the transaction."
+        }
+
+        // The signatures must be valid and the transaction must be valid.
+        partiallySignedTx.verifySignaturesExcept(*notSigned.toTypedArray())
+        partiallySignedTx.tx.toLedgerTransaction(serviceHub).verify()
+
+        // Determine who still needs to sign.
+        progressTracker.currentStep = COLLECTING
+        val notaryKey = partiallySignedTx.tx.notary?.owningKey
+        // If present, we need to exclude the notary's PublicKey as the notary signature is collected separately with
+        // the FinalityFlow.
+        val unsigned = if (notaryKey != null) notSigned - notaryKey else notSigned
+
+        // If the unsigned counter-parties list is empty then we don't need to collect any more signatures here.
+        if (unsigned.isEmpty()) return partiallySignedTx
+
+        // Collect signatures from all counter-parties and append them to the partially signed transaction.
+        val counterpartySignatures = keysToParties(unsigned).map { collectSignature(it.first, it.second) }
+        val stx = partiallySignedTx + counterpartySignatures
+
+        // Verify all but the notary's signature if the transaction requires a notary, otherwise verify all signatures.
+        progressTracker.currentStep = VERIFYING
+        if (notaryKey != null) stx.verifySignaturesExcept(notaryKey) else stx.verifyRequiredSignatures()
+
+        return stx
+    }
+
+    /**
+     * Lookup the [Party] object for each [PublicKey] using the [ServiceHub.identityService].
+     *
+     * @return a pair of the well known identity to contact for a signature, and the public key that party should sign
+     * with (this may belong to a confidential identity).
+     */
+    @Suspendable private fun keysToParties(keys: Collection<PublicKey>): List<Pair<Party, PublicKey>> = keys.map {
+        val party = serviceHub.identityService.partyFromAnonymous(AnonymousParty(it))
+                ?: throw IllegalStateException("Party ${it.toBase58String()} not found on the network.")
+        Pair(party, it)
+    }
+
+    // DOCSTART 1
+    /**
+     * Get and check the required signature.
+     *
+     * @param counterparty the party to request a signature from.
+     * @param signingKey the key the party should use to sign the transaction.
+     */
+    @Suspendable private fun collectSignature(counterparty: Party, signingKey: PublicKey): TransactionSignature {
+        // SendTransactionFlow allows counterparty to access our data to resolve the transaction.
+        subFlow(SendTransactionFlow(counterparty, partiallySignedTx))
+        // Send the key we expect the counterparty to sign with - this is important where they may have several
+        // keys to sign with, as it makes it faster for them to identify the key to sign with, and more straight forward
+        // for us to check we have the expected signature returned.
+        send(counterparty, signingKey)
+        return receive<TransactionSignature>(counterparty).unwrap {
+            require(signingKey.isFulfilledBy(it.by)) { "Not signed by the required signing key." }
+            it
+        }
+    }
+    // DOCEND 1
+}
+
+/**
+ * The [SignTransactionFlow] should be called in response to the [CollectSignaturesFlow]. It automates the signing of
+ * a transaction providing the transaction:
+ *
+ * 1. Should actually be signed by the [Party] invoking this flow
+ * 2. Is valid as per the contracts referenced in the transaction
+ * 3. Has been, at least, signed by the counter-party which created it
+ * 4. Conforms to custom checking provided in the [checkTransaction] method of the [SignTransactionFlow]
+ *
+ * Usage:
+ *
+ * - Subclass [SignTransactionFlow] - this can be done inside an existing flow (as shown below)
+ * - Override the [checkTransaction] method to add some custom verification logic
+ * - Call the flow via [FlowLogic.subFlow]
+ * - The flow returns the fully signed transaction once it has been committed to the ledger
+ *
+ * Example - checking and signing a transaction involving a [net.corda.core.contracts.DummyContract], see
+ * CollectSignaturesFlowTests.kt for further examples:
+ *
+ *     class Responder(val otherParty: Party): FlowLogic<SignedTransaction>() {
+ *          @Suspendable override fun call(): SignedTransaction {
+ *              // [SignTransactionFlow] sub-classed as a singleton object.
+ *              val flow = object : SignTransactionFlow(otherParty) {
+ *                  @Suspendable override fun checkTransaction(stx: SignedTransaction) = requireThat {
+ *                      val tx = stx.tx
+ *                      val magicNumberState = tx.outputs.single().data as DummyContract.MultiOwnerState
+ *                      "Must be 1337 or greater" using (magicNumberState.magicNumber >= 1337)
+ *                  }
+ *              }
+ *
+ *              // Invoke the subFlow, in response to the counterparty calling [CollectSignaturesFlow].
+ *              val stx = subFlow(flow)
+ *
+ *              return waitForLedgerCommit(stx.id)
+ *          }
+ *      }
+ *
+ * @param otherParty The counter-party which is providing you a transaction to sign.
+ */
+@Deprecated("Use net.corda.core.flows.SignTransactionFlow")
+abstract class SignTransactionFlow(val otherParty: Party,
+                                   override val progressTracker: ProgressTracker = tracker()) : FlowLogic<SignedTransaction>() {
+
+    companion object {
+        object RECEIVING : ProgressTracker.Step("Receiving transaction proposal for signing.")
+        object VERIFYING : ProgressTracker.Step("Verifying transaction proposal.")
+        object SIGNING : ProgressTracker.Step("Signing transaction proposal.")
+
+        fun tracker() = ProgressTracker(RECEIVING, VERIFYING, SIGNING)
+    }
+
+    @Suspendable override fun call(): SignedTransaction {
+        progressTracker.currentStep = RECEIVING
+        // Receive transaction and resolve dependencies, check sufficient signatures is disabled as we don't have all signatures.
+        val stx = subFlow(ReceiveTransactionFlow(otherParty, checkSufficientSignatures = false))
+        // Receive the signing key that the party requesting the signature expects us to sign with. Having this provided
+        // means we only have to check we own that one key, rather than matching all keys in the transaction against all
+        // keys we own.
+        val signingKey = receive<PublicKey>(otherParty).unwrap {
+            // TODO: We should have a faster way of verifying we own a single key
+            serviceHub.keyManagementService.filterMyKeys(listOf(it)).single()
+        }
+        progressTracker.currentStep = VERIFYING
+        // Check that the Responder actually needs to sign.
+        checkMySignatureRequired(stx, signingKey)
+        // Check the signatures which have already been provided. Usually the Initiators and possibly an Oracle's.
+        checkSignatures(stx)
+        stx.tx.toLedgerTransaction(serviceHub).verify()
+        // Perform some custom verification over the transaction.
+        try {
+            checkTransaction(stx)
+        } catch(e: Exception) {
+            if (e is IllegalStateException || e is IllegalArgumentException || e is AssertionError)
+                throw FlowException(e)
+            else
+                throw e
+        }
+        // Sign and send back our signature to the Initiator.
+        progressTracker.currentStep = SIGNING
+        val mySignature = serviceHub.createSignature(stx, signingKey)
+        send(otherParty, mySignature)
+
+        // Return the fully signed transaction once it has been committed.
+        return waitForLedgerCommit(stx.id)
+    }
+
+    @Suspendable private fun checkSignatures(stx: SignedTransaction) {
+        val signingIdentities = stx.sigs.map(TransactionSignature::by).mapNotNull(serviceHub.identityService::partyFromKey)
+        val signingWellKnownIdentities = signingIdentities.mapNotNull(serviceHub.identityService::partyFromAnonymous)
+        require(otherParty in signingWellKnownIdentities) {
+            "The Initiator of CollectSignaturesFlow must have signed the transaction. Found ${signingWellKnownIdentities}, expected ${otherParty}"
+        }
+        val signed = stx.sigs.map { it.by }
+        val allSigners = stx.tx.requiredSigningKeys
+        val notSigned = allSigners - signed
+        stx.verifySignaturesExcept(*notSigned.toTypedArray())
+    }
+
+    /**
+     * The [checkTransaction] method allows the caller of this flow to provide some additional checks over the proposed
+     * transaction received from the counter-party. For example:
+     *
+     * - Ensuring that the transaction you are receiving is the transaction you *EXPECT* to receive. I.e. is has the
+     *   expected type and number of inputs and outputs
+     * - Checking that the properties of the outputs are as you would expect. Linking into any reference data sources
+     *   might be appropriate here
+     * - Checking that the transaction is not incorrectly spending (perhaps maliciously) one of your asset states, as
+     *   potentially the transaction creator has access to some of your state references
+     *
+     * **WARNING**: If appropriate checks, such as the ones listed above, are not defined then it is likely that your
+     * node will sign any transaction if it conforms to the contract code in the transaction's referenced contracts.
+     *
+     * [IllegalArgumentException], [IllegalStateException] and [AssertionError] will be caught and rethrown as flow
+     * exceptions i.e. the other side will be given information about what exact check failed.
+     *
+     * @param stx a partially signed transaction received from your counter-party.
+     * @throws FlowException if the proposed transaction fails the checks.
+     */
+    @Suspendable
+    @Throws(FlowException::class)
+    abstract protected fun checkTransaction(stx: SignedTransaction)
+
+    @Suspendable private fun checkMySignatureRequired(stx: SignedTransaction, signingKey: PublicKey) {
+        require(signingKey in stx.tx.requiredSigningKeys) {
+            "Party is not a participant for any of the input states of transaction ${stx.id}"
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/ContractUpgradeFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/ContractUpgradeFlow.kt
@@ -1,0 +1,152 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.*
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import java.security.PublicKey
+
+/**
+ * A flow to be used for authorising and upgrading state objects of an old contract to a new contract.
+ *
+ * This assembles the transaction for contract upgrade and sends out change proposals to all participants
+ * of that state. If participants agree to the proposed change, they each sign the transaction.
+ * Finally, the transaction containing all signatures is sent back to each participant so they can record it and
+ * use the new updated state for future transactions.
+ */
+@Deprecated("Use net.corda.core.flows.ContractUpgradeFlow")
+object ContractUpgradeFlow {
+
+    /**
+     * Authorise a contract state upgrade.
+     * This will store the upgrade authorisation in persistent store, and will be queried by [ContractUpgradeFlow.Acceptor] during contract upgrade process.
+     * Invoking this flow indicates the node is willing to upgrade the [StateAndRef] using the [UpgradedContract] class.
+     * This method will NOT initiate the upgrade process. To start the upgrade process, see [Initiator].
+     */
+    @StartableByRPC
+    @Deprecated("Use net.corda.core.flows.Authorise")
+    class Authorise(
+            val stateAndRef: StateAndRef<*>,
+            private val upgradedContractClass: Class<out UpgradedContract<*, *>>
+        ) : FlowLogic<Void?>() {
+        @Suspendable
+        override fun call(): Void? {
+            val upgrade = upgradedContractClass.newInstance()
+            if (upgrade.legacyContract != stateAndRef.state.contract) {
+                throw FlowException("The contract state cannot be upgraded using provided UpgradedContract.")
+            }
+            serviceHub.contractUpgradeService.storeAuthorisedContractUpgrade(stateAndRef.ref, upgradedContractClass)
+            return null
+        }
+
+    }
+
+    /**
+     * Deauthorise a contract state upgrade.
+     * This will remove the upgrade authorisation from persistent store (and prevent any further upgrade)
+     */
+    @StartableByRPC
+    @Deprecated("Use net.corda.core.flows.Deauthorise")
+    class Deauthorise(
+            val stateRef: StateRef
+    ) : FlowLogic<Void?>() {
+        @Suspendable
+        override fun call(): Void? {
+            serviceHub.contractUpgradeService.removeAuthorisedContractUpgrade(stateRef)
+            return null
+        }
+    }
+
+    @InitiatingFlow
+    @StartableByRPC
+    @Deprecated("Use net.corda.core.flows.Initiator")
+    class Initiator<OldState : ContractState, out NewState : ContractState>(
+            originalState: StateAndRef<OldState>,
+            newContractClass: Class<out UpgradedContract<OldState, NewState>>
+    ) : AbstractStateReplacementFlow.Instigator<OldState, NewState, Class<out UpgradedContract<OldState, NewState>>>(originalState, newContractClass) {
+
+        companion object {
+            fun <OldState : ContractState, NewState : ContractState> assembleBareTx(
+                    stateRef: StateAndRef<OldState>,
+                    upgradedContractClass: Class<out UpgradedContract<OldState, NewState>>,
+                    privacySalt: PrivacySalt
+            ): TransactionBuilder {
+                val contractUpgrade = upgradedContractClass.newInstance()
+                return TransactionBuilder(stateRef.state.notary)
+                        .withItems(
+                                stateRef,
+                                StateAndContract(contractUpgrade.upgrade(stateRef.state.data), upgradedContractClass.name),
+                                Command(UpgradeCommand(upgradedContractClass.name), stateRef.state.data.participants.map { it.owningKey }),
+                                privacySalt
+                        )
+            }
+        }
+
+        @Suspendable
+        override fun assembleTx(): AbstractStateReplacementFlow.UpgradeTx {
+            val baseTx = assembleBareTx(originalState, modification, PrivacySalt())
+            val participantKeys = originalState.state.data.participants.map { it.owningKey }.toSet()
+            // TODO: We need a much faster way of finding our key in the transaction
+            val myKey = serviceHub.keyManagementService.filterMyKeys(participantKeys).single()
+            val stx = serviceHub.signInitialTransaction(baseTx, myKey)
+            return AbstractStateReplacementFlow.UpgradeTx(stx, participantKeys, myKey)
+        }
+    }
+
+    @StartableByRPC
+    @InitiatedBy(Initiator::class)
+    @Deprecated("Use net.corda.core.flows.Acceptor")
+    class Acceptor(otherSide: Party) : AbstractStateReplacementFlow.Acceptor<Class<out UpgradedContract<ContractState, *>>>(otherSide) {
+
+        companion object {
+            @JvmStatic
+            fun verify(tx: LedgerTransaction) {
+                // Contract Upgrade transaction should have 1 input, 1 output and 1 command.
+                verify(tx.inputs.single().state,
+                        tx.outputs.single(),
+                        tx.commandsOfType<UpgradeCommand>().single())
+            }
+
+            @JvmStatic
+            fun verify(input: TransactionState<ContractState>, output: TransactionState<ContractState>, commandData: Command<UpgradeCommand>) {
+                val command = commandData.value
+                val participantKeys: Set<PublicKey> = input.data.participants.map { it.owningKey }.toSet()
+                val keysThatSigned: Set<PublicKey> = commandData.signers.toSet()
+                @Suppress("UNCHECKED_CAST")
+                val upgradedContract = javaClass.classLoader.loadClass(command.upgradedContractClass).newInstance() as UpgradedContract<ContractState, *>
+                requireThat {
+                    "The signing keys include all participant keys" using keysThatSigned.containsAll(participantKeys)
+                    "Inputs state reference the legacy contract" using (input.contract == upgradedContract.legacyContract)
+                    "Outputs state reference the upgraded contract" using (output.contract == command.upgradedContractClass)
+                    "Output state must be an upgraded version of the input state" using (output.data == upgradedContract.upgrade(input.data))
+                }
+            }
+        }
+
+        @Suspendable
+        @Throws(StateReplacementException::class)
+        override fun verifyProposal(stx: SignedTransaction, proposal: AbstractStateReplacementFlow.Proposal<Class<out UpgradedContract<ContractState, *>>>) {
+            // Retrieve signed transaction from our side, we will apply the upgrade logic to the transaction on our side, and
+            // verify outputs matches the proposed upgrade.
+            val ourSTX = serviceHub.validatedTransactions.getTransaction(proposal.stateRef.txhash)
+            requireNotNull(ourSTX) { "We don't have a copy of the referenced state" }
+            val oldStateAndRef = ourSTX!!.tx.outRef<ContractState>(proposal.stateRef.index)
+            val authorisedUpgrade = serviceHub.contractUpgradeService.getAuthorisedContractUpgrade(oldStateAndRef.ref) ?:
+                    throw IllegalStateException("Contract state upgrade is unauthorised. State hash : ${oldStateAndRef.ref}")
+            val proposedTx = stx.tx
+            val expectedTx = Initiator.assembleBareTx(oldStateAndRef, proposal.modification, proposedTx.privacySalt).toWireTransaction()
+            requireThat {
+                "The instigator is one of the participants" using (otherSide in oldStateAndRef.state.data.participants)
+                "The proposed upgrade ${proposal.modification.javaClass} is a trusted upgrade path" using (proposal.modification.name == authorisedUpgrade)
+                "The proposed tx matches the expected tx for this upgrade" using (proposedTx == expectedTx)
+            }
+            verify(
+                    oldStateAndRef.state,
+                    expectedTx.outRef<ContractState>(0).state,
+                    expectedTx.toLedgerTransaction(serviceHub).commandsOfType<UpgradeCommand>().single())
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/FinalityFlow.kt
@@ -1,0 +1,160 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
+import net.corda.core.crypto.isFulfilledBy
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import net.corda.core.internal.ResolveTransactionsFlow
+import net.corda.core.node.ServiceHub
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.NonEmptySet
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.toNonEmptySet
+
+/**
+ * Verifies the given transactions, then sends them to the named notary. If the notary agrees that the transactions
+ * are acceptable then they are from that point onwards committed to the ledger, and will be written through to the
+ * vault. Additionally they will be distributed to the parties reflected in the participants list of the states.
+ *
+ * The transactions will be topologically sorted before commitment to ensure that dependencies are committed before
+ * dependers, so you don't need to do this yourself.
+ *
+ * The transactions are expected to have already been resolved: if their dependencies are not available in local
+ * storage or within the given set, verification will fail. They must have signatures from all necessary parties
+ * other than the notary.
+ *
+ * If specified, the extra recipients are sent all the given transactions. The base set of parties to inform of each
+ * transaction are calculated on a per transaction basis from the contract-given set of participants.
+ *
+ * The flow returns the same transactions, in the same order, with the additional signatures.
+ *
+ * @param transactions What to commit.
+ * @param extraRecipients A list of additional participants to inform of the transaction.
+ */
+@Deprecated("Use net.corda.core.flows.FinalityFlow")
+open class FinalityFlow(val transactions: Iterable<SignedTransaction>,
+                        private val extraRecipients: Set<Party>,
+                        override val progressTracker: ProgressTracker) : FlowLogic<List<SignedTransaction>>() {
+    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(listOf(transaction), extraParticipants, tracker())
+    constructor(transaction: SignedTransaction) : this(listOf(transaction), emptySet(), tracker())
+    constructor(transaction: SignedTransaction, progressTracker: ProgressTracker) : this(listOf(transaction), emptySet(), progressTracker)
+
+    companion object {
+        object NOTARISING : ProgressTracker.Step("Requesting signature by notary service") {
+            override fun childProgressTracker() = NotaryFlow.Client.tracker()
+        }
+
+        object BROADCASTING : ProgressTracker.Step("Broadcasting transaction to participants")
+
+        // TODO: Make all tracker() methods @JvmStatic
+        fun tracker() = ProgressTracker(NOTARISING, BROADCASTING)
+    }
+
+    @Suspendable
+    @Throws(NotaryException::class)
+    override fun call(): List<SignedTransaction> {
+        // Note: this method is carefully broken up to minimize the amount of data reachable from the stack at
+        // the point where subFlow is invoked, as that minimizes the checkpointing work to be done.
+        //
+        // Lookup the resolved transactions and use them to map each signed transaction to the list of participants.
+        // Then send to the notary if needed, record locally and distribute.
+        progressTracker.currentStep = NOTARISING
+        val notarisedTxns: List<Pair<SignedTransaction, Set<Party>>> = resolveDependenciesOf(transactions)
+                .map { (stx, ltx) -> Pair(notariseAndRecord(stx), lookupParties(ltx)) }
+
+        // Each transaction has its own set of recipients, but extra recipients get them all.
+        progressTracker.currentStep = BROADCASTING
+        for ((stx, parties) in notarisedTxns) {
+            val participants = (parties + extraRecipients).filter { !serviceHub.myInfo.isLegalIdentity(it) }.toSet()
+            if (participants.isNotEmpty()) {
+                broadcastTransaction(stx, participants.toNonEmptySet())
+            }
+        }
+        return notarisedTxns.map { it.first }
+    }
+
+    /**
+     * Broadcast a transaction to the participants. By default calls [BroadcastTransactionFlow], however can be
+     * overridden for more complex transaction delivery protocols (for example where not all parties know each other).
+     *
+     * @param participants the participants to send the transaction to. This is expected to include extra participants
+     * and exclude the local node.
+     */
+    @Suspendable
+    open protected fun broadcastTransaction(stx: SignedTransaction, participants: NonEmptySet<Party>) {
+        subFlow(BroadcastTransactionFlow(stx, participants))
+    }
+
+    @Suspendable
+    private fun notariseAndRecord(stx: SignedTransaction): SignedTransaction {
+        val notarised = if (needsNotarySignature(stx)) {
+            val notarySignatures = subFlow(NotaryFlow.Client(stx))
+            stx + notarySignatures
+        } else {
+            stx
+        }
+        serviceHub.recordTransactions(notarised)
+        return notarised
+    }
+
+    private fun needsNotarySignature(stx: SignedTransaction): Boolean {
+        val wtx = stx.tx
+        val needsNotarisation = wtx.inputs.isNotEmpty() || wtx.timeWindow != null
+        return needsNotarisation && hasNoNotarySignature(stx)
+    }
+
+    private fun hasNoNotarySignature(stx: SignedTransaction): Boolean {
+        val notaryKey = stx.tx.notary?.owningKey
+        val signers = stx.sigs.map { it.by }.toSet()
+        return !(notaryKey?.isFulfilledBy(signers) ?: false)
+    }
+
+    /**
+     * Resolve the parties involved in a transaction.
+     *
+     * The default implementation throws an exception if an unknown party is encountered.
+     */
+    open protected fun lookupParties(ltx: LedgerTransaction): Set<Party> {
+        // Calculate who is meant to see the results based on the participants involved.
+        return extractParticipants(ltx).map {
+            serviceHub.identityService.partyFromAnonymous(it)
+                    ?: throw IllegalArgumentException("Could not resolve well known identity of participant $it")
+        }.toSet()
+    }
+
+    /**
+     * Helper function to extract all participants from a ledger transaction. Intended to help implement [lookupParties]
+     * overriding functions.
+     */
+    protected fun extractParticipants(ltx: LedgerTransaction): List<AbstractParty> {
+        return ltx.outputStates.flatMap { it.participants } + ltx.inputStates.flatMap { it.participants }
+    }
+
+    private fun resolveDependenciesOf(signedTransactions: Iterable<SignedTransaction>): List<Pair<SignedTransaction, LedgerTransaction>> {
+        // Make sure the dependencies come before the dependers.
+        val sorted = ResolveTransactionsFlow.topologicalSort(signedTransactions.toList())
+        // Build a ServiceHub that consults the argument list as well as what's in local tx storage so uncommitted
+        // transactions can depend on each other.
+        val augmentedLookup = object : ServiceHub by serviceHub {
+            val hashToTx = sorted.associateBy { it.id }
+            override fun loadState(stateRef: StateRef): TransactionState<*> {
+                val provided: TransactionState<ContractState>? = hashToTx[stateRef.txhash]?.let { it.tx.outputs[stateRef.index] }
+                return provided ?: super.loadState(stateRef)
+            }
+        }
+        // Load and verify each transaction.
+        return sorted.map { stx ->
+            val notary = stx.tx.notary
+            // The notary signature(s) are allowed to be missing but no others.
+            if (notary != null) stx.verifySignaturesExcept(notary.owningKey) else stx.verifyRequiredSignatures()
+            val ltx = stx.toLedgerTransaction(augmentedLookup, false)
+            ltx.verify()
+            stx to ltx
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/IdentitySyncFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/IdentitySyncFlow.kt
@@ -1,0 +1,100 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.ContractState
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.unwrap
+
+@Deprecated("Use net.corda.core.flows.IdentitySyncFlow")
+object IdentitySyncFlow {
+    /**
+     * Flow for ensuring that one or more counterparties to a transaction have the full certificate paths of confidential
+     * identities used in the transaction. This is intended for use as a subflow of another flow, typically between
+     * transaction assembly and signing. An example of where this is useful is where a recipient of a [Cash] state wants
+     * to know that it is being paid by the correct party, and the owner of the state is a confidential identity of that
+     * party. This flow would send a copy of the confidential identity path to the recipient, enabling them to verify that
+     * identity.
+     *
+     * @return a mapping of well known identities to the confidential identities used in the transaction.
+     */
+    // TODO: Can this be triggered automatically from [SendTransactionFlow]
+    @Deprecated("Use net.corda.core.flows.Send")
+    class Send(val otherSides: Set<Party>,
+               val tx: WireTransaction,
+               override val progressTracker: ProgressTracker) : FlowLogic<Unit>() {
+        constructor(otherSide: Party, tx: WireTransaction) : this(setOf(otherSide), tx, tracker())
+
+        companion object {
+            object SYNCING_IDENTITIES : ProgressTracker.Step("Syncing identities")
+
+            fun tracker() = ProgressTracker(SYNCING_IDENTITIES)
+        }
+
+        @Suspendable
+        override fun call() {
+            progressTracker.currentStep = SYNCING_IDENTITIES
+            val states: List<ContractState> = (tx.inputs.map { serviceHub.loadState(it) }.requireNoNulls().map { it.data } + tx.outputs.map { it.data })
+            val identities: Set<AbstractParty> = states.flatMap { it.participants }.toSet()
+            // Filter participants down to the set of those not in the network map (are not well known)
+            val confidentialIdentities = identities
+                    .filter { serviceHub.networkMapCache.getNodesByLegalIdentityKey(it.owningKey).isEmpty() }
+                    .toList()
+            val identityCertificates: Map<AbstractParty, PartyAndCertificate?> = identities
+                    .map { Pair(it, serviceHub.identityService.certificateFromKey(it.owningKey)) }.toMap()
+
+            otherSides.forEach { otherSide ->
+                val requestedIdentities: List<AbstractParty> = sendAndReceive<List<AbstractParty>>(otherSide, confidentialIdentities).unwrap { req ->
+                    require(req.all { it in identityCertificates.keys }) { "${otherSide} requested a confidential identity not part of transaction: ${tx.id}" }
+                    req
+                }
+                val sendIdentities: List<PartyAndCertificate?> = requestedIdentities.map {
+                    val identityCertificate = identityCertificates[it]
+                    if (identityCertificate != null)
+                        identityCertificate
+                    else
+                        throw IllegalStateException("Counterparty requested a confidential identity for which we do not have the certificate path: ${tx.id}")
+                }
+                send(otherSide, sendIdentities)
+            }
+        }
+
+    }
+
+    /**
+     * Handle an offer to provide proof of identity (in the form of certificate paths) for confidential identities which
+     * we do not yet know about.
+     */
+    @Deprecated("Use net.corda.core.flows.Receive")
+    class Receive(val otherSide: Party) : FlowLogic<Unit>() {
+        companion object {
+            object RECEIVING_IDENTITIES : ProgressTracker.Step("Receiving confidential identities")
+            object RECEIVING_CERTIFICATES : ProgressTracker.Step("Receiving certificates for unknown identities")
+        }
+
+        override val progressTracker: ProgressTracker = ProgressTracker(RECEIVING_IDENTITIES, RECEIVING_CERTIFICATES)
+
+        @Suspendable
+        override fun call(): Unit {
+            progressTracker.currentStep = RECEIVING_IDENTITIES
+            val allIdentities = receive<List<AbstractParty>>(otherSide).unwrap { it }
+            val unknownIdentities = allIdentities.filter { serviceHub.identityService.partyFromAnonymous(it) == null }
+            progressTracker.currentStep = RECEIVING_CERTIFICATES
+            val missingIdentities = sendAndReceive<List<PartyAndCertificate>>(otherSide, unknownIdentities)
+
+            // Batch verify the identities we've received, so we know they're all correct before we start storing them in
+            // the identity service
+            missingIdentities.unwrap { identities ->
+                identities.forEach { it.verify(serviceHub.identityService.trustAnchor) }
+                identities
+            }.forEach { identity ->
+                // Store the received confidential identities in the identity service so we have a record of which well known identity they map to.
+                serviceHub.identityService.verifyAndRegisterIdentity(identity)
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/ManualFinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/ManualFinalityFlow.kt
@@ -1,0 +1,21 @@
+package net.corda.core.flows.deprecated
+
+import net.corda.core.identity.Party
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ProgressTracker
+
+/**
+ * Alternative finality flow which only does not attempt to take participants from the transaction, but instead all
+ * participating parties must be provided manually.
+ *
+ * @param transactions What to commit.
+ * @param recipients List of participants to inform of the transaction.
+ */
+@Deprecated("Use net.corda.core.flows.ManualFinalityFlow")
+class ManualFinalityFlow(transactions: Iterable<SignedTransaction>,
+                         recipients: Set<Party>,
+                         progressTracker: ProgressTracker) : FinalityFlow(transactions, recipients, progressTracker) {
+    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(listOf(transaction), extraParticipants, tracker())
+    override fun lookupParties(ltx: LedgerTransaction): Set<Party> = emptySet()
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/NotaryChangeFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/NotaryChangeFlow.kt
@@ -1,0 +1,61 @@
+package net.corda.core.flows.deprecated
+
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SignableData
+import net.corda.core.crypto.SignatureMetadata
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.identity.Party
+import net.corda.core.transactions.NotaryChangeWireTransaction
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ProgressTracker
+
+/**
+ * A flow to be used for changing a state's Notary. This is required since all input states to a transaction
+ * must point to the same notary.
+ *
+ * This assembles the transaction for notary replacement and sends out change proposals to all participants
+ * of that state. If participants agree to the proposed change, they each sign the transaction.
+ * Finally, the transaction containing all signatures is sent back to each participant so they can record it and
+ * use the new updated state for future transactions.
+ */
+@InitiatingFlow
+@Deprecated("Use net.corda.core.flows.NotaryChangeFlow")
+class NotaryChangeFlow<out T : ContractState>(
+        originalState: StateAndRef<T>,
+        newNotary: Party,
+        progressTracker: ProgressTracker = tracker())
+    : AbstractStateReplacementFlow.Instigator<T, T, Party>(originalState, newNotary, progressTracker) {
+
+    override fun assembleTx(): AbstractStateReplacementFlow.UpgradeTx {
+        val inputs = resolveEncumbrances(originalState)
+
+        val tx = NotaryChangeWireTransaction(
+                inputs.map { it.ref },
+                originalState.state.notary,
+                modification
+        )
+
+        val participantKeys = inputs.flatMap { it.state.data.participants }.map { it.owningKey }.toSet()
+        // TODO: We need a much faster way of finding our key in the transaction
+        val myKey = serviceHub.keyManagementService.filterMyKeys(participantKeys).single()
+        val signableData = SignableData(tx.id, SignatureMetadata(serviceHub.myInfo.platformVersion, Crypto.findSignatureScheme(myKey).schemeNumberID))
+        val mySignature = serviceHub.keyManagementService.sign(signableData, myKey)
+        val stx = SignedTransaction(tx, listOf(mySignature))
+
+        return AbstractStateReplacementFlow.UpgradeTx(stx, participantKeys, myKey)
+    }
+
+    /** Resolves the encumbrance state chain for the given [state] */
+    private fun resolveEncumbrances(state: StateAndRef<T>): List<StateAndRef<T>> {
+        val states = mutableListOf(state)
+        while (states.last().state.encumbrance != null) {
+            val encumbranceStateRef = StateRef(states.last().ref.txhash, states.last().state.encumbrance!!)
+            val encumbranceState = serviceHub.toStateAndRef<T>(encumbranceStateRef)
+            states.add(encumbranceState)
+        }
+        return states
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/NotaryFlow.kt
@@ -1,0 +1,170 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TimeWindow
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SignedData
+import net.corda.core.crypto.TransactionSignature
+import net.corda.core.crypto.keys
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.identity.Party
+import net.corda.core.internal.FetchDataFlow
+import net.corda.core.node.services.NotaryService
+import net.corda.core.node.services.TrustedAuthorityNotaryService
+import net.corda.core.node.services.UniquenessProvider
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.UntrustworthyData
+import net.corda.core.utilities.unwrap
+import java.security.SignatureException
+import java.util.function.Predicate
+
+@Deprecated("Use net.corda.core.flows.NotaryFlow")
+class NotaryFlow {
+    /**
+     * A flow to be used by a party for obtaining signature(s) from a [NotaryService] ascertaining the transaction
+     * time-window is correct and none of its inputs have been used in another completed transaction.
+     *
+     * In case of a single-node or Raft notary, the flow will return a single signature. For the BFT notary multiple
+     * signatures will be returned – one from each replica that accepted the input state commit.
+     *
+     * @throws NotaryException in case the any of the inputs to the transaction have been consumed
+     *                         by another transaction or the time-window is invalid.
+     */
+    @InitiatingFlow
+    @Deprecated("Use net.corda.core.flows.Client")
+    open class Client(private val stx: SignedTransaction,
+                      override val progressTracker: ProgressTracker) : FlowLogic<List<TransactionSignature>>() {
+        constructor(stx: SignedTransaction) : this(stx, tracker())
+
+        companion object {
+            object REQUESTING : ProgressTracker.Step("Requesting signature by Notary service")
+            object VALIDATING : ProgressTracker.Step("Validating response from Notary service")
+
+            fun tracker() = ProgressTracker(REQUESTING, VALIDATING)
+        }
+
+        @Suspendable
+        @Throws(NotaryException::class)
+        override fun call(): List<TransactionSignature> {
+            progressTracker.currentStep = REQUESTING
+
+            val notaryParty = stx.notary ?: throw IllegalStateException("Transaction does not specify a Notary")
+            check(stx.inputs.all { stateRef -> serviceHub.loadState(stateRef).notary == notaryParty }) {
+                "Input states must have the same Notary"
+            }
+
+            try {
+                if (stx.isNotaryChangeTransaction()) {
+                    stx.resolveNotaryChangeTransaction(serviceHub).verifySignaturesExcept(notaryParty.owningKey)
+                } else {
+                    stx.verifySignaturesExcept(notaryParty.owningKey)
+                }
+            } catch (ex: SignatureException) {
+                throw NotaryException(NotaryError.TransactionInvalid(ex))
+            }
+
+            val response = try {
+                if (serviceHub.networkMapCache.isValidatingNotary(notaryParty)) {
+                    subFlow(SendTransactionWithRetry(notaryParty, stx))
+                    receive<List<TransactionSignature>>(notaryParty)
+                } else {
+                    val tx: Any = if (stx.isNotaryChangeTransaction()) {
+                        stx.notaryChangeTx
+                    } else {
+                        stx.buildFilteredTransaction(Predicate { it is StateRef || it is TimeWindow })
+                    }
+                    sendAndReceiveWithRetry(notaryParty, tx)
+                }
+            } catch (e: NotaryException) {
+                if (e.error is NotaryError.Conflict) {
+                    e.error.conflict.verified()
+                }
+                throw e
+            }
+
+            return response.unwrap { signatures ->
+                signatures.forEach { validateSignature(it, stx.id, notaryParty) }
+                signatures
+            }
+        }
+
+        private fun validateSignature(sig: TransactionSignature, txId: SecureHash, notaryParty: Party) {
+            check(sig.by in notaryParty.owningKey.keys) { "Invalid signer for the notary result" }
+            sig.verify(txId)
+        }
+    }
+
+    /**
+     * The [SendTransactionWithRetry] flow is equivalent to [SendTransactionFlow] but using [sendAndReceiveWithRetry]
+     * instead of [sendAndReceive], [SendTransactionWithRetry] is intended to be use by the notary client only.
+     */
+    @Deprecated("Use net.corda.core.flows.SendTransactionWithRetry")
+    private class SendTransactionWithRetry(otherSide: Party, stx: SignedTransaction) : SendTransactionFlow(otherSide, stx) {
+        @Suspendable
+        override fun sendPayloadAndReceiveDataRequest(otherSide: Party, payload: Any): UntrustworthyData<FetchDataFlow.Request> {
+            return sendAndReceiveWithRetry(otherSide, payload)
+        }
+    }
+
+    /**
+     * A flow run by a notary service that handles notarisation requests.
+     *
+     * It checks that the time-window command is valid (if present) and commits the input state, or returns a conflict
+     * if any of the input states have been previously committed.
+     *
+     * Additional transaction validation logic can be added when implementing [receiveAndVerifyTx].
+     */
+    // See AbstractStateReplacementFlow.Acceptor for why it's Void?
+    @Deprecated("Use net.corda.core.flows.Service")
+    abstract class Service(val otherSide: Party, val service: TrustedAuthorityNotaryService) : FlowLogic<Void?>() {
+
+        @Suspendable
+        override fun call(): Void? {
+            val (id, inputs, timeWindow) = receiveAndVerifyTx()
+            service.validateTimeWindow(timeWindow)
+            service.commitInputStates(inputs, id, otherSide)
+            signAndSendResponse(id)
+            return null
+        }
+
+        /**
+         * Implement custom logic to receive the transaction to notarise, and perform verification based on validity and
+         * privacy requirements.
+         */
+        @Suspendable
+        abstract fun receiveAndVerifyTx(): TransactionParts
+
+        @Suspendable
+        private fun signAndSendResponse(txId: SecureHash) {
+            val signature = service.sign(txId)
+            send(otherSide, listOf(signature))
+        }
+    }
+}
+
+/**
+ * The minimum amount of information needed to notarise a transaction. Note that this does not include
+ * any sensitive transaction details.
+ */
+data class TransactionParts(val id: SecureHash, val inputs: List<StateRef>, val timestamp: TimeWindow?)
+
+class NotaryException(val error: NotaryError) : FlowException("Error response from Notary - $error")
+
+@CordaSerializable
+sealed class NotaryError {
+    data class Conflict(val txId: SecureHash, val conflict: SignedData<UniquenessProvider.Conflict>) : NotaryError() {
+        override fun toString() = "One or more input states for transaction $txId have been used in another transaction"
+    }
+
+    /** Thrown if the time specified in the [TimeWindow] command is outside the allowed tolerance. */
+    object TimeWindowInvalid : NotaryError()
+
+    data class TransactionInvalid(val cause: Throwable) : NotaryError() {
+        override fun toString() = cause.toString()
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/ReceiveTransactionFlow.kt
@@ -1,0 +1,51 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.*
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.Party
+import net.corda.core.internal.deprecated.ResolveTransactionsFlow
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.unwrap
+import java.security.SignatureException
+
+/**
+ * The [ReceiveTransactionFlow] should be called in response to the [SendTransactionFlow].
+ *
+ * This flow is a combination of [receive], resolve and [SignedTransaction.verify]. This flow will receive the [SignedTransaction]
+ * and perform the resolution back-and-forth required to check the dependencies and download any missing attachments.
+ * The flow will return the [SignedTransaction] after it is resolved and then verified using [SignedTransaction.verify].
+ */
+@Deprecated("Use net.corda.core.flows.ReceiveTransactionFlow")
+class ReceiveTransactionFlow
+@JvmOverloads
+constructor(private val otherParty: Party, private val checkSufficientSignatures: Boolean = true) : FlowLogic<SignedTransaction>() {
+    @Suspendable
+    @Throws(SignatureException::class, AttachmentResolutionException::class, TransactionResolutionException::class, TransactionVerificationException::class)
+    override fun call(): SignedTransaction {
+        return receive<SignedTransaction>(otherParty).unwrap {
+            subFlow(ResolveTransactionsFlow(it, otherParty))
+            it.verify(serviceHub, checkSufficientSignatures)
+            it
+        }
+    }
+}
+
+/**
+ * The [ReceiveStateAndRefFlow] should be called in response to the [SendStateAndRefFlow].
+ *
+ * This flow is a combination of [receive] and resolve. This flow will receive a list of [StateAndRef]
+ * and perform the resolution back-and-forth required to check the dependencies.
+ * The flow will return the list of [StateAndRef] after it is resolved.
+ */
+// @JvmSuppressWildcards is used to suppress wildcards in return type when calling `subFlow(new ReceiveStateAndRef<T>(otherParty))` in java.
+@Deprecated("Use net.corda.core.flows.ReceiveStateAndRefFlow")
+class ReceiveStateAndRefFlow<out T : ContractState>(private val otherParty: Party) : FlowLogic<@JvmSuppressWildcards List<StateAndRef<T>>>() {
+    @Suspendable
+    override fun call(): List<StateAndRef<T>> {
+        return receive<List<StateAndRef<T>>>(otherParty).unwrap {
+            subFlow(ResolveTransactionsFlow(it.map { it.ref.txhash }.toSet(), otherParty))
+            it
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/flows/deprecated/SendTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/deprecated/SendTransactionFlow.kt
@@ -1,0 +1,73 @@
+package net.corda.core.flows.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.Party
+import net.corda.core.internal.FetchDataFlow
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.unwrap
+
+/**
+ * The [SendTransactionFlow] should be used to send a transaction to another peer that wishes to verify that transaction's
+ * integrity by resolving and checking the dependencies as well. The other side should invoke [ReceiveTransactionFlow] at
+ * the right point in the conversation to receive the sent transaction and perform the resolution back-and-forth required
+ * to check the dependencies and download any missing attachments.
+ *
+ * @param otherSide the target party.
+ * @param stx the [SignedTransaction] being sent to the [otherSide].
+ */
+@Deprecated("Use net.corda.core.flows.SendTransactionFlow")
+open class SendTransactionFlow(otherSide: Party, stx: SignedTransaction) : DataVendingFlow(otherSide, stx)
+
+/**
+ * The [SendStateAndRefFlow] should be used to send a list of input [StateAndRef] to another peer that wishes to verify
+ * the input's integrity by resolving and checking the dependencies as well. The other side should invoke [ReceiveStateAndRefFlow]
+ * at the right point in the conversation to receive the input state and ref and perform the resolution back-and-forth
+ * required to check the dependencies.
+ *
+ * @param otherSide the target party.
+ * @param stateAndRefs the list of [StateAndRef] being sent to the [otherSide].
+ */
+@Deprecated("Use net.corda.core.flows.SendStateAndRefFlow")
+open class SendStateAndRefFlow(otherSide: Party, stateAndRefs: List<StateAndRef<*>>) : DataVendingFlow(otherSide, stateAndRefs)
+
+@Deprecated("Use net.corda.core.flows.DataVendingFlow")
+sealed class DataVendingFlow(val otherSide: Party, val payload: Any) : FlowLogic<Void?>() {
+    @Suspendable
+    protected open fun sendPayloadAndReceiveDataRequest(otherSide: Party, payload: Any) = sendAndReceive<FetchDataFlow.Request>(otherSide, payload)
+
+    @Suspendable
+    protected open fun verifyDataRequest(dataRequest: FetchDataFlow.Request.Data) {
+        // User can override this method to perform custom request verification.
+    }
+
+    @Suspendable
+    override fun call(): Void? {
+        // The first payload will be the transaction data, subsequent payload will be the transaction/attachment data.
+        var payload = payload
+        // This loop will receive [FetchDataFlow.Request] continuously until the `otherSide` has all the data they need
+        // to resolve the transaction, a [FetchDataFlow.EndRequest] will be sent from the `otherSide` to indicate end of
+        // data request.
+        while (true) {
+            val dataRequest = sendPayloadAndReceiveDataRequest(otherSide, payload).unwrap { request ->
+                when (request) {
+                    is FetchDataFlow.Request.Data -> {
+                        // Security TODO: Check for abnormally large or malformed data requests
+                        verifyDataRequest(request)
+                        request
+                    }
+                    FetchDataFlow.Request.End -> return null
+                }
+            }
+            payload = when (dataRequest.dataType) {
+                FetchDataFlow.DataType.TRANSACTION -> dataRequest.hashes.map {
+                    serviceHub.validatedTransactions.getTransaction(it) ?: throw FetchDataFlow.HashNotFound(it)
+                }
+                FetchDataFlow.DataType.ATTACHMENT -> dataRequest.hashes.map {
+                    serviceHub.attachments.openAttachment(it)?.open()?.readBytes() ?: throw FetchDataFlow.HashNotFound(it)
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/internal/deprecated/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/deprecated/FetchDataFlow.kt
@@ -1,0 +1,182 @@
+package net.corda.core.internal.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.Attachment
+import net.corda.core.contracts.NamedByHash
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.sha256
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.Party
+import net.corda.core.internal.AbstractAttachment
+import net.corda.core.internal.FetchDataFlow.DownloadedVsRequestedDataMismatch
+import net.corda.core.internal.FetchDataFlow.HashNotFound
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.SerializationToken
+import net.corda.core.serialization.SerializeAsToken
+import net.corda.core.serialization.SerializeAsTokenContext
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.NonEmptySet
+import net.corda.core.utilities.UntrustworthyData
+import net.corda.core.utilities.unwrap
+import java.util.*
+
+/**
+ * An abstract flow for fetching typed data from a remote peer.
+ *
+ * Given a set of hashes (IDs), either loads them from local disk or asks the remote peer to provide them.
+ *
+ * A malicious response in which the data provided by the remote peer does not hash to the requested hash results in
+ * [DownloadedVsRequestedDataMismatch] being thrown. If the remote peer doesn't have an entry, it results in a
+ * [HashNotFound] exception being thrown.
+ *
+ * By default this class does not insert data into any local database, if you want to do that after missing items were
+ * fetched then override [maybeWriteToDisk]. You *must* override [load]. If the wire type is not the same as the
+ * ultimate type, you must also override [convert].
+ *
+ * @param T The ultimate type of the data being fetched.
+ * @param W The wire type of the data being fetched, for when it isn't the same as the ultimate type.
+ */
+@Deprecated("Use net.corda.core.internal.FetchDataFlow")
+sealed class FetchDataFlow<T : NamedByHash, in W : Any>(
+        protected val requests: Set<SecureHash>,
+        protected val otherSide: Party,
+        protected val dataType: DataType) : FlowLogic<FetchDataFlow.Result<T>>() {
+
+    @CordaSerializable
+    class DownloadedVsRequestedDataMismatch(val requested: SecureHash, val got: SecureHash) : IllegalArgumentException()
+
+    @CordaSerializable
+    class DownloadedVsRequestedSizeMismatch(val requested: Int, val got: Int) : IllegalArgumentException()
+
+    class HashNotFound(val requested: SecureHash) : FlowException()
+
+    @CordaSerializable
+    data class Result<out T : NamedByHash>(val fromDisk: List<T>, val downloaded: List<T>)
+
+    @CordaSerializable
+    sealed class Request {
+        data class Data(val hashes: NonEmptySet<SecureHash>, val dataType: DataType) : Request()
+        object End : Request()
+    }
+
+    @CordaSerializable
+    enum class DataType {
+        TRANSACTION, ATTACHMENT
+    }
+
+    @Suspendable
+    @Throws(HashNotFound::class)
+    override fun call(): Result<T> {
+        // Load the items we have from disk and figure out which we're missing.
+        val (fromDisk, toFetch) = loadWhatWeHave()
+
+        return if (toFetch.isEmpty()) {
+            Result(fromDisk, emptyList())
+        } else {
+            logger.info("Requesting ${toFetch.size} dependency(s) for verification from ${otherSide.name}")
+
+            // TODO: Support "large message" response streaming so response sizes are not limited by RAM.
+            // We can then switch to requesting items in large batches to minimise the latency penalty.
+            // This is blocked by bugs ARTEMIS-1278 and ARTEMIS-1279. For now we limit attachments and txns to 10mb each
+            // and don't request items in batch, which is a performance loss, but works around the issue. We have
+            // configured Artemis to not fragment messages up to 10mb so we can send 10mb messages without problems.
+            // Above that, we start losing authentication data on the message fragments and take exceptions in the
+            // network layer.
+            val maybeItems = ArrayList<W>(toFetch.size)
+            for (hash in toFetch) {
+                // We skip the validation here (with unwrap { it }) because we will do it below in validateFetchResponse.
+                // The only thing checked is the object type. It is a protocol violation to send results out of order.
+                maybeItems += sendAndReceive<List<W>>(otherSide, Request.Data(NonEmptySet.of(hash), dataType)).unwrap { it }
+            }
+            // Check for a buggy/malicious peer answering with something that we didn't ask for.
+            val downloaded = validateFetchResponse(UntrustworthyData(maybeItems), toFetch)
+            logger.info("Fetched ${downloaded.size} elements from ${otherSide.name}")
+            maybeWriteToDisk(downloaded)
+            Result(fromDisk, downloaded)
+        }
+    }
+
+    protected open fun maybeWriteToDisk(downloaded: List<T>) {
+        // Do nothing by default.
+    }
+
+    private fun loadWhatWeHave(): Pair<List<T>, List<SecureHash>> {
+        val fromDisk = ArrayList<T>()
+        val toFetch = ArrayList<SecureHash>()
+        for (txid in requests) {
+            val stx = load(txid)
+            if (stx == null)
+                toFetch += txid
+            else
+                fromDisk += stx
+        }
+        return Pair(fromDisk, toFetch)
+    }
+
+    protected abstract fun load(txid: SecureHash): T?
+
+    @Suppress("UNCHECKED_CAST")
+    protected open fun convert(wire: W): T = wire as T
+
+    private fun validateFetchResponse(maybeItems: UntrustworthyData<ArrayList<W>>,
+                                      requests: List<SecureHash>): List<T> {
+        return maybeItems.unwrap { response ->
+            if (response.size != requests.size)
+                throw DownloadedVsRequestedSizeMismatch(requests.size, response.size)
+            val answers = response.map { convert(it) }
+            // Check transactions actually hash to what we requested, if this fails the remote node
+            // is a malicious flow violator or buggy.
+            for ((index, item) in answers.withIndex()) {
+                if (item.id != requests[index])
+                    throw DownloadedVsRequestedDataMismatch(requests[index], item.id)
+            }
+            answers
+        }
+    }
+}
+
+
+/**
+ * Given a set of hashes either loads from from local storage  or requests them from the other peer. Downloaded
+ * attachments are saved to local storage automatically.
+ */
+@Deprecated("Use net.corda.core.internal.FetchAttachmentsFlow")
+class FetchAttachmentsFlow(requests: Set<SecureHash>,
+                           otherSide: Party) : FetchDataFlow<Attachment, ByteArray>(requests, otherSide, DataType.ATTACHMENT) {
+
+    override fun load(txid: SecureHash): Attachment? = serviceHub.attachments.openAttachment(txid)
+
+    override fun convert(wire: ByteArray): Attachment = FetchedAttachment({ wire })
+
+    override fun maybeWriteToDisk(downloaded: List<Attachment>) {
+        for (attachment in downloaded) {
+            serviceHub.attachments.importAttachment(attachment.open())
+        }
+    }
+
+    private class FetchedAttachment(dataLoader: () -> ByteArray) : AbstractAttachment(dataLoader), SerializeAsToken {
+        override val id: SecureHash by lazy { attachmentData.sha256() }
+
+        private class Token(private val id: SecureHash) : SerializationToken {
+            override fun fromToken(context: SerializeAsTokenContext) = FetchedAttachment(context.attachmentDataLoader(id))
+        }
+
+        override fun toToken(context: SerializeAsTokenContext) = Token(id)
+    }
+}
+
+/**
+ * Given a set of tx hashes (IDs), either loads them from local disk or asks the remote peer to provide them.
+ *
+ * A malicious response in which the data provided by the remote peer does not hash to the requested hash results in
+ * [FetchDataFlow.DownloadedVsRequestedDataMismatch] being thrown. If the remote peer doesn't have an entry, it
+ * results in a [FetchDataFlow.HashNotFound] exception. Note that returned transactions are not inserted into
+ * the database, because it's up to the caller to actually verify the transactions are valid.
+ */
+@Deprecated("Use net.corda.core.internal.FetchTransactionsFlow")
+class FetchTransactionsFlow(requests: Set<SecureHash>, otherSide: Party) :
+        FetchDataFlow<SignedTransaction, SignedTransaction>(requests, otherSide, DataType.TRANSACTION) {
+
+    override fun load(txid: SecureHash): SignedTransaction? = serviceHub.validatedTransactions.getTransaction(txid)
+}

--- a/core/src/main/kotlin/net/corda/core/internal/deprecated/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/deprecated/ResolveTransactionsFlow.kt
@@ -1,0 +1,168 @@
+package net.corda.core.internal.deprecated
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.exactAdd
+import java.util.*
+
+// TODO: This code is currently unit tested by TwoPartyTradeFlowTests, it should have its own tests.
+/**
+ * Resolves transactions for the specified [txHashes] along with their full history (dependency graph) from [otherSide].
+ * Each retrieved transaction is validated and inserted into the local transaction storage.
+ *
+ * @return a list of verified [SignedTransaction] objects, in a depth-first order.
+ */
+@Deprecated("Use net.corda.core.internal.ResolveTransactionsFlow")
+class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
+                              private val otherSide: Party) : FlowLogic<List<SignedTransaction>>() {
+    /**
+     * Resolves and validates the dependencies of the specified [signedTransaction]. Fetches the attachments, but does
+     * *not* validate or store the [signedTransaction] itself.
+     *
+     * @return a list of verified [SignedTransaction] objects, in a depth-first order.
+     */
+    constructor(signedTransaction: SignedTransaction, otherSide: Party) : this(dependencyIDs(signedTransaction), otherSide) {
+        this.signedTransaction = signedTransaction
+    }
+    companion object {
+        private fun dependencyIDs(stx: SignedTransaction) = stx.inputs.map { it.txhash }.toSet()
+
+        /**
+         * Topologically sorts the given transactions such that dependencies are listed before dependers. */
+        @JvmStatic
+        fun topologicalSort(transactions: Collection<SignedTransaction>): List<SignedTransaction> {
+            // Construct txhash -> dependent-txs map
+            val forwardGraph = HashMap<SecureHash, HashSet<SignedTransaction>>()
+            transactions.forEach { stx ->
+                stx.inputs.forEach { (txhash) ->
+                    // Note that we use a LinkedHashSet here to make the traversal deterministic (as long as the input list is)
+                    forwardGraph.getOrPut(txhash) { LinkedHashSet() }.add(stx)
+                }
+            }
+
+            val visited = HashSet<SecureHash>(transactions.size)
+            val result = ArrayList<SignedTransaction>(transactions.size)
+
+            fun visit(transaction: SignedTransaction) {
+                if (transaction.id !in visited) {
+                    visited.add(transaction.id)
+                    forwardGraph[transaction.id]?.forEach(::visit)
+                    result.add(transaction)
+                }
+            }
+
+            transactions.forEach(::visit)
+
+            result.reverse()
+            require(result.size == transactions.size)
+            return result
+        }
+    }
+
+    @CordaSerializable
+    class ExcessivelyLargeTransactionGraph : Exception()
+
+    /** Transaction for fetch attachments for */
+    private var signedTransaction: SignedTransaction? = null
+
+    // TODO: Figure out a more appropriate DOS limit here, 5000 is simply a very bad guess.
+    /** The maximum number of transactions this flow will try to download before bailing out. */
+    var transactionCountLimit = 5000
+        set(value) {
+            require(value > 0) { "$value is not a valid count limit" }
+            field = value
+        }
+
+    @Suspendable
+    @Throws(FetchDataFlow.HashNotFound::class)
+    override fun call(): List<SignedTransaction> {
+        // Start fetching data.
+        val newTxns = downloadDependencies(txHashes)
+        fetchMissingAttachments(signedTransaction?.let { newTxns + it } ?: newTxns)
+        send(otherSide, FetchDataFlow.Request.End)
+        // Finish fetching data.
+
+        val result = topologicalSort(newTxns)
+        result.forEach {
+            // For each transaction, verify it and insert it into the database. As we are iterating over them in a
+            // depth-first order, we should not encounter any verification failures due to missing data. If we fail
+            // half way through, it's no big deal, although it might result in us attempting to re-download data
+            // redundantly next time we attempt verification.
+            it.verify(serviceHub)
+            serviceHub.recordTransactions(false, it)
+        }
+
+        return signedTransaction?.let {
+            result + it
+        } ?: result
+    }
+
+    @Suspendable
+    private fun downloadDependencies(depsToCheck: Set<SecureHash>): List<SignedTransaction> {
+        // Maintain a work queue of all hashes to load/download, initialised with our starting set. Then do a breadth
+        // first traversal across the dependency graph.
+        //
+        // TODO: This approach has two problems. Analyze and resolve them:
+        //
+        // (1) This flow leaks private data. If you download a transaction and then do NOT request a
+        // dependency, it means you already have it, which in turn means you must have been involved with it before
+        // somehow, either in the tx itself or in any following spend of it. If there were no following spends, then
+        // your peer knows for sure that you were involved ... this is bad! The only obvious ways to fix this are
+        // something like onion routing of requests, secure hardware, or both.
+        //
+        // (2) If the identity service changes the assumed identity of one of the public keys, it's possible
+        // that the "tx in db is valid" invariant is violated if one of the contracts checks the identity! Should
+        // the db contain the identities that were resolved when the transaction was first checked, or should we
+        // accept this kind of change is possible? Most likely solution is for identity data to be an attachment.
+
+        val nextRequests = LinkedHashSet<SecureHash>()   // Keep things unique but ordered, for unit test stability.
+        nextRequests.addAll(depsToCheck)
+        val resultQ = LinkedHashMap<SecureHash, SignedTransaction>()
+
+        val limit = transactionCountLimit
+        var limitCounter = 0
+        while (nextRequests.isNotEmpty()) {
+            // Don't re-download the same tx when we haven't verified it yet but it's referenced multiple times in the
+            // graph we're traversing.
+            val notAlreadyFetched = nextRequests.filterNot { it in resultQ }.toSet()
+            nextRequests.clear()
+
+            if (notAlreadyFetched.isEmpty())   // Done early.
+                break
+
+            // Request the standalone transaction data (which may refer to things we don't yet have).
+            val downloads: List<SignedTransaction> = subFlow(FetchTransactionsFlow(notAlreadyFetched, otherSide)).downloaded
+
+            for (stx in downloads)
+                check(resultQ.putIfAbsent(stx.id, stx) == null)   // Assert checks the filter at the start.
+
+            // Add all input states to the work queue.
+            val inputHashes = downloads.flatMap { it.inputs }.map { it.txhash }
+            nextRequests.addAll(inputHashes)
+
+            limitCounter = limitCounter exactAdd nextRequests.size
+            if (limitCounter > limit)
+                throw ExcessivelyLargeTransactionGraph()
+        }
+        return resultQ.values.toList()
+    }
+
+    /**
+     * Returns a list of all the dependencies of the given transactions, deepest first i.e. the last downloaded comes
+     * first in the returned list and thus doesn't have any unverified dependencies.
+     */
+    @Suspendable
+    private fun fetchMissingAttachments(downloads: List<SignedTransaction>) {
+        // TODO: This could be done in parallel with other fetches for extra speed.
+        val wireTransactions = downloads.filterNot { it.isNotaryChangeTransaction() }.map { it.tx }
+        val missingAttachments = wireTransactions.flatMap { wtx ->
+            wtx.attachments.filter { serviceHub.attachments.openAttachment(it) == null }
+        }
+        if (missingAttachments.isNotEmpty())
+            subFlow(FetchAttachmentsFlow(missingAttachments.toSet(), otherSide))
+    }
+}


### PR DESCRIPTION
This PR introduces deprecated packages that contain old flows using the deprecated Party-based send/receive api. It's literally just a copy of the old flows.

This is to complement #1530