### PR TITLE
CORDA-751: Eliminate duplicating entry for classpath when OutOfProcess node is started

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -1022,7 +1022,7 @@ class DriverDSL(
                 )
                 // See experimental/quasar-hook/README.md for how to generate.
                 val excludePattern = "x(antlr**;bftsmart**;ch**;co.paralleluniverse**;com.codahale**;com.esotericsoftware**;com.fasterxml**;com.google**;com.ibm**;com.intellij**;com.jcabi**;com.nhaarman**;com.opengamma**;com.typesafe**;com.zaxxer**;de.javakaffee**;groovy**;groovyjarjarantlr**;groovyjarjarasm**;io.atomix**;io.github**;io.netty**;jdk**;joptsimple**;junit**;kotlin**;net.bytebuddy**;net.i2p**;org.apache**;org.assertj**;org.bouncycastle**;org.codehaus**;org.crsh**;org.dom4j**;org.fusesource**;org.h2**;org.hamcrest**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.junit**;org.mockito**;org.objectweb**;org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**)"
-                val extraJvmArguments = systemProperties.map { "-D${it.key}=${it.value}" } +
+                val extraJvmArguments = systemProperties.removeResolvedClasspath().map { "-D${it.key}=${it.value}" } +
                         "-javaagent:$quasarJarPath=$excludePattern"
                 val loggingLevel = if (debugPort == null) "INFO" else "DEBUG"
 
@@ -1074,6 +1074,14 @@ class DriverDSL(
                     .first { it.fileName != "Driver.kt" }
                     .let { Class.forName(it.className).`package`?.name }
                     ?: throw IllegalStateException("Function instantiating driver must be defined in a package.")
+        }
+
+        /**
+         * We have an alternative way of specifying classpath for spawned process: by using "-cp" option. So duplicating the setting of this
+         * rather long string is un-necessary and can be harmful on Windows.
+         */
+        private fun Map<String, Any>.removeResolvedClasspath(): Map<String, Any> {
+            return filterNot { it.key == "java.class.path" }
         }
     }
 }


### PR DESCRIPTION
Please see Jira for background info.
The change should help all the Windows developers.

Closer examination shows that in the command line we include the classpath of size ~20,000 characters twice.
Once with `-cp` option - which is fine and second time with `-Djava.class.path=` - the latter is completely unnecessary and can be eliminated shortening the command length dramatically to around: 24,000 characters which should give us some leg room for further expanding the classpath.