### PR TITLE
Retired getDefaultNotary test extension method.

### DIFF
--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -7,8 +7,11 @@ import net.corda.finance.POUNDS
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.issuedBy
 import net.corda.node.services.api.StartedNodeServices
-import net.corda.testing.*
+import net.corda.testing.ALICE_NAME
+import net.corda.testing.BOB_NAME
+import net.corda.testing.CHARLIE
 import net.corda.testing.node.MockNetwork
+import net.corda.testing.singleIdentity
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -32,7 +35,7 @@ class FinalityFlowTests {
         bobServices = bobNode.services
         alice = aliceNode.info.singleIdentity()
         bob = bobNode.info.singleIdentity()
-        notary = aliceServices.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
     }
 
     @After

--- a/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
@@ -12,7 +12,6 @@ import net.corda.testing.MEGA_CORP
 import net.corda.testing.MINI_CORP
 import net.corda.testing.chooseIdentity
 import net.corda.testing.contracts.DummyContract
-import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -44,7 +43,7 @@ class ResolveTransactionsFlowTest {
         miniCorpNode = mockNet.createPartyNode(MINI_CORP.name)
         megaCorpNode.internals.registerInitiatedFlow(TestResponseFlow::class.java)
         miniCorpNode.internals.registerInitiatedFlow(TestResponseFlow::class.java)
-        notary = notaryNode.services.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
         megaCorp = megaCorpNode.info.chooseIdentity()
         miniCorp = miniCorpNode.info.chooseIdentity()
     }
@@ -54,7 +53,6 @@ class ResolveTransactionsFlowTest {
         mockNet.stopNodes()
     }
 // DOCEND 3
-
 
     // DOCSTART 1
     @Test

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
@@ -9,7 +9,6 @@ import net.corda.finance.contracts.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.node.internal.StartedNode
 import net.corda.testing.chooseIdentity
-import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Assert
@@ -29,7 +28,7 @@ class CustomVaultQueryTest {
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
         nodeA.internals.registerInitiatedFlow(TopupIssuerFlow.TopupIssuer::class.java)
-        notary = nodeA.services.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
     }
 
     @After

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
@@ -9,7 +9,6 @@ import net.corda.finance.contracts.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.node.internal.StartedNode
 import net.corda.testing.chooseIdentity
-import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.MockNetwork
 import org.junit.After
 import org.junit.Before
@@ -28,7 +27,7 @@ class FxTransactionBuildTutorialTest {
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
         nodeB.internals.registerInitiatedFlow(ForeignExchangeRemoteFlow::class.java)
-        notary = nodeA.services.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
     }
 
     @After

--- a/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
@@ -9,7 +9,6 @@ import net.corda.finance.contracts.asset.Cash
 import net.corda.node.internal.StartedNode
 import net.corda.testing.BOC
 import net.corda.testing.chooseIdentity
-import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetwork.MockNode
@@ -33,7 +32,7 @@ class CashExitFlowTests {
                 cordappPackages = listOf("net.corda.finance.contracts.asset"))
         bankOfCordaNode = mockNet.createPartyNode(BOC.name)
         bankOfCorda = bankOfCordaNode.info.chooseIdentity()
-        notary = bankOfCordaNode.services.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
         val future = bankOfCordaNode.services.startFlow(CashIssueFlow(initialBalance, ref, notary)).resultFuture
         mockNet.runNetwork()
         future.getOrThrow()

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -97,7 +97,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             val bankNode = mockNet.createPartyNode(BOC_NAME)
             val alice = aliceNode.info.singleIdentity()
             val bank = bankNode.info.singleIdentity()
-            val notary = notaryNode.services.getDefaultNotary()
+            val notary = mockNet.defaultNotaryIdentity
             val cashIssuer = bank.ref(1)
             val cpIssuer = bank.ref(1, 2, 3)
 
@@ -148,7 +148,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             val alice = aliceNode.info.singleIdentity()
             val bank = bankNode.info.singleIdentity()
             val issuer = bank.ref(1)
-            val notary = aliceNode.services.getDefaultNotary()
+            val notary = mockNet.defaultNotaryIdentity
 
             aliceNode.internals.disableDBCloseOnStop()
             bobNode.internals.disableDBCloseOnStop()
@@ -207,7 +207,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             val bobAddr = bobNode.network.myAddress as InMemoryMessagingNetwork.PeerHandle
             mockNet.runNetwork() // Clear network map registration messages
 
