### PR TITLE
Introduction of network parameters.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -120,7 +120,7 @@ interface NetworkMapCacheBase {
 
     /**
      * Returns true if and only if the given [Party] is validating notary. For every party that is a validating notary,
-     * [isNotary] is only true.
+     * [isNotary] is also true.
      * @see isNotary
      */
     fun isValidatingNotary(party: Party): Boolean

--- a/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
+++ b/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
@@ -18,14 +18,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.fail;
 
 public class FlowsInJavaTest {
-
     private final MockNetwork mockNet = new MockNetwork();
     private StartedNode<MockNetwork.MockNode> aliceNode;
     private StartedNode<MockNetwork.MockNode> bobNode;
 
     @Before
     public void setUp() throws Exception {
-        mockNet.createNotaryNode();
         aliceNode = mockNet.createPartyNode(TestConstants.getALICE().getName());
         bobNode = mockNet.createPartyNode(TestConstants.getBOB().getName());
         mockNet.runNetwork();

--- a/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
@@ -110,11 +110,11 @@ class AttachmentTests {
     @Test
     fun maliciousResponse() {
         // Make a node that doesn't do sanity checking at load time.
-        val aliceNode = mockNet.createNotaryNode(MockNodeParameters(legalName = ALICE.name), nodeFactory = { args ->
+        val aliceNode = mockNet.createNode(MockNodeParameters(legalName = ALICE.name), nodeFactory = { args ->
             object : MockNetwork.MockNode(args) {
                 override fun start() = super.start().apply { attachments.checkAttachmentsOnLoad = false }
             }
-        }, validating = false)
+        })
         val bobNode = mockNet.createNode(MockNodeParameters(legalName = BOB.name))
         mockNet.runNetwork()
         val alice = aliceNode.services.myInfo.identityFromX500Name(ALICE_NAME)

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -27,19 +27,18 @@ class CollectSignaturesFlowTests {
         private val cordappPackages = listOf("net.corda.testing.contracts")
     }
 
-    lateinit var mockNet: MockNetwork
-    lateinit var aliceNode: StartedNode<MockNetwork.MockNode>
-    lateinit var bobNode: StartedNode<MockNetwork.MockNode>
-    lateinit var charlieNode: StartedNode<MockNetwork.MockNode>
-    lateinit var alice: Party
-    lateinit var bob: Party
-    lateinit var charlie: Party
-    lateinit var notary: Party
+    private lateinit var mockNet: MockNetwork
+    private lateinit var aliceNode: StartedNode<MockNetwork.MockNode>
+    private lateinit var bobNode: StartedNode<MockNetwork.MockNode>
+    private lateinit var charlieNode: StartedNode<MockNetwork.MockNode>
+    private lateinit var alice: Party
+    private lateinit var bob: Party
+    private lateinit var charlie: Party
+    private lateinit var notary: Party
 
     @Before
     fun setup() {
         mockNet = MockNetwork(cordappPackages = cordappPackages)
-        val notaryNode = mockNet.createNotaryNode()
         aliceNode = mockNet.createPartyNode(ALICE.name)
         bobNode = mockNet.createPartyNode(BOB.name)
         charlieNode = mockNet.createPartyNode(CHARLIE.name)
@@ -47,7 +46,7 @@ class CollectSignaturesFlowTests {
         alice = aliceNode.info.singleIdentity()
         bob = bobNode.info.singleIdentity()
         charlie = charlieNode.info.singleIdentity()
-        notary = notaryNode.services.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
     }
 
     @After

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -41,14 +41,13 @@ class ContractUpgradeFlowTest {
     @Before
     fun setup() {
         mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset", "net.corda.core.flows"))
-        val notaryNode = mockNet.createNotaryNode()
         aliceNode = mockNet.createPartyNode(ALICE.name)
         bobNode = mockNet.createPartyNode(BOB.name)
 
         // Process registration
         mockNet.runNetwork()
 
-        notary = notaryNode.services.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
     }
 
     @After

--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -26,7 +26,6 @@ class FinalityFlowTests {
     @Before
     fun setup() {
         mockNet = MockNetwork(cordappPackages = listOf("net.corda.finance.contracts.asset"))
-        val notaryNode = mockNet.createNotaryNode()
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)
         val bobNode = mockNet.createPartyNode(BOB_NAME)
         mockNet.runNetwork()
@@ -34,7 +33,7 @@ class FinalityFlowTests {
         bobServices = bobNode.services
         alice = aliceNode.info.singleIdentity()
         bob = bobNode.info.singleIdentity()
-        notary = notaryNode.services.getDefaultNotary()
+        notary = aliceServices.getDefaultNotary()
     }
 
     @After

--- a/core/src/test/kotlin/net/corda/core/flows/ReceiveAllFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ReceiveAllFlowTests.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 class ReceiveMultipleFlowTests {
     @Test
     fun `receive all messages in parallel using map style`() {
-        network(3) { nodes, _ ->
+        network(3) { nodes ->
             val doubleValue = 5.0
             nodes[1].registerAnswer(AlgorithmDefinition::class, doubleValue)
             val stringValue = "Thriller"
@@ -30,7 +30,7 @@ class ReceiveMultipleFlowTests {
 
     @Test
     fun `receive all messages in parallel using list style`() {
-        network(3) { nodes, _ ->
+        network(3) { nodes ->
             val value1 = 5.0
             nodes[1].registerAnswer(ParallelAlgorithmList::class, value1)
             val value2 = 6.0

--- a/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
@@ -8,7 +8,9 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.sequence
 import net.corda.node.internal.StartedNode
-import net.corda.testing.*
+import net.corda.testing.MEGA_CORP
+import net.corda.testing.MINI_CORP
+import net.corda.testing.chooseIdentity
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.MockNetwork
@@ -26,18 +28,18 @@ import kotlin.test.assertNull
 
 // DOCSTART 3
 class ResolveTransactionsFlowTest {
-    lateinit var mockNet: MockNetwork
-    lateinit var notaryNode: StartedNode<MockNetwork.MockNode>
-    lateinit var megaCorpNode: StartedNode<MockNetwork.MockNode>
-    lateinit var miniCorpNode: StartedNode<MockNetwork.MockNode>
-    lateinit var megaCorp: Party
-    lateinit var miniCorp: Party
-    lateinit var notary: Party
+    private lateinit var mockNet: MockNetwork
+    private lateinit var notaryNode: StartedNode<MockNetwork.MockNode>
+    private lateinit var megaCorpNode: StartedNode<MockNetwork.MockNode>
+    private lateinit var miniCorpNode: StartedNode<MockNetwork.MockNode>
+    private lateinit var megaCorp: Party
+    private lateinit var miniCorp: Party
+    private lateinit var notary: Party
 
     @Before
     fun setup() {
         mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
-        notaryNode = mockNet.createNotaryNode()
+        notaryNode = mockNet.defaultNotaryNode
         megaCorpNode = mockNet.createPartyNode(MEGA_CORP.name)
         miniCorpNode = mockNet.createPartyNode(MINI_CORP.name)
         megaCorpNode.internals.registerInitiatedFlow(TestResponseFlow::class.java)

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -37,8 +37,7 @@ class IntegrationTestingTutorial {
                     invokeRpc("vaultTrackBy"),
                     invokeRpc(CordaRPCOps::networkMapFeed)
             ))
-            val (_, alice, bob) = listOf(
-                    startNotaryNode(DUMMY_NOTARY.name),
+            val (alice, bob) = listOf(
                     startNode(providedName = ALICE.name, rpcUsers = listOf(aliceUser)),
                     startNode(providedName = BOB.name, rpcUsers = listOf(bobUser))
             ).transpose().getOrThrow()

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package net.corda.docs
 
 import net.corda.core.contracts.Amount
@@ -17,7 +19,6 @@ import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
 import net.corda.testing.ALICE
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.driver
 import org.graphstream.graph.Edge
 import org.graphstream.graph.Node
@@ -48,7 +49,6 @@ fun main(args: Array<String>) {
             invokeRpc(CordaRPCOps::nodeInfo)
     ))
     driver(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf("net.corda.finance")) {
-        startNotaryNode(DUMMY_NOTARY.name)
         val node = startNode(providedName = ALICE.name, rpcUsers = listOf(user)).get()
         // END 1
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt
@@ -55,7 +55,6 @@ class TutorialMockNetwork {
     }
 
     lateinit private var mockNet: MockNetwork
-    lateinit private var notary: StartedNode<MockNetwork.MockNode>
     lateinit private var nodeA: StartedNode<MockNetwork.MockNode>
     lateinit private var nodeB: StartedNode<MockNetwork.MockNode>
 
@@ -66,7 +65,6 @@ class TutorialMockNetwork {
     @Before
     fun setUp() {
         mockNet = MockNetwork()
-        notary = mockNet.createNotaryNode()
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
 

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
@@ -10,7 +10,8 @@ import net.corda.finance.contracts.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.node.internal.StartedNode
-import net.corda.testing.*
+import net.corda.testing.chooseIdentity
+import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Assert
@@ -19,23 +20,20 @@ import org.junit.Test
 import java.util.*
 
 class CustomVaultQueryTest {
-
-    lateinit var mockNet: MockNetwork
-    lateinit var nodeA: StartedNode<MockNetwork.MockNode>
-    lateinit var nodeB: StartedNode<MockNetwork.MockNode>
-    lateinit var notary: Party
+    private lateinit var mockNet: MockNetwork
+    private lateinit var nodeA: StartedNode<MockNetwork.MockNode>
+    private lateinit var nodeB: StartedNode<MockNetwork.MockNode>
+    private lateinit var notary: Party
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(
-                threadPerNode = true,
+        mockNet = MockNetwork(threadPerNode = true,
                 cordappPackages = listOf(
                         "net.corda.finance.contracts.asset",
                         CashSchemaV1::class.packageName,
                         "net.corda.docs"
                 )
         )
-        mockNet.createNotaryNode()
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
         nodeA.internals.registerInitiatedFlow(TopupIssuerFlow.TopupIssuer::class.java)

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
@@ -10,7 +10,8 @@ import net.corda.finance.contracts.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.node.internal.StartedNode
-import net.corda.testing.*
+import net.corda.testing.chooseIdentity
+import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -18,15 +19,14 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class FxTransactionBuildTutorialTest {
-    lateinit var mockNet: MockNetwork
-    lateinit var nodeA: StartedNode<MockNetwork.MockNode>
-    lateinit var nodeB: StartedNode<MockNetwork.MockNode>
-    lateinit var notary: Party
+    private lateinit var mockNet: MockNetwork
+    private lateinit var nodeA: StartedNode<MockNetwork.MockNode>
+    private lateinit var nodeB: StartedNode<MockNetwork.MockNode>
+    private lateinit var notary: Party
 
     @Before
     fun setup() {
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance.contracts.asset", CashSchemaV1::class.packageName))
-        mockNet.createNotaryNode()
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
         nodeB.internals.registerInitiatedFlow(ForeignExchangeRemoteFlow::class.java)

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
@@ -10,7 +10,8 @@ import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.toFuture
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.api.StartedNodeServices
-import net.corda.testing.*
+import net.corda.testing.ALICE_NAME
+import net.corda.testing.BOB_NAME
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -18,11 +19,11 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class WorkflowTransactionBuildTutorialTest {
-    lateinit var mockNet: MockNetwork
-    lateinit var aliceServices: StartedNodeServices
-    lateinit var bobServices: StartedNodeServices
-    lateinit var alice: Party
-    lateinit var bob: Party
+    private lateinit var mockNet: MockNetwork
+    private lateinit var aliceServices: StartedNodeServices
+    private lateinit var bobServices: StartedNodeServices
+    private lateinit var alice: Party
+    private lateinit var bob: Party
 
     // Helper method to locate the latest Vault version of a LinearState
     private inline fun <reified T : LinearState> ServiceHub.latest(ref: UniqueIdentifier): StateAndRef<T> {
@@ -33,8 +34,6 @@ class WorkflowTransactionBuildTutorialTest {
     @Before
     fun setup() {
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.docs"))
-        // While we don't use the notary, we need there to be one on the network
-        mockNet.createNotaryNode()
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)
         val bobNode = mockNet.createPartyNode(BOB_NAME)
         aliceNode.internals.registerInitiatedFlow(RecordCompletionFlow::class.java)

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashSelectionH2Test.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashSelectionH2Test.kt
@@ -1,41 +1,38 @@
 package net.corda.finance.contracts.asset
 
-import net.corda.core.internal.packageName
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.DOLLARS
 import net.corda.finance.flows.CashException
 import net.corda.finance.flows.CashPaymentFlow
-import net.corda.finance.schemas.CashSchemaV1
-import net.corda.testing.chooseIdentity
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNodeParameters
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.After
 import org.junit.Test
 
-
 class CashSelectionH2Test {
+    private val mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance"))
+
+    @After
+    fun cleanUp() {
+        mockNet.stopNodes()
+    }
 
     @Test
     fun `check does not hold connection over retries`() {
-        val mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance.contracts.asset", CashSchemaV1::class.packageName))
-        try {
-            val notaryNode = mockNet.createNotaryNode()
-            val bankA = mockNet.createNode(MockNodeParameters(configOverrides = { existingConfig ->
-                // Tweak connections to be minimal to make this easier (1 results in a hung node during start up, so use 2 connections).
-                existingConfig.dataSourceProperties.setProperty("maximumPoolSize", "2")
-            }))
-            mockNet.startNodes()
+        val bankA = mockNet.createNode(MockNodeParameters(configOverrides = {
+            // Tweak connections to be minimal to make this easier (1 results in a hung node during start up, so use 2 connections).
+            it.dataSourceProperties.setProperty("maximumPoolSize", "2")
+        }))
+        val notary = mockNet.defaultNotaryIdentity
 
-            // Start more cash spends than we have connections.  If spend leaks a connection on retry, we will run out of connections.
-            val flow1 = bankA.services.startFlow(CashPaymentFlow(amount = 100.DOLLARS, anonymous = false, recipient = notaryNode.info.chooseIdentity()))
-            val flow2 = bankA.services.startFlow(CashPaymentFlow(amount = 100.DOLLARS, anonymous = false, recipient = notaryNode.info.chooseIdentity()))
-            val flow3 = bankA.services.startFlow(CashPaymentFlow(amount = 100.DOLLARS, anonymous = false, recipient = notaryNode.info.chooseIdentity()))
+        // Start more cash spends than we have connections.  If spend leaks a connection on retry, we will run out of connections.
+        val flow1 = bankA.services.startFlow(CashPaymentFlow(amount = 100.DOLLARS, anonymous = false, recipient = notary))
+        val flow2 = bankA.services.startFlow(CashPaymentFlow(amount = 100.DOLLARS, anonymous = false, recipient = notary))
+        val flow3 = bankA.services.startFlow(CashPaymentFlow(amount = 100.DOLLARS, anonymous = false, recipient = notary))
 
-            assertThatThrownBy { flow1.resultFuture.getOrThrow() }.isInstanceOf(CashException::class.java)
-            assertThatThrownBy { flow2.resultFuture.getOrThrow() }.isInstanceOf(CashException::class.java)
-            assertThatThrownBy { flow3.resultFuture.getOrThrow() }.isInstanceOf(CashException::class.java)
-        } finally {
-            mockNet.stopNodes()
-        }
+        assertThatThrownBy { flow1.resultFuture.getOrThrow() }.isInstanceOf(CashException::class.java)
+        assertThatThrownBy { flow2.resultFuture.getOrThrow() }.isInstanceOf(CashException::class.java)
+        assertThatThrownBy { flow3.resultFuture.getOrThrow() }.isInstanceOf(CashException::class.java)
     }
 }

--- a/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
@@ -7,7 +7,9 @@ import net.corda.finance.DOLLARS
 import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
 import net.corda.node.internal.StartedNode
-import net.corda.testing.*
+import net.corda.testing.BOC
+import net.corda.testing.chooseIdentity
+import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
@@ -23,15 +25,13 @@ class CashExitFlowTests {
     private val ref = OpaqueBytes.of(0x01)
     private lateinit var bankOfCordaNode: StartedNode<MockNode>
     private lateinit var bankOfCorda: Party
-    private lateinit var notaryNode: StartedNode<MockNode>
     private lateinit var notary: Party
 
     @Before
     fun start() {
-        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance.contracts.asset"))
-        notaryNode = mockNet.createNotaryNode()
+        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(),
+                cordappPackages = listOf("net.corda.finance.contracts.asset"))
         bankOfCordaNode = mockNet.createPartyNode(BOC.name)
-        notary = notaryNode.services.getDefaultNotary()
         bankOfCorda = bankOfCordaNode.info.chooseIdentity()
 
         mockNet.runNetwork()

--- a/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt
@@ -7,9 +7,8 @@ import net.corda.finance.DOLLARS
 import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
 import net.corda.node.internal.StartedNode
-import net.corda.testing.chooseIdentity
-import net.corda.testing.getDefaultNotary
 import net.corda.testing.BOC
+import net.corda.testing.chooseIdentity
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
@@ -23,16 +22,14 @@ class CashIssueFlowTests {
     private lateinit var mockNet: MockNetwork
     private lateinit var bankOfCordaNode: StartedNode<MockNode>
     private lateinit var bankOfCorda: Party
-    private lateinit var notaryNode: StartedNode<MockNode>
     private lateinit var notary: Party
 
     @Before
     fun start() {
         mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance.contracts.asset"))
-        notaryNode = mockNet.createNotaryNode()
         bankOfCordaNode = mockNet.createPartyNode(BOC.name)
         bankOfCorda = bankOfCordaNode.info.chooseIdentity()
-        notary = notaryNode.services.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
         mockNet.runNetwork()
     }
 

--- a/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
@@ -26,18 +26,16 @@ class CashPaymentFlowTests {
     private val ref = OpaqueBytes.of(0x01)
     private lateinit var bankOfCordaNode: StartedNode<MockNode>
     private lateinit var bankOfCorda: Party
-    private lateinit var notaryNode: StartedNode<MockNode>
-    private lateinit var notary: Party
+    private lateinit var aliceNode: StartedNode<MockNode>
 
     @Before
     fun start() {
         mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance.contracts.asset"))
-        notaryNode = mockNet.createNotaryNode()
         bankOfCordaNode = mockNet.createPartyNode(BOC.name)
+        aliceNode = mockNet.createPartyNode(ALICE.name)
         bankOfCorda = bankOfCordaNode.info.chooseIdentity()
-        notary = notaryNode.services.getDefaultNotary()
-        val future = bankOfCordaNode.services.startFlow(CashIssueFlow(initialBalance, ref, notary)).resultFuture
         mockNet.runNetwork()
+        val future = bankOfCordaNode.services.startFlow(CashIssueFlow(initialBalance, ref, mockNet.defaultNotaryIdentity)).resultFuture
         future.getOrThrow()
     }
 
@@ -48,7 +46,7 @@ class CashPaymentFlowTests {
 
     @Test
     fun `pay some cash`() {
-        val payTo = notaryNode.info.chooseIdentity()
+        val payTo = aliceNode.info.chooseIdentity()
         val expectedPayment = 500.DOLLARS
         val expectedChange = 1500.DOLLARS
 
@@ -56,7 +54,7 @@ class CashPaymentFlowTests {
             // Register for vault updates
             val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val (_, vaultUpdatesBoc) = bankOfCordaNode.services.vaultService.trackBy<Cash.State>(criteria)
-            val (_, vaultUpdatesBankClient) = notaryNode.services.vaultService.trackBy<Cash.State>(criteria)
+            val (_, vaultUpdatesBankClient) = aliceNode.services.vaultService.trackBy<Cash.State>(criteria)
 
             val future = bankOfCordaNode.services.startFlow(CashPaymentFlow(expectedPayment,
                     payTo)).resultFuture
@@ -88,7 +86,7 @@ class CashPaymentFlowTests {
 
     @Test
     fun `pay more than we have`() {
-        val payTo = notaryNode.info.chooseIdentity()
+        val payTo = aliceNode.info.chooseIdentity()
         val expected = 4000.DOLLARS
         val future = bankOfCordaNode.services.startFlow(CashPaymentFlow(expected,
                 payTo)).resultFuture
@@ -100,7 +98,7 @@ class CashPaymentFlowTests {
 
     @Test
     fun `pay zero cash`() {
-        val payTo = notaryNode.info.chooseIdentity()
+        val payTo = aliceNode.info.chooseIdentity()
         val expected = 0.DOLLARS
         val future = bankOfCordaNode.services.startFlow(CashPaymentFlow(expected,
                 payTo)).resultFuture

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -15,9 +15,9 @@ import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
 import net.corda.testing.DUMMY_NOTARY
-import net.corda.testing.chooseIdentity
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
+import net.corda.testing.node.NotarySpec
 import net.corda.testing.performance.div
 import net.corda.testing.performance.startPublishingFixedRateInjector
 import net.corda.testing.performance.startReporter
@@ -102,26 +102,25 @@ class NodePerformanceTests {
 
     @Test
     fun `self pay rate`() {
-        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance")) {
-            val a = startNotaryNode(
-                    DUMMY_NOTARY.name,
-                    rpcUsers = listOf(User("A", "A", setOf(startFlow<CashIssueFlow>(), startFlow<CashPaymentFlow>())))
-            ).getOrThrow()
-            a as NodeHandle.InProcess
-            val metricRegistry = startReporter(shutdownManager, a.node.services.monitoringService.metrics)
-            a.rpcClientToNode().use("A", "A") { connection ->
-                val notary = connection.proxy.notaryIdentities().first()
+        val user = User("A", "A", setOf(startFlow<CashIssueFlow>(), startFlow<CashPaymentFlow>()))
+        driver(
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name, rpcUsers = listOf(user))),
+                startNodesInProcess = true,
+                extraCordappPackagesToScan = listOf("net.corda.finance")
+        ) {
+            val notary = defaultNotaryNode.getOrThrow() as NodeHandle.InProcess
+            val metricRegistry = startReporter(shutdownManager, notary.node.services.monitoringService.metrics)
+            notary.rpcClientToNode().use("A", "A") { connection ->
                 println("ISSUING")
                 val doneFutures = (1..100).toList().parallelStream().map {
-                    connection.proxy.startFlow(::CashIssueFlow, 1.DOLLARS, OpaqueBytes.of(0), notary).returnValue
+                    connection.proxy.startFlow(::CashIssueFlow, 1.DOLLARS, OpaqueBytes.of(0), defaultNotaryIdentity).returnValue
                 }.toList()
                 doneFutures.transpose().get()
                 println("STARTING PAYMENT")
                 startPublishingFixedRateInjector(metricRegistry, 8, 5.minutes, 100L / TimeUnit.SECONDS) {
-                    connection.proxy.startFlow(::CashPaymentFlow, 1.DOLLARS, a.nodeInfo.chooseIdentity()).returnValue.get()
+                    connection.proxy.startFlow(::CashPaymentFlow, 1.DOLLARS, defaultNotaryIdentity).returnValue.get()
                 }
             }
-
         }
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
@@ -13,20 +13,16 @@ import net.corda.core.internal.div
 import net.corda.core.internal.toLedgerTransaction
 import net.corda.core.serialization.SerializationFactory
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
-import net.corda.core.utilities.seconds
 import net.corda.node.internal.cordapp.CordappLoader
 import net.corda.node.internal.cordapp.CordappProviderImpl
-import net.corda.nodeapi.User
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.SerializationEnvironmentRule
 import net.corda.testing.driver.DriverDSLExposedInterface
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
-import net.corda.testing.eventually
 import net.corda.testing.node.MockServices
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -56,19 +52,15 @@ class AttachmentLoadingTests {
 
         val bankAName = CordaX500Name("BankA", "Zurich", "CH")
         val bankBName = CordaX500Name("BankB", "Zurich", "CH")
-        val notaryName = CordaX500Name("Notary", "Zurich", "CH")
         val flowInitiatorClass: Class<out FlowLogic<*>> =
                 Class.forName("net.corda.finance.contracts.isolated.IsolatedDummyFlow\$Initiator", true, URLClassLoader(arrayOf(isolatedJAR)))
                         .asSubclass(FlowLogic::class.java)
 
-        private fun DriverDSLExposedInterface.createNotaryAndTwoNodes(): List<NodeHandle> {
-            val adminUser = User("admin", "admin", permissions = setOf("ALL"))
-            val nodes = listOf(
-                    startNotaryNode(providedName = notaryName, rpcUsers = listOf(adminUser), validating = false),
-                    startNode(providedName = bankAName, rpcUsers = listOf(adminUser)),
-                    startNode(providedName = bankBName, rpcUsers = listOf(adminUser))
-            ).transpose().getOrThrow()   // Wait for all nodes to start up.
-            return nodes
+        private fun DriverDSLExposedInterface.createTwoNodes(): List<NodeHandle> {
+            return listOf(
+                    startNode(providedName = bankAName),
+                    startNode(providedName = bankBName)
+            ).transpose().getOrThrow()
         }
 
         private fun DriverDSLExposedInterface.installIsolatedCordappTo(nodeName: CordaX500Name) {
@@ -79,15 +71,6 @@ class AttachmentLoadingTests {
                 Files.newOutputStream(path).buffered().use { output ->
                     input.copyTo(output)
                 }
-            }
-        }
-
-        // Due to cluster instability after nodes been started it may take some time to all the nodes to become available
-        // *and* discover each other to reliably communicate. Hence, eventual nature of the test.
-        // TODO: Remove this method and usages of it once NetworkMap service been re-worked
-        private fun eventuallyPassingTest(block: () -> Unit) {
-            eventually<Throwable, Unit>(30.seconds) {
-                block()
             }
         }
     }
@@ -105,9 +88,8 @@ class AttachmentLoadingTests {
         val contractClass = appClassLoader.loadClass(ISOLATED_CONTRACT_ID).asSubclass(Contract::class.java)
         val generateInitialMethod = contractClass.getDeclaredMethod("generateInitial", PartyAndReference::class.java, Integer.TYPE, Party::class.java)
         val contract = contractClass.newInstance()
-        val txBuilder = generateInitialMethod.invoke(contract, PartyAndReference(DUMMY_BANK_A, OpaqueBytes(kotlin.ByteArray(1))), 1, DUMMY_NOTARY) as TransactionBuilder
-        val context = SerializationFactory.defaultFactory.defaultContext
-                .withClassLoader(appClassLoader)
+        val txBuilder = generateInitialMethod.invoke(contract, DUMMY_BANK_A.ref(1), 1, DUMMY_NOTARY) as TransactionBuilder
+        val context = SerializationFactory.defaultFactory.defaultContext.withClassLoader(appClassLoader)
         val ledgerTx = txBuilder.toLedgerTransaction(services, context)
         contract.verify(ledgerTx)
 
@@ -121,11 +103,9 @@ class AttachmentLoadingTests {
     fun `test that attachments retrieved over the network are not used for code`() {
         driver(initialiseSerialization = false) {
             installIsolatedCordappTo(bankAName)
-            val (_, bankA, bankB) = createNotaryAndTwoNodes()
-            eventuallyPassingTest {
-                assertFailsWith<UnexpectedFlowEndException>("Party C=CH,L=Zurich,O=BankB rejected session request: Don't know net.corda.finance.contracts.isolated.IsolatedDummyFlow\$Initiator") {
-                    bankA.rpc.startFlowDynamic(flowInitiatorClass, bankB.nodeInfo.legalIdentities.first()).returnValue.getOrThrow()
-                }
+            val (bankA, bankB) = createTwoNodes()
+            assertFailsWith<UnexpectedFlowEndException>("Party C=CH,L=Zurich,O=BankB rejected session request: Don't know net.corda.finance.contracts.isolated.IsolatedDummyFlow\$Initiator") {
+                bankA.rpc.startFlowDynamic(flowInitiatorClass, bankB.nodeInfo.legalIdentities.first()).returnValue.getOrThrow()
             }
         }
     }
@@ -135,10 +115,8 @@ class AttachmentLoadingTests {
         driver(initialiseSerialization = false) {
             installIsolatedCordappTo(bankAName)
             installIsolatedCordappTo(bankBName)
-            val (_, bankA, bankB) = createNotaryAndTwoNodes()
-            eventuallyPassingTest {
-                bankA.rpc.startFlowDynamic(flowInitiatorClass, bankB.nodeInfo.legalIdentities.first()).returnValue.getOrThrow()
-            }
+            val (bankA, bankB) = createTwoNodes()
+            bankA.rpc.startFlowDynamic(flowInitiatorClass, bankB.nodeInfo.legalIdentities.first()).returnValue.getOrThrow()
         }
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -11,60 +11,64 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.finance.POUNDS
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
-import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.node.services.Permissions.Companion.invokeRpc
-import net.corda.node.services.transactions.RaftValidatingNotaryService
+import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
 import net.corda.testing.*
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
+import net.corda.testing.node.ClusterSpec
+import net.corda.testing.node.NotarySpec
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import rx.Observable
 import java.util.*
-import kotlin.test.assertEquals
 
 class DistributedServiceTests {
-    lateinit var alice: NodeHandle
-    lateinit var notaries: List<NodeHandle.OutOfProcess>
-    lateinit var aliceProxy: CordaRPCOps
-    lateinit var raftNotaryIdentity: Party
-    lateinit var notaryStateMachines: Observable<Pair<Party, StateMachineUpdate>>
-    private fun setup(runTest: () -> Unit) = driver(extraCordappPackagesToScan = listOf("net.corda.finance.contracts")) {
-        // Start Alice and 3 notaries in a RAFT cluster
-        val clusterSize = 3
+    private lateinit var alice: NodeHandle
+    private lateinit var notaryNodes: List<NodeHandle.OutOfProcess>
+    private lateinit var aliceProxy: CordaRPCOps
+    private lateinit var raftNotaryIdentity: Party
+    private lateinit var notaryStateMachines: Observable<Pair<Party, StateMachineUpdate>>
+
+    private fun setup(testBlock: () -> Unit) {
         val testUser = User("test", "test", permissions = setOf(
                 startFlow<CashIssueFlow>(),
                 startFlow<CashPaymentFlow>(),
                 invokeRpc(CordaRPCOps::nodeInfo),
                 invokeRpc(CordaRPCOps::stateMachinesFeed))
         )
-        val notariesFuture = startNotaryCluster(
-                DUMMY_NOTARY.name.copy(commonName = RaftValidatingNotaryService.id),
-                rpcUsers = listOf(testUser),
-                clusterSize = clusterSize
-        )
-        val aliceFuture = startNode(providedName = ALICE.name, rpcUsers = listOf(testUser))
 
-        alice = aliceFuture.get()
-        val (notaryIdentity, notaryNodes) = notariesFuture.get()
-        raftNotaryIdentity = notaryIdentity
-        notaries = notaryNodes.map { it as NodeHandle.OutOfProcess }
+        driver(
+                extraCordappPackagesToScan = listOf("net.corda.finance.contracts"),
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name, rpcUsers = listOf(testUser), cluster = ClusterSpec.Raft(clusterSize = 3))))
+        {
+            alice = startNode(providedName = ALICE.name, rpcUsers = listOf(testUser)).getOrThrow()
+            raftNotaryIdentity = defaultNotaryIdentity
+            notaryNodes = defaultNotaryHandle.nodeHandles.getOrThrow().map { it as NodeHandle.OutOfProcess }
 
-        assertEquals(notaries.size, clusterSize)
-        // Check that each notary has different identity as a node.
-        assertEquals(notaries.size, notaries.map { it.nodeInfo.chooseIdentity() }.toSet().size)
-        // Connect to Alice and the notaries
-        fun connectRpc(node: NodeHandle): CordaRPCOps {
-            val client = node.rpcClientToNode()
-            return client.start("test", "test").proxy
+            assertThat(notaryNodes).hasSize(3)
+
+            for (notaryNode in notaryNodes) {
+                assertThat(notaryNode.nodeInfo.legalIdentities).contains(raftNotaryIdentity)
+            }
+
+            // Check that each notary has different identity as a node.
+            assertThat(notaryNodes.flatMap { it.nodeInfo.legalIdentities - raftNotaryIdentity }.toSet()).hasSameSizeAs(notaryNodes)
+
+            // Connect to Alice and the notaries
+            fun connectRpc(node: NodeHandle): CordaRPCOps {
+                val client = node.rpcClientToNode()
+                return client.start("test", "test").proxy
+            }
+            aliceProxy = connectRpc(alice)
+            val rpcClientsToNotaries = notaryNodes.map(::connectRpc)
+            notaryStateMachines = Observable.from(rpcClientsToNotaries.map { proxy ->
+                proxy.stateMachinesFeed().updates.map { Pair(proxy.nodeInfo().chooseIdentity(), it) }
+            }).flatMap { it.onErrorResumeNext(Observable.empty()) }.bufferUntilSubscribed()
+
+            testBlock()
         }
-        aliceProxy = connectRpc(alice)
-        val rpcClientsToNotaries = notaries.map(::connectRpc)
-        notaryStateMachines = Observable.from(rpcClientsToNotaries.map { proxy ->
-            proxy.stateMachinesFeed().updates.map { Pair(proxy.nodeInfo().chooseIdentity(), it) }
-        }).flatMap { it.onErrorResumeNext(Observable.empty()) }.bufferUntilSubscribed()
-
-        runTest()
     }
 
     // TODO Use a dummy distributed service rather than a Raft Notary Service as this test is only about Artemis' ability
@@ -106,8 +110,8 @@ class DistributedServiceTests {
             paySelf(5.POUNDS)
         }
 
-        // Now kill a notary
-        with(notaries[0].process) {
+        // Now kill a notary node
+        with(notaryNodes[0].process) {
             destroy()
             waitFor()
         }

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -8,11 +8,11 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.testing.BOB
 import net.corda.testing.DUMMY_NOTARY
+import net.corda.testing.aliceAndBob
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyState
 import net.corda.testing.driver.driver
 import net.corda.testing.dummyCommand
-import net.corda.testing.notaryAliceAndBob
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -65,7 +65,7 @@ class LargeTransactionsTest {
         val bigFile3 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 2)
         val bigFile4 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 3)
         driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.testing.contracts")) {
-            val (_, alice) = notaryAliceAndBob()
+            val (alice, _) = aliceAndBob()
             alice.useRPC {
                 val hash1 = it.uploadAttachment(bigFile1.inputStream)
                 val hash2 = it.uploadAttachment(bigFile2.inputStream)

--- a/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
@@ -17,10 +17,9 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.getOrThrow
-import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.node.services.Permissions.Companion.invokeRpc
+import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.chooseIdentity
 import net.corda.testing.driver.driver
 import org.junit.Assume.assumeFalse
@@ -43,7 +42,6 @@ class NodeStatePersistenceTests {
         val message = Message("Hello world!")
         driver(isDebug = true, startNodesInProcess = isQuasarAgentSpecified()) {
             val nodeName = {
-                startNotaryNode(DUMMY_NOTARY.name, validating = false).getOrThrow()
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name
                 nodeHandle.rpcClientToNode().start(user.username, user.password).use {

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -31,6 +31,7 @@ import java.security.PublicKey
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
 import kotlin.collections.HashMap
+import kotlin.collections.HashSet
 
 class NetworkMapCacheImpl(
         networkMapCacheBase: NetworkMapCacheBaseInternal,
@@ -85,7 +86,7 @@ open class PersistentNetworkMapCache(
     override val loadDBSuccess get() = _loadDBSuccess
 
     override val notaryIdentities: List<Party> = notaries.map { it.identity }
-    private val validatingNotaries = notaries.mapNotNull { if (it.validating) it.identity else null }
+    private val validatingNotaries = notaries.mapNotNullTo(HashSet()) { if (it.validating) it.identity else null }
 
     private val nodeInfoSerializer = NodeInfoWatcher(configuration.baseDirectory,
             configuration.additionalNodeInfoPollingFrequencyMsec)

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -50,14 +50,12 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CordaRPCOpsImplTest {
-
     private companion object {
         val testJar = "net/corda/node/testing/test.jar"
     }
 
     private lateinit var mockNet: MockNetwork
     private lateinit var aliceNode: StartedNode<MockNode>
-    private lateinit var notaryNode: StartedNode<MockNode>
     private lateinit var notary: Party
     private lateinit var rpc: CordaRPCOps
     private lateinit var stateMachineUpdates: Observable<StateMachineUpdate>
@@ -69,7 +67,6 @@ class CordaRPCOpsImplTest {
     @Before
     fun setup() {
         mockNet = MockNetwork(cordappPackages = listOf("net.corda.finance.contracts.asset"))
-        notaryNode = mockNet.createNotaryNode(validating = false)
         aliceNode = mockNet.createNode()
         rpc = SecureCordaRPCOps(aliceNode.services, aliceNode.smm, aliceNode.database, aliceNode.services)
         CURRENT_RPC_CONTEXT.set(RpcContext(user))

--- a/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
@@ -74,14 +74,12 @@ class TestCordaService2(val appServiceHub: AppServiceHub): SingletonSerializeAsT
 class LegacyCordaService(@Suppress("UNUSED_PARAMETER") simpleServiceHub: ServiceHub) : SingletonSerializeAsToken()
 
 class CordaServiceTest {
-    lateinit var mockNet: MockNetwork
-    lateinit var notaryNode: StartedNode<MockNetwork.MockNode>
-    lateinit var nodeA: StartedNode<MockNetwork.MockNode>
+    private lateinit var mockNet: MockNetwork
+    private lateinit var nodeA: StartedNode<MockNetwork.MockNode>
 
     @Before
     fun start() {
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.node.internal","net.corda.finance"))
-        notaryNode = mockNet.createNotaryNode()
         nodeA = mockNet.createNode()
         mockNet.startNodes()
     }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -63,7 +63,7 @@ import kotlin.test.assertTrue
  * We assume that Alice and Bob already found each other via some market, and have agreed the details already.
  */
 @RunWith(Parameterized::class)
-class TwoPartyTradeFlowTests(val anonymous: Boolean) {
+class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
     companion object {
         private val cordappPackages = listOf("net.corda.finance.contracts")
         @JvmStatic
@@ -93,7 +93,7 @@ class TwoPartyTradeFlowTests(val anonymous: Boolean) {
         // allow interruption half way through.
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = cordappPackages)
         ledger(MockServices(cordappPackages), initialiseSerialization = false) {
-            val notaryNode = mockNet.createNotaryNode()
+            val notaryNode = mockNet.defaultNotaryNode
             val aliceNode = mockNet.createPartyNode(ALICE_NAME)
             val bobNode = mockNet.createPartyNode(BOB_NAME)
             val bankNode = mockNet.createPartyNode(BOC_NAME)
@@ -143,7 +143,7 @@ class TwoPartyTradeFlowTests(val anonymous: Boolean) {
     fun `trade cash for commercial paper fails using soft locking`() {
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = cordappPackages)
         ledger(MockServices(cordappPackages), initialiseSerialization = false) {
-            val notaryNode = mockNet.createNotaryNode()
+            val notaryNode = mockNet.defaultNotaryNode
             val aliceNode = mockNet.createPartyNode(ALICE_NAME)
             val bobNode = mockNet.createPartyNode(BOB_NAME)
             val bankNode = mockNet.createPartyNode(BOC_NAME)
@@ -199,7 +199,7 @@ class TwoPartyTradeFlowTests(val anonymous: Boolean) {
     fun `shutdown and restore`() {
         mockNet = MockNetwork(cordappPackages = cordappPackages)
         ledger(MockServices(cordappPackages), initialiseSerialization = false) {
-            val notaryNode = mockNet.createNotaryNode()
+            val notaryNode = mockNet.defaultNotaryNode
             val aliceNode = mockNet.createPartyNode(ALICE_NAME)
             var bobNode = mockNet.createPartyNode(BOB_NAME)
             val bankNode = mockNet.createPartyNode(BOC_NAME)
@@ -292,7 +292,8 @@ class TwoPartyTradeFlowTests(val anonymous: Boolean) {
 
     // Creates a mock node with an overridden storage service that uses a RecordingMap, that lets us test the order
     // of gets and puts.
-    private fun makeNodeWithTracking(name: CordaX500Name): StartedNode<MockNetwork.MockNode> {
+    private fun makeNodeWithTracking(
+            name: CordaX500Name): StartedNode<MockNetwork.MockNode> {
         // Create a node in the mock network ...
         return mockNet.createNode(MockNodeParameters(legalName = name), nodeFactory = { args ->
             object : MockNetwork.MockNode(args) {
@@ -307,7 +308,7 @@ class TwoPartyTradeFlowTests(val anonymous: Boolean) {
     @Test
     fun `check dependencies of sale asset are resolved`() {
         mockNet = MockNetwork(cordappPackages = cordappPackages)
-        val notaryNode = mockNet.createNotaryNode()
+        val notaryNode = mockNet.defaultNotaryNode
         val aliceNode = makeNodeWithTracking(ALICE_NAME)
         val bobNode = makeNodeWithTracking(BOB_NAME)
         val bankNode = makeNodeWithTracking(BOC_NAME)
@@ -413,7 +414,7 @@ class TwoPartyTradeFlowTests(val anonymous: Boolean) {
     @Test
     fun `track works`() {
         mockNet = MockNetwork(cordappPackages = cordappPackages)
-        val notaryNode = mockNet.createNotaryNode()
+        val notaryNode = mockNet.defaultNotaryNode
         val aliceNode = makeNodeWithTracking(ALICE_NAME)
         val bobNode = makeNodeWithTracking(BOB_NAME)
         val bankNode = makeNodeWithTracking(BOC_NAME)
@@ -568,7 +569,7 @@ class TwoPartyTradeFlowTests(val anonymous: Boolean) {
             aliceError: Boolean,
             expectedMessageSubstring: String
     ) {
-        val notaryNode = mockNet.createNotaryNode()
+        val notaryNode = mockNet.defaultNotaryNode
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)
         val bobNode = mockNet.createPartyNode(BOB_NAME)
         val bankNode = mockNet.createPartyNode(BOC_NAME)

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -35,7 +35,6 @@ class ScheduledFlowTests {
     }
 
     lateinit var mockNet: MockNetwork
-    lateinit var notaryNode: StartedNode<MockNetwork.MockNode>
     lateinit var nodeA: StartedNode<MockNetwork.MockNode>
     lateinit var nodeB: StartedNode<MockNetwork.MockNode>
 
@@ -94,7 +93,6 @@ class ScheduledFlowTests {
     @Before
     fun setup() {
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.testing.contracts"))
-        notaryNode = mockNet.createNotaryNode()
         val a = mockNet.createUnstartedNode()
         val b = mockNet.createUnstartedNode()
 

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt
@@ -38,13 +38,13 @@ class NetworkMapCacheTest {
 
     @Test
     fun `getNodeByLegalIdentity`() {
-        val notaryNode = mockNet.createNotaryNode()
         val aliceNode = mockNet.createPartyNode(ALICE.name)
-        val notaryCache: NetworkMapCache = notaryNode.services.networkMapCache
+        val bobNode = mockNet.createPartyNode(BOB.name)
+        val bobCache: NetworkMapCache = bobNode.services.networkMapCache
         val expected = aliceNode.info
 
         mockNet.runNetwork()
-        val actual = notaryNode.database.transaction { notaryCache.getNodeByLegalIdentity(aliceNode.info.chooseIdentity()) }
+        val actual = bobNode.database.transaction { bobCache.getNodeByLegalIdentity(aliceNode.info.chooseIdentity()) }
         assertEquals(expected, actual)
 
         // TODO: Should have a test case with anonymous lookup
@@ -52,30 +52,30 @@ class NetworkMapCacheTest {
 
     @Test
     fun `getPeerByLegalName`() {
-        val notaryNode = mockNet.createNotaryNode()
         val aliceNode = mockNet.createPartyNode(ALICE.name)
-        val notaryCache: NetworkMapCache = notaryNode.services.networkMapCache
+        val bobNode = mockNet.createPartyNode(BOB.name)
+        val bobCache: NetworkMapCache = bobNode.services.networkMapCache
         val expected = aliceNode.info.legalIdentities.single()
 
         mockNet.runNetwork()
-        val actual = notaryNode.database.transaction { notaryCache.getPeerByLegalName(ALICE.name) }
+        val actual = bobNode.database.transaction { bobCache.getPeerByLegalName(ALICE.name) }
         assertEquals(expected, actual)
     }
 
     @Test
     fun `remove node from cache`() {
-        val notaryNode = mockNet.createNotaryNode()
         val aliceNode = mockNet.createPartyNode(ALICE.name)
-        val notaryLegalIdentity = notaryNode.info.chooseIdentity()
+        val bobNode = mockNet.createPartyNode(BOB.name)
+        val bobLegalIdentity = bobNode.info.chooseIdentity()
         val alice = aliceNode.info.chooseIdentity()
-        val notaryCache = notaryNode.services.networkMapCache
+        val bobCache = bobNode.services.networkMapCache
         mockNet.runNetwork()
-        notaryNode.database.transaction {
-            assertThat(notaryCache.getNodeByLegalIdentity(alice) != null)
-            notaryCache.removeNode(aliceNode.info)
-            assertThat(notaryCache.getNodeByLegalIdentity(alice) == null)
-            assertThat(notaryCache.getNodeByLegalIdentity(notaryLegalIdentity) != null)
-            assertThat(notaryCache.getNodeByLegalName(alice.name) == null)
+        bobNode.database.transaction {
+            assertThat(bobCache.getNodeByLegalIdentity(alice) != null)
+            bobCache.removeNode(aliceNode.info)
+            assertThat(bobCache.getNodeByLegalIdentity(alice) == null)
+            assertThat(bobCache.getNodeByLegalIdentity(bobLegalIdentity) != null)
+            assertThat(bobCache.getNodeByLegalName(alice.name) == null)
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -74,8 +74,8 @@ class FlowFrameworkTests {
     fun start() {
         mockNet = MockNetwork(
                 servicePeerAllocationStrategy = RoundRobin(),
-                cordappPackages = listOf("net.corda.finance.contracts", "net.corda.testing.contracts"))
-        val notary = mockNet.createNotaryNode()
+                cordappPackages = listOf("net.corda.finance.contracts", "net.corda.testing.contracts")
+        )
         aliceNode = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         bobNode = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))
 
@@ -84,7 +84,7 @@ class FlowFrameworkTests {
         // Extract identities
         alice = aliceNode.info.singleIdentity()
         bob = bobNode.info.singleIdentity()
-        notaryIdentity = notary.services.getDefaultNotary()
+        notaryIdentity = aliceNode.services.getDefaultNotary()
     }
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -15,10 +15,13 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.issueInvalidState
-import net.corda.testing.*
+import net.corda.testing.ALICE_NAME
+import net.corda.testing.MEGA_CORP_KEY
 import net.corda.testing.contracts.DummyContract
+import net.corda.testing.dummyCommand
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.singleIdentity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -28,21 +31,20 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class ValidatingNotaryServiceTests {
-    lateinit var mockNet: MockNetwork
-    lateinit var notaryServices: StartedNodeServices
-    lateinit var aliceServices: StartedNodeServices
-    lateinit var notary: Party
-    lateinit var alice: Party
+    private lateinit var mockNet: MockNetwork
+    private lateinit var notaryServices: StartedNodeServices
+    private lateinit var aliceServices: StartedNodeServices
+    private lateinit var notary: Party
+    private lateinit var alice: Party
 
     @Before
     fun setup() {
         mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
-        val notaryNode = mockNet.createNotaryNode()
         val aliceNode = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         mockNet.runNetwork() // Clear network map registration messages
-        notaryServices = notaryNode.services
+        notaryServices = mockNet.defaultNotaryNode.services
         aliceServices = aliceNode.services
-        notary = notaryServices.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
         alice = aliceNode.info.singleIdentity()
     }
 
@@ -97,7 +99,7 @@ class ValidatingNotaryServiceTests {
         return future
     }
 
-    fun issueState(serviceHub: ServiceHub, identity: Party): StateAndRef<*> {
+    private fun issueState(serviceHub: ServiceHub, identity: Party): StateAndRef<*> {
         val tx = DummyContract.generateInitial(Random().nextInt(), notary, identity.ref(0))
         val signedByNode = serviceHub.signInitialTransaction(tx)
         val stx = notaryServices.addSignature(signedByNode, notary.owningKey)

--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -7,7 +7,6 @@ import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import org.junit.Test
@@ -27,11 +26,10 @@ class AttachmentDemoTest {
                     invokeRpc(CordaRPCOps::wellKnownPartyFromX500Name),
                     invokeRpc(CordaRPCOps::internalVerifiedTransactionsFeed)
             )))
-            val (_, nodeA, nodeB) = listOf(
-                    startNotaryNode(DUMMY_NOTARY.name, validating = false),
+            val (nodeA, nodeB) = listOf(
                     startNode(providedName = DUMMY_BANK_A.name, rpcUsers = demoUser, maximumHeapSize = "1g"),
-                    startNode(providedName = DUMMY_BANK_B.name, rpcUsers = demoUser, maximumHeapSize = "1g"))
-                    .map { it.getOrThrow() }
+                    startNode(providedName = DUMMY_BANK_B.name, rpcUsers = demoUser, maximumHeapSize = "1g")
+            ).map { it.getOrThrow() }
             startWebserver(nodeB).getOrThrow()
 
             val senderThread = supplyAsync {

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
@@ -4,7 +4,6 @@ import net.corda.core.internal.div
 import net.corda.nodeapi.User
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.driver
 
 /**
@@ -14,7 +13,6 @@ import net.corda.testing.driver.driver
 fun main(args: Array<String>) {
     val demoUser = listOf(User("demo", "demo", setOf("StartFlow.net.corda.flows.FinalityFlow")))
     driver(isDebug = true, driverDirectory = "build" / "attachment-demo-nodes") {
-        startNotaryNode(DUMMY_NOTARY.name, validating = false)
         startNode(providedName = DUMMY_BANK_A.name, rpcUsers = demoUser)
         startNode(providedName = DUMMY_BANK_B.name, rpcUsers = demoUser)
         waitForAllNodesToFinish()

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaHttpAPITest.kt
@@ -2,10 +2,8 @@ package net.corda.bank
 
 import net.corda.bank.api.BankOfCordaClientApi
 import net.corda.bank.api.BankOfCordaWebApi.IssueRequestParams
-import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.BOC
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.driver
 import org.junit.Test
 import kotlin.test.assertTrue
@@ -13,14 +11,13 @@ import kotlin.test.assertTrue
 class BankOfCordaHttpAPITest {
     @Test
     fun `issuer flow via Http`() {
-        driver(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.finance")) {
-            val (_, bocNode) = listOf(
-                    startNotaryNode(providedName = DUMMY_NOTARY.name),
+        driver(extraCordappPackagesToScan = listOf("net.corda.finance"), isDebug = true) {
+            val (bocNode) = listOf(
                     startNode(providedName = BOC.name),
                     startNode(providedName = BIGCORP_LEGAL_NAME)
-            ).transpose().getOrThrow()
+            ).map { it.getOrThrow() }
             val bocApiAddress = startWebserver(bocNode).getOrThrow().listenAddress
-            val issueRequestParams = IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name, DUMMY_NOTARY.name)
+            val issueRequestParams = IssueRequestParams(1000, "USD", BIGCORP_LEGAL_NAME, "1", BOC.name, defaultNotaryIdentity.name)
             assertTrue(BankOfCordaClientApi(bocApiAddress).requestWebIssue(issueRequestParams))
         }
     }

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
@@ -10,7 +10,6 @@ import net.corda.finance.flows.CashExitFlow
 import net.corda.finance.flows.CashIssueAndPaymentFlow
 import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.startFlow
-import net.corda.node.services.transactions.ValidatingNotaryService
 import net.corda.nodeapi.User
 import net.corda.testing.BOC
 import net.corda.testing.DUMMY_NOTARY
@@ -58,7 +57,6 @@ private class BankOfCordaDriver {
             when (role) {
                 Role.ISSUER -> {
                     driver(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.finance.contracts.asset")) {
-                        startNotaryNode(providedName = DUMMY_NOTARY.name, validating = true)
                         val bankUser = User(
                                 BANK_USERNAME,
                                 "test",
@@ -83,7 +81,7 @@ private class BankOfCordaDriver {
                 }
                 else -> {
                     val requestParams = IssueRequestParams(options.valueOf(quantity), options.valueOf(currency), BIGCORP_LEGAL_NAME,
-                            "1", BOC.name, DUMMY_NOTARY.name.copy(commonName = ValidatingNotaryService.id))
+                            "1", BOC.name, DUMMY_NOTARY.name)
                     when(role) {
                         Role.ISSUE_CASH_RPC -> {
                             println("Requesting Cash via RPC ...")

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt
@@ -3,7 +3,6 @@ package net.corda.irs
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.driver
 
 /**
@@ -11,17 +10,17 @@ import net.corda.testing.driver.driver
  * Do not use in a production environment.
  */
 fun main(args: Array<String>) {
-    driver(dsl = {
-        val (controller, nodeA, nodeB) = listOf(
-                startNotaryNode(DUMMY_NOTARY.name, validating = false),
+    driver(useTestClock = true, isDebug = true) {
+        val (nodeA, nodeB) = listOf(
                 startNode(providedName = DUMMY_BANK_A.name),
-                startNode(providedName = DUMMY_BANK_B.name))
-                .map { it.getOrThrow() }
+                startNode(providedName = DUMMY_BANK_B.name)
+        ).map { it.getOrThrow() }
+        val controller = defaultNotaryNode.getOrThrow()
 
         startWebserver(controller)
         startWebserver(nodeA)
         startWebserver(nodeB)
 
         waitForAllNodesToFinish()
-    }, useTestClock = true, isDebug = true)
+    }
 }

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.readValue
+import net.corda.client.jackson.JacksonSupport
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.Party
@@ -24,6 +25,7 @@ import net.corda.nodeapi.User
 import net.corda.test.spring.springDriver
 import net.corda.testing.*
 import net.corda.testing.http.HttpApi
+import net.corda.testing.node.NotarySpec
 import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -44,11 +46,17 @@ class IRSDemoTest : IntegrationTestCategory {
 
     @Test
     fun `runs IRS demo`() {
-        springDriver(useTestClock = true, isDebug = true, extraCordappPackagesToScan = listOf("net.corda.irs")) {
-            val (controller, nodeA, nodeB) = listOf(
-                    startNotaryNode(DUMMY_NOTARY.name, validating = true, rpcUsers = rpcUsers),
+        springDriver(
+                useTestClock = true,
+                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name, rpcUsers = rpcUsers)),
+                isDebug = true,
+                extraCordappPackagesToScan = listOf("net.corda.irs")
+        ) {
+            val (nodeA, nodeB) = listOf(
                     startNode(providedName = DUMMY_BANK_A.name, rpcUsers = rpcUsers),
-                    startNode(providedName = DUMMY_BANK_B.name, rpcUsers = rpcUsers)).map { it.getOrThrow() }
+                    startNode(providedName = DUMMY_BANK_B.name, rpcUsers = rpcUsers)
+            ).map { it.getOrThrow() }
+            val controller = defaultNotaryNode.getOrThrow()
 
             log.info("All nodes started")
 
@@ -61,7 +69,7 @@ class IRSDemoTest : IntegrationTestCategory {
             log.info("All webservers started")
 
             val (controllerApi, nodeAApi, nodeBApi) = listOf(controller, nodeA, nodeB).zip(listOf(controllerAddr, nodeAAddr, nodeBAddr)).map {
-                val mapper = net.corda.client.jackson.JacksonSupport.createDefaultMapper(it.first.rpc)
+                val mapper = JacksonSupport.createDefaultMapper(it.first.rpc)
                 registerFinanceJSONMappers(mapper)
                 registerIRSModule(mapper)
                 HttpApi.fromHostAndPort(it.second, "api/irs", mapper = mapper)
@@ -86,7 +94,9 @@ class IRSDemoTest : IntegrationTestCategory {
         }
     }
 
-    fun getFloatingLegFixCount(nodeApi: HttpApi) = getTrades(nodeApi)[0].calculation.floatingLegPaymentSchedule.count { it.value.rate.ratioUnit != null }
+    private fun getFloatingLegFixCount(nodeApi: HttpApi): Int {
+        return getTrades(nodeApi)[0].calculation.floatingLegPaymentSchedule.count { it.value.rate.ratioUnit != null }
+    }
 
     private fun getFixingDateObservable(config: NodeConfiguration): Observable<LocalDate?> {
         val client = CordaRPCClient(config.rpcAddress!!)

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
@@ -6,6 +6,7 @@ import net.corda.core.internal.concurrent.fork
 import net.corda.core.internal.concurrent.map
 import net.corda.core.utilities.loggerFor
 import net.corda.testing.driver.*
+import net.corda.testing.node.NotarySpec
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.ConnectException
@@ -41,6 +42,7 @@ fun <A> springDriver(
         useTestClock: Boolean = defaultParameters.useTestClock,
         initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
         startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
+        notarySpecs: List<NotarySpec>,
         extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
         dsl: SpringDriverExposedDSLInterface.() -> A
 ) = genericDriver(
@@ -54,9 +56,9 @@ fun <A> springDriver(
         initialiseSerialization = initialiseSerialization,
         startNodesInProcess = startNodesInProcess,
         extraCordappPackagesToScan = extraCordappPackagesToScan,
+        notarySpecs = notarySpecs,
         driverDslWrapper = { driverDSL:DriverDSL -> SpringBootDriverDSL(driverDSL) },
-        coerce = { it },
-        dsl = dsl
+        coerce = { it }, dsl = dsl
 )
 
 data class SpringBootDriverDSL(

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/IRSSimulation.kt
@@ -31,7 +31,6 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletableFuture.allOf
 
-
 /**
  * A simulation in which banks execute interest rate swaps with each other, including the fixing events.
  */
@@ -140,8 +139,6 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
         node1.internals.registerInitiatedFlow(FixingFlow.Fixer::class.java)
         node2.internals.registerInitiatedFlow(FixingFlow.Fixer::class.java)
 
-        val notaryId = notary.info.legalIdentities[0]
-
         @InitiatingFlow
         class StartDealFlow(val otherParty: Party,
                             val payload: AutoOffer) : FlowLogic<SignedTransaction>() {
@@ -166,7 +163,7 @@ class IRSSimulation(networkSendManuallyPumped: Boolean, runAsync: Boolean, laten
 
         val instigator = StartDealFlow(
                 node2.info.chooseIdentity(),
-                AutoOffer(notaryId, irs)) // TODO Pass notary as parameter to Simulation.
+                AutoOffer(mockNet.defaultNotaryIdentity, irs)) // TODO Pass notary as parameter to Simulation.
         val instigatorTxFuture = node1.services.startFlow(instigator).resultFuture
 
         return allOf(instigatorTxFuture.toCompletableFuture(), acceptorTxFuture).thenCompose { instigatorTxFuture.toCompletableFuture() }

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
@@ -9,7 +9,6 @@ import net.corda.finance.utils.CityDatabase
 import net.corda.irs.api.NodeInterestRates
 import net.corda.node.internal.StartedNode
 import net.corda.node.services.statemachine.StateMachineManager
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.DUMMY_REGULATOR
 import net.corda.testing.node.*
 import net.corda.testing.node.MockNetwork.MockNode
@@ -71,14 +70,13 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
             networkSendManuallyPumped = networkSendManuallyPumped,
             threadPerNode = runAsync,
             cordappPackages = listOf("net.corda.irs.contract", "net.corda.finance.contract", "net.corda.irs"))
-    val notary = mockNet.createNotaryNode(defaultParams.copy(legalName = DUMMY_NOTARY.name), false)
     // TODO: Regulatory nodes don't actually exist properly, this is a last minute demo request.
     //       So we just fire a message at a node that doesn't know how to handle it, and it'll ignore it.
     //       But that's fine for visualisation purposes.
     val regulators = listOf(mockNet.createUnstartedNode(defaultParams.copy(legalName = DUMMY_REGULATOR.name)))
     val ratesOracle = mockNet.createUnstartedNode(defaultParams.copy(legalName = RatesOracleNode.RATES_SERVICE_NAME), ::RatesOracleNode)
     // All nodes must be in one of these two lists for the purposes of the visualiser tool.
-    val serviceProviders: List<MockNode> = listOf(notary.internals, ratesOracle)
+    val serviceProviders: List<MockNode> = listOf(mockNet.defaultNotaryNode.internals, ratesOracle)
     val banks: List<MockNode> = bankLocations.mapIndexed { i, (city, country) ->
         val legalName = CordaX500Name(organisation = "Bank ${'A' + i}", locality = city, country = country)
         // Use deterministic seeds so the simulation is stable. Needed so that party owning keys are stable.

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -3,7 +3,9 @@ package net.corda.vega
 import com.opengamma.strata.product.common.BuySell
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
-import net.corda.testing.*
+import net.corda.testing.DUMMY_BANK_A
+import net.corda.testing.DUMMY_BANK_B
+import net.corda.testing.IntegrationTestCategory
 import net.corda.testing.driver.driver
 import net.corda.testing.http.HttpApi
 import net.corda.vega.api.PortfolioApi
@@ -27,7 +29,6 @@ class SimmValuationTest : IntegrationTestCategory {
     @Test
     fun `runs SIMM valuation demo`() {
         driver(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.vega.contracts")) {
-            startNotaryNode(DUMMY_NOTARY.name, validating = false).getOrThrow()
             val nodeAFuture = startNode(providedName = nodeALegalName)
             val nodeBFuture = startNode(providedName = nodeBLegalName)
             val (nodeA, nodeB) = listOf(nodeAFuture, nodeBFuture).map { it.getOrThrow() }

--- a/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
+++ b/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
@@ -4,7 +4,6 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
 import net.corda.testing.DUMMY_BANK_C
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.driver
 
 /**
@@ -13,17 +12,17 @@ import net.corda.testing.driver.driver
  * via the web api.
  */
 fun main(args: Array<String>) {
-    driver(dsl = {
-        val notaryFuture = startNotaryNode(DUMMY_NOTARY.name, validating = false)
-        val nodeAFuture = startNode(providedName = DUMMY_BANK_A.name)
-        val nodeBFuture = startNode(providedName = DUMMY_BANK_B.name)
-        val nodeCFuture = startNode(providedName = DUMMY_BANK_C.name)
-        val (nodeA, nodeB, nodeC) = listOf(nodeAFuture, nodeBFuture, nodeCFuture, notaryFuture).map { it.getOrThrow() }
+    driver(isDebug = true) {
+        val (nodeA, nodeB, nodeC) = listOf(
+                startNode(providedName = DUMMY_BANK_A.name),
+                startNode(providedName = DUMMY_BANK_B.name),
+                startNode(providedName = DUMMY_BANK_C.name)
+        ).map { it.getOrThrow() }
 
         startWebserver(nodeA)
         startWebserver(nodeB)
         startWebserver(nodeC)
 
         waitForAllNodesToFinish()
-    }, isDebug = true)
+    }
 }

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -9,7 +9,10 @@ import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
-import net.corda.testing.*
+import net.corda.testing.BOC
+import net.corda.testing.DUMMY_BANK_A
+import net.corda.testing.DUMMY_BANK_B
+import net.corda.testing.chooseIdentity
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.poll
@@ -30,8 +33,7 @@ class TraderDemoTest {
                 startFlow<CommercialPaperIssueFlow>(),
                 all()))
         driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance")) {
-            val (_, nodeA, nodeB, bankNode) = listOf(
-                    startNotaryNode(DUMMY_NOTARY.name, validating = false),
+            val (nodeA, nodeB, bankNode) = listOf(
                     startNode(providedName = DUMMY_BANK_A.name, rpcUsers = listOf(demoUser)),
                     startNode(providedName = DUMMY_BANK_B.name, rpcUsers = listOf(demoUser)),
                     startNode(providedName = BOC.name, rpcUsers = listOf(bankUser))

--- a/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt
+++ b/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt
@@ -8,7 +8,6 @@ import net.corda.nodeapi.User
 import net.corda.testing.BOC
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.driver
 import net.corda.traderdemo.flow.CommercialPaperIssueFlow
 import net.corda.traderdemo.flow.SellerFlow
@@ -27,7 +26,6 @@ fun main(args: Array<String>) {
         val user = User("user1", "test", permissions = setOf(startFlow<CashIssueFlow>(),
                 startFlow<CommercialPaperIssueFlow>(),
                 startFlow<SellerFlow>()))
-        startNotaryNode(DUMMY_NOTARY.name, validating = false)
         startNode(providedName = DUMMY_BANK_A.name, rpcUsers = demoUser)
         startNode(providedName = DUMMY_BANK_B.name, rpcUsers = demoUser)
         startNode(providedName = BOC.name, rpcUsers = listOf(user))

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/FlowStackSnapshotTest.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/FlowStackSnapshotTest.kt
@@ -290,7 +290,6 @@ class FlowStackSnapshotTest {
     @Test
     fun `flowStackSnapshot object is serializable`() {
         val mockNet = MockNetwork(threadPerNode = true)
-        mockNet.createNotaryNode()
         val node = mockNet.createPartyNode()
         node.internals.registerInitiatedFlow(DummyFlow::class.java)
         node.services.startFlow(FlowStackSnapshotSerializationTestingFlow()).resultFuture.get()

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -7,7 +7,6 @@ import net.corda.core.internal.readLines
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.NodeStartup
 import net.corda.testing.DUMMY_BANK_A
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.DUMMY_REGULATOR
 import net.corda.testing.ProjectStructure.projectRootDir
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +17,6 @@ import java.util.concurrent.ScheduledExecutorService
 class DriverTests {
 
     companion object {
-
         private val executorService: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
 
         private fun nodeMustBeUp(handleFuture: CordaFuture<out NodeHandle>) = handleFuture.getOrThrow().apply {
@@ -32,26 +30,15 @@ class DriverTests {
             // Check that the port is bound
             addressMustNotBeBound(executorService, hostAndPort)
         }
-
     }
 
     @Test
     fun `simple node startup and shutdown`() {
-        val handles = driver {
-            val notary = startNotaryNode(DUMMY_NOTARY.name, validating = false)
+        val handle = driver {
             val regulator = startNode(providedName = DUMMY_REGULATOR.name)
-            listOf(nodeMustBeUp(notary), nodeMustBeUp(regulator))
+            nodeMustBeUp(regulator)
         }
-        handles.map { nodeMustBeDown(it) }
-    }
-
-    @Test
-    fun `starting node with no services`() {
-        val noService = driver {
-            val noService = startNode(providedName = DUMMY_BANK_A.name)
-            nodeMustBeUp(noService)
-        }
-        nodeMustBeDown(noService)
+        nodeMustBeDown(handle)
     }
 
     @Test

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/DriverConstants.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/DriverConstants.kt
@@ -15,17 +15,11 @@ import net.corda.testing.driver.DriverDSLExposedInterface
 /**
  * A simple wrapper for objects provided by the integration test driver DSL. The fields are lazy so
  * node construction won't start until you access the members. You can get one of these from the
- * [alice], [bob] and [notaryAliceAndBob] functions.
+ * [alice], [bob] and [aliceAndBob] functions.
  */
-class PredefinedTestNode internal constructor(party: Party, driver: DriverDSLExposedInterface, ifNotaryIsValidating: Boolean?) {
+class PredefinedTestNode internal constructor(party: Party, driver: DriverDSLExposedInterface) {
     val rpcUsers = listOf(User("admin", "admin", setOf("ALL")))  // TODO: Randomize?
-    val nodeFuture by lazy {
-        if (ifNotaryIsValidating != null) {
-            driver.startNotaryNode(providedName = party.name, rpcUsers = rpcUsers, validating = ifNotaryIsValidating)
-        } else {
-            driver.startNode(providedName = party.name, rpcUsers = rpcUsers)
-        }
-    }
+    val nodeFuture by lazy { driver.startNode(providedName = party.name, rpcUsers = rpcUsers) }
     val node by lazy { nodeFuture.get()!! }
     val rpc by lazy { node.rpcClientToNode() }
 
@@ -38,28 +32,21 @@ class PredefinedTestNode internal constructor(party: Party, driver: DriverDSLExp
  * Returns a plain, entirely stock node pre-configured with the [ALICE] identity. Note that a random key will be generated
  * for it: you won't have [ALICE_KEY].
  */
-fun DriverDSLExposedInterface.alice(): PredefinedTestNode = PredefinedTestNode(ALICE, this, null)
+fun DriverDSLExposedInterface.alice(): PredefinedTestNode = PredefinedTestNode(ALICE, this)
 
 /**
  * Returns a plain, entirely stock node pre-configured with the [BOB] identity. Note that a random key will be generated
  * for it: you won't have [BOB_KEY].
  */
-fun DriverDSLExposedInterface.bob(): PredefinedTestNode = PredefinedTestNode(BOB, this, null)
+fun DriverDSLExposedInterface.bob(): PredefinedTestNode = PredefinedTestNode(BOB, this)
 
 /**
- * Returns a plain single node notary pre-configured with the [DUMMY_NOTARY] identity. Note that a random key will be generated
- * for it: you won't have [DUMMY_NOTARY_KEY].
+ * Returns plain, entirely stock nodes pre-configured with the [ALICE] and [BOB] X.500 names in that order. They have been
+ * started up in parallel and are now ready to use.
  */
-fun DriverDSLExposedInterface.notary(): PredefinedTestNode = PredefinedTestNode(DUMMY_NOTARY, this, true)
-
-/**
- * Returns plain, entirely stock nodes pre-configured with the [ALICE], [BOB] and [DUMMY_NOTARY] X.500 names in that
- * order. They have been started up in parallel and are now ready to use.
- */
-fun DriverDSLExposedInterface.notaryAliceAndBob(): List<PredefinedTestNode> {
-    val notary = notary()
+fun DriverDSLExposedInterface.aliceAndBob(): List<PredefinedTestNode> {
     val alice = alice()
     val bob = bob()
-    listOf(notary.nodeFuture, alice.nodeFuture, bob.nodeFuture).transpose().get()
-    return listOf(alice, bob, notary)
+    listOf(alice.nodeFuture, bob.nodeFuture).transpose().get()
+    return listOf(alice, bob)
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/RPCDriver.kt
@@ -23,6 +23,7 @@ import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.User
 import net.corda.nodeapi.internal.serialization.KRYO_RPC_CLIENT_CONTEXT
 import net.corda.testing.driver.*
+import net.corda.testing.node.NotarySpec
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.TransportConfiguration
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient
@@ -230,6 +231,7 @@ fun <A> rpcDriver(
         initialiseSerialization: Boolean = true,
         startNodesInProcess: Boolean = false,
         extraCordappPackagesToScan: List<String> = emptyList(),
+        notarySpecs: List<NotarySpec> = emptyList(),
         dsl: RPCDriverExposedDSLInterface.() -> A
 ) = genericDriver(
         driverDsl = RPCDriverDSL(
@@ -241,7 +243,8 @@ fun <A> rpcDriver(
                         useTestClock = useTestClock,
                         isDebug = isDebug,
                         startNodesInProcess = startNodesInProcess,
-                        extraCordappPackagesToScan = extraCordappPackagesToScan
+                        extraCordappPackagesToScan = extraCordappPackagesToScan,
+                        notarySpecs = notarySpecs
                 )
         ),
         coerce = { it },

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -16,6 +16,7 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.*
 import net.corda.core.internal.concurrent.*
 import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.NotaryInfo
 import net.corda.core.node.services.NetworkMapCache
@@ -33,13 +34,12 @@ import net.corda.nodeapi.NodeInfoFilesCopier
 import net.corda.nodeapi.User
 import net.corda.nodeapi.config.toConfig
 import net.corda.nodeapi.internal.addShutdownHook
-import net.corda.testing.ALICE
-import net.corda.testing.BOB
-import net.corda.testing.DUMMY_BANK_A
+import net.corda.testing.*
 import net.corda.testing.common.internal.NetworkParametersCopier
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.initialiseTestSerialization
+import net.corda.testing.node.ClusterSpec
 import net.corda.testing.node.MockServices.Companion.MOCK_VERSION_INFO
+import net.corda.testing.node.NotarySpec
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.slf4j.Logger
@@ -85,9 +85,47 @@ private val DRIVER_REQUIRED_PERMISSIONS = setOf(
 )
 
 /**
+ * Object ecapsulating a notary started automatically by the driver.
+ */
+data class NotaryHandle(val identity: Party, val validating: Boolean, val nodeHandles: CordaFuture<List<NodeHandle>>)
+
+/**
  * This is the interface that's exposed to DSL users.
  */
 interface DriverDSLExposedInterface : CordformContext {
+    /** Returns a list of [NotaryHandle]s matching the list of [NotarySpec]s passed into [driver]. */
+    val notaryHandles: List<NotaryHandle>
+
+    /**
+     * Returns the [NotaryHandle] for the single notary on the network. Throws if there are none or more than one.
+     * @see notaryHandles
+     */
+    val defaultNotaryHandle: NotaryHandle get() {
+        return when (notaryHandles.size) {
+            0 -> throw IllegalStateException("There are no notaries defined on the network")
+            1 -> notaryHandles[0]
+            else -> throw IllegalStateException("There is more than one notary defined on the network")
+        }
+    }
+
+    /**
+     * Returns the identity of the single notary on the network. Throws if there are none or more than one.
+     * @see defaultNotaryHandle
+     */
+    val defaultNotaryIdentity: Party get() = defaultNotaryHandle.identity
+
+    /**
+     * Returns a [CordaFuture] on the [NodeHandle] for the single-node notary on the network. Throws if there
+     * are no notaries or more than one, or if the notary is a distributed cluster.
+     * @see defaultNotaryHandle
+     * @see notaryHandles
+     */
+    val defaultNotaryNode: CordaFuture<NodeHandle> get() {
+        return defaultNotaryHandle.nodeHandles.map {
+            it.singleOrNull() ?: throw IllegalStateException("Default notary is not a single node")
+        }
+    }
+
     /**
      * Start a node.
      *
@@ -110,13 +148,6 @@ interface DriverDSLExposedInterface : CordformContext {
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize): CordaFuture<NodeHandle>
 
-    // TODO This method has been added temporarily, to be deleted once the set of notaries is defined at the network level.
-    fun startNotaryNode(providedName: CordaX500Name,
-                        rpcUsers: List<User> = emptyList(),
-                        verifierType: VerifierType = VerifierType.InMemory,
-                        customOverrides: Map<String, Any?> = emptyMap(),
-                        validating: Boolean = true): CordaFuture<NodeHandle>
-
     /**
      * Helper function for starting a [Node] with custom parameters from Java.
      *
@@ -130,24 +161,6 @@ interface DriverDSLExposedInterface : CordformContext {
             startInSameProcess: Boolean? = null,
             maximumHeapSize: String = "200m"
     ): List<CordaFuture<NodeHandle>>
-
-    /**
-     * Starts a distributed notary cluster.
-     *
-     * @param notaryName The legal name of the advertised distributed notary service.
-     * @param clusterSize Number of nodes to create for the cluster.
-     * @param verifierType The type of transaction verifier to use. See: [VerifierType]
-     * @param rpcUsers List of users who are authorised to use the RPC system. Defaults to empty list.
-     * @param startInSameProcess Determines if the node should be started inside the same process the Driver is running
-     *     in. If null the Driver-level value will be used.
-     * @return The [Party] identity of the distributed notary service, and the [NodeInfo]s of the notaries in the cluster.
-     */
-    fun startNotaryCluster(
-            notaryName: CordaX500Name,
-            clusterSize: Int = 3,
-            verifierType: VerifierType = VerifierType.InMemory,
-            rpcUsers: List<User> = emptyList(),
-            startInSameProcess: Boolean? = null): CordaFuture<Pair<Party, List<NodeHandle>>>
 
     /** Call [startWebserver] with a default maximumHeapSize. */
     fun startWebserver(handle: NodeHandle): CordaFuture<WebserverHandle> = startWebserver(handle, "200m")
@@ -310,6 +323,8 @@ data class NodeParameters(
  * @param useTestClock If true the test clock will be used in Node.
  * @param startNodesInProcess Provides the default behaviour of whether new nodes should start inside this process or
  *     not. Note that this may be overridden in [DriverDSLExposedInterface.startNode].
+ * @param notarySpecs The notaries advertised in the [NetworkParameters] for this network. These nodes will be started
+ * automatically and will be available from [DriverDSLExposedInterface.notaryHandles]. Defaults to a simple validating notary.
  * @param dsl The dsl itself.
  * @return The value returned in the [dsl] closure.
  */
@@ -323,6 +338,7 @@ fun <A> driver(
         useTestClock: Boolean = defaultParameters.useTestClock,
         initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
         startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
+        notarySpecs: List<NotarySpec> = defaultParameters.notarySpecs,
         extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
         dsl: DriverDSLExposedInterface.() -> A
 ): A {
@@ -335,6 +351,7 @@ fun <A> driver(
                     useTestClock = useTestClock,
                     isDebug = isDebug,
                     startNodesInProcess = startNodesInProcess,
+                    notarySpecs = notarySpecs,
                     extraCordappPackagesToScan = extraCordappPackagesToScan
             ),
             coerce = { it },
@@ -368,6 +385,7 @@ data class DriverParameters(
         val useTestClock: Boolean = false,
         val initialiseSerialization: Boolean = true,
         val startNodesInProcess: Boolean = false,
+        val notarySpecs: List<NotarySpec> = listOf(NotarySpec(DUMMY_NOTARY.name)),
         val extraCordappPackagesToScan: List<String> = emptyList()
 ) {
     fun setIsDebug(isDebug: Boolean) = copy(isDebug = isDebug)
@@ -379,6 +397,7 @@ data class DriverParameters(
     fun setInitialiseSerialization(initialiseSerialization: Boolean) = copy(initialiseSerialization = initialiseSerialization)
     fun setStartNodesInProcess(startNodesInProcess: Boolean) = copy(startNodesInProcess = startNodesInProcess)
     fun setExtraCordappPackagesToScan(extraCordappPackagesToScan: List<String>) = copy(extraCordappPackagesToScan = extraCordappPackagesToScan)
+    fun setNotarySpecs(notarySpecs: List<NotarySpec>) = copy(notarySpecs = notarySpecs)
 }
 
 /**
@@ -428,10 +447,10 @@ fun <DI : DriverDSLExposedInterface, D : DriverDSLInternalInterface, A> genericD
         useTestClock: Boolean = defaultParameters.useTestClock,
         initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
         startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
+        notarySpecs: List<NotarySpec>,
         extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
         driverDslWrapper: (DriverDSL) -> D,
-        coerce: (D) -> DI,
-        dsl: DI.() -> A
+        coerce: (D) -> DI, dsl: DI.() -> A
 ): A {
     val serializationEnv = initialiseTestSerialization(initialiseSerialization)
     val driverDsl = driverDslWrapper(
@@ -443,7 +462,8 @@ fun <DI : DriverDSLExposedInterface, D : DriverDSLInternalInterface, A> genericD
                     useTestClock = useTestClock,
                     isDebug = isDebug,
                     startNodesInProcess = startNodesInProcess,
-                    extraCordappPackagesToScan = extraCordappPackagesToScan
+                    extraCordappPackagesToScan = extraCordappPackagesToScan,
+                    notarySpecs = notarySpecs
             )
     )
     val shutdownHook = addShutdownHook(driverDsl::shutdown)
@@ -643,7 +663,8 @@ class DriverDSL(
         val useTestClock: Boolean,
         val isDebug: Boolean,
         val startNodesInProcess: Boolean,
-        extraCordappPackagesToScan: List<String>
+        extraCordappPackagesToScan: List<String>,
+        val notarySpecs: List<NotarySpec>
 ) : DriverDSLInternalInterface {
     private var _executorService: ScheduledExecutorService? = null
     val executorService get() = _executorService!!
@@ -656,7 +677,9 @@ class DriverDSL(
     private val nodeInfoFilesCopier = NodeInfoFilesCopier()
     // Map from a nodes legal name to an observable emitting the number of nodes in its network map.
     private val countObservables = mutableMapOf<CordaX500Name, Observable<Int>>()
-    private var networkParameters: NetworkParametersCopier? = null
+    private lateinit var _notaries: List<NotaryHandle>
+    override val notaryHandles: List<NotaryHandle> get() = _notaries
+    private lateinit var networkParameters: NetworkParametersCopier
 
     class State {
         val processes = ArrayList<CordaFuture<Process>>()
@@ -744,16 +767,6 @@ class DriverDSL(
         return startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize)
     }
 
-    override fun startNotaryNode(providedName: CordaX500Name,
-                                 rpcUsers: List<User>,
-                                 verifierType: VerifierType,
-                                 customOverrides: Map<String, Any?>,
-                                 validating: Boolean): CordaFuture<NodeHandle> {
-        createNetworkParameters(listOf(providedName), providedName, validating, "identity")
-        val config = customOverrides + NotaryConfig(validating).toConfigMap()
-        return startNode(providedName = providedName, rpcUsers = rpcUsers, verifierType = verifierType, customOverrides = config)
-    }
-
     override fun startNodes(nodes: List<CordformNode>, startInSameProcess: Boolean?, maximumHeapSize: String): List<CordaFuture<NodeHandle>> {
         return nodes.map { node ->
             portAllocation.nextHostAndPort() // rpcAddress
@@ -770,72 +783,6 @@ class DriverDSL(
             )
             startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize)
         }
-    }
-
-    // TODO This mapping is done is several plaecs including the gradle plugin. In general we need a better way of
-    // generating the configs for the nodes, probably making use of Any.toConfig()
-    private fun NotaryConfig.toConfigMap(): Map<String, Any> = mapOf("notary" to toConfig().root().unwrapped())
-
-    override fun startNotaryCluster(
-            notaryName: CordaX500Name,
-            clusterSize: Int,
-            verifierType: VerifierType,
-            rpcUsers: List<User>,
-            startInSameProcess: Boolean?
-    ): CordaFuture<Pair<Party, List<NodeHandle>>> {
-        fun notaryConfig(nodeAddress: NetworkHostAndPort, clusterAddress: NetworkHostAndPort? = null): Map<String, Any> {
-            val clusterAddresses = if (clusterAddress != null) listOf(clusterAddress) else emptyList()
-            val config = NotaryConfig(validating = true, raft = RaftConfig(nodeAddress = nodeAddress, clusterAddresses = clusterAddresses))
-            return config.toConfigMap()
-        }
-
-        require(clusterSize > 0)
-
-        val nodeNames = (0 until clusterSize).map { notaryName.copy(organisation = "${notaryName.organisation}-$it") }
-        val notaryIdentity = createNetworkParameters(
-                nodeNames,
-                notaryName,
-                validating = true,
-                serviceId = NotaryService.constructId(validating = true, raft = true))
-
-        val clusterAddress = portAllocation.nextHostAndPort()
-
-        // Start the first node that will bootstrap the cluster
-        val firstNotaryFuture = startNode(
-                providedName = nodeNames[0],
-                rpcUsers = rpcUsers,
-                verifierType = verifierType,
-                customOverrides = notaryConfig(clusterAddress) + mapOf(
-                        "database.serverNameTablePrefix" to nodeNames[0].toString().replace(Regex("[^0-9A-Za-z]+"), "")
-                ),
-                startInSameProcess = startInSameProcess
-        )
-
-        // All other nodes will join the cluster
-        val restNotaryFutures = nodeNames.drop(1).map {
-            val nodeAddress = portAllocation.nextHostAndPort()
-            startNode(
-                    providedName = it,
-                    rpcUsers = rpcUsers,
-                    verifierType = verifierType,
-                    customOverrides = notaryConfig(nodeAddress, clusterAddress) + mapOf(
-                            "database.serverNameTablePrefix" to it.toString().replace(Regex("[^0-9A-Za-z]+"), "")
-                    ))
-        }
-
-        return firstNotaryFuture.flatMap { firstNotary ->
-            restNotaryFutures.transpose().map { restNotaries -> Pair(notaryIdentity, listOf(firstNotary) + restNotaries) }
-        }
-    }
-
-    private fun createNetworkParameters(notaryNodeNames: List<CordaX500Name>, notaryName: CordaX500Name, validating: Boolean, serviceId: String): Party {
-        check(networkParameters == null) { "Notaries must be started first" }
-        val identity = ServiceIdentityGenerator.generateToDisk(
-                notaryNodeNames.map { baseDirectory(it) },
-                notaryName,
-                serviceId)
-        networkParameters = NetworkParametersCopier(testNetworkParameters(listOf(NotaryInfo(identity, validating))))
-        return identity
     }
 
     private fun queryWebserver(handle: NodeHandle, process: Process): WebserverHandle {
@@ -866,6 +813,97 @@ class DriverDSL(
         _executorService = Executors.newScheduledThreadPool(2, ThreadFactoryBuilder().setNameFormat("driver-pool-thread-%d").build())
         _shutdownManager = ShutdownManager(executorService)
         shutdownManager.registerShutdown { nodeInfoFilesCopier.close() }
+        val notaryInfos = generateNotaryIdentities()
+        // The network parameters must be serialised before starting any of the nodes
+        networkParameters = NetworkParametersCopier(testNetworkParameters(notaryInfos))
+        val nodeHandles = startNotaries()
+        _notaries = notaryInfos.zip(nodeHandles) { (identity, validating), nodes -> NotaryHandle(identity, validating, nodes) }
+    }
+
+    private fun generateNotaryIdentities(): List<NotaryInfo> {
+        return notarySpecs.map { spec ->
+            val identity = if (spec.cluster == null) {
+                ServiceIdentityGenerator.generateToDisk(
+                        dirs = listOf(baseDirectory(spec.name)),
+                        serviceName = spec.name,
+                        serviceId = "identity")
+            } else {
+                ServiceIdentityGenerator.generateToDisk(
+                        dirs = generateNodeNames(spec).map { baseDirectory(it) },
+                        serviceName = spec.name,
+                        serviceId = NotaryService.constructId(
+                                validating = spec.validating,
+                                raft = spec.cluster is ClusterSpec.Raft))
+            }
+            NotaryInfo(identity, spec.validating)
+        }
+    }
+
+    private fun generateNodeNames(spec: NotarySpec): List<CordaX500Name> {
+        return (0 until spec.cluster!!.clusterSize).map { spec.name.copy(organisation = "${spec.name.organisation}-$it") }
+    }
+
+    private fun startNotaries(): List<CordaFuture<List<NodeHandle>>> {
+        return notarySpecs.map {
+            when {
+                it.cluster == null -> startSingleNotary(it)
+                it.cluster is ClusterSpec.Raft -> startRaftNotaryCluster(it)
+                else -> throw IllegalArgumentException("BFT-SMaRt not supported")
+            }
+        }
+    }
+
+    // TODO This mapping is done is several places including the gradle plugin. In general we need a better way of
+    // generating the configs for the nodes, probably making use of Any.toConfig()
+    private fun NotaryConfig.toConfigMap(): Map<String, Any> = mapOf("notary" to toConfig().root().unwrapped())
+
+    private fun startSingleNotary(spec: NotarySpec): CordaFuture<List<NodeHandle>> {
+        return startNode(
+                providedName = spec.name,
+                rpcUsers = spec.rpcUsers,
+                verifierType = spec.verifierType,
+                customOverrides = NotaryConfig(spec.validating).toConfigMap()
+        ).map { listOf(it) }
+    }
+
+    private fun startRaftNotaryCluster(spec: NotarySpec): CordaFuture<List<NodeHandle>> {
+        fun notaryConfig(nodeAddress: NetworkHostAndPort, clusterAddress: NetworkHostAndPort? = null): Map<String, Any> {
+            val clusterAddresses = if (clusterAddress != null) listOf(clusterAddress) else emptyList()
+            val config = NotaryConfig(
+                    validating = spec.validating,
+                    raft = RaftConfig(nodeAddress = nodeAddress, clusterAddresses = clusterAddresses))
+            return config.toConfigMap()
+        }
+
+        val nodeNames = generateNodeNames(spec)
+        val clusterAddress = portAllocation.nextHostAndPort()
+
+        // Start the first node that will bootstrap the cluster
+        val firstNodeFuture = startNode(
+                providedName = nodeNames[0],
+                rpcUsers = spec.rpcUsers,
+                verifierType = spec.verifierType,
+                customOverrides = notaryConfig(clusterAddress) + mapOf(
+                        "database.serverNameTablePrefix" to nodeNames[0].toString().replace(Regex("[^0-9A-Za-z]+"), "")
+                )
+        )
+
+        // All other nodes will join the cluster
+        val restNodeFutures = nodeNames.drop(1).map {
+            val nodeAddress = portAllocation.nextHostAndPort()
+            startNode(
+                    providedName = it,
+                    rpcUsers = spec.rpcUsers,
+                    verifierType = spec.verifierType,
+                    customOverrides = notaryConfig(nodeAddress, clusterAddress) + mapOf(
+                            "database.serverNameTablePrefix" to it.toString().replace(Regex("[^0-9A-Za-z]+"), "")
+                    )
+            )
+        }
+
+        return firstNodeFuture.flatMap { first ->
+            restNodeFutures.transpose().map { rest -> listOf(first) + rest }
+        }
     }
 
     fun baseDirectory(nodeName: CordaX500Name): Path {
@@ -925,10 +963,7 @@ class DriverDSL(
                                   maximumHeapSize: String): CordaFuture<NodeHandle> {
         val configuration = config.parseAsNodeConfiguration()
         val baseDirectory = configuration.baseDirectory.createDirectories()
-        if (networkParameters == null) {
-            networkParameters = NetworkParametersCopier(testNetworkParameters(emptyList()))
-        }
-        networkParameters!!.install(baseDirectory)
+        networkParameters.install(baseDirectory)
         nodeInfoFilesCopier.addConfig(baseDirectory)
         val onNodeExit: () -> Unit = {
             nodeInfoFilesCopier.removeConfig(baseDirectory)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
@@ -1,0 +1,23 @@
+package net.corda.testing.node
+
+import net.corda.core.identity.CordaX500Name
+import net.corda.node.services.config.VerifierType
+import net.corda.nodeapi.User
+
+data class NotarySpec(
+        val name: CordaX500Name,
+        val validating: Boolean = true,
+        val rpcUsers: List<User> = emptyList(),
+        val verifierType: VerifierType = VerifierType.InMemory,
+        val cluster: ClusterSpec? = null
+)
+
+sealed class ClusterSpec {
+    abstract val clusterSize: Int
+
+    data class Raft(override val clusterSize: Int) : ClusterSpec() {
+        init {
+            require(clusterSize > 0)
+        }
+    }
+}

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -24,14 +24,13 @@ import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
 import net.corda.testing.ALICE
 import net.corda.testing.BOB
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import java.time.Instant
 import java.util.*
 
-class ExplorerSimulation(val options: OptionSet) {
+class ExplorerSimulation(private val options: OptionSet) {
     private val user = User("user1", "test", permissions = setOf(
             startFlow<CashPaymentFlow>(),
             startFlow<CashConfigDataFlow>()
@@ -67,23 +66,16 @@ class ExplorerSimulation(val options: OptionSet) {
         val portAllocation = PortAllocation.Incremental(20000)
         driver(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance")) {
             // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
-            val notary = startNotaryNode(DUMMY_NOTARY.name, customOverrides = mapOf("nearestCity" to "Zurich"), validating = false)
-            val alice = startNode(providedName = ALICE.name, rpcUsers = arrayListOf(user),
-                    customOverrides = mapOf("nearestCity" to "Milan"))
-            val bob = startNode(providedName = BOB.name, rpcUsers = arrayListOf(user),
-                    customOverrides = mapOf("nearestCity" to "Madrid"))
+            val alice = startNode(providedName = ALICE.name, rpcUsers = listOf(user))
+            val bob = startNode(providedName = BOB.name, rpcUsers = listOf(user))
             val ukBankName = CordaX500Name(organisation = "UK Bank Plc", locality = "London", country = "GB")
             val usaBankName = CordaX500Name(organisation = "USA Bank Corp", locality = "New York", country = "US")
-            val issuerGBP = startNode(providedName = ukBankName, rpcUsers = arrayListOf(manager),
-                    customOverrides = mapOf(
-                            "issuableCurrencies" to listOf("GBP"),
-                            "nearestCity" to "London"))
-            val issuerUSD = startNode(providedName = usaBankName, rpcUsers = arrayListOf(manager),
-                    customOverrides = mapOf(
-                            "issuableCurrencies" to listOf("USD"),
-                            "nearestCity" to "New York"))
+            val issuerGBP = startNode(providedName = ukBankName, rpcUsers = listOf(manager),
+                    customOverrides = mapOf("issuableCurrencies" to listOf("GBP")))
+            val issuerUSD = startNode(providedName = usaBankName, rpcUsers = listOf(manager),
+                    customOverrides = mapOf("issuableCurrencies" to listOf("USD")))
 
-            notaryNode = notary.get()
+            notaryNode = defaultNotaryNode.get()
             aliceNode = alice.get()
             bobNode = bob.get()
             issuerNodeGBP = issuerGBP.get()

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -19,6 +19,7 @@ import net.corda.nodeapi.VerifierApi
 import net.corda.nodeapi.config.NodeSSLConfiguration
 import net.corda.nodeapi.config.SSLConfiguration
 import net.corda.testing.driver.*
+import net.corda.testing.node.NotarySpec
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient
 import org.apache.activemq.artemis.api.core.client.ClientProducer
@@ -77,6 +78,7 @@ fun <A> verifierDriver(
         useTestClock: Boolean = false,
         startNodesInProcess: Boolean = false,
         extraCordappPackagesToScan: List<String> = emptyList(),
+        notarySpecs: List<NotarySpec> = emptyList(),
         dsl: VerifierExposedDSLInterface.() -> A
 ) = genericDriver(
         driverDsl = VerifierDriverDSL(
@@ -88,7 +90,8 @@ fun <A> verifierDriver(
                         useTestClock = useTestClock,
                         isDebug = isDebug,
                         startNodesInProcess = startNodesInProcess,
-                        extraCordappPackagesToScan = extraCordappPackagesToScan
+                        extraCordappPackagesToScan = extraCordappPackagesToScan,
+                        notarySpecs = notarySpecs
                 )
         ),
         coerce = { it },

--- a/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt
+++ b/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
-class DriverTests {
+class WebserverDriverTests {
     companion object {
         val executorService: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
 


### PR DESCRIPTION
Note: This work was mostly done by @kasiastreich. I took over as she's on holiday. I've made changes of my own off of her work.

Introducing the concept of network parameters, which is a list of parameters which all nodes on the same network must abide by. For now this is a file in the node's directory which is read on startup. 

Most of the parameters are not used yet. The one that is is the list of notaries. The network map cache uses the network parameters to get the list of notaries (including whether they're validating or not). This means the list of notaries is fix at the network level, and so that is mirrored in the driver and MockNetwork as well. For these you have to specify a list of notary specs and accordingly notary nodes will be started up automatically. The various `startNotaryNode` methods have been removed as it would cause confusion since these nodes won't be visible as notaries to the other members since they won't be part of the network parameters (the idea of updating network parameters is not handled in this PR). The bulk of the changes are related to this.

This PR also removes the second notary identity for nodes running as single notaries. For now only nodes which are part of a distributed notary will have a second identity, which is the composite identity of the notary cluster.

There's a whole bunch still not implemented, such as network parameter updates, downloading it from the doorman on first startup, actually making use of the other parameters, etc. These are separate pieces of work.

There are things missing in this PR which should have been addressed but will be in a separate PR so to unblock several people. These are:
* docs
* gradle/demos