### PR TITLE
FlowSnapshot serialization error

### DIFF
--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/FlowStackSnapshotTest.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/FlowStackSnapshotTest.kt
@@ -191,7 +191,7 @@ class FlowStackSnapshotSerializationTestingFlow : FlowLogic<Unit>() {
     override fun call() {
         val flowStackSnapshot = flowStackSnapshot()
         val mySession = initiateFlow(ourIdentity)
-        mySession.send("TestMessage")
+        mySession.sendAndReceive<String>("Ping")
     }
 }
 
@@ -201,6 +201,7 @@ class DummyFlow(private val otherSideSession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val message = otherSideSession.receive<String>()
+        otherSideSession.send("$message Pong")
     }
 }
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/FlowStackSnapshot.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/FlowStackSnapshot.kt
@@ -54,7 +54,8 @@ class FlowStackSnapshotFactoryImpl : FlowStackSnapshotFactory {
         val objectStack = getObjectStack(stack).toList()
         val frameOffsets = getFrameOffsets(stack)
         val frameObjects = frameOffsets.map { (frameOffset, frameSize) ->
-            objectStack.subList(frameOffset + 1, frameOffset + frameSize + 1)
+            // We need to convert the sublist to a list due to the Kryo lack of support when serializing
+            objectStack.subList(frameOffset + 1, frameOffset + frameSize + 1).toList()
         }
         // We drop the first element as it is corda internal call irrelevant from the perspective of a CordApp developer
         val relevantStackTrace = removeConstructorStackTraceElements(stackTrace).drop(1)


### PR DESCRIPTION
There is an error when serialising the snapshot object (just before the checkpointing). It is due to the Kryo lack of support for the SubList class (thanks @mnesbit for spotting this).
