### PR TITLE
Fail the API check for lines starting with a single '-'.

### DIFF
--- a/.ci/check-api-changes.sh
+++ b/.ci/check-api-changes.sh
@@ -11,7 +11,7 @@ fi
 diffContents=`diff -u $apiCurrent ../build/api/api-corda-*.txt`
 echo "Diff contents: " 
 echo "$diffContents"
-removals=`echo "$diffContents" | grep "^-" | wc -l`
+removals=`echo "$diffContents" | grep "^-\s" | wc -l`
 echo "Number of API removals/changes: "$removals
 echo "Exiting with exit code" $removals
 exit $removals


### PR DESCRIPTION
Don't fail the API check for lines like:
```diff
--- .ci/api-current.txt	2017-10-03 10:51:43.794307705 +0100
```