### PR TITLE
Make the Driver use global port allocation by default

### DIFF
--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -16,7 +16,7 @@ class AttachmentDemoTest {
     @Test
     fun `attachment demo using a 10MB zip file`() {
         val numOfExpectedBytes = 10_000_000
-        driver(isDebug = true, portAllocation = PortAllocation.Incremental(20000)) {
+        driver(isDebug = true) {
             val demoUser = listOf(User("demo", "demo", setOf(startFlowPermission<AttachmentDemoFlow>())))
             val (nodeA, nodeB) = listOf(
                     startNode(providedName = DUMMY_BANK_A.name, rpcUsers = demoUser, maximumHeapSize = "1g"),

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -55,15 +55,6 @@ class DriverTests {
     }
 
     @Test
-    fun `random free port allocation`() {
-        val nodeHandle = driver(portAllocation = PortAllocation.RandomFree) {
-            val nodeInfo = startNode(providedName = DUMMY_BANK_A.name)
-            nodeMustBeUp(nodeInfo)
-        }
-        nodeMustBeDown(nodeHandle)
-    }
-
-    @Test
     fun `debug mode enables debug logging level`() {
         // Make sure we're using the log4j2 config which writes to the log file
         val logConfigFile = projectRootDir / "config" / "dev" / "log4j2.xml"

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/RPCDriver.kt
@@ -217,9 +217,6 @@ data class RpcServerHandle(
 val rpcTestUser = User("user1", "test", permissions = emptySet())
 val fakeNodeLegalName = CordaX500Name(organisation = "Not:a:real:name", locality = "Nowhere", country = "GB")
 
-// Use a global pool so that we can run RPC tests in parallel
-private val globalPortAllocation = PortAllocation.Incremental(10000)
-private val globalDebugPortAllocation = PortAllocation.Incremental(5005)
 fun <A> rpcDriver(
         isDebug: Boolean = false,
         driverDirectory: Path = Paths.get("build", getTimestampAsDirectoryName()),

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -353,6 +353,7 @@ fun <A> driver(
     return driver(defaultParameters = parameters, dsl = dsl)
 }
 
+// We use global port pools by default. This way if a test leaks a port subsequent tests will not clash.
 val globalPortAllocation = PortAllocation.Incremental(10000)
 val globalDebugPortAllocation = PortAllocation.Incremental(5005)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -353,13 +353,16 @@ fun <A> driver(
     return driver(defaultParameters = parameters, dsl = dsl)
 }
 
+val globalPortAllocation = PortAllocation.Incremental(10000)
+val globalDebugPortAllocation = PortAllocation.Incremental(5005)
+
 /** Helper builder for configuring a [driver] from Java. */
 @Suppress("unused")
 data class DriverParameters(
         val isDebug: Boolean = false,
         val driverDirectory: Path = Paths.get("build", getTimestampAsDirectoryName()),
-        val portAllocation: PortAllocation = PortAllocation.Incremental(10000),
-        val debugPortAllocation: PortAllocation = PortAllocation.Incremental(5005),
+        val portAllocation: PortAllocation = globalPortAllocation,
+        val debugPortAllocation: PortAllocation = globalDebugPortAllocation,
         val systemProperties: Map<String, String> = emptyMap(),
         val useTestClock: Boolean = false,
         val initialiseSerialization: Boolean = true,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/demorun/DemoRunner.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/demorun/DemoRunner.kt
@@ -18,7 +18,7 @@ fun CordformDefinition.clean() {
 fun CordformDefinition.runNodes() = driver(
         isDebug = true,
         driverDirectory = driverDirectory,
-        portAllocation = PortAllocation.Incremental(10001)
+        portAllocation = PortAllocation(10001)
 ) {
     setup(this)
     startNodes(nodeConfigurers.map { configurer -> CordformNode().also { configurer.accept(it) } })

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -64,7 +64,7 @@ class ExplorerSimulation(val options: OptionSet) {
     }
 
     private fun startDemoNodes() {
-        val portAllocation = PortAllocation.Incremental(20000)
+        val portAllocation = PortAllocation(20000)
         driver(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance")) {
             // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
             val notary = startNotaryNode(DUMMY_NOTARY.name, customOverrides = mapOf("nearestCity" to "Zurich"), validating = false)

--- a/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt
+++ b/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt
@@ -174,7 +174,7 @@ fun runLoadTests(configuration: LoadTestConfiguration, tests: List<Pair<LoadTest
 
     val networkMap = remoteNodes[0].hostname// TODO Should be taken from configs? but also we don't care that much about that, because networkMapService will be gone and no one uses LoadTesting now
 
-    connectToNodes(remoteNodes, PortAllocation.Incremental(configuration.localTunnelStartingPort)) { connections ->
+    connectToNodes(remoteNodes, PortAllocation(configuration.localTunnelStartingPort)) { connections ->
         log.info("Connected to all nodes!")
         val hostNodeMap = ConcurrentHashMap<String, NodeConnection>()
         connections.parallelStream().forEach { connection ->

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -70,8 +70,8 @@ interface VerifierInternalDSLInterface : DriverDSLInternalInterface, VerifierExp
 fun <A> verifierDriver(
         isDebug: Boolean = false,
         driverDirectory: Path = Paths.get("build", getTimestampAsDirectoryName()),
-        portAllocation: PortAllocation = PortAllocation.Incremental(10000),
-        debugPortAllocation: PortAllocation = PortAllocation.Incremental(5005),
+        portAllocation: PortAllocation = globalPortAllocation,
+        debugPortAllocation: PortAllocation = globalDebugPortAllocation,
         systemProperties: Map<String, String> = emptyMap(),
         useTestClock: Boolean = false,
         startNodesInProcess: Boolean = false,


### PR DESCRIPTION
This will make the driver use a global port pool, which means node-leaking tests won't affect subsequent ones