### PR TITLE
Removed incorrect @Lob annotation from key_hash schema fields.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
@@ -91,7 +91,6 @@ object NodeInfoSchemaV1 : MappedSchema(
             @Column(name = "party_name", nullable = false)
             val name: String,
 
-            @Lob
             @Column(name = "owning_key_hash", length = MAX_HASH_HEX_SIZE)
             val owningKeyHash: String,
 

--- a/finance/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt
+++ b/finance/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt
@@ -33,7 +33,6 @@ object CashSchemaV1 : MappedSchema(schemaFamily = CashSchema.javaClass, version 
             @Column(name = "ccy_code", length = 3)
             var currency: String,
 
-            @Lob
             @Column(name = "issuer_key_hash", length = MAX_HASH_HEX_SIZE)
             var issuerPartyHash: String,
 


### PR DESCRIPTION
Certain Database providers do not work well with LOB field types when joining across different tables. Specifically, certain cash queries were failing when attempting to query by issuer_key_hash.