### PR TITLE
Better error for driver instantiated outside package.

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -991,7 +991,7 @@ class DriverDSL(
                     .stackTrace
                     .first { it.fileName != "Driver.kt" }
                     .let { Class.forName(it.className).`package`?.name }
-                    ?: throw IllegalArgumentException("Function instantiating driver must be defined in a package.")
+                    ?: throw IllegalStateException("Function instantiating driver must be defined in a package.")
         }
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -990,7 +990,8 @@ class DriverDSL(
             return Exception()
                     .stackTrace
                     .first { it.fileName != "Driver.kt" }
-                    .let { Class.forName(it.className).`package`.name }
+                    .let { Class.forName(it.className).`package`?.name }
+                    ?: throw IllegalArgumentException("Function instantiating driver must be defined in a package.")
         }
     }
 }


### PR DESCRIPTION
Throws helpful error message when driver is instantiated by a function outside a package.