### PR TITLE
Ensure that the contents of OpaqueBytes cannot be modified.

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2923,7 +2923,7 @@ public static final class net.corda.core.utilities.NonEmptySet$iterator$1 extend
 ##
 public class net.corda.core.utilities.OpaqueBytes extends net.corda.core.utilities.ByteSequence
   public <init>(byte[])
-  @org.jetbrains.annotations.NotNull public byte[] getBytes()
+  @org.jetbrains.annotations.NotNull public final byte[] getBytes()
   public int getOffset()
   public int getSize()
   public static final net.corda.core.utilities.OpaqueBytes$Companion Companion

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -19,13 +19,29 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         }
     }
 
+    /**
+     * Convert the hash value to a hexadecimal [String].
+     */
     override fun toString(): String = bytes.toHexString()
 
+    /**
+     * Returns the first [prefixLen] hexadecimal digits of the [SecureHash] value.
+     * @param prefixLen
+     */
     fun prefixChars(prefixLen: Int = 6) = toString().substring(0, prefixLen)
+
+    /**
+     * Append a second hash value to this hash value, and then compute the SHA-256 hash of the result.
+     * @param other
+     */
     fun hashConcat(other: SecureHash) = (this.bytes + other.bytes).sha256()
 
     // Like static methods in Java, except the 'companion' is a singleton that can have state.
     companion object {
+        /**
+         * Converts a SHA-256 hash value represented as a hexadecimal [String] into a [SecureHash].
+         * @param str A sequence of 64 hexadecimal digits that represents a SHA-256 hash value.
+         */
         @JvmStatic
         fun parse(str: String) = str.toUpperCase().parseAsHex().let {
             when (it.size) {
@@ -34,24 +50,55 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
             }
         }
 
+        /**
+         * Computes the SHA-256 hash value of the [ByteArray].
+         * @param bytes
+         */
         @JvmStatic
         fun sha256(bytes: ByteArray) = SHA256(MessageDigest.getInstance("SHA-256").digest(bytes))
 
+        /**
+         * Computes the SHA-256 hash of the [ByteArray], and then computes the SHA-256 hash of the hash.
+         * @param bytes
+         */
         @JvmStatic
         fun sha256Twice(bytes: ByteArray) = sha256(sha256(bytes).bytes)
 
+        /**
+         * Computes the SHA-256 hash of the [String]'s UTF-8 byte contents.
+         * @param str
+         */
         @JvmStatic
         fun sha256(str: String) = sha256(str.toByteArray())
 
+        /**
+         * Generates a random SHA-256 value.
+         */
         @JvmStatic
         fun randomSHA256() = sha256(newSecureRandom().generateSeed(32))
 
+        /**
+         * A SHA-256 hash value consisting of 32 0x00 bytes.
+         */
+        @JvmField
         val zeroHash = SecureHash.SHA256(ByteArray(32, { 0.toByte() }))
+
+        /**
+         * A SHA-256 hash value consisting of 32 0xFF bytes.
+         */
+        @JvmField
         val allOnesHash = SecureHash.SHA256(ByteArray(32, { 255.toByte() }))
     }
 
     // In future, maybe SHA3, truncated hashes etc.
 }
 
+/**
+ * Compute the SHA-256 hash for the contents of the [ByteArray].
+ */
 fun ByteArray.sha256(): SecureHash.SHA256 = SecureHash.sha256(this)
+
+/**
+ * Compute the SHA-256 hash for the contents of the [OpaqueBytes].
+ */
 fun OpaqueBytes.sha256(): SecureHash.SHA256 = SecureHash.sha256(this.bytes)

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -32,7 +32,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
 
     /**
      * Append a second hash value to this hash value, and then compute the SHA-256 hash of the result.
-     * @param other
+     * @param other The hash to append to this one.
      */
     fun hashConcat(other: SecureHash) = (this.bytes + other.bytes).sha256()
 
@@ -41,33 +41,35 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         /**
          * Converts a SHA-256 hash value represented as a hexadecimal [String] into a [SecureHash].
          * @param str A sequence of 64 hexadecimal digits that represents a SHA-256 hash value.
-         * @throws IllegalArgumentException The input string does not contain 64 hexadecimal digits.
+         * @throws IllegalArgumentException The input string does not contain 64 hexadecimal digits, or it contains incorrectly-encoded characters.
          */
         @JvmStatic
