### PR TITLE
Improve the way formatting to String is done for Amounts

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Amount.kt
@@ -6,6 +6,7 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.exactAdd
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.text.DecimalFormat
 import java.util.*
 
 /**
@@ -244,7 +245,7 @@ data class Amount<T : Any>(val quantity: Long, val displayTokenSize: BigDecimal,
         val residualTokens = quantity - (commonTokensPerPartition * partitions)
         val splitAmount = Amount(commonTokensPerPartition, displayTokenSize, token)
         val splitAmountPlusOne = Amount(commonTokensPerPartition + 1L, displayTokenSize, token)
-        return (0..partitions - 1).map { if (it < residualTokens) splitAmountPlusOne else splitAmount }.toList()
+        return (0 until partitions).map { if (it < residualTokens) splitAmountPlusOne else splitAmount }.toList()
     }
 
     /**
@@ -267,7 +268,8 @@ data class Amount<T : Any>(val quantity: Long, val displayTokenSize: BigDecimal,
      * @see Amount.fromDecimal
      */
     override fun toString(): String {
-        return toDecimal().toPlainString() + " " + token
+        val df = DecimalFormat("#,##0.00")
+        return df.format(toDecimal()) + " " + token
     }
 
     /** @suppress */

--- a/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/AmountTests.kt
@@ -162,4 +162,12 @@ class AmountTests {
         assertEquals(originalTotals[Pair(partyA, GBP)], newTotals3[Pair(partyA, GBP)])
         assertEquals(originalTotals[Pair(partyB, GBP)], newTotals3[Pair(partyB, GBP)])
     }
+
+    @Test
+    fun `large amount formatting`() {
+        val largeNotional = SWISS_FRANCS(Int.MAX_VALUE)
+        val formattedValue = largeNotional.toString()
+        assertEquals("2,147,483,647.00 CHF", formattedValue)
+        assertEquals(largeNotional, Amount.parseCurrency(formattedValue))
+    }
 }


### PR DESCRIPTION
This comes especially handy when amount, like notional amount, is big and it is rather difficult to count zeros.
