### PR TITLE
[CORDA-665] Add node warning windows users they might need to manually kill node explorer demo nodes

### DIFF
--- a/docs/source/node-explorer.rst
+++ b/docs/source/node-explorer.rst
@@ -73,6 +73,9 @@ Explorer login credentials to the Issuer nodes are defaulted to ``manager`` and 
 Explorer login credentials to the Participants nodes are defaulted to ``user1`` and ``test``.
 Please note you are not allowed to login to the notary.
 
+.. note:: When you start the nodes in Windows using the command prompt, they might not be killed when you close the
+          window or terminate the task. If that happens you need to manually terminate the Java processes running the nodes.
+
 .. note:: Alternatively, you may start the demo nodes from within IntelliJ using either of the run configurations
           ``Explorer - demo nodes`` or ``Explorer - demo nodes (simulation)``
 


### PR DESCRIPTION
Add a comment in the docs, warning users of:
https://r3-cev.atlassian.net/projects/CORDA/issues/CORDA-665