### PR TITLE
Clarify method names on IdentityService for well known party methods

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -46,25 +46,25 @@ object JacksonSupport {
     // If you change this API please update the docs in the docsite (json.rst)
 
     interface PartyObjectMapper {
-        fun partyFromX500Name(name: CordaX500Name): Party?
+        fun wellKnownPartyFromX500Name(name: CordaX500Name): Party?
         fun partyFromKey(owningKey: PublicKey): Party?
         fun partiesFromName(query: String): Set<Party>
     }
 
     class RpcObjectMapper(val rpc: CordaRPCOps, factory: JsonFactory, val fuzzyIdentityMatch: Boolean) : PartyObjectMapper, ObjectMapper(factory) {
-        override fun partyFromX500Name(name: CordaX500Name): Party? = rpc.partyFromX500Name(name)
+        override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = rpc.wellKnownPartyFromX500Name(name)
         override fun partyFromKey(owningKey: PublicKey): Party? = rpc.partyFromKey(owningKey)
         override fun partiesFromName(query: String) = rpc.partiesFromName(query, fuzzyIdentityMatch)
     }
 
     class IdentityObjectMapper(val identityService: IdentityService, factory: JsonFactory, val fuzzyIdentityMatch: Boolean) : PartyObjectMapper, ObjectMapper(factory) {
-        override fun partyFromX500Name(name: CordaX500Name): Party? = identityService.partyFromX500Name(name)
+        override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = identityService.wellKnownPartyFromX500Name(name)
         override fun partyFromKey(owningKey: PublicKey): Party? = identityService.partyFromKey(owningKey)
         override fun partiesFromName(query: String) = identityService.partiesFromName(query, fuzzyIdentityMatch)
     }
 
     class NoPartyObjectMapper(factory: JsonFactory) : PartyObjectMapper, ObjectMapper(factory) {
-        override fun partyFromX500Name(name: CordaX500Name): Party? = throw UnsupportedOperationException()
+        override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = throw UnsupportedOperationException()
         override fun partyFromKey(owningKey: PublicKey): Party? = throw UnsupportedOperationException()
         override fun partiesFromName(query: String) = throw UnsupportedOperationException()
     }
@@ -192,7 +192,7 @@ object JacksonSupport {
             // how to parse the content
             return if (parser.text.contains("=")) {
                 val principal = CordaX500Name.parse(parser.text)
-                mapper.partyFromX500Name(principal) ?: throw JsonParseException(parser, "Could not find a Party with name $principal")
+                mapper.wellKnownPartyFromX500Name(principal) ?: throw JsonParseException(parser, "Could not find a Party with name $principal")
             } else {
                 val nameMatches = mapper.partiesFromName(parser.text)
                 if (nameMatches.isEmpty()) {

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt
@@ -79,7 +79,7 @@ object IdentitySyncFlow {
         override fun call(): Unit {
             progressTracker.currentStep = RECEIVING_IDENTITIES
             val allIdentities = otherSideSession.receive<List<AbstractParty>>().unwrap { it }
-            val unknownIdentities = allIdentities.filter { serviceHub.identityService.partyFromAnonymous(it) == null }
+            val unknownIdentities = allIdentities.filter { serviceHub.identityService.wellKnownPartyFromAnonymous(it) == null }
             progressTracker.currentStep = RECEIVING_CERTIFICATES
             val missingIdentities = otherSideSession.sendAndReceive<List<PartyAndCertificate>>(unknownIdentities)
 

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
@@ -52,15 +52,15 @@ class IdentitySyncFlowTests {
         val issueFlow = aliceNode.services.startFlow(CashIssueAndPaymentFlow(1000.DOLLARS, ref, alice, anonymous, notary))
         val issueTx = issueFlow.resultFuture.getOrThrow().stx
         val confidentialIdentity = issueTx.tx.outputs.map { it.data }.filterIsInstance<Cash.State>().single().owner
-        assertNull(bobNode.database.transaction { bobNode.services.identityService.partyFromAnonymous(confidentialIdentity) })
+        assertNull(bobNode.database.transaction { bobNode.services.identityService.wellKnownPartyFromAnonymous(confidentialIdentity) })
 
         // Run the flow to sync up the identities
         aliceNode.services.startFlow(Initiator(bob, issueTx.tx)).resultFuture.getOrThrow()
         val expected = aliceNode.database.transaction {
-            aliceNode.services.identityService.partyFromAnonymous(confidentialIdentity)
+            aliceNode.services.identityService.wellKnownPartyFromAnonymous(confidentialIdentity)
         }
         val actual = bobNode.database.transaction {
-            bobNode.services.identityService.partyFromAnonymous(confidentialIdentity)
+            bobNode.services.identityService.wellKnownPartyFromAnonymous(confidentialIdentity)
         }
         assertEquals(expected, actual)
     }

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -42,8 +42,8 @@ class SwapIdentitiesFlowTests {
         assertNotEquals<AbstractParty>(bob, bobAnonymousIdentity)
 
         // Verify that the anonymous identities look sane
-        assertEquals(alice.name, aliceNode.database.transaction { aliceNode.services.identityService.partyFromAnonymous(aliceAnonymousIdentity)!!.name })
-        assertEquals(bob.name, bobNode.database.transaction { bobNode.services.identityService.partyFromAnonymous(bobAnonymousIdentity)!!.name })
+        assertEquals(alice.name, aliceNode.database.transaction { aliceNode.services.identityService.wellKnownPartyFromAnonymous(aliceAnonymousIdentity)!!.name })
+        assertEquals(bob.name, bobNode.database.transaction { bobNode.services.identityService.wellKnownPartyFromAnonymous(bobAnonymousIdentity)!!.name })
 
         // Verify that the nodes have the right anonymous identities
         assertTrue { aliceAnonymousIdentity.owningKey in aliceNode.services.keyManagementService.keys }

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -249,12 +249,12 @@ interface CordaRPCOps : RPCOps {
      * @param party identity to determine well known identity for.
      * @return well known identity, if found.
      */
-    fun partyFromAnonymous(party: AbstractParty): Party?
+    fun wellKnownPartyFromAnonymous(party: AbstractParty): Party?
     /** Returns the [Party] corresponding to the given key, if found. */
     fun partyFromKey(key: PublicKey): Party?
 
     /** Returns the [Party] with the X.500 principal as it's [Party.name]. */
-    fun partyFromX500Name(x500Name: CordaX500Name): Party?
+    fun wellKnownPartyFromX500Name(x500Name: CordaX500Name): Party?
 
     /**
      * Returns a list of candidate matches for a given string, with optional fuzzy(ish) matching. Fuzzy matching may

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -309,7 +309,7 @@ interface ServiceHub : ServicesForResolution {
     @Throws(IllegalArgumentException::class)
     fun groupAbstractPartyByWellKnownParty(parties: Collection<AbstractParty>, ignoreUnrecognisedParties: Boolean): Map<Party, List<AbstractParty>> {
         val partyToPublicKey: Iterable<Pair<Party, AbstractParty>> = parties.mapNotNull {
-            (identityService.partyFromAnonymous(it) ?: if (ignoreUnrecognisedParties) return@mapNotNull null else throw IllegalArgumentException("Could not find Party for $it")) to it
+            (identityService.wellKnownPartyFromAnonymous(it) ?: if (ignoreUnrecognisedParties) return@mapNotNull null else throw IllegalArgumentException("Could not find Party for $it")) to it
         }
         return partyToPublicKey.toMultiMap()
     }
@@ -331,7 +331,7 @@ interface ServiceHub : ServicesForResolution {
     /**
      * Remove this node from a map of well known [Party]s.
      *
-     * @return a new copy of the map, with the well known [Party] for this node removed.
+     * @return a new copy of the map, with he well known [Party] for this node removed.
      */
     fun <T> excludeMe(map: Map<Party, T>): Map<Party, T> = map.filterKeys { !myInfo.isLegalIdentity(it) }
 

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -42,46 +42,48 @@ interface IdentityService {
     fun getAllIdentities(): Iterable<PartyAndCertificate>
 
     /**
-     * Get the certificate and path for a well known identity's owning key.
+     * Get the certificate and path for a known identity's owning key.
      *
      * @return the party and certificate, or null if unknown.
      */
     fun certificateFromKey(owningKey: PublicKey): PartyAndCertificate?
 
     /**
-     * Get the certificate and path for a well known identity.
-     *
-     * @return the party and certificate.
-     * @throws IllegalArgumentException if the certificate and path are unknown. This should never happen for a well
-     * known identity.
+     * Converts an owning [PublicKey] to the X500Name extended [Party] object if the [Party] has been
+     * previously registered with the [IdentityService] either as a well known network map identity,
+     * or as a part of flows creating and exchanging the identity.
+     * @param key The owning [PublicKey] of the [Party].
+     * @return Returns a [Party] with a matching owningKey if known, else returns null.
      */
-    fun certificateFromParty(party: Party): PartyAndCertificate
-
-    // There is no method for removing identities, as once we are made aware of a Party we want to keep track of them
-    // indefinitely. It may be that in the long term we need to drop or archive very old Party information for space,
-    // but for now this is not supported.
-
     fun partyFromKey(key: PublicKey): Party?
 
-    fun partyFromX500Name(name: CordaX500Name): Party?
+    /**
+     * Resolves a party name to the well known identity [Party] instance for this name.
+     * @param name The [CordaX500Name] to search for.
+     * @return If known the canonical [Party] with that name, else null.
+     */
+    fun wellKnownPartyFromX500Name(name: CordaX500Name): Party?
 
     /**
-     * Returns the well known identity from an abstract party. This is intended to resolve the well known identity
-     * from a confidential identity, however it transparently handles returning the well known identity back if
+     * Returns the well known identity from an [AbstractParty]. This is intended to resolve the well known identity,
+     * as visible in the [NetworkMapCache] from a confidential identity.
+     * It transparently handles returning the well known identity back if
      * a well known identity is passed in.
      *
      * @param party identity to determine well known identity for.
      * @return well known identity, if found.
      */
-    fun partyFromAnonymous(party: AbstractParty): Party?
+    fun wellKnownPartyFromAnonymous(party: AbstractParty): Party?
 
     /**
-     * Resolve the well known identity of a party. If the party passed in is already a well known identity
-     * (i.e. a [Party]) this returns it as-is.
+     * Returns the well known identity from a PartyAndReference. This is intended to resolve the well known identity,
+     * as visible in the [NetworkMapCache] from a confidential identity.
+     * It transparently handles returning the well known identity back if
+     * a well known identity is passed in.
      *
      * @return the well known identity, or null if unknown.
      */
-    fun partyFromAnonymous(partyRef: PartyAndReference) = partyFromAnonymous(partyRef.party)
+    fun wellKnownPartyFromAnonymous(partyRef: PartyAndReference) = wellKnownPartyFromAnonymous(partyRef.party)
 
     /**
      * Resolve the well known identity of a party. Throws an exception if the party cannot be identified.
@@ -90,7 +92,7 @@ interface IdentityService {
      * @return the well known identity.
      * @throws IllegalArgumentException
      */
-    fun requirePartyFromAnonymous(party: AbstractParty): Party
+    fun requireWellKnownPartyFromAnonymous(party: AbstractParty): Party
 
     /**
      * Returns a list of candidate matches for a given string, with optional fuzzy(ish) matching. Fuzzy matching may

--- a/docs/source/api-rpc.rst
+++ b/docs/source/api-rpc.rst
@@ -23,7 +23,7 @@ The key RPC operations exposed by the node are:
     * Returns the node's identity
 * ``CordaRPCOps.currentNodeTime``
     * Returns the node's current time
-* ``CordaRPCOps.partyFromKey/CordaRPCOps.partyFromX500Name``
+* ``CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name``
     * Retrieves a party on the network based on a public key or X500 name
 * ``CordaRPCOps.uploadAttachment``/``CordaRPCOps.openAttachment``/``CordaRPCOps.attachmentExists``
     * Uploads, opens and checks for the existence of attachments

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -135,7 +135,7 @@ public class FlowCookbookJava {
             // We may also need to identify a specific counterparty.
             // Again, we do so using the network map.
             // DOCSTART 2
-            Party namedCounterparty = getServiceHub().getIdentityService().partyFromX500Name(new CordaX500Name("NodeA", "London", "UK"));
+            Party namedCounterparty = getServiceHub().getIdentityService().wellKnownPartyFromX500Name(new CordaX500Name("NodeA", "London", "UK"));
             Party keyedCounterparty = getServiceHub().getIdentityService().partyFromKey(dummyPubKey);
             // DOCEND 2
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
@@ -116,7 +116,7 @@ object FlowCookbook {
             // We may also need to identify a specific counterparty. We
             // do so using identity service.
             // DOCSTART 2
-            val namedCounterparty: Party = serviceHub.identityService.partyFromX500Name(CordaX500Name(organisation = "NodeA", locality = "London", country = "UK")) ?:
+            val namedCounterparty: Party = serviceHub.identityService.wellKnownPartyFromX500Name(CordaX500Name(organisation = "NodeA", locality = "London", country = "UK")) ?:
                     throw IllegalArgumentException("Couldn't find counterparty for NodeA in identity service")
             val keyedCounterparty: Party = serviceHub.identityService.partyFromKey(dummyPubKey) ?:
                     throw IllegalArgumentException("Couldn't find counterparty with key: $dummyPubKey in identity service")

--- a/docs/source/tutorial-attachments.rst
+++ b/docs/source/tutorial-attachments.rst
@@ -90,7 +90,7 @@ transaction and send it to the recipient node:
 
    fun sender(rpc: CordaRPCOps) {
        // Get the identity key of the other side (the recipient).
-       val otherSide: Party = rpc.partyFromName("Bank B")!!
+       val otherSide: Party = rpc.wellKnownPartyFromName("Bank B")!!
 
        // Make sure we have the file in storage
        // TODO: We should have our own demo file, not share the trader demo file

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
@@ -65,7 +65,7 @@ class CashExitFlow(private val amount: Amount<Currency>,
         // TODO: Is it safe to drop participants we don't know how to contact? Does not knowing how to contact them
         //       count as a reason to fail?
         val participants: Set<Party> = inputStates
-                .mapNotNull { serviceHub.identityService.partyFromAnonymous(it.state.data.owner) }
+                .mapNotNull { serviceHub.identityService.wellKnownPartyFromAnonymous(it.state.data.owner) }
                 .toSet()
         // Sign transaction
         progressTracker.currentStep = SIGNING_TX

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
@@ -134,8 +134,8 @@ object TwoPartyDealFlow {
             progressTracker.currentStep = VERIFYING
             return handshake.unwrap {
                 // Verify the transaction identities represent the correct parties
-                val wellKnownOtherParty = serviceHub.identityService.partyFromAnonymous(it.primaryIdentity)
-                val wellKnownMe = serviceHub.identityService.partyFromAnonymous(it.secondaryIdentity)
+                val wellKnownOtherParty = serviceHub.identityService.wellKnownPartyFromAnonymous(it.primaryIdentity)
+                val wellKnownMe = serviceHub.identityService.wellKnownPartyFromAnonymous(it.secondaryIdentity)
                 require(wellKnownOtherParty == otherSideSession.counterparty)
                 require(wellKnownMe == ourIdentity)
                 validateHandshake(it)

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
@@ -98,7 +98,7 @@ object TwoPartyTradeFlow {
                     val states: Iterable<ContractState> = stx.tx.inputs.map { serviceHub.loadState(it).data } + stx.tx.outputs.map { it.data }
                     states.forEach { state ->
                         state.participants.forEach { anon ->
-                            require(serviceHub.identityService.partyFromAnonymous(anon) != null) {
+                            require(serviceHub.identityService.wellKnownPartyFromAnonymous(anon) != null) {
                                 "Transaction state $state involves unknown participant $anon"
                             }
                         }
@@ -197,7 +197,7 @@ object TwoPartyTradeFlow {
 
                 // The asset must either be owned by the well known identity of the counterparty, or we must be able to
                 // prove the owner is a confidential identity of the counterparty.
-                val assetForSaleIdentity = serviceHub.identityService.partyFromAnonymous(asset.owner)
+                val assetForSaleIdentity = serviceHub.identityService.wellKnownPartyFromAnonymous(asset.owner)
                 require(assetForSaleIdentity == sellerSession.counterparty)
 
                 // Register the identity we're about to send payment to. This shouldn't be the same as the asset owner

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -37,7 +37,7 @@ class LargeTransactionsTest {
                     .addAttachment(hash4)
             val stx = serviceHub.signInitialTransaction(tx, ourIdentity.owningKey)
             // Send to the other side and wait for it to trigger resolution from us.
-            val bob = serviceHub.identityService.partyFromX500Name(BOB.name)!!
+            val bob = serviceHub.identityService.wellKnownPartyFromX500Name(BOB.name)!!
             val bobSession = initiateFlow(bob)
             subFlow(SendTransactionFlow(bobSession, stx))
             bobSession.receive<Unit>()

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -182,9 +182,9 @@ class CordaRPCOpsImpl(
         }
     }
 
-    override fun partyFromAnonymous(party: AbstractParty): Party? {
+    override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
         return database.transaction {
-            services.identityService.partyFromAnonymous(party)
+            services.identityService.wellKnownPartyFromAnonymous(party)
         }
     }
 
@@ -194,9 +194,9 @@ class CordaRPCOpsImpl(
         }
     }
 
-    override fun partyFromX500Name(x500Name: CordaX500Name): Party? {
+    override fun wellKnownPartyFromX500Name(x500Name: CordaX500Name): Party? {
         return database.transaction {
-            services.identityService.partyFromX500Name(x500Name)
+            services.identityService.wellKnownPartyFromX500Name(x500Name)
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -75,14 +75,13 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate> = emptyS
     }
 
     override fun certificateFromKey(owningKey: PublicKey): PartyAndCertificate? = keyToParties[owningKey]
-    override fun certificateFromParty(party: Party): PartyAndCertificate = principalToParties[party.name] ?: throw IllegalArgumentException("Unknown identity ${party.name}")
 
     // We give the caller a copy of the data set to avoid any locking problems
     override fun getAllIdentities(): Iterable<PartyAndCertificate> = ArrayList(keyToParties.values)
 
     override fun partyFromKey(key: PublicKey): Party? = keyToParties[key]?.party
-    override fun partyFromX500Name(name: CordaX500Name): Party? = principalToParties[name]?.party
-    override fun partyFromAnonymous(party: AbstractParty): Party? {
+    override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = principalToParties[name]?.party
+    override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
         // Expand the anonymous party to a full party (i.e. has a name) if possible
         val candidate = party as? Party ?: keyToParties[party.owningKey]?.party
         // TODO: This should be done via the network map cache, which is the authoritative source of well known identities
@@ -95,9 +94,9 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate> = emptyS
             null
         }
     }
-    override fun partyFromAnonymous(partyRef: PartyAndReference) = partyFromAnonymous(partyRef.party)
-    override fun requirePartyFromAnonymous(party: AbstractParty): Party {
-        return partyFromAnonymous(party) ?: throw IllegalStateException("Could not deanonymise party ${party.owningKey.toStringShort()}")
+    override fun wellKnownPartyFromAnonymous(partyRef: PartyAndReference) = wellKnownPartyFromAnonymous(partyRef.party)
+    override fun requireWellKnownPartyFromAnonymous(party: AbstractParty): Party {
+        return wellKnownPartyFromAnonymous(party) ?: throw IllegalStateException("Could not deanonymise party ${party.owningKey.toStringShort()}")
     }
 
     override fun partiesFromName(query: String, exactMatch: Boolean): Set<Party> {

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -110,7 +110,7 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
     override fun getNodesByLegalIdentityKey(identityKey: PublicKey): List<NodeInfo> =
             serviceHub.database.transaction { queryByIdentityKey(identityKey) }
     override fun getNodeByLegalIdentity(party: AbstractParty): NodeInfo? {
-        val wellKnownParty = serviceHub.identityService.partyFromAnonymous(party)
+        val wellKnownParty = serviceHub.identityService.wellKnownPartyFromAnonymous(party)
         return wellKnownParty?.let {
             getNodesByLegalIdentityKey(it.owningKey).singleOrNull()
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt
@@ -21,7 +21,7 @@ class AbstractPartyToX500NameAsStringConverter(identitySvc: () -> IdentityServic
 
     override fun convertToDatabaseColumn(party: AbstractParty?): String? {
         if (party != null) {
-            val partyName = identityService.partyFromAnonymous(party)?.toString()
+            val partyName = identityService.wellKnownPartyFromAnonymous(party)?.toString()
             if (partyName != null) return partyName
             log.warn("Identity service unable to resolve AbstractParty: $party")
         }
@@ -30,7 +30,7 @@ class AbstractPartyToX500NameAsStringConverter(identitySvc: () -> IdentityServic
 
     override fun convertToEntityAttribute(dbData: String?): AbstractParty? {
         if (dbData != null) {
-            val party = identityService.partyFromX500Name(CordaX500Name.parse(dbData))
+            val party = identityService.wellKnownPartyFromX500Name(CordaX500Name.parse(dbData))
             if (party != null) return party
             log.warn ("Identity service unable to resolve X500name: $dbData")
         }

--- a/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/InMemoryIdentityServiceTests.kt
@@ -54,7 +54,7 @@ class InMemoryIdentityServiceTests {
     @Test
     fun `get identity by name with no registered identities`() {
         val service = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
-        assertNull(service.partyFromX500Name(ALICE.name))
+        assertNull(service.wellKnownPartyFromX500Name(ALICE.name))
     }
 
     @Test
@@ -74,9 +74,9 @@ class InMemoryIdentityServiceTests {
         val service = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
         val identities = listOf("Org A", "Org B", "Org C")
                 .map { getTestPartyAndCertificate(CordaX500Name(organisation = it, locality = "London", country = "GB"), generateKeyPair().public) }
-        assertNull(service.partyFromX500Name(identities.first().name))
+        assertNull(service.wellKnownPartyFromX500Name(identities.first().name))
         identities.forEach { service.verifyAndRegisterIdentity(it) }
-        identities.forEach { assertEquals(it.party, service.partyFromX500Name(it.name)) }
+        identities.forEach { assertEquals(it.party, service.wellKnownPartyFromX500Name(it.name)) }
     }
 
     /**
@@ -171,7 +171,7 @@ class InMemoryIdentityServiceTests {
     @Test
     fun `deanonymising a well known identity`() {
         val expected = ALICE
-        val actual = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT).partyFromAnonymous(expected)
+        val actual = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT).wellKnownPartyFromAnonymous(expected)
         assertEquals(expected, actual)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/network/PersistentIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/PersistentIdentityServiceTests.kt
@@ -88,7 +88,7 @@ class PersistentIdentityServiceTests {
     @Test
     fun `get identity by name with no registered identities`() {
         database.transaction {
-            assertNull(identityService.partyFromX500Name(ALICE.name))
+            assertNull(identityService.wellKnownPartyFromX500Name(ALICE.name))
         }
     }
 
@@ -112,7 +112,7 @@ class PersistentIdentityServiceTests {
         val identities = listOf("Organisation A", "Organisation B", "Organisation C")
                 .map { getTestPartyAndCertificate(CordaX500Name(organisation = it, locality = "London", country = "GB"), generateKeyPair().public) }
         database.transaction {
-            assertNull(identityService.partyFromX500Name(identities.first().name))
+            assertNull(identityService.wellKnownPartyFromX500Name(identities.first().name))
         }
         identities.forEach {
             database.transaction {
@@ -121,7 +121,7 @@ class PersistentIdentityServiceTests {
         }
         identities.forEach {
             database.transaction {
-                assertEquals(it.party, identityService.partyFromX500Name(it.name))
+                assertEquals(it.party, identityService.wellKnownPartyFromX500Name(it.name))
             }
         }
     }
@@ -245,7 +245,7 @@ class PersistentIdentityServiceTests {
         }
 
         val aliceParent = database.transaction {
-            newPersistentIdentityService.partyFromAnonymous(anonymousAlice.party.anonymise())
+            newPersistentIdentityService.wellKnownPartyFromAnonymous(anonymousAlice.party.anonymise())
         }
         assertEquals(alice.party, aliceParent!!)
 
@@ -272,7 +272,7 @@ class PersistentIdentityServiceTests {
     fun `deanonymising a well known identity`() {
         val expected = ALICE
         val actual = database.transaction {
-            identityService.partyFromAnonymous(expected)
+            identityService.wellKnownPartyFromAnonymous(expected)
         }
         assertEquals(expected, actual)
     }

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
@@ -87,8 +87,8 @@ fun sender(rpc: CordaRPCOps, numOfClearBytes: Int = 1024) { // default size 1K.
 private fun sender(rpc: CordaRPCOps, inputStream: InputStream, hash: SecureHash.SHA256, executor: ScheduledExecutorService) {
 
     // Get the identity key of the other side (the recipient).
-    val notaryFuture: CordaFuture<Party> = poll(executor, DUMMY_NOTARY.name.toString()) { rpc.partyFromX500Name(DUMMY_NOTARY.name) }
-    val otherSideFuture: CordaFuture<Party> = poll(executor, DUMMY_BANK_B.name.toString()) { rpc.partyFromX500Name(DUMMY_BANK_B.name) }
+    val notaryFuture: CordaFuture<Party> = poll(executor, DUMMY_NOTARY.name.toString()) { rpc.wellKnownPartyFromX500Name(DUMMY_NOTARY.name) }
+    val otherSideFuture: CordaFuture<Party> = poll(executor, DUMMY_BANK_B.name.toString()) { rpc.wellKnownPartyFromX500Name(DUMMY_BANK_B.name) }
 
     // Make sure we have the file in storage
     if (!rpc.attachmentExists(hash)) {

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaClientApi.kt
@@ -39,7 +39,7 @@ class BankOfCordaClientApi(val hostAndPort: NetworkHostAndPort) {
             rpc.waitUntilNetworkReady()
 
             // Resolve parties via RPC
-            val issueToParty = rpc.partyFromX500Name(params.issueToPartyName)
+            val issueToParty = rpc.wellKnownPartyFromX500Name(params.issueToPartyName)
                     ?: throw IllegalStateException("Unable to locate ${params.issueToPartyName} in Network Map Service")
             val notaryLegalIdentity = rpc.notaryIdentities().firstOrNull { it.name == params.notaryName } ?:
                     throw IllegalStateException("Couldn't locate notary ${params.notaryName} in NetworkMapCache")

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/api/BankOfCordaWebApi.kt
@@ -41,9 +41,9 @@ class BankOfCordaWebApi(val rpc: CordaRPCOps) {
     @Consumes(MediaType.APPLICATION_JSON)
     fun issueAssetRequest(params: IssueRequestParams): Response {
         // Resolve parties via RPC
-        val issueToParty = rpc.partyFromX500Name(params.issueToPartyName)
+        val issueToParty = rpc.wellKnownPartyFromX500Name(params.issueToPartyName)
                 ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issueToPartyName} in identity service").build()
-        rpc.partyFromX500Name(params.issuerBankName) ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issuerBankName} in identity service").build()
+        rpc.wellKnownPartyFromX500Name(params.issuerBankName) ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate ${params.issuerBankName} in identity service").build()
         val notaryParty = rpc.notaryIdentities().firstOrNull { it.name == params.notaryName }
                 ?: return Response.status(Response.Status.FORBIDDEN).entity("Unable to locate notary ${params.notaryName} in network map").build()
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -136,7 +136,7 @@ object FixingFlow {
             val myKey = ourIdentity.owningKey
             if (parties[0].owningKey == myKey) {
                 val fixing = FixingSession(ref, fixableDeal.oracle)
-                val counterparty = serviceHub.identityService.partyFromAnonymous(parties[1]) ?: throw IllegalStateException("Cannot resolve floater party")
+                val counterparty = serviceHub.identityService.wellKnownPartyFromAnonymous(parties[1]) ?: throw IllegalStateException("Cannot resolve floater party")
                 // Start the Floater which will then kick-off the Fixer
                 val session = initiateFlow(counterparty)
                 subFlow(Floater(session, fixing))

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
@@ -115,7 +115,7 @@ object SimmFlow {
             val state = stateRef.state.data
             val portfolio = serviceHub.vaultQueryService.queryBy<IRSState>(VaultQueryCriteria(stateRefs = state.portfolio)).states.toPortfolio()
 
-            val valuer = serviceHub.identityService.partyFromAnonymous(state.valuer)
+            val valuer = serviceHub.identityService.wellKnownPartyFromAnonymous(state.valuer)
             require(valuer != null) { "Valuer party must be known to this node" }
             val valuation = agreeValuation(portfolio, valuationDate, valuer!!)
             val update = PortfolioState.Update(valuation = valuation)
@@ -317,7 +317,7 @@ object SimmFlow {
         @Suspendable
         private fun updateValuation(stateRef: StateAndRef<PortfolioState>) {
             val portfolio = serviceHub.vaultQueryService.queryBy<IRSState>(VaultQueryCriteria(stateRefs = stateRef.state.data.portfolio)).states.toPortfolio()
-            val valuer = serviceHub.identityService.partyFromAnonymous(stateRef.state.data.valuer) ?: throw IllegalStateException("Unknown valuer party ${stateRef.state.data.valuer}")
+            val valuer = serviceHub.identityService.wellKnownPartyFromAnonymous(stateRef.state.data.valuer) ?: throw IllegalStateException("Unknown valuer party ${stateRef.state.data.valuer}")
             val valuation = agreeValuation(portfolio, offer.valuationDate, valuer)
             subFlow(object : StateRevisionFlow.Receiver<PortfolioState.Update>(replyToSession) {
                 override fun verifyProposal(stx: SignedTransaction, proposal: Proposal<PortfolioState.Update>) {

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmRevaluation.kt
@@ -23,7 +23,7 @@ object SimmRevaluation {
             val stateAndRef = serviceHub.vaultQueryService.queryBy<PortfolioState>(VaultQueryCriteria(stateRefs = listOf(curStateRef))).states.single()
             val curState = stateAndRef.state.data
             if (ourIdentity == curState.participants[0]) {
-                val otherParty = serviceHub.identityService.partyFromAnonymous(curState.participants[1])
+                val otherParty = serviceHub.identityService.wellKnownPartyFromAnonymous(curState.participants[1])
                 require(otherParty != null) { "Other party must be known by this node" }
                 subFlow(SimmFlow.Requester(otherParty!!, valuationDate, stateAndRef))
             }

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemoClientApi.kt
@@ -43,8 +43,8 @@ class TraderDemoClientApi(val rpc: CordaRPCOps) {
 
     fun runIssuer(amount: Amount<Currency>, buyerName: CordaX500Name, sellerName: CordaX500Name) {
         val ref = OpaqueBytes.of(1)
-        val buyer = rpc.partyFromX500Name(buyerName) ?: throw IllegalStateException("Don't know $buyerName")
-        val seller = rpc.partyFromX500Name(sellerName) ?: throw IllegalStateException("Don't know $sellerName")
+        val buyer = rpc.wellKnownPartyFromX500Name(buyerName) ?: throw IllegalStateException("Don't know $buyerName")
+        val seller = rpc.wellKnownPartyFromX500Name(sellerName) ?: throw IllegalStateException("Don't know $sellerName")
         val notaryIdentity = rpc.notaryIdentities().first()
 
         val amounts = calculateRandomlySizedAmounts(amount, 3, 10, Random())
@@ -73,7 +73,7 @@ class TraderDemoClientApi(val rpc: CordaRPCOps) {
     }
 
     fun runSeller(amount: Amount<Currency> = 1000.0.DOLLARS, buyerName: CordaX500Name) {
-        val otherParty = rpc.partyFromX500Name(buyerName) ?: throw IllegalStateException("Don't know $buyerName")
+        val otherParty = rpc.wellKnownPartyFromX500Name(buyerName) ?: throw IllegalStateException("Don't know $buyerName")
         // The seller will sell some commercial paper to the buyer, who will pay with (self issued) cash.
         //
         // The CP sale transaction comes with a prospectus PDF, which will tag along for the ride in an


### PR DESCRIPTION
The partyFromXXX methods on IdentityService actually return different forms of Party. Some return well known Parties i.e. In NetworkMapCache and some return the requested Party only i.e. only qualify the X500Name for a key. To make this clearer this PR just renames those returning a well known party.

There has been lots of debate about making well known identity type safe, but for now I am just cleaning the API.