### PR TITLE
Add support for observer nodes (alternative approach)

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -42,6 +42,7 @@
       <module name="explorer-capsule_test" target="1.6" />
       <module name="explorer_main" target="1.8" />
       <module name="explorer_test" target="1.8" />
+      <module name="finance_integrationTest" target="1.8" />
       <module name="finance_main" target="1.8" />
       <module name="finance_test" target="1.8" />
       <module name="graphs_main" target="1.8" />

--- a/core/src/main/kotlin/net/corda/core/flows/InitiatedBy.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/InitiatedBy.kt
@@ -15,4 +15,5 @@ import kotlin.reflect.KClass
  * @see InitiatingFlow
  */
 @Target(CLASS)
+@MustBeDocumented
 annotation class InitiatedBy(val value: KClass<out FlowLogic<*>>)

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -3,6 +3,7 @@ package net.corda.core.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.internal.ResolveTransactionsFlow
+import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
 import java.security.SignatureException
@@ -14,25 +15,41 @@ import java.security.SignatureException
  * [SignedTransaction] and perform the resolution back-and-forth required to check the dependencies and download any missing
  * attachments. The flow will return the [SignedTransaction] after it is resolved and then verified using [SignedTransaction.verify].
  *
- * @param otherSideSession session to the other side which is calling [SendTransactionFlow].
- * @param checkSufficientSignatures if true checks all required signatures are present. See [SignedTransaction.verify].
+ * Please note that it will *not* store the transaction to the vault unless that is explicitly requested.
+ *
+ * @property otherSideSession session to the other side which is calling [SendTransactionFlow].
+ * @property checkSufficientSignatures if true checks all required signatures are present. See [SignedTransaction.verify].
+ * @property statesToRecord which transaction states should be recorded in the vault, if any.
  */
