### PR TITLE
CORDA-249: Remove cyclic call from CompositeKey

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -88,7 +88,9 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
             if (node is CompositeKey) {
                 val curVisitedMap = IdentityHashMap<CompositeKey, Boolean>()
                 curVisitedMap.putAll(visitedMap)
-                require(!curVisitedMap.contains(node)) { "Cycle detected for CompositeKey: $node" }
+                // We can't print the node details, because doing so involves serializing the node, which we can't
+                // do because of the cyclic graph
+                require(!curVisitedMap.contains(node)) { "Cycle detected for CompositeKey" }
                 curVisitedMap.put(node, true)
                 node.cycleDetection(curVisitedMap)
             }

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -89,7 +89,7 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
                 val curVisitedMap = IdentityHashMap<CompositeKey, Boolean>()
                 curVisitedMap.putAll(visitedMap)
                 // We can't print the node details, because doing so involves serializing the node, which we can't
-                // do because of the cyclic graph
+                // do because of the cyclic graph.
                 require(!curVisitedMap.contains(node)) { "Cycle detected for CompositeKey" }
                 curVisitedMap.put(node, true)
                 node.cycleDetection(curVisitedMap)


### PR DESCRIPTION
Remove cyclic call from CompositeKey cycle detection code. Previously when trying to report a cyclic graph in a CompositeKey, it called toString() which resulted in serialization of the graph, which of course was cyclic, so it failed.