-            val notary = notaryNode.services.getDefaultNotary()
+            val notary = mockNet.defaultNotaryIdentity
             val alice = aliceNode.info.singleIdentity()
             val bank = bankNode.info.singleIdentity()
             val issuer = bank.ref(1, 2, 3)
@@ -311,7 +311,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
         val bobNode = makeNodeWithTracking(BOB_NAME)
         val bankNode = makeNodeWithTracking(BOC_NAME)
         mockNet.runNetwork()
-        val notary = aliceNode.services.getDefaultNotary()
+        val notary = mockNet.defaultNotaryIdentity
         val alice = aliceNode.info.singleIdentity()
         val bob = bobNode.info.singleIdentity()
         val bank = bankNode.info.singleIdentity()
@@ -417,7 +417,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
         val bobNode = makeNodeWithTracking(BOB_NAME)
         val bankNode = makeNodeWithTracking(BOC_NAME)
 
-        val notary = aliceNode.services.getDefaultNotary()
+        val notary = mockNet.defaultNotaryIdentity
         val alice: Party = aliceNode.info.singleIdentity()
         val bank: Party = bankNode.info.singleIdentity()
         val issuer = bank.ref(1, 2, 3)
@@ -569,7 +569,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
         val bobNode = mockNet.createPartyNode(BOB_NAME)
         val bankNode = mockNet.createPartyNode(BOC_NAME)
 
-        val notary = aliceNode.services.getDefaultNotary()
+        val notary = mockNet.defaultNotaryIdentity
         val alice = aliceNode.info.singleIdentity()
         val bob = bobNode.info.singleIdentity()
         val bank = bankNode.info.singleIdentity()
@@ -607,8 +607,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
             node: StartedNode<*>,
             notaryNode: StartedNode<*>,
             vararg extraSigningNodes: StartedNode<*>): Map<SecureHash, SignedTransaction> {
-
-        val notaryParty = node.services.getDefaultNotary()
+        val notaryParty = mockNet.defaultNotaryIdentity
         val signed = wtxToSign.map {
             val id = it.id
             val sigs = mutableListOf<TransactionSignature>()
@@ -714,7 +713,10 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
     }
 
 
-    class RecordingTransactionStorage(val database: CordaPersistence, val delegate: WritableTransactionStorage) : WritableTransactionStorage, SingletonSerializeAsToken() {
+    class RecordingTransactionStorage(
+            private val database: CordaPersistence,
+            private val delegate: WritableTransactionStorage
+    ) : WritableTransactionStorage, SingletonSerializeAsToken() {
         override fun track(): DataFeed<List<SignedTransaction>, SignedTransaction> {
             return database.transaction {
                 delegate.track()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -84,7 +84,7 @@ class FlowFrameworkTests {
         // Extract identities
         alice = aliceNode.info.singleIdentity()
         bob = bobNode.info.singleIdentity()
-        notaryIdentity = aliceNode.services.getDefaultNotary()
+        notaryIdentity = mockNet.defaultNotaryIdentity
     }
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -17,7 +17,6 @@ import net.corda.node.services.api.StartedNodeServices
 import net.corda.testing.ALICE_NAME
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.dummyCommand
-import net.corda.testing.getDefaultNotary
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNodeParameters
 import net.corda.testing.singleIdentity
@@ -42,7 +41,7 @@ class NotaryServiceTests {
         mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
         aliceServices = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME)).services
         notaryServices = mockNet.defaultNotaryNode.services //TODO get rid of that
-        notary = aliceServices.getDefaultNotary()
+        notary = mockNet.defaultNotaryIdentity
         alice = aliceServices.myInfo.singleIdentity()
     }
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -12,7 +12,6 @@ import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.cert
 import net.corda.core.node.NodeInfo
-import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.IdentityService
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.OpaqueBytes
@@ -178,8 +177,6 @@ fun NodeInfo.singleIdentityAndCert(): PartyAndCertificate = legalIdentitiesAndCe
  * Extract a single identity from the node info. Throws an error if the node has multiple identities.
  */
 fun NodeInfo.singleIdentity(): Party = singleIdentityAndCert().party
-/** Returns the identity of the first notary found on the network */
-fun ServiceHub.getDefaultNotary(): Party = networkMapCache.notaryIdentities.first()
 
 /**
  * A method on a mock was called, but no behaviour was previously specified for that method.


### PR DESCRIPTION
Most uses where with MockNetwork which recently got a defaultNotaryIdentity property for dealing with the default single notary case. The remaining uses where in flows.

