### PR TITLE
Command toString signers keys format

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -4,6 +4,7 @@ package net.corda.core.contracts
 
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.secureRandomBytes
+import net.corda.core.crypto.toStringShort
 import net.corda.core.flows.FlowLogicRef
 import net.corda.core.flows.FlowLogicRefFactory
 import net.corda.core.identity.AbstractParty
@@ -183,7 +184,7 @@ data class Command<T : CommandData>(val value: T, val signers: List<PublicKey>) 
     constructor(data: T, key: PublicKey) : this(data, listOf(key))
 
     private fun commandDataToString() = value.toString().let { if (it.contains("@")) it.replace('$', '.').split("@")[0] else it }
-    override fun toString() = "${commandDataToString()} with pubkeys ${signers.joinToString()}"
+    override fun toString() = "${commandDataToString()} with pubkeys ${signers.map { it.toStringShort() }.joinToString()}"
 }
 
 /** A common move command for contract states which can change owner. */


### PR DESCRIPTION
Pretty print for keys on `Command.toString()` to remove the ugly net.i2p.crypto.eddsa.EdDSAPublicKey@a008fda0 when printing info about transactions.

It will print the hash of signers' keys:
Transaction:
▶︎INPUT:      7E81CBEC6A4281697E5A366623C692B90EF1E4439B71B7D0A0C473FE56470141(0)
▶︎INPUT:      F9AA9322B83651C88D330D55F574228D672CFCC26118B7F5FCDDB4D0BC9A18B4(1)
▶︎INPUT:      44ACD46E9A8E6B5F9542981FF7F37F17279021348A0087EF634F60C46A0E29E4(0)
OUTPUT:     DummyState(magicNumber=0)
OUTPUT:     DummyState(magicNumber=0)
COMMAND:   Move(contract=null) with pubkeys **DLuthJPURTGFuGvyivv3EEwD7QeSkgGhrDK4d4SEj6HeD, DLBVrDkXKJpuK2iEyJqnu3V99BkYbnBbgNAUja1p1WCyQp**
