### PR TITLE
CORDA-296: added rpc that returns an observable for node state

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -5,12 +5,15 @@ import net.corda.client.rpc.internal.RPCClientConfiguration
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.concurrent.fork
 import net.corda.core.internal.concurrent.transpose
+import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.RPCOps
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.*
+import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.nodeapi.RPCApi
+import net.corda.nodeapi.User
 import net.corda.testing.driver.poll
 import net.corda.testing.internal.*
 import org.apache.activemq.artemis.api.core.SimpleString
@@ -233,6 +236,30 @@ class RPCStabilityTests {
             val pingFuture = ForkJoinPool.commonPool().fork(client::ping)
             assertEquals("pong", pingFuture.getOrThrow(10.seconds))
             clientFollower.shutdown() // Driver would do this after the new server, causing hang.
+        }
+    }
+
+    @Test
+    fun `clients receive notifications that node is shutting down`() {
+        val alice = User("Alice", "Alice", setOf(invokeRpc(CordaRPCOps::nodeStateObservable)))
+        val bob = User("Bob", "Bob", setOf(invokeRpc(CordaRPCOps::nodeStateObservable)))
+        val slagathor = User("Slagathor", "Slagathor", setOf(invokeRpc(CordaRPCOps::nodeStateObservable)))
+        val userList = listOf(alice, bob, slagathor)
+        val expectedMessages = ArrayList<String>()
+
+        rpcDriver(startNodesInProcess = true) {
+            val node = startNode(rpcUsers = listOf(alice, bob, slagathor)).getOrThrow()
+            userList.forEach {
+                val connection = node.rpcClientToNode().start(it.username, it.password)
+                val nodeStateObservable = connection.proxy.nodeStateObservable()
+                nodeStateObservable.subscribe { update ->
+                    expectedMessages.add(update)
+                }
+            }
+
+            node.stop()
+            assertEquals(userList.size, expectedMessages.size)
+            assertEquals("Node shutting down.", expectedMessages.first())
         }
     }
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.concurrent.fork
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.messaging.NodeState
 import net.corda.core.messaging.RPCOps
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.serialize
@@ -245,7 +246,7 @@ class RPCStabilityTests {
         val bob = User("Bob", "Bob", setOf(invokeRpc(CordaRPCOps::nodeStateObservable)))
         val slagathor = User("Slagathor", "Slagathor", setOf(invokeRpc(CordaRPCOps::nodeStateObservable)))
         val userList = listOf(alice, bob, slagathor)
-        val expectedMessages = ArrayList<String>()
+        val expectedMessages = ArrayList<NodeState>()
 
         rpcDriver(startNodesInProcess = true) {
             val node = startNode(rpcUsers = listOf(alice, bob, slagathor)).getOrThrow()
@@ -258,9 +259,9 @@ class RPCStabilityTests {
             }
 
             node.stop()
-            assertEquals(userList.size, expectedMessages.size)
-            assertEquals("Node shutting down.", expectedMessages.first())
         }
+        assertEquals(userList.size, expectedMessages.size)
+        assertEquals(NodeState.SHUTTING_DOWN, expectedMessages.first())
     }
 
     interface TrackSubscriberOps : RPCOps {

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -198,7 +198,7 @@ interface CordaRPCOps : RPCOps {
 
     /** Returns and [Observable] object with future states of the node. */
     @RPCReturnsObservables
-    fun nodeStateObservable(): Observable<String>
+    fun nodeStateObservable(): Observable<NodeState>
 
     /**
      * Returns network's notary identities, assuming this will not change while the node is running.
@@ -432,3 +432,8 @@ inline fun <T, A, B, C, D, E, F, reified R : FlowLogic<T>> CordaRPCOps.startTrac
  */
 @CordaSerializable
 data class DataFeed<out A, B>(val snapshot: A, val updates: Observable<B>)
+
+@CordaSerializable
+enum class NodeState {
+    SHUTTING_DOWN
+}

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -196,6 +196,10 @@ interface CordaRPCOps : RPCOps {
     /** Returns Node's NodeInfo, assuming this will not change while the node is running. */
     fun nodeInfo(): NodeInfo
 
+    /** Returns and [Observable] object with future states of the node. */
+    @RPCReturnsObservables
+    fun nodeStateObservable(): Observable<String>
+
     /**
      * Returns network's notary identities, assuming this will not change while the node is running.
      *

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -13,6 +13,7 @@ import net.corda.core.serialization.SerializeAsToken
 import net.corda.core.transactions.FilteredTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
+import rx.Observable
 import java.security.PublicKey
 import java.sql.Connection
 import java.time.Clock
@@ -137,6 +138,9 @@ interface ServiceHub : ServicesForResolution {
 
     /** The [NodeInfo] object corresponding to our own entry in the network map. */
     val myInfo: NodeInfo
+
+    /** The [Observable] object used to communicate to RPC clients the state of the node. */
+    val myNodeStateObservable: Observable<String>
 
     /**
      * Return the singleton instance of the given Corda service type. This is a class that is annotated with

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -8,6 +8,7 @@ import net.corda.core.crypto.SignableData
 import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.flows.ContractUpgradeFlow
+import net.corda.core.messaging.NodeState
 import net.corda.core.node.services.*
 import net.corda.core.serialization.SerializeAsToken
 import net.corda.core.transactions.FilteredTransaction
@@ -140,7 +141,7 @@ interface ServiceHub : ServicesForResolution {
     val myInfo: NodeInfo
 
     /** The [Observable] object used to communicate to RPC clients the state of the node. */
-    val myNodeStateObservable: Observable<String>
+    val myNodeStateObservable: Observable<NodeState>
 
     /**
      * Return the singleton instance of the given Corda service type. This is a class that is annotated with

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -62,6 +62,7 @@ import net.corda.node.utilities.*
 import org.apache.activemq.artemis.utils.ReusableLatch
 import org.slf4j.Logger
 import rx.Observable
+import rx.subjects.PublishSubject
 import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 import java.security.KeyPair
@@ -124,6 +125,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
     protected val services: ServiceHubInternal get() = _services
     private lateinit var _services: ServiceHubInternalImpl
     protected lateinit var info: NodeInfo
+    protected val nodeStateObservable: PublishSubject<String> = PublishSubject.create<String>()
     protected var myNotaryIdentity: PartyAndCertificate? = null
     protected lateinit var checkpointStorage: CheckpointStorage
     protected lateinit var smm: StateMachineManager
@@ -636,6 +638,9 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
         // Meanwhile, we let the remote service send us updates until the acknowledgment buffer overflows and it
         // unsubscribes us forcibly, rather than blocking the shutdown process.
 
+        // Notify observers that the node is shutting down
+        nodeStateObservable.onNext("Node shutting down.")
+
         // Run shutdown hooks in opposite order to starting
         for (toRun in runOnStop.reversed()) {
             toRun()
@@ -737,6 +742,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
         override val networkService: MessagingService get() = network
         override val clock: Clock get() = platformClock
         override val myInfo: NodeInfo get() = info
+        override val myNodeStateObservable: Observable<String> get() = nodeStateObservable
         override val database: CordaPersistence get() = this@AbstractNode.database
         override val configuration: NodeConfiguration get() = this@AbstractNode.configuration
         override fun <T : SerializeAsToken> cordaService(type: Class<T>): T {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -125,7 +125,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
     protected val services: ServiceHubInternal get() = _services
     private lateinit var _services: ServiceHubInternalImpl
     protected lateinit var info: NodeInfo
-    protected val nodeStateObservable: PublishSubject<String> = PublishSubject.create<String>()
+    protected val nodeStateObservable: PublishSubject<NodeState> = PublishSubject.create<NodeState>()
     protected var myNotaryIdentity: PartyAndCertificate? = null
     protected lateinit var checkpointStorage: CheckpointStorage
     protected lateinit var smm: StateMachineManager
@@ -639,7 +639,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
         // unsubscribes us forcibly, rather than blocking the shutdown process.
 
         // Notify observers that the node is shutting down
-        nodeStateObservable.onNext("Node shutting down.")
+        nodeStateObservable.onNext(NodeState.SHUTTING_DOWN)
 
         // Run shutdown hooks in opposite order to starting
         for (toRun in runOnStop.reversed()) {
@@ -742,7 +742,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
         override val networkService: MessagingService get() = network
         override val clock: Clock get() = platformClock
         override val myInfo: NodeInfo get() = info
-        override val myNodeStateObservable: Observable<String> get() = nodeStateObservable
+        override val myNodeStateObservable: Observable<NodeState> get() = nodeStateObservable
         override val database: CordaPersistence get() = this@AbstractNode.database
         override val configuration: NodeConfiguration get() = this@AbstractNode.configuration
         override fun <T : SerializeAsToken> cordaService(type: Class<T>): T {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -115,7 +115,7 @@ internal class CordaRPCOpsImpl(
         return services.myInfo
     }
 
-    override fun nodeStateObservable(): Observable<String> {
+    override fun nodeStateObservable(): Observable<NodeState> {
         return services.myNodeStateObservable
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -115,6 +115,10 @@ internal class CordaRPCOpsImpl(
         return services.myInfo
     }
 
+    override fun nodeStateObservable(): Observable<String> {
+        return services.myNodeStateObservable
+    }
+
     override fun notaryIdentities(): List<Party> {
         return services.networkMapCache.notaryIdentities
     }

--- a/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
@@ -8,6 +8,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.DataFeed
+import net.corda.core.messaging.NodeState
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.core.node.services.Vault
@@ -61,7 +62,7 @@ class RpcAuthorisationProxy(private val implementation: CordaRPCOps, private val
 
     override fun nodeInfo(): NodeInfo = guard("nodeInfo", implementation::nodeInfo)
 
-    override fun nodeStateObservable(): Observable<String> = guard("nodeStateObservable", implementation::nodeStateObservable)
+    override fun nodeStateObservable(): Observable<NodeState> = guard("nodeStateObservable", implementation::nodeStateObservable)
 
     override fun notaryIdentities(): List<Party> = guard("notaryIdentities", implementation::notaryIdentities)
 

--- a/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
@@ -16,6 +16,7 @@ import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.Sort
 import net.corda.node.services.messaging.RpcContext
 import net.corda.node.services.messaging.requireEitherPermission
+import rx.Observable
 import java.io.InputStream
 import java.security.PublicKey
 
@@ -59,6 +60,8 @@ class RpcAuthorisationProxy(private val implementation: CordaRPCOps, private val
     }
 
     override fun nodeInfo(): NodeInfo = guard("nodeInfo", implementation::nodeInfo)
+
+    override fun nodeStateObservable(): Observable<String> = guard("nodeStateObservable", implementation::nodeStateObservable)
 
     override fun notaryIdentities(): List<Party> = guard("notaryIdentities", implementation::notaryIdentities)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -9,6 +9,7 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.FlowProgressHandle
+import net.corda.core.messaging.NodeState
 import net.corda.core.node.*
 import net.corda.core.node.services.*
 import net.corda.core.serialization.SerializeAsToken
@@ -161,8 +162,8 @@ open class MockServices(
             val identity = getTestPartyAndCertificate(MEGA_CORP.name, key.public)
             return NodeInfo(emptyList(), listOf(identity), 1, serial = 1L)
         }
-    override val myNodeStateObservable: Observable<String>
-        get() = PublishSubject.create<String>()
+    override val myNodeStateObservable: Observable<NodeState>
+        get() = PublishSubject.create<NodeState>()
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
     val mockCordappProvider = MockCordappProvider(cordappLoader, attachments)
     override val cordappProvider: CordappProvider get() = mockCordappProvider

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -161,6 +161,8 @@ open class MockServices(
             val identity = getTestPartyAndCertificate(MEGA_CORP.name, key.public)
             return NodeInfo(emptyList(), listOf(identity), 1, serial = 1L)
         }
+    override val myNodeStateObservable: Observable<String>
+        get() = PublishSubject.create<String>()
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
     val mockCordappProvider = MockCordappProvider(cordappLoader, attachments)
     override val cordappProvider: CordappProvider get() = mockCordappProvider


### PR DESCRIPTION
A first step towards making the node shutdown and overall RPC client-to-node connection better.
RPC clients can subscribe to an observable and be notified when the node will shutdown intentionally. 
