### PR TITLE
Fixes java-docs breaking typo.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -20,8 +20,8 @@ import java.util.*
 class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
                               private val otherSide: FlowSession) : FlowLogic<List<SignedTransaction>>() {
     /**
-     * Resolves and validates the dependencies of the specified [signedTransaction]. Fetches the attachments, but does
-     * *not* validate or store the [signedTransaction] itself.
+     * Resolves and validates the dependencies of the specified [SignedTransaction]. Fetches the attachments, but does
+     * *not* validate or store the [SignedTransaction] itself.
      *
      * @return a list of verified [SignedTransaction] objects, in a depth-first order.
      */


### PR DESCRIPTION
Fixes a typo in the java-docs for ResolveTransactionsFlow, which causes the java-docs links to break.