### PR TITLE
Allow Gradle to set dependency between Jar and ScanApi tasks.

### DIFF
--- a/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
+++ b/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
@@ -32,11 +32,11 @@ public class ApiScanner implements Plugin<Project> {
             project.getLogger().info("Adding scanApi task to {}", project.getName());
             project.getTasks().create("scanApi", ScanApi.class, scanTask -> {
                 scanTask.setClasspath(compilationClasspath(project.getConfigurations()));
+                // Automatically creates a dependency on jar tasks.
                 scanTask.setSources(project.files(jarTasks));
                 scanTask.setExcludeClasses(extension.getExcludeClasses());
                 scanTask.setVerbose(extension.isVerbose());
                 scanTask.setEnabled(extension.isEnabled());
-                scanTask.dependsOn(jarTasks);
 
                 // Declare this ScanApi task to be a dependency of any
                 // GenerateApi tasks belonging to any of our ancestors.


### PR DESCRIPTION
Trivial fix that still applies to Gradle 4.1.
Gradle will set the dependency between the `jar` and `scanApi` tasks automatically because the input source is a `ConfigurableFileCollection`.

There is no functional change, so this can wait for the next plugins release.