### PR TITLE
optional warning when adding duplicated key to AppendOnlyPersistenMap

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -102,11 +102,11 @@ class PersistentIdentityService(identities: Iterable<PartyAndCertificate> = empt
         caCertStore = CertStore.getInstance("Collection", CollectionCertStoreParameters(caCertificatesWithRoot))
         identities.forEach {
             val key = mapToKey(it)
-            keyToParties.addWithDuplicatesAllowed(key, it)
-            principalToParties.addWithDuplicatesAllowed(it.name, key)
+            keyToParties.addWithDuplicatesAllowed(key, it, false)
+            principalToParties.addWithDuplicatesAllowed(it.name, key, false)
         }
         confidentialIdentities.forEach {
-            principalToParties.addWithDuplicatesAllowed(it.name, mapToKey(it))
+            principalToParties.addWithDuplicatesAllowed(it.name, mapToKey(it), false)
         }
     }
 
@@ -129,7 +129,7 @@ class PersistentIdentityService(identities: Iterable<PartyAndCertificate> = empt
         val key = mapToKey(identity)
         keyToParties.addWithDuplicatesAllowed(key, identity)
         // Always keep the first party we registered, as that's the well known identity
-        principalToParties.addWithDuplicatesAllowed(identity.name, key)
+        principalToParties.addWithDuplicatesAllowed(identity.name, key, false)
         val parentId = mapToKey(identity.certPath.certificates[1].publicKey)
         return keyToParties[parentId]
     }

--- a/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
@@ -48,7 +48,7 @@ class AppendOnlyPersistentMap<K, V, E, out EK> (
         return result.map { x -> fromPersistentEntity(x) }.asSequence()
     }
 
-    private tailrec fun set(key: K, value: V, logWarning: Boolean = true, store: (K,V) -> V?): Boolean {
+    private tailrec fun set(key: K, value: V, logWarning: Boolean, store: (K,V) -> V?): Boolean {
         var insertionAttempt = false
         var isUnique = true
         val existingInCache = cache.get(key) { // Thread safe, if multiple threads may wait until the first one has loaded.
@@ -95,8 +95,8 @@ class AppendOnlyPersistentMap<K, V, E, out EK> (
      * If the map previously contained a mapping for the key, the old value is not replaced.
      * @return true if added key was unique, otherwise false
      */
-    fun addWithDuplicatesAllowed(key: K, value: V): Boolean =
-            set(key, value) {
+    fun addWithDuplicatesAllowed(key: K, value: V, logWarning: Boolean = true): Boolean =
+            set(key, value, logWarning) {
                 k, v ->
                 val existingEntry = DatabaseTransactionManager.current().session.find(persistentEntityClass, toPersistentEntityKey(k))
                 if (existingEntry == null) {


### PR DESCRIPTION
* depends on the context the warning about inserting a duplicated key is not needed 