### PR TITLE
[CORDA-694] Commands visibility for Oracles (without sacrificing privacy)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/ComponentGroupEnum.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ComponentGroupEnum.kt
@@ -10,5 +10,6 @@ enum class ComponentGroupEnum {
     COMMANDS_GROUP, // ordinal = 2.
     ATTACHMENTS_GROUP, // ordinal = 3.
     NOTARY_GROUP, // ordinal = 4.
-    TIMEWINDOW_GROUP // ordinal = 5.
+    TIMEWINDOW_GROUP, // ordinal = 5.
+    SIGNERS_GROUP // ordinal = 6.
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -273,6 +273,8 @@ class FilteredTransaction private constructor(
             val groupPartialRoot = groupHashes[group.groupIndex]
             val groupFullRoot = MerkleTree.getMerkleTree(group.components.mapIndexed { index, component -> componentHash(group.nonces[index], component) }).hash
             visibilityCheck(groupPartialRoot == groupFullRoot) { "Some components for group ${group.groupIndex} are not visible" }
+            // TODO: should we add an extra call call to verify() to ensure the transaction is well-formed
+            //      or we accept they should always run together as mentioned in the api doc.
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -273,8 +273,8 @@ class FilteredTransaction private constructor(
             val groupPartialRoot = groupHashes[group.groupIndex]
             val groupFullRoot = MerkleTree.getMerkleTree(group.components.mapIndexed { index, component -> componentHash(group.nonces[index], component) }).hash
             visibilityCheck(groupPartialRoot == groupFullRoot) { "Some components for group ${group.groupIndex} are not visible" }
-            // TODO: should we add an extra call call to verify() to ensure the transaction is well-formed
-            //      or we accept they should always run together as mentioned in the api doc.
+            // Verify the top level Merkle tree from groupHashes.
+            visibilityCheck(MerkleTree.getMerkleTree(groupHashes).hash == id) { "Transaction is malformed. Top level Merkle tree cannot be verified against transaction's id" }
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -6,9 +6,10 @@ import net.corda.core.crypto.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.Emoji
 import net.corda.core.node.ServicesForResolution
-import net.corda.core.serialization.*
-import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.node.services.AttachmentId
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.serialize
+import net.corda.core.utilities.OpaqueBytes
 import java.security.PublicKey
 import java.security.SignatureException
 import java.util.function.Predicate
@@ -213,10 +214,14 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
             val componentGroupMap: MutableList<ComponentGroup> = mutableListOf()
             if (inputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(INPUTS_GROUP.ordinal, inputs.map { it.serialize() }))
             if (outputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(OUTPUTS_GROUP.ordinal, outputs.map { it.serialize() }))
-            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(COMMANDS_GROUP.ordinal, commands.map { it.serialize() }))
+            // Adding commandData only to the commands group. Signers are added in their own group.
+            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(COMMANDS_GROUP.ordinal, commands.map { it.value.serialize() }))
             if (attachments.isNotEmpty()) componentGroupMap.add(ComponentGroup(ATTACHMENTS_GROUP.ordinal, attachments.map { it.serialize() }))
             if (notary != null) componentGroupMap.add(ComponentGroup(NOTARY_GROUP.ordinal, listOf(notary.serialize())))
             if (timeWindow != null) componentGroupMap.add(ComponentGroup(TIMEWINDOW_GROUP.ordinal, listOf(timeWindow.serialize())))
+            // Adding signers to their own group. This is required for command visibility purposes: a party receiving
+            // a FilteredTransaction can now verify it sees all the commands it should sign.
+            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(SIGNERS_GROUP.ordinal, commands.map { it.signers.serialize() }))
             return componentGroupMap
         }
     }

--- a/core/src/test/kotlin/net/corda/core/contracts/CompatibleTransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/CompatibleTransactionTests.kt
@@ -485,7 +485,7 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
         // verify() will pass as the transaction is well-formed.
         ftxNoLastCommandAndSigners.verify()
         // checkCommandVisibility() will not pass, because checkAllComponentsVisible(ComponentGroupEnum.SIGNERS_GROUP) will fail.
