### PR TITLE
Remove the two header lines from the diff output to simplify the +/- …

### DIFF
--- a/.ci/check-api-changes.sh
+++ b/.ci/check-api-changes.sh
@@ -10,13 +10,14 @@ if [ ! -f $apiCurrent ]; then
    exit -1
 fi
 
-diffContents=`diff -u $apiCurrent $APIHOME/../build/api/api-corda-*.txt`
-echo "Diff contents:" 
+# Remove the two header lines from the diff output.
+diffContents=`diff -u $apiCurrent $APIHOME/../build/api/api-corda-*.txt | tail --lines=+3`
+echo "Diff contents:"
 echo "$diffContents"
 echo
 
 # A removed line means that an API was either deleted or modified.
-removals=$(echo "$diffContents" | grep "^-\s")
+removals=$(echo "$diffContents" | grep "^-")
 removalCount=`grep -v "^$" <<EOF | wc -l
 $removals
 EOF
@@ -29,7 +30,7 @@ if [ $removalCount -gt 0 ]; then
 fi
 
 # Adding new abstract methods could also break the API.
-newAbstracts=$(echo "$diffContents" | grep "^+\s" | grep "\(public\|protected\) abstract")
+newAbstracts=$(echo "$diffContents" | grep "^+" | grep "\(public\|protected\) abstract")
 abstractCount=`grep -v "^$" <<EOF | wc -l
 $newAbstracts
 EOF

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -1,5 +1,3 @@
-@file:JvmName("SerializationAPI")
-
 package net.corda.core.serialization
 
 import net.corda.core.crypto.SecureHash

--- a/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
@@ -1,5 +1,3 @@
-@file:JvmName("KotlinUtils")
-
 package net.corda.core.utilities
 
 import net.corda.core.internal.concurrent.get


### PR DESCRIPTION
The point of checking for whitespace was that we wanted to distinguish change lines from lines like:
```diff
--- .ci/api-current.txt	2017-10-12 09:11:55.491079103 +0100
+++ .ci/../build/api/api-corda-1.1-SNAPSHOT.txt	2017-10-12 09:15:00.485183512 +0
```
These are always the first two lines of the diff output, so just remove them. Then we can check for changes using simple "^+" and "^-" patterns.