### PR TITLE
Move IdentitySyncFlow into confidential-identities

### DIFF
--- a/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt
@@ -1,7 +1,8 @@
-package net.corda.core.flows
+package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.ContractState
+import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
@@ -1,6 +1,9 @@
-package net.corda.core.flows
+package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.Party
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
@@ -1,11 +1,11 @@
 package net.corda.finance.flows
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.confidential.IdentitySyncFlow
 import net.corda.core.contracts.*
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder


### PR DESCRIPTION
Move IdentitySyncFlow into confidential-identities for consistency in where confidential identity components are in the 1.0 release.
