### PR TITLE
Deflake node infoWatcherTest

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -70,9 +70,9 @@ class NodeInfoWatcherTest : NodeBasedTest() {
 
         nodeInfoWatcher.nodeInfoUpdates()
                 .subscribe(testSubscriber)
+        advanceTime()
 
         val readNodes = testSubscriber.onNextEvents.distinct()
-        advanceTime()
         assertEquals(0, readNodes.size)
     }
 
@@ -82,6 +82,7 @@ class NodeInfoWatcherTest : NodeBasedTest() {
 
         nodeInfoWatcher.nodeInfoUpdates()
                 .subscribe(testSubscriber)
+        advanceTime()
 
         val readNodes = testSubscriber.onNextEvents.distinct()
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -90,6 +90,7 @@ class NodeInfoWatcherTest : NodeBasedTest() {
     }
 
     @Test
+    //@Ignore
     fun `polling folder`() {
         nodeInfoPath.createDirectories()
 
@@ -114,7 +115,7 @@ class NodeInfoWatcherTest : NodeBasedTest() {
     }
 
     private fun advanceTime() {
-        scheduler.advanceTimeBy(1, TimeUnit.HOURS)
+        scheduler.advanceTimeBy(1, TimeUnit.MINUTES)
     }
 
     // Write a nodeInfo under the right path.

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -90,7 +90,6 @@ class NodeInfoWatcherTest : NodeBasedTest() {
     }
 
     @Test
-    //@Ignore
     fun `polling folder`() {
         nodeInfoPath.createDirectories()
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -67,17 +67,15 @@ class NodeInfoWatcher(private val nodePath: Path,
      * Read all the files contained in [nodePath] / [CordformNode.NODE_INFO_DIRECTORY] and keep watching
      * the folder for further updates.
      *
-     * We simply list the direcotry content every 5 seconds, the Java implementation of WatchService has been proven to
+     * We simply list the directory content every 5 seconds, the Java implementation of WatchService has been proven to
      * be unreliable on MacOs and given the fairly simple use case we have, this simple implementation should do.
      *
      * @return an [Observable] returning [NodeInfo]s, there is no guarantee that the same value isn't returned more
      *      than once.
      */
     fun nodeInfoUpdates(): Observable<NodeInfo> {
-        val pollForFiles = Observable.interval(5, TimeUnit.SECONDS, scheduler)
+        return Observable.interval(5, TimeUnit.SECONDS, scheduler)
                 .flatMapIterable { loadFromDirectory() }
-        val readCurrentFiles = Observable.from(loadFromDirectory())
-        return readCurrentFiles.mergeWith(pollForFiles)
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -67,6 +67,9 @@ class NodeInfoWatcher(private val nodePath: Path,
      * Read all the files contained in [nodePath] / [CordformNode.NODE_INFO_DIRECTORY] and keep watching
      * the folder for further updates.
      *
+     * We simply list the direcotry content every 5 seconds, the Java implementation of WatchService has been proven to
+     * be unreliable on MacOs and given the fairly simple use case we have, this simple implementation should do.
+     *
      * @return an [Observable] returning [NodeInfo]s, there is no guarantee that the same value isn't returned more
      *      than once.
      */


### PR DESCRIPTION
Change the implementation not to rely on the Java WatchService and instead just list the whole directory contents every time.