### PR TITLE
CORDA-653 - Serialised enums should respect whitelist

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,10 @@ UNRELEASED
 
 * ``Cordapp`` now has a name field for identifying CorDapps and all CorDapp names are printed to console at startup.
 
+* Enums now respsect the whitelist applied to the Serializer factory serializing / deserializing them. If the enum isn't
+  either annotated with the @CordaSerializable annotation or explicitly whitelisted then a NotSerializableException is
+  thrown.
+
 Release 1.0
 -----------
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializerFactory.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializerFactory.kt
@@ -82,6 +82,7 @@ class SerializerFactory(val whitelist: ClassWhitelist, cl: ClassLoader) {
                 }
             }
             Enum::class.java.isAssignableFrom(actualClass ?: declaredClass) -> serializersByType.computeIfAbsent(actualClass ?: declaredClass) {
+                whitelisted(actualType)
                 EnumSerializer(actualType, actualClass ?: declaredClass, this)
             }
             else -> makeClassSerializer(actualClass ?: declaredClass, actualType, declaredType)


### PR DESCRIPTION
Have the serialiser factories apply whitelisting to enumerated types