### PR TITLE
Vault query - don't return repeated column which groups multiple aggregation functions.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -196,6 +196,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                             AggregateFunctionType.MAX -> criteriaBuilder.max(column)
                             AggregateFunctionType.MIN -> criteriaBuilder.min(column)
                         }
+                //TODO investigate possibility to avoid producing redundant joins in SQL for multiple aggregate functions against the same table
                 aggregateExpressions.add(aggregateExpression)
                 // optionally order by this aggregate function
                 expression.orderBy?.let {

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -395,37 +395,28 @@ public class VaultQueryJavaTests {
                 Vault.Page<Cash.State> results = vaultService.queryBy(Cash.State.class, criteria);
                 // DOCEND VaultJavaQueryExample22
 
-                assertThat(results.getOtherResults()).hasSize(27);
+                assertThat(results.getOtherResults()).hasSize(18);
                 /** CHF */
                 assertThat(results.getOtherResults().get(0)).isEqualTo(500L);
-                assertThat(results.getOtherResults().get(1)).isEqualTo("CHF");
-                assertThat(results.getOtherResults().get(2)).isEqualTo(5L);
-                assertThat(results.getOtherResults().get(3)).isEqualTo(102L);
-                assertThat(results.getOtherResults().get(4)).isEqualTo("CHF");
-                assertThat(results.getOtherResults().get(5)).isEqualTo(94L);
-                assertThat(results.getOtherResults().get(6)).isEqualTo("CHF");
-                assertThat(results.getOtherResults().get(7)).isEqualTo(100.00);
-                assertThat(results.getOtherResults().get(8)).isEqualTo("CHF");
+                assertThat(results.getOtherResults().get(1)).isEqualTo(5L);
+                assertThat(results.getOtherResults().get(2)).isEqualTo(102L);
+                assertThat(results.getOtherResults().get(3)).isEqualTo(94L);
+                assertThat(results.getOtherResults().get(4)).isEqualTo(100.00);
+                assertThat(results.getOtherResults().get(5)).isEqualTo("CHF");
                 /** GBP */
-                assertThat(results.getOtherResults().get(9)).isEqualTo(400L);
-                assertThat(results.getOtherResults().get(10)).isEqualTo("GBP");
-                assertThat(results.getOtherResults().get(11)).isEqualTo(4L);
-                assertThat(results.getOtherResults().get(12)).isEqualTo(103L);
-                assertThat(results.getOtherResults().get(13)).isEqualTo("GBP");
-                assertThat(results.getOtherResults().get(14)).isEqualTo(93L);
-                assertThat(results.getOtherResults().get(15)).isEqualTo("GBP");
-                assertThat(results.getOtherResults().get(16)).isEqualTo(100.0);
-                assertThat(results.getOtherResults().get(17)).isEqualTo("GBP");
+                assertThat(results.getOtherResults().get(6)).isEqualTo(400L);
+                assertThat(results.getOtherResults().get(7)).isEqualTo(4L);
+                assertThat(results.getOtherResults().get(8)).isEqualTo(103L);
+                assertThat(results.getOtherResults().get(9)).isEqualTo(93L);
+                assertThat(results.getOtherResults().get(10)).isEqualTo(100.0);
+                assertThat(results.getOtherResults().get(11)).isEqualTo("GBP");
                 /** USD */
-                assertThat(results.getOtherResults().get(18)).isEqualTo(600L);
-                assertThat(results.getOtherResults().get(19)).isEqualTo("USD");
-                assertThat(results.getOtherResults().get(20)).isEqualTo(6L);
-                assertThat(results.getOtherResults().get(21)).isEqualTo(113L);
-                assertThat(results.getOtherResults().get(22)).isEqualTo("USD");
-                assertThat(results.getOtherResults().get(23)).isEqualTo(87L);
-                assertThat(results.getOtherResults().get(24)).isEqualTo("USD");
-                assertThat(results.getOtherResults().get(25)).isEqualTo(100.0);
-                assertThat(results.getOtherResults().get(26)).isEqualTo("USD");
+                assertThat(results.getOtherResults().get(12)).isEqualTo(600L);
+                assertThat(results.getOtherResults().get(13)).isEqualTo(6L);
+                assertThat(results.getOtherResults().get(14)).isEqualTo(113L);
+                assertThat(results.getOtherResults().get(15)).isEqualTo(87L);
+                assertThat(results.getOtherResults().get(16)).isEqualTo(100.0);
+                assertThat(results.getOtherResults().get(17)).isEqualTo("USD");
 
             } catch (NoSuchFieldException e) {
                 e.printStackTrace();

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -790,34 +790,25 @@ class VaultQueryTests {
                     .and(avgCriteria))
             // DOCEND VaultQueryExample22
 
-            assertThat(results.otherResults).hasSize(24)
+            assertThat(results.otherResults).hasSize(15)
             /** CHF */
             assertThat(results.otherResults[0]).isEqualTo(50000L)
-            assertThat(results.otherResults[1]).isEqualTo("CHF")
-            assertThat(results.otherResults[2]).isEqualTo(10274L)
-            assertThat(results.otherResults[3]).isEqualTo("CHF")
-            assertThat(results.otherResults[4]).isEqualTo(9481L)
-            assertThat(results.otherResults[5]).isEqualTo("CHF")
-            assertThat(results.otherResults[6]).isEqualTo(10000.0)
-            assertThat(results.otherResults[7]).isEqualTo("CHF")
+            assertThat(results.otherResults[1]).isEqualTo(10274L)
+            assertThat(results.otherResults[2]).isEqualTo(9481L)
+            assertThat(results.otherResults[3]).isEqualTo(10000.0)
+            assertThat(results.otherResults[4]).isEqualTo("CHF")
             /** GBP */
-            assertThat(results.otherResults[8]).isEqualTo(40000L)
+            assertThat(results.otherResults[5]).isEqualTo(40000L)
+            assertThat(results.otherResults[6]).isEqualTo(10343L)
+            assertThat(results.otherResults[7]).isEqualTo(9351L)
+            assertThat(results.otherResults[8]).isEqualTo(10000.0)
             assertThat(results.otherResults[9]).isEqualTo("GBP")
-            assertThat(results.otherResults[10]).isEqualTo(10343L)
-            assertThat(results.otherResults[11]).isEqualTo("GBP")
-            assertThat(results.otherResults[12]).isEqualTo(9351L)
-            assertThat(results.otherResults[13]).isEqualTo("GBP")
-            assertThat(results.otherResults[14]).isEqualTo(10000.0)
-            assertThat(results.otherResults[15]).isEqualTo("GBP")
             /** USD */
-            assertThat(results.otherResults[16]).isEqualTo(60000L)
-            assertThat(results.otherResults[17]).isEqualTo("USD")
-            assertThat(results.otherResults[18]).isEqualTo(11298L)
-            assertThat(results.otherResults[19]).isEqualTo("USD")
-            assertThat(results.otherResults[20]).isEqualTo(8702L)
-            assertThat(results.otherResults[21]).isEqualTo("USD")
-            assertThat(results.otherResults[22]).isEqualTo(10000.0)
-            assertThat(results.otherResults[23]).isEqualTo("USD")
+            assertThat(results.otherResults[10]).isEqualTo(60000L)
+            assertThat(results.otherResults[11]).isEqualTo(11298L)
+            assertThat(results.otherResults[12]).isEqualTo(8702L)
+            assertThat(results.otherResults[13]).isEqualTo(10000.0)
+            assertThat(results.otherResults[14]).isEqualTo("USD")
         }
     }
 


### PR DESCRIPTION
When a vault query has multiple aggregate function (e.g sum and avg), the column used to group by was repeated accordingly to number of aggregate functions.

Example aggregate sum and max of `pennies` group by `currency`:


    val sumCriteria = VaultCustomQueryCriteria(builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) })
    val maxCriteria = VaultCustomQueryCriteria(builder { CashSchemaV1.PersistentCashState::pennies.max(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) })
    vaultService.queryBy<FungibleAsset<*>>(sumCriteria.and(maxCriteria))

Before the change the query would return the following columns:
`sum, currency, max, currency`,
after the change (the column with currency is not duplicated):
`sum, max, currency`.