### PR TITLE
Write the logs of nodes in Cordform, that should avoid hangs in the p…

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=2.0.4
+gradlePluginsVersion=2.0.5
 kotlinVersion=1.1.50
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
+++ b/gradle-plugins/cordformation/src/main/groovy/net/corda/plugins/Cordform.groovy
@@ -132,9 +132,12 @@ class Cordform extends DefaultTask {
 
     private generateNodeInfos() {
         nodes.each { Node node ->
+            def logDir = new File(fullNodePath(node).toFile(), "logs")
+            logDir.mkdirs()
             def process = new ProcessBuilder("java", "-jar", Node.NODEJAR_NAME, "--just-generate-node-info")
                     .directory(fullNodePath(node).toFile())
                     .redirectErrorStream(true)
+                    .redirectOutput(new File(logDir, "generate-info-log.txt"))
                     .start()
                     .waitFor()
         }


### PR DESCRIPTION
Change the gradle pulg-in to write the output of a nodes to a log file.
That should make it less likely for the plug-in process to hang while running.

This is a "backport" of the logic here:
https://github.com/corda/corda/pull/1873/files
This PR is smaller and hopefully approved sooner.