### PR TITLE
CORDA-540: AMQP specific fixes in "node-api" project

### DIFF
--- a/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CompositeKeyTests.kt
@@ -216,7 +216,7 @@ class CompositeKeyTests : TestDependencyInjectionBase() {
     }
 
     @Test()
-    fun `composite key validation with graph cycle detection`() = kryoSpecific<CompositeKeyTests>("Cycle exists in the object graph which is not currently supported in AMQP mode") {
+    fun `composite key validation with graph cycle detection`() = kryoSpecific("Cycle exists in the object graph which is not currently supported in AMQP mode") {
         val key1 = CompositeKey.Builder().addKeys(alicePublicKey, bobPublicKey).build() as CompositeKey
         val key2 = CompositeKey.Builder().addKeys(alicePublicKey, key1).build() as CompositeKey
         val key3 = CompositeKey.Builder().addKeys(alicePublicKey, key2).build() as CompositeKey

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException
 
 val attachmentsClassLoaderEnabledPropertyName = "attachments.class.loader.enabled"
 
-object NotSupportedSeralizationScheme : SerializationScheme {
+object NotSupportedSerializationScheme : SerializationScheme {
     private fun doThrow(): Nothing = throw UnsupportedOperationException("Serialization scheme not supported.")
 
     override fun canDeserializeVersion(byteSequence: ByteSequence, target: SerializationContext.UseCase): Boolean = doThrow()
@@ -107,7 +107,7 @@ open class SerializationFactoryImpl : SerializationFactory() {
             registeredSchemes
                     .filter { scheme -> scheme.canDeserializeVersion(it.first, it.second) }
                     .forEach { return@computeIfAbsent it }
-            NotSupportedSeralizationScheme
+            NotSupportedSerializationScheme
         }
     }
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderTests.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.declaredField
-import net.corda.core.internal.toLedgerTransaction
 import net.corda.core.internal.toWireTransaction
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.AttachmentStorage
@@ -302,7 +301,7 @@ class AttachmentsClassLoaderTests : TestDependencyInjectionBase() {
 
     @Test
     fun `test deserialize of WireTransaction where contract cannot be found`() {
-        kryoSpecific<AttachmentsClassLoaderTests>("Kryo verifies/loads attachments on deserialization, whereas AMQP currently does not") {
+        kryoSpecific("Kryo verifies/loads attachments on deserialization, whereas AMQP currently does not") {
             ClassLoaderForTests().use { child ->
                 val contractClass = Class.forName(ISOLATED_CONTRACT_CLASS_NAME, true, child)
                 val contract = contractClass.newInstance() as DummyContractBackdoor

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/ListsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/ListsSerializationTest.kt
@@ -23,7 +23,7 @@ class ListsSerializationTest : TestDependencyInjectionBase() {
         val javaEmptyListClass = Collections.emptyList<Any>().javaClass
 
         fun<T : Any> verifyEnvelope(serBytes: SerializedBytes<T>, envVerBody: (Envelope) -> Unit) =
-            amqpSpecific<ListsSerializationTest>("AMQP specific envelope verification") {
+            amqpSpecific("AMQP specific envelope verification") {
                 val context = SerializationFactory.defaultFactory.defaultContext
                 val envelope = DeserializationInput(SerializerFactory(context.whitelist, context.deserializationClassLoader)).getEnvelope(serBytes)
                 envVerBody(envelope)
@@ -54,7 +54,7 @@ class ListsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check empty list serialises as Java emptyList`() = kryoSpecific<ListsSerializationTest>("Kryo specific test"){
+    fun `check empty list serialises as Java emptyList`() = kryoSpecific("Kryo specific test"){
         val nameID = 0
         val serializedForm = emptyList<Int>().serialize()
         val output = ByteArrayOutputStream().apply {
@@ -71,7 +71,7 @@ class ListsSerializationTest : TestDependencyInjectionBase() {
     data class WrongPayloadType(val payload: ArrayList<Int>)
 
     @Test
-    fun `check throws for forbidden declared type`() = amqpSpecific<ListsSerializationTest>("Such exceptions are not expected in Kryo mode.") {
+    fun `check throws for forbidden declared type`() = amqpSpecific("Such exceptions are not expected in Kryo mode.") {
         val payload = ArrayList<Int>()
         payload.add(1)
         payload.add(2)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/MapsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/MapsSerializationTest.kt
@@ -22,7 +22,7 @@ class MapsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check EmptyMap serialization`() = amqpSpecific<MapsSerializationTest>("kotlin.collections.EmptyMap is not enabled for Kryo serialization") {
+    fun `check EmptyMap serialization`() = amqpSpecific("kotlin.collections.EmptyMap is not enabled for Kryo serialization") {
         assertEqualAfterRoundTripSerialization(emptyMap<Any, Any>())
     }
 
@@ -41,7 +41,7 @@ class MapsSerializationTest : TestDependencyInjectionBase() {
     data class WrongPayloadType(val payload: HashMap<String, String>)
 
     @Test
-    fun `check throws for forbidden declared type`() = amqpSpecific<ListsSerializationTest>("Such exceptions are not expected in Kryo mode.") {
+    fun `check throws for forbidden declared type`() = amqpSpecific("Such exceptions are not expected in Kryo mode.") {
         val payload = HashMap<String, String>(smallMap)
         val wrongPayloadType = WrongPayloadType(payload)
         Assertions.assertThatThrownBy { wrongPayloadType.serialize() }
@@ -64,7 +64,7 @@ class MapsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check empty map serialises as Java emptyMap`() = kryoSpecific<MapsSerializationTest>("Specifically checks Kryo serialization") {
+    fun `check empty map serialises as Java emptyMap`() = kryoSpecific("Specifically checks Kryo serialization") {
         val nameID = 0
         val serializedForm = emptyMap<Int, Int>().serialize()
         val output = ByteArrayOutputStream().apply {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
@@ -40,7 +40,7 @@ class SetsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check empty set serialises as Java emptySet`() = kryoSpecific<ListsSerializationTest>("Checks Kryo header properties") {
+    fun `check empty set serialises as Java emptySet`() = kryoSpecific("Checks Kryo header properties") {
         val nameID = 0
         val serializedForm = emptySet<Int>().serialize()
         val output = ByteArrayOutputStream().apply {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/SetsSerializationTest.kt
@@ -5,6 +5,7 @@ import com.esotericsoftware.kryo.util.DefaultClassResolver
 import net.corda.core.serialization.serialize
 import net.corda.node.services.statemachine.SessionData
 import net.corda.testing.TestDependencyInjectionBase
+import net.corda.testing.kryoSpecific
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -39,7 +40,7 @@ class SetsSerializationTest : TestDependencyInjectionBase() {
     }
 
     @Test
-    fun `check empty set serialises as Java emptySet`() {
+    fun `check empty set serialises as Java emptySet`() = kryoSpecific<ListsSerializationTest>("Checks Kryo header properties") {
         val nameID = 0
         val serializedForm = emptySet<Int>().serialize()
         val output = ByteArrayOutputStream().apply {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -146,13 +146,15 @@ fun getTestPartyAndCertificate(name: CordaX500Name, publicKey: PublicKey, trustR
     return getTestPartyAndCertificate(Party(name, publicKey), trustRoot)
 }
 
-inline fun <reified T : Any> kryoSpecific(reason: String, function: () -> Unit) = if(!AMQP_ENABLED) {
+@Suppress("unused")
+inline fun <reified T : Any> T.kryoSpecific(reason: String, function: () -> Unit) = if(!AMQP_ENABLED) {
     function()
 } else {
     loggerFor<T>().info("Ignoring Kryo specific test, reason: $reason" )
 }
 
-inline fun <reified T : Any> amqpSpecific(reason: String, function: () -> Unit) = if(AMQP_ENABLED) {
+@Suppress("unused")
+inline fun <reified T : Any> T.amqpSpecific(reason: String, function: () -> Unit) = if(AMQP_ENABLED) {
     function()
 } else {
     loggerFor<T>().info("Ignoring AMQP specific test, reason: $reason" )
@@ -169,14 +171,14 @@ fun ServiceHub.getDefaultNotary(): Party = networkMapCache.notaryIdentities.firs
 
 /**
  * Set the package to scan for cordapps - this overrides the default behaviour of scanning the cordapps directory
- * @param packageName A package name that you wish to scan for cordapps
+ * @param packageNames A package name that you wish to scan for cordapps
  */
 fun setCordappPackages(vararg packageNames: String) {
     CordappLoader.testPackages = packageNames.toList()
 }
 
 /**
- * Unsets the default overriding behaviour of [setCordappPackage]
+ * Unsets the default overriding behaviour of [setCordappPackages]
  */
 fun unsetCordappPackages() {
     CordappLoader.testPackages = emptyList()


### PR DESCRIPTION
Use special instruction to exclude newly introduced tests from running in AMQP mode.