### PR TITLE
Cordformation now allows addresses to be used for non-database addresses.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,9 +257,9 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
     node {
         name "O=Bank B,OU=corda,L=London,C=GB"
-        p2pPort 10007
-        rpcPort 10008
-        webPort 10009
+        p2pAddress "localhost:10007"
+        rpcAddress "localhost:10008"
+        webAddress "localhost:10009"
         cordapps = []
     }
 }

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=2.0.6
+gradlePluginsVersion=2.0.7
 kotlinVersion=1.1.50
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/docs/source/deploying-a-node.rst
+++ b/docs/source/deploying-a-node.rst
@@ -41,11 +41,12 @@ notary node:
             cordapps = []
             rpcUsers = [[ user: "user1", "password": "test", "permissions": []]]
         }
+        // Example of explicit addresses being used.
         node {
             name "CN=NodeC,O=NodeC,L=Paris,C=FR"
-            p2pPort 10011
-            rpcPort 10012
-            webPort 10013
+            p2pAddress "localhost:10011"
+            rpcAddress "localhost:10012"
+            webAddress "localhost:10013"
             cordapps = []
             rpcUsers = [[ user: "user1", "password": "test", "permissions": []]]
         }

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -58,7 +58,16 @@ public class CordformNode implements NodeDefinition {
     }
 
     /**
-     * Set the Artemis P2P port for this node.
+     * Get the artemis address for this node.
+     *
+     * @return This node's P2P address.
+     */
+    public String getP2PAddress() {
+        return config.getString("p2pAddress");
+    }
+
+    /**
+     * Set the Artemis P2P port for this node on localhost.
      *
      * @param p2pPort The Artemis messaging queue port.
      */
@@ -67,12 +76,30 @@ public class CordformNode implements NodeDefinition {
     }
 
     /**
-     * Set the Artemis RPC port for this node.
+     * Set the Artemis P2P address for this node.
+     *
+     * @param p2pAddress The Artemis messaging queue host and port.
+     */
+    public void p2pAddress(String p2pAddress) {
+        config = config.withValue("p2pAddress", ConfigValueFactory.fromAnyRef(p2pAddress));
+    }
+
+    /**
+     * Set the Artemis RPC port for this node on localhost.
      *
      * @param rpcPort The Artemis RPC queue port.
      */
     public void rpcPort(Integer rpcPort) {
         config = config.withValue("rpcAddress", ConfigValueFactory.fromAnyRef(DEFAULT_HOST + ':' + rpcPort));
+    }
+
+    /**
+     * Set the Artemis RPC address for this node.
+     *
+     * @param rpcAddress The Artemis RPC queue host and port.
+     */
+    public void rpcAddress(String rpcAddress) {
+        config = config.withValue("rpcAddress", ConfigValueFactory.fromAnyRef(rpcAddress));
     }
 
     /**

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -62,7 +62,7 @@ public class CordformNode implements NodeDefinition {
      *
      * @return This node's P2P address.
      */
-    public String getP2PAddress() {
+    public String getP2pAddress() {
         return config.getString("p2pAddress");
     }
 

--- a/gradle-plugins/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/gradle-plugins/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -61,13 +61,23 @@ class Node(private val project: Project) : CordformNode() {
     }
 
     /**
-     * Set the HTTP web server port for this node.
+     * Set the HTTP web server port for this node. Will use localhost as the address.
      *
      * @param webPort The web port number for this node.
      */
     fun webPort(webPort: Int) {
         config = config.withValue("webAddress",
                 ConfigValueFactory.fromAnyRef("$DEFAULT_HOST:$webPort"))
+    }
+
+    /**
+     * Set the HTTP web server address and port for this node.
+     *
+     * @param webAddress The web address for this node.
+     */
+    fun webAddress(webAddress: String) {
+        config = config.withValue("webAddress",
+                ConfigValueFactory.fromAnyRef(webAddress))
     }
 
     /**
@@ -105,15 +115,6 @@ class Node(private val project: Project) : CordformNode() {
         installCordapps()
         installConfig()
         appendOptionalConfig()
-    }
-
-    /**
-     * Get the artemis address for this node.
-     *
-     * @return This node's P2P address.
-     */
-    fun getP2PAddress(): String {
-        return config.getString("p2pAddress")
     }
 
     internal fun rootDir(rootDir: Path) {


### PR DESCRIPTION
Why: A part of API stability for cordformation and a common request.