### PR TITLE
Fix Gradle warning for example-code project.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -33,7 +33,8 @@ include 'tools:explorer:capsule'
 include 'tools:demobench'
 include 'tools:loadtest'
 include 'tools:graphs'
-include 'docs/source/example-code' // Note that we are deliberately choosing to use '/' here. With ':' gradle would treat the directories as actual projects.
+include 'example-code'
+project(':example-code').projectDir = file("$settingsDir/docs/source/example-code")
 include 'samples:attachment-demo'
 include 'samples:trader-demo'
 include 'samples:irs-demo'


### PR DESCRIPTION
Replace unsupported syntax with official Gradle approach for changing the project directory.