### PR TITLE
removed unused variable in PersistentNetworkMapCache

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -19,7 +19,6 @@ import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.loggerFor
-import net.corda.core.utilities.parsePublicKeyBase58
 import net.corda.core.utilities.toBase58String
 import net.corda.node.services.api.NetworkCacheException
 import net.corda.node.services.api.NetworkMapCacheInternal
@@ -274,7 +273,6 @@ open class PersistentNetworkMapCache(private val serviceHub: ServiceHubInternal)
             for (nodeInfo in result) {
                 try {
                     logger.info("Loaded node info: $nodeInfo")
-                    val publicKey = parsePublicKeyBase58(nodeInfo.legalIdentitiesAndCerts.single { it.isMain }.owningKey)
                     val node = nodeInfo.toNodeInfo()
                     addNode(node)
                     _loadDBSuccess = true // This is used in AbstractNode to indicate that node is ready.


### PR DESCRIPTION
 val publicKey in unused.

I've removed it.

It was causing a warning in building corda.