### PR TITLE
[CORDA-519] Hash agility - step1

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -191,24 +191,24 @@ fun random63BitValue(): Long {
 
 /**
  * Compute the hash of each serialised component so as to be used as Merkle tree leaf. The resultant output (leaf) is
- * calculated using the SHA256d algorithm, thus SHA256(SHA256(nonce || serializedComponent)), where nonce is computed
- * from [computeNonce].
+ * calculated using double hashing, thus hash(hash(nonce || serializedComponent)), where nonce is computed
+ * from [computeNonce] and [SecureHash.DEFAULT_ALGORITHM] is the default hash algorithm.
  */
 fun componentHash(opaqueBytes: OpaqueBytes, privacySalt: PrivacySalt, componentGroupIndex: Int, internalIndex: Int): SecureHash =
         componentHash(computeNonce(privacySalt, componentGroupIndex, internalIndex), opaqueBytes)
 
-/** Return the SHA256(SHA256(nonce || serializedComponent)). */
-fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash = SecureHash.sha256Twice(nonce.bytes + opaqueBytes.bytes)
+/** Return the hash(hash(nonce || serializedComponent)) using the [SecureHash.DEFAULT_ALGORITHM] hash function. */
+fun componentHash(nonce: SecureHash, opaqueBytes: OpaqueBytes): SecureHash = SecureHash.hashTwice(nonce.bytes + opaqueBytes.bytes)
 
-/** Serialise the object and return the hash of the serialized bytes. */
-fun <T : Any> serializedHash(x: T): SecureHash = x.serialize(context = SerializationDefaults.P2P_CONTEXT.withoutReferences()).bytes.sha256()
+/** Serialise the object and return the [SecureHash.DEFAULT_ALGORITHM] hash of the serialized bytes.*/
+fun <T : Any> serializedHash(x: T): SecureHash = x.serialize(context = SerializationDefaults.P2P_CONTEXT.withoutReferences()).bytes.hash()
 
 /**
  * Method to compute a nonce based on privacySalt, component group index and component internal index.
- * SHA256d (double SHA256) is used to prevent length extension attacks.
+ * Double hashing is used to prevent length extension attacks. The [SecureHash.DEFAULT_ALGORITHM] is used as hash function.
  * @param privacySalt a [PrivacySalt].
  * @param groupIndex the fixed index (ordinal) of this component group.
  * @param internalIndex the internal index of this object in its corresponding components list.
- * @return SHA256(SHA256(privacySalt || groupIndex || internalIndex))
+ * @return hash(hash(privacySalt || groupIndex || internalIndex))
  */
-fun computeNonce(privacySalt: PrivacySalt, groupIndex: Int, internalIndex: Int) = SecureHash.sha256Twice(privacySalt.bytes + ByteBuffer.allocate(8).putInt(groupIndex).putInt(internalIndex).array())
+fun computeNonce(privacySalt: PrivacySalt, groupIndex: Int, internalIndex: Int) = SecureHash.hashTwice(privacySalt.bytes + ByteBuffer.allocate(8).putInt(groupIndex).putInt(internalIndex).array())

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -5,13 +5,21 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.parseAsHex
 import net.corda.core.utilities.toHexString
 import java.security.MessageDigest
+import kotlin.reflect.KClass
 
 /**
  * Container for a cryptographically secure hash value.
- * Provides utilities for generating a cryptographic hash using different algorithms (currently only SHA-256 supported).
+ * Provides utilities for generating a cryptographic hash using different algorithms.
+ * Currently, the following cryptographic hash algorithms are supported:
+ * <p><ul>
+ * <li>SHA-256, member of the SHA-2 cryptographic hash functions with an output of 32 bytes. This is the default algorithm
+ * for Merkle tree generation.
+ * <li>SHA-512, member of the SHA-2 cryptographic hash functions with an output of 64 bytes.
+ * </ul></p>
  */
 @CordaSerializable
 sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
+
     /** SHA-256 is part of the SHA-2 hash function family. Generated hash is fixed size, 256-bits (32-bytes). */
     class SHA256(bytes: ByteArray) : SecureHash(bytes) {
         init {
@@ -19,32 +27,143 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         }
     }
 
+    /** SHA-512 is part of the SHA-2 hash function family. Generated hash is fixed size, 512-bits (64-bytes). */
+    class SHA512(bytes: ByteArray) : SecureHash(bytes) {
+        init {
+            require(bytes.size == 64)
+        }
+    }
+
     override fun toString(): String = bytes.toHexString()
 
+    /** The first 6 characters of the hash HEX String. */
     fun prefixChars(prefixLen: Int = 6) = toString().substring(0, prefixLen)
-    fun hashConcat(other: SecureHash) = (this.bytes + other.bytes).sha256()
 
-    // Like static methods in Java, except the 'companion' is a singleton that can have state.
+    /**
+     * Concatenate the bytes of this object with the bytes of another [SecureHash] (of the same type)
+     * and return the hash of the concatenated result.
+     */
+    fun hashConcat(other: SecureHash): SecureHash {
+        return if (this::class == other::class) {
+            SecureHash.hash(this.bytes + other.bytes, this::class)
+        } else throw IllegalArgumentException("You can only hashConcat SecureHash objects of the same type.")
+    }
+
     companion object {
+        /** Properties of the [SHA256] algorithm. */
+        val SHA256_ALGORITHM = SecureHashAlgorithm(
+                "SHA-256",
+                32,
+                SHA256(ByteArray(32, { 0.toByte() })),
+                SHA256(ByteArray(32, { 255.toByte() }))
+        )
+
+        /** Properties of the [SHA512] algorithm. */
+        val SHA512_ALGORITHM = SecureHashAlgorithm(
+                "SHA-512",
+                64,
+                SHA512(ByteArray(64, { 0.toByte() })),
+                SHA512(ByteArray(64, { 255.toByte() }))
+        )
+
+        /** SHA256 is currently the default [SecureHash] algorithm. */
+        val DEFAULT_ALGORITHM = SHA256_ALGORITHM
+
+        /**
+         * Method that receives a HEX [String] which represents a hash output and returns its corresponding [SecureHash]
+         * object. Selection of the Hash algorithm is based on the input String size and if there are more than one hash
+         * functions offering the same hash output size, then the default per size is selected.
+         */
         @JvmStatic
         fun parse(str: String) = str.toUpperCase().parseAsHex().let {
             when (it.size) {
                 32 -> SHA256(it)
-                else -> throw IllegalArgumentException("Provided string is ${it.size} bytes not 32 bytes in hex: $str")
+                64 -> SHA512(it) // TODO: define default 64-bit SecureHash function when SHA3-512 is introduced.
+                else -> throw IllegalArgumentException("Provided string is ${it.size} bytes not 32 or 64 bytes in hex: $str")
             }
         }
 
-        @JvmStatic fun sha256(bytes: ByteArray) = SHA256(MessageDigest.getInstance("SHA-256").digest(bytes))
-        @JvmStatic fun sha256Twice(bytes: ByteArray) = sha256(sha256(bytes).bytes)
-        @JvmStatic fun sha256(str: String) = sha256(str.toByteArray())
+        /**
+         * Method that receives a HEX [String] which represents a hash output and returns its corresponding [SecureHash]
+         * object. The hash secureHashAlgorithm is defined by the input [secureHashAlgorithm].
+         */
+        @JvmStatic
+        fun parse(str: String, secureHashAlgorithm: SecureHashAlgorithm = DEFAULT_ALGORITHM) = str.toUpperCase().parseAsHex().let {
+            when(secureHashAlgorithm) {
+                SHA256_ALGORITHM -> SHA256(it)
+                SHA512_ALGORITHM -> SHA512(it)
+                else -> throw IllegalArgumentException("Hash secureHashAlgorithm $secureHashAlgorithm is not supported")
+            }
+        }
 
-        @JvmStatic fun randomSHA256() = sha256(newSecureRandom().generateSeed(32))
-        val zeroHash = SecureHash.SHA256(ByteArray(32, { 0.toByte() }))
-        val allOnesHash = SecureHash.SHA256(ByteArray(32, { 255.toByte() }))
+        /**
+         * Returns the corresponding [SecureHash] object by hashing the input [bytes], using the provided [SecureHashAlgorithm].
+         * If the algorithm is not provided, then the [DEFAULT_ALGORITHM] is used.
+         */
+        @JvmStatic
+        fun hash(bytes: ByteArray, secureHashAlgorithm: SecureHashAlgorithm = DEFAULT_ALGORITHM): SecureHash =
+            when(secureHashAlgorithm) {
+                SHA256_ALGORITHM -> SHA256(MessageDigest.getInstance(secureHashAlgorithm.algorithmName).digest(bytes))
+                SHA512_ALGORITHM -> SHA512(MessageDigest.getInstance(secureHashAlgorithm.algorithmName).digest(bytes))
+                else -> throw IllegalArgumentException("Hash secureHashAlgorithm $secureHashAlgorithm is not supported")
+            }
+
+        // Overloaded hash method, required for hashConcat.
+        private fun hash(bytes: ByteArray, clazz: KClass<out SecureHash>): SecureHash =
+            when(clazz) {
+                SHA256::class -> hash(bytes, SHA256_ALGORITHM)
+                SHA512::class -> hash(bytes, SHA512_ALGORITHM)
+                else -> throw IllegalArgumentException("${clazz.simpleName} is not a supported SecureHash type")
+            }
+
+        /**
+         * Returns the corresponding [SecureHash] object by double-hashing the input bytes, thus hash(hash(bytes)),
+         * using the provided [SecureHashAlgorithm]. If the algorithm is not provided, then the [DEFAULT_ALGORITHM] is used.
+         */
+        @JvmStatic
+        fun hashTwice(bytes: ByteArray, secureHashAlgorithm: SecureHashAlgorithm = DEFAULT_ALGORITHM): SecureHash =
+                hash(hash(bytes, secureHashAlgorithm).bytes, secureHashAlgorithm)
+
+        /**
+         * Returns a random [SecureHash] object using the provided [SecureHashAlgorithm]. If the algorithm
+         * is not provided, then the [DEFAULT_ALGORITHM] is used.
+         */
+        @JvmStatic
+        fun randomHash(secureHashAlgorithm: SecureHashAlgorithm = DEFAULT_ALGORITHM): SecureHash =
+                hash(newSecureRandom().generateSeed(secureHashAlgorithm.outputSize), secureHashAlgorithm)
+
+        /** Computes the hash output of the input [bytes] and returns the corresponding [SHA256] object. */
+        @JvmStatic fun sha256(bytes: ByteArray) = hash(bytes, SHA256_ALGORITHM) as SHA256
+        /** Computes the double-hash output of the input [bytes], thus sha256(sha256(bytes)), and returns the corresponding [SHA256] object. */
+        @JvmStatic fun sha256Twice(bytes: ByteArray) = hashTwice(bytes, SHA256_ALGORITHM) as SHA256
+
+        /** Computes the hash output of the input [String]'s bytes and returns the corresponding [SHA256] object. */
+        @JvmStatic fun sha256(str: String) = hash(str.toByteArray(), SHA256_ALGORITHM) as SHA256
+        /** Returns a random [SHA256] object. */
+        @JvmStatic fun randomSHA256() = randomHash(SHA256_ALGORITHM) as SHA256
+
+        /** ZeroHash of the [DEFAULT_ALGORITHM]. */
+        val zeroHash = DEFAULT_ALGORITHM.zeroHash
+        /** AllOnesHash of the [DEFAULT_ALGORITHM]. */
+        val allOnesHash = DEFAULT_ALGORITHM.allOnesHash
     }
-
-    // In future, maybe SHA3, truncated hashes etc.
 }
 