-        ftxNoLastCommandAndSigners.checkCommandVisibility(DUMMY_KEY_1.public)
+        assertFailsWith<ComponentVisibilityException> { ftxNoLastCommandAndSigners.checkCommandVisibility(DUMMY_KEY_1.public) }
 
         // Remove last signer for which there is no pointer from a visible commandData. This is the case of Key2.
         // Do not change partial Merkle tree for signers.
@@ -533,8 +533,8 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
         val ftxAlterSignerB = ftxConstructor.newInstance(key1CommandsFtx.id, alterFilteredComponents, key1CommandsFtx.groupHashes.subList(0, 6) + alterMTree.hash) as FilteredTransaction
         // Visible components in signers group cannot be verified against their partial Merkle tree.
         assertFailsWith<FilteredTransactionVerificationException> { ftxAlterSignerB.verify() }
-        // However, checkCommandVisibility() will pass. This is why checkCommandVisibility() should run before or after verify().
-        ftxAlterSignerB.checkCommandVisibility(DUMMY_KEY_1.public)
+        // Also, checkAllComponentsVisible() will not pass (top level Merkle tree cannot be verified against transaction's id).
+        assertFailsWith<ComponentVisibilityException> { ftxAlterSignerB.checkCommandVisibility(DUMMY_KEY_1.public) }
 
         ftxConstructor.isAccessible = false
     }

--- a/core/src/test/kotlin/net/corda/core/contracts/CompatibleTransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/CompatibleTransactionTests.kt
@@ -34,22 +34,24 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
 
     private val inputGroup by lazy { ComponentGroup(INPUTS_GROUP.ordinal, inputs.map { it.serialize() }) }
     private val outputGroup by lazy { ComponentGroup(OUTPUTS_GROUP.ordinal, outputs.map { it.serialize() }) }
-    private val commandGroup by lazy { ComponentGroup(COMMANDS_GROUP.ordinal, commands.map { it.serialize() }) }
+    private val commandGroup by lazy { ComponentGroup(COMMANDS_GROUP.ordinal, commands.map { it.value.serialize() }) }
     private val attachmentGroup by lazy { ComponentGroup(ATTACHMENTS_GROUP.ordinal, attachments.map { it.serialize() }) } // The list is empty.
     private val notaryGroup by lazy { ComponentGroup(NOTARY_GROUP.ordinal, listOf(notary.serialize())) }
     private val timeWindowGroup by lazy { ComponentGroup(TIMEWINDOW_GROUP.ordinal, listOf(timeWindow.serialize())) }
+    private val signersGroup by lazy { ComponentGroup(SIGNERS_GROUP.ordinal, commands.map { it.signers.serialize() }) }
 
-    private val newUnknownComponentGroup = ComponentGroup(20, listOf(OpaqueBytes(secureRandomBytes(4)), OpaqueBytes(secureRandomBytes(8))))
-    private val newUnknownComponentEmptyGroup = ComponentGroup(21, emptyList())
+    private val newUnknownComponentGroup = ComponentGroup(100, listOf(OpaqueBytes(secureRandomBytes(4)), OpaqueBytes(secureRandomBytes(8))))
+    private val newUnknownComponentEmptyGroup = ComponentGroup(101, emptyList())
 
     // Do not add attachments (empty list).
     private val componentGroupsA by lazy {
         listOf(
-                inputGroup,
-                outputGroup,
-                commandGroup,
-                notaryGroup,
-                timeWindowGroup
+            inputGroup,
+            outputGroup,
+            commandGroup,
+            notaryGroup,
+            timeWindowGroup,
+            signersGroup
         )
     }
     private val wireTransactionA by lazy { WireTransaction(componentGroups = componentGroupsA, privacySalt = privacySalt) }
@@ -74,7 +76,8 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
                 commandGroup,
                 attachmentGroup,
                 notaryGroup,
-                timeWindowGroup
+                timeWindowGroup,
+                signersGroup
         )
         assertFails { WireTransaction(componentGroups = componentGroupsEmptyAttachment, privacySalt = privacySalt) }
 
@@ -86,7 +89,8 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
                 outputGroup,
                 commandGroup,
                 notaryGroup,
-                timeWindowGroup
+                timeWindowGroup,
+                signersGroup
         )
         val wireTransaction1ShuffledInputs = WireTransaction(componentGroups = componentGroupsB, privacySalt = privacySalt)
         // The ID has changed due to change of the internal ordering in inputs.
