### PR TITLE
Moved VerifierApi into internal package

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/VerifierApi.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/VerifierApi.kt
@@ -1,4 +1,4 @@
-package net.corda.nodeapi
+package net.corda.nodeapi.internal
 
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -29,6 +29,7 @@ import net.corda.node.utilities.loadKeyStore
 import net.corda.nodeapi.*
 import net.corda.nodeapi.ArtemisMessagingComponent.Companion.NODE_USER
 import net.corda.nodeapi.ArtemisMessagingComponent.Companion.PEER_USER
+import net.corda.nodeapi.internal.VerifierApi
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
 import org.apache.activemq.artemis.core.config.BridgeConfiguration
@@ -56,7 +57,6 @@ import java.math.BigInteger
 import java.security.KeyStore
 import java.security.KeyStoreException
 import java.security.Principal
-import java.security.cert.X509Certificate
 import java.util.*
 import java.util.concurrent.Executor
 import java.util.concurrent.ScheduledExecutorService

--- a/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/NodeMessagingClient.kt
@@ -29,9 +29,9 @@ import net.corda.node.utilities.*
 import net.corda.nodeapi.ArtemisMessagingComponent
 import net.corda.nodeapi.ArtemisTcpTransport
 import net.corda.nodeapi.ConnectionDirection
-import net.corda.nodeapi.VerifierApi
-import net.corda.nodeapi.VerifierApi.VERIFICATION_REQUESTS_QUEUE_NAME
-import net.corda.nodeapi.VerifierApi.VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX
+import net.corda.nodeapi.internal.VerifierApi
+import net.corda.nodeapi.internal.VerifierApi.VERIFICATION_REQUESTS_QUEUE_NAME
+import net.corda.nodeapi.internal.VerifierApi.VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX
 import org.apache.activemq.artemis.api.core.ActiveMQObjectClosedException
 import org.apache.activemq.artemis.api.core.Message.*
 import org.apache.activemq.artemis.api.core.RoutingType
@@ -48,7 +48,6 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
-import javax.security.auth.x500.X500Principal
 
 // TODO: Stop the wallet explorer and other clients from using this class and get rid of persistentInbox
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/OutOfProcessTransactionVerifierService.kt
@@ -12,7 +12,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.api.MonitoringService
-import net.corda.nodeapi.VerifierApi
+import net.corda.nodeapi.internal.VerifierApi
 import org.apache.activemq.artemis.api.core.client.ClientConsumer
 import java.util.concurrent.ConcurrentHashMap
 

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -14,7 +14,7 @@ import net.corda.node.services.config.configureDevKeyAndTrustStores
 import net.corda.nodeapi.ArtemisMessagingComponent.Companion.NODE_USER
 import net.corda.nodeapi.ArtemisTcpTransport
 import net.corda.nodeapi.ConnectionDirection
-import net.corda.nodeapi.VerifierApi
+import net.corda.nodeapi.internal.VerifierApi
 import net.corda.nodeapi.config.NodeSSLConfiguration
 import net.corda.nodeapi.config.SSLConfiguration
 import net.corda.testing.driver.*

--- a/verifier/src/main/kotlin/net/corda/verifier/Verifier.kt
+++ b/verifier/src/main/kotlin/net/corda/verifier/Verifier.kt
@@ -12,8 +12,8 @@ import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import net.corda.nodeapi.ArtemisTcpTransport.Companion.tcpTransport
 import net.corda.nodeapi.ConnectionDirection
-import net.corda.nodeapi.VerifierApi
-import net.corda.nodeapi.VerifierApi.VERIFICATION_REQUESTS_QUEUE_NAME
+import net.corda.nodeapi.internal.VerifierApi
+import net.corda.nodeapi.internal.VerifierApi.VERIFICATION_REQUESTS_QUEUE_NAME
 import net.corda.nodeapi.config.NodeSSLConfiguration
 import net.corda.nodeapi.config.getValue
 import net.corda.nodeapi.internal.addShutdownHook


### PR DESCRIPTION
`node-api` is part of the API we're locking down so the verifier stuff needs to be moved into internal package.