-        fun parse(str: String) = str.toUpperCase().parseAsHex().let {
-            when (it.size) {
-                32 -> SHA256(it)
-                else -> throw IllegalArgumentException("Provided string is ${it.size} bytes not 32 bytes in hex: $str")
+        fun parse(str: String): SHA256 {
+            return str.toUpperCase().parseAsHex().let {
+                when (it.size) {
+                    32 -> SHA256(it)
+                    else -> throw IllegalArgumentException("Provided string is ${it.size} bytes not 32 bytes in hex: $str")
+                }
             }
         }
 
         /**
          * Computes the SHA-256 hash value of the [ByteArray].
-         * @param bytes
+         * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
         fun sha256(bytes: ByteArray) = SHA256(MessageDigest.getInstance("SHA-256").digest(bytes))
 
         /**
          * Computes the SHA-256 hash of the [ByteArray], and then computes the SHA-256 hash of the hash.
-         * @param bytes
+         * @param bytes The [ByteArray] to hash.
          */
         @JvmStatic
         fun sha256Twice(bytes: ByteArray) = sha256(sha256(bytes).bytes)
 
         /**
          * Computes the SHA-256 hash of the [String]'s UTF-8 byte contents.
-         * @param str
+         * @param str [String] whose UTF-8 contents will be hashed.
          */
         @JvmStatic
         fun sha256(str: String) = sha256(str.toByteArray())

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -20,13 +20,13 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
     }
 
     /**
-     * Convert the hash value to a hexadecimal [String].
+     * Convert the hash value to an uppercase hexadecimal [String].
      */
     override fun toString(): String = bytes.toHexString()
 
     /**
      * Returns the first [prefixLen] hexadecimal digits of the [SecureHash] value.
-     * @param prefixLen
+     * @param prefixLen The number of characters in the prefix.
      */
     fun prefixChars(prefixLen: Int = 6) = toString().substring(0, prefixLen)
 
@@ -41,6 +41,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         /**
          * Converts a SHA-256 hash value represented as a hexadecimal [String] into a [SecureHash].
          * @param str A sequence of 64 hexadecimal digits that represents a SHA-256 hash value.
+         * @throws IllegalArgumentException The input string does not contain 64 hexadecimal digits.
          */
         @JvmStatic
         fun parse(str: String) = str.toUpperCase().parseAsHex().let {
@@ -80,13 +81,11 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
         /**
          * A SHA-256 hash value consisting of 32 0x00 bytes.
          */
-        @JvmField
         val zeroHash = SecureHash.SHA256(ByteArray(32, { 0.toByte() }))
 
         /**
          * A SHA-256 hash value consisting of 32 0xFF bytes.
          */
-        @JvmField
         val allOnesHash = SecureHash.SHA256(ByteArray(32, { 255.toByte() }))
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -1,8 +1,6 @@
 package net.corda.core.transactions
 
-import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.NamedByHash
-import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.transactions.SignedTransaction.SignaturesMissingException

--- a/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
@@ -118,8 +118,11 @@ sealed class ByteSequence : Comparable<ByteSequence> {
  * In an ideal JVM this would be a value type and be completely overhead free. Project Valhalla is adding such
  * functionality to Java, but it won't arrive for a few years yet!
  */
-open class OpaqueBytes(override val bytes: ByteArray) : ByteSequence() {
+open class OpaqueBytes(bytes: ByteArray) : ByteSequence() {
     companion object {
+        /**
+         * Create [OpaqueBytes] from a sequence of [Byte] values.
+         */
         @JvmStatic
         fun of(vararg b: Byte) = OpaqueBytes(byteArrayOf(*b))
     }
@@ -128,13 +131,28 @@ open class OpaqueBytes(override val bytes: ByteArray) : ByteSequence() {
         require(bytes.isNotEmpty())
     }
 
-    override val size: Int get() = bytes.size
-    override val offset: Int get() = 0
+    // The bytes are always cloned so that this object becomes immutable. We need this for security reasons.
+    override final val bytes: ByteArray = bytes
+        get() = field.clone()
+    override val size: Int = bytes.size
+    override val offset: Int = 0
 }
 
+/**
+ * Copy [size] bytes from this [ByteArray] starting from [offset] into a new [ByteArray].
+ * @param offset
+ * @param size
+ */
 fun ByteArray.sequence(offset: Int = 0, size: Int = this.size) = ByteSequence.of(this, offset, size)
 
+/**
+ * Converts this [ByteArray] into a [String] of hexadecimal digits.
+ */
 fun ByteArray.toHexString(): String = DatatypeConverter.printHexBinary(this)
+
+/**
+ * Converts this [String] of hexadecimal digits  into a [ByteArray].
+ */
 fun String.parseAsHex(): ByteArray = DatatypeConverter.parseHexBinary(this)
 
 /**

--- a/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
@@ -131,7 +131,14 @@ open class OpaqueBytes(bytes: ByteArray) : ByteSequence() {
         require(bytes.isNotEmpty())
     }
 
-    // The bytes are always cloned so that this object becomes immutable. We need this for security reasons.
+    /* The bytes are always cloned so that this object becomes immutable. This has been done
+     * to prevent tampering with entities such as [SecureHash] and [PrivacySalt], as well as
+     * preserve the integrity of our hash constants [zeroHash] and [allOnesHash].
+     *
+     * Cloning like this may become a performance issue, depending on whether or not the JIT
+     * compiler is ever able to optimise away the clone. In which case we may need to revisit
+     * this later.
+     */
     override final val bytes: ByteArray = bytes
         get() = field.clone()
     override val size: Int = bytes.size

--- a/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ByteArrays.kt
@@ -131,7 +131,8 @@ open class OpaqueBytes(bytes: ByteArray) : ByteSequence() {
         require(bytes.isNotEmpty())
     }
 
-    /* The bytes are always cloned so that this object becomes immutable. This has been done
+    /**
+     * The bytes are always cloned so that this object becomes immutable. This has been done
      * to prevent tampering with entities such as [SecureHash] and [PrivacySalt], as well as
      * preserve the integrity of our hash constants [zeroHash] and [allOnesHash].
      *
@@ -147,8 +148,6 @@ open class OpaqueBytes(bytes: ByteArray) : ByteSequence() {
 
 /**
  * Copy [size] bytes from this [ByteArray] starting from [offset] into a new [ByteArray].
- * @param offset
- * @param size
  */
 fun ByteArray.sequence(offset: Int = 0, size: Int = this.size) = ByteSequence.of(this, offset, size)
 
@@ -158,7 +157,8 @@ fun ByteArray.sequence(offset: Int = 0, size: Int = this.size) = ByteSequence.of
 fun ByteArray.toHexString(): String = DatatypeConverter.printHexBinary(this)
 
 /**
- * Converts this [String] of hexadecimal digits  into a [ByteArray].
+ * Converts this [String] of hexadecimal digits into a [ByteArray].
+ * @throws IllegalArgumentException if the [String] contains incorrectly-encoded characters.
  */
 fun String.parseAsHex(): ByteArray = DatatypeConverter.parseHexBinary(this)
 

--- a/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
@@ -1,6 +1,7 @@
 package net.corda.core.serialization
 
 import net.corda.core.contracts.*
+import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -16,7 +17,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class TransactionSerializationTests : TestDependencyInjectionBase() {
-    val TEST_CASH_PROGRAM_ID = "net.corda.core.serialization.TransactionSerializationTests\$TestCash"
+    private val TEST_CASH_PROGRAM_ID = "net.corda.core.serialization.TransactionSerializationTests\$TestCash"
 
     class TestCash : Contract {
         override fun verify(tx: LedgerTransaction) {
@@ -63,12 +64,6 @@ class TransactionSerializationTests : TestDependencyInjectionBase() {
 
         // Now check that the signature we just made verifies.
         stx.verifyRequiredSignatures()
-
-        // Corrupt the data and ensure the signature catches the problem.
-        stx.id.bytes[5] = stx.id.bytes[5].inc()
-        assertFailsWith(SignatureException::class) {
-            stx.verifyRequiredSignatures()
-        }
     }
 
     @Test

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,9 @@ from the previous milestone release.
 
 UNRELEASED
 ----------
+* ``OpaqueBytes.bytes`` now returns a clone of its underlying ``ByteArray``, and has been redeclared as ``final``.
+  This is a minor change to the public API, but is required to ensure that classes like ``SecureHash`` are immutable.
+
 * ``FlowLogic`` now exposes a series of function called ``receiveAll(...)`` allowing to join ``receive(...)`` instructions.
 
 * The ``Cordformation`` gradle plugin has been split into ``cordformation`` and ``cordapp``. The former builds and


### PR DESCRIPTION
Force `OpaqueBytes.bytes` to return a clone of its contents, and then make this field `final`. This effectively makes the contents immutable.