### PR TITLE
Declare this internal message string as "const".

### DIFF
--- a/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/concurrent/ConcurrencyUtils.kt
@@ -28,7 +28,7 @@ fun <V, W> firstOf(vararg futures: CordaFuture<out V>, handler: (CordaFuture<out
 
 private val defaultLog = LoggerFactory.getLogger("net.corda.core.concurrent")
 @VisibleForTesting
-internal val shortCircuitedTaskFailedMessage = "Short-circuited task failed:"
+internal const val shortCircuitedTaskFailedMessage = "Short-circuited task failed:"
 
 internal fun <V, W> firstOf(futures: Array<out CordaFuture<out V>>, log: Logger, handler: (CordaFuture<out V>) -> W): CordaFuture<W> {
     val resultFuture = openFuture<W>()


### PR DESCRIPTION
This message shouldn't be visible anyway, although it is. Declare it as `const` to make it `static final`.