### PR TITLE
CORDA-351: added dependency check plugin to gradle build script

### DIFF
--- a/.ci/dependency-checker/suppressedLibraries.xml
+++ b/.ci/dependency-checker/suppressedLibraries.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+    <!--  Example of a suppressed library -->
+    <!-- The suppress node can be generated from the HTML report by using the 'suppress' option for each vulnerability found
+    <suppress>
+      <notes><![CDATA[
+      file name: some.jar
+      ]]></notes>
+      <sha1>66734244CE86857018B023A8C56AE0635C56B6A1</sha1>
+      <cpe>cpe:/a:apache:struts:2.0.0</cpe>
+   </suppress>
+    -->
+
+</suppressions>

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ buildscript {
     ext.rxjava_version = '1.2.4'
     ext.dokka_version = '0.9.14'
     ext.eddsa_version = '0.2.0'
+    ext.dependency_checker_version = '3.0.1'
 
     // Update 121 is required for ObjectInputFilter and at time of writing 131 was latest:
     ext.java8_minUpdateVersion = '131'
@@ -67,6 +68,7 @@ buildscript {
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
         classpath "org.ajoberstar:grgit:1.1.0"
         classpath "net.i2p.crypto:eddsa:$eddsa_version" // Needed for ServiceIdentityGenerator in the build environment.
+        classpath "org.owasp:dependency-check-gradle:${dependency_checker_version}"
     }
 }
 
@@ -101,6 +103,12 @@ allprojects {
     apply plugin: 'kotlin'
     apply plugin: 'java'
     apply plugin: 'jacoco'
+    apply plugin: 'org.owasp.dependencycheck'
+
+    dependencyCheck {
+        cveValidForHours = 1
+        format = 'ALL'
+    }
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -106,10 +106,10 @@ allprojects {
     apply plugin: 'org.owasp.dependencycheck'
 
     dependencyCheck {
+        suppressionFile = '.ci/dependency-checker/suppressedLibraries.xml'
         cveValidForHours = 1
         format = 'ALL'
     }
-
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 


### PR DESCRIPTION
Added the OWASP dependency check plugin to the gradle build script. It comes with several configurable tasks, 3 of which are the most important:

1. `gradle dependencyCheckAnalyze` will run for all projects and create a report containing detailed descriptions of known library vulnerabilities. The report can be found in several formats(html, xml, json, csv) in /corda/build/reports/

2. `gradle dependencyCheckUpdate` will update the local h2 database with the latest information in the National Vulnerability Database

3. `gradle :dependencyCheckPurge` will delete the h2 database. This task needs to be run only for the root project or it will fail when it's run for the subprojects(database already deleted)

The h2 database is create by default in the .gradle directory and takes up about 300MB. A different location can be configured.