### PR TITLE
Change constants values to Kotlin const type

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -27,15 +27,17 @@ class CashSelectionH2Impl : CashSelection {
     companion object {
         const val JDBC_DRIVER_NAME = "H2 JDBC Driver"
         val log = loggerFor<CashSelectionH2Impl>()
+
+        // coin selection retry loop counter and sleep (msecs)
+        private const val MAX_RETRIES = 5
+        private const val RETRY_SLEEP = 100
     }
 
     override fun isCompatible(metadata: DatabaseMetaData): Boolean {
         return metadata.driverName == JDBC_DRIVER_NAME
     }
 
-    // coin selection retry loop counter, sleep (msecs) and lock for selecting states
-    private val MAX_RETRIES = 5
-    private val RETRY_SLEEP = 100
+    // coin selection lock for selecting states
     private val spendLock: ReentrantLock = ReentrantLock()
 
     /**

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializationInput.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializationInput.kt
@@ -25,7 +25,7 @@ class DeserializationInput(internal val serializerFactory: SerializerFactory) {
     private val objectHistory: MutableList<Any> = mutableListOf()
 
     internal companion object {
-        private val BYTES_NEEDED_TO_PEEK: Int = 23
+        private const val BYTES_NEEDED_TO_PEEK: Int = 23
 
         fun peekSize(bytes: ByteArray): Int {
             // There's an 8 byte header, and then a 0 byte plus descriptor followed by constructor

--- a/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
@@ -32,7 +32,7 @@ interface MessagingService {
          * Session ID to use for services listening for the first message in a session (before a
          * specific session ID has been established).
          */
-        val DEFAULT_SESSION_ID = 0L
+        const val DEFAULT_SESSION_ID = 0L
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/AddressUtils.kt
@@ -4,7 +4,7 @@ import java.net.InetAddress
 import java.net.NetworkInterface
 
 object AddressUtils {
-    private val REACHABLE_TIMEOUT_MS = 1000
+    private const val REACHABLE_TIMEOUT_MS = 1000
 
     /** Returns the first public IP address found on any of the network interfaces, or `null` if none found. */
     fun tryDetectPublicIP(): InetAddress? {

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -34,7 +34,7 @@ import kotlin.test.assertEquals
 
 class ScheduledFlowTests {
     companion object {
-        val PAGE_SIZE = 20
+        const val PAGE_SIZE = 20
         val SORTING = Sort(listOf(Sort.SortColumn(SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_TXN_ID), Sort.Direction.DESC)))
     }
 

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/identicon/IdenticonRenderer.kt
@@ -66,17 +66,17 @@ object IdenticonRenderer {
             byteArrayOf(0, 2, 10, 0),
             byteArrayOf(0, 4, 24, 20, 0)).map(::Patch)
 
-    private val PATCH_CELLS = 4
-    private val PATCH_GRIDS = PATCH_CELLS + 1
-    private val PATCH_SYMMETRIC: Byte = 1
-    private val PATCH_INVERTED: Byte = 2
+    private const val PATCH_CELLS = 4
+    private const val PATCH_GRIDS = PATCH_CELLS + 1
+    private const val PATCH_SYMMETRIC: Byte = 1
+    private const val PATCH_INVERTED: Byte = 2
 
     private val patchFlags = byteArrayOf(PATCH_SYMMETRIC, 0, 0, 0, PATCH_SYMMETRIC, 0, 0, 0, PATCH_SYMMETRIC, 0, 0, 0, 0, 0, 0, (PATCH_SYMMETRIC + PATCH_INVERTED).toByte())
 
-    private val renderingSize = 30.0
+    private const val RENDERING_SIZE = 30.0
 
     private val cache = CacheBuilder.newBuilder().build(CacheLoader.from<SecureHash, Image> { key ->
-        key?.let { render(key.hashCode(), renderingSize) }
+        key?.let { render(key.hashCode(), RENDERING_SIZE) }
     })
 
     private class Patch(private val byteArray: ByteArray) {


### PR DESCRIPTION
Follow-up to #1588 to change remaining constant values into `const` types, targeting 1.1.