@@ -106,7 +110,8 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
                 inputGroup,
                 commandGroup,
                 notaryGroup,
-                timeWindowGroup
+                timeWindowGroup,
+                signersGroup
         )
         assertEquals(wireTransactionA, WireTransaction(componentGroups = shuffledComponentGroupsA, privacySalt = privacySalt))
     }
@@ -123,7 +128,8 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
                 commandGroup,
                 ComponentGroup(ATTACHMENTS_GROUP.ordinal, inputGroup.components),
                 notaryGroup,
-                timeWindowGroup
+                timeWindowGroup,
+                signersGroup
         )
         assertFails { WireTransaction(componentGroupsB, privacySalt) }
 
@@ -134,7 +140,8 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
                 commandGroup, // First commandsGroup.
                 commandGroup, // Second commandsGroup.
                 notaryGroup,
-                timeWindowGroup
+                timeWindowGroup,
+                signersGroup
         )
         assertFails { WireTransaction(componentGroupsDuplicatedCommands, privacySalt) }
 
@@ -144,7 +151,8 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
                 outputGroup,
                 commandGroup,
                 notaryGroup,
-                timeWindowGroup
+                timeWindowGroup,
+                signersGroup
         )
         assertFails { WireTransaction(componentGroupsC, privacySalt) }
 
@@ -154,23 +162,24 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
                 commandGroup,
                 notaryGroup,
                 timeWindowGroup,
-                newUnknownComponentGroup // A new unknown component with ordinal 20 that we cannot process.
+                signersGroup,
+                newUnknownComponentGroup // A new unknown component with ordinal 100 that we cannot process.
         )
 
         // The old client (receiving more component types than expected) is still compatible.
         val wireTransactionCompatibleA = WireTransaction(componentGroupsCompatibleA, privacySalt)
         assertEquals(wireTransactionCompatibleA.availableComponentGroups, wireTransactionA.availableComponentGroups) // The known components are the same.
         assertNotEquals(wireTransactionCompatibleA, wireTransactionA) // But obviously, its Merkle root has changed Vs wireTransactionA (which doesn't include this extra component).
-        assertEquals(6, wireTransactionCompatibleA.componentGroups.size)
 
-        // The old client will trhow if receiving an empty component (even if this unknown).
+        // The old client will throw if receiving an empty component (even if this is unknown).
         val componentGroupsCompatibleEmptyNew = listOf(
                 inputGroup,
                 outputGroup,
                 commandGroup,
                 notaryGroup,
                 timeWindowGroup,
-                newUnknownComponentEmptyGroup // A new unknown component with ordinal 21 that we cannot process.
+                signersGroup,
+                newUnknownComponentEmptyGroup // A new unknown component with ordinal 101 that we cannot process.
         )
         assertFails { WireTransaction(componentGroupsCompatibleEmptyNew, privacySalt) }
     }
