### PR TITLE
Last minute API changes

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,11 @@ UNRELEASED
   either annotated with the @CordaSerializable annotation or explicitly whitelisted then a NotSerializableException is
   thrown.
 
+* If you're using the deprecated web server, it no longer connects to the node using node-internal privileges. Your
+  node configs must specify an RPC user that has sufficient privileges to do what your app needs (usually just starting
+  flows). If using the Cordformation Gradle plugin to build local nodes please see the samples, for instance the IRS
+  sample, for how to specify required permissions.
+
 Release 1.0
 -----------
 

--- a/samples/irs-demo/build.gradle
+++ b/samples/irs-demo/build.gradle
@@ -49,6 +49,11 @@ dependencies {
 }
 
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
+    ext.rpcUsers = [['username': "demo", 'password': "demo", 'permissions': [
+            'StartFlow.net.corda.irs.flows.AutoOfferFlow$Requester',
+            'StartFlow.net.corda.irs.flows.UpdateBusinessDayFlow$Broadcast'
+    ]]]
+
     directory "./build/nodes"
     networkMap "O=Notary Service,L=Zurich,C=CH"
     node {
@@ -59,6 +64,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         webPort 10004
         cordapps = ["net.corda:finance:$corda_release_version"]
         useTestClock true
+        rpcUsers = ext.rpcUsers
     }
     node {
         name "O=Bank A,L=London,C=GB"
@@ -68,6 +74,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         webPort 10007
         cordapps = ["net.corda:finance:$corda_release_version"]
         useTestClock true
+        rpcUsers = ext.rpcUsers
     }
     node {
         name "O=Bank B,L=New York,C=US"
@@ -77,6 +84,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         webPort 10010
         cordapps = ["net.corda:finance:$corda_release_version"]
         useTestClock true
+        rpcUsers = ext.rpcUsers
     }
 }
 


### PR DESCRIPTION
Move/rename CordaPluginRegistry because it's name is no longer reflective of what it does. Simplify the API and serialisation code along the way. Move CompositeSignaturesWithKeys which was the only class in its package.