### PR TITLE
Annotate Gradle task inputs and outputs correctly.

### DIFF
--- a/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/GenerateApi.java
+++ b/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/GenerateApi.java
@@ -48,7 +48,7 @@ public class GenerateApi extends DefaultTask {
     @TaskAction
     public void generate() {
         FileCollection apiFiles = getSources();
-        if (!apiFiles.isEmpty() && (outputDir.isDirectory() || outputDir.mkdirs())) {
+        if (!apiFiles.isEmpty()) {
             try (OutputStream output = new BufferedOutputStream(new FileOutputStream(getTarget()))) {
                 for (File apiFile : apiFiles) {
                     Files.copy(apiFile.toPath(), output);

--- a/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -8,7 +8,9 @@ import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFiles;
 import org.gradle.api.tasks.TaskAction;
 
@@ -55,7 +57,7 @@ public class ScanApi extends DefaultTask {
         outputDir = new File(getProject().getBuildDir(), "api");
     }
 
-    @Input
+    @InputFiles
     public FileCollection getSources() {
         return sources;
     }
@@ -64,7 +66,8 @@ public class ScanApi extends DefaultTask {
         this.sources.setFrom(sources);
     }
 
-    @Input
+    @CompileClasspath
+    @InputFiles
     public FileCollection getClasspath() {
         return classpath;
     }
@@ -106,16 +109,12 @@ public class ScanApi extends DefaultTask {
 
     @TaskAction
     public void scan() {
-        if (outputDir.isDirectory() || outputDir.mkdirs()) {
-            try (Scanner scanner = new Scanner(classpath)) {
-                for (File source : sources) {
-                    scanner.scan(source);
-                }
-            } catch (IOException e) {
-                getLogger().error("Failed to write API file", e);
+        try (Scanner scanner = new Scanner(classpath)) {
+            for (File source : sources) {
+                scanner.scan(source);
             }
-        } else {
-            getLogger().error("Cannot create directory '{}'", outputDir.getAbsolutePath());
+        } catch (IOException e) {
+            getLogger().error("Failed to write API file", e);
         }
     }
 


### PR DESCRIPTION
Just a few tweaks to the API Scanner plugin so that it behaves correctly for incremental builds.
- `@Input` -> `@InputFiles` so that Gradle checks whether the files' _content_ have changed. This should make Gradle rescan the APIs _more_ aggressively.
- Add `@CompileClasspath` so that Gradle is less sensitive to changes to these particular file inputs. This should make Gradle rescan the APIs _less_ aggressively.

Also, Gradle will automatically create the output directory for every property annotated as an `@OutputFile`, so we don't need to do this manually.

There's no hurry to re-release the Gradle plugins just yet either. I'm still looking for more tweaks, and our main use-case doesn't use incremental builds.