### PR TITLE
CORDA-641: A temporary fix for contract upgrade transactions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -198,9 +198,6 @@ interface MoveCommand : CommandData {
     val contract: Class<out Contract>?
 }
 
-/** Indicates that this transaction replaces the inputs contract state to another contract state */
-data class UpgradeCommand(val upgradedContractClass: ContractClassName) : CommandData
-
 // DOCSTART 6
 /** A [Command] where the signing parties have been looked up if they have a well known/recognised institutional key. */
 @CordaSerializable

--- a/core/src/main/kotlin/net/corda/core/internal/UpgradeCommand.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/UpgradeCommand.kt
@@ -1,0 +1,7 @@
+package net.corda.core.internal
+
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.ContractClassName
+
+/** Indicates that this transaction replaces the inputs contract state to another contract state */
+data class UpgradeCommand(val upgradedContractClass: ContractClassName) : CommandData

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -3,8 +3,10 @@ package net.corda.core.transactions
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.Party
+import net.corda.core.internal.UpgradeCommand
 import net.corda.core.internal.castIfPossible
 import net.corda.core.serialization.CordaSerializable
+import java.security.PublicKey
 import java.util.*
 import java.util.function.Predicate
 
@@ -63,7 +65,13 @@ data class LedgerTransaction(
     @Throws(TransactionVerificationException::class)
     fun verify() {
         verifyConstraints()
-        verifyContracts()
+        // TODO: make contract upgrade transactions have a separate type
+        if (commands.any { it.value is UpgradeCommand }) {
+            verifyContractUpgrade()
+        }
+        else {
+            verifyContracts()
+        }
     }
 
     /**
@@ -150,6 +158,25 @@ data class LedgerTransaction(
                         encumbranceIndex,
                         TransactionVerificationException.Direction.OUTPUT)
             }
+        }
+    }
+
+    private fun verifyContractUpgrade() {
+        // Contract Upgrade transaction should have 1 input, 1 output and 1 command.
+        val input = inputs.single().state
+        val output = outputs.single()
+        val commandData = commandsOfType<UpgradeCommand>().single()
+
+        val command = commandData.value
+        val participantKeys: Set<PublicKey> = input.data.participants.map { it.owningKey }.toSet()
+        val keysThatSigned: Set<PublicKey> = commandData.signers.toSet()
+        @Suppress("UNCHECKED_CAST")
+        val upgradedContract = javaClass.classLoader.loadClass(command.upgradedContractClass).newInstance() as UpgradedContract<ContractState, *>
+        requireThat {
+            "The signing keys include all participant keys" using keysThatSigned.containsAll(participantKeys)
+            "Inputs state reference the legacy contract" using (input.contract == upgradedContract.legacyContract)
+            "Outputs state reference the upgraded contract" using (output.contract == command.upgradedContractClass)
+            "Output state must be an upgraded version of the input state" using (output.data == upgradedContract.upgrade(input.data))
         }
     }
 

--- a/core/src/test/kotlin/net/corda/core/contracts/DummyContractV2Tests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/DummyContractV2Tests.kt
@@ -1,20 +1,15 @@
 package net.corda.core.contracts
 
-import com.nhaarman.mockito_kotlin.mock
-import net.corda.testing.contracts.DummyContract
-import net.corda.testing.contracts.DummyContractV2
 import net.corda.core.crypto.SecureHash
-import net.corda.core.node.ServicesForResolution
+import net.corda.core.internal.UpgradeCommand
 import net.corda.testing.ALICE
 import net.corda.testing.DUMMY_NOTARY
+import net.corda.testing.TestDependencyInjectionBase
 import net.corda.testing.contracts.DUMMY_PROGRAM_ID
 import net.corda.testing.contracts.DUMMY_V2_PROGRAM_ID
-import net.corda.testing.TestDependencyInjectionBase
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.contracts.DummyContractV2
 import net.corda.testing.node.MockServices
-import net.corda.testing.setCordappPackages
-import net.corda.testing.unsetCordappPackages
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -43,22 +43,15 @@ class ContractUpgradeFlowTest {
     fun setup() {
         setCordappPackages("net.corda.testing.contracts", "net.corda.finance.contracts.asset", "net.corda.core.flows")
         mockNet = MockNetwork()
-        val nodes = mockNet.createSomeNodes(notaryKeyPair = null) // prevent generation of notary override
-        a = nodes.partyNodes[0]
-        b = nodes.partyNodes[1]
+        val notaryNode = mockNet.createNotaryNode()
+        a = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
+        b = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
 
         // Process registration
         mockNet.runNetwork()
         a.internals.ensureRegistered()
 
-        notary = a.services.getDefaultNotary()
-        val nodeIdentity = nodes.notaryNode.info.legalIdentitiesAndCerts.single { it.party == notary }
-        a.database.transaction {
-            a.services.identityService.verifyAndRegisterIdentity(nodeIdentity)
-        }
-        b.database.transaction {
-            b.services.identityService.verifyAndRegisterIdentity(nodeIdentity)
-        }
+        notary = notaryNode.services.getDefaultNotary()
     }
 
     @After

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -2,7 +2,6 @@ package net.corda.node.services
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.ContractState
-import net.corda.core.contracts.UpgradeCommand
 import net.corda.core.contracts.UpgradedContract
 import net.corda.core.contracts.requireThat
 import net.corda.core.flows.*
@@ -64,9 +63,6 @@ class ContractUpgradeHandler(otherSide: FlowSession) : AbstractStateReplacementF
             "The proposed upgrade ${proposal.modification.javaClass} is a trusted upgrade path" using (proposal.modification.name == authorisedUpgrade)
             "The proposed tx matches the expected tx for this upgrade" using (proposedTx == expectedTx)
         }
-        ContractUpgradeFlow.verify(
-                oldStateAndRef.state,
-                expectedTx.outRef<ContractState>(0).state,
-                expectedTx.toLedgerTransaction(serviceHub).commandsOfType<UpgradeCommand>().single())
+        proposedTx.toLedgerTransaction(serviceHub).verify()
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -391,7 +391,7 @@ class MockNetwork(private val networkSendManuallyPumped: Boolean = false,
     @JvmOverloads
     fun createSomeNodes(numPartyNodes: Int = 2, nodeFactory: Factory<*> = defaultFactory, notaryKeyPair: KeyPair? = DUMMY_NOTARY_KEY): BasketOfNodes {
         require(nodes.isEmpty())
-        val notaryServiceInfo = ServiceInfo(SimpleNotaryService.type)
+        val notaryServiceInfo = ServiceInfo(ValidatingNotaryService.type)
         val notaryOverride = if (notaryKeyPair != null)
             mapOf(Pair(notaryServiceInfo, notaryKeyPair))
         else

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt
@@ -1,8 +1,8 @@
 package net.corda.testing.contracts
 
 import net.corda.core.contracts.*
-import net.corda.core.flows.ContractUpgradeFlow
 import net.corda.core.identity.AbstractParty
+import net.corda.core.internal.UpgradeCommand
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -32,7 +32,6 @@ class DummyContractV2 : UpgradedContract<DummyContract.State, DummyContractV2.St
     }
 
     override fun verify(tx: LedgerTransaction) {
-        if (tx.commands.any { it.value is UpgradeCommand }) ContractUpgradeFlow.verify(tx)
         // Other verifications.
     }
     // DOCEND 1


### PR DESCRIPTION
During LedgerTransaction verification run the right logic based on whether
it contains the UpgradeCommand.

The current still has some issues:
- Changing contracts break encumbrance links
- We need a separate vault update type for these types of transactions
- Need to make sure expected state equality checks always work properly

Further work will be fixing the above and potentially introducing a new transaction type inline with the current notary change transaction model.