### PR TITLE
Deflake NodeInfoWatcherTest

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -104,6 +104,7 @@ class NodeInfoWatcherTest : NodeBasedTest() {
 
         advanceTime()
 
+        // We need the WatchService to report a change and that might not happen immediately.
         eventually<AssertionError, Unit>(5.seconds) {
             // The same folder can be reported more than once, so take unique values.
             val readNodes = testSubscriber.onNextEvents.distinct()

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -5,10 +5,12 @@ import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.KeyManagementService
+import net.corda.core.utilities.seconds
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.testing.ALICE
 import net.corda.testing.ALICE_KEY
 import net.corda.testing.DEV_TRUST_ROOT
+import net.corda.testing.eventually
 import net.corda.testing.getTestPartyAndCertificate
 import net.corda.testing.node.MockKeyManagementService
 import net.corda.testing.node.NodeBasedTest
@@ -102,15 +104,15 @@ class NodeInfoWatcherTest : NodeBasedTest() {
 
         advanceTime()
 
-        // The same folder can be reported more than once, so take unique values.
-        val readNodes = testSubscriber.onNextEvents.distinct()
-        assertEquals(1, readNodes.size)
-        assertEquals(nodeInfo, readNodes.first())
+        eventually<AssertionError, Unit>(5.seconds) {
+            // The same folder can be reported more than once, so take unique values.
+            val readNodes = testSubscriber.onNextEvents.distinct()
+            assertEquals(1, readNodes.size)
+            assertEquals(nodeInfo, readNodes.first())
+        }
     }
 
     private fun advanceTime() {
-        // Give the filesystem time to report the change to the WatchService.
-        Thread.sleep(100)
         scheduler.advanceTimeBy(1, TimeUnit.HOURS)
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -6,21 +6,24 @@ import net.corda.core.internal.div
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.KeyManagementService
 import net.corda.node.services.identity.InMemoryIdentityService
-import net.corda.testing.*
+import net.corda.testing.ALICE
+import net.corda.testing.ALICE_KEY
+import net.corda.testing.DEV_TRUST_ROOT
+import net.corda.testing.getTestPartyAndCertificate
 import net.corda.testing.node.MockKeyManagementService
 import net.corda.testing.node.NodeBasedTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.contentOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import rx.observers.TestSubscriber
 import rx.schedulers.TestScheduler
+import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.contentOf
-import java.nio.file.Path
 
 class NodeInfoWatcherTest : NodeBasedTest() {
 
@@ -67,7 +70,7 @@ class NodeInfoWatcherTest : NodeBasedTest() {
                 .subscribe(testSubscriber)
 
         val readNodes = testSubscriber.onNextEvents.distinct()
-        scheduler.advanceTimeBy(1, TimeUnit.HOURS)
+        advanceTime()
         assertEquals(0, readNodes.size)
     }
 
@@ -92,18 +95,23 @@ class NodeInfoWatcherTest : NodeBasedTest() {
         nodeInfoWatcher.nodeInfoUpdates()
                 .subscribe(testSubscriber)
         // Ensure the watch service is started.
-        scheduler.advanceTimeBy(1, TimeUnit.HOURS)
-
+        advanceTime()
         // Check no nodeInfos are read.
         assertEquals(0, testSubscriber.valueCount)
         createNodeInfoFileInPath(nodeInfo)
 
-        scheduler.advanceTimeBy(1, TimeUnit.HOURS)
+        advanceTime()
 
         // The same folder can be reported more than once, so take unique values.
         val readNodes = testSubscriber.onNextEvents.distinct()
         assertEquals(1, readNodes.size)
         assertEquals(nodeInfo, readNodes.first())
+    }
+
+    private fun advanceTime() {
+        // Give the filesystem time to report the change to the WatchService.
+        Thread.sleep(100)
+        scheduler.advanceTimeBy(1, TimeUnit.HOURS)
     }
 
     // Write a nodeInfo under the right path.


### PR DESCRIPTION
See
https://ci-master.corda.r3cev.com/viewLog.html?buildId=26873&tab=buildResultsDiv&buildTypeId=Corda_CordaBuild#
for a flake.

The test exercises the filesystem WatchService so we need to wait for the filesystem to report file changes.
