### PR TITLE
checkpoint checker thread

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -102,7 +102,7 @@ class NodePerformanceTests {
 
     @Test
     fun `self pay rate`() {
-        driver(startNodesInProcess = true) {
+        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance")) {
             val a = startNotaryNode(
                     DUMMY_NOTARY.name,
                     rpcUsers = listOf(User("A", "A", setOf(startFlowPermission<CashIssueFlow>(), startFlowPermission<CashPaymentFlow>())))

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -36,6 +36,10 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val notary: NotaryConfig?
     val activeMQServer: ActiveMqServerConfiguration
     val additionalNodeInfoPollingFrequencyMsec: Long
+
+    companion object {
+        val disableCheckpointCheckerFlag = "disableCheckpointChecker"
+    }
 }
 
 fun NodeConfiguration.isDevModeOptionsFlagSet(flag: String):Boolean{

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -28,6 +28,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val database: Properties?
     val rpcUsers: List<User>
     val devMode: Boolean
+    val debugOptions: Properties?
     val certificateSigningService: URL
     val certificateChainCheckPolicies: List<CertChainPolicyConfig>
     val verifierType: VerifierType
@@ -93,6 +94,7 @@ data class FullNodeConfiguration(
         override val notary: NotaryConfig?,
         override val certificateChainCheckPolicies: List<CertChainPolicyConfig>,
         override val devMode: Boolean = false,
+        override val debugOptions: Properties? = null,
         val useTestClock: Boolean = false,
         val detectPublicIp: Boolean = true,
         override val activeMQServer: ActiveMqServerConfiguration,
@@ -103,6 +105,7 @@ data class FullNodeConfiguration(
     init {
         // This is a sanity feature do not remove.
         require(!useTestClock || devMode) { "Cannot use test clock outside of dev mode" }
+        require(debugOptions == null || devMode){"Cannot use debugOptions outside of dev mode"}
         // TODO Move this to ArtemisMessagingServer
         rpcUsers.forEach {
             require(it.username.matches("\\w+".toRegex())) { "Username ${it.username} contains invalid characters" }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -42,7 +42,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     }
 }
 
-fun NodeConfiguration.isDevModeOptionsFlagSet(flag: String):Boolean{
+fun NodeConfiguration.isDevModeOptionsFlagSet(flag: String): Boolean {
     return this.devModeOptions?.get(flag).toString().toLowerCase() == "true"
 }
 
@@ -113,7 +113,7 @@ data class FullNodeConfiguration(
     init {
         // This is a sanity feature do not remove.
         require(!useTestClock || devMode) { "Cannot use test clock outside of dev mode" }
-        require(devModeOptions == null || devMode){ "Cannot use devModeOptions outside of dev mode" }
+        require(devModeOptions == null || devMode) { "Cannot use devModeOptions outside of dev mode" }
         // TODO Move this to ArtemisMessagingServer
         rpcUsers.forEach {
             require(it.username.matches("\\w+".toRegex())) { "Username ${it.username} contains invalid characters" }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -11,6 +11,8 @@ import java.net.URL
 import java.nio.file.Path
 import java.util.*
 
+data class DevModeOptions(val disableCheckpointChecker: Boolean?)
+
 interface NodeConfiguration : NodeSSLConfiguration {
     // myLegalName should be only used in the initial network registration, we should use the name from the certificate instead of this.
     // TODO: Remove this so we don't accidentally use this identity in the code?
@@ -28,7 +30,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val database: Properties?
     val rpcUsers: List<User>
     val devMode: Boolean
-    val devModeOptions: Properties?
+    val devModeOptions: DevModeOptions?
     val certificateSigningService: URL
     val certificateChainCheckPolicies: List<CertChainPolicyConfig>
     val verifierType: VerifierType
@@ -40,10 +42,6 @@ interface NodeConfiguration : NodeSSLConfiguration {
     companion object {
         const val DISABLE_CHECKPOINT_CHECKER = "disableCheckpointChecker"
     }
-}
-
-fun NodeConfiguration.isDevModeOptionsFlagSet(flag: String): Boolean {
-    return this.devModeOptions?.get(flag).toString().toLowerCase() == "true"
 }
 
 data class NotaryConfig(val validating: Boolean,
@@ -102,7 +100,7 @@ data class FullNodeConfiguration(
         override val notary: NotaryConfig?,
         override val certificateChainCheckPolicies: List<CertChainPolicyConfig>,
         override val devMode: Boolean = false,
-        override val devModeOptions: Properties? = null,
+        override val devModeOptions: DevModeOptions? = null,
         val useTestClock: Boolean = false,
         val detectPublicIp: Boolean = true,
         override val activeMQServer: ActiveMqServerConfiguration,

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -28,7 +28,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val database: Properties?
     val rpcUsers: List<User>
     val devMode: Boolean
-    val debugOptions: Properties?
+    val devModeOptions: Properties?
     val certificateSigningService: URL
     val certificateChainCheckPolicies: List<CertChainPolicyConfig>
     val verifierType: VerifierType
@@ -36,6 +36,10 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val notary: NotaryConfig?
     val activeMQServer: ActiveMqServerConfiguration
     val additionalNodeInfoPollingFrequencyMsec: Long
+}
+
+fun NodeConfiguration.isDevModeOptionsFlagSet(flag: String):Boolean{
+    return this.devModeOptions?.get(flag).toString().toLowerCase() == "true"
 }
 
 data class NotaryConfig(val validating: Boolean,
@@ -94,7 +98,7 @@ data class FullNodeConfiguration(
         override val notary: NotaryConfig?,
         override val certificateChainCheckPolicies: List<CertChainPolicyConfig>,
         override val devMode: Boolean = false,
-        override val debugOptions: Properties? = null,
+        override val devModeOptions: Properties? = null,
         val useTestClock: Boolean = false,
         val detectPublicIp: Boolean = true,
         override val activeMQServer: ActiveMqServerConfiguration,
@@ -105,7 +109,7 @@ data class FullNodeConfiguration(
     init {
         // This is a sanity feature do not remove.
         require(!useTestClock || devMode) { "Cannot use test clock outside of dev mode" }
-        require(debugOptions == null || devMode){"Cannot use debugOptions outside of dev mode"}
+        require(devModeOptions == null || devMode){ "Cannot use devModeOptions outside of dev mode" }
         // TODO Move this to ArtemisMessagingServer
         rpcUsers.forEach {
             require(it.username.matches("\\w+".toRegex())) { "Username ${it.username} contains invalid characters" }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -38,7 +38,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val additionalNodeInfoPollingFrequencyMsec: Long
 
     companion object {
-        val disableCheckpointCheckerFlag = "disableCheckpointChecker"
+        const val DISABLE_CHECKPOINT_CHECKER = "disableCheckpointChecker"
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -31,6 +31,7 @@ import net.corda.node.internal.InitiatedFlowFactory
 import net.corda.node.services.api.Checkpoint
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.ServiceHubInternal
+import net.corda.node.services.config.isDevModeOptionsFlagSet
 import net.corda.node.services.messaging.ReceivedMessage
 import net.corda.node.services.messaging.TopicSession
 import net.corda.node.utilities.*
@@ -43,7 +44,6 @@ import rx.subjects.PublishSubject
 import java.io.NotSerializableException
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit.SECONDS
 import javax.annotation.concurrent.ThreadSafe
 
@@ -89,7 +89,7 @@ class StateMachineManagerImpl(
     private val scheduler = FiberScheduler()
     private val mutex = ThreadBox(InnerState())
     // This thread (only enabled in dev mode) deserialises checkpoints in the background to shake out bugs in checkpoint restore.
-    private val checkpointCheckerThread = if (serviceHub.configuration.devMode && serviceHub.configuration.debugOptions?.getProperty("disableCheckpointChecking") != "true") newNamedSingleThreadExecutor("CheckpointChecker") else null
+    private val checkpointCheckerThread = if (serviceHub.configuration.devMode && !serviceHub.configuration.isDevModeOptionsFlagSet("disableCheckpointChecking")) newNamedSingleThreadExecutor("CheckpointChecker") else null
 
     @Volatile private var unrestorableCheckpoints = false
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -32,7 +32,6 @@ import net.corda.node.services.api.Checkpoint
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.config.NodeConfiguration
-import net.corda.node.services.config.isDevModeOptionsFlagSet
 import net.corda.node.services.messaging.ReceivedMessage
 import net.corda.node.services.messaging.TopicSession
 import net.corda.node.utilities.*
@@ -91,7 +90,7 @@ class StateMachineManagerImpl(
     private val mutex = ThreadBox(InnerState())
     // This thread (only enabled in dev mode) deserialises checkpoints in the background to shake out bugs in checkpoint restore.
     private val checkpointCheckerThread = if (serviceHub.configuration.devMode
-            && !serviceHub.configuration.isDevModeOptionsFlagSet(NodeConfiguration.DISABLE_CHECKPOINT_CHECKER))
+            && serviceHub.configuration.devModeOptions?.disableCheckpointChecker != true)
         newNamedSingleThreadExecutor("CheckpointChecker") else null
 
     @Volatile private var unrestorableCheckpoints = false

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -33,10 +33,7 @@ import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.messaging.ReceivedMessage
 import net.corda.node.services.messaging.TopicSession
-import net.corda.node.utilities.AffinityExecutor
-import net.corda.node.utilities.CordaPersistence
-import net.corda.node.utilities.bufferUntilDatabaseCommit
-import net.corda.node.utilities.wrapWithDatabaseTransaction
+import net.corda.node.utilities.*
 import net.corda.nodeapi.internal.serialization.SerializeAsTokenContextImpl
 import net.corda.nodeapi.internal.serialization.withTokenContext
 import org.apache.activemq.artemis.utils.ReusableLatch
@@ -92,7 +89,7 @@ class StateMachineManagerImpl(
     private val scheduler = FiberScheduler()
     private val mutex = ThreadBox(InnerState())
     // This thread (only enabled in dev mode) deserialises checkpoints in the background to shake out bugs in checkpoint restore.
-    private val checkpointCheckerThread = if (serviceHub.configuration.devMode) Executors.newSingleThreadExecutor() else null
+    private val checkpointCheckerThread = if (serviceHub.configuration.devMode && serviceHub.configuration.debugOptions?.getProperty("disableCheckpointChecking") != "true") newNamedSingleThreadExecutor("CheckpointChecker") else null
 
     @Volatile private var unrestorableCheckpoints = false
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -91,7 +91,7 @@ class StateMachineManagerImpl(
     private val mutex = ThreadBox(InnerState())
     // This thread (only enabled in dev mode) deserialises checkpoints in the background to shake out bugs in checkpoint restore.
     private val checkpointCheckerThread = if (serviceHub.configuration.devMode
-            && !serviceHub.configuration.isDevModeOptionsFlagSet(NodeConfiguration.disableCheckpointCheckerFlag))
+            && !serviceHub.configuration.isDevModeOptionsFlagSet(NodeConfiguration.DISABLE_CHECKPOINT_CHECKER))
         newNamedSingleThreadExecutor("CheckpointChecker") else null
 
     @Volatile private var unrestorableCheckpoints = false

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -31,6 +31,7 @@ import net.corda.node.internal.InitiatedFlowFactory
 import net.corda.node.services.api.Checkpoint
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.ServiceHubInternal
+import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.isDevModeOptionsFlagSet
 import net.corda.node.services.messaging.ReceivedMessage
 import net.corda.node.services.messaging.TopicSession
@@ -89,7 +90,9 @@ class StateMachineManagerImpl(
     private val scheduler = FiberScheduler()
     private val mutex = ThreadBox(InnerState())
     // This thread (only enabled in dev mode) deserialises checkpoints in the background to shake out bugs in checkpoint restore.
-    private val checkpointCheckerThread = if (serviceHub.configuration.devMode && !serviceHub.configuration.isDevModeOptionsFlagSet("disableCheckpointChecking")) newNamedSingleThreadExecutor("CheckpointChecker") else null
+    private val checkpointCheckerThread = if (serviceHub.configuration.devMode
+            && !serviceHub.configuration.isDevModeOptionsFlagSet(NodeConfiguration.disableCheckpointCheckerFlag))
+        newNamedSingleThreadExecutor("CheckpointChecker") else null
 
     @Volatile private var unrestorableCheckpoints = false
 

--- a/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
@@ -14,6 +14,6 @@ class NamedThreadFactory(private val name:String, private val underlyingFactory:
     }
 }
 
-fun newNamedSinleThreadExecutor(name: String): ExecutorService {
+fun newNamedSingleThreadExecutor(name: String): ExecutorService {
     return Executors.newSingleThreadExecutor(NamedThreadFactory(name, Executors.defaultThreadFactory()))
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
@@ -5,15 +5,25 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
 
+
+/**
+ * Utility class that allows to give threads arbitrary name prefixes when they are created
+ * via an executor. It will use an underlying thread factory to create the actual thread
+ * and then override the thread name with the prefix and an ever increasing number
+ */
 class NamedThreadFactory(private val name:String, private val underlyingFactory: ThreadFactory) : ThreadFactory{
     val threadNumber = AtomicInteger(1)
-    override fun newThread(r: Runnable?): Thread {
-        val t = underlyingFactory.newThread(r)
-        t.name = name + "-" + threadNumber.getAndIncrement()
-        return t
+    override fun newThread(runnable: Runnable?): Thread {
+        val thread = underlyingFactory.newThread(runnable)
+        thread.name = name + "-" + threadNumber.getAndIncrement()
+        return thread
     }
 }
 
+/**
+ * Create a single thread executor with a NamedThreadFactory based on the default thread factory
+ * defined in java.util.concurrent.Executors
+ */
 fun newNamedSingleThreadExecutor(name: String): ExecutorService {
     return Executors.newSingleThreadExecutor(NamedThreadFactory(name, Executors.defaultThreadFactory()))
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
@@ -1,0 +1,19 @@
+package net.corda.node.utilities
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+class NamedThreadFactory(private val name:String, private val underlyingFactory: ThreadFactory) : ThreadFactory{
+    val threadNumber = AtomicInteger(1)
+    override fun newThread(r: Runnable?): Thread {
+        val t = underlyingFactory.newThread(r)
+        t.name = name + "-" + threadNumber.getAndIncrement()
+        return t
+    }
+}
+
+fun newNamedSinleThreadExecutor(name: String): ExecutorService {
+    return Executors.newSingleThreadExecutor(NamedThreadFactory(name, Executors.defaultThreadFactory()))
+}

--- a/node/src/test/kotlin/net/corda/node/services/config/FullNodeConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/FullNodeConfigurationTest.kt
@@ -10,6 +10,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import java.net.URL
 import java.nio.file.Paths
+import java.util.*
+import kotlin.test.assertFalse
 
 class FullNodeConfigurationTest {
     @Test
@@ -43,4 +45,74 @@ class FullNodeConfigurationTest {
         assertThatThrownBy { configWithRPCUsername("user*1") }.hasMessageContaining("*")
         assertThatThrownBy { configWithRPCUsername("user#1") }.hasMessageContaining("#")
     }
+
+    @Test
+    fun `Can't have debug options if not in dev mode`() {
+        val testConfiguration = FullNodeConfiguration(
+                baseDirectory = Paths.get("."),
+                myLegalName = ALICE.name,
+                networkMapService = null,
+                emailAddress = "",
+                keyStorePassword = "cordacadevpass",
+                trustStorePassword = "trustpass",
+                dataSourceProperties = makeTestDataSourceProperties(ALICE.name.organisation),
+                database = makeTestDatabaseProperties(),
+                certificateSigningService = URL("http://localhost"),
+                rpcUsers = emptyList(),
+                verifierType = VerifierType.InMemory,
+                useHTTPS = false,
+                p2pAddress = NetworkHostAndPort("localhost", 0),
+                rpcAddress = NetworkHostAndPort("localhost", 1),
+                messagingServerAddress = null,
+                notary = null,
+                certificateChainCheckPolicies = emptyList(),
+                devMode = true,
+                activeMQServer = ActiveMqServerConfiguration(BridgeConfiguration(0, 0, 0.0)),
+                additionalNodeInfoPollingFrequencyMsec = 5.seconds.toMillis())
+
+        fun configDebugOptions(devMode: Boolean, debugOptions: Properties?) {
+            testConfiguration.copy(devMode = devMode, debugOptions = debugOptions)
+        }
+        val debugOptions = Properties()
+        configDebugOptions(true, debugOptions)
+        configDebugOptions(true,null)
+        assertThatThrownBy{configDebugOptions(false, debugOptions)}.hasMessageMatching("Cannot use debugOptions outside of dev mode")
+        configDebugOptions(false,null)
+    }
+
+    @Test
+    fun `check properties behave as expected`()
+    {
+        val testConfiguration = FullNodeConfiguration(
+                baseDirectory = Paths.get("."),
+                myLegalName = ALICE.name,
+                networkMapService = null,
+                emailAddress = "",
+                keyStorePassword = "cordacadevpass",
+                trustStorePassword = "trustpass",
+                dataSourceProperties = makeTestDataSourceProperties(ALICE.name.organisation),
+                database = makeTestDatabaseProperties(),
+                certificateSigningService = URL("http://localhost"),
+                rpcUsers = emptyList(),
+                verifierType = VerifierType.InMemory,
+                useHTTPS = false,
+                p2pAddress = NetworkHostAndPort("localhost", 0),
+                rpcAddress = NetworkHostAndPort("localhost", 1),
+                messagingServerAddress = null,
+                notary = null,
+                certificateChainCheckPolicies = emptyList(),
+                devMode = true,
+                activeMQServer = ActiveMqServerConfiguration(BridgeConfiguration(0, 0, 0.0)),
+                additionalNodeInfoPollingFrequencyMsec = 5.seconds.toMillis())
+
+        fun configDebugOptions(devMode: Boolean, debugOptions: Properties?) : NodeConfiguration {
+            return testConfiguration.copy(devMode = devMode, debugOptions = debugOptions)
+        }
+        val debugOptions = Properties()
+        assertFalse { configDebugOptions(true, debugOptions).debugOptions?.getProperty("foo") == "bar"}
+        assertFalse { configDebugOptions(true,null).debugOptions?.getProperty("foo") == "bar"}
+        debugOptions.setProperty("foo", "bar")
+        assert( configDebugOptions(true, debugOptions).debugOptions?.getProperty("foo") == "bar")
+    }
+
 }

--- a/node/src/test/kotlin/net/corda/node/services/config/FullNodeConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/FullNodeConfigurationTest.kt
@@ -70,10 +70,10 @@ class FullNodeConfigurationTest {
                 activeMQServer = ActiveMqServerConfiguration(BridgeConfiguration(0, 0, 0.0)),
                 additionalNodeInfoPollingFrequencyMsec = 5.seconds.toMillis())
 
-        fun configDebugOptions(devMode: Boolean, debugOptions: Properties?) {
+        fun configDebugOptions(devMode: Boolean, debugOptions: DevModeOptions?) {
             testConfiguration.copy(devMode = devMode, devModeOptions = debugOptions)
         }
-        val debugOptions = Properties()
+        val debugOptions = DevModeOptions(null)
         configDebugOptions(true, debugOptions)
         configDebugOptions(true,null)
         assertThatThrownBy{configDebugOptions(false, debugOptions)}.hasMessageMatching( "Cannot use devModeOptions outside of dev mode" )
@@ -105,14 +105,13 @@ class FullNodeConfigurationTest {
                 activeMQServer = ActiveMqServerConfiguration(BridgeConfiguration(0, 0, 0.0)),
                 additionalNodeInfoPollingFrequencyMsec = 5.seconds.toMillis())
 
-        fun configDebugOptions(devMode: Boolean, debugOptions: Properties?) : NodeConfiguration {
-            return testConfiguration.copy(devMode = devMode, devModeOptions = debugOptions)
+        fun configDebugOptions(devMode: Boolean, devModeOptions: DevModeOptions?) : NodeConfiguration {
+            return testConfiguration.copy(devMode = devMode, devModeOptions = devModeOptions)
         }
-        val debugOptions = Properties()
-        assertFalse { configDebugOptions(true,null).isDevModeOptionsFlagSet("foo")}
-        assertFalse { configDebugOptions(true,debugOptions).isDevModeOptionsFlagSet("foo")}
-        debugOptions.setProperty("foo", "tRuE")
-        assert( configDebugOptions(true, debugOptions).isDevModeOptionsFlagSet("foo"))
+        assertFalse { configDebugOptions(true,null).devModeOptions?.disableCheckpointChecker == true}
+        assertFalse { configDebugOptions(true,DevModeOptions(null)).devModeOptions?.disableCheckpointChecker == true}
+        assertFalse { configDebugOptions(true,DevModeOptions(false)).devModeOptions?.disableCheckpointChecker == true}
+        assert ( configDebugOptions(true,DevModeOptions(true)).devModeOptions?.disableCheckpointChecker == true)
     }
 
 }

--- a/node/src/test/kotlin/net/corda/node/services/config/FullNodeConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/FullNodeConfigurationTest.kt
@@ -71,17 +71,17 @@ class FullNodeConfigurationTest {
                 additionalNodeInfoPollingFrequencyMsec = 5.seconds.toMillis())
 
         fun configDebugOptions(devMode: Boolean, debugOptions: Properties?) {
-            testConfiguration.copy(devMode = devMode, debugOptions = debugOptions)
+            testConfiguration.copy(devMode = devMode, devModeOptions = debugOptions)
         }
         val debugOptions = Properties()
         configDebugOptions(true, debugOptions)
         configDebugOptions(true,null)
-        assertThatThrownBy{configDebugOptions(false, debugOptions)}.hasMessageMatching("Cannot use debugOptions outside of dev mode")
+        assertThatThrownBy{configDebugOptions(false, debugOptions)}.hasMessageMatching( "Cannot use devModeOptions outside of dev mode" )
         configDebugOptions(false,null)
     }
 
     @Test
-    fun `check properties behave as expected`()
+    fun `check devModeOptions flag helper`()
     {
         val testConfiguration = FullNodeConfiguration(
                 baseDirectory = Paths.get("."),
@@ -106,13 +106,13 @@ class FullNodeConfigurationTest {
                 additionalNodeInfoPollingFrequencyMsec = 5.seconds.toMillis())
 
         fun configDebugOptions(devMode: Boolean, debugOptions: Properties?) : NodeConfiguration {
-            return testConfiguration.copy(devMode = devMode, debugOptions = debugOptions)
+            return testConfiguration.copy(devMode = devMode, devModeOptions = debugOptions)
         }
         val debugOptions = Properties()
-        assertFalse { configDebugOptions(true, debugOptions).debugOptions?.getProperty("foo") == "bar"}
-        assertFalse { configDebugOptions(true,null).debugOptions?.getProperty("foo") == "bar"}
-        debugOptions.setProperty("foo", "bar")
-        assert( configDebugOptions(true, debugOptions).debugOptions?.getProperty("foo") == "bar")
+        assertFalse { configDebugOptions(true,null).isDevModeOptionsFlagSet("foo")}
+        assertFalse { configDebugOptions(true,debugOptions).isDevModeOptionsFlagSet("foo")}
+        debugOptions.setProperty("foo", "tRuE")
+        assert( configDebugOptions(true, debugOptions).isDevModeOptionsFlagSet("foo"))
     }
 
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
@@ -78,6 +78,7 @@ fun testNodeConfiguration(
         doReturn(5).whenever(it).messageRedeliveryDelaySeconds
         doReturn(0L).whenever(it).additionalNodeInfoPollingFrequencyMsec
         doReturn(null).whenever(it).networkMapService
+        doReturn(null).whenever(it).devModeOptions
         doCallRealMethod().whenever(it).certificatesDirectory
         doCallRealMethod().whenever(it).trustStoreFile
         doCallRealMethod().whenever(it).sslKeystore


### PR DESCRIPTION
- Give  the checkpoint checker thread a meaningful name so it can be identified while debugging or profiling
- Add devModeOptions as a bag of options that can be set for dev mode and add an options to turn the checkpoint checker off in dev mode (e.g. for profiling)