### PR TITLE
Move node info schema to internal package

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2344,66 +2344,6 @@ public class net.corda.core.schemas.MappedSchema extends java.lang.Object
   public final int getVersion()
   @org.jetbrains.annotations.NotNull public String toString()
 ##
-public final class net.corda.core.schemas.NodeInfoSchema extends java.lang.Object
-  public static final net.corda.core.schemas.NodeInfoSchema INSTANCE
-##
-public final class net.corda.core.schemas.NodeInfoSchemaV1 extends net.corda.core.schemas.MappedSchema
-  public static final net.corda.core.schemas.NodeInfoSchemaV1 INSTANCE
-##
-@javax.persistence.Entity public static final class net.corda.core.schemas.NodeInfoSchemaV1$DBHostAndPort extends java.lang.Object
-  public <init>()
-  public <init>(net.corda.core.schemas.NodeInfoSchemaV1$PKHostAndPort)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.schemas.NodeInfoSchemaV1$DBHostAndPort copy(net.corda.core.schemas.NodeInfoSchemaV1$PKHostAndPort)
-  public boolean equals(Object)
-  public int hashCode()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NetworkHostAndPort toHostAndPort()
-  public String toString()
-  public static final net.corda.core.schemas.NodeInfoSchemaV1$DBHostAndPort$Companion Companion
-##
-public static final class net.corda.core.schemas.NodeInfoSchemaV1$DBHostAndPort$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.schemas.NodeInfoSchemaV1$DBHostAndPort fromHostAndPort(net.corda.core.utilities.NetworkHostAndPort)
-##
-@javax.persistence.Entity @javax.persistence.Table public static final class net.corda.core.schemas.NodeInfoSchemaV1$DBPartyAndCertificate extends java.lang.Object
-  public <init>()
-  public <init>(String, String, byte[], boolean, Set)
-  public <init>(net.corda.core.identity.PartyAndCertificate, boolean)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final byte[] component3()
-  public final boolean component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.schemas.NodeInfoSchemaV1$DBPartyAndCertificate copy(String, String, byte[], boolean, Set)
-  public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getName()
-  @org.jetbrains.annotations.NotNull public final String getOwningKeyHash()
-  @org.jetbrains.annotations.NotNull public final byte[] getPartyCertBinary()
-  public int hashCode()
-  public final boolean isMain()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.PartyAndCertificate toLegalIdentityAndCert()
-  public String toString()
-##
-@javax.persistence.Embeddable public static final class net.corda.core.schemas.NodeInfoSchemaV1$PKHostAndPort extends java.lang.Object implements java.io.Serializable
-  public <init>()
-  public <init>(String, Integer)
-  @org.jetbrains.annotations.Nullable public final String component1()
-  @org.jetbrains.annotations.Nullable public final Integer component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.schemas.NodeInfoSchemaV1$PKHostAndPort copy(String, Integer)
-  public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final String getHost()
-  @org.jetbrains.annotations.Nullable public final Integer getPort()
-  public int hashCode()
-  public String toString()
-##
-@javax.persistence.Entity @javax.persistence.Table public static final class net.corda.core.schemas.NodeInfoSchemaV1$PersistentNodeInfo extends java.lang.Object
-  public <init>()
-  public <init>(int, List, List, int, long)
-  @org.jetbrains.annotations.NotNull public final List getAddresses()
-  public final int getId()
-  @org.jetbrains.annotations.NotNull public final List getLegalIdentitiesAndCerts()
-  public final int getPlatformVersion()
-  public final long getSerial()
-  public final void setId(int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo toNodeInfo()
-##
 @javax.persistence.MappedSuperclass @net.corda.core.serialization.CordaSerializable public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.StatePersistable
   public <init>()
   public <init>(net.corda.core.schemas.PersistentStateRef)

--- a/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
@@ -1,8 +1,9 @@
-package net.corda.core.schemas
+package net.corda.core.internal.schemas
 
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.NodeInfo
+import net.corda.core.schemas.MappedSchema
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -72,6 +72,9 @@ UNRELEASED
 * The ``ReceiveTransactionFlow`` can now be told to record the transaction at the same time as receiving it. Using this
   feature, better support for observer/regulator nodes has been added. See :doc:`tutorial-observer-nodes`.
 
+* Moved ``NodeInfoSchema`` to internal package as the node info's database schema is not part of the public API. This is
+  needed to allow new ``node_info_hash`` column to be added for the network map redesign work.
+
 .. _changelog_v1:
 
 Release 1.0

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -8,13 +8,13 @@ import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.internal.schemas.NodeInfoSchemaV1
 import net.corda.core.messaging.DataFeed
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.NetworkMapCache.MapChange
 import net.corda.core.node.services.NotaryService
 import net.corda.core.node.services.PartyInfo
-import net.corda.core.schemas.NodeInfoSchemaV1
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.loggerFor

--- a/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
@@ -3,7 +3,11 @@ package net.corda.node.services.schema
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.FungibleAsset
 import net.corda.core.contracts.LinearState
-import net.corda.core.schemas.*
+import net.corda.core.internal.schemas.NodeInfoSchemaV1
+import net.corda.core.schemas.CommonSchemaV1
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import net.corda.core.schemas.QueryableState
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.node.internal.cordapp.CordappLoader
 import net.corda.node.services.api.SchemaService


### PR DESCRIPTION
NodeInfoSchema shouldn't be part of the public API, moving it to internal package and modified api-current.txt.

This changes is  needed to allow new ``node_info_hash`` column to be added for the network map redesign work.