### PR TITLE
Protect against VERY unlikey chance of overflow.

### DIFF
--- a/.ci/check-api-changes.sh
+++ b/.ci/check-api-changes.sh
@@ -52,6 +52,10 @@ if [ $abstractCount -gt 0 ]; then
 fi
 
 badChanges=$(($removalCount + $abstractCount))
+if [ $badChanges -gt 255 ]; then
+    echo "OVERFLOW! Number of bad API changes: $badChanges"
+    badChanges=255
+fi
 
 echo "Exiting with exit code" $badChanges
 exit $badChanges


### PR DESCRIPTION
The valid range of a process exit code is 0 - 255. So protect against overflow by capping this value at 255.