### PR TITLE
Correct unchecked cast call

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ContractStateModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/ContractStateModel.kt
@@ -40,7 +40,7 @@ class ContractStateModel {
             return this.map { stateAndRef ->
                 if (stateAndRef.state.data is Cash.State) {
                     // Kotlin doesn't unify here for some reason
-                    uncheckedCast(stateAndRef)
+                    uncheckedCast<StateAndRef<ContractState>, StateAndRef<Cash.State>>(stateAndRef)
                 } else {
                     null
                 }


### PR DESCRIPTION
Or else NodeExplorer will not start due to exception, see below.

It looks like during the `map()` call resulting type cannot be inferred correctly.
This is likely to be caused by: #1667

```
java.lang.ClassCastException: net.corda.core.contracts.StateAndRef cannot be cast to java.lang.Void
	at net.corda.client.jfx.model.ContractStateModel$Companion.filterCashStateAndRefs(ContractStateModel.kt:43)
	at net.corda.client.jfx.model.ContractStateModel$Companion.access$filterCashStateAndRefs(ContractStateModel.kt:38)
	at net.corda.client.jfx.model.ContractStateModel$cashStatesDiff$1.call(ContractStateModel.kt:29)
	at net.corda.client.jfx.model.ContractStateModel$cashStatesDiff$1.call(ContractStateModel.kt:22)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:69)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.subjects.PublishSubject$PublishSubjectProducer.onNext(PublishSubject.java:304)
	at rx.subjects.PublishSubject$PublishSubjectState.onNext(PublishSubject.java:219)
	at rx.subjects.PublishSubject.onNext(PublishSubject.java:72)
```