### PR TITLE
Instantiate Contract classes outside of LedgerTransaction.verify()

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -50,7 +50,7 @@ data class LedgerTransaction(
 
     private companion object {
         @JvmStatic
-        fun createContractFor(className: ContractClassName): ContractResult {
+        private fun createContractFor(className: ContractClassName): ContractResult {
             return try {
                 ContractResult(contract = this::class.java.classLoader.loadClass(className).asSubclass(Contract::class.java).getConstructor().newInstance())
             } catch (e: Exception) {

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -59,6 +59,7 @@ data class LedgerTransaction(
         }
     }
 
+    @CordaSerializable
     private data class ContractResult(val contract: Contract?, val error: Throwable? = null)
 
     private val contracts: Map<ContractClassName, ContractResult> = (inputs.map { it.state.contract } + outputs.map { it.contract })

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -52,15 +52,15 @@ data class LedgerTransaction(
         @JvmStatic
         fun createContractFor(className: ContractClassName): ContractResult {
             return try {
-                ContractResult(this::class.java.classLoader.loadClass(className).asSubclass(Contract::class.java).getConstructor().newInstance())
+                ContractResult(contract = this::class.java.classLoader.loadClass(className).asSubclass(Contract::class.java).getConstructor().newInstance())
             } catch (e: Exception) {
-                ContractResult(null, e)
+                ContractResult(error = e)
             }
         }
     }
 
     @CordaSerializable
-    private data class ContractResult(val contract: Contract?, val error: Throwable? = null)
+    private data class ContractResult(val contract: Contract? = null, val error: Throwable? = null)
 
     private val contracts: Map<ContractClassName, ContractResult> = (inputs.map { it.state.contract } + outputs.map { it.contract })
             .toSet().map { it to createContractFor(it) }.toMap()

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class VerifierTests {
     private fun generateTransactions(number: Int): List<LedgerTransaction> {
         var currentLedger = GeneratedLedger.empty
-        val transactions = ArrayList<WireTransaction>()
+        val transactions = arrayListOf<WireTransaction>()
         val random = SplittableRandom()
         for (i in 0 until number) {
             val (tx, ledger) = currentLedger.transactionGenerator.generateOrFail(random)


### PR DESCRIPTION
The `LedgerTransaction.verify()` function does not have access to Java Reflection, so instantiate the contract classes when creating the `LedgerTransaction` instance instead.