### PR TITLE
CORDA-759: Enforce key checks on identity de-anonymisation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,9 @@ UNRELEASED
 
 * ``CordaRPCOps`` implementation now checks permissions for any function invocation, rather than just when starting flows.
 
+* ``wellKnownPartyFromAnonymous()`` now always resolve the key to a ``Party``, then the party to the well known party.
+  Previously if it was passed a ``Party`` it would use its name as-is without verifying the key matched that name.
+
 * ``OpaqueBytes.bytes`` now returns a clone of its underlying ``ByteArray``, and has been redeclared as ``final``.
   This is a minor change to the public API, but is required to ensure that classes like ``SecureHash`` are immutable.
 

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -3,7 +3,6 @@ package net.corda.finance.contracts.asset
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.*
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.VaultService
@@ -84,13 +83,13 @@ class CashTests {
         // Create some cash. Any attempt to spend >$500 will require multiple issuers to be involved.
                 database.transaction {
             ourServices.fillWithSomeTestCash(howMuch = 100.DOLLARS, atLeastThisManyStates = 1, atMostThisManyStates = 1,
-                    ownedBy = ourIdentity, issuedBy = MEGA_CORP.ref(1), issuerServices = megaCorpServices)
+                    owner = ourIdentity, issuedBy = MEGA_CORP.ref(1), issuerServices = megaCorpServices)
             ourServices.fillWithSomeTestCash(howMuch = 400.DOLLARS, atLeastThisManyStates = 1, atMostThisManyStates = 1,
-                    ownedBy = ourIdentity, issuedBy = MEGA_CORP.ref(1), issuerServices = megaCorpServices)
+                    owner = ourIdentity, issuedBy = MEGA_CORP.ref(1), issuerServices = megaCorpServices)
             ourServices.fillWithSomeTestCash(howMuch = 80.DOLLARS, atLeastThisManyStates = 1, atMostThisManyStates = 1,
-                    ownedBy = ourIdentity, issuedBy = MINI_CORP.ref(1), issuerServices = miniCorpServices)
+                    owner = ourIdentity, issuedBy = MINI_CORP.ref(1), issuerServices = miniCorpServices)
             ourServices.fillWithSomeTestCash(howMuch = 80.SWISS_FRANCS, atLeastThisManyStates = 1, atMostThisManyStates = 1,
-                    ownedBy = ourIdentity, issuedBy = MINI_CORP.ref(1), issuerServices = miniCorpServices)
+                    owner = ourIdentity, issuedBy = MINI_CORP.ref(1), issuerServices = miniCorpServices)
         }
         database.transaction {
             vaultStatesUnconsumed = ourServices.vaultService.queryBy<Cash.State>().states

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -80,6 +80,10 @@ class CashTests {
             ourServices.identityService.verifyAndRegisterIdentity(identity)
         }
 
+        // As we're only creating mock services instead of a full network, we have to manually register identities
+        megaCorpServices.identityService.verifyAndRegisterIdentity(miniCorpServices.myInfo.singleIdentityAndCert())
+        miniCorpServices.identityService.verifyAndRegisterIdentity(megaCorpServices.myInfo.singleIdentityAndCert())
+
         // Create some cash. Any attempt to spend >$500 will require multiple issuers to be involved.
                 database.transaction {
             ourServices.fillWithSomeTestCash(howMuch = 100.DOLLARS, atLeastThisManyStates = 1, atMostThisManyStates = 1,

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -80,10 +80,6 @@ class CashTests {
             ourServices.identityService.verifyAndRegisterIdentity(identity)
         }
 
-        // As we're only creating mock services instead of a full network, we have to manually register identities
-        megaCorpServices.identityService.verifyAndRegisterIdentity(miniCorpServices.myInfo.singleIdentityAndCert())
-        miniCorpServices.identityService.verifyAndRegisterIdentity(megaCorpServices.myInfo.singleIdentityAndCert())
-
         // Create some cash. Any attempt to spend >$500 will require multiple issuers to be involved.
                 database.transaction {
             ourServices.fillWithSomeTestCash(howMuch = 100.DOLLARS, atLeastThisManyStates = 1, atMostThisManyStates = 1,

--- a/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
@@ -20,7 +20,6 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
-import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.chooseIdentity
 import net.corda.testing.driver.driver
 import org.junit.Assume.assumeFalse
@@ -41,13 +40,13 @@ class NodeStatePersistenceTests {
 
         val user = User("mark", "dadada", setOf(startFlow<SendMessageFlow>(), invokeRpc("vaultQuery")))
         val message = Message("Hello world!")
-        var stateAndRef: StateAndRef<MessageState>? = null
-        driver(isDebug = true, startNodesInProcess = isQuasarAgentSpecified()) {
+        val stateAndRef: StateAndRef<MessageState>? = driver(isDebug = true, startNodesInProcess = isQuasarAgentSpecified()) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name
+                // Ensure the notary node has finished starting up, before starting a flow that needs a notary
+                defaultNotaryNode.getOrThrow()
                 nodeHandle.rpcClientToNode().start(user.username, user.password).use {
-                    // TODO: Wait until notaries have registered
                     it.proxy.startFlow(::SendMessageFlow, message).returnValue.getOrThrow()
                 }
                 nodeHandle.stop()
@@ -55,11 +54,12 @@ class NodeStatePersistenceTests {
             }()
 
             val nodeHandle = startNode(providedName = nodeName, rpcUsers = listOf(user)).getOrThrow()
-            stateAndRef = nodeHandle.rpcClientToNode().start(user.username, user.password).use {
+            val result = nodeHandle.rpcClientToNode().start(user.username, user.password).use {
                 val page = it.proxy.vaultQuery(MessageState::class.java)
                 page.states.singleOrNull()
             }
             nodeHandle.stop()
+            result
         }
         assertNotNull(stateAndRef)
         val retrievedMessage = stateAndRef!!.state.data.message
@@ -146,8 +146,7 @@ class SendMessageFlow(private val message: Message) : FlowLogic<SignedTransactio
 
     @Suspendable
     override fun call(): SignedTransaction {
-        // We fall back to the expected notary identity, but shouldn't start the flow until notaries are registered
-        val notary = serviceHub.networkMapCache.notaryIdentities.firstOrNull() ?: DUMMY_NOTARY
+        val notary = serviceHub.networkMapCache.notaryIdentities.firstOrNull() ?: throw IllegalStateException("No registered notaries")
 
         progressTracker.currentStep = GENERATING_TRANSACTION
 

--- a/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
@@ -52,13 +52,13 @@ class NodeStatePersistenceTests {
             }()
 
             val nodeHandle = startNode(providedName = nodeName, rpcUsers = listOf(user)).getOrThrow()
-            nodeHandle.rpcClientToNode().start(user.username, user.password).use {
+            val stateAndRef = nodeHandle.rpcClientToNode().start(user.username, user.password).use {
                 val page = it.proxy.vaultQuery(MessageState::class.java)
-                val stateAndRef = page.states.singleOrNull()
-                assertNotNull(stateAndRef)
-                val retrievedMessage = stateAndRef!!.state.data.message
-                assertEquals(message, retrievedMessage)
+                page.states.singleOrNull()
             }
+            assertNotNull(stateAndRef)
+            val retrievedMessage = stateAndRef!!.state.data.message
+            assertEquals(message, retrievedMessage)
         }
     }
 }
@@ -142,7 +142,7 @@ class SendMessageFlow(private val message: Message) : FlowLogic<SignedTransactio
 
     @Suspendable
     override fun call(): SignedTransaction {
-        val notary = serviceHub.networkMapCache.notaryIdentities.first()
+        val notary = serviceHub.networkMapCache.notaryIdentities.firstOrNull() ?: throw IllegalStateException("No registered notaries")
 
         progressTracker.currentStep = GENERATING_TRANSACTION
 

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -105,6 +105,7 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate> = emptyS
         val candidate = partyFromKey(party.owningKey)
         // TODO: This should be done via the network map cache, which is the authoritative source of well known identities
         return if (candidate != null) {
+            require(party.nameOrNull() == null || party.nameOrNull() == candidate.name) { "Candidate party ${candidate} does not match expected ${party}" }
             wellKnownPartyFromX500Name(candidate.name)
         } else {
             null

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -99,14 +99,13 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate> = emptyS
     override fun partyFromKey(key: PublicKey): Party? = keyToParties[key]?.party
     override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = principalToParties[name]?.party
     override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
-        // Expand the anonymous party to a full party (i.e. has a name) if possible
-        val candidate = party as? Party ?: keyToParties[party.owningKey]?.party
+        // The original version of this would return the party as-is if it was a Party (rather than AnonymousParty),
+        // however that means that we don't verify that we know who owns the key. As such as now enforce turning the key
+        // into a party, and from there figure out the well known party.
+        val candidate = partyFromKey(party.owningKey)
         // TODO: This should be done via the network map cache, which is the authoritative source of well known identities
-        // Look up the well known identity for that name
         return if (candidate != null) {
-            // If we have a well known identity by that name, use it in preference to the candidate. Otherwise default
-            // back to the candidate.
-            principalToParties[candidate.name]?.party ?: candidate
+            wellKnownPartyFromX500Name(candidate.name)
         } else {
             null
         }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -164,15 +164,13 @@ class PersistentIdentityService(identities: Iterable<PartyAndCertificate> = empt
     override fun partyFromKey(key: PublicKey): Party? = certificateFromKey(key)?.party
     override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = certificateFromCordaX500Name(name)?.party
     override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
-        // Expand the anonymous party to a full party (i.e. has a name) if possible
-        val candidate = party as? Party ?: partyFromKey(party.owningKey)
+        // The original version of this would return the party as-is if it was a Party (rather than AnonymousParty),
+        // however that means that we don't verify that we know who owns the key. As such as now enforce turning the key
+        // into a party, and from there figure out the well known party.
+        val candidate = partyFromKey(party.owningKey)
         // TODO: This should be done via the network map cache, which is the authoritative source of well known identities
-        // Look up the well known identity for that name
         return if (candidate != null) {
-            // If we have a well known identity by that name, use it in preference to the candidate. Otherwise default
-            // back to the candidate.
-            val res = wellKnownPartyFromX500Name(candidate.name) ?: candidate
-            res
+            wellKnownPartyFromX500Name(candidate.name)
         } else {
             null
         }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt
@@ -23,7 +23,7 @@ class AbstractPartyToX500NameAsStringConverter(identitySvc: () -> IdentityServic
         if (party != null) {
             val partyName = identityService.wellKnownPartyFromAnonymous(party)?.toString()
             if (partyName != null) return partyName
-            log.warn("Identity service unable to resolve AbstractParty: $party")
+             log.warn("Identity service unable to resolve AbstractParty: $party")
         }
         return null // non resolvable anonymous parties
     }

--- a/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/identity/InMemoryIdentityServiceTests.kt
@@ -169,9 +169,23 @@ class InMemoryIdentityServiceTests {
      * Ensure if we feed in a full identity, we get the same identity back.
      */
     @Test
-    fun `deanonymising a well known identity`() {
+    fun `deanonymising a well known identity should return the identity`() {
+        val service = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
         val expected = ALICE
-        val actual = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT).wellKnownPartyFromAnonymous(expected)
+        service.verifyAndRegisterIdentity(ALICE_IDENTITY)
+        val actual = service.wellKnownPartyFromAnonymous(expected)
         assertEquals(expected, actual)
+    }
+
+    /**
+     * Ensure we don't blindly trust what an anonymous identity claims to be.
+     */
+    @Test
+    fun `deanonymising a false well known identity should return null`() {
+        val service = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
+        val notAlice = Party(ALICE.name, generateKeyPair().public)
+        service.verifyAndRegisterIdentity(ALICE_IDENTITY)
+        val actual = service.wellKnownPartyFromAnonymous(notAlice)
+        assertNull(actual)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
@@ -277,11 +277,23 @@ class PersistentIdentityServiceTests {
      * Ensure if we feed in a full identity, we get the same identity back.
      */
     @Test
-    fun `deanonymising a well known identity`() {
+    fun `deanonymising a well known identity should return the identity`() {
+        val service = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
         val expected = ALICE
-        val actual = database.transaction {
-            identityService.wellKnownPartyFromAnonymous(expected)
-        }
+        service.verifyAndRegisterIdentity(ALICE_IDENTITY)
+        val actual = service.wellKnownPartyFromAnonymous(expected)
         assertEquals(expected, actual)
+    }
+
+    /**
+     * Ensure we don't blindly trust what an anonymous identity claims to be.
+     */
+    @Test
+    fun `deanonymising a false well known identity should return null`() {
+        val service = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
+        val notAlice = Party(ALICE.name, generateKeyPair().public)
+        service.verifyAndRegisterIdentity(ALICE_IDENTITY)
+        val actual = service.wellKnownPartyFromAnonymous(notAlice)
+        assertNull(actual)
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -5,20 +5,25 @@ import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.generateKeyPair
+import net.corda.core.crypto.toStringShort
+import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
-import net.corda.core.utilities.toBase58String
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultService
 import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentStateRef
-import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.SerializationDefaults
+import net.corda.core.serialization.deserialize
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.toBase58String
 import net.corda.finance.DOLLARS
 import net.corda.finance.POUNDS
 import net.corda.finance.SWISS_FRANCS
-import net.corda.finance.contracts.asset.*
+import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.contracts.asset.DUMMY_CASH_ISSUER_NAME
+import net.corda.finance.contracts.asset.DummyFungibleContract
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.finance.schemas.SampleCashSchemaV2
 import net.corda.finance.schemas.SampleCashSchemaV3
@@ -54,7 +59,9 @@ class HibernateConfigurationTest {
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
     lateinit var services: MockServices
+    lateinit var bankServices: MockServices
     lateinit var issuerServices: MockServices
+    lateinit var notaryServices: MockServices
     lateinit var database: CordaPersistence
     val vault: VaultService get() = services.vaultService
 
@@ -65,19 +72,27 @@ class HibernateConfigurationTest {
     lateinit var entityManager: EntityManager
     lateinit var criteriaBuilder: CriteriaBuilder
 
+    // Identities used
+    private lateinit var identity: Party
+    private lateinit var issuer: Party
+    private lateinit var notary: Party
+
     // test States
     lateinit var cashStates: List<StateAndRef<Cash.State>>
 
     @Before
     fun setUp() {
         val cordappPackages = listOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset")
-        issuerServices = MockServices(cordappPackages, DUMMY_CASH_ISSUER_NAME, DUMMY_CASH_ISSUER_KEY, BOB_KEY, BOC_KEY)
+        bankServices = MockServices(cordappPackages, BOC.name, generateKeyPair())
+        issuerServices = MockServices(cordappPackages, DUMMY_CASH_ISSUER_NAME, generateKeyPair())
+        notaryServices = MockServices(cordappPackages, DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
         val dataSourceProps = makeTestDataSourceProperties()
         val defaultDatabaseProperties = makeTestDatabaseProperties()
         database = configureDatabase(dataSourceProps, defaultDatabaseProperties, ::makeTestIdentityService)
         database.transaction {
             hibernateConfig = database.hibernateConfig
-            services = object : MockServices(cordappPackages, BOB_NAME, BOB_KEY, BOC_KEY, DUMMY_NOTARY_KEY) {
+            // `consumeCash` expects we can self-notarise transactions
+            services = object : MockServices(cordappPackages, BOB_NAME, generateKeyPair(), DUMMY_NOTARY_KEY) {
                 override val vaultService = makeVaultService(database.hibernateConfig)
                 override fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>) {
                     for (stx in txs) {
@@ -91,7 +106,25 @@ class HibernateConfigurationTest {
             }
             hibernatePersister = services.hibernatePersister
         }
-        setUpDb()
+
+        // Register all of the identities so persistence works
+        val allServices = listOf(issuerServices, notaryServices, bankServices, services)
+        val identites = allServices.flatMap { it.myInfo.legalIdentitiesAndCerts }.toSet()
+        println("Identities: ${identites.map { it.party.owningKey.toStringShort() }}")
+        allServices.forEach { serviceHub ->
+            identites.forEach { identity -> serviceHub.identityService.verifyAndRegisterIdentity(identity) }
+        }
+
+        identity = services.myInfo.singleIdentity()
+        issuer = issuerServices.myInfo.singleIdentity()
+        notary = notaryServices.myInfo.singleIdentity()
+
+        database.transaction {
+            val numStates = 10
+            cashStates = services.fillWithSomeTestCash(100.DOLLARS, issuerServices, notary, numStates, numStates, Random(0L), issuedBy = issuer.ref(1))
+                    .states.toList()
+        }
+
         sessionFactory = sessionFactoryForSchemas(VaultSchemaV1, CashSchemaV1, SampleCashSchemaV2, SampleCashSchemaV3)
         entityManager = sessionFactory.createEntityManager()
         criteriaBuilder = sessionFactory.criteriaBuilder
@@ -102,12 +135,6 @@ class HibernateConfigurationTest {
     @After
     fun cleanUp() {
         database.close()
-    }
-
-    private fun setUpDb() {
-        database.transaction {
-            cashStates = services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 10, 10, Random(0L)).states.toList()
-        }
     }
 
     @Test
@@ -125,7 +152,7 @@ class HibernateConfigurationTest {
     @Test
     fun `consumed states`() {
         database.transaction {
-            services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
+            services.consumeCash(50.DOLLARS, notary = notary)
         }
 
         // structure query
@@ -206,11 +233,11 @@ class HibernateConfigurationTest {
     fun `with sorting by state ref desc and asc`() {
         // generate additional state ref indexes
         database.transaction {
-            services.consumeCash(1.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(2.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(3.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(4.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(5.DOLLARS, notary = DUMMY_NOTARY)
+            services.consumeCash(1.DOLLARS, notary = notary)
+            services.consumeCash(2.DOLLARS, notary = notary)
+            services.consumeCash(3.DOLLARS, notary = notary)
+            services.consumeCash(4.DOLLARS, notary = notary)
+            services.consumeCash(5.DOLLARS, notary = notary)
         }
 
         // structure query
@@ -236,11 +263,11 @@ class HibernateConfigurationTest {
     fun `with sorting by state ref index and txId desc and asc`() {
         // generate additional state ref indexes
         database.transaction {
-            services.consumeCash(1.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(2.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(3.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(4.DOLLARS, notary = DUMMY_NOTARY)
-            services.consumeCash(5.DOLLARS, notary = DUMMY_NOTARY)
+            services.consumeCash(1.DOLLARS, notary = notary)
+            services.consumeCash(2.DOLLARS, notary = notary)
+            services.consumeCash(3.DOLLARS, notary = notary)
+            services.consumeCash(4.DOLLARS, notary = notary)
+            services.consumeCash(5.DOLLARS, notary = notary)
         }
 
         // structure query
@@ -267,7 +294,7 @@ class HibernateConfigurationTest {
     fun `with pagination`() {
         // add 100 additional cash entries
         database.transaction {
-            services.fillWithSomeTestCash(1000.POUNDS, issuerServices, DUMMY_NOTARY, 100, 100, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
+            services.fillWithSomeTestCash(1000.POUNDS, issuerServices, notary, 100, 100, Random(0L), issuedBy = issuer.ref(1))
         }
 
         // structure query
@@ -369,11 +396,11 @@ class HibernateConfigurationTest {
     fun `calculate cash balances`() {
         database.transaction {
 
-            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 10, 10, Random(0L))        // +$100 = $200
-            services.fillWithSomeTestCash(50.POUNDS, issuerServices, DUMMY_NOTARY, 5, 5, Random(0L))            // £50 = £50
-            services.fillWithSomeTestCash(25.POUNDS, issuerServices, DUMMY_NOTARY, 5, 5, Random(0L))            // +£25 = £175
-            services.fillWithSomeTestCash(500.SWISS_FRANCS, issuerServices, DUMMY_NOTARY, 10, 10, Random(0L))   // CHF500 = CHF500
-            services.fillWithSomeTestCash(250.SWISS_FRANCS, issuerServices, DUMMY_NOTARY, 5, 5, Random(0L))     // +CHF250 = CHF750
+            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, notary, 10, issuer.ref(1))        // +$100 = $200
+            services.fillWithSomeTestCash(50.POUNDS, issuerServices, notary, 5, issuer.ref(1))            // £50 = £50
+            services.fillWithSomeTestCash(25.POUNDS, issuerServices, notary, 5, issuer.ref(1))            // +£25 = £175
+            services.fillWithSomeTestCash(500.SWISS_FRANCS, issuerServices, notary, 10, issuer.ref(1))   // CHF500 = CHF500
+            services.fillWithSomeTestCash(250.SWISS_FRANCS, issuerServices, notary, 5, issuer.ref(1))     // +CHF250 = CHF750
         }
 
         // structure query
@@ -402,8 +429,8 @@ class HibernateConfigurationTest {
     @Test
     fun `calculate cash balance for single currency`() {
         database.transaction {
-            services.fillWithSomeTestCash(50.POUNDS, issuerServices, DUMMY_NOTARY, 5, 5, Random(0L))            // £50 = £50
-            services.fillWithSomeTestCash(25.POUNDS, issuerServices, DUMMY_NOTARY, 5, 5, Random(0L))            // +£25 = £175
+            services.fillWithSomeTestCash(50.POUNDS, issuerServices, notary, 5, issuer.ref(1))            // £50 = £50
+            services.fillWithSomeTestCash(25.POUNDS, issuerServices, notary, 5, issuer.ref(1))            // +£25 = £175
         }
 
         // structure query
@@ -432,10 +459,10 @@ class HibernateConfigurationTest {
     @Test
     fun `calculate and order by cash balance for owner and currency`() {
         database.transaction {
-
-            services.fillWithSomeTestCash(200.DOLLARS, issuerServices, DUMMY_NOTARY, 2, 2, Random(0L), issuedBy = BOC.ref(1))
-            services.fillWithSomeTestCash(300.POUNDS, issuerServices, DUMMY_NOTARY, 3, 3, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
-            services.fillWithSomeTestCash(400.POUNDS, issuerServices, DUMMY_NOTARY, 4, 4, Random(0L), issuedBy = BOC.ref(2))
+            val bank = bankServices.myInfo.legalIdentities.single()
+            services.fillWithSomeTestCash(200.DOLLARS, bankServices, notary, 2, bank.ref(1))
+            services.fillWithSomeTestCash(300.POUNDS, issuerServices, notary, 3, issuer.ref(1))
+            services.fillWithSomeTestCash(400.POUNDS, bankServices, notary, 4, bank.ref(2))
         }
 
         // structure query
@@ -622,9 +649,9 @@ class HibernateConfigurationTest {
                 hibernatePersister.persistStateWithSchema(dummyFungibleState, it.ref, SampleCashSchemaV3)
             }
 
-            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 2, 2, Random(0L), ownedBy = ALICE)
-            val cashStates = services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 2, 2, Random(0L),
-                    issuedBy = BOB.ref(0), ownedBy = (BOB)).states
+            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, notary, 2, 2, Random(0L),
+                    issuedBy = issuer.ref(1), owner = ALICE)
+            val cashStates = services.fillWithSomeTestCash(100.DOLLARS, services, notary, 2,  identity.ref(0)).states
             // persist additional cash states explicitly with V3 schema
             cashStates.forEach {
                 val cashState = it.state.data
@@ -646,7 +673,7 @@ class HibernateConfigurationTest {
         // search predicate
         val cashStatesSchema = criteriaQuery.from(SampleCashSchemaV3.PersistentCashState::class.java)
 
-        val queryOwner = BOB.name.toString()
+        val queryOwner = identity.name.toString()
         criteriaQuery.where(criteriaBuilder.equal(cashStatesSchema.get<String>("owner"), queryOwner))
 
         val joinVaultStatesToCash = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), cashStatesSchema.get<PersistentStateRef>("stateRef"))
@@ -701,8 +728,8 @@ class HibernateConfigurationTest {
                         hibernatePersister.persistStateWithSchema(dummyFungibleState, it.ref, SampleCashSchemaV3)
                     }
 
-                    val moreCash = services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 2, 2, Random(0L),
-                            issuedBy = BOB.ref(0), ownedBy = BOB).states
+                    val moreCash = services.fillWithSomeTestCash(100.DOLLARS, services, notary, 2, 2, Random(0L),
+                            issuedBy = identity.ref(0), owner = identity).states
                     // persist additional cash states explicitly with V3 schema
                     moreCash.forEach {
                         val cashState = it.state.data
@@ -710,7 +737,7 @@ class HibernateConfigurationTest {
                         hibernatePersister.persistStateWithSchema(dummyFungibleState, it.ref, SampleCashSchemaV3)
                     }
 
-                    val cashStates = services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 2, 2, Random(0L), ownedBy = (ALICE)).states
+                    val cashStates = services.fillWithSomeTestCash(100.DOLLARS, issuerServices, notary, 2, 2, Random(0L), owner = ALICE, issuedBy = issuer.ref(1)).states
                     // persist additional cash states explicitly with V3 schema
                     cashStates.forEach {
                         val cashState = it.state.data

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -18,6 +18,7 @@ import net.corda.finance.DOLLARS
 import net.corda.finance.POUNDS
 import net.corda.finance.SWISS_FRANCS
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.contracts.asset.DUMMY_CASH_ISSUER_KEY
 import net.corda.finance.contracts.asset.DUMMY_CASH_ISSUER_NAME
 import net.corda.finance.contracts.asset.DummyFungibleContract
 import net.corda.finance.schemas.CashSchemaV1
@@ -79,8 +80,8 @@ class HibernateConfigurationTest {
     @Before
     fun setUp() {
         val cordappPackages = listOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset")
-        bankServices = MockServices(cordappPackages, BOC.name, generateKeyPair())
-        issuerServices = MockServices(cordappPackages, DUMMY_CASH_ISSUER_NAME, generateKeyPair())
+        bankServices = MockServices(cordappPackages, BOC.name, BOC_KEY)
+        issuerServices = MockServices(cordappPackages, DUMMY_CASH_ISSUER_NAME, DUMMY_CASH_ISSUER_KEY)
         notaryServices = MockServices(cordappPackages, DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
         val dataSourceProps = makeTestDataSourceProperties()
         val defaultDatabaseProperties = makeTestDatabaseProperties()
@@ -101,13 +102,6 @@ class HibernateConfigurationTest {
                 override fun jdbcSession() = database.createSession()
             }
             hibernatePersister = services.hibernatePersister
-        }
-
-        // Register all of the identities so persistence works
-        val allServices = listOf(issuerServices, notaryServices, bankServices, services)
-        val identites = allServices.flatMap { it.myInfo.legalIdentitiesAndCerts }.toSet()
-        allServices.forEach { serviceHub ->
-            identites.forEach { identity -> serviceHub.identityService.verifyAndRegisterIdentity(identity) }
         }
 
         identity = services.myInfo.singleIdentity()

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -1,12 +1,10 @@
 package net.corda.node.services.persistence
 
-import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.Vault
@@ -14,8 +12,6 @@ import net.corda.core.node.services.VaultService
 import net.corda.core.schemas.CommonSchemaV1
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentStateRef
-import net.corda.core.serialization.SerializationDefaults
-import net.corda.core.serialization.deserialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.toBase58String
 import net.corda.finance.DOLLARS
@@ -110,7 +106,6 @@ class HibernateConfigurationTest {
         // Register all of the identities so persistence works
         val allServices = listOf(issuerServices, notaryServices, bankServices, services)
         val identites = allServices.flatMap { it.myInfo.legalIdentitiesAndCerts }.toSet()
-        println("Identities: ${identites.map { it.party.owningKey.toStringShort() }}")
         allServices.forEach { serviceHub ->
             identites.forEach { identity -> serviceHub.identityService.verifyAndRegisterIdentity(identity) }
         }

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -5,7 +5,8 @@ import net.corda.core.contracts.Amount
 import net.corda.core.contracts.Issued
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.*
+import net.corda.core.crypto.NullKeys
+import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -583,6 +583,7 @@ class NodeVaultServiceTest {
         val initialCashState = StateAndRef(issueStx.tx.outputs.single(), StateRef(issueStx.id, 0))
 
         // Change notary
+        services.identityService.verifyAndRegisterIdentity(DUMMY_NOTARY_IDENTITY)
         val newNotary = DUMMY_NOTARY
         val changeNotaryTx = NotaryChangeWireTransaction(listOf(initialCashState.ref), issueStx.notary!!, newNotary)
         val cashStateWithNewNotary = StateAndRef(initialCashState.state.copy(notary = newNotary), StateRef(changeNotaryTx.id, 0))

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -1413,8 +1413,9 @@ class VaultQueryTests {
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = BOC.ref(1))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
-                    issuedBy = MEGA_CORP.ref(0), ownedBy = (MINI_CORP))
-
+                    issuedBy = MEGA_CORP.ref(0), owner = (MINI_CORP))
+        }
+        database.transaction {
             val criteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP))
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
             assertThat(results.states).hasSize(1)   // can only be 1 owner of a node (MEGA_CORP in this MockServices setup)
@@ -1426,10 +1427,11 @@ class VaultQueryTests {
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
-                    issuedBy = MEGA_CORP.ref(0), ownedBy = (MEGA_CORP))
+                    issuedBy = MEGA_CORP.ref(0), owner = (MEGA_CORP))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
-                    issuedBy = BOC.ref(0), ownedBy = (MINI_CORP))  // irrelevant to this vault
-
+                    issuedBy = BOC.ref(0), owner = MINI_CORP)  // irrelevant to this vault
+        }
+        database.transaction {
             // DOCSTART VaultQueryExample5.2
             val criteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP, BOC))
             val results = vaultService.queryBy<ContractState>(criteria)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -12,7 +12,10 @@ import net.corda.core.internal.packageName
 import net.corda.core.node.services.*
 import net.corda.core.node.services.vault.*
 import net.corda.core.node.services.vault.QueryCriteria.*
-import net.corda.core.utilities.*
+import net.corda.core.utilities.NonEmptySet
+import net.corda.core.utilities.days
+import net.corda.core.utilities.seconds
+import net.corda.core.utilities.toHexString
 import net.corda.finance.*
 import net.corda.finance.contracts.CommercialPaper
 import net.corda.finance.contracts.Commodity
@@ -31,7 +34,6 @@ import net.corda.testing.contracts.*
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.MockServices.Companion.makeTestDatabaseAndMockServices
 import net.corda.testing.node.MockServices.Companion.makeTestDatabaseProperties
-import net.corda.testing.node.MockServices.Companion.makeTestIdentityService
 import net.corda.testing.schemas.DummyLinearStateSchemaV1
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -57,7 +59,7 @@ class VaultQueryTests {
     private lateinit var services: MockServices
     private lateinit var notaryServices: MockServices
     private val vaultService: VaultService get() = services.vaultService
-    private val identitySvc: IdentityService = makeTestIdentityService()
+    private lateinit var identitySvc: IdentityService
     private lateinit var database: CordaPersistence
 
     // test cash notary
@@ -68,14 +70,14 @@ class VaultQueryTests {
     @Before
     fun setUp() {
         // register additional identities
-        identitySvc.verifyAndRegisterIdentity(CASH_NOTARY_IDENTITY)
-        identitySvc.verifyAndRegisterIdentity(BOC_IDENTITY)
         val databaseAndServices = makeTestDatabaseAndMockServices(keys = listOf(MEGA_CORP_KEY, DUMMY_NOTARY_KEY),
-                createIdentityService = { identitySvc },
                 cordappPackages = cordappPackages)
         database = databaseAndServices.first
         services = databaseAndServices.second
         notaryServices = MockServices(cordappPackages, DUMMY_NOTARY.name, DUMMY_NOTARY_KEY, DUMMY_CASH_ISSUER_KEY, BOC_KEY, MEGA_CORP_KEY)
+        identitySvc = services.identityService
+        identitySvc.verifyAndRegisterIdentity(CASH_NOTARY_IDENTITY)
+        identitySvc.verifyAndRegisterIdentity(BOC_IDENTITY)
     }
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -148,7 +148,7 @@ class VaultWithCashTest {
 
         database.transaction {
             // A tx that sends us money.
-            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 10, 10, Random(0L), ownedBy = AnonymousParty(freshKey),
+            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 10, 10, Random(0L), owner = AnonymousParty(freshKey),
                     issuedBy = MEGA_CORP.ref(1))
             println("Cash balance: ${services.getCashBalance(USD)}")
         }
@@ -298,7 +298,7 @@ class VaultWithCashTest {
 
         val freshKey = services.keyManagementService.freshKey()
         database.transaction {
-            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 3, 3, Random(0L), ownedBy = AnonymousParty(freshKey))
+            services.fillWithSomeTestCash(100.DOLLARS, issuerServices, DUMMY_NOTARY, 3, 3, Random(0L), owner = AnonymousParty(freshKey))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, issuerServices, DUMMY_NOTARY, 2, 2, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, issuerServices, DUMMY_NOTARY, 1, 1, Random(0L))
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
@@ -26,6 +26,8 @@ import net.corda.testing.node.MockServices.Companion.makeTestDataSourcePropertie
 import net.corda.testing.node.MockServices.Companion.makeTestDatabaseProperties
 import java.nio.file.Path
 
+private val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY)
+
 /**
  * Creates and tests a ledger built by the passed in dsl. The provided services can be customised, otherwise a default
  * of a freshly built [MockServices] is used.
@@ -48,7 +50,11 @@ fun transaction(
         transactionBuilder: TransactionBuilder = TransactionBuilder(notary = DUMMY_NOTARY),
         cordappPackages: List<String> = emptyList(),
         dsl: TransactionDSL<TransactionDSLInterpreter>.() -> EnforceVerifyOrFail
-) = ledger(services = MockServices(cordappPackages)) {
+) = ledger(services = MockServices(cordappPackages).apply {
+    MOCK_IDENTITIES.forEach { identity ->
+        identityService.verifyAndRegisterIdentity(identity)
+    }
+}) {
     dsl(TransactionDSL(TestTransactionDSLInterpreter(this.interpreter, transactionBuilder)))
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
@@ -26,8 +26,6 @@ import net.corda.testing.node.MockServices.Companion.makeTestDataSourcePropertie
 import net.corda.testing.node.MockServices.Companion.makeTestDatabaseProperties
 import java.nio.file.Path
 
-private val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY)
-
 /**
  * Creates and tests a ledger built by the passed in dsl. The provided services can be customised, otherwise a default
  * of a freshly built [MockServices] is used.
@@ -50,11 +48,7 @@ fun transaction(
         transactionBuilder: TransactionBuilder = TransactionBuilder(notary = DUMMY_NOTARY),
         cordappPackages: List<String> = emptyList(),
         dsl: TransactionDSL<TransactionDSLInterpreter>.() -> EnforceVerifyOrFail
-) = ledger(services = MockServices(cordappPackages).apply {
-    MOCK_IDENTITIES.forEach { identity ->
-        identityService.verifyAndRegisterIdentity(identity)
-    }
-}) {
+) = ledger(services = MockServices(cordappPackages)) {
     dsl(TransactionDSL(TestTransactionDSLInterpreter(this.interpreter, transactionBuilder)))
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -56,8 +56,6 @@ open class MockServices(
         vararg val keys: KeyPair
 ) : ServiceHub, StateLoader by stateLoader {
     companion object {
-        private val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)
-
         @JvmStatic
         val MOCK_VERSION_INFO = VersionInfo(1, "Mock release", "Mock revision", "Mock Vendor")
 
@@ -94,10 +92,10 @@ open class MockServices(
         }
 
         /**
-         * Creates an instance of [InMemoryIdentityService] with [MOCK_IDENTITIES].
+         * Creates an instance of [InMemoryIdentityService].
          */
         @JvmStatic
-        fun makeTestIdentityService() = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DEV_TRUST_ROOT)
+        fun makeTestIdentityService() = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
 
         /**
          * Makes database and mock services appropriate for unit tests.
@@ -145,6 +143,9 @@ open class MockServices(
                     override fun jdbcSession(): Connection = database.createSession()
                 }
             }
+            database.transaction {
+                mockService.myInfo.legalIdentitiesAndCerts.forEach { identity -> mockService.identityService.verifyAndRegisterIdentity(identity) }
+            }
             return Pair(database, mockService)
         }
     }
@@ -167,7 +168,7 @@ open class MockServices(
 
     final override val attachments = MockAttachmentStorage()
     val stateMachineRecordedTransactionMapping: StateMachineRecordedTransactionMappingStorage = MockStateMachineRecordedTransactionMappingStorage()
-    override val identityService: IdentityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DEV_TRUST_ROOT)
+    override val identityService: IdentityService = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
     override val keyManagementService: KeyManagementService by lazy { MockKeyManagementService(identityService, *keys) }
 
     override val vaultService: VaultService get() = throw UnsupportedOperationException()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -56,6 +56,7 @@ open class MockServices(
         vararg val keys: KeyPair
 ) : ServiceHub, StateLoader by stateLoader {
     companion object {
+        private val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)
 
         @JvmStatic
         val MOCK_VERSION_INFO = VersionInfo(1, "Mock release", "Mock revision", "Mock Vendor")
@@ -101,7 +102,7 @@ open class MockServices(
         /**
          * Makes database and mock services appropriate for unit tests.
          * @param keys a list of [KeyPair] instances to be used by [MockServices]. Defaults to [MEGA_CORP_KEY]
-         * @param createIdentityService a lambda function returning an instance of [IdentityService]. Defauts to [InMemoryIdentityService].
+         * @param createIdentityService a lambda function returning an instance of [IdentityService]. Defaults to [InMemoryIdentityService].
          *
          * @return a pair where the first element is the instance of [CordaPersistence] and the second is [MockServices].
          */

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -56,6 +56,8 @@ open class MockServices(
         vararg val keys: KeyPair
 ) : ServiceHub, StateLoader by stateLoader {
     companion object {
+        private val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)
+
         @JvmStatic
         val MOCK_VERSION_INFO = VersionInfo(1, "Mock release", "Mock revision", "Mock Vendor")
 
@@ -92,10 +94,10 @@ open class MockServices(
         }
 
         /**
-         * Creates an instance of [InMemoryIdentityService].
+         * Creates an instance of [InMemoryIdentityService] with [MOCK_IDENTITIES].
          */
         @JvmStatic
-        fun makeTestIdentityService() = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
+        fun makeTestIdentityService() = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DEV_TRUST_ROOT)
 
         /**
          * Makes database and mock services appropriate for unit tests.
@@ -143,9 +145,6 @@ open class MockServices(
                     override fun jdbcSession(): Connection = database.createSession()
                 }
             }
-            database.transaction {
-                mockService.myInfo.legalIdentitiesAndCerts.forEach { identity -> mockService.identityService.verifyAndRegisterIdentity(identity) }
-            }
             return Pair(database, mockService)
         }
     }
@@ -168,7 +167,7 @@ open class MockServices(
 
     final override val attachments = MockAttachmentStorage()
     val stateMachineRecordedTransactionMapping: StateMachineRecordedTransactionMappingStorage = MockStateMachineRecordedTransactionMappingStorage()
-    override val identityService: IdentityService = InMemoryIdentityService(trustRoot = DEV_TRUST_ROOT)
+    override val identityService: IdentityService = InMemoryIdentityService(MOCK_IDENTITIES, trustRoot = DEV_TRUST_ROOT)
     override val keyManagementService: KeyManagementService by lazy { MockKeyManagementService(identityService, *keys) }
 
     override val vaultService: VaultService get() = throw UnsupportedOperationException()

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -87,9 +87,6 @@ val ALL_TEST_KEYS: List<KeyPair> get() = listOf(MEGA_CORP_KEY, MINI_CORP_KEY, AL
 
 val DUMMY_CASH_ISSUER_IDENTITY: PartyAndCertificate get() = getTestPartyAndCertificate(DUMMY_CASH_ISSUER.party as Party)
 
-val MOCK_IDENTITIES = listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)
-val MOCK_IDENTITY_SERVICE: IdentityService get() = InMemoryIdentityService(MOCK_IDENTITIES, emptySet(), DEV_CA.certificate.cert)
-
 val MOCK_HOST_AND_PORT = NetworkHostAndPort("mockHost", 30000)
 
 fun generateStateRef() = StateRef(SecureHash.randomSHA256(), 0)


### PR DESCRIPTION
Previously when de-anonymising a Party instance, the name of the Party was used rather than
the key, meaning a Party could be constructed with a random nonsense key and any name, and be
treated as corresponding to the well known identity. This is not a security hole in itself as
in any real scenario a party shouldn't be trusted without having been registered, it creates
a significant risk of a security hole depending on how trusted the anonymous identity is, and
the returned identity is considered.