### PR TITLE
Removed SSLConfiguration parameter from CordaRPCClient, thus removing…

### DIFF
--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -57,7 +57,7 @@ public class CordaRPCJavaClientTest extends NodeBasedTest {
         CordaFuture<StartedNode<Node>> nodeFuture = startNode(getALICE().getName(), 1, services, singletonList(rpcUser), emptyMap());
         node = nodeFuture.get();
         node.getInternals().registerCustomSchemas(Collections.singleton(CashSchemaV1.INSTANCE));
-        client = new CordaRPCClient(requireNonNull(node.getInternals().getConfiguration().getRpcAddress()), null, getDefault(), false);
+        client = new CordaRPCClient(requireNonNull(node.getInternals().getConfiguration().getRpcAddress()), getDefault(), false);
     }
 
     @After

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -7,7 +7,6 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.nodeapi.ArtemisTcpTransport.Companion.tcpTransport
 import net.corda.nodeapi.ConnectionDirection
-import net.corda.nodeapi.config.SSLConfiguration
 import net.corda.nodeapi.internal.serialization.KRYO_RPC_CLIENT_CONTEXT
 import java.time.Duration
 
@@ -34,9 +33,9 @@ data class CordaRPCClientConfiguration(
 }
 
 /** @see RPCClient */
