### PR TITLE
[CORDA-446] Remove mentions of networkmap node in DemoBench

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/InstallFactory.kt
@@ -25,10 +25,6 @@ class InstallFactory : Controller() {
 
         val tempDir = Files.createTempDirectory(baseDir, ".node")
 
-        if (nodeConfig.isNetworkMap) {
-            log.info("Node '${nodeConfig.myLegalName}' is the network map")
-        }
-
         return InstallConfig(tempDir, NodeConfigWrapper(tempDir, nodeConfig))
     }
 }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -22,7 +22,6 @@ data class NodeConfig(
         /** This is not used by the node but by the webserver which looks at node.conf. */
         val webAddress: NetworkHostAndPort,
         val notary: NotaryService?,
-        val networkMapService: NetworkMapConfig?,
         val h2port: Int,
         val rpcUsers: List<User> = listOf(defaultUser),
         /** This is an extra config used by the Cash app. */
@@ -39,15 +38,8 @@ data class NodeConfig(
     @Suppress("unused")
     private val useTestClock = true
 
-    val isNetworkMap: Boolean get() = networkMapService == null
-
     fun toText(): String = toConfig().root().render(renderOptions)
 }
-
-/**
- * This is a mirror of NetworkMapInfo.
- */
-data class NetworkMapConfig(val legalName: CordaX500Name, val address: NetworkHostAndPort)
 
 /**
  * This is a subset of NotaryConfig. It implements [ExtraService] to avoid unnecessary copying.

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -114,7 +114,7 @@ class NodeTabView : Fragment() {
 
                 fieldset("Additional configuration") {
                     styleClass.addAll("services-panel")
-                    val extraServices = if (nodeController.hasNetworkMap()) {
+                    val extraServices = if (nodeController.hasNotary()) {
                         listOf(USD, GBP, CHF, EUR).map { CurrencyIssuer(it) }
                     } else {
                         listOf(NotaryService(true), NotaryService(false))
@@ -123,7 +123,7 @@ class NodeTabView : Fragment() {
                     val servicesList = CheckListView(extraServices.observable()).apply {
                         vboxConstraints { vGrow = Priority.ALWAYS }
                         model.item.extraServices.set(checkModel.checkedItems)
-                        if (!nodeController.hasNetworkMap()) {
+                        if (!nodeController.hasNotary()) {
                             checkModel.check(0)
                             checkModel.checkedItems.addListener(ListChangeListener { change ->
                                 while (change.next()) {

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -7,7 +7,6 @@ import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.services.config.parseAsNodeConfiguration
 import net.corda.nodeapi.User
 import net.corda.nodeapi.config.toConfig
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.webserver.WebServerConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -32,7 +31,6 @@ class NodeConfigTest {
                 webPort = 20001,
                 h2port = 30001,
                 notary = NotaryService(validating = false),
-                networkMap = NetworkMapConfig(DUMMY_NOTARY.name, localPort(12345)),
                 users = listOf(user("jenny"))
         )
 
@@ -60,7 +58,6 @@ class NodeConfigTest {
                 webPort = 20001,
                 h2port = 30001,
                 notary = NotaryService(validating = false),
-                networkMap = NetworkMapConfig(DUMMY_NOTARY.name, localPort(12345)),
                 users = listOf(user("jenny"))
         )
 
@@ -83,7 +80,6 @@ class NodeConfigTest {
             webPort: Int = -1,
             h2port: Int = -1,
             notary: NotaryService?,
-            networkMap: NetworkMapConfig?,
             users: List<User> = listOf(user("guest"))
     ): NodeConfig {
         return NodeConfig(
@@ -93,7 +89,6 @@ class NodeConfigTest {
                 webAddress = localPort(webPort),
                 h2port = h2port,
                 notary = notary,
-                networkMapService = networkMap,
                 rpcUsers = users
         )
     }

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt
@@ -24,6 +24,22 @@ class NodeControllerTest {
     }
 
     @Test
+    fun `register notary`() {
+        assertFalse(controller.hasNotary())
+        val config = createConfig(commonName = "Name", notary = NotaryService(false))
+        controller.register(config)
+        assertTrue(controller.hasNotary())
+    }
+
+    @Test
+    fun `register non notary`() {
+        assertFalse(controller.hasNotary())
+        val config = createConfig(commonName = "Name")
+        controller.register(config)
+        assertFalse(controller.hasNotary())
+    }
+
+    @Test
     fun `test unique key after validate`() {
         val data = NodeData()
         data.legalName.value = node1Name

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeControllerTest.kt
@@ -3,7 +3,6 @@ package net.corda.demobench.model
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.nodeapi.User
-import net.corda.testing.DUMMY_NOTARY
 import org.junit.Test
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -49,17 +48,6 @@ class NodeControllerTest {
     }
 
     @Test
-    fun `test first validated node becomes network map`() {
-        val data = NodeData()
-        data.legalName.value = node1Name
-        data.p2pPort.value = 10000
-
-        assertFalse(controller.hasNetworkMap())
-        controller.validate(data)
-        assertTrue(controller.hasNetworkMap())
-    }
-
-    @Test
     fun `test register unique nodes`() {
         val config = createConfig(commonName = organisation2Name)
         assertTrue(controller.register(config))
@@ -86,28 +74,6 @@ class NodeControllerTest {
         assertTrue(controller.nameExists("Organisation 2"))
         assertTrue(controller.nameExists("Organisation2"))
         assertTrue(controller.nameExists("organisation 2"))
-    }
-
-    @Test
-    fun `test register network map node`() {
-        val config = createConfig(commonName = "Organisation is Network Map")
-        assertTrue(config.nodeConfig.isNetworkMap)
-
-        assertFalse(controller.hasNetworkMap())
-        controller.register(config)
-        assertTrue(controller.hasNetworkMap())
-    }
-
-    @Test
-    fun `test register non-network-map node`() {
-        val config = createConfig(
-                commonName = "Organisation is not Network Map",
-                networkMap = NetworkMapConfig(DUMMY_NOTARY.name, localPort(10000)))
-        assertFalse(config.nodeConfig.isNetworkMap)
-
-        assertFalse(controller.hasNetworkMap())
-        controller.register(config)
-        assertFalse(controller.hasNetworkMap())
     }
 
     @Test
@@ -173,7 +139,6 @@ class NodeControllerTest {
             webPort: Int = 0,
             h2port: Int = 0,
             notary: NotaryService? = null,
-            networkMap: NetworkMapConfig? = null,
             users: List<User> = listOf(user("guest"))
     ): NodeConfigWrapper {
         val nodeConfig = NodeConfig(
@@ -187,7 +152,6 @@ class NodeControllerTest {
                 webAddress = localPort(webPort),
                 h2port = h2port,
                 notary = notary,
-                networkMapService = networkMap,
                 rpcUsers = users
         )
         return NodeConfigWrapper(baseDir, nodeConfig)


### PR DESCRIPTION
Remove mentions of networkmap node from Demobench.

Note that Demobench used to check for a network map to decide whether one could launch a Notary or a non-notary node.
Now it checks for there being a running notary.