### PR TITLE
Improve NetworkMapCache docs.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -271,6 +271,8 @@ interface CordaRPCOps : RPCOps {
 
     /**
      * Returns a node's info from the network map cache, where known.
+     * Notice that when there are more than one node for a given name (in case of distributed services) first service node
+     * found will be returned.
      *
      * @return the node info if available.
      */

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -50,6 +50,8 @@ interface NetworkMapCache {
      * Look up the node info for a specific party. Will attempt to de-anonymise the party if applicable; if the party
      * is anonymised and the well known party cannot be resolved, it is impossible ot identify the node and therefore this
      * returns null.
+     * Notice that when there are more than one node for a given party (in case of distributed services) first service node
+     * found will be returned. See also: [getNodesByLegalIdentityKey].
      *
      * @param party party to retrieve node information for.
      * @return the node for the identity, or null if the node could not be found. This does not necessarily mean there is
@@ -57,7 +59,11 @@ interface NetworkMapCache {
      */
     fun getNodeByLegalIdentity(party: AbstractParty): NodeInfo?
 
-    /** Look up the node info for a legal name. */
+    /**
+     * Look up the node info for a legal name.
+     * Notice that when there are more than one node for a given name (in case of distributed services) first service node
+     * found will be returned.
+     */
     fun getNodeByLegalName(name: CordaX500Name): NodeInfo?
 
     /** Look up the node info for a host and port. */

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -112,7 +112,7 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
     override fun getNodeByLegalIdentity(party: AbstractParty): NodeInfo? {
         val wellKnownParty = serviceHub.identityService.wellKnownPartyFromAnonymous(party)
         return wellKnownParty?.let {
-            getNodesByLegalIdentityKey(it.owningKey).singleOrNull()
+            getNodesByLegalIdentityKey(it.owningKey).firstOrNull()
         }
     }
 


### PR DESCRIPTION
NodeInfo lookup can return more than one node for distribute services. 