### PR TITLE
Moved ShutdownManager into an internal package.

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -11,8 +11,8 @@ import net.corda.core.serialization.serialize
 import net.corda.core.utilities.*
 import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.nodeapi.RPCApi
-import net.corda.testing.*
 import net.corda.testing.driver.poll
+import net.corda.testing.internal.*
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -335,7 +335,7 @@ class RPCStabilityTests {
 
 }
 
-fun RPCDriverExposedDSLInterface.pollUntilClientNumber(server: RpcServerHandle, expected: Int) {
+fun RPCDriverDSLInternalInterface.pollUntilClientNumber(server: RpcServerHandle, expected: Int) {
     pollUntilTrue("number of RPC clients to become $expected") {
         val clientAddresses = server.broker.serverControl.addressNames.filter { it.startsWith(RPCApi.RPC_CLIENT_QUEUE_NAME_PREFIX) }
         clientAddresses.size == expected

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt
@@ -6,10 +6,10 @@ import net.corda.core.internal.concurrent.map
 import net.corda.core.messaging.RPCOps
 import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.nodeapi.User
-import net.corda.testing.RPCDriverExposedDSLInterface
-import net.corda.testing.rpcTestUser
-import net.corda.testing.startInVmRpcClient
-import net.corda.testing.startRpcClient
+import net.corda.testing.internal.RPCDriverDSLInternalInterface
+import net.corda.testing.internal.rpcTestUser
+import net.corda.testing.internal.startInVmRpcClient
+import net.corda.testing.internal.startRpcClient
 import org.apache.activemq.artemis.api.core.client.ClientSession
 import org.junit.runners.Parameterized
 
@@ -35,7 +35,7 @@ open class AbstractRPCTest {
             val createSession: () -> ClientSession
     )
 
-    inline fun <reified I : RPCOps> RPCDriverExposedDSLInterface.testProxy(
+    inline fun <reified I : RPCOps> RPCDriverDSLInternalInterface.testProxy(
             ops: I,
             rpcUser: User = rpcTestUser,
             clientConfiguration: RPCClientConfiguration = RPCClientConfiguration.default,

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
@@ -7,9 +7,9 @@ import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.messaging.rpcContext
-import net.corda.testing.RPCDriverExposedDSLInterface
-import net.corda.testing.rpcDriver
-import net.corda.testing.rpcTestUser
+import net.corda.testing.internal.RPCDriverDSLInternalInterface
+import net.corda.testing.internal.rpcDriver
+import net.corda.testing.internal.rpcTestUser
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,7 +26,7 @@ import kotlin.test.assertTrue
 class ClientRPCInfrastructureTests : AbstractRPCTest() {
     // TODO: Test that timeouts work
 
-    private fun RPCDriverExposedDSLInterface.testProxy(): TestOps {
+    private fun RPCDriverDSLInternalInterface.testProxy(): TestOps {
         return testProxy<TestOps>(TestOpsImpl()).ops
     }
 

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
@@ -7,8 +7,8 @@ import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.concurrent.fork
 import net.corda.core.serialization.CordaSerializable
 import net.corda.node.services.messaging.RPCServerConfiguration
-import net.corda.testing.RPCDriverExposedDSLInterface
-import net.corda.testing.rpcDriver
+import net.corda.testing.internal.RPCDriverDSLInternalInterface
+import net.corda.testing.internal.rpcDriver
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -82,7 +82,7 @@ class RPCConcurrencyTests : AbstractRPCTest() {
     }
 
     private lateinit var testOpsImpl: TestOpsImpl
-    private fun RPCDriverExposedDSLInterface.testProxy(): TestProxy<TestOps> {
+    private fun RPCDriverDSLInternalInterface.testProxy(): TestProxy<TestOps> {
         testOpsImpl = TestOpsImpl()
         return testProxy<TestOps>(
                 testOpsImpl,

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCFailureTests.kt
@@ -5,8 +5,8 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.messaging.*
 import net.corda.core.utilities.getOrThrow
-import net.corda.testing.rpcDriver
-import net.corda.testing.startRpcClient
+import net.corda.testing.internal.rpcDriver
+import net.corda.testing.internal.startRpcClient
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt
@@ -5,14 +5,14 @@ import net.corda.client.rpc.internal.RPCClientConfiguration
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.minutes
 import net.corda.core.utilities.seconds
-import net.corda.testing.performance.div
 import net.corda.node.services.messaging.RPCServerConfiguration
-import net.corda.testing.RPCDriverExposedDSLInterface
+import net.corda.testing.internal.RPCDriverDSLInternalInterface
+import net.corda.testing.internal.rpcDriver
 import net.corda.testing.measure
+import net.corda.testing.performance.div
 import net.corda.testing.performance.startPublishingFixedRateInjector
 import net.corda.testing.performance.startReporter
 import net.corda.testing.performance.startTightLoopInjector
-import net.corda.testing.rpcDriver
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,7 +42,7 @@ class RPCPerformanceTests : AbstractRPCTest() {
         }
     }
 
-    private fun RPCDriverExposedDSLInterface.testProxy(
+    private fun RPCDriverDSLInternalInterface.testProxy(
             clientConfiguration: RPCClientConfiguration,
             serverConfiguration: RPCServerConfiguration
     ): TestProxy<TestOps> {

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt
@@ -6,8 +6,8 @@ import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.messaging.rpcContext
 import net.corda.node.services.messaging.requirePermission
 import net.corda.nodeapi.User
-import net.corda.testing.RPCDriverExposedDSLInterface
-import net.corda.testing.rpcDriver
+import net.corda.testing.internal.RPCDriverDSLInternalInterface
+import net.corda.testing.internal.rpcDriver
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -38,7 +38,7 @@ class RPCPermissionsTests : AbstractRPCTest() {
     /**
      * Create an RPC proxy for the given user.
      */
-    private fun RPCDriverExposedDSLInterface.testProxyFor(rpcUser: User) = testProxy<TestOps>(TestOpsImpl(), rpcUser).ops
+    private fun RPCDriverDSLInternalInterface.testProxyFor(rpcUser: User) = testProxy<TestOps>(TestOpsImpl(), rpcUser).ops
 
     private fun userOf(name: String, permissions: Set<String>) = User(name, "password", permissions)
 

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -23,6 +23,10 @@ import net.corda.nodeapi.User
 import net.corda.testing.*
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyContractV2
+import net.corda.testing.internal.RPCDriverDSLInternalInterface
+import net.corda.testing.internal.rpcDriver
+import net.corda.testing.internal.rpcTestUser
+import net.corda.testing.internal.startRpcClient
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -113,7 +117,7 @@ class ContractUpgradeFlowTest {
         check(bobNode)
     }
 
-    private fun RPCDriverExposedDSLInterface.startProxy(node: StartedNode<*>, user: User): CordaRPCOps {
+    private fun RPCDriverDSLInternalInterface.startProxy(node: StartedNode<*>, user: User): CordaRPCOps {
         return startRpcClient<CordaRPCOps>(
                 rpcAddress = startRpcServer(
                         rpcUser = user,

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -15,6 +15,7 @@ import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.User
 import net.corda.testing.DUMMY_NOTARY
+import net.corda.testing.driver.DriverDSLInternalInterface
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
@@ -89,6 +90,7 @@ class NodePerformanceTests {
     @Test
     fun `empty flow rate`() {
         driver(startNodesInProcess = true) {
+            this as DriverDSLInternalInterface
             val a = startNode(rpcUsers = listOf(User("A", "A", setOf(startFlow<EmptyFlow>())))).get()
             a as NodeHandle.InProcess
             val metricRegistry = startReporter(shutdownManager, a.node.services.monitoringService.metrics)
@@ -108,6 +110,7 @@ class NodePerformanceTests {
                 startNodesInProcess = true,
                 extraCordappPackagesToScan = listOf("net.corda.finance")
         ) {
+            this as DriverDSLInternalInterface
             val notary = defaultNotaryNode.getOrThrow() as NodeHandle.InProcess
             val metricRegistry = startReporter(shutdownManager, notary.node.services.monitoringService.metrics)
             notary.rpcClientToNode().use("A", "A") { connection ->

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -37,6 +37,7 @@ import net.corda.nodeapi.internal.addShutdownHook
 import net.corda.testing.*
 import net.corda.testing.common.internal.NetworkParametersCopier
 import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.internal.ShutdownManager
 import net.corda.testing.node.ClusterSpec
 import net.corda.testing.node.MockServices.Companion.MOCK_VERSION_INFO
 import net.corda.testing.node.NotarySpec
@@ -54,12 +55,10 @@ import java.time.Instant
 import java.time.ZoneOffset.UTC
 import java.time.format.DateTimeFormatter
 import java.util.*
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
-import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.collections.ArrayList
 import kotlin.concurrent.thread
@@ -173,6 +172,14 @@ interface DriverDSLExposedInterface : CordformContext {
     fun startWebserver(handle: NodeHandle, maximumHeapSize: String): CordaFuture<WebserverHandle>
 
     fun waitForAllNodesToFinish()
+}
+
+interface DriverDSLInternalInterface : DriverDSLExposedInterface {
+    val shutdownManager: ShutdownManager
+
+    fun start()
+
+    fun shutdown()
 
     /**
      * Polls a function until it returns a non-null value. Note that there is no timeout on the polling.
@@ -192,13 +199,6 @@ interface DriverDSLExposedInterface : CordformContext {
     fun pollUntilTrue(pollName: String, pollInterval: Duration = DEFAULT_POLL_INTERVAL, warnCount: Int = DEFAULT_WARN_COUNT, check: () -> Boolean): CordaFuture<Unit> {
         return pollUntilNonNull(pollName, pollInterval, warnCount) { if (check()) Unit else null }
     }
-
-    val shutdownManager: ShutdownManager
-}
-
-interface DriverDSLInternalInterface : DriverDSLExposedInterface {
-    fun start()
-    fun shutdown()
 }
 
 sealed class NodeHandle {
@@ -557,102 +557,6 @@ fun <A> poll(
     }
     executorService.submit(task) // The check may be expensive, so always run it in the background even the first time.
     return resultFuture
-}
-
-class ShutdownManager(private val executorService: ExecutorService) {
-    private class State {
-        val registeredShutdowns = ArrayList<CordaFuture<() -> Unit>>()
-        var isShutdown = false
-    }
-
-    private val state = ThreadBox(State())
-
-    companion object {
-        inline fun <A> run(providedExecutorService: ExecutorService? = null, block: ShutdownManager.() -> A): A {
-            val executorService = providedExecutorService ?: Executors.newScheduledThreadPool(1)
-            val shutdownManager = ShutdownManager(executorService)
-            try {
-                return block(shutdownManager)
-            } finally {
-                shutdownManager.shutdown()
-                providedExecutorService ?: executorService.shutdown()
-            }
-        }
-    }
-
-    fun shutdown() {
-        val shutdownActionFutures = state.locked {
-            if (isShutdown) {
-                emptyList<CordaFuture<() -> Unit>>()
-            } else {
-                isShutdown = true
-                registeredShutdowns
-            }
-        }
-        val shutdowns = shutdownActionFutures.map { Try.on { it.getOrThrow(1.seconds) } }
-        shutdowns.reversed().forEach {
-            when (it) {
-                is Try.Success ->
-                    try {
-                        it.value()
-                    } catch (t: Throwable) {
-                        log.warn("Exception while shutting down", t)
-                    }
-                is Try.Failure -> log.warn("Exception while getting shutdown method, disregarding", it.exception)
-            }
-        }
-    }
-
-    fun registerShutdown(shutdown: CordaFuture<() -> Unit>) {
-        state.locked {
-            require(!isShutdown)
-            registeredShutdowns.add(shutdown)
-        }
-    }
-
-    fun registerShutdown(shutdown: () -> Unit) = registerShutdown(doneFuture(shutdown))
-
-    fun registerProcessShutdown(processFuture: CordaFuture<Process>) {
-        val processShutdown = processFuture.map { process ->
-            {
-                process.destroy()
-                /** Wait 5 seconds, then [Process.destroyForcibly] */
-                val finishedFuture = executorService.submit {
-                    process.waitFor()
-                }
-                try {
-                    finishedFuture.get(5, SECONDS)
-                } catch (exception: TimeoutException) {
-                    finishedFuture.cancel(true)
-                    process.destroyForcibly()
-                }
-                Unit
-            }
-        }
-        registerShutdown(processShutdown)
-    }
-
-    interface Follower {
-        fun unfollow()
-        fun shutdown()
-    }
-
-    fun follower() = object : Follower {
-        private val start = state.locked { registeredShutdowns.size }
-        private val end = AtomicInteger(start - 1)
-        override fun unfollow() = end.set(state.locked { registeredShutdowns.size })
-        override fun shutdown() = end.get().let { end ->
-            start > end && throw IllegalStateException("You haven't called unfollow.")
-            state.locked {
-                registeredShutdowns.subList(start, end).listIterator(end - start).run {
-                    while (hasPrevious()) {
-                        previous().getOrThrow().invoke()
-                        set(doneFuture {}) // Don't break other followers by doing a remove.
-                    }
-                }
-            }
-        }
-    }
 }
 
 class DriverDSL(

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/ShutdownManager.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/ShutdownManager.kt
@@ -1,0 +1,113 @@
+package net.corda.testing.internal
+
+import net.corda.core.concurrent.CordaFuture
+import net.corda.core.internal.ThreadBox
+import net.corda.core.internal.concurrent.doneFuture
+import net.corda.core.internal.concurrent.map
+import net.corda.core.utilities.Try
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.loggerFor
+import net.corda.core.utilities.seconds
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+class ShutdownManager(private val executorService: ExecutorService) {
+    private class State {
+        val registeredShutdowns = ArrayList<CordaFuture<() -> Unit>>()
+        var isShutdown = false
+    }
+
+    private val state = ThreadBox(State())
+
+    companion object {
+        private val log = loggerFor<ShutdownManager>()
+
+        inline fun <A> run(providedExecutorService: ExecutorService? = null, block: ShutdownManager.() -> A): A {
+            val executorService = providedExecutorService ?: Executors.newScheduledThreadPool(1)
+            val shutdownManager = ShutdownManager(executorService)
+            try {
+                return block(shutdownManager)
+            } finally {
+                shutdownManager.shutdown()
+                providedExecutorService ?: executorService.shutdown()
+            }
+        }
+    }
+
+    fun shutdown() {
+        val shutdownActionFutures = state.locked {
+            if (isShutdown) {
+                emptyList<CordaFuture<() -> Unit>>()
+            } else {
+                isShutdown = true
+                registeredShutdowns
+            }
+        }
+        val shutdowns = shutdownActionFutures.map { Try.on { it.getOrThrow(1.seconds) } }
+        shutdowns.reversed().forEach {
+            when (it) {
+                is Try.Success ->
+                    try {
+                        it.value()
+                    } catch (t: Throwable) {
+                        log.warn("Exception while shutting down", t)
+                    }
+                is Try.Failure -> log.warn("Exception while getting shutdown method, disregarding", it.exception)
+            }
+        }
+    }
+
+    fun registerShutdown(shutdown: CordaFuture<() -> Unit>) {
+        state.locked {
+            require(!isShutdown)
+            registeredShutdowns.add(shutdown)
+        }
+    }
+
+    fun registerShutdown(shutdown: () -> Unit) = registerShutdown(doneFuture(shutdown))
+
+    fun registerProcessShutdown(processFuture: CordaFuture<Process>) {
+        val processShutdown = processFuture.map { process ->
+            {
+                process.destroy()
+                /** Wait 5 seconds, then [Process.destroyForcibly] */
+                val finishedFuture = executorService.submit {
+                    process.waitFor()
+                }
+                try {
+                    finishedFuture.get(5, TimeUnit.SECONDS)
+                } catch (exception: TimeoutException) {
+                    finishedFuture.cancel(true)
+                    process.destroyForcibly()
+                }
+                Unit
+            }
+        }
+        registerShutdown(processShutdown)
+    }
+
+    interface Follower {
+        fun unfollow()
+        fun shutdown()
+    }
+
+    fun follower() = object : Follower {
+        private val start = state.locked { registeredShutdowns.size }
+        private val end = AtomicInteger(start - 1)
+        override fun unfollow() = end.set(state.locked { registeredShutdowns.size })
+        override fun shutdown() = end.get().let { end ->
+            start > end && throw IllegalStateException("You haven't called unfollow.")
+            state.locked {
+                registeredShutdowns.subList(start, end).listIterator(end - start).run {
+                    while (hasPrevious()) {
+                        previous().getOrThrow().invoke()
+                        set(doneFuture {}) // Don't break other followers by doing a remove.
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/performance/Injectors.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/performance/Injectors.kt
@@ -3,7 +3,7 @@ package net.corda.testing.performance
 import com.codahale.metrics.Gauge
 import com.codahale.metrics.MetricRegistry
 import com.google.common.base.Stopwatch
-import net.corda.testing.driver.ShutdownManager
+import net.corda.testing.internal.ShutdownManager
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.CountDownLatch

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/performance/Reporter.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/performance/Reporter.kt
@@ -3,7 +3,7 @@ package net.corda.testing.performance
 import com.codahale.metrics.ConsoleReporter
 import com.codahale.metrics.JmxReporter
 import com.codahale.metrics.MetricRegistry
-import net.corda.testing.driver.ShutdownManager
+import net.corda.testing.internal.ShutdownManager
 import java.util.concurrent.TimeUnit
 import javax.management.ObjectName
 import kotlin.concurrent.thread

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -135,10 +135,8 @@ data class VerificationRequestorHandle(
 }
 
 
-data class VerifierDriverDSL(
-        val driverDSL: DriverDSL
-) : DriverDSLInternalInterface by driverDSL, VerifierInternalDSLInterface {
-    val verifierCount = AtomicInteger(0)
+data class VerifierDriverDSL(private val driverDSL: DriverDSL) : DriverDSLInternalInterface by driverDSL, VerifierInternalDSLInterface {
+    private val verifierCount = AtomicInteger(0)
 
     companion object {
         private val log = loggerFor<VerifierDriverDSL>()


### PR DESCRIPTION
This meant having to also move the shutdownManager property into the interal driver DSL interface, which further meant also moving RPCDriver into an internal package (which makes sense as it's not a public testing API).
