### PR TITLE
Fix outdated shell command.

### DIFF
--- a/docs/source/hello-world-running.rst
+++ b/docs/source/hello-world-running.rst
@@ -116,15 +116,9 @@ commands.
 
 We want to create an IOU of 100 with PartyB. We start the ``IOUFlow`` by typing:
 
-.. container:: codeset
+.. code:: python
 
-    .. code-block:: java
-
-        start IOUFlow arg0: 99, arg1: "O=PartyB,L=New York,C=US"
-
-    .. code-block:: kotlin
-
-        start IOUFlow iouValue: 99, otherParty: "O=PartyB,L=New York,C=US"
+    start IOUFlow iouValue: 99, otherParty: "O=PartyB,L=New York,C=US"
 
 PartyA and PartyB will automatically agree an IOU. If the flow worked, it should have led to the recording of a new IOU
 in the vaults of both PartyA and PartyB.


### PR DESCRIPTION
The Java version of the instructions for running the Hello, World tutorial was outdated, and is now fixed.