### PR TITLE
CORDA-650: Eliminate unnecessary dependency on "graphstream" library

### DIFF
--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile "org.graphstream:gs-core:1.3"
     compile("org.graphstream:gs-ui:1.3") {
         exclude group: "bouncycastle"
+        exclude group: "junit"
     }
 
     cordaCompile project(path: ":node:capsule", configuration: 'runtimeArtifacts')

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -108,11 +108,6 @@ dependencies {
     // Manifests: for reading stuff from the manifest file
     compile "com.jcabi:jcabi-manifests:1.1"
 
-    // GraphStream: For visualisation
-    testCompile "org.graphstream:gs-core:1.3"
-    testCompile("org.graphstream:gs-ui:1.3") {
-        exclude group: "bouncycastle"
-    }
     compile("com.intellij:forms_rt:7.0.3") {
         exclude group: "asm"
     }

--- a/samples/network-visualiser/build.gradle
+++ b/samples/network-visualiser/build.gradle
@@ -21,8 +21,6 @@ dependencies {
     // Cordapp dependencies
     // GraphStream: For visualisation
     compileOnly "co.paralleluniverse:capsule:$capsule_version"
-    compile "org.graphstream:gs-core:1.3"
-    compile "org.graphstream:gs-ui:1.3"
 }
 
 idea {


### PR DESCRIPTION
This library has one usage in ClientRPC example and:
* Uses Scala 2.10 - which is quite dated
* Has a transitive dependency on JUnit