### PR TITLE
Eliminate use of PublicKey (as string or binary) as primary key in database

### DIFF
--- a/core/src/main/kotlin/net/corda/core/schemas/NodeInfoSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/NodeInfoSchema.kt
@@ -85,12 +85,11 @@ object NodeInfoSchemaV1 : MappedSchema(
     @Table(name = "node_info_party_cert")
     data class DBPartyAndCertificate(
             @Id
-            @Column(name = "owning_key", length = 65535, nullable = false)
-            val owningKey: String,
-
-            //@Id // TODO Do we assume that names are unique? Note: We can't have it as Id, because our toString on X500 is inconsistent.
             @Column(name = "party_name", nullable = false)
             val name: String,
+
+            @Column(name = "owning_key", length = 65535, nullable = false)
+            val owningKey: String,
 
             @Column(name = "party_cert_binary")
             @Lob
@@ -102,10 +101,10 @@ object NodeInfoSchemaV1 : MappedSchema(
             private val persistentNodeInfos: Set<PersistentNodeInfo> = emptySet()
     ) {
         constructor(partyAndCert: PartyAndCertificate, isMain: Boolean = false)
-                : this(partyAndCert.party.owningKey.toBase58String(), partyAndCert.party.name.toString(), partyAndCert.serialize().bytes, isMain)
+                : this(partyAndCert.name.toString(), partyAndCert.party.owningKey.toBase58String(), partyAndCert.serialize().bytes, isMain)
 
         fun toLegalIdentityAndCert(): PartyAndCertificate {
-            return partyCertBinary.deserialize<PartyAndCertificate>()
+            return partyCertBinary.deserialize()
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -12,6 +12,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import net.corda.node.utilities.AppendOnlyPersistentMap
+import net.corda.node.utilities.MAX_HASH_HEX_SIZE
 import net.corda.node.utilities.NODE_DATABASE_PREFIX
 import org.bouncycastle.cert.X509CertificateHolder
 import java.io.ByteArrayInputStream
@@ -72,7 +73,7 @@ class PersistentIdentityService(identities: Iterable<PartyAndCertificate> = empt
     @javax.persistence.Table(name = "${NODE_DATABASE_PREFIX}identities")
     class PersistentIdentity(
             @Id
-            @Column(name = "pk_hash", length = 64)
+            @Column(name = "pk_hash", length = MAX_HASH_HEX_SIZE)
             var publicKeyHash: String = "",
 
             @Lob
@@ -87,7 +88,7 @@ class PersistentIdentityService(identities: Iterable<PartyAndCertificate> = empt
             @Column(name = "name", length = 128)
             var name: String = "",
 
-            @Column(name = "pk_hash", length = 64)
+            @Column(name = "pk_hash", length = MAX_HASH_HEX_SIZE)
             var publicKeyHash: String = ""
     )
 

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -8,9 +8,8 @@ import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
-import net.corda.core.utilities.parsePublicKeyBase58
-import net.corda.core.utilities.toBase58String
 import net.corda.node.utilities.AppendOnlyPersistentMap
+import net.corda.node.utilities.MAX_HASH_HEX_SIZE
 import net.corda.node.utilities.NODE_DATABASE_PREFIX
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
@@ -36,27 +35,31 @@ class PersistentKeyManagementService(val identityService: IdentityService,
     class PersistentKey(
 
             @Id
-            @Column(length = 6000, name = "public_key")
-            var publicKey: String = "",
+            @Column(name = "public_key_hash", length = MAX_HASH_HEX_SIZE)
+            var publicKeyHash: String,
+
+            @Lob
+            @Column(name = "public_key")
+            var publicKey: ByteArray = ByteArray(0),
 
             @Lob
             @Column(name = "private_key")
             var privateKey: ByteArray = ByteArray(0)
-    )
+    ) {
+        constructor(publicKey: PublicKey, privateKey: PrivateKey)
+            : this(publicKey.toStringShort(),
+                   publicKey.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes,
+                   privateKey.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes)
+    }
 
     private companion object {
         fun createKeyMap(): AppendOnlyPersistentMap<PublicKey, PrivateKey, PersistentKey, String> {
             return AppendOnlyPersistentMap(
-                    toPersistentEntityKey = { it.toBase58String() },
-                    fromPersistentEntity = {
-                        Pair(parsePublicKeyBase58(it.publicKey),
-                                it.privateKey.deserialize<PrivateKey>(context = SerializationDefaults.STORAGE_CONTEXT))
-                    },
+                    toPersistentEntityKey = { it.toStringShort() },
+                    fromPersistentEntity = { Pair(it.publicKey.deserialize(context = SerializationDefaults.STORAGE_CONTEXT),
+                                                  it.privateKey.deserialize(context = SerializationDefaults.STORAGE_CONTEXT)) },
                     toPersistentEntity = { key: PublicKey, value: PrivateKey ->
-                        PersistentKey().apply {
-                            publicKey = key.toBase58String()
-                            privateKey = value.serialize(context = SerializationDefaults.STORAGE_CONTEXT).bytes
-                        }
+                        PersistentKey(key, value)
                     },
                     persistentEntityClass = PersistentKey::class.java
             )

--- a/node/src/main/kotlin/net/corda/node/utilities/CordaPersistence.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/CordaPersistence.kt
@@ -20,6 +20,14 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 const val NODE_DATABASE_PREFIX = "node_"
 
+/**
+ * The maximum supported field-size for hash HEX-encoded outputs (e.g. database fields).
+ * This value is enough to support hash functions with outputs up to 512 bits (e.g. SHA3-512), in which
+ * case 128 HEX characters are required.
+ * 130 was selected instead of 128, to allow for 2 extra characters that will be used as hash-scheme identifiers.
+ */
+internal const val MAX_HASH_HEX_SIZE = 130
+
 //HikariDataSource implements Closeable which allows CordaPersistence to be Closeable
 class CordaPersistence(var dataSource: HikariDataSource, private val schemaService: SchemaService,
                        private val createIdentityService: () -> IdentityService, databaseProperties: Properties) : Closeable {


### PR DESCRIPTION
Retrofit changes from https://github.com/corda/enterprise/pull/61
