### PR TITLE
CORDA-540: Add verification to ensure that private keys can only be serialized with specific contexts

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AllButBlacklisted.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/AllButBlacklisted.kt
@@ -30,6 +30,9 @@ import kotlin.collections.LinkedHashSet
  * we can often end up pulling in a lot of objects that do not make sense to put in a checkpoint.
  * Thus, by blacklisting classes/interfaces we don't expect to be serialised, we can better handle/monitor the aforementioned behaviour.
  * Inheritance works for blacklisted items, but one can specifically exclude classes from blacklisting as well.
+ * Note: Custom serializer registration trumps white/black lists. So if a given type has a custom serializer and has its name
+ * in the blacklist - it will still be serialized as specified by custom serializer.
+ * For more details, see [net.corda.nodeapi.internal.serialization.CordaClassResolver.getRegistration]
  */
 object AllButBlacklisted : ClassWhitelist {
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/Kryo.kt
@@ -16,6 +16,7 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.identity.Party
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationContext.UseCase.*
 import net.corda.core.serialization.SerializeAsTokenContext
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.toFuture
@@ -285,9 +286,77 @@ object SignedTransactionSerializer : Serializer<SignedTransaction>() {
     }
 }
 
+sealed class UseCaseSerializer<T>(private val allowedUseCases: EnumSet<SerializationContext.UseCase>) : Serializer<T>() {
+    protected fun checkUseCase() {
+        checkUseCase(allowedUseCases)
+    }
+}
+
+/** For serialising an ed25519 private key */
 @ThreadSafe
