### PR TITLE
Change IdentitySyncFlow to only offer own identities

### DIFF
--- a/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
@@ -13,12 +13,14 @@ import net.corda.core.utilities.unwrap
 import net.corda.finance.DOLLARS
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashIssueAndPaymentFlow
+import net.corda.finance.flows.CashPaymentFlow
 import net.corda.testing.*
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class IdentitySyncFlowTests {
@@ -45,12 +47,12 @@ class IdentitySyncFlowTests {
         val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
         val alice: Party = aliceNode.services.myInfo.chooseIdentity()
         val bob: Party = bobNode.services.myInfo.chooseIdentity()
+        val notary = notaryNode.services.getDefaultNotary()
         bobNode.internals.registerInitiatedFlow(Receive::class.java)
 
         // Alice issues then pays some cash to a new confidential identity that Bob doesn't know about
         val anonymous = true
         val ref = OpaqueBytes.of(0x01)
-        val notary = aliceNode.services.getDefaultNotary()
         val issueFlow = aliceNode.services.startFlow(CashIssueAndPaymentFlow(1000.DOLLARS, ref, alice, anonymous, notary))
         val issueTx = issueFlow.resultFuture.getOrThrow().stx
         val confidentialIdentity = issueTx.tx.outputs.map { it.data }.filterIsInstance<Cash.State>().single().owner
@@ -65,6 +67,40 @@ class IdentitySyncFlowTests {
             bobNode.services.identityService.wellKnownPartyFromAnonymous(confidentialIdentity)
         }
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `don't offer other's identities confidential identities`() {
+        // Set up values we'll need
+        val notaryNode = mockNet.createNotaryNode()
+        val aliceNode = mockNet.createPartyNode(notaryNode.network.myAddress, ALICE.name)
+        val bobNode = mockNet.createPartyNode(notaryNode.network.myAddress, BOB.name)
+        val charlieNode = mockNet.createPartyNode(notaryNode.network.myAddress, CHARLIE.name)
+        val alice: Party = aliceNode.services.myInfo.chooseIdentity()
+        val bob: Party = bobNode.services.myInfo.chooseIdentity()
+        val charlie: Party = charlieNode.services.myInfo.chooseIdentity()
+        val notary = notaryNode.services.getDefaultNotary()
+        bobNode.internals.registerInitiatedFlow(Receive::class.java)
+
+        // Charlie issues then pays some cash to a new confidential identity
+        val anonymous = true
+        val ref = OpaqueBytes.of(0x01)
+        val issueFlow = charlieNode.services.startFlow(CashIssueAndPaymentFlow(1000.DOLLARS, ref, charlie, anonymous, notary))
+        val issueTx = issueFlow.resultFuture.getOrThrow().stx
+        val confidentialIdentity = issueTx.tx.outputs.map { it.data }.filterIsInstance<Cash.State>().single().owner
+        val confidentialIdentCert = charlieNode.services.identityService.certificateFromKey(confidentialIdentity.owningKey)!!
+
+        // Manually inject this identity into Alice's database so the node could leak it, but we prove won't
+        aliceNode.database.transaction { aliceNode.services.identityService.verifyAndRegisterIdentity(confidentialIdentCert) }
+        assertNotNull(aliceNode.database.transaction { aliceNode.services.identityService.wellKnownPartyFromAnonymous(confidentialIdentity) })
+
+        // Generate a payment from Charlie to Alice, including the confidential state
+        val payTx = charlieNode.services.startFlow(CashPaymentFlow(1000.DOLLARS, alice, anonymous)).resultFuture.getOrThrow().stx
+
+        // Run the flow to sync up the identities, and confirm Charlie's confidential identity doesn't leak
+        assertNull(bobNode.database.transaction { bobNode.services.identityService.wellKnownPartyFromAnonymous(confidentialIdentity) })
+        aliceNode.services.startFlow(Initiator(bob, payTx.tx)).resultFuture.getOrThrow()
+        assertNull(bobNode.database.transaction { bobNode.services.identityService.wellKnownPartyFromAnonymous(confidentialIdentity) })
     }
 
     /**


### PR DESCRIPTION
Change IdentitySyncFlow to only offer confidential identities matching the identity the flow is run as. This avoids risks of nodes being convinced to include a state with a confidential identity in it, by a remote node, then feeding the well known identity to the node during identity sync.
