### PR TITLE
Hide companion object completely from external visibility

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -189,7 +189,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
 
     override fun toString(): String = "${javaClass.simpleName}(id=$id)"
 
-    companion object {
+    private companion object {
         private fun missingSignatureMsg(missing: Set<PublicKey>, descriptions: List<String>, id: SecureHash): String =
                 "Missing signatures for $descriptions on transaction ${id.prefixChars()} for ${missing.joinToString()}"
     }


### PR DESCRIPTION
As discussed with @chrisr3 - hide companion object completely from external visibility