### PR TITLE
Change public constant values to Kotlin constants

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -30,7 +30,7 @@ import java.util.*
 @CordaSerializable
 class CompositeKey private constructor(val threshold: Int, children: List<NodeAndWeight>) : PublicKey {
     companion object {
-        val KEY_ALGORITHM = "COMPOSITE"
+        const val KEY_ALGORITHM = "COMPOSITE"
         /**
          * Build a composite key from a DER encoded form.
          */

--- a/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt
+++ b/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt
@@ -10,7 +10,7 @@ import net.corda.finance.contracts.FixOf
 import java.math.BigDecimal
 import java.time.Instant
 
-val UNIVERSAL_PROGRAM_ID = "net.corda.finance.contracts.universal.UniversalContract"
+const val UNIVERSAL_PROGRAM_ID = "net.corda.finance.contracts.universal.UniversalContract"
 
 class UniversalContract : Contract {
     data class State(override val participants: List<AbstractParty>,

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -25,7 +25,7 @@ import kotlin.concurrent.withLock
 class CashSelectionH2Impl : CashSelection {
 
     companion object {
-        val JDBC_DRIVER_NAME = "H2 JDBC Driver"
+        const val JDBC_DRIVER_NAME = "H2 JDBC Driver"
         val log = loggerFor<CashSelectionH2Impl>()
     }
 

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionMySQLImpl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionMySQLImpl.kt
@@ -14,7 +14,7 @@ import java.util.*
 class CashSelectionMySQLImpl : CashSelection {
 
     companion object {
-        val JDBC_DRIVER_NAME = "MySQL JDBC Driver"
+        const val JDBC_DRIVER_NAME = "MySQL JDBC Driver"
     }
 
     override fun isCompatible(metadata: DatabaseMetaData): Boolean {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/VerifierApi.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/VerifierApi.kt
@@ -8,11 +8,11 @@ import org.apache.activemq.artemis.api.core.client.ClientMessage
 import org.apache.activemq.artemis.reader.MessageUtil
 
 object VerifierApi {
-    val VERIFIER_USERNAME = "SystemUsers/Verifier"
-    val VERIFICATION_REQUESTS_QUEUE_NAME = "verifier.requests"
-    val VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX = "verifier.responses"
-    private val VERIFICATION_ID_FIELD_NAME = "id"
-    private val RESULT_EXCEPTION_FIELD_NAME = "result-exception"
+    const val VERIFIER_USERNAME = "SystemUsers/Verifier"
+    const val VERIFICATION_REQUESTS_QUEUE_NAME = "verifier.requests"
+    const val VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX = "verifier.responses"
+    private const val VERIFICATION_ID_FIELD_NAME = "id"
+    private const val RESULT_EXCEPTION_FIELD_NAME = "result-exception"
 
     data class VerificationRequest(
             val verificationId: Long,

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/Schema.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/Schema.kt
@@ -18,9 +18,9 @@ import net.corda.nodeapi.internal.serialization.carpenter.Field as CarpenterFiel
 import net.corda.nodeapi.internal.serialization.carpenter.Schema as CarpenterSchema
 
 // TODO: get an assigned number as per AMQP spec
-val DESCRIPTOR_TOP_32BITS: Long = 0xc0da0000
+const val DESCRIPTOR_TOP_32BITS: Long = 0xc0da0000
 
-val DESCRIPTOR_DOMAIN: String = "net.corda"
+const val DESCRIPTOR_DOMAIN: String = "net.corda"
 
 // "corda" + majorVersionByte + minorVersionMSB + minorVersionLSB
 val AmqpHeaderV1_0: OpaqueBytes = OpaqueBytes("corda\u0001\u0000\u0000".toByteArray())

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
@@ -62,15 +62,15 @@ interface NetworkMapService {
 
     companion object {
         val DEFAULT_EXPIRATION_PERIOD: Period = Period.ofWeeks(4)
-        val FETCH_TOPIC = "platform.network_map.fetch"
-        val QUERY_TOPIC = "platform.network_map.query"
-        val REGISTER_TOPIC = "platform.network_map.register"
-        val SUBSCRIPTION_TOPIC = "platform.network_map.subscribe"
+        const val FETCH_TOPIC = "platform.network_map.fetch"
+        const val QUERY_TOPIC = "platform.network_map.query"
+        const val REGISTER_TOPIC = "platform.network_map.register"
+        const val SUBSCRIPTION_TOPIC = "platform.network_map.subscribe"
         // Base topic used when pushing out updates to the network map. Consumed, for example, by the map cache.
         // When subscribing to these updates, remember they must be acknowledged
-        val PUSH_TOPIC = "platform.network_map.push"
+        const val PUSH_TOPIC = "platform.network_map.push"
         // Base topic for messages acknowledging pushed updates
-        val PUSH_ACK_TOPIC = "platform.network_map.push_ack"
+        const val PUSH_ACK_TOPIC = "platform.network_map.push_ack"
 
         val type = ServiceType.networkMap
     }

--- a/node/src/main/kotlin/net/corda/node/utilities/KeyStoreUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/KeyStoreUtilities.kt
@@ -1,3 +1,5 @@
+@file:JvmName("KeyStoreUtilities")
+
 package net.corda.node.utilities
 
 import net.corda.core.crypto.Crypto

--- a/node/src/main/kotlin/net/corda/node/utilities/KeyStoreUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/KeyStoreUtilities.kt
@@ -14,7 +14,7 @@ import java.security.cert.Certificate
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 
-val KEYSTORE_TYPE = "JKS"
+const val KEYSTORE_TYPE = "JKS"
 
 /**
  * Helper method to either open an existing keystore for modification, or create a new blank keystore.

--- a/node/src/main/kotlin/net/corda/node/utilities/X509Utilities.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/X509Utilities.kt
@@ -44,12 +44,12 @@ object X509Utilities {
     val DEFAULT_TLS_SIGNATURE_SCHEME = Crypto.ECDSA_SECP256R1_SHA256
 
     // Aliases for private keys and certificates.
-    val CORDA_ROOT_CA = "cordarootca"
-    val CORDA_INTERMEDIATE_CA = "cordaintermediateca"
-    val CORDA_CLIENT_TLS = "cordaclienttls"
-    val CORDA_CLIENT_CA = "cordaclientca"
+    const val CORDA_ROOT_CA = "cordarootca"
+    const val CORDA_INTERMEDIATE_CA = "cordaintermediateca"
+    const val CORDA_CLIENT_TLS = "cordaclienttls"
+    const val CORDA_CLIENT_CA = "cordaclientca"
 
-    val CORDA_CLIENT_CA_CN = "Corda Client CA Certificate"
+    const val CORDA_CLIENT_CA_CN = "Corda Client CA Certificate"
 
     private val DEFAULT_VALIDITY_WINDOW = Pair(0.millis, 3650.days)
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/InMemoryMessagingNetwork.kt
@@ -50,7 +50,7 @@ class InMemoryMessagingNetwork(
         private val messagesInFlight: ReusableLatch = ReusableLatch()
 ) : SingletonSerializeAsToken() {
     companion object {
-        val MESSAGES_LOG_NAME = "messages"
+        const val MESSAGES_LOG_NAME = "messages"
         private val log = LoggerFactory.getLogger(MESSAGES_LOG_NAME)
     }
 


### PR DESCRIPTION
There are a number of places in the code where we have Kotlin values which appear to be constants. As-is, these are exposed to Java via getter methods, for example `getKEY_ALGORITHM()`. By changing them to constants they are instead exposed in a more natural way, for example as `KEY_ALGORITHM`.

This change has impact on Java API, and therefore I'd like to get it in for 1.0 if practical.
