### PR TITLE
On exit, the driver will automaticallly shutdown any nodes which were…

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -16,6 +16,9 @@
       <module name="client_test" target="1.8" />
       <module name="confidential-identities_main" target="1.8" />
       <module name="confidential-identities_test" target="1.8" />
+      <module name="corda-core_integrationTest" target="1.8" />
+      <module name="corda-core_smokeTest" target="1.8" />
+      <module name="corda-finance_integrationTest" target="1.8" />
       <module name="corda-project_main" target="1.8" />
       <module name="corda-project_test" target="1.8" />
       <module name="corda-webserver_integrationTest" target="1.8" />
@@ -43,6 +46,8 @@
       <module name="example-code_integrationTest" target="1.8" />
       <module name="example-code_main" target="1.8" />
       <module name="example-code_test" target="1.8" />
+      <module name="experimental-kryo-hook_main" target="1.8" />
+      <module name="experimental-kryo-hook_test" target="1.8" />
       <module name="experimental_main" target="1.8" />
       <module name="experimental_test" target="1.8" />
       <module name="explorer-capsule_main" target="1.6" />
@@ -54,8 +59,13 @@
       <module name="finance_test" target="1.8" />
       <module name="graphs_main" target="1.8" />
       <module name="graphs_test" target="1.8" />
+      <module name="irs-demo-cordapp_integrationTest" target="1.8" />
       <module name="irs-demo-cordapp_main" target="1.8" />
+      <module name="irs-demo-cordapp_main~1" target="1.8" />
       <module name="irs-demo-cordapp_test" target="1.8" />
+      <module name="irs-demo-cordapp_test~1" target="1.8" />
+      <module name="irs-demo-web_main" target="1.8" />
+      <module name="irs-demo-web_test" target="1.8" />
       <module name="irs-demo_integrationTest" target="1.8" />
       <module name="irs-demo_main" target="1.8" />
       <module name="irs-demo_test" target="1.8" />
@@ -106,6 +116,9 @@
       <module name="simm-valuation-demo_test" target="1.8" />
       <module name="smoke-test-utils_main" target="1.8" />
       <module name="smoke-test-utils_test" target="1.8" />
+      <module name="source-example-code_integrationTest" target="1.8" />
+      <module name="source-example-code_main" target="1.8" />
+      <module name="source-example-code_test" target="1.8" />
       <module name="test-common_main" target="1.8" />
       <module name="test-common_test" target="1.8" />
       <module name="test-utils_integrationTest" target="1.8" />

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -83,6 +83,8 @@ UNRELEASED
 * Replaced node configuration parameter ``certificateSigningService`` with ``compatibilityZoneURL``, which is Corda
   compatibility zone network management service's address.
 
+* ``waitForAllNodesToFinish()`` method in ``DriverDSLExposedInterface`` has instead become a parameter on driver creation.
+
 .. _changelog_v1:
 
 Release 1.0

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
@@ -48,7 +48,7 @@ fun main(args: Array<String>) {
             startFlow<CashExitFlow>(),
             invokeRpc(CordaRPCOps::nodeInfo)
     ))
