### PR TITLE
Scan API for addition of new abstract methods.

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -465,6 +465,7 @@ public interface net.corda.core.cordapp.Cordapp
   @org.jetbrains.annotations.NotNull public abstract List getRpcFlows()
   @org.jetbrains.annotations.NotNull public abstract List getSchedulableFlows()
   @org.jetbrains.annotations.NotNull public abstract List getSerializationWhitelists()
+  @org.jetbrains.annotations.NotNull public abstract List getServiceFlows()
   @org.jetbrains.annotations.NotNull public abstract List getServices()
 ##
 public final class net.corda.core.cordapp.CordappContext extends java.lang.Object
@@ -1353,6 +1354,7 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.NodeInfo nodeInfo()
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
   @org.jetbrains.annotations.NotNull public abstract List notaryIdentities()
+  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party notaryPartyFromX500Name(net.corda.core.identity.CordaX500Name)
   @org.jetbrains.annotations.NotNull public abstract java.io.InputStream openAttachment(net.corda.core.crypto.SecureHash)
   @org.jetbrains.annotations.NotNull public abstract Set partiesFromName(String, boolean)
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
@@ -1485,6 +1487,10 @@ public static final class net.corda.core.messaging.StateMachineUpdate$Removed ex
   public int hashCode()
   public String toString()
 ##
+public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.ServiceHub
+  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowHandle startFlow(net.corda.core.flows.FlowLogic)
+  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowProgressHandle startTrackedFlow(net.corda.core.flows.FlowLogic)
+##
 public final class net.corda.core.node.NodeInfo extends java.lang.Object
   public <init>(List, List, int, long)
   @org.jetbrains.annotations.NotNull public final List component1()
@@ -1579,10 +1585,12 @@ public interface net.corda.core.node.services.NetworkMapCache
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.NodeInfo getNodeByLegalName(net.corda.core.identity.CordaX500Name)
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture getNodeReady()
   @org.jetbrains.annotations.NotNull public abstract List getNodesByLegalIdentityKey(java.security.PublicKey)
+  @org.jetbrains.annotations.NotNull public abstract List getNodesByLegalName(net.corda.core.identity.CordaX500Name)
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party getNotary(net.corda.core.identity.CordaX500Name)
   @org.jetbrains.annotations.NotNull public abstract List getNotaryIdentities()
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.services.PartyInfo getPartyInfo(net.corda.core.identity.Party)
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party getPeerByLegalName(net.corda.core.identity.CordaX500Name)
+  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.PartyAndCertificate getPeerCertificateByLegalName(net.corda.core.identity.CordaX500Name)
   public abstract boolean isNotary(net.corda.core.identity.Party)
   public abstract boolean isValidatingNotary(net.corda.core.identity.Party)
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed track()

--- a/.ci/check-api-changes.sh
+++ b/.ci/check-api-changes.sh
@@ -17,7 +17,7 @@ echo
 
 # A removed line means that an API was either deleted or modified.
 removals=$(echo "$diffContents" | grep "^-\s")
-removalCount=`wc -l <<EOF
+removalCount=`grep -v "^$" <<EOF | wc -l
 $removals
 EOF
 `
@@ -30,7 +30,7 @@ fi
 
 # Adding new abstract methods could also break the API.
 newAbstracts=$(echo "$diffContents" | grep "^+\s" | grep "\(public\|protected\) abstract")
-abstractCount=`wc -l <<EOF
+abstractCount=`grep -v "^$" <<EOF | wc -l
 $newAbstracts
 EOF
 `

--- a/.ci/check-api-changes.sh
+++ b/.ci/check-api-changes.sh
@@ -11,9 +11,37 @@ if [ ! -f $apiCurrent ]; then
 fi
 
 diffContents=`diff -u $apiCurrent $APIHOME/../build/api/api-corda-*.txt`
-echo "Diff contents: " 
+echo "Diff contents:" 
 echo "$diffContents"
-removals=`echo "$diffContents" | grep "^-\s" | wc -l`
-echo "Number of API removals/changes: "$removals
-echo "Exiting with exit code" $removals
-exit $removals
+echo
+
+# A removed line means that an API was either deleted or modified.
+removals=$(echo "$diffContents" | grep "^-\s")
+removalCount=`wc -l <<EOF
+$removals
+EOF
+`
+
+echo "Number of API removals/changes: "$removalCount
+if [ $removalCount -gt 0 ]; then
+    echo "$removals"
+    echo
+fi
+
+# Adding new abstract methods could also break the API.
+newAbstracts=$(echo "$diffContents" | grep "^+\s" | grep "\(public\|protected\) abstract")
+abstractCount=`wc -l <<EOF
+$newAbstracts
+EOF
+`
+
+echo "Number of new abstract APIs: "$abstractCount
+if [ $abstractCount -gt 0 ]; then
+    echo "$newAbstracts"
+    echo
+fi
+
+badChanges=$(($removalCount + $abstractCount))
+
+echo "Exiting with exit code" $badChanges
+exit $badChanges


### PR DESCRIPTION
We can also break the API by adding new abstract methods to classes or interfaces, so check for that too.