### PR TITLE
Move StateLoader logic into ServicesForResolution

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -4,11 +4,10 @@ import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.serializedHash
-import net.corda.core.utilities.toBase58String
 import net.corda.core.identity.Party
-import net.corda.core.node.ServiceHub
-import net.corda.core.node.StateLoader
+import net.corda.core.node.ServicesForResolution
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.toBase58String
 import java.security.PublicKey
 
 /**
@@ -40,10 +39,9 @@ data class NotaryChangeWireTransaction(
      */
     override val id: SecureHash by lazy { serializedHash(inputs + notary + newNotary) }
 
-    fun resolve(services: ServiceHub, sigs: List<TransactionSignature>) = resolve(services as StateLoader, sigs)
-    fun resolve(stateLoader: StateLoader, sigs: List<TransactionSignature>): NotaryChangeLedgerTransaction {
+    fun resolve(services: ServicesForResolution, sigs: List<TransactionSignature>): NotaryChangeLedgerTransaction {
         val resolvedInputs = inputs.map { ref ->
-            stateLoader.loadState(ref).let { StateAndRef(it, ref) }
+            services.loadState(ref).let { StateAndRef(it, ref) }
         }
         return NotaryChangeLedgerTransaction(resolvedInputs, notary, newNotary, id, sigs)
     }

--- a/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
@@ -1,13 +1,8 @@
 package net.corda.node.internal
 
-import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.TransactionResolutionException
-import net.corda.core.contracts.TransactionState
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
-import net.corda.core.node.StateLoader
-import net.corda.core.node.services.TransactionStorage
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.messaging.MessagingService
@@ -27,12 +22,4 @@ interface StartedNode<out N : AbstractNode> {
     val rpcOps: CordaRPCOps
     fun dispose() = internals.stop()
     fun <T : FlowLogic<*>> registerInitiatedFlow(initiatedFlowClass: Class<T>) = internals.registerInitiatedFlow(initiatedFlowClass)
-}
-
-class StateLoaderImpl(private val validatedTransactions: TransactionStorage) : StateLoader {
-    @Throws(TransactionResolutionException::class)
-    override fun loadState(stateRef: StateRef): TransactionState<*> {
-        val stx = validatedTransactions.getTransaction(stateRef.txhash) ?: throw TransactionResolutionException(stateRef.txhash)
-        return stx.resolveBaseTransaction(this).outputs[stateRef.index]
-    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -14,7 +14,7 @@ import net.corda.core.internal.ThreadBox
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.until
-import net.corda.core.node.StateLoader
+import net.corda.core.node.ServicesForResolution
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.loggerFor
@@ -58,7 +58,7 @@ import com.google.common.util.concurrent.SettableFuture as GuavaSettableFuture
 class NodeSchedulerService(private val clock: Clock,
                            private val database: CordaPersistence,
                            private val flowStarter: FlowStarter,
-                           private val stateLoader: StateLoader,
+                           private val services: ServicesForResolution,
                            private val schedulerTimerExecutor: Executor = Executors.newSingleThreadExecutor(),
                            private val unfinishedSchedules: ReusableLatch = ReusableLatch(),
                            private val serverThread: AffinityExecutor)
@@ -292,7 +292,7 @@ class NodeSchedulerService(private val clock: Clock,
     }
 
     private fun getScheduledActivity(scheduledState: ScheduledStateRef): ScheduledActivity? {
-        val txState = stateLoader.loadState(scheduledState.ref)
+        val txState = services.loadState(scheduledState.ref)
         val state = txState.data as SchedulableState
         return try {
             // This can throw as running contract code.

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -5,15 +5,12 @@ import co.paralleluniverse.strands.Strand
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.*
-import net.corda.core.node.StateLoader
-import net.corda.core.node.services.*
+import net.corda.core.messaging.DataFeed
+import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.StatesToRecord
+import net.corda.core.node.services.KeyManagementService
 import net.corda.core.node.services.StatesNotAvailableException
 import net.corda.core.node.services.Vault
-import net.corda.core.node.services.vault.QueryCriteria
-import net.corda.core.node.services.vault.Sort
-import net.corda.core.node.services.vault.SortAttribute
-import net.corda.core.messaging.DataFeed
-import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.VaultQueryException
 import net.corda.core.node.services.vault.*
 import net.corda.core.schemas.PersistentStateRef
@@ -62,7 +59,7 @@ private fun CriteriaBuilder.executeUpdate(session: Session, configure: Root<*>.(
 class NodeVaultService(
         private val clock: Clock,
         private val keyManagementService: KeyManagementService,
-        private val stateLoader: StateLoader,
+        private val services: ServicesForResolution,
         hibernateConfig: HibernateConfiguration
 ) : SingletonSerializeAsToken(), VaultServiceInternal {
     private companion object {
@@ -184,7 +181,7 @@ class NodeVaultService(
             // We need to resolve the full transaction here because outputs are calculated from inputs
             // We also can't do filtering beforehand, since output encumbrance pointers get recalculated based on
             // input positions
-            val ltx = tx.resolve(stateLoader, emptyList())
+            val ltx = tx.resolve(services, emptyList())
             val myKeys = keyManagementService.filterMyKeys(ltx.outputs.flatMap { it.data.participants.map { it.owningKey } })
             val (consumedStateAndRefs, producedStates) = ltx.inputs.
                     zip(ltx.outputs).

--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -12,13 +12,13 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceHub
+import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.StatesToRecord
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.days
 import net.corda.node.internal.FlowStarterImpl
-import net.corda.node.internal.StateLoaderImpl
 import net.corda.node.internal.cordapp.CordappLoader
 import net.corda.node.internal.cordapp.CordappProviderImpl
 import net.corda.node.services.api.MonitoringService
@@ -100,7 +100,11 @@ class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
         kms = MockKeyManagementService(identityService, ALICE_KEY)
         val configuration = testNodeConfiguration(Paths.get("."), CordaX500Name("Alice", "London", "GB"))
         val validatedTransactions = MockTransactionStorage()
-        val stateLoader = StateLoaderImpl(validatedTransactions)
+        val servicesForResolution = rigorousMock<ServicesForResolution>().also {
+            doReturn(validatedTransactions).whenever(it).validatedTransactions
+            doReturn(identityService).whenever(it).identityService
+            doReturn(validatedTransactions).whenever(it).validatedTransactions
+        }
         database.transaction {
             services = rigorousMock<Services>().also {
                 doReturn(configuration).whenever(it).configuration
@@ -114,13 +118,13 @@ class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
                 doCallRealMethod().whenever(it).recordTransactions(any<StatesToRecord>(), any())
                 doCallRealMethod().whenever(it).recordTransactions(any<Iterable<SignedTransaction>>())
                 doCallRealMethod().whenever(it).recordTransactions(any<SignedTransaction>(), anyVararg())
-                doReturn(NodeVaultService(testClock, kms, stateLoader, database.hibernateConfig)).whenever(it).vaultService
+                doCallRealMethod().whenever(it).loadState(any())
+                doReturn(NodeVaultService(testClock, kms, servicesForResolution, database.hibernateConfig)).whenever(it).vaultService
                 doReturn(this@NodeSchedulerServiceTest).whenever(it).testReference
-
             }
             smmExecutor = AffinityExecutor.ServiceAffinityExecutor("test", 1)
             mockSMM = StateMachineManagerImpl(services, DBCheckpointStorage(), smmExecutor, database)
-            scheduler = NodeSchedulerService(testClock, database, FlowStarterImpl(smmExecutor, mockSMM), stateLoader, schedulerGatedExecutor, serverThread = smmExecutor)
+            scheduler = NodeSchedulerService(testClock, database, FlowStarterImpl(smmExecutor, mockSMM), services, schedulerGatedExecutor, serverThread = smmExecutor)
             mockSMM.changes.subscribe { change ->
                 if (change is StateMachineManager.Change.Removed && mockSMM.allStateMachines.isEmpty()) {
                     smmHasRemovedAllFlows.countDown()

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -47,7 +47,7 @@ class DBTransactionStorageTests {
             services = object : MockServices(BOB_KEY) {
                 override val vaultService: VaultServiceInternal
                     get() {
-                        val vaultService = NodeVaultService(clock, keyManagementService, stateLoader, database.hibernateConfig)
+                        val vaultService = NodeVaultService(clock, keyManagementService, this, database.hibernateConfig)
                         hibernatePersister = HibernateObserver.install(vaultService.rawUpdates, database.hibernateConfig)
                         return vaultService
                     }

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -11,7 +11,7 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.packageName
 import net.corda.core.internal.uncheckedCast
-import net.corda.core.node.StateLoader
+import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria.SoftLockingCondition
@@ -27,8 +27,8 @@ import net.corda.node.internal.InitiatedFlowFactory
 import net.corda.node.services.api.VaultServiceInternal
 import net.corda.testing.chooseIdentity
 import net.corda.testing.node.MockNetwork
-import net.corda.testing.rigorousMock
 import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.rigorousMock
 import org.junit.After
 import org.junit.Test
 import java.util.*
@@ -81,8 +81,8 @@ class VaultSoftLockManagerTest {
     }
     private val mockNet = MockNetwork(cordappPackages = listOf(ContractImpl::class.packageName), defaultFactory = { args ->
         object : MockNetwork.MockNode(args) {
-            override fun makeVaultService(keyManagementService: KeyManagementService, stateLoader: StateLoader): VaultServiceInternal {
-                val realVault = super.makeVaultService(keyManagementService, stateLoader)
+            override fun makeVaultService(keyManagementService: KeyManagementService, services: ServicesForResolution): VaultServiceInternal {
+                val realVault = super.makeVaultService(keyManagementService, services)
                 return object : VaultServiceInternal by realVault {
                     override fun softLockRelease(lockId: UUID, stateRefs: NonEmptySet<StateRef>?) {
                         mockVault.softLockRelease(lockId, stateRefs) // No need to also call the real one for these tests.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -15,7 +15,6 @@ import net.corda.core.serialization.SerializeAsToken
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.transactions.SignedTransaction
 import net.corda.node.VersionInfo
-import net.corda.node.internal.StateLoaderImpl
 import net.corda.node.internal.cordapp.CordappLoader
 import net.corda.node.services.api.StateMachineRecordedTransactionMappingStorage
 import net.corda.node.services.api.VaultServiceInternal
@@ -49,9 +48,8 @@ import java.util.*
 open class MockServices(
         cordappLoader: CordappLoader,
         override val validatedTransactions: WritableTransactionStorage,
-        protected val stateLoader: StateLoaderImpl = StateLoaderImpl(validatedTransactions),
         vararg val keys: KeyPair
-) : ServiceHub, StateLoader by stateLoader {
+) : ServiceHub {
     companion object {
 
         @JvmStatic
@@ -167,7 +165,7 @@ open class MockServices(
     lateinit var hibernatePersister: HibernateObserver
 
     fun makeVaultService(hibernateConfig: HibernateConfiguration): VaultServiceInternal {
-        val vaultService = NodeVaultService(Clock.systemUTC(), keyManagementService, stateLoader, hibernateConfig)
+        val vaultService = NodeVaultService(Clock.systemUTC(), keyManagementService, this, hibernateConfig)
         hibernatePersister = HibernateObserver.install(vaultService.rawUpdates, hibernateConfig)
         return vaultService
     }


### PR DESCRIPTION
As a consequence of https://github.com/corda/corda/pull/1927, loading output states for some transactions now requires resolving a full transaction – e.g. for contract upgrade transactions  outputs get generated by running contract upgrade code on the inputs. So StateLoader requires access to cordapp provider, tx storage and attachments.

I ended up moving StateLoader logic into ServicesForResolution, but that re-introduces the circular dependency between ServiceHub and NodeVaultService.. Not sure what's the best solution here.