### PR TITLE
Checking out the latest milestone will no longer be required.

### DIFF
--- a/docs/source/getting-set-up.rst
+++ b/docs/source/getting-set-up.rst
@@ -76,8 +76,6 @@ Download a sample project
 1. Open a command prompt
 2. Clone the CorDapp example repo by running ``git clone https://github.com/corda/cordapp-example``
 3. Move into the cordapp-example folder by running ``cd cordapp-example``
-4. Retrieve a list of all the releases by running ``git branch -a --list``
-5. Check out the latest milestone release by running ``git checkout release-MX`` (where "X" is the latest milestone)
 
 Run from the command prompt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,8 +123,6 @@ Download a sample project
 1. Open a terminal
 2. Clone the CorDapp example repo by running ``git clone https://github.com/corda/cordapp-example``
 3. Move into the cordapp-example folder by running ``cd cordapp-example``
-4. Retrieve a list of all the releases by running ``git branch -a --list``
-5. Check out the latest milestone release by running ``git checkout release-MX`` (where "X" is the latest milestone)
 
 Run from the terminal
 ^^^^^^^^^^^^^^^^^^^^^
@@ -164,9 +160,6 @@ And a simple example CorDapp for you to explore basic concepts is available here
 	https://github.com/corda/cordapp-example.git
 
 You can clone these repos to your local machine by running the command ``git clone [repo URL]``.
-
-By default, these repos will be on the unstable ``master`` branch. You should check out the latest milestone release
-instead by running ``git checkout release-MX`` (where “X” is the latest milestone).
 
 Next steps
 ----------

--- a/docs/source/hello-world-template.rst
+++ b/docs/source/hello-world-template.rst
@@ -22,7 +22,7 @@ Downloading the template
 ------------------------
 Open a terminal window in the directory where you want to download the CorDapp template, and run the following commands:
 
-.. code-block:: text
+.. code-block:: bash
 
     # Clone the template from GitHub:
     git clone https://github.com/corda/cordapp-template-java.git ; cd cordapp-template-java
@@ -30,12 +30,6 @@ Open a terminal window in the directory where you want to download the CorDapp t
     *or*
 
     git clone https://github.com/corda/cordapp-template-kotlin.git ; cd cordapp-template-kotlin
-
-    # Retrieve a list of the stable Milestone branches using:
-    git branch -a --list *release-M*
-
-    # Check out the Milestone branch with the latest version number:
-    git checkout release-M[*version number*] ; git pull
 
 Template structure
 ------------------

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,13 +1,6 @@
 Troubleshooting
 ===============
 
-Milestone releases
-------------------
-
-When you clone the corda or cordapp-template repos, they will default to the master branch. The master branch is being continuously developed upon, and its features may not align with the state of Corda as described in the docs. Additionally, the master branch of the CorDapp template may break in response to changes in the main corda repo.
-
-When developing on Corda, you should always check out the latest milestone (i.e. stable) branch instead. For example, to check out milestone 0, you'd run ``git checkout release-M0``.
-
 Java issues
 -----------
 

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -36,16 +36,6 @@ We need to download the example CorDapp from GitHub.
 
 * Change directories to the freshly cloned repo: ``cd cordapp-example``
 
-* We want to work off the latest Milestone release
-
-  * To enumerate all the Milestone releases, run: ``git tag``
-
-  * Check out the latest (highest-numbered) Milestone release using: ``git checkout [tag_name]``
-
-    Where ``tag_name`` is the name of the tag you wish to checkout
-
-  * Gradle will grab all the required dependencies for you from `Maven <https://bintray.com/r3/corda>`_
-
 .. note:: If you wish to build off the latest, unstable version of the codebase, follow the instructions in
    :doc:`building against Master <building-against-master>` instead.
 


### PR DESCRIPTION
Cordapp templates and example will point to the latest milestone by default, so there's no need to tell people to check out the latest version.