+//TODO Add SSL support
 class CordaRPCClient(
         hostAndPort: NetworkHostAndPort,
-        sslConfiguration: SSLConfiguration? = null,
         configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default,
         initialiseSerialization: Boolean = true
 ) {
@@ -50,7 +49,7 @@ class CordaRPCClient(
     }
 
     private val rpcClient = RPCClient<CordaRPCOps>(
-            tcpTransport(ConnectionDirection.Outbound(), hostAndPort, sslConfiguration),
+            tcpTransport(ConnectionDirection.Outbound(), hostAndPort, config = null),
             configuration.toRpcClientConfiguration(),
             KRYO_RPC_CLIENT_CONTEXT
     )

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -228,6 +228,9 @@ Release 1.0
 
 * ``@RPCSinceVersion``, ``RPCException`` and ``PermissionException`` have moved to ``net.corda.client.rpc``.
 
+* Current implementation of SSL in ``CordaRPCClient`` has been removed until we have a better solution which doesn't rely
+  on the node's keystore.
+
 Milestone 14
 ------------
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisMessagingComponent.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisMessagingComponent.kt
@@ -1,17 +1,15 @@
 package net.corda.nodeapi
 
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.utilities.toBase58String
 import net.corda.core.identity.Party
 import net.corda.core.messaging.MessageRecipientGroup
 import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.SingleMessageRecipient
-import net.corda.core.internal.read
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.core.utilities.toBase58String
 import net.corda.nodeapi.config.SSLConfiguration
-import java.security.KeyStore
 import java.security.PublicKey
 
 /**
@@ -84,22 +82,6 @@ abstract class ArtemisMessagingComponent : SingletonSerializeAsToken() {
 
     /** The config object is used to pass in the passwords for the certificate KeyStore and TrustStore */
     abstract val config: SSLConfiguration?
-
-    /**
-     * Returns nothing if the keystore was opened OK or throws if not. Useful to check the password, as
-     * unfortunately Artemis tends to bury the exception when the password is wrong.
-     */
-    fun checkStorePasswords() {
-        val config = config ?: return
-        arrayOf(config.sslKeystore, config.nodeKeystore).forEach {
-            it.read {
-                KeyStore.getInstance("JKS").load(it, config.keyStorePassword.toCharArray())
-            }
-        }
-        config.trustStoreFile.read {
-            KeyStore.getInstance("JKS").load(it, config.trustStorePassword.toCharArray())
-        }
-    }
 
     // Used for bridges creation.
     fun getArtemisPeerAddress(party: Party, address: NetworkHostAndPort, netMapName: CordaX500Name? = null): ArtemisPeerAddress {

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsRPCTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsRPCTest.kt
@@ -1,10 +1,7 @@
 package net.corda.services.messaging
 
 import net.corda.nodeapi.User
-import net.corda.testing.configureTestSSL
 import net.corda.testing.messaging.SimpleMQClient
-import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
 
 /**
@@ -25,12 +22,5 @@ class MQSecurityAsRPCTest : MQSecurityTest() {
 
     override fun startAttacker(attacker: SimpleMQClient) {
         attacker.start(extraRPCUsers[0].username, extraRPCUsers[0].password, false)
-    }
-
-    @Test
-    fun `login to a ssl port as a RPC user`() {
-        assertThatExceptionOfType(ActiveMQSecurityException::class.java).isThrownBy {
-            loginToRPC(alice.internals.configuration.p2pAddress, extraRPCUsers[0], configureTestSSL())
-        }
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -153,8 +153,8 @@ abstract class MQSecurityTest : NodeBasedTest() {
         return client
     }
 
-    fun loginToRPC(target: NetworkHostAndPort, rpcUser: User, sslConfiguration: SSLConfiguration? = null): CordaRPCOps {
-        return CordaRPCClient(target, sslConfiguration, initialiseSerialization = false).start(rpcUser.username, rpcUser.password).proxy
+    fun loginToRPC(target: NetworkHostAndPort, rpcUser: User): CordaRPCOps {
+        return CordaRPCClient(target, initialiseSerialization = false).start(rpcUser.username, rpcUser.password).proxy
     }
 
     fun loginToRPCAndGetClientQueue(): String {

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -20,15 +20,11 @@ import net.corda.core.utilities.seconds
 import net.corda.finance.plugin.registerFinanceJSONMappers
 import net.corda.irs.contract.InterestRateSwap
 import net.corda.irs.utilities.uploadFile
-import net.corda.nodeapi.internal.ServiceInfo
 import net.corda.node.services.config.FullNodeConfiguration
 import net.corda.node.services.transactions.SimpleNotaryService
 import net.corda.nodeapi.User
-import net.corda.testing.DUMMY_BANK_A
-import net.corda.testing.DUMMY_BANK_B
-import net.corda.testing.DUMMY_NOTARY
-import net.corda.testing.IntegrationTestCategory
-import net.corda.testing.chooseIdentity
+import net.corda.nodeapi.internal.ServiceInfo
+import net.corda.testing.*
 import net.corda.testing.driver.driver
 import net.corda.testing.http.HttpApi
 import org.apache.commons.io.IOUtils
@@ -45,7 +41,7 @@ class IRSDemoTest : IntegrationTestCategory {
         val log = loggerFor<IRSDemoTest>()
     }
 
-    private val rpcUser = User("user", "password", emptySet())
+    private val rpcUser = User("user", "password", setOf("ALL"))
     private val currentDate: LocalDate = LocalDate.now()
     private val futureDate: LocalDate = currentDate.plusMonths(6)
     private val maxWaitTime: Duration = 60.seconds
@@ -58,15 +54,16 @@ class IRSDemoTest : IntegrationTestCategory {
                             providedName = DUMMY_NOTARY.name,
                             advertisedServices = setOf(ServiceInfo(SimpleNotaryService.type))),
                     startNode(providedName = DUMMY_BANK_A.name, rpcUsers = listOf(rpcUser)),
-                    startNode(providedName = DUMMY_BANK_B.name)).map { it.getOrThrow() }
+                    startNode(providedName = DUMMY_BANK_B.name))
+                    .map { it.getOrThrow() }
 
             log.info("All nodes started")
 
-            val controllerAddrFuture = startWebserver(controller)
-            val nodeAAddrFuture = startWebserver(nodeA)
-            val nodeBAddrFuture = startWebserver(nodeB)
-            val (controllerAddr, nodeAAddr, nodeBAddr) =
-                    listOf(controllerAddrFuture, nodeAAddrFuture, nodeBAddrFuture).map { it.getOrThrow().listenAddress }
+            val (controllerAddr, nodeAAddr, nodeBAddr) = listOf(
+                    startWebserver(controller),
+                    startWebserver(nodeA),
+                    startWebserver(nodeB))
+                    .map { it.getOrThrow().listenAddress }
 
             log.info("All webservers started")
 

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -235,7 +235,7 @@ class NodeConfigTest {
         val webConfig = WebServerConfig(baseDir, nodeConfig)
 
         assertEquals(localPort(20001), webConfig.webAddress)
-        assertEquals(localPort(10001), webConfig.p2pAddress)
+        assertEquals(localPort(40002), webConfig.rpcAddress)
         assertEquals("trustpass", webConfig.trustStorePassword)
         assertEquals("cordacadevpass", webConfig.keyStorePassword)
     }

--- a/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt
@@ -2,6 +2,7 @@ package net.corda.webserver
 
 import com.typesafe.config.Config
 import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.User
 import net.corda.nodeapi.config.NodeSSLConfiguration
 import net.corda.nodeapi.config.getValue
 import java.nio.file.Path
@@ -15,6 +16,7 @@ class WebServerConfig(override val baseDirectory: Path, val config: Config) : No
     val exportJMXto: String get() = "http"
     val useHTTPS: Boolean by config
     val myLegalName: String by config
-    val p2pAddress: NetworkHostAndPort by config // TODO: Use RPC port instead of P2P port (RPC requires authentication, P2P does not)
+    val rpcAddress: NetworkHostAndPort by config
     val webAddress: NetworkHostAndPort by config
+    val rpcUsers: List<User> by config
 }


### PR DESCRIPTION
… SSL support.

The current use of SSL RPC relies on access to the node's keystore file, and further to that some uses where using the NODE_USER to login on the p2p port.

As far as I'm aware we've not used RPC SSL without replying on the node keystore file so it doesn't make sense to ship 1.0 with RPC in this state.