### PR TITLE
CORDA-649: Second attempt to make PersistentNetworkMapCacheTest more stable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ buildscript {
     ext.jersey_version = '2.25'
     ext.jolokia_version = '2.0.0-M3'
     ext.assertj_version = '3.6.1'
-    ext.kotlintest_version = '2.0.5'
     ext.slf4j_version = '1.7.25'
     ext.log4j_version = '2.7'
     ext.bouncycastle_version = constants.getProperty("bouncycastleVersion")

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -189,7 +189,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
 
     override fun toString(): String = "${javaClass.simpleName}(id=$id)"
 
-    companion object {
+    private companion object {
         private fun missingSignatureMsg(missing: Set<PublicKey>, descriptions: List<String>, id: SecureHash): String =
                 "Missing signatures for $descriptions on transaction ${id.prefixChars()} for ${missing.joinToString()}"
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -189,7 +189,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
 
     override fun toString(): String = "${javaClass.simpleName}(id=$id)"
 
-    private companion object {
+    companion object {
         private fun missingSignatureMsg(missing: Set<PublicKey>, descriptions: List<String>, id: SecureHash): String =
                 "Missing signatures for $descriptions on transaction ${id.prefixChars()} for ${missing.joinToString()}"
     }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -127,7 +127,6 @@ dependencies {
     // Unit testing helpers.
     testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
-    testCompile "io.kotlintest:kotlintest:${kotlintest_version}"
     testCompile project(':test-utils')
     testCompile project(':client:jfx')
     testCompile project(':finance')

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -143,7 +143,7 @@ class PersistentNetworkMapCacheTest : NodeBasedTest() {
 
         // This is prediction of the longest time it will take to get the cluster into a stable state such that further
         // testing can be performed upon it
-        val maxInstabilityInterval = BRIDGE_RETRY_MS * allTheStartedNodesPopulation.size * 2
+        val maxInstabilityInterval = BRIDGE_RETRY_MS * allTheStartedNodesPopulation.size * 30
         logger.info("Instability interval is set to: $maxInstabilityInterval ms")
 
         eventually<AssertionError, Unit>(Duration.ofMillis(maxInstabilityInterval)) {

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -1,8 +1,6 @@
 package net.corda.node.services.network
 
 import co.paralleluniverse.fibers.Suspendable
-import io.kotlintest.eventually
-import io.kotlintest.milliseconds
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
@@ -17,8 +15,8 @@ import net.corda.testing.*
 import net.corda.testing.node.NodeBasedTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
+import java.time.Duration
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertTrue
@@ -114,7 +112,6 @@ class PersistentNetworkMapCacheTest : NodeBasedTest() {
         assertFails { startNode(CHARLIE.name, noNetworkMap = true).getOrThrow(2.seconds) }
     }
 
-    @Ignore("Unstable test that needs more work")
     @Test
     fun `new node joins network without network map started`() {
 
@@ -147,8 +144,9 @@ class PersistentNetworkMapCacheTest : NodeBasedTest() {
         // This is prediction of the longest time it will take to get the cluster into a stable state such that further
         // testing can be performed upon it
         val maxInstabilityInterval = BRIDGE_RETRY_MS * allTheStartedNodesPopulation.size * 2
+        logger.info("Instability interval is set to: $maxInstabilityInterval ms")
 
-        eventually(maxInstabilityInterval.milliseconds) {
+        eventually<AssertionError, Unit>(Duration.ofMillis(maxInstabilityInterval)) {
             logger.info("Checking connectivity")
             checkConnectivity(listOf(otherNodes[0], nms)) // Checks connectivity from A to NMS.
             logger.info("Loading caches")

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -146,6 +146,7 @@ class PersistentNetworkMapCacheTest : NodeBasedTest() {
         val maxInstabilityInterval = BRIDGE_RETRY_MS * allTheStartedNodesPopulation.size * 30
         logger.info("Instability interval is set to: $maxInstabilityInterval ms")
 
+        // TODO: Re-visit this sort of re-try for stable cluster once network map redesign is finished.
         eventually<AssertionError, Unit>(Duration.ofMillis(maxInstabilityInterval)) {
             logger.info("Checking connectivity")
             checkConnectivity(listOf(otherNodes[0], nms)) // Checks connectivity from A to NMS.

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/Eventually.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/Eventually.kt
@@ -1,0 +1,24 @@
+package net.corda.testing
+
+import java.time.Duration
+
+/**
+ * Ideas borrowed from "io.kotlintest" with some improvements made
+ * This is meant for use from Kotlin code use only mainly due to it's inline/reified nature
+ */
+inline fun <reified E : Throwable, R>eventually(duration: Duration, f: () -> R): R {
+    val end = System.nanoTime() + duration.toNanos()
+    var times = 0
+    while (System.nanoTime() < end) {
+        try {
+            return f()
+        } catch (e: Throwable) {
+            when(e) {
+                is E -> {}// ignore and continue
+                else -> throw e // unexpected exception type - rethrow
+            }
+        }
+        times++
+    }
+    throw AssertionError("Test failed after ${duration}; attempted $times times")
+}

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/Eventually.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/Eventually.kt
@@ -20,5 +20,5 @@ inline fun <reified E : Throwable, R>eventually(duration: Duration, f: () -> R):
         }
         times++
     }
-    throw AssertionError("Test failed after ${duration}; attempted $times times")
+    throw AssertionError("Test failed after $duration; attempted $times times")
 }


### PR DESCRIPTION
Ended-up writing custom "eventually" that handles gracefully AssertionError and continues

I will be running Integration tests multiple times to ensure the test is indeed stable before merging