-class ReceiveTransactionFlow(private val otherSideSession: FlowSession,
-                             private val checkSufficientSignatures: Boolean) : FlowLogic<SignedTransaction>() {
-    /** Receives a [SignedTransaction] from [otherSideSession], verifies it and then records it in the vault. */
-    constructor(otherSideSession: FlowSession) : this(otherSideSession, true)
-
+class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSideSession: FlowSession,
+                                                       private val checkSufficientSignatures: Boolean = true,
+                                                       private val statesToRecord: StatesToRecord = StatesToRecord.NONE) : FlowLogic<SignedTransaction>() {
+    @Suppress("KDocMissingDocumentation")
     @Suspendable
     @Throws(SignatureException::class,
             AttachmentResolutionException::class,
             TransactionResolutionException::class,
             TransactionVerificationException::class)
     override fun call(): SignedTransaction {
-        return otherSideSession.receive<SignedTransaction>().unwrap {
+        if (checkSufficientSignatures) {
+            logger.trace("Receiving a transaction from ${otherSideSession.counterparty}")
+        } else {
+            logger.trace("Receiving a transaction (but without checking the signatures) from ${otherSideSession.counterparty}")
+        }
+
+        val stx = otherSideSession.receive<SignedTransaction>().unwrap {
             subFlow(ResolveTransactionsFlow(it, otherSideSession))
             it.verify(serviceHub, checkSufficientSignatures)
             it
         }
+
+        if (checkSufficientSignatures) {
+            // We should only send a transaction to the vault for processing if we did in fact fully verify it, and
+            // there are no missing signatures. We don't want partly signed stuff in the vault.
+            logger.trace("Successfully received fully signed tx ${stx.id}, sending to the vault for processing")
+            serviceHub.recordTransactions(statesToRecord, setOf(stx))
+        }
+        return stx
     }
 }
 

--- a/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ResolveTransactionsFlow.kt
@@ -5,6 +5,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
+import net.corda.core.node.StatesToRecord
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.exactAdd
@@ -94,7 +95,7 @@ class ResolveTransactionsFlow(private val txHashes: Set<SecureHash>,
             // half way through, it's no big deal, although it might result in us attempting to re-download data
             // redundantly next time we attempt verification.
             it.verify(serviceHub)
-            serviceHub.recordTransactions(false, it)
+            serviceHub.recordTransactions(StatesToRecord.NONE, listOf(it))
         }
 
         return signedTransaction?.let {

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -51,6 +51,26 @@ interface ServicesForResolution : StateLoader {
 }
 
 /**
+ * Controls whether the transaction is sent to the vault at all, and if so whether states have to be relevant
+ * or not in order to be recorded. Used in [ServiceHub.recordTransactions]
+ */
+enum class StatesToRecord {
+    /** The received transaction is not sent to the vault at all. This is used within transaction resolution. */
+    NONE,
+    /**
+     * All states that can be seen in the transaction will be recorded by the vault, even if none of the identities
+     * on this node are a participant or owner.
+     */
+    ALL_VISIBLE,
+    /**
+     * Only states that involve one of our public keys will be stored in the vault. This is the default. A public
+     * key is involved (relevant) if it's in the [OwnableState.owner] field, or appears in the [ContractState.participants]
+     * collection. This is usually equivalent to "can I change the contents of this state by signing a transaction".
+     */
+    ONLY_RELEVANT
+}
+
+/**
  * A service hub is the starting point for most operations you can do inside the node. You are provided with one
  * when a class annotated with [CordaService] is constructed, and you have access to one inside flows. Most RPCs
  * simply forward to the services found here after some access checking.
@@ -132,7 +152,9 @@ interface ServiceHub : ServicesForResolution {
      * @param txs The transactions to record.
      * @param notifyVault indicate if the vault should be notified for the update.
      */
-    fun recordTransactions(notifyVault: Boolean, txs: Iterable<SignedTransaction>)
+    fun recordTransactions(notifyVault: Boolean, txs: Iterable<SignedTransaction>) {
+        recordTransactions(if (notifyVault) StatesToRecord.ONLY_RELEVANT else StatesToRecord.NONE, txs)
+    }
 
     /**
      * Stores the given [SignedTransaction]s in the local transaction storage and then sends them to the vault for
@@ -144,10 +166,20 @@ interface ServiceHub : ServicesForResolution {
 
     /**
      * Stores the given [SignedTransaction]s in the local transaction storage and then sends them to the vault for
+     * further processing if [statesToRecord] is not [StatesToRecord.NONE].
+     * This is expected to be run within a database transaction.
+     *
+     * @param txs The transactions to record.
+     * @param statesToRecord how the vault should treat the output states of the transaction.
+     */
+    fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>)
+
+    /**
+     * Stores the given [SignedTransaction]s in the local transaction storage and then sends them to the vault for
      * further processing. This is expected to be run within a database transaction.
      */
     fun recordTransactions(first: SignedTransaction, vararg remaining: SignedTransaction) {
-        recordTransactions(true, first, *remaining)
+        recordTransactions(listOf(first, *remaining))
     }
 
     /**
@@ -155,7 +187,7 @@ interface ServiceHub : ServicesForResolution {
      * further processing. This is expected to be run within a database transaction.
      */
     fun recordTransactions(txs: Iterable<SignedTransaction>) {
-        recordTransactions(true, txs)
+        recordTransactions(StatesToRecord.ONLY_RELEVANT, txs)
     }
 
     /**

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ from the previous milestone release.
 
 UNRELEASED
 ----------
+
 * ``OpaqueBytes.bytes`` now returns a clone of its underlying ``ByteArray``, and has been redeclared as ``final``.
   This is a minor change to the public API, but is required to ensure that classes like ``SecureHash`` are immutable.
 
@@ -37,17 +38,17 @@ UNRELEASED
   ``notaryNodeAddress``, ``notaryClusterAddresses`` and ``bftSMaRt`` have also been removed and replaced by a single
   ``notary`` config object. See :doc:`corda-configuration-file` for more details.
 
-* Gradle task ``deployNodes`` can have an additional parameter `configFile` with the path to a properties file
+* Gradle task ``deployNodes`` can have an additional parameter ``configFile`` with the path to a properties file
   to be appended to node.conf.
 
-* Cordformation node building DSL can have an additional parameter `configFile` with the path to a properties file
+* Cordformation node building DSL can have an additional parameter ``configFile`` with the path to a properties file
   to be appended to node.conf.
 
 * ``FlowLogic`` now has a static method called ``sleep`` which can be used in certain circumstances to help with resolving
   contention over states in flows.  This should be used in place of any other sleep primitive since these are not compatible
   with flows and their use will be prevented at some point in the future.  Pay attention to the warnings and limitations
   described in the documentation for this method.  This helps resolve a bug in ``Cash`` coin selection.
-  A new static property `currentTopLevel` returns the top most `FlowLogic` instance, or null if not in a flow.
+  A new static property ``currentTopLevel`` returns the top most ``FlowLogic`` instance, or null if not in a flow.
 
 * ``CordaService`` annotated classes should be upgraded to take a constructor parameter of type ``AppServiceHub`` which
   allows services to start flows marked with the ``StartableByService`` annotation. For backwards compatability
@@ -65,7 +66,10 @@ UNRELEASED
 * A new function ``checkCommandVisibility(publicKey: PublicKey)`` has been added to ``FilteredTransaction`` to check
   if every command that a signer should receive (e.g. an Oracle) is indeed visible.
 
-* Change the AMQP serialiser to use the oficially assigned R3 identifier rather than a placeholder.
+* Changed the AMQP serialiser to use the oficially assigned R3 identifier rather than a placeholder.
+
+* The ``ReceiveTransactionFlow`` can now be told to record the transaction at the same time as receiving it. Using this
+  feature, better support for observer/regulator nodes has been added. See :doc:`tutorial-observer-nodes`.
 
 .. _changelog_v1:
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -6,6 +6,9 @@ Here are release notes for each snapshot release from M9 onwards.
 Unreleased
 ----------
 
+Support for observer/regulator nodes has returned. Read :doc:`tutorial-observer-nodes` to learn more or examine the
+interest rate swaps demo.
+
 Release 1.0
 -----------
 Corda 1.0 is finally here!

--- a/docs/source/tutorial-observer-nodes.rst
+++ b/docs/source/tutorial-observer-nodes.rst
@@ -1,0 +1,36 @@
+.. highlight:: kotlin
+.. raw:: html
+
+   <script type="text/javascript" src="_static/jquery.js"></script>
+   <script type="text/javascript" src="_static/codesets.js"></script>
+
+Observer nodes
+==============
+
+Posting transactions to an observer node is a common requirement in finance, where regulators often want
+to receive comprehensive reporting on all actions taken. By running their own node, regulators can receive a stream
+of digitally signed, de-duplicated reports useful for later processing.
+
+Adding support for observer nodes to your application is easy. The IRS (interest rate swap) demo shows to do it.
+
+Just define a new flow that wraps the SendTransactionFlow/ReceiveTransactionFlow, as follows:
+
+.. container:: codeset
+
+    .. literalinclude:: ../../samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
+        :language: kotlin
+        :start-after: DOCSTART 1
+        :end-before: DOCEND 1
+
+In this example, the ``AutoOfferFlow`` is the business logic, and we define two very short and simple flows to send
+the transaction to the regulator. There are two important aspects to note here:
+
+1. The ``ReportToRegulatorFlow`` is marked as an ``@InitiatingFlow`` because it will start a new conversation, context
+   free, with the regulator.
+2. The ``ReceiveRegulatoryReportFlow`` uses ``ReceiveTransactionFlow`` in a special way - it tells it to send the
+   transaction to the vault for processing, including all states even if not involving our public keys. This is required
+   because otherwise the vault will ignore states that don't list any of the node's public keys, but in this case,
+   we do want to passively observe states we can't change. So overriding this behaviour is required.
+
+If the states define a relational mapping (see :doc:`api-persistence`) then the regulator will be able to query the
+reports from their database and observe new transactions coming in via RPC.

--- a/docs/source/tutorial-observer-nodes.rst
+++ b/docs/source/tutorial-observer-nodes.rst
@@ -34,3 +34,9 @@ the transaction to the regulator. There are two important aspects to note here:
 
 If the states define a relational mapping (see :doc:`api-persistence`) then the regulator will be able to query the
 reports from their database and observe new transactions coming in via RPC.
+
+.. warning:: Nodes which act as both observers and which directly take part in the ledger are not supported at this
+   time. In particular, coin selection may return states which you do not have the private keys to be able to sign
+   for. Future versions of Corda may address this issue, but for now, if you wish to both participate in the ledger
+   and also observe transactions that you can't sign for you will need to run two nodes and have two separate
+   identities.

--- a/docs/source/tutorials-index.rst
+++ b/docs/source/tutorials-index.rst
@@ -20,3 +20,4 @@ Tutorials
    tutorial-tear-offs
    tutorial-attachments
    event-scheduling
+   tutorial-observer-nodes

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -16,10 +16,7 @@ import net.corda.core.internal.concurrent.doneFuture
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.messaging.*
-import net.corda.core.node.AppServiceHub
-import net.corda.core.node.NodeInfo
-import net.corda.core.node.ServiceHub
-import net.corda.core.node.StateLoader
+import net.corda.core.node.*
 import net.corda.core.node.services.*
 import net.corda.core.serialization.SerializationWhitelist
 import net.corda.core.serialization.SerializeAsToken
@@ -803,9 +800,9 @@ abstract class AbstractNode(config: NodeConfiguration,
             return flowFactories[initiatingFlowClass]
         }
 
-        override fun recordTransactions(notifyVault: Boolean, txs: Iterable<SignedTransaction>) {
+        override fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>) {
             database.transaction {
-                super.recordTransactions(notifyVault, txs)
+                super.recordTransactions(statesToRecord, txs)
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -274,6 +274,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
     /** @param rootPackageName only this package and subpackages may be extracted from [url], or null to allow all packages. */
     private class RestrictedURL(val url: URL, rootPackageName: String?) {
         val qualifiedNamePrefix = rootPackageName?.let { it + '.' } ?: ""
+        override fun toString() = url.toString()
     }
 
     private inner class RestrictedScanResult(private val scanResult: ScanResult, private val qualifiedNamePrefix: String) {

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -7,6 +7,7 @@ import net.corda.core.contracts.requireThat
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.ContractUpgradeUtils
+import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
 
 // TODO: We should have a whitelist of contracts we're willing to accept at all, and reject if the transaction
@@ -16,8 +17,7 @@ import net.corda.core.transactions.SignedTransaction
 class FinalityHandler(private val sender: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
-        val stx = subFlow(ReceiveTransactionFlow(sender))
-        serviceHub.recordTransactions(stx)
+        subFlow(ReceiveTransactionFlow(sender, true, StatesToRecord.ONLY_RELEVANT))
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -108,6 +108,40 @@ interface ServiceHubInternal : ServiceHub {
 
         if (statesToRecord != StatesToRecord.NONE) {
             val toNotify = recordedTransactions.map { if (it.isNotaryChangeTransaction()) it.notaryChangeTx else it.tx }
+            // When the user has requested StatesToRecord.ALL we may end up recording and relationally mapping states
+            // that do not involve us and that we cannot sign for. This will break coin selection and thus a warning
+            // is present in the documentation for this feature (see the "Observer nodes" tutorial on docs.corda.net).
+            //
+            // The reason for this is three-fold:
+            //
+            // 1) We are putting in place the observer mode feature relatively quickly to meet specific customer
+            //    launch target dates.
+            //
+            // 2) The right design for vaults which mix observations and relevant states isn't entirely clear yet.
+            //
+            // 3) If we get the design wrong it could create security problems and business confusions.
+            //
+            // Back in the bitcoinj days I did add support for "watching addresses" to the wallet code, which is the
+            // Bitcoin equivalent of observer nodes:
+            //
+            //   https://bitcoinj.github.io/working-with-the-wallet#watching-wallets
+            //
+            // The ability to have a wallet containing both irrelevant and relevant states complicated everything quite
+            // dramatically, even methods as basic as the getBalance() API which required additional modes to let you
+            // query "balance I can spend" vs "balance I am observing". In the end it might have been better to just
+            // require the user to create an entirely separate wallet for observing with.
+            //
+            // In Corda we don't support a single node having multiple vaults (at the time of writing), and it's not
+            // clear that's the right way to go: perhaps adding an "origin" column to the VAULT_STATES table is a better
+            // solution. Then you could select subsets of states depending on where the report came from.
+            //
+            // The risk of doing this is that apps/developers may use 'canned SQL queries' not written by us that forget
+            // to add a WHERE clause for the origin column. Those queries will seem to work most of the time until
+            // they're run on an observer node and mix in irrelevant data. In the worst case this may result in
+            // erroneous data being reported to the user, which could cause security problems.
+            //
+            // Because the primary use case for recording irrelevant states is observer/regulator nodes, who are unlikely
+            // to make writes to the ledger very often or at all, we choose to punt this issue for the time being.
             vaultService.notifyAll(statesToRecord, toNotify)
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.api
 
+import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.VaultService
 import net.corda.core.transactions.CoreTransaction
 import net.corda.core.transactions.NotaryChangeWireTransaction
@@ -12,8 +13,8 @@ interface VaultServiceInternal : VaultService {
      * indicate whether an update consists entirely of regular or notary change transactions, which may require
      * different processing logic.
      */
-    fun notifyAll(txns: Iterable<CoreTransaction>)
+    fun notifyAll(statesToRecord: StatesToRecord, txns: Iterable<CoreTransaction>)
 
     /** Same as notifyAll but with a single transaction. */
-    fun notify(tx: CoreTransaction) = notifyAll(listOf(tx))
+    fun notify(statesToRecord: StatesToRecord, tx: CoreTransaction) = notifyAll(statesToRecord, listOf(tx))
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSessionImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSessionImpl.kt
@@ -8,10 +8,7 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.utilities.UntrustworthyData
 
-class FlowSessionImpl(
-        override val counterparty: Party
-) : FlowSession() {
-
+class FlowSessionImpl(override val counterparty: Party) : FlowSession() {
     internal lateinit var stateMachine: FlowStateMachine<*>
     internal lateinit var sessionFlow: FlowLogic<*>
 
@@ -57,5 +54,7 @@ class FlowSessionImpl(
 
     @Suspendable
     override fun send(payload: Any) = send(payload, maySkipCheckpoint = false)
+
+    override fun toString() = "Flow session with $counterparty"
 }
 

--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -12,6 +12,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceHub
+import net.corda.core.node.StatesToRecord
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -107,11 +108,12 @@ class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
                 doReturn(myInfo).whenever(it).myInfo
                 doReturn(kms).whenever(it).keyManagementService
                 doReturn(CordappProviderImpl(CordappLoader.createWithTestPackages(listOf("net.corda.testing.contracts")), MockAttachmentStorage())).whenever(it).cordappProvider
-                doCallRealMethod().whenever(it).recordTransactions(any<SignedTransaction>())
-                doCallRealMethod().whenever(it).recordTransactions(any<Boolean>(), any<SignedTransaction>())
-                doCallRealMethod().whenever(it).recordTransactions(any(), any<Iterable<SignedTransaction>>())
+                doCallRealMethod().whenever(it).recordTransactions(any<StatesToRecord>(), any<Iterable<SignedTransaction>>())
+                doCallRealMethod().whenever(it).recordTransactions(any<Iterable<SignedTransaction>>())
+                doCallRealMethod().whenever(it).recordTransactions(any<SignedTransaction>(), anyVararg<SignedTransaction>())
                 doReturn(NodeVaultService(testClock, kms, stateLoader, database.hibernateConfig)).whenever(it).vaultService
                 doReturn(this@NodeSchedulerServiceTest).whenever(it).testReference
+
             }
             smmExecutor = AffinityExecutor.ServiceAffinityExecutor("test", 1)
             mockSMM = StateMachineManagerImpl(services, DBCheckpointStorage(), smmExecutor, database)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -5,13 +5,13 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.crypto.TransactionSignature
+import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.VaultService
 import net.corda.core.toFuture
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
 import net.corda.node.services.api.VaultServiceInternal
 import net.corda.node.services.schema.HibernateObserver
-import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.CordaPersistence
@@ -40,7 +40,6 @@ class DBTransactionStorageTests : TestDependencyInjectionBase() {
         val dataSourceProps = makeTestDataSourceProperties()
         database = configureDatabase(dataSourceProps, makeTestDatabaseProperties(), ::makeTestIdentityService)
         database.transaction {
-
             services = object : MockServices(BOB_KEY) {
                 override val vaultService: VaultServiceInternal
                     get() {
@@ -54,7 +53,7 @@ class DBTransactionStorageTests : TestDependencyInjectionBase() {
                         validatedTransactions.addTransaction(stx)
                     }
                     // Refactored to use notifyAll() as we have no other unit test for that method with multiple transactions.
-                    vaultService.notifyAll(txs.map { it.tx })
+                    vaultService.notifyAll(StatesToRecord.ONLY_RELEVANT, txs.map { it.tx })
                 }
             }
         }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.SecureHash
+import net.corda.core.node.StatesToRecord
 import net.corda.core.utilities.toBase58String
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultService
@@ -82,12 +83,12 @@ class HibernateConfigurationTest : TestDependencyInjectionBase() {
             hibernateConfig = database.hibernateConfig
             services = object : MockServices(cordappPackages, BOB_KEY, BOC_KEY, DUMMY_NOTARY_KEY) {
                 override val vaultService = makeVaultService(database.hibernateConfig)
-                override fun recordTransactions(notifyVault: Boolean, txs: Iterable<SignedTransaction>) {
+                override fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>) {
                     for (stx in txs) {
                         validatedTransactions.addTransaction(stx)
                     }
                     // Refactored to use notifyAll() as we have no other unit test for that method with multiple transactions.
-                    vaultService.notifyAll(txs.map { it.tx })
+                    vaultService.notifyAll(statesToRecord, txs.map { it.tx })
                 }
 
                 override fun jdbcSession() = database.createSession()

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -1,16 +1,15 @@
 package net.corda.node.services.vault
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.contracts.Amount
-import net.corda.core.contracts.Issued
-import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.*
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.internal.packageName
+import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.*
+import net.corda.core.node.services.vault.PageSpecification
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.QueryCriteria.*
 import net.corda.core.transactions.NotaryChangeWireTransaction
@@ -30,7 +29,6 @@ import net.corda.node.utilities.CordaPersistence
 import net.corda.testing.*
 import net.corda.testing.contracts.fillWithSomeTestCash
 import net.corda.testing.node.MockServices
-import net.corda.testing.node.MockServices.Companion.makeTestDatabaseAndMockServices
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
@@ -58,8 +56,10 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
     @Before
     fun setUp() {
         LogHelper.setLevel(NodeVaultService::class)
-        val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(BOC_KEY, DUMMY_CASH_ISSUER_KEY),
-                cordappPackages = cordappPackages)
+        val databaseAndServices = MockServices.makeTestDatabaseAndMockServices(
+                keys = listOf(BOC_KEY, DUMMY_CASH_ISSUER_KEY),
+                cordappPackages = cordappPackages
+        )
         database = databaseAndServices.first
         services = databaseAndServices.second
         issuerServices = MockServices(cordappPackages, DUMMY_CASH_ISSUER_KEY, BOC_KEY)
@@ -102,10 +102,10 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
             val originalVault = vaultService
             val services2 = object : MockServices() {
                 override val vaultService: NodeVaultService get() = originalVault
-                override fun recordTransactions(notifyVault: Boolean, txs: Iterable<SignedTransaction>) {
+                override fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>) {
                     for (stx in txs) {
                         validatedTransactions.addTransaction(stx)
-                        vaultService.notify(stx.tx)
+                        vaultService.notify(statesToRecord, stx.tx)
                     }
                 }
             }
@@ -512,14 +512,14 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
         }.toWireTransaction(services)
         val cashState = StateAndRef(issueTx.outputs.single(), StateRef(issueTx.id, 0))
 
-        database.transaction { service.notify(issueTx) }
+        database.transaction { service.notify(StatesToRecord.ONLY_RELEVANT, issueTx) }
         val expectedIssueUpdate = Vault.Update(emptySet(), setOf(cashState), null)
 
         database.transaction {
             val moveTx = TransactionBuilder(services.myInfo.chooseIdentity()).apply {
                 Cash.generateSpend(services, this, Amount(1000, GBP), thirdPartyIdentity)
             }.toWireTransaction(services)
-            service.notify(moveTx)
+            service.notify(StatesToRecord.ONLY_RELEVANT, moveTx)
         }
         val expectedMoveUpdate = Vault.Update(setOf(cashState), emptySet(), null)
 
@@ -556,7 +556,7 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
         val cashStateWithNewNotary = StateAndRef(initialCashState.state.copy(notary = newNotary), StateRef(changeNotaryTx.id, 0))
 
         database.transaction {
-            service.notifyAll(listOf(issueStx.tx, changeNotaryTx))
+            service.notifyAll(StatesToRecord.ONLY_RELEVANT, listOf(issueStx.tx, changeNotaryTx))
         }
 
         // Move cash
@@ -567,7 +567,7 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
         }
 
         database.transaction {
-            service.notify(moveTx)
+            service.notify(StatesToRecord.ONLY_RELEVANT, moveTx)
         }
 
         val expectedIssueUpdate = Vault.Update(emptySet(), setOf(initialCashState), null)
@@ -576,5 +576,33 @@ class NodeVaultServiceTest : TestDependencyInjectionBase() {
 
         val observedUpdates = vaultSubscriber.onNextEvents
         assertEquals(observedUpdates, listOf(expectedIssueUpdate, expectedNotaryChangeUpdate, expectedMoveUpdate))
+    }
+
+    @Test
+    fun observerMode() {
+        fun countCash(): Long {
+            return database.transaction {
+                vaultService.queryBy(Cash.State::class.java, QueryCriteria.VaultQueryCriteria(), PageSpecification(1)).totalStatesAvailable
+            }
+        }
+        val currentCashStates = countCash()
+
+        // Send some minimalist dummy transaction.
+        val txb = TransactionBuilder(DUMMY_NOTARY)
+        txb.addOutputState(Cash.State(MEGA_CORP.ref(0), 100.DOLLARS, MINI_CORP), Cash::class.java.name)
+        txb.addCommand(Cash.Commands.Move(), MEGA_CORP_PUBKEY)
+        val wtx = txb.toWireTransaction(services)
+        database.transaction {
+            vaultService.notify(StatesToRecord.ONLY_RELEVANT, wtx)
+        }
+
+        // Check that it was ignored as irrelevant.
+        assertEquals(currentCashStates, countCash())
+
+        // Now try again and check it was accepted.
+        database.transaction {
+            vaultService.notify(StatesToRecord.ALL_VISIBLE, wtx)
+        }
+        assertEquals(currentCashStates + 1, countCash())
     }
 }

--- a/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
+++ b/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/AutoOfferFlow.kt
@@ -2,8 +2,10 @@ package net.corda.irs.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.*
+import net.corda.core.identity.Party
 import net.corda.core.identity.excludeHostNode
 import net.corda.core.identity.groupAbstractPartyByWellKnownParty
+import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.DealState
@@ -23,7 +25,6 @@ object AutoOfferFlow {
     @InitiatingFlow
     @StartableByRPC
     class Requester(val dealToBeOffered: DealState) : FlowLogic<SignedTransaction>() {
-
         companion object {
             object RECEIVED : ProgressTracker.Step("Received API call")
             object DEALING : ProgressTracker.Step("Starting the deal flow") {
@@ -55,11 +56,45 @@ object AutoOfferFlow {
                     AutoOffer(notary, dealToBeOffered),
                     progressTracker.getChildProgressTracker(DEALING)!!
             )
-            val stx = subFlow(instigator)
-            return stx
+            return subFlow(instigator)
         }
     }
 
+    // DOCSTART 1
     @InitiatedBy(Requester::class)
-    class AutoOfferAcceptor(otherSideSession: FlowSession) : Acceptor(otherSideSession)
+    class AutoOfferAcceptor(otherSideSession: FlowSession) : Acceptor(otherSideSession) {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val finalTx = super.call()
+            // Our transaction is now committed to the ledger, so report it to our regulator. We use a custom flow
+            // that wraps SendTransactionFlow to allow the receiver to customise how ReceiveTransactionFlow is run,
+            // and because in a real life app you'd probably have more complex logic here e.g. describing why the report
+            // was filed, checking that the reportee is a regulated entity and not some random node from the wrong
+            // country and so on.
+            val regulator = serviceHub.identityService.partiesFromName("Regulator", true).single()
+            subFlow(ReportToRegulatorFlow(regulator, finalTx))
+            return finalTx
+        }
+
+    }
+
+    @InitiatingFlow
+    class ReportToRegulatorFlow(private val regulator: Party, private val finalTx: SignedTransaction) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val session = initiateFlow(regulator)
+            subFlow(SendTransactionFlow(session, finalTx))
+        }
+    }
+
+    @InitiatedBy(ReportToRegulatorFlow::class)
+    class ReceiveRegulatoryReportFlow(private val otherSideSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            // Start the matching side of SendTransactionFlow above, but tell it to record all visible states even
+            // though they (as far as the node can tell) are nothing to do with us.
+            subFlow(ReceiveTransactionFlow(otherSideSession, true, StatesToRecord.ALL_VISIBLE))
+        }
+    }
+    // DOCEND 1
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -9,10 +9,7 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.FlowProgressHandle
-import net.corda.core.node.AppServiceHub
-import net.corda.core.node.NodeInfo
-import net.corda.core.node.ServiceHub
-import net.corda.core.node.StateLoader
+import net.corda.core.node.*
 import net.corda.core.node.services.*
 import net.corda.core.serialization.SerializeAsToken
 import net.corda.core.serialization.SingletonSerializeAsToken
@@ -30,7 +27,6 @@ import net.corda.node.services.persistence.HibernateConfiguration
 import net.corda.node.services.persistence.InMemoryStateMachineRecordedTransactionMappingStorage
 import net.corda.node.services.schema.HibernateObserver
 import net.corda.node.services.schema.NodeSchemaService
-import net.corda.node.services.statemachine.FlowStateMachineImpl
 import net.corda.node.services.transactions.InMemoryTransactionVerifierService
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.CordaPersistence
@@ -101,7 +97,7 @@ open class MockServices(
 
         /**
          * Makes database and mock services appropriate for unit tests.
-         * @param keys a list of [KeyPair] instances to be used by [MockServices]. Defualts to [MEGA_CORP_KEY]
+         * @param keys a list of [KeyPair] instances to be used by [MockServices]. Defaults to [MEGA_CORP_KEY]
          * @param createIdentityService a lambda function returning an instance of [IdentityService]. Defauts to [InMemoryIdentityService].
          *
          * @return a pair where the first element is the instance of [CordaPersistence] and the second is [MockServices].
@@ -118,14 +114,14 @@ open class MockServices(
             val mockService = database.transaction {
                 object : MockServices(cordappLoader, *(keys.toTypedArray())) {
                     override val identityService: IdentityService = database.transaction { identityServiceRef }
-                    override val vaultService = makeVaultService(database.hibernateConfig)
+                    override val vaultService: VaultServiceInternal = makeVaultService(database.hibernateConfig)
 
-                    override fun recordTransactions(notifyVault: Boolean, txs: Iterable<SignedTransaction>) {
+                    override fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>) {
                         for (stx in txs) {
                             validatedTransactions.addTransaction(stx)
                         }
                         // Refactored to use notifyAll() as we have no other unit test for that method with multiple transactions.
-                        vaultService.notifyAll(txs.map { it.tx })
+                        vaultService.notifyAll(statesToRecord, txs.map { it.tx })
                     }
 
                     override fun jdbcSession(): Connection = database.createSession()
@@ -142,7 +138,7 @@ open class MockServices(
 
     val key: KeyPair get() = keys.first()
 
-    override fun recordTransactions(notifyVault: Boolean, txs: Iterable<SignedTransaction>) {
+    override fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>) {
         txs.forEach {
             stateMachineRecordedTransactionMapping.addMapping(StateMachineRunId.createRandom(), it.id)
         }


### PR DESCRIPTION
This PR adds support for observer nodes in a different way to PR #1918 - the primary differences are:

* No tagging of states
* No new demo, just a small extension to the IRS demo
* There is no distinction in vault queries or observables between observed or not-observed states.
* Whether states should be "observed" or not is passed through the API from the flows, rather than inferred by the vault based on the state contents.

The latter approach avoids verb/noun type conceptual mixup and solves the probably common case where two sides to a transaction wish to report the same transaction to different regulators (which would otherwise require both to be listed in the observers and involve both receiving duplicated reports). In the case where the regulatory reporting process is more involved than just dispatching a transaction e.g. more country-specific data is required, it makes sense to me to let the developer control this process.

It's possible that some apps could benefit from separation between relevant/irrelevant states at the level of the observables. This would seem to be an issue when a regulator is e.g. also making payments of their own, on the ledger, and an app is written to assume all states entering the vault are relevant. However, it's easy to solve this later by simply extending the vault API to let you request filtered streams of updates, and coin selection should at any rate ignore irrelevant transactions. For now we can simply punt on the issue of a regulator that also interacts on the ledger themselves using apps not written with that scenario in mind.

The change is a fair bit smaller as a consequence of these differences.