-object PrivateKeySerializer : Serializer<PrivateKey>() {
+object Ed25519PrivateKeySerializer : UseCaseSerializer<EdDSAPrivateKey>(EnumSet.of(Storage, Checkpoint)) {
+    override fun write(kryo: Kryo, output: Output, obj: EdDSAPrivateKey) {
+        checkUseCase()
+        check(obj.params == Crypto.EDDSA_ED25519_SHA512.algSpec)
+        output.writeBytesWithLength(obj.seed)
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<EdDSAPrivateKey>): EdDSAPrivateKey {
+        val seed = input.readBytesWithLength()
+        return EdDSAPrivateKey(EdDSAPrivateKeySpec(seed, Crypto.EDDSA_ED25519_SHA512.algSpec as EdDSANamedCurveSpec))
+    }
+}
+
+/** For serialising an ed25519 public key */
+@ThreadSafe
+object Ed25519PublicKeySerializer : Serializer<EdDSAPublicKey>() {
+    override fun write(kryo: Kryo, output: Output, obj: EdDSAPublicKey) {
+        check(obj.params == Crypto.EDDSA_ED25519_SHA512.algSpec)
+        output.writeBytesWithLength(obj.abyte)
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<EdDSAPublicKey>): EdDSAPublicKey {
+        val A = input.readBytesWithLength()
+        return EdDSAPublicKey(EdDSAPublicKeySpec(A, Crypto.EDDSA_ED25519_SHA512.algSpec as EdDSANamedCurveSpec))
+    }
+}
+
+/** For serialising an ed25519 public key */
+@ThreadSafe
+object ECPublicKeyImplSerializer : Serializer<ECPublicKeyImpl>() {
+    override fun write(kryo: Kryo, output: Output, obj: ECPublicKeyImpl) {
+        output.writeBytesWithLength(obj.encoded)
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<ECPublicKeyImpl>): ECPublicKeyImpl {
+        val A = input.readBytesWithLength()
+        val der = DerValue(A)
+        return ECPublicKeyImpl.parse(der) as ECPublicKeyImpl
+    }
+}
+
+// TODO Implement standardized serialization of CompositeKeys. See JIRA issue: CORDA-249.
+@ThreadSafe
+object CompositeKeySerializer : Serializer<CompositeKey>() {
+    override fun write(kryo: Kryo, output: Output, obj: CompositeKey) {
+        output.writeInt(obj.threshold)
+        output.writeInt(obj.children.size)
+        obj.children.forEach { kryo.writeClassAndObject(output, it) }
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<CompositeKey>): CompositeKey {
+        val threshold = input.readInt()
+        val children = readListOfLength<CompositeKey.NodeAndWeight>(kryo, input, minLen = 2)
+        val builder = CompositeKey.Builder()
+        children.forEach { builder.addKey(it.node, it.weight) }
+        return builder.build(threshold) as CompositeKey
+    }
+}
+
+@ThreadSafe
+object PrivateKeySerializer : UseCaseSerializer<PrivateKey>(EnumSet.of(Storage, Checkpoint)) {
     override fun write(kryo: Kryo, output: Output, obj: PrivateKey) {
+        checkUseCase()
         output.writeBytesWithLength(obj.encoded)
     }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/Kryo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/Kryo.kt
@@ -10,7 +10,6 @@ import com.esotericsoftware.kryo.util.MapReferenceResolver
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.identity.Party
@@ -22,19 +21,12 @@ import net.corda.core.serialization.SerializedBytes
 import net.corda.core.toFuture
 import net.corda.core.toObservable
 import net.corda.core.transactions.*
-import net.i2p.crypto.eddsa.EdDSAPrivateKey
-import net.i2p.crypto.eddsa.EdDSAPublicKey
-import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec
-import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
-import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
 import org.bouncycastle.asn1.ASN1InputStream
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.cert.X509CertificateHolder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rx.Observable
-import sun.security.ec.ECPublicKeyImpl
-import sun.security.util.DerValue
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.lang.reflect.InvocationTargetException
@@ -289,67 +281,6 @@ object SignedTransactionSerializer : Serializer<SignedTransaction>() {
 sealed class UseCaseSerializer<T>(private val allowedUseCases: EnumSet<SerializationContext.UseCase>) : Serializer<T>() {
     protected fun checkUseCase() {
         checkUseCase(allowedUseCases)
-    }
-}
-
-/** For serialising an ed25519 private key */
-@ThreadSafe
-object Ed25519PrivateKeySerializer : UseCaseSerializer<EdDSAPrivateKey>(EnumSet.of(Storage, Checkpoint)) {
-    override fun write(kryo: Kryo, output: Output, obj: EdDSAPrivateKey) {
-        checkUseCase()
-        check(obj.params == Crypto.EDDSA_ED25519_SHA512.algSpec)
-        output.writeBytesWithLength(obj.seed)
-    }
-
-    override fun read(kryo: Kryo, input: Input, type: Class<EdDSAPrivateKey>): EdDSAPrivateKey {
-        val seed = input.readBytesWithLength()
-        return EdDSAPrivateKey(EdDSAPrivateKeySpec(seed, Crypto.EDDSA_ED25519_SHA512.algSpec as EdDSANamedCurveSpec))
-    }
-}
-
-/** For serialising an ed25519 public key */
-@ThreadSafe
-object Ed25519PublicKeySerializer : Serializer<EdDSAPublicKey>() {
-    override fun write(kryo: Kryo, output: Output, obj: EdDSAPublicKey) {
-        check(obj.params == Crypto.EDDSA_ED25519_SHA512.algSpec)
-        output.writeBytesWithLength(obj.abyte)
-    }
-
-    override fun read(kryo: Kryo, input: Input, type: Class<EdDSAPublicKey>): EdDSAPublicKey {
-        val A = input.readBytesWithLength()
-        return EdDSAPublicKey(EdDSAPublicKeySpec(A, Crypto.EDDSA_ED25519_SHA512.algSpec as EdDSANamedCurveSpec))
-    }
-}
-
-/** For serialising an ed25519 public key */
-@ThreadSafe
-object ECPublicKeyImplSerializer : Serializer<ECPublicKeyImpl>() {
-    override fun write(kryo: Kryo, output: Output, obj: ECPublicKeyImpl) {
-        output.writeBytesWithLength(obj.encoded)
-    }
-
-    override fun read(kryo: Kryo, input: Input, type: Class<ECPublicKeyImpl>): ECPublicKeyImpl {
-        val A = input.readBytesWithLength()
-        val der = DerValue(A)
-        return ECPublicKeyImpl.parse(der) as ECPublicKeyImpl
-    }
-}
-
-// TODO Implement standardized serialization of CompositeKeys. See JIRA issue: CORDA-249.
-@ThreadSafe
-object CompositeKeySerializer : Serializer<CompositeKey>() {
-    override fun write(kryo: Kryo, output: Output, obj: CompositeKey) {
-        output.writeInt(obj.threshold)
-        output.writeInt(obj.children.size)
-        obj.children.forEach { kryo.writeClassAndObject(output, it) }
-    }
-
-    override fun read(kryo: Kryo, input: Input, type: Class<CompositeKey>): CompositeKey {
-        val threshold = input.readInt()
-        val children = readListOfLength<CompositeKey.NodeAndWeight>(kryo, input, minLen = 2)
-        val builder = CompositeKey.Builder()
-        children.forEach { builder.addKey(it.node, it.weight) }
-        return builder.build(threshold) as CompositeKey
     }
 }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/UseCaseAwareness.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/UseCaseAwareness.kt
@@ -1,0 +1,12 @@
+package net.corda.nodeapi.internal.serialization
+
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationFactory
+import java.util.*
+
+internal fun checkUseCase(allowedUseCases: EnumSet<SerializationContext.UseCase>) {
+    val currentContext: SerializationContext = SerializationFactory.currentFactory?.currentContext ?: throw IllegalStateException("Current context is not set")
+    if(!allowedUseCases.contains(currentContext.useCase)) {
+        throw IllegalStateException("UseCase '${currentContext.useCase}' is not within '$allowedUseCases'")
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/KryoTests.kt
@@ -43,7 +43,7 @@ class KryoTests : TestDependencyInjectionBase() {
                 AllWhitelist,
                 emptyMap(),
                 true,
-                SerializationContext.UseCase.P2P)
+                SerializationContext.UseCase.Storage)
     }
 
     @Test

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
@@ -1,30 +1,21 @@
 package net.corda.nodeapi.internal.serialization
 
+import net.corda.core.crypto.Crypto
 import net.corda.core.serialization.SerializationContext.UseCase.*
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.serialize
 import net.corda.testing.TestDependencyInjectionBase
-import net.i2p.crypto.eddsa.KeyPairGenerator
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi
 import org.junit.Test
 import java.security.PrivateKey
-import java.security.SecureRandom
 import kotlin.test.assertTrue
 
 class PrivateKeySerializationTest : TestDependencyInjectionBase() {
 
-    private val privateKeys: List<PrivateKey>
-
-    init {
-        val generator = KeyPairGenerator()
-        generator.initialize(256, SecureRandom())
-
-        val ec = KeyPairGeneratorSpi.EC()
-        ec.initialize(256)
-
-        privateKeys = listOf(generator.generateKeyPair().private, ec.generateKeyPair().private)
-    }
+    private val privateKeys: List<PrivateKey> = setOf(
+            Crypto.RSA_SHA256, Crypto.ECDSA_SECP256K1_SHA256,
+            Crypto.ECDSA_SECP256R1_SHA256, Crypto.EDDSA_ED25519_SHA512, Crypto.SPHINCS256_SHA256)
+            .map { Crypto.generateKeyPair(it).private }
 
     @Test
     fun `passed with expected UseCases`() {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
@@ -1,6 +1,6 @@
 package net.corda.nodeapi.internal.serialization
 
-import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationContext.UseCase.*
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.serialize
 import net.corda.testing.TestDependencyInjectionBase
@@ -34,8 +34,9 @@ class PrivateKeySerializationTest : TestDependencyInjectionBase() {
 
     @Test
     fun `failed with wrong UseCase`() {
-        assertThatThrownBy { privateKeys.serialize(context = SerializationDefaults.RPC_CLIENT_CONTEXT) }
-                .hasMessageContaining("UseCase '${SerializationContext.UseCase.RPCClient}' is not within")
+        assertThatThrownBy { privateKeys.serialize(context = SerializationDefaults.P2P_CONTEXT) }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("UseCase '${P2P}' is not within")
 
     }
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
@@ -12,9 +12,7 @@ import kotlin.test.assertTrue
 
 class PrivateKeySerializationTest : TestDependencyInjectionBase() {
 
-    private val privateKeys: List<PrivateKey> = setOf(
-            Crypto.RSA_SHA256, Crypto.ECDSA_SECP256K1_SHA256,
-            Crypto.ECDSA_SECP256R1_SHA256, Crypto.EDDSA_ED25519_SHA512, Crypto.SPHINCS256_SHA256)
+    private val privateKeys: List<PrivateKey> = Crypto.supportedSignatureSchemes().filterNot { Crypto.COMPOSITE_KEY === it }
             .map { Crypto.generateKeyPair(it).private }
 
     @Test

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/PrivateKeySerializationTest.kt
@@ -1,0 +1,36 @@
+package net.corda.nodeapi.internal.serialization
+
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationDefaults
+import net.corda.core.serialization.serialize
+import net.corda.testing.TestDependencyInjectionBase
+import net.i2p.crypto.eddsa.KeyPairGenerator
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import java.security.PrivateKey
+import java.security.SecureRandom
+import kotlin.test.assertTrue
+
+class PrivateKeySerializationTest : TestDependencyInjectionBase() {
+
+    private val privateKey: PrivateKey
+
+    init {
+        val generator = KeyPairGenerator()
+        generator.initialize(256, SecureRandom())
+        privateKey = generator.generateKeyPair().private
+    }
+
+    @Test
+    fun `passed with expected UseCases`() {
+        assertTrue { privateKey.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes.isNotEmpty() }
+        assertTrue { privateKey.serialize(context = SerializationDefaults.CHECKPOINT_CONTEXT).bytes.isNotEmpty() }
+    }
+
+    @Test
+    fun `failed with wrong UseCase`() {
+        assertThatThrownBy { privateKey.serialize(context = SerializationDefaults.RPC_CLIENT_CONTEXT) }
+                .hasMessageContaining("UseCase '${SerializationContext.UseCase.RPCClient}' is not within")
+
+    }
+}


### PR DESCRIPTION
At the moment, even in Kryo mode, we allow unconstrained serialization of Private Keys.
This could be dangerous as the the key may leak to the external party.