### PR TITLE
InitiatingFlowLogic

### DIFF
--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -1,8 +1,8 @@
 package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.InitiatingFlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
@@ -20,7 +20,7 @@ import net.corda.core.utilities.unwrap
 @InitiatingFlow
 class SwapIdentitiesFlow(private val otherParty: Party,
                          private val revocationEnabled: Boolean,
-                         override val progressTracker: ProgressTracker) : FlowLogic<LinkedHashMap<Party, AnonymousParty>>() {
+                         override val progressTracker: ProgressTracker) : InitiatingFlowLogic<LinkedHashMap<Party, AnonymousParty>>() {
     constructor(otherParty: Party) : this(otherParty, false, tracker())
 
     companion object {

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
@@ -1,10 +1,7 @@
 package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
-import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes
@@ -69,7 +66,7 @@ class IdentitySyncFlowTests {
      * Very lightweight wrapping flow to trigger the counterparty flow that receives the identities.
      */
     @InitiatingFlow
-    class Initiator(val otherSide: Party, val tx: WireTransaction): FlowLogic<Boolean>() {
+    class Initiator(val otherSide: Party, val tx: WireTransaction): InitiatingFlowLogic<Boolean>() {
         @Suspendable
         override fun call(): Boolean {
             val session = initiateFlow(otherSide)

--- a/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt
@@ -48,7 +48,7 @@ abstract class AbstractStateReplacementFlow {
     abstract class Instigator<out S : ContractState, out T : ContractState, out M>(
             val originalState: StateAndRef<S>,
             val modification: M,
-            override val progressTracker: ProgressTracker = Instigator.tracker()) : FlowLogic<StateAndRef<T>>() {
+            override val progressTracker: ProgressTracker = Instigator.tracker()) : InitiatingFlowLogic<StateAndRef<T>>() {
         companion object {
             object SIGNING : ProgressTracker.Step("Requesting signatures from other parties")
             object NOTARY : ProgressTracker.Step("Requesting notary signature")

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -26,7 +26,7 @@ import net.corda.core.utilities.ProgressTracker
 @InitiatingFlow
 class FinalityFlow(val transaction: SignedTransaction,
                         private val extraRecipients: Set<Party>,
-                        override val progressTracker: ProgressTracker) : FlowLogic<SignedTransaction>() {
+                        override val progressTracker: ProgressTracker) : InitiatingFlowLogic<SignedTransaction>() {
     constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(transaction, extraParticipants, tracker())
     constructor(transaction: SignedTransaction) : this(transaction, emptySet(), tracker())
     constructor(transaction: SignedTransaction, progressTracker: ProgressTracker) : this(transaction, emptySet(), progressTracker)

--- a/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FlowLogic.kt
@@ -55,9 +55,6 @@ abstract class FlowLogic<out T> {
      */
     val serviceHub: ServiceHub get() = stateMachine.serviceHub
 
-    @Suspendable
-    fun initiateFlow(party: Party): FlowSession = stateMachine.initiateFlow(party, flowUsedForSessions)
-
     /**
      * Specifies the identity, with certificate, to use for this flow. This will be one of the multiple identities that
      * belong to this node.
@@ -317,7 +314,7 @@ abstract class FlowLogic<out T> {
 
     // This is the flow used for managing sessions. It defaults to the current flow but if this is an inlined sub-flow
     // then it will point to the flow it's been inlined to.
-    private var flowUsedForSessions: FlowLogic<*> = this
+    internal var flowUsedForSessions: FlowLogic<*> = this
 
     private fun maybeWireUpProgressTracking(subLogic: FlowLogic<*>) {
         val ours = progressTracker
@@ -330,6 +327,11 @@ abstract class FlowLogic<out T> {
             ours.setChildProgressTracker(ours.currentStep, theirs)
         }
     }
+}
+
+abstract class InitiatingFlowLogic<out A> : FlowLogic<A>() {
+    @Suspendable
+    fun initiateFlow(party: Party): FlowSession = stateMachine.initiateFlow(party, flowUsedForSessions)
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/flows/InitiatedBy.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/InitiatedBy.kt
@@ -15,4 +15,4 @@ import kotlin.reflect.KClass
  * @see InitiatingFlow
  */
 @Target(CLASS)
-annotation class InitiatedBy(val value: KClass<out FlowLogic<*>>)
+annotation class InitiatedBy(val value: KClass<out InitiatingFlowLogic<*>>)

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -34,7 +34,7 @@ class NotaryFlow {
      */
     @InitiatingFlow
     open class Client(private val stx: SignedTransaction,
-                      override val progressTracker: ProgressTracker) : FlowLogic<List<TransactionSignature>>() {
+                      override val progressTracker: ProgressTracker) : InitiatingFlowLogic<List<TransactionSignature>>() {
         constructor(stx: SignedTransaction) : this(stx, tracker())
 
         companion object {

--- a/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
+++ b/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
@@ -70,7 +70,7 @@ public class FlowsInJavaTest {
     }
 
     @InitiatingFlow
-    private static class SendInUnwrapFlow extends FlowLogic<String> {
+    private static class SendInUnwrapFlow extends InitiatingFlowLogic<String> {
         private final Party otherParty;
 
         private SendInUnwrapFlow(Party otherParty) {
@@ -104,7 +104,7 @@ public class FlowsInJavaTest {
     }
 
     @InitiatingFlow
-    private static class PrimitiveReceiveFlow extends FlowLogic<Void> {
+    private static class PrimitiveReceiveFlow extends InitiatingFlowLogic<Void> {
         private final Party otherParty;
         private final Class<?> receiveType;
 

--- a/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
@@ -160,7 +160,7 @@ class AttachmentTests {
     private fun StartedNode<*>.startAttachmentFlow(hashes: Set<SecureHash>, otherSide: Party) = services.startFlow(InitiatingFetchAttachmentsFlow(otherSide, hashes))
 
     @InitiatingFlow
-    private class InitiatingFetchAttachmentsFlow(val otherSide: Party, val hashes: Set<SecureHash>) : FlowLogic<FetchDataFlow.Result<Attachment>>() {
+    private class InitiatingFetchAttachmentsFlow(val otherSide: Party, val hashes: Set<SecureHash>) : InitiatingFlowLogic<FetchDataFlow.Result<Attachment>>() {
         @Suspendable
         override fun call(): FetchDataFlow.Result<Attachment> {
             val session = initiateFlow(otherSide)

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -59,7 +59,7 @@ class CollectSignaturesFlowTests {
     // "collectSignaturesFlow" and "SignTransactionFlow" can be used in practise.
     object TestFlow {
         @InitiatingFlow
-        class Initiator(private val state: DummyContract.MultiOwnerState, private val otherParty: Party) : FlowLogic<SignedTransaction>() {
+        class Initiator(private val state: DummyContract.MultiOwnerState, private val otherParty: Party) : InitiatingFlowLogic<SignedTransaction>() {
             @Suspendable
             override fun call(): SignedTransaction {
                 val session = initiateFlow(otherParty)
@@ -104,7 +104,7 @@ class CollectSignaturesFlowTests {
     // receiving off the wire.
     object TestFlowTwo {
         @InitiatingFlow
-        class Initiator(private val state: DummyContract.MultiOwnerState) : FlowLogic<SignedTransaction>() {
+        class Initiator(private val state: DummyContract.MultiOwnerState) : InitiatingFlowLogic<SignedTransaction>() {
             @Suspendable
             override fun call(): SignedTransaction {
                 val notary = serviceHub.getDefaultNotary()

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -252,7 +252,7 @@ class ContractUpgradeFlowTest {
 
     @StartableByRPC
     class FinalityInvoker(private val transaction: SignedTransaction,
-                          private val extraRecipients: Set<Party>) : FlowLogic<SignedTransaction>() {
+                          private val extraRecipients: Set<Party>) : InitiatingFlowLogic<SignedTransaction>() {
         @Suspendable
         override fun call(): SignedTransaction = subFlow(FinalityFlow(transaction, extraRecipients))
     }

--- a/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
@@ -192,7 +192,7 @@ class ResolveTransactionsFlowTest {
     // DOCEND 2
 
     @InitiatingFlow
-    private class TestFlow(val otherSide: Party, private val resolveTransactionsFlowFactory: (FlowSession) -> ResolveTransactionsFlow, private val txCountLimit: Int? = null) : FlowLogic<List<SignedTransaction>>() {
+    private class TestFlow(val otherSide: Party, private val resolveTransactionsFlowFactory: (FlowSession) -> ResolveTransactionsFlow, private val txCountLimit: Int? = null) : InitiatingFlowLogic<List<SignedTransaction>>() {
         constructor(txHashes: Set<SecureHash>, otherSide: Party, txCountLimit: Int? = null) : this(otherSide, { ResolveTransactionsFlow(txHashes, it) }, txCountLimit = txCountLimit)
         constructor(stx: SignedTransaction, otherSide: Party) : this(otherSide, { ResolveTransactionsFlow(stx, it) })
 

--- a/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/AttachmentSerializationTest.kt
@@ -3,10 +3,7 @@ package net.corda.core.serialization
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Attachment
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatingFlow
-import net.corda.core.flows.TestDataVendingFlow
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.FetchAttachmentsFlow
 import net.corda.core.internal.FetchDataFlow
@@ -97,7 +94,7 @@ class AttachmentSerializationTest {
     private class ClientResult(internal val attachmentContent: String)
 
     @InitiatingFlow
-    private abstract class ClientLogic(server: StartedNode<*>) : FlowLogic<ClientResult>() {
+    private abstract class ClientLogic(server: StartedNode<*>) : InitiatingFlowLogic<ClientResult>() {
         internal val server = server.info.chooseIdentity()
 
         @Suspendable

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -49,7 +49,7 @@ public class FlowCookbookJava {
     @StartableByRPC
     // Every flow must subclass ``FlowLogic``. The generic indicates the
     // flow's return type.
-    public static class InitiatorFlow extends FlowLogic<Void> {
+    public static class InitiatorFlow extends InitiatingFlowLogic<Void> {
 
         private final boolean arg1;
         private final int arg2;

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt
@@ -77,7 +77,7 @@ object TopupIssuerFlow {
     class TopupIssuanceRequester(val issueToParty: Party,
                                  val issueToPartyRef: OpaqueBytes,
                                  val issuerBankParty: Party,
-                                 val notaryParty: Party) : FlowLogic<List<AbstractCashFlow.Result>>() {
+                                 val notaryParty: Party) : InitiatingFlowLogic<List<AbstractCashFlow.Result>>() {
         @Suspendable
         @Throws(CashException::class)
         override fun call(): List<AbstractCashFlow.Result> {

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
@@ -42,7 +42,7 @@ object FlowCookbook {
     @StartableByRPC
     // Every flow must subclass ``FlowLogic``. The generic indicates the
     // flow's return type.
-    class InitiatorFlow(val arg1: Boolean, val arg2: Int, private val counterparty: Party, val regulator: Party) : FlowLogic<Unit>() {
+    class InitiatorFlow(val arg1: Boolean, val arg2: Int, private val counterparty: Party, val regulator: Party) : InitiatingFlowLogic<Unit>() {
 
         /**---------------------------------
          * WIRING UP THE PROGRESS TRACKER *

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FxTransactionBuildTutorial.kt
@@ -91,7 +91,7 @@ class ForeignExchangeFlow(private val tradeId: String,
                           private val baseCurrencyAmount: Amount<Issued<Currency>>,
                           private val quoteCurrencyAmount: Amount<Issued<Currency>>,
                           private val counterparty: Party,
-                          private val weAreBaseCurrencySeller: Boolean) : FlowLogic<SecureHash>() {
+                          private val weAreBaseCurrencySeller: Boolean) : InitiatingFlowLogic<SecureHash>() {
     @Suspendable
     override fun call(): SecureHash {
         // Select correct sides of the Fx exchange to query for.

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/WorkflowTransactionBuildTutorial.kt
@@ -92,7 +92,7 @@ data class TradeApprovalContract(val blank: Unit? = null) : Contract {
  * as their approval/rejection is to follow.
  */
 class SubmitTradeApprovalFlow(private val tradeId: String,
-                              private val counterparty: Party) : FlowLogic<StateAndRef<TradeApprovalContract.State>>() {
+                              private val counterparty: Party) : InitiatingFlowLogic<StateAndRef<TradeApprovalContract.State>>() {
     @Suspendable
     override fun call(): StateAndRef<TradeApprovalContract.State> {
         // Manufacture an initial state
@@ -118,7 +118,7 @@ class SubmitTradeApprovalFlow(private val tradeId: String,
  * end up with a fully signed copy of the state either as APPROVED, or REJECTED
  */
 @InitiatingFlow
-class SubmitCompletionFlow(private val ref: StateRef, private val verdict: WorkflowState) : FlowLogic<StateAndRef<TradeApprovalContract.State>>() {
+class SubmitCompletionFlow(private val ref: StateRef, private val verdict: WorkflowState) : InitiatingFlowLogic<StateAndRef<TradeApprovalContract.State>>() {
     init {
         require(verdict in setOf(WorkflowState.APPROVED, WorkflowState.REJECTED)) {
             "Verdict must be a final state"

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
@@ -77,7 +77,7 @@ object TwoPartyDealFlow {
      * Abstracted bilateral deal flow participant that is recipient of initial communication.
      */
     abstract class Secondary<U>(override val progressTracker: ProgressTracker = Secondary.tracker(),
-                                val regulators: Set<Party> = emptySet()) : FlowLogic<SignedTransaction>() {
+                                val regulators: Set<Party> = emptySet()) : InitiatingFlowLogic<SignedTransaction>() {
 
         companion object {
             object RECEIVING : ProgressTracker.Step("Waiting for deal info.")

--- a/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CordappScanningDriverTest.kt
@@ -36,7 +36,7 @@ class CordappScanningDriverTest {
 
     @StartableByRPC
     @InitiatingFlow
-    class ReceiveFlow(val otherParty: Party) :FlowLogic<String>() {
+    class ReceiveFlow(val otherParty: Party) : InitiatingFlowLogic<String>() {
         @Suspendable
         override fun call(): String = initiateFlow(otherParty).receive<String>().unwrap { it }
     }

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/FlowVersioningTest.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.InitiatingFlowLogic
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.getOrThrow
@@ -29,7 +30,7 @@ class FlowVersioningTest : NodeBasedTest() {
     }
 
     @InitiatingFlow
-    private class PretendInitiatingCoreFlow(val initiatedParty: Party) : FlowLogic<Pair<Int, Int>>() {
+    private class PretendInitiatingCoreFlow(val initiatedParty: Party) : InitiatingFlowLogic<Pair<Int, Int>>() {
         @Suspendable
         override fun call(): Pair<Int, Int> {
             // Execute receive() outside of the Pair constructor to avoid Kotlin/Quasar instrumentation bug.

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -25,7 +25,7 @@ class LargeTransactionsTest {
     class SendLargeTransactionFlow(private val hash1: SecureHash,
                                    private val hash2: SecureHash,
                                    private val hash3: SecureHash,
-                                   private val hash4: SecureHash) : FlowLogic<Unit>() {
+                                   private val hash4: SecureHash) : InitiatingFlowLogic<Unit>() {
         @Suspendable
         override fun call() {
             val tx = TransactionBuilder(notary = DUMMY_NOTARY)

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -4,10 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
-import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.NetworkHostAndPort
@@ -228,7 +225,7 @@ abstract class MQSecurityTest : NodeBasedTest() {
     }
 
     @InitiatingFlow
-    private class SendFlow(val otherParty: Party, val payload: Any) : FlowLogic<Unit>() {
+    private class SendFlow(val otherParty: Party, val payload: Any) : InitiatingFlowLogic<Unit>() {
         @Suspendable
         override fun call() = initiateFlow(otherParty).send(payload)
     }

--- a/node/src/smoke-test/kotlin/net/corda/node/CordappSmokeTest.kt
+++ b/node/src/smoke-test/kotlin/net/corda/node/CordappSmokeTest.kt
@@ -66,7 +66,7 @@ class CordappSmokeTest {
 
     @InitiatingFlow
     @StartableByRPC
-    class GatherContextsFlow(private val otherParty: Party) : FlowLogic<Pair<FlowInfo, FlowInfo>>() {
+    class GatherContextsFlow(private val otherParty: Party) : InitiatingFlowLogic<Pair<FlowInfo, FlowInfo>>() {
         @Suspendable
         override fun call(): Pair<FlowInfo, FlowInfo> {
             // This receive will kick off SendBackInitiatorFlowContext by sending a session-init with our app name.

--- a/node/src/test/kotlin/net/corda/node/cordapp/CordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/cordapp/CordappLoaderTest.kt
@@ -1,16 +1,13 @@
 package net.corda.node.cordapp
 
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
-import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.*
 import net.corda.node.internal.cordapp.CordappLoader
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.nio.file.Paths
 
 @InitiatingFlow
-class DummyFlow : FlowLogic<Unit>() {
+class DummyFlow : InitiatingFlowLogic<Unit>() {
     override fun call() { }
 }
 

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -551,7 +551,7 @@ class TwoPartyTradeFlowTests {
                           private val notary: Party,
                           private val assetToSell: StateAndRef<OwnableState>,
                           private val price: Amount<Currency>,
-                          private val anonymous: Boolean) : FlowLogic<SignedTransaction>() {
+                          private val anonymous: Boolean) : InitiatingFlowLogic<SignedTransaction>() {
         @Suspendable
         override fun call(): SignedTransaction {
             val myPartyAndCert = if (anonymous) {

--- a/node/src/test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -1,10 +1,7 @@
 package net.corda.node.services.network
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
-import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.*
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
@@ -166,7 +163,7 @@ class PersistentNetworkMapCacheTest : NodeBasedTest() {
     }
 
     @InitiatingFlow
-    private class SendFlow(val otherParty: Party) : FlowLogic<String>() {
+    private class SendFlow(val otherParty: Party) : InitiatingFlowLogic<String>() {
         @Suspendable
         override fun call(): String {
             println("SEND FLOW to $otherParty")

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -416,7 +416,7 @@ class FlowFrameworkTests {
 
     @InitiatingFlow
     private class WaitForOtherSideEndBeforeSendAndReceive(val otherParty: Party,
-                                                          @Transient val receivedOtherFlowEnd: Semaphore) : FlowLogic<Unit>() {
+                                                          @Transient val receivedOtherFlowEnd: Semaphore) : InitiatingFlowLogic<Unit>() {
         @Suspendable
         override fun call() {
             // Kick off the flow on the other side ...
@@ -558,7 +558,7 @@ class FlowFrameworkTests {
     @Test
     fun `retry subFlow due to receiving FlowException`() {
         @InitiatingFlow
-        class AskForExceptionFlow(val otherParty: Party, val throwException: Boolean) : FlowLogic<String>() {
+        class AskForExceptionFlow(val otherParty: Party, val throwException: Boolean) : InitiatingFlowLogic<String>() {
             @Suspendable
             override fun call(): String = initiateFlow(otherParty).sendAndReceive<String>(throwException).unwrap { it }
         }
@@ -747,7 +747,7 @@ class FlowFrameworkTests {
     }
 
     @InitiatingFlow
-    private class DoubleInitiatingFlow : FlowLogic<Unit>() {
+    private class DoubleInitiatingFlow : InitiatingFlowLogic<Unit>() {
         @Suspendable
         override fun call() {
             initiateFlow(serviceHub.myInfo.chooseIdentity())
@@ -867,7 +867,7 @@ class FlowFrameworkTests {
     }
 
     @InitiatingFlow
-    private open class SendFlow(val payload: Any, vararg val otherParties: Party) : FlowLogic<FlowInfo>() {
+    private open class SendFlow(val payload: Any, vararg val otherParties: Party) : InitiatingFlowLogic<FlowInfo>() {
         init {
             require(otherParties.isNotEmpty())
         }
@@ -896,7 +896,7 @@ class FlowFrameworkTests {
     private class IncorrectCustomSendFlow(payload: String, otherParty: Party) : CustomInterface, SendFlow(payload, otherParty)
 
     @InitiatingFlow
-    private class ReceiveFlow(vararg val otherParties: Party) : FlowLogic<Unit>() {
+    private class ReceiveFlow(vararg val otherParties: Party) : InitiatingFlowLogic<Unit>() {
         object START_STEP : ProgressTracker.Step("Starting")
         object RECEIVED_STEP : ProgressTracker.Step("Received")
 
@@ -950,7 +950,7 @@ class FlowFrameworkTests {
     }
 
     @InitiatingFlow
-    private class SendAndReceiveFlow(val otherParty: Party, val payload: Any, val otherPartySession: FlowSession? = null) : FlowLogic<Any>() {
+    private class SendAndReceiveFlow(val otherParty: Party, val payload: Any, val otherPartySession: FlowSession? = null) : InitiatingFlowLogic<Any>() {
         constructor(otherPartySession: FlowSession, payload: Any) : this(otherPartySession.counterparty, payload, otherPartySession)
         @Suspendable
         override fun call(): Any = (otherPartySession ?: initiateFlow(otherParty)).sendAndReceive<Any>(payload).unwrap { it }
@@ -962,7 +962,7 @@ class FlowFrameworkTests {
     }
 
     @InitiatingFlow
-    private class PingPongFlow(val otherParty: Party, val payload: Long, val otherPartySession: FlowSession? = null) : FlowLogic<Unit>() {
+    private class PingPongFlow(val otherParty: Party, val payload: Long, val otherPartySession: FlowSession? = null) : InitiatingFlowLogic<Unit>() {
         constructor(otherPartySession: FlowSession, payload: Long) : this(otherPartySession.counterparty, payload, otherPartySession)
         @Transient var receivedPayload: Long? = null
         @Transient var receivedPayload2: Long? = null
@@ -996,7 +996,7 @@ class FlowFrameworkTests {
 
     private object WaitingFlows {
         @InitiatingFlow
-        class Waiter(val stx: SignedTransaction, val otherParty: Party) : FlowLogic<SignedTransaction>() {
+        class Waiter(val stx: SignedTransaction, val otherParty: Party) : InitiatingFlowLogic<SignedTransaction>() {
             @Suspendable
             override fun call(): SignedTransaction {
                 val otherPartySession = initiateFlow(otherParty)
@@ -1016,7 +1016,7 @@ class FlowFrameworkTests {
     }
 
     @InitiatingFlow
-    private class VaultQueryFlow(val stx: SignedTransaction, val otherParty: Party) : FlowLogic<List<StateAndRef<ContractState>>>() {
+    private class VaultQueryFlow(val stx: SignedTransaction, val otherParty: Party) : InitiatingFlowLogic<List<StateAndRef<ContractState>>>() {
         @Suspendable
         override fun call(): List<StateAndRef<ContractState>> {
             val otherPartySession = initiateFlow(otherParty)
@@ -1030,7 +1030,7 @@ class FlowFrameworkTests {
     }
 
     @InitiatingFlow(version = 2)
-    private class UpgradedFlow(val otherParty: Party, val otherPartySession: FlowSession? = null) : FlowLogic<Pair<Any, Int>>() {
+    private class UpgradedFlow(val otherParty: Party, val otherPartySession: FlowSession? = null) : InitiatingFlowLogic<Pair<Any, Int>>() {
         constructor(otherPartySession: FlowSession) : this(otherPartySession.counterparty, otherPartySession)
         @Suspendable
         override fun call(): Pair<Any, Int> {

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
@@ -20,7 +20,7 @@ import net.corda.finance.flows.TwoPartyDealFlow.Instigator
 object AutoOfferFlow {
     @InitiatingFlow
     @StartableByRPC
-    class Requester(val dealToBeOffered: DealState) : FlowLogic<SignedTransaction>() {
+    class Requester(val dealToBeOffered: DealState) : InitiatingFlowLogic<SignedTransaction>() {
 
         companion object {
             object RECEIVED : ProgressTracker.Step("Received API call")

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -117,7 +117,7 @@ object FixingFlow {
      */
     @InitiatingFlow
     @SchedulableFlow
-    class FixingRoleDecider(val ref: StateRef, override val progressTracker: ProgressTracker) : FlowLogic<Unit>() {
+    class FixingRoleDecider(val ref: StateRef, override val progressTracker: ProgressTracker) : InitiatingFlowLogic<Unit>() {
         @Suppress("unused") // Used via reflection.
         constructor(ref: StateRef) : this(ref, tracker())
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/flows/RatesFixFlow.kt
@@ -4,8 +4,8 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.InitiatingFlowLogic
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.FilteredTransaction
@@ -95,7 +95,7 @@ open class RatesFixFlow(protected val tx: TransactionBuilder,
 
     // DOCSTART 1
     @InitiatingFlow
-    class FixQueryFlow(val fixOf: FixOf, val oracle: Party) : FlowLogic<Fix>() {
+    class FixQueryFlow(val fixOf: FixOf, val oracle: Party) : InitiatingFlowLogic<Fix>() {
         @Suspendable
         override fun call(): Fix {
             val oracleSession = initiateFlow(oracle)
@@ -113,7 +113,7 @@ open class RatesFixFlow(protected val tx: TransactionBuilder,
 
     @InitiatingFlow
     class FixSignFlow(val tx: TransactionBuilder, val oracle: Party,
-                      val partialMerkleTx: FilteredTransaction) : FlowLogic<TransactionSignature>() {
+                      val partialMerkleTx: FilteredTransaction) : InitiatingFlowLogic<TransactionSignature>() {
         @Suspendable
         override fun call(): TransactionSignature {
             val oracleSession = initiateFlow(oracle)

--- a/samples/irs-demo/src/test/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt
+++ b/samples/irs-demo/src/test/kotlin/net/corda/irs/flows/UpdateBusinessDayFlow.kt
@@ -33,7 +33,7 @@ object UpdateBusinessDayFlow {
 
     @InitiatingFlow
     @StartableByRPC
-    class Broadcast(val date: LocalDate, override val progressTracker: ProgressTracker) : FlowLogic<Unit>() {
+    class Broadcast(val date: LocalDate, override val progressTracker: ProgressTracker) : InitiatingFlowLogic<Unit>() {
         constructor(date: LocalDate) : this(date, tracker())
 
         companion object {

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import net.corda.client.jackson.JacksonSupport
 import net.corda.core.contracts.StateAndRef
-import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.InitiatingFlowLogic
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.node.services.queryBy
@@ -142,7 +142,7 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
         val notaryId = node1.rpcOps.notaryIdentities().first()
         @InitiatingFlow
         class StartDealFlow(val otherParty: Party,
-                            val payload: AutoOffer) : FlowLogic<SignedTransaction>() {
+                            val payload: AutoOffer) : InitiatingFlowLogic<SignedTransaction>() {
             @Suspendable
             override fun call(): SignedTransaction {
                 val session = initiateFlow(otherParty)

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/IRSTradeFlow.kt
@@ -16,7 +16,7 @@ object IRSTradeFlow {
 
     @InitiatingFlow
     @StartableByRPC
-    class Requester(val swap: SwapData, val otherParty: Party) : FlowLogic<SignedTransaction>() {
+    class Requester(val swap: SwapData, val otherParty: Party) : InitiatingFlowLogic<SignedTransaction>() {
         @Suspendable
         override fun call(): SignedTransaction {
             require(serviceHub.networkMapCache.notaryIdentities.isNotEmpty()) { "No notary nodes registered" }

--- a/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
+++ b/samples/simm-valuation-demo/src/main/kotlin/net/corda/vega/flows/SimmFlow.kt
@@ -55,7 +55,7 @@ object SimmFlow {
     class Requester(private val otherParty: Party,
                     private val valuationDate: LocalDate,
                     private val existing: StateAndRef<PortfolioState>?)
-        : FlowLogic<RevisionedState<PortfolioState.Update>>() {
+        : InitiatingFlowLogic<RevisionedState<PortfolioState.Update>>() {
         constructor(otherParty: Party, valuationDate: LocalDate) : this(otherParty, valuationDate, null)
         lateinit var notary: Party
         lateinit var otherPartySession: FlowSession

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/CommercialPaperIssueFlow.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
@@ -26,7 +26,7 @@ class CommercialPaperIssueFlow(private val amount: Amount<Currency>,
                                private val issueRef: OpaqueBytes,
                                private val recipient: Party,
                                private val notary: Party,
-                               override val progressTracker: ProgressTracker) : FlowLogic<SignedTransaction>() {
+                               override val progressTracker: ProgressTracker) : InitiatingFlowLogic<SignedTransaction>() {
     constructor(amount: Amount<Currency>, issueRef: OpaqueBytes, recipient: Party, notary: Party) : this(amount, issueRef, recipient, notary, tracker())
 
     companion object {

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/SellerFlow.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.Amount
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.InitiatingFlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
@@ -17,7 +18,7 @@ import java.util.*
 @StartableByRPC
 class SellerFlow(private val otherParty: Party,
                  private val amount: Amount<Currency>,
-                 override val progressTracker: ProgressTracker) : FlowLogic<SignedTransaction>() {
+                 override val progressTracker: ProgressTracker) : InitiatingFlowLogic<SignedTransaction>() {
     constructor(otherParty: Party, amount: Amount<Currency>) : this(otherParty, amount, tracker())
 
     companion object {


### PR DESCRIPTION
This is a PR implementing @shamsasari's suggestion for a type-safe enforcement of the invariant "Only flows annotated with `@InitiatingFlow` should ever call `initiateFlow`".
