### PR TITLE
H2 coin selection uses Prepared Statement to protect against SQL injection

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -121,7 +121,7 @@ class CashSelectionH2Impl : CashSelection {
                     psSelectJoin.setObject(5, onlyFromIssuerParties.map { it.owningKey.toBase58String() as Any}.toTypedArray() )
                 if (withIssuerRefs.isNotEmpty())
                     psSelectJoin.setObject(6, withIssuerRefs.map { it.bytes.toHexString() as Any }.toTypedArray())
-                log.info(psSelectJoin.toString())
+                log.debug { psSelectJoin.toString() }
 
                 // Retrieve spendable state refs
                 val rs = psSelectJoin.executeQuery()

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -112,15 +112,16 @@ class CashSelectionH2Impl : CashSelection {
 
                 // Use prepared statement for protection against SQL Injection (http://www.h2database.com/html/advanced.html#sql_injection)
                 val psSelectJoin = connection.prepareStatement(selectJoin)
-                psSelectJoin.setString(1, amount.token.currencyCode)
-                psSelectJoin.setLong(2, amount.quantity)
-                psSelectJoin.setString(3, lockId.toString())
+                var pIndex = 0
+                psSelectJoin.setString(++pIndex, amount.token.currencyCode)
+                psSelectJoin.setLong(++pIndex, amount.quantity)
+                psSelectJoin.setString(++pIndex, lockId.toString())
                 if (notary != null)
-                    psSelectJoin.setString(4, notary.name.toString())
+                    psSelectJoin.setString(++pIndex, notary.name.toString())
                 if (onlyFromIssuerParties.isNotEmpty())
-                    psSelectJoin.setObject(5, onlyFromIssuerParties.map { it.owningKey.toBase58String() as Any}.toTypedArray() )
+                    psSelectJoin.setObject(++pIndex, onlyFromIssuerParties.map { it.owningKey.toBase58String() as Any}.toTypedArray() )
                 if (withIssuerRefs.isNotEmpty())
-                    psSelectJoin.setObject(6, withIssuerRefs.map { it.bytes.toHexString() as Any }.toTypedArray())
+                    psSelectJoin.setObject(++pIndex, withIssuerRefs.map { it.bytes.toHexString() as Any }.toTypedArray())
                 log.debug { psSelectJoin.toString() }
 
                 // Retrieve spendable state refs

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -96,13 +96,13 @@ class CashSelectionH2Impl : CashSelection {
                 statement.execute("CALL SET(@t, CAST(0 AS BIGINT));")
 
                 val selectJoin = """
-                SELECT vs.transaction_id, vs.output_index, vs.contract_state, ccs.pennies, SET(@t, ifnull(@t,0)+ccs.pennies) total_pennies, vs.lock_id
-                FROM vault_states AS vs, contract_cash_states AS ccs
-                WHERE vs.transaction_id = ccs.transaction_id AND vs.output_index = ccs.output_index
-                AND vs.state_status = 0
-                AND ccs.ccy_code = ? and @t < ?
-                AND (vs.lock_id = ? OR vs.lock_id is null)
-                """ +
+                    SELECT vs.transaction_id, vs.output_index, vs.contract_state, ccs.pennies, SET(@t, ifnull(@t,0)+ccs.pennies) total_pennies, vs.lock_id
+                    FROM vault_states AS vs, contract_cash_states AS ccs
+                    WHERE vs.transaction_id = ccs.transaction_id AND vs.output_index = ccs.output_index
+                    AND vs.state_status = 0
+                    AND ccs.ccy_code = ? and @t < ?
+                    AND (vs.lock_id = ? OR vs.lock_id is null)
+                    """ +
                         (if (notary != null)
                             " AND vs.notary_name = ?" else "") +
                         (if (onlyFromIssuerParties.isNotEmpty())


### PR DESCRIPTION
Updated H2 coin selection code to use Prepared Statement to protect against SQL Injection attacks, as per http://www.h2database.com/html/advanced.html#sql_injection

