### PR TITLE
Fix CashSelectionH2Test unit test.

### DIFF
--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashSelectionH2Test.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashSelectionH2Test.kt
@@ -1,9 +1,11 @@
 package net.corda.finance.contracts.asset
 
+import net.corda.core.internal.packageName
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.DOLLARS
 import net.corda.finance.flows.CashException
 import net.corda.finance.flows.CashPaymentFlow
+import net.corda.finance.schemas.CashSchemaV1
 import net.corda.testing.chooseIdentity
 import net.corda.testing.node.MockNetwork
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -14,7 +16,7 @@ class CashSelectionH2Test {
 
     @Test
     fun `check does not hold connection over retries`() {
-        val mockNet = MockNetwork(threadPerNode = true)
+        val mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance.contracts.asset", CashSchemaV1::class.packageName))
         try {
             val notaryNode = mockNet.createNotaryNode()
             val bankA = mockNet.createNode(configOverrides = { existingConfig ->


### PR DESCRIPTION
Although test assertions were passing, the code was not executing correctly due to missing declaration of CashSchema:

```
[ERROR] 15:14:55,725 [Mock node 2 thread] (AbstractCashSelection.kt:158) selection.AbstractCashSelection.attemptSpend - Failed retrieving unconsumed states for: amount [100.00 USD], onlyFromIssuerParties [[]], notary [null], lockId [45310aee-1904-4c2f-8148-981791a7abdb]
                            org.h2.jdbc.JdbcSQLException: Table "CONTRACT_CASH_STATES" not found; SQL statement:
```