-    driver(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf("net.corda.finance")) {
+    driver(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true) {
         val node = startNode(providedName = ALICE.name, rpcUsers = listOf(user)).get()
         // END 1
 
@@ -96,7 +96,6 @@ fun main(args: Array<String>) {
                 graph.display()
             }
         }
-        waitForAllNodesToFinish()
         // END 5
     }
 }

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -283,7 +283,7 @@ IntelliJ
       fun main(args: Array<String>) {
           // No permissions required as we are not invoking flows.
           val user = User("user1", "test", permissions = setOf())
-          driver(isDebug = true) {
+          driver(isDebug = true, waitForNodesToFinish = true) {
               startNode(getX500Name(O="Controller",L="London",C='GB"), setOf(ServiceInfo(ValidatingNotaryService.type)))
               val (nodeA, nodeB, nodeC) = Futures.allAsList(
                       startNode(getX500Name(O="PartyA",L="London",C="GB"), rpcUsers = listOf(user)),
@@ -293,8 +293,6 @@ IntelliJ
               startWebserver(nodeA)
               startWebserver(nodeB)
               startWebserver(nodeC)
-
-              waitForAllNodesToFinish()
           }
       }
 
@@ -505,7 +503,7 @@ Debugging is done via IntelliJ as follows:
     fun main(args: Array<String>) {
         // No permissions required as we are not invoking flows.
         val user = User("user1", "test", permissions = setOf())
-        driver(isDebug = true) {
+        driver(isDebug = true, waitForNodesToFinish = true) {
             startNode(getX500Name(O="Controller",L="London",C="GB"), setOf(ServiceInfo(ValidatingNotaryService.type)))
             val (nodeA, nodeB, nodeC) = Futures.allAsList(
                     startNode(getX500Name(O="PartyA",L=London,C=GB"), rpcUsers = listOf(user)),
@@ -515,8 +513,6 @@ Debugging is done via IntelliJ as follows:
             startWebserver(nodeA)
             startWebserver(nodeB)
             startWebserver(nodeC)
-
-            waitForAllNodesToFinish()
         }
     }
 

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
@@ -12,9 +12,8 @@ import net.corda.testing.driver.driver
  */
 fun main(args: Array<String>) {
     val demoUser = listOf(User("demo", "demo", setOf("StartFlow.net.corda.flows.FinalityFlow")))
-    driver(isDebug = true, driverDirectory = "build" / "attachment-demo-nodes") {
+    driver(isDebug = true, driverDirectory = "build" / "attachment-demo-nodes", waitForAllNodesToFinish = true) {
         startNode(providedName = DUMMY_BANK_A.name, rpcUsers = demoUser)
         startNode(providedName = DUMMY_BANK_B.name, rpcUsers = demoUser)
-        waitForAllNodesToFinish()
     }
 }

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaDriver.kt
@@ -56,7 +56,7 @@ private class BankOfCordaDriver {
         try {
             when (role) {
                 Role.ISSUER -> {
-                    driver(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.finance.contracts.asset")) {
+                    driver(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.finance.contracts.asset"), waitForAllNodesToFinish = true) {
                         val bankUser = User(
                                 BANK_USERNAME,
                                 "test",
@@ -76,7 +76,6 @@ private class BankOfCordaDriver {
                                         startFlow<CashConfigDataFlow>()))
                         startNode(providedName = BIGCORP_LEGAL_NAME, rpcUsers = listOf(bigCorpUser))
                         startWebserver(bankOfCorda.get())
-                        waitForAllNodesToFinish()
                     }
                 }
                 else -> {

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt
@@ -10,7 +10,7 @@ import net.corda.testing.driver.driver
  * Do not use in a production environment.
  */
 fun main(args: Array<String>) {
-    driver(useTestClock = true, isDebug = true) {
+    driver(useTestClock = true, isDebug = true, waitForAllNodesToFinish = true) {
         val (nodeA, nodeB) = listOf(
                 startNode(providedName = DUMMY_BANK_A.name),
                 startNode(providedName = DUMMY_BANK_B.name)
@@ -20,7 +20,5 @@ fun main(args: Array<String>) {
         startWebserver(controller)
         startWebserver(nodeA)
         startWebserver(nodeB)
-
-        waitForAllNodesToFinish()
     }
 }

--- a/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
+++ b/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
@@ -12,7 +12,7 @@ import net.corda.testing.driver.driver
  * via the web api.
  */
 fun main(args: Array<String>) {
-    driver(isDebug = true) {
+    driver(isDebug = true, waitForAllNodesToFinish = true) {
         val (nodeA, nodeB, nodeC) = listOf(
                 startNode(providedName = DUMMY_BANK_A.name),
                 startNode(providedName = DUMMY_BANK_B.name),
@@ -22,7 +22,5 @@ fun main(args: Array<String>) {
         startWebserver(nodeA)
         startWebserver(nodeB)
         startWebserver(nodeC)
-
-        waitForAllNodesToFinish()
     }
 }

--- a/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt
+++ b/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt
@@ -22,13 +22,12 @@ fun main(args: Array<String>) {
             startFlow<SellerFlow>(),
             all())
     val demoUser = listOf(User("demo", "demo", permissions))
-    driver(driverDirectory = "build" / "trader-demo-nodes", isDebug = true) {
+    driver(driverDirectory = "build" / "trader-demo-nodes", isDebug = true, waitForAllNodesToFinish = true) {
         val user = User("user1", "test", permissions = setOf(startFlow<CashIssueFlow>(),
                 startFlow<CommercialPaperIssueFlow>(),
                 startFlow<SellerFlow>()))
         startNode(providedName = DUMMY_BANK_A.name, rpcUsers = demoUser)
         startNode(providedName = DUMMY_BANK_B.name, rpcUsers = demoUser)
         startNode(providedName = BOC.name, rpcUsers = listOf(user))
-        waitForAllNodesToFinish()
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
@@ -7,6 +7,7 @@ import net.corda.client.rpc.internal.RPCClientConfiguration
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.internal.concurrent.doneFuture
 import net.corda.core.internal.concurrent.fork
 import net.corda.core.internal.concurrent.map
 import net.corda.core.internal.div
@@ -229,6 +230,7 @@ fun <A> rpcDriver(
         useTestClock: Boolean = false,
         initialiseSerialization: Boolean = true,
         startNodesInProcess: Boolean = false,
+        waitForNodesToFinish: Boolean = false,
         extraCordappPackagesToScan: List<String> = emptyList(),
         notarySpecs: List<NotarySpec> = emptyList(),
         dsl: RPCDriverExposedDSLInterface.() -> A
@@ -242,6 +244,7 @@ fun <A> rpcDriver(
                         useTestClock = useTestClock,
                         isDebug = isDebug,
                         startNodesInProcess = startNodesInProcess,
+                        waitForNodesToFinish = waitForNodesToFinish,
                         extraCordappPackagesToScan = extraCordappPackagesToScan,
                         notarySpecs = notarySpecs
                 )
@@ -404,11 +407,9 @@ data class RPCDriverDSL(
     }
 
     override fun <I : RPCOps> startRandomRpcClient(rpcOpsClass: Class<I>, rpcAddress: NetworkHostAndPort, username: String, password: String): CordaFuture<Process> {
-        val processFuture = driverDSL.executorService.fork {
-            ProcessUtilities.startJavaProcess<RandomRpcUser>(listOf(rpcOpsClass.name, rpcAddress.toString(), username, password))
-        }
-        driverDSL.shutdownManager.registerProcessShutdown(processFuture)
-        return processFuture
+        val process = ProcessUtilities.startJavaProcess<RandomRpcUser>(listOf(rpcOpsClass.name, rpcAddress.toString(), username, password))
+        driverDSL.shutdownManager.registerProcessShutdown(process)
+        return doneFuture(process)
     }
 
     override fun startArtemisSession(rpcAddress: NetworkHostAndPort, username: String, password: String): ClientSession {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/demorun/DemoRunner.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/demorun/DemoRunner.kt
@@ -16,12 +16,9 @@ fun CordformDefinition.clean() {
  * Creates and starts all nodes required for the demo.
  */
 // TODO add notaries to cordform!
-fun CordformDefinition.runNodes() = driver(
-        isDebug = true,
-        driverDirectory = driverDirectory,
-        portAllocation = PortAllocation.Incremental(10001)
-) {
-    setup(this)
-    startNodes(nodeConfigurers.map { configurer -> CordformNode().also { configurer.accept(it) } })
-    waitForAllNodesToFinish()
+fun CordformDefinition.runNodes() {
+    driver(isDebug = true, driverDirectory = driverDirectory, portAllocation = PortAllocation.Incremental(10001), waitForAllNodesToFinish = true) {
+        setup(this)
+        startNodes(nodeConfigurers.map { configurer -> CordformNode().also { configurer.accept(it) } })
+    }
 }

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -64,7 +64,7 @@ class ExplorerSimulation(private val options: OptionSet) {
 
     private fun startDemoNodes() {
         val portAllocation = PortAllocation.Incremental(20000)
-        driver(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance")) {
+        driver(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true) {
             // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
             val alice = startNode(providedName = ALICE.name, rpcUsers = listOf(user))
             val bob = startNode(providedName = BOB.name, rpcUsers = listOf(user))
@@ -89,8 +89,6 @@ class ExplorerSimulation(private val options: OptionSet) {
                 options.has("S") -> startNormalSimulation()
                 options.has("F") -> startErrorFlowsSimulation()
             }
-
-            waitForAllNodesToFinish()
         }
     }
 


### PR DESCRIPTION
…n't waited for.

The motivation for this came with the recent change that a default notary is started by the driver, which if ignored will leak the notary process.

This change removes the need for waitForAllNodesToFinish().
