### PR TITLE
Supported TLS cipher suites

### DIFF
--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -5,7 +5,6 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_BANK_B
-import net.corda.testing.IntegrationTestCategory
 import net.corda.testing.driver.driver
 import net.corda.testing.http.HttpApi
 import net.corda.vega.api.PortfolioApi


### PR DESCRIPTION
Remove unsafe/unused TLS cipher suites.
Reasoning:
- We currently issue ECDSA TLS certs.
- However, we should support RSA keys because we've seen that some cloud providers support RSA HSMs, but not ECDSA yet.
- We don't (and it seems we won't) support DSS.
- ECDHE is more secure (forward secrecy) than ECDH and RSA (no DH at all), however slightly slower than ECDH (need to create an ephemeral key per session).
- TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 is also an option for anyone wanting to avoid any use of ECC  (and potentially corrupted curves) when using RSA, but it is slower than ECDHE.