### PR TITLE
Step through cert path when registering

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -85,9 +85,6 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate> = emptyS
         }
 
         log.trace { "Registering identity $identity" }
-        identity.certPath.certificates.reversed().forEach {
-
-        }
         keyToParties[identity.owningKey] = identity
         // Always keep the first party we registered, as that's the well known identity
         principalToParties.computeIfAbsent(identity.name) { identity }

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -16,6 +16,7 @@ import java.security.PublicKey
 import java.security.cert.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.annotation.concurrent.ThreadSafe
+import javax.security.auth.x500.X500Principal
 
 /**
  * Simple identity service which caches parties and provides functionality for efficient lookup.
@@ -68,7 +69,25 @@ class InMemoryIdentityService(identities: Iterable<PartyAndCertificate> = emptyS
             }
             throw e
         }
+
+        // Ensure we record the first identity of the same name, first
+        val identityPrincipal = identity.name.x500Principal
+        val firstCertWithThisName: Certificate = identity.certPath.certificates.last { it ->
+            val principal = (it as? X509Certificate)?.subjectX500Principal
+            principal == identityPrincipal
+        }
+        if (firstCertWithThisName != identity.certificate) {
+            val certificates = identity.certPath.certificates
+            val idx = certificates.lastIndexOf(firstCertWithThisName)
+            val certFactory = CertificateFactory.getInstance("X509")
+            val firstPath = certFactory.generateCertPath(certificates.slice(idx..certificates.size - 1))
+            verifyAndRegisterIdentity(PartyAndCertificate(firstPath))
+        }
+
         log.trace { "Registering identity $identity" }
+        identity.certPath.certificates.reversed().forEach {
+
+        }
         keyToParties[identity.owningKey] = identity
         // Always keep the first party we registered, as that's the well known identity
         principalToParties.computeIfAbsent(identity.name) { identity }


### PR DESCRIPTION
Always register identities in a certificate path from the root down to the target certificate, so that the first certificate with a name is always the one recorded in the name lookup map.