@@ -179,7 +188,9 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
     fun `FilteredTransaction constructors and compatibility`() {
         // Filter out all of the components.
         val ftxNothing = wireTransactionA.buildFilteredTransaction(Predicate { false }) // Nothing filtered.
-        assertEquals(6, ftxNothing.groupHashes.size) // Although nothing filtered, we still receive the group hashes for the top level Merkle tree.
+        // Although nothing filtered, we still receive the group hashes for the top level Merkle tree.
+        // Note that attachments are not sent, but group hashes include the allOnesHash flag for the attachment group hash; that's why we expect +1 group hashes.
+        assertEquals(wireTransactionA.componentGroups.size + 1, ftxNothing.groupHashes.size)
         ftxNothing.verify()
 
         // Include all of the components.
@@ -191,6 +202,7 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
         ftxAll.checkAllComponentsVisible(ATTACHMENTS_GROUP)
         ftxAll.checkAllComponentsVisible(NOTARY_GROUP)
         ftxAll.checkAllComponentsVisible(TIMEWINDOW_GROUP)
+        ftxAll.checkAllComponentsVisible(SIGNERS_GROUP)
 
         // Filter inputs only.
         fun filtering(elem: Any): Boolean {
@@ -222,12 +234,14 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
         assertNotNull(ftxOneInput.filteredComponentGroups.firstOrNull { it.groupIndex == INPUTS_GROUP.ordinal }!!.partialMerkleTree) // And the Merkle tree.
 
         // The old client (receiving more component types than expected) is still compatible.
-        val componentGroupsCompatibleA = listOf(inputGroup,
+        val componentGroupsCompatibleA = listOf(
+                inputGroup,
                 outputGroup,
                 commandGroup,
                 notaryGroup,
                 timeWindowGroup,
-                newUnknownComponentGroup // A new unknown component with ordinal 10,000 that we cannot process.
+                signersGroup,
+                newUnknownComponentGroup // A new unknown component with ordinal 100 that we cannot process.
         )
         val wireTransactionCompatibleA = WireTransaction(componentGroupsCompatibleA, privacySalt)
         val ftxCompatible = wireTransactionCompatibleA.buildFilteredTransaction(Predicate(::filtering))
@@ -245,9 +259,142 @@ class CompatibleTransactionTests : TestDependencyInjectionBase() {
         ftxCompatibleAll.verify()
         assertEquals(wireTransactionCompatibleA.id, ftxCompatibleAll.id)
 
-        // Check we received the last (6th) element that we cannot process (backwards compatibility).
-        assertEquals(6, ftxCompatibleAll.filteredComponentGroups.size)
+        // Check we received the last element that we cannot process (backwards compatibility).
+        assertEquals(wireTransactionCompatibleA.componentGroups.size, ftxCompatibleAll.filteredComponentGroups.size)
 
+        // Hide one component group only.
+        // Filter inputs only.
+        fun filterOutInputs(elem: Any): Boolean {
+            return when (elem) {
+                is StateRef -> false
+                else -> true
+            }
+        }
 
+        val ftxCompatibleNoInputs = wireTransactionCompatibleA.buildFilteredTransaction(Predicate(::filterOutInputs))
+        ftxCompatibleNoInputs.verify()
+        assertFailsWith<ComponentVisibilityException> { ftxCompatibleNoInputs.checkAllComponentsVisible(INPUTS_GROUP) }
+        assertEquals(wireTransactionCompatibleA.componentGroups.size - 1, ftxCompatibleNoInputs.filteredComponentGroups.size)
+        assertEquals(wireTransactionCompatibleA.componentGroups.map { it.groupIndex }.max()!!, ftxCompatibleNoInputs.groupHashes.size - 1)
+    }
+
+    @Test
+    fun `Command visibility tests`() {
+        // 1st and 3rd commands require a signature from KEY_1.
+        val twoCommandsforKey1 = listOf(dummyCommand(DUMMY_KEY_1.public, DUMMY_KEY_2.public), dummyCommand(DUMMY_KEY_2.public),  dummyCommand(DUMMY_KEY_1.public))
+        val componentGroups = listOf(
+                inputGroup,
+                outputGroup,
+                ComponentGroup(COMMANDS_GROUP.ordinal, twoCommandsforKey1.map { it.value.serialize() }),
+                notaryGroup,
+                timeWindowGroup,
+                ComponentGroup(SIGNERS_GROUP.ordinal, twoCommandsforKey1.map { it.signers.serialize() }),
+                newUnknownComponentGroup // A new unknown component with ordinal 100 that we cannot process.
+        )
+        val wtx = WireTransaction(componentGroups = componentGroups, privacySalt = PrivacySalt())
+
+        // Filter all commands.
+        fun filterCommandsOnly(elem: Any): Boolean {
+            return when (elem) {
+                is Command<*> -> true // Even if one Command is filtered, all signers are automatically filtered as well
+                else -> false
+            }
+        }
+
+        // Filter out commands only.
+        fun filterOutCommands(elem: Any): Boolean {
+            return when (elem) {
+                is Command<*> -> false
+                else -> true
+            }
+        }
+
+        // Filter KEY_1 commands.
+        fun filterKEY1Commands(elem: Any): Boolean {
+            return when (elem) {
+                is Command<*> -> DUMMY_KEY_1.public in elem.signers
+                else -> false
+            }
+        }
+
+        // Filter only one KEY_1 command.
+        fun filterTwoSignersCommands(elem: Any): Boolean {
+            return when (elem) {
+                is Command<*> -> elem.signers.size == 2 // dummyCommand(DUMMY_KEY_1.public) is filtered out.
+                else -> false
+            }
+        }
+
+        // Again filter only one KEY_1 command.
+        fun filterSingleSignersCommands(elem: Any): Boolean {
+            return when (elem) {
+                is Command<*> -> elem.signers.size == 1 // dummyCommand(DUMMY_KEY_1.public, DUMMY_KEY_2.public) is filtered out.
+                else -> false
+            }
+        }
+
+        val allCommandsFtx = wtx.buildFilteredTransaction(Predicate(::filterCommandsOnly))
+        val noCommandsFtx = wtx.buildFilteredTransaction(Predicate(::filterOutCommands))
+        val key1CommandsFtx = wtx.buildFilteredTransaction(Predicate(::filterKEY1Commands))
+        val oneKey1CommandFtxA = wtx.buildFilteredTransaction(Predicate(::filterTwoSignersCommands))
+        val oneKey1CommandFtxB = wtx.buildFilteredTransaction(Predicate(::filterSingleSignersCommands))
+
+        allCommandsFtx.checkCommandVisibility(DUMMY_KEY_1.public)
+        assertFailsWith<ComponentVisibilityException> { noCommandsFtx.checkCommandVisibility(DUMMY_KEY_1.public) }
+        key1CommandsFtx.checkCommandVisibility(DUMMY_KEY_1.public)
+        assertFailsWith<ComponentVisibilityException> { oneKey1CommandFtxA.checkCommandVisibility(DUMMY_KEY_1.public) }
+        assertFailsWith<ComponentVisibilityException> { oneKey1CommandFtxB.checkCommandVisibility(DUMMY_KEY_1.public) }
+
+        allCommandsFtx.checkAllComponentsVisible(SIGNERS_GROUP)
+        assertFailsWith<ComponentVisibilityException> { noCommandsFtx.checkAllComponentsVisible(SIGNERS_GROUP) } // If we filter out all commands, signers are not sent as well.
+        key1CommandsFtx.checkAllComponentsVisible(SIGNERS_GROUP) // If at least one Command is visible, then all Signers are visible.
+        oneKey1CommandFtxA.checkAllComponentsVisible(SIGNERS_GROUP) // If at least one Command is visible, then all Signers are visible.
+        oneKey1CommandFtxB.checkAllComponentsVisible(SIGNERS_GROUP) // If at least one Command is visible, then all Signers are visible.
+
+        // We don't send a list of signers.
+        val componentGroupsCompatible = listOf(
+                inputGroup,
+                outputGroup,
+                ComponentGroup(COMMANDS_GROUP.ordinal, twoCommandsforKey1.map { it.value.serialize() }),
+                notaryGroup,
+                timeWindowGroup,
+                // ComponentGroup(SIGNERS_GROUP.ordinal, twoCommandsforKey1.map { it.signers.serialize() }),
+                newUnknownComponentGroup // A new unknown component with ordinal 100 that we cannot process.
+        )
+
+        // Invalid Transaction. Sizes of CommandData and Signers (empty) do not match.
+        assertFailsWith<IllegalStateException> { WireTransaction(componentGroups = componentGroupsCompatible, privacySalt = PrivacySalt()) }
+
+        // We send smaller list of signers.
+        val componentGroupsLessSigners = listOf(
+                inputGroup,
+                outputGroup,
+                ComponentGroup(COMMANDS_GROUP.ordinal, twoCommandsforKey1.map { it.value.serialize() }),
+                notaryGroup,
+                timeWindowGroup,
+                ComponentGroup(SIGNERS_GROUP.ordinal, twoCommandsforKey1.map { it.signers.serialize() }.subList(0, 1)), // Send first signer only.
+                newUnknownComponentGroup // A new unknown component with ordinal 100 that we cannot process.
+        )
+
+        // Invalid Transaction. Sizes of CommandData and Signers (empty) do not match.
+        assertFailsWith<IllegalStateException> { WireTransaction(componentGroups = componentGroupsLessSigners, privacySalt = PrivacySalt()) }
+
+        // Test if there is no command to sign.
+        val commandsNoKey1= listOf(dummyCommand(DUMMY_KEY_2.public))
+
+        val componentGroupsNoKey1ToSign = listOf(
+                inputGroup,
+                outputGroup,
+                ComponentGroup(COMMANDS_GROUP.ordinal, commandsNoKey1.map { it.value.serialize() }),
+                notaryGroup,
+                timeWindowGroup,
+                ComponentGroup(SIGNERS_GROUP.ordinal, commandsNoKey1.map { it.signers.serialize() }),
+                newUnknownComponentGroup // A new unknown component with ordinal 100 that we cannot process.
+        )
+
+        val wtxNoKey1 = WireTransaction(componentGroups = componentGroupsNoKey1ToSign, privacySalt = PrivacySalt())
+        val allCommandsNoKey1Ftx= wtxNoKey1.buildFilteredTransaction(Predicate(::filterCommandsOnly))
+        allCommandsNoKey1Ftx.checkCommandVisibility(DUMMY_KEY_1.public) // This will pass, because there are indeed no commands to sign in the original transaction.
     }
 }
+

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -26,7 +26,7 @@ UNRELEASED
 
 * ``Cordapp`` now has a name field for identifying CorDapps and all CorDapp names are printed to console at startup.
 
-* Enums now respsect the whitelist applied to the Serializer factory serializing / deserializing them. If the enum isn't
+* Enums now respect the whitelist applied to the Serializer factory serializing / deserializing them. If the enum isn't
   either annotated with the @CordaSerializable annotation or explicitly whitelisted then a NotSerializableException is
   thrown.
 
@@ -53,6 +53,15 @@ UNRELEASED
 
 * ``TimeWindow`` now has a ``length`` property that returns the length of the time-window, or ``null`` if the
   time-window is open-ended.
+
+* A new ``SIGNERS_GROUP`` with ordinal 6 has been added to ``ComponentGroupEnum`` that corresponds to the ``Command``
+  signers.
+
+* ``PartialMerkleTree`` is equipped with a ``leafIndex`` function that returns the index of a hash (leaf) in the
+  partial Merkle tree structure.
+
+* A new function ``checkCommandVisibility(publicKey: PublicKey)`` has been added to ``FilteredTransaction`` to check
+  if every command that a signer should receive (e.g. an Oracle) is indeed visible.
 
 .. _changelog_v1:
 

--- a/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
+++ b/samples/irs-demo/src/main/kotlin/net/corda/irs/api/NodeInterestRates.kt
@@ -145,7 +145,7 @@ object NodeInterestRates {
             }
 
             require(ftx.checkWithFun(::check))
-
+            ftx.checkCommandVisibility(services.myInfo.legalIdentities.first().owningKey)
             // It all checks out, so we can return a signature.
             //
             // Note that we will happily sign an invalid transaction, as we are only being presented with a filtered


### PR DESCRIPTION
A new functionality is implemented to enable command visibility for Oracles without sacrificing privacy.
Previously, one could achieve the above functionality by requiring full access to every command in the original transaction.
In contrast, this approach suggests we only send the list of `signers` per `command`, but not `CommandData` for unrelated `Command`s.
![oraclevisibility_commands](https://user-images.githubusercontent.com/25659162/31348653-3de2c764-ad18-11e7-8051-dfd7a777ff3b.png)
The algorithm works as follows:
a) a new `SIGNERS_GROUP` with ordinal 6 is added.

b) Unlike other components, signers is NOT a property in `TraversableTransaction`, but of course it is part of the `ComponentGroup` `OpaqueBytes`.

c) Due to the above, we ensure that filtering over `signers` is not possible (eg. someone by mistake sends some commands but filters out the signers)

d) If even one `Command` is included in the `FilteredTransaction`, the list of `signers` for all commands should be sent.

e) The ftx receiver (eg an Oracle) does the following check:
 - `checkAllComponentsVisible(SIGNERS_GROUP)`
 - Match the number of received commands (for its owning key) with the expected commands to sign based on the list of signers received.

Note that although a new component_type is added, this model remains backwards compatible with Corda 1.0 (both as an api and as a process).

Based on various conversations with @rick-r3 
![command_visibility_versiontable](https://user-images.githubusercontent.com/25659162/31544007-ca4629c6-b010-11e7-91c1-3dec14f837df.png)
