### PR TITLE
Update Gradle not to generate Java/Kotlin documentation for internal packages.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
     ext.hibernate_version = '5.2.6.Final'
     ext.h2_version = '1.4.194' // Update docs if renamed or removed.
     ext.rxjava_version = '1.2.4'
-    ext.dokka_version = '0.9.14'
+    ext.dokka_version = '0.9.15-corda'
     ext.eddsa_version = '0.2.0'
 
     // Update 121 is required for ObjectInputFilter and at time of writing 131 was latest:

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'kotlin'
 
 dependencies {
     compile rootProject
@@ -24,6 +23,15 @@ dokka {
     externalDocumentationLink {
         url = new URL("http://www.bouncycastle.org/docs/docs1.5on/")
     }
+
+    packageOptions {
+        prefix = 'net.corda.core.internal'
+        suppress = true
+    }
+    packageOptions {
+        prefix = 'net.corda.client.rpc.internal'
+        suppress = true
+    }
 }
 
 task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
@@ -44,6 +52,15 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
     }
     externalDocumentationLink {
         url = new URL("http://www.bouncycastle.org/docs/docs1.5on/")
+    }
+
+    packageOptions {
+        prefix = 'net.corda.core.internal'
+        suppress = true
+    }
+    packageOptions {
+        prefix = 'net.corda.client.rpc.internal'
+        suppress = true
     }
 }
 


### PR DESCRIPTION
We do not want to generate JavaDoc/KDoc for internal APIs, and so we configure Dokka to suppress these entire packages:
- net.corda.core.internal
- net.corda.client.rpc.internal

This PR requires that we have already built and installed Dokka 0.9.15-corda into our Artifactory.