+/**
+ * This class is used to define properties a [SecureHash] algorithm.
+ * @property algorithmName the [String] name of the hash algorithm (eg. SHA-256, SHA-512).
+ * @property outputSize the output size in bytes of this hash algorithm (eg. 32 for SHA-256, 64 for SHA-512).
+ * @property zeroHash a flag-object used as a "padding" leaf to ensure hash-trees are binary trees. By convention, this is a [SecureHash] object with all bytes set to zero.
+ * @property allOnesHash a flag-object used as a root of an empty Merkle tree (without leaves). By convention, this is a [SecureHash] object with all bits set to one.
+ */
+data class SecureHashAlgorithm(val algorithmName: String, val outputSize: Int, val zeroHash: SecureHash, val allOnesHash: SecureHash)
+
+/** Compute the hash of this [ByteArray] using the [SecureHash.DEFAULT_ALGORITHM] and return its corresponding [SecureHash] object. */
+fun ByteArray.hash(): SecureHash = SecureHash.hash(this, SecureHash.DEFAULT_ALGORITHM)
+/** Compute the hash of this [OpaqueBytes] object using the [SecureHash.DEFAULT_ALGORITHM] and return its corresponding [SecureHash] object. */
+fun OpaqueBytes.hash(): SecureHash = this.bytes.hash()
+
+/** Compute the hash of this [ByteArray] using the [SecureHash.SHA256_ALGORITHM] and return its corresponding [SecureHash.SHA256] object. */
 fun ByteArray.sha256(): SecureHash.SHA256 = SecureHash.sha256(this)
-fun OpaqueBytes.sha256(): SecureHash.SHA256 = SecureHash.sha256(this.bytes)
+/** Compute the hash of this [OpaqueBytes] object using the [SecureHash.SHA256_ALGORITHM] and return its corresponding [SecureHash.SHA256] object. */
+fun OpaqueBytes.sha256(): SecureHash.SHA256 = this.bytes.sha256()

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -1,7 +1,7 @@
 package net.corda.core.serialization
 
 import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.sha256
+import net.corda.core.crypto.hash
 import net.corda.core.internal.WriteOnceProperty
 import net.corda.core.utilities.ByteSequence
 import net.corda.core.utilities.OpaqueBytes
@@ -198,7 +198,7 @@ fun <T : Any> T.serialize(serializationFactory: SerializationFactory = Serializa
 @Suppress("unused") // Type parameter is just for documentation purposes.
 class SerializedBytes<T : Any>(bytes: ByteArray) : OpaqueBytes(bytes) {
     // It's OK to use lazy here because SerializedBytes is configured to use the ImmutableClassSerializer.
-    val hash: SecureHash by lazy { bytes.sha256() }
+    val hash: SecureHash by lazy { bytes.hash() }
 }
 
 interface ClassWhitelist {

--- a/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
@@ -179,7 +179,7 @@ class PartialMerkleTreeTest : TestDependencyInjectionBase() {
     @Test
     fun `build Partial Merkle Tree - only duplicate leaves, less included failure`() {
         val leaves = "aaa"
-        val hashes = leaves.map { it.serialize().hash }
+        val hashes = leaves.map { it.serialize().bytes.hash() }
         val mt = MerkleTree.getMerkleTree(hashes)
         assertFailsWith<MerkleTreeException> { PartialMerkleTree.build(mt, hashes.subList(0, 1)) }
     }

--- a/core/src/test/kotlin/net/corda/core/crypto/SecureHashTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/SecureHashTest.kt
@@ -1,0 +1,77 @@
+package net.corda.core.crypto
+
+import net.corda.core.utilities.hexToByteArray
+import net.corda.core.utilities.toHexString
+import org.junit.Test
+import java.security.MessageDigest
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class SecureHashTest {
+
+    private val text = "CORDA DLT"
+    private val textBytes = text.toByteArray()
+    private val textSHA256 = "CA45C38A9343DB867D68C44E0159A0CEFF9809D505A98AFBF2FE66C3D0DE6309"
+    private val textSHA256Bytes = textSHA256.hexToByteArray()
+    private val textSHA512 = "EAB53A15394843FB096BDABAF909DC608F13DD47527AC21773CD13538EA2C04903FF2C3D8D9BAF046C876A821B8C1760A5B8EE20CB4782ECD98935E0D2F1D60C"
+    private val textSHA512Bytes = textSHA512.hexToByteArray()
+
+    @Test
+    fun `Correct hash outputs`() {
+        val javaSHA256 = MessageDigest.getInstance("SHA-256").digest(textBytes)
+        assertEquals(javaSHA256.toHexString(), textSHA256)
+
+        val javaSHA512 = MessageDigest.getInstance("SHA-512").digest(textBytes)
+        assertEquals(javaSHA512.toHexString(), textSHA512)
+
+        val sha256OfText = SecureHash.hash(textBytes, SecureHash.SHA256_ALGORITHM)
+        assertEquals(textSHA256, sha256OfText.toString())
+
+        val sha512OfText = SecureHash.hash(textBytes, SecureHash.SHA512_ALGORITHM)
+        assertEquals(textSHA512, sha512OfText.toString())
+
+        // Double hashing.
+        val javaDoubleSHA256 = MessageDigest.getInstance("SHA-256").digest(javaSHA256)
+        val doubleSha256OfText = SecureHash.hashTwice(textBytes, SecureHash.SHA256_ALGORITHM)
+        val doubleSha256OfTextV2 = SecureHash.hash(textSHA256Bytes, SecureHash.SHA256_ALGORITHM)
+        assertEquals(javaDoubleSHA256.toHexString(), doubleSha256OfText.toString())
+        assertEquals(doubleSha256OfTextV2, doubleSha256OfText)
+
+        val javaDoubleSHA512 = MessageDigest.getInstance("SHA-512").digest(javaSHA512)
+        val doubleSha512OfText = SecureHash.hashTwice(textBytes, SecureHash.SHA512_ALGORITHM)
+        val doubleSha512OfTextV2 = SecureHash.hash(textSHA512Bytes, SecureHash.SHA512_ALGORITHM)
+        assertEquals(javaDoubleSHA512.toHexString(), doubleSha512OfText.toString())
+        assertEquals(doubleSha512OfTextV2, doubleSha512OfText)
+
+        // Hash concat.
+        val javaSHA256Concat = MessageDigest.getInstance("SHA-256").digest(javaSHA256 + javaSHA256)
+        val sha256OfTextConcat = sha256OfText.hashConcat(sha256OfText)
+        assertEquals(javaSHA256Concat.toHexString(), sha256OfTextConcat.toString())
+
+        val javaSHA512Concat = MessageDigest.getInstance("SHA-512").digest(javaSHA512 + javaSHA512)
+        val sha512OfTextConcat = sha512OfText.hashConcat(sha512OfText)
+        assertEquals(javaSHA512Concat.toHexString(), sha512OfTextConcat.toString())
+
+        // Try to concat two different hash types.
+        assertFailsWith<IllegalArgumentException> { sha256OfText.hashConcat(sha512OfText) }
+        assertFailsWith<IllegalArgumentException> { sha512OfText.hashConcat(sha256OfText) }
+    }
+
+    @Test
+    fun `default algorithm checks`() {
+        // Current default algorithm is SHA256.
+        val sha256OfText = SecureHash.hash(textBytes, SecureHash.SHA256_ALGORITHM)
+        val defaultHashOfText = SecureHash.hash(textBytes)
+        assertEquals(sha256OfText, defaultHashOfText)
+
+        val sha256Object = SecureHash.parse(textSHA256)
+        assertTrue(sha256Object is SecureHash.SHA256)
+
+        val sha512Object = SecureHash.parse(textSHA512)
+        assertTrue(sha512Object is SecureHash.SHA512)
+
+        // Try to parse a non 32 or 64 bytes value.
+        assertFailsWith<IllegalArgumentException> { SecureHash.parse(textSHA512 + textSHA256) }
+    }
+}

--- a/core/src/test/kotlin/net/corda/core/crypto/SecureHashTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/SecureHashTest.kt
@@ -68,7 +68,7 @@ class SecureHashTest {
         val sha256Object = SecureHash.parse(textSHA256)
         assertTrue(sha256Object is SecureHash.SHA256)
 
-        val sha512Object = SecureHash.parse(textSHA512)
+        val sha512Object = SecureHash.parse(textSHA512, SecureHash.SHA512_ALGORITHM)
         assertTrue(sha512Object is SecureHash.SHA512)
 
         // Try to parse a non 32 or 64 bytes value.

--- a/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/CheckpointStorage.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services.api
 
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.sha256
 import net.corda.core.serialization.SerializedBytes
 import net.corda.node.services.statemachine.FlowStateMachineImpl
 
@@ -32,7 +33,7 @@ interface CheckpointStorage {
 // This class will be serialised, so everything it points to transitively must also be serialisable (with Kryo).
 class Checkpoint(val serializedFiber: SerializedBytes<FlowStateMachineImpl<*>>) {
 
-    val id: SecureHash get() = serializedFiber.hash
+    val id: SecureHash get() = serializedFiber.bytes.sha256()
 
     override fun equals(other: Any?): Boolean = other === this || other is Checkpoint && other.id == this.id
 


### PR DESCRIPTION
This is the first part for hash agility enabling `.hash` that uses the default SHA256 algorithm.
Application specific calls of `SecureHash` were remained intact and they still use `.sha256`.
Leaf computation is using the default algorithm.
This is step 1: in an upcoming PR, the Merkle tree computation will take the hash algorithm as input and will validate data, also the tx should know which algorithm is used, probably this information will be a metadata leaf.
See [here ](https://r3-cev.atlassian.net/wiki/spaces/AWG/pages/132068319/Hash+Agility) for the related design doc. We should agree on the HEX prefix method + store in DBs.