### PR TITLE
Enforce JSON serialized key format

### DIFF
--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -186,7 +186,7 @@ object JacksonSupport {
             // The comma character is invalid in base64, and required as a separator for X.500 names. As Corda
             // X.500 names all involve at least three attributes (organisation, locality, country), they must
             // include a comma. As such we can use it as a distinguisher between the two types.
-            return if (parser.text.indexOf(",") >= 0) {
+            return if (parser.text.contains(",")) {
                 val principal = CordaX500Name.parse(parser.text)
                 mapper.wellKnownPartyFromX500Name(principal) ?: throw JsonParseException(parser, "Could not find a Party with name $principal")
             } else {

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -85,9 +85,8 @@ object JacksonSupport {
             addDeserializer(SecureHash.SHA256::class.java, SecureHashDeserializer())
 
             // Public key types
+            addSerializer(PublicKey::class.java, PublicKeySerializer)
             addDeserializer(PublicKey::class.java, PublicKeyDeserializer)
-            addSerializer(EdDSAPublicKey::class.java, PublicKeySerializer)
-            addSerializer(CompositeKey::class.java, PublicKeySerializer)
 
             // For NodeInfo
             // TODO this tunnels the Kryo representation as a Base58 encoded string. Replace when RPC supports this.

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -29,6 +29,13 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.*
 import net.i2p.crypto.eddsa.EdDSAPublicKey
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.bouncycastle.util.io.pem.PemReader
+import java.io.FileReader
+import java.io.FileWriter
+import java.io.StringReader
+import java.io.StringWriter
 import java.math.BigDecimal
 import java.security.PublicKey
 import java.util.*
@@ -278,27 +285,44 @@ object JacksonSupport {
 
     object PublicKeySerializer : JsonSerializer<PublicKey>() {
         override fun serialize(obj: PublicKey, generator: JsonGenerator, provider: SerializerProvider) {
-            generator.writeString(obj.encoded.toBase58())
+            StringWriter().use { writer ->
+                JcaPEMWriter(writer).use { pem ->
+                    pem.writeObject(obj)
+                }
+                generator.writeString(writer.toString())
+            }
         }
     }
 
     object EdDSAPublicKeyDeserializer : JsonDeserializer<EdDSAPublicKey>() {
         override fun deserialize(parser: JsonParser, context: DeserializationContext): EdDSAPublicKey {
-            return try {
-                Crypto.decodePublicKey(parser.text.base58ToByteArray()) as EdDSAPublicKey
-            } catch (e: Exception) {
-                throw JsonParseException(parser, "Invalid EdDSA key ${parser.text}: ${e.message}")
+            var key: EdDSAPublicKey? = null
+            StringReader(parser.text).use { reader ->
+                PemReader(reader).use { pem ->
+                    key = try {
+                        Crypto.decodePublicKey(pem.readPemObject().content) as EdDSAPublicKey
+                    } catch (e: Exception) {
+                        throw JsonParseException(parser, "Invalid EdDSA key ${parser.text}: ${e.message}")
+                    }
+                }
             }
+            return key!!
         }
     }
 
     object CompositeKeyDeserializer : JsonDeserializer<CompositeKey>() {
         override fun deserialize(parser: JsonParser, context: DeserializationContext): CompositeKey {
-            return try {
-                Crypto.decodePublicKey(parser.text.base58ToByteArray()) as CompositeKey
-            } catch (e: Exception) {
-                throw JsonParseException(parser, "Invalid composite key ${parser.text}: ${e.message}")
+            var key: CompositeKey? = null
+            StringReader(parser.text).use { reader ->
+                PemReader(reader).use { pem ->
+                    key = try {
+                        Crypto.decodePublicKey(pem.readPemObject().content) as CompositeKey
+                    } catch (e: Exception) {
+                        throw JsonParseException(parser, "Invalid EdDSA key ${parser.text}: ${e.message}")
+                    }
+                }
             }
+            return key!!
         }
     }
 

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -84,16 +84,10 @@ object JacksonSupport {
             addDeserializer(SecureHash::class.java, SecureHashDeserializer())
             addDeserializer(SecureHash.SHA256::class.java, SecureHashDeserializer())
 
-            // Generic deserializer for public keys
+            // Public key types
             addDeserializer(PublicKey::class.java, PublicKeyDeserializer)
-
-            // For ed25519 pubkeys
             addSerializer(EdDSAPublicKey::class.java, PublicKeySerializer)
-            addDeserializer(EdDSAPublicKey::class.java, EdDSAPublicKeyDeserializer)
-
-            // For composite keys
             addSerializer(CompositeKey::class.java, PublicKeySerializer)
-            addDeserializer(CompositeKey::class.java, CompositeKeyDeserializer)
 
             // For NodeInfo
             // TODO this tunnels the Kryo representation as a Base58 encoded string. Replace when RPC supports this.
@@ -292,20 +286,6 @@ object JacksonSupport {
             } catch (e: Exception) {
                 throw JsonParseException(parser, "Invalid public key ${parser.text}: ${e.message}")
             }
-        }
-    }
-
-    object EdDSAPublicKeyDeserializer : JsonDeserializer<EdDSAPublicKey>() {
-        override fun deserialize(parser: JsonParser, context: DeserializationContext): EdDSAPublicKey {
-            val key = PublicKeyDeserializer.deserialize(parser, context) as? EdDSAPublicKey
-            return key ?: throw JsonParseException(parser, "Invalid EdDSA key ${parser.text}")
-        }
-    }
-
-    object CompositeKeyDeserializer : JsonDeserializer<CompositeKey>() {
-        override fun deserialize(parser: JsonParser, context: DeserializationContext): CompositeKey {
-            val key = PublicKeyDeserializer.deserialize(parser, context) as? CompositeKey
-            return key ?: throw JsonParseException(parser, "Invalid composite key ${parser.text}")
         }
     }
 

--- a/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
+++ b/client/jackson/src/main/kotlin/net/corda/client/jackson/JacksonSupport.kt
@@ -183,7 +183,10 @@ object JacksonSupport {
             }
 
             val mapper = parser.codec as PartyObjectMapper
-            return if (parser.text.contains("=") && !parser.text.endsWith("=")) {
+            // The comma character is invalid in base64, and required as a separator for X.500 names. As Corda
+            // X.500 names all involve at least three attributes (organisation, locality, country), they must
+            // include a comma. As such we can use it as a distinguisher between the two types.
+            return if (parser.text.indexOf(",") >= 0) {
                 val principal = CordaX500Name.parse(parser.text)
                 mapper.wellKnownPartyFromX500Name(principal) ?: throw JsonParseException(parser, "Could not find a Party with name $principal")
             } else {

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -39,7 +39,7 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
 
     @Test
     fun `should serialize Composite keys`() {
-        val expected = "\"-----BEGIN PUBLIC KEY-----\\r\\nMIHAMBUGE2mtoq+J1bjir/ONk6yd5pab0FoDgaYAMIGiAgECMIGcMDIDLQAwKjAF\\r\\nBgMrZXADIQAgIX1QlJRgaLlD0ttLlJF5kNqT/7P7QwCvrWc9+/248gIBATAyAy0A\\r\\nMCowBQYDK2VwAyEAqS0JPGlzdviBZjB9FaNY+w6cVs3/CQ2A5EimE9Lyng4CAQEw\\r\\nMgMtADAqMAUGAytlcAMhALq4GG0gBQZIlaKE6ucooZsuoKUbH4MtGSmA6cwj136+\\r\\nAgEB\\r\\n-----END PUBLIC KEY-----\\r\\n\""
+        val expected = "\"MIHAMBUGE2mtoq+J1bjir/ONk6yd5pab0FoDgaYAMIGiAgECMIGcMDIDLQAwKjAFBgMrZXADIQAgIX1QlJRgaLlD0ttLlJF5kNqT/7P7QwCvrWc9+/248gIBATAyAy0AMCowBQYDK2VwAyEAqS0JPGlzdviBZjB9FaNY+w6cVs3/CQ2A5EimE9Lyng4CAQEwMgMtADAqMAUGAytlcAMhALq4GG0gBQZIlaKE6ucooZsuoKUbH4MtGSmA6cwj136+AgEB\""
         val innerKeys = (1..3).map { i ->
             Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, SEED.plus(BigInteger.valueOf(i.toLong()))).public
         }
@@ -58,12 +58,12 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
 
     @Test
     fun `should serialize EdDSA keys`() {
-        val expected = "\"-----BEGIN PUBLIC KEY-----\\r\\nMCowBQYDK2VwAyEACFTgLk1NOqYXAfxLoR7ctSbZcl9KMXu58Mq31Kv1Dwk=\\r\\n-----END PUBLIC KEY-----\\r\\n\""
+        val expected = "\"MCowBQYDK2VwAyEACFTgLk1NOqYXAfxLoR7ctSbZcl9KMXu58Mq31Kv1Dwk=\""
         val publicKey = Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, SEED).public
         val serialized = mapper.writeValueAsString(publicKey)
+        assertEquals(expected, serialized)
         val parsedKey = mapper.readValue(serialized, EdDSAPublicKey::class.java)
         assertEquals(publicKey, parsedKey)
-        assertEquals(expected, serialized)
     }
 
     @Test

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -17,12 +17,13 @@ import net.corda.testing.contracts.DummyContract
 import net.i2p.crypto.eddsa.EdDSAPublicKey
 import org.junit.Before
 import org.junit.Test
+import java.math.BigInteger
 import java.util.*
-import kotlin.reflect.jvm.jvmName
 import kotlin.test.assertEquals
 
 class JacksonSupportTest : TestDependencyInjectionBase() {
     companion object {
+        private val SEED = BigInteger.valueOf(20170922L)
         val mapper = JacksonSupport.createNonRpcMapper()
     }
 
@@ -37,14 +38,33 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun publicKeySerializingWorks() {
-        val publicKey = generateKeyPair().public
+    fun `should serialize Composite keys`() {
+        val expected = "\"efa46Lo8bTrZpaCRfEm9tkgdndkZxrLEjBu9u4gGzvGcnjP3Yiyo7pq9wTLSARZNBCB3QFbFUpPhwybedjb6TLAG9nXraiohqnq7RemKQ53V6kKXoKsVPCkodbZJSjimTdwx6YFc3ejoJsuiTjur86e7HrxGXQjxPSfwYr1c2DLpqBxsX6BY1pbrp6yWHXvnwjakQfPBiredAu6kFqsDmDgy3tV6wefNCcdWZD6CxLhvd4B8mniDWbux6LQobRV4fsVratpiDW\""
+        val innerKeys = (1..3).map { i ->
+            Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, SEED.plus(BigInteger.valueOf(i.toLong()))).public
+        }
+        // Build a 2 of 3 composite key
+        val publicKey = CompositeKey.Builder().let {
+            innerKeys.forEach { key -> it.addKey(key, 1) }
+            it.build(2)
+        }
         val serialized = mapper.writeValueAsString(publicKey)
-        val parsedKey = mapper.readValue(serialized, EdDSAPublicKey::class.java)
+        assertEquals(expected, serialized)
+        val parsedKey = mapper.readValue(serialized, CompositeKey::class.java)
         assertEquals(publicKey, parsedKey)
     }
 
     private class Dummy(val notional: Amount<Currency>)
+
+    @Test
+    fun `should serialize EdDSA keys`() {
+        val expected = "\"GfHq2tTVk9z4eXgyEsvWqXUh2iSTHrzAD5R3xU9kdn2oYs57sG7FyNmibWL8\""
+        val publicKey = Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, SEED).public
+        val serialized = mapper.writeValueAsString(publicKey)
+        assertEquals(expected, serialized)
+        val parsedKey = mapper.readValue(serialized, EdDSAPublicKey::class.java)
+        assertEquals(publicKey, parsedKey)
+    }
 
     @Test
     fun readAmount() {

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -14,10 +14,10 @@ import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.MINI_CORP
 import net.corda.testing.TestDependencyInjectionBase
 import net.corda.testing.contracts.DummyContract
-import net.i2p.crypto.eddsa.EdDSAPublicKey
 import org.junit.Before
 import org.junit.Test
 import java.math.BigInteger
+import java.security.PublicKey
 import java.util.*
 import kotlin.test.assertEquals
 
@@ -50,7 +50,7 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
         }
         val serialized = mapper.writeValueAsString(publicKey)
         assertEquals(expected, serialized)
-        val parsedKey = mapper.readValue(serialized, CompositeKey::class.java)
+        val parsedKey = mapper.readValue(serialized, PublicKey::class.java)
         assertEquals(publicKey, parsedKey)
     }
 
@@ -62,7 +62,7 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
         val publicKey = Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, SEED).public
         val serialized = mapper.writeValueAsString(publicKey)
         assertEquals(expected, serialized)
-        val parsedKey = mapper.readValue(serialized, EdDSAPublicKey::class.java)
+        val parsedKey = mapper.readValue(serialized, PublicKey::class.java)
         assertEquals(publicKey, parsedKey)
     }
 

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -39,7 +39,7 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
 
     @Test
     fun `should serialize Composite keys`() {
-        val expected = "\"efa46Lo8bTrZpaCRfEm9tkgdndkZxrLEjBu9u4gGzvGcnjP3Yiyo7pq9wTLSARZNBCB3QFbFUpPhwybedjb6TLAG9nXraiohqnq7RemKQ53V6kKXoKsVPCkodbZJSjimTdwx6YFc3ejoJsuiTjur86e7HrxGXQjxPSfwYr1c2DLpqBxsX6BY1pbrp6yWHXvnwjakQfPBiredAu6kFqsDmDgy3tV6wefNCcdWZD6CxLhvd4B8mniDWbux6LQobRV4fsVratpiDW\""
+        val expected = "\"-----BEGIN PUBLIC KEY-----\\r\\nMIHAMBUGE2mtoq+J1bjir/ONk6yd5pab0FoDgaYAMIGiAgECMIGcMDIDLQAwKjAF\\r\\nBgMrZXADIQAgIX1QlJRgaLlD0ttLlJF5kNqT/7P7QwCvrWc9+/248gIBATAyAy0A\\r\\nMCowBQYDK2VwAyEAqS0JPGlzdviBZjB9FaNY+w6cVs3/CQ2A5EimE9Lyng4CAQEw\\r\\nMgMtADAqMAUGAytlcAMhALq4GG0gBQZIlaKE6ucooZsuoKUbH4MtGSmA6cwj136+\\r\\nAgEB\\r\\n-----END PUBLIC KEY-----\\r\\n\""
         val innerKeys = (1..3).map { i ->
             Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, SEED.plus(BigInteger.valueOf(i.toLong()))).public
         }
@@ -58,12 +58,12 @@ class JacksonSupportTest : TestDependencyInjectionBase() {
 
     @Test
     fun `should serialize EdDSA keys`() {
-        val expected = "\"GfHq2tTVk9z4eXgyEsvWqXUh2iSTHrzAD5R3xU9kdn2oYs57sG7FyNmibWL8\""
+        val expected = "\"-----BEGIN PUBLIC KEY-----\\r\\nMCowBQYDK2VwAyEACFTgLk1NOqYXAfxLoR7ctSbZcl9KMXu58Mq31Kv1Dwk=\\r\\n-----END PUBLIC KEY-----\\r\\n\""
         val publicKey = Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, SEED).public
         val serialized = mapper.writeValueAsString(publicKey)
-        assertEquals(expected, serialized)
         val parsedKey = mapper.readValue(serialized, EdDSAPublicKey::class.java)
         assertEquals(publicKey, parsedKey)
+        assertEquals(expected, serialized)
     }
 
     @Test

--- a/samples/irs-demo/src/main/resources/net/corda/irs/simulation/trade.json
+++ b/samples/irs-demo/src/main/resources/net/corda/irs/simulation/trade.json
@@ -1,6 +1,6 @@
 {
   "fixedLeg": {
-    "fixedRatePayer": "8Kqd4oWdx4KQGHGR7xcgpFf9JmP6HiXqTf85NpSgdSu431EGEhujA6ePaFD",
+    "fixedRatePayer": "MCowBQYDK2VwAyEAzswVB9wd3XKVlRwpCIjwla25BE0bc9aW5t8GXWg71Pw=",
     "notional": "$25000000",
     "paymentFrequency": "SemiAnnual",
     "effectiveDate": "2016-03-11",
@@ -22,7 +22,7 @@
     "interestPeriodAdjustment": "Adjusted"
   },
   "floatingLeg": {
-    "floatingRatePayer": "8Kqd4oWdx4KQGHGJSFTX4kdZukmHohBRN3gvPekticL4eHTdmbJTVZNZJUj",
+    "floatingRatePayer": "MCowBQYDK2VwAyEAa3nFfmoJUjkoLASBjpYRLz8DpAAbqXpWTCOFKj8epfw=",
     "notional": {
       "quantity": 2500000000,
       "token": "USD"
@@ -71,7 +71,7 @@
     "notificationTime": "2:00pm London",
     "resolutionTime": "2:00pm London time on the first LocalBusiness Day following the date on which the notice is given ",
     "interestRate": {
-      "oracle": "Rates Service Provider",
+      "oracle": "C=ES,L=Madrid,O=Rates Service Provider",
       "tenor": {
         "name": "6M"
       },


### PR DESCRIPTION
This changes JSON serialized key format to base58 encoded DER, and enforces it in the unit tests by using stably generated keys so the serialized form should always be the same.
