### PR TITLE
Fix circular dependency

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -1,5 +1,6 @@
 package net.corda.core.node
 
+import net.corda.core.DoNotImplement
 import net.corda.core.contracts.*
 import net.corda.core.cordapp.CordappProvider
 import net.corda.core.crypto.Crypto
@@ -17,10 +18,24 @@ import java.sql.Connection
 import java.time.Clock
 
 /**
+ * Part of [ServiceHub].
+ */
+@DoNotImplement
+interface StateLoader {
+    /**
+     * Given a [StateRef] loads the referenced transaction and looks up the specified output [ContractState].
+     *
+     * @throws TransactionResolutionException if [stateRef] points to a non-existent transaction.
+     */
+    @Throws(TransactionResolutionException::class)
+    fun loadState(stateRef: StateRef): TransactionState<*>
+}
+
+/**
  * Subset of node services that are used for loading transactions from the wire into fully resolved, looked up
  * forms ready for verification.
  */
-interface ServicesForResolution {
+interface ServicesForResolution : StateLoader {
     /**
      * An identity service maintains a directory of parties by their associated distinguished name/public keys and thus
      * supports lookup of a party given its key, or name. The service also manages the certificates linking confidential
@@ -33,24 +48,6 @@ interface ServicesForResolution {
 
     /** Provides access to anything relating to cordapps including contract attachment resolution and app context */
     val cordappProvider: CordappProvider
-
-    /**
-     * A map of hash->tx where tx has been signature/contract validated and the states are known to be correct.
-     * The signatures aren't technically needed after that point, but we keep them around so that we can relay
-     * the transaction data to other nodes that need it.
-     */
-    val validatedTransactions: TransactionStorage
-
-    /**
-     * Given a [StateRef] loads the referenced transaction and looks up the specified output [ContractState].
-     *
-     * @throws TransactionResolutionException if [stateRef] points to a non-existent transaction.
-     */
-    @Throws(TransactionResolutionException::class)
-    fun loadState(stateRef: StateRef): TransactionState<*> {
-        val stx = validatedTransactions.getTransaction(stateRef.txhash) ?: throw TransactionResolutionException(stateRef.txhash)
-        return stx.resolveBaseTransaction(this).outputs[stateRef.index]
-    }
 }
 
 /**
@@ -110,6 +107,13 @@ interface ServiceHub : ServicesForResolution {
      * @see ContractUpgradeFlow to understand the workflow associated with contract upgrades.
      */
     val contractUpgradeService: ContractUpgradeService
+
+    /**
+     * A map of hash->tx where tx has been signature/contract validated and the states are known to be correct.
+     * The signatures aren't technically needed after that point, but we keep them around so that we can relay
+     * the transaction data to other nodes that need it.
+     */
+    val validatedTransactions: TransactionStorage
 
     /**
      * A network map contains lists of nodes on the network along with information about their identity keys, services

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -6,6 +6,8 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.serializedHash
 import net.corda.core.identity.Party
 import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.StateLoader
+import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.toBase58String
 import java.security.PublicKey
@@ -42,13 +44,15 @@ data class ContractUpgradeWireTransaction(
     override val id: SecureHash by lazy { serializedHash(inputs + notary).hashConcat(hiddenComponentHash) }
 
     /** Resolves input states and contract attachments, and builds a ContractUpgradeLedgerTransaction. */
-    fun resolve(services: ServicesForResolution, sigs: List<TransactionSignature>): ContractUpgradeLedgerTransaction {
+    fun resolve(services: ServicesForResolution, sigs: List<TransactionSignature>) = resolve(services, services.attachments, sigs)
+
+    fun resolve(stateLoader: StateLoader, attachments: AttachmentStorage, sigs: List<TransactionSignature>): ContractUpgradeLedgerTransaction {
         val resolvedInputs = inputs.map { ref ->
-            services.loadState(ref).let { StateAndRef(it, ref) }
+            stateLoader.loadState(ref).let { StateAndRef(it, ref) }
         }
         val legacyContractClassName = resolvedInputs.first().state.contract
-        val legacyContractAttachment = services.attachments.openAttachment(legacyContractAttachmentId) ?: throw AttachmentResolutionException(legacyContractAttachmentId)
-        val upgradedContractAttachment = services.attachments.openAttachment(upgradedContractAttachmentId) ?: throw AttachmentResolutionException(upgradedContractAttachmentId)
+        val legacyContractAttachment = attachments.openAttachment(legacyContractAttachmentId) ?: throw AttachmentResolutionException(legacyContractAttachmentId)
+        val upgradedContractAttachment = attachments.openAttachment(upgradedContractAttachmentId) ?: throw AttachmentResolutionException(upgradedContractAttachmentId)
 
         return ContractUpgradeLedgerTransaction(
                 resolvedInputs,

--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -5,7 +5,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.crypto.serializedHash
 import net.corda.core.identity.Party
-import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.StateLoader
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.toBase58String
 import java.security.PublicKey
@@ -40,9 +40,9 @@ data class NotaryChangeWireTransaction(
      */
     override val id: SecureHash by lazy { serializedHash(inputs + notary + newNotary) }
 
-    fun resolve(services: ServicesForResolution, sigs: List<TransactionSignature>): NotaryChangeLedgerTransaction {
+    fun resolve(stateLoader: StateLoader, sigs: List<TransactionSignature>): NotaryChangeLedgerTransaction {
         val resolvedInputs = inputs.map { ref ->
-            services.loadState(ref).let { StateAndRef(it, ref) }
+            stateLoader.loadState(ref).let { StateAndRef(it, ref) }
         }
         return NotaryChangeLedgerTransaction(resolvedInputs, notary, newNotary, id, sigs)
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -8,6 +8,8 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.StateLoader
+import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
@@ -184,10 +186,12 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
      * Resolves the underlying base transaction and then returns it, handling any special case transactions such as
      * [NotaryChangeWireTransaction].
      */
-    fun resolveBaseTransaction(services: ServicesForResolution): BaseTransaction {
+    fun resolveBaseTransaction(services: ServicesForResolution) = resolveBaseTransaction(services, services.attachments)
+
+    fun resolveBaseTransaction(stateLoader: StateLoader, attachments: AttachmentStorage): BaseTransaction {
         return when (coreTransaction) {
-            is NotaryChangeWireTransaction -> resolveNotaryChangeTransaction(services)
-            is ContractUpgradeWireTransaction -> resolveContractUpgradeTransaction(services)
+            is NotaryChangeWireTransaction -> resolveNotaryChangeTransaction(stateLoader)
+            is ContractUpgradeWireTransaction -> resolveContractUpgradeTransaction(stateLoader, attachments)
             is WireTransaction -> this.tx
             is FilteredTransaction -> throw IllegalStateException("Persistence of filtered transactions is not supported.")
             else -> throw IllegalStateException("Unknown transaction type ${coreTransaction::class.qualifiedName}")
@@ -212,20 +216,22 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
      * If [coreTransaction] is a [NotaryChangeWireTransaction], loads the input states and resolves it to a
      * [NotaryChangeLedgerTransaction] so the signatures can be verified.
      */
-    fun resolveNotaryChangeTransaction(services: ServicesForResolution): NotaryChangeLedgerTransaction {
+    fun resolveNotaryChangeTransaction(stateLoader: StateLoader): NotaryChangeLedgerTransaction {
         val ntx = coreTransaction as? NotaryChangeWireTransaction
                 ?: throw IllegalStateException("Expected a ${NotaryChangeWireTransaction::class.simpleName} but found ${coreTransaction::class.simpleName}")
-        return ntx.resolve(services, sigs)
+        return ntx.resolve(stateLoader, sigs)
     }
 
     /**
      * If [coreTransaction] is a [ContractUpgradeWireTransaction], loads the input states and resolves it to a
      * [ContractUpgradeLedgerTransaction] so the signatures can be verified.
      */
-    fun resolveContractUpgradeTransaction(services: ServicesForResolution): ContractUpgradeLedgerTransaction {
+    fun resolveContractUpgradeTransaction(services: ServicesForResolution) = resolveContractUpgradeTransaction(services, services.attachments)
+
+    fun resolveContractUpgradeTransaction(stateLoader: StateLoader, attachments: AttachmentStorage): ContractUpgradeLedgerTransaction {
         val ctx = coreTransaction as? ContractUpgradeWireTransaction
                 ?: throw IllegalStateException("Expected a ${ContractUpgradeWireTransaction::class.simpleName} but found ${coreTransaction::class.simpleName}")
-        return ctx.resolve(services, sigs)
+        return ctx.resolve(stateLoader, attachments, sigs)
     }
 
     override fun toString(): String = "${javaClass.simpleName}(id=$id)"

--- a/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
@@ -1,8 +1,14 @@
 package net.corda.node.internal
 
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionResolutionException
+import net.corda.core.contracts.TransactionState
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.StateLoader
+import net.corda.core.node.services.AttachmentStorage
+import net.corda.core.node.services.TransactionStorage
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.messaging.MessagingService
@@ -22,4 +28,12 @@ interface StartedNode<out N : AbstractNode> {
     val rpcOps: CordaRPCOps
     fun dispose() = internals.stop()
     fun <T : FlowLogic<*>> registerInitiatedFlow(initiatedFlowClass: Class<T>) = internals.registerInitiatedFlow(initiatedFlowClass)
+}
+
+class StateLoaderImpl(private val validatedTransactions: TransactionStorage, private val attachments: AttachmentStorage) : StateLoader {
+    @Throws(TransactionResolutionException::class)
+    override fun loadState(stateRef: StateRef): TransactionState<*> {
+        val stx = validatedTransactions.getTransaction(stateRef.txhash) ?: throw TransactionResolutionException(stateRef.txhash)
+        return stx.resolveBaseTransaction(this, attachments).outputs[stateRef.index]
+    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -14,7 +14,7 @@ import net.corda.core.internal.ThreadBox
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.until
-import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.StateLoader
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.loggerFor
@@ -58,7 +58,7 @@ import com.google.common.util.concurrent.SettableFuture as GuavaSettableFuture
 class NodeSchedulerService(private val clock: Clock,
                            private val database: CordaPersistence,
                            private val flowStarter: FlowStarter,
-                           private val services: ServicesForResolution,
+                           private val stateLoader: StateLoader,
                            private val schedulerTimerExecutor: Executor = Executors.newSingleThreadExecutor(),
                            private val unfinishedSchedules: ReusableLatch = ReusableLatch(),
                            private val serverThread: AffinityExecutor)
@@ -292,7 +292,7 @@ class NodeSchedulerService(private val clock: Clock,
     }
 
     private fun getScheduledActivity(scheduledState: ScheduledStateRef): ScheduledActivity? {
-        val txState = services.loadState(scheduledState.ref)
+        val txState = stateLoader.loadState(scheduledState.ref)
         val state = txState.data as SchedulableState
         return try {
             // This can throw as running contract code.

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -47,7 +47,7 @@ class DBTransactionStorageTests {
             services = object : MockServices(BOB_KEY) {
                 override val vaultService: VaultServiceInternal
                     get() {
-                        val vaultService = NodeVaultService(clock, keyManagementService, this, database.hibernateConfig)
+                        val vaultService = NodeVaultService(clock, keyManagementService, stateLoader, attachments, database.hibernateConfig)
                         hibernatePersister = HibernateObserver.install(vaultService.rawUpdates, database.hibernateConfig)
                         return vaultService
                     }

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -11,7 +11,8 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.packageName
 import net.corda.core.internal.uncheckedCast
-import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.StateLoader
+import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.node.services.KeyManagementService
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria.SoftLockingCondition
@@ -81,8 +82,8 @@ class VaultSoftLockManagerTest {
     }
     private val mockNet = MockNetwork(cordappPackages = listOf(ContractImpl::class.packageName), defaultFactory = { args ->
         object : MockNetwork.MockNode(args) {
-            override fun makeVaultService(keyManagementService: KeyManagementService, services: ServicesForResolution): VaultServiceInternal {
-                val realVault = super.makeVaultService(keyManagementService, services)
+            override fun makeVaultService(keyManagementService: KeyManagementService, stateLoader: StateLoader, attachments: AttachmentStorage): VaultServiceInternal {
+                val realVault = super.makeVaultService(keyManagementService, stateLoader, attachments)
                 return object : VaultServiceInternal by realVault {
                     override fun softLockRelease(lockId: UUID, stateRefs: NonEmptySet<StateRef>?) {
                         mockVault.softLockRelease(lockId, stateRefs) // No need to also call the real one for these tests.


### PR DESCRIPTION
* strategy is for functions to take what they need, with ServiceHub helpers where convenient
* this all makes AbstractNode a little less crazy which is a good thing
* some files reverted to master state
