### PR TITLE
Removal of transaction contract state as BLOB in VaultStates table.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -37,8 +37,10 @@ interface StateLoader {
      *
      * @throws TransactionResolutionException if [stateRef] points to a non-existent transaction.
      */
+    // TODO: future implementation to use a Vault state ref -> contract state BLOB table and perform single query bulk load
+    // as the existing transaction store will become encrypted at some point
     @Throws(TransactionResolutionException::class)
-    fun loadStates(stateRefs: Set<StateRef>): Set<TransactionState<*>>
+    fun loadStates(stateRefs: Set<StateRef>): Set<StateAndRef<ContractState>>
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -31,6 +31,14 @@ interface StateLoader {
      */
     @Throws(TransactionResolutionException::class)
     fun loadState(stateRef: StateRef): TransactionState<*>
+
+    /**
+     * Given a [Set] of [StateRef]'s loads the referenced transaction and looks up the specified output [ContractState].
+     *
+     * @throws TransactionResolutionException if [stateRef] points to a non-existent transaction.
+     */
+    @Throws(TransactionResolutionException::class)
+    fun loadStates(stateRefs: Set<StateRef>): Set<TransactionState<*>>
 }
 
 /**

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt
@@ -134,11 +134,11 @@ abstract class AbstractCashSelection {
                 while (rs.next()) {
                     val txHash = SecureHash.parse(rs.getString(1))
                     val index = rs.getInt(2)
+                    val pennies = rs.getLong(3)
+                    totalPennies = rs.getLong(4)
+                    val rowLockId = rs.getString(5)
                     val stateRef = StateRef(txHash, index)
-                    val state = rs.getBlob(3).deserialize<TransactionState<Cash.State>>(context = SerializationDefaults.STORAGE_CONTEXT)
-                    val pennies = rs.getLong(4)
-                    totalPennies = rs.getLong(5)
-                    val rowLockId = rs.getString(6)
+                    val state = services.loadState(stateRef) as TransactionState<Cash.State>
                     stateAndRefs.add(StateAndRef(state, stateRef))
                     log.trace { "ROW: $rowLockId ($lockId): $stateRef : $pennies ($totalPennies)" }
                 }

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt
@@ -145,7 +145,7 @@ abstract class AbstractCashSelection {
                     // TODO: future implementation to retrieve contract states from a Vault BLOB store
                     stateAndRefs.addAll(services.loadStates(stateRefs) as Collection<StateAndRef<Cash.State>>)
 
-                if (totalPennies >= amount.quantity) {
+                if (stateAndRefs.isNotEmpty() && totalPennies >= amount.quantity) {
                     // we should have a minimum number of states to satisfy our selection `amount` criteria
                     log.trace("Coin selection for $amount retrieved ${stateAndRefs.count()} states totalling $totalPennies pennies: $stateAndRefs")
 

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -35,7 +35,7 @@ class CashSelectionH2Impl : AbstractCashSelection() {
         connection.createStatement().execute("CALL SET(@t, 0);")
 
         val selectJoin = """
-                    SELECT vs.transaction_id, vs.output_index, vs.contract_state, ccs.pennies, SET(@t, ifnull(@t,0)+ccs.pennies) total_pennies, vs.lock_id
+                    SELECT vs.transaction_id, vs.output_index, ccs.pennies, SET(@t, ifnull(@t,0)+ccs.pennies) total_pennies, vs.lock_id
                     FROM vault_states AS vs, contract_cash_states AS ccs
                     WHERE vs.transaction_id = ccs.transaction_id AND vs.output_index = ccs.output_index
                     AND vs.state_status = 0

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
@@ -32,10 +32,10 @@ class CashSelectionPostgreSQLImpl : AbstractCashSelection() {
     //       3) Currently (version 9.6), FOR UPDATE cannot be specified with window functions
     override fun executeQuery(connection: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?,
                               onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>) : ResultSet {
-        val selectJoin = """SELECT nested.transaction_id, nested.output_index, nested.contract_state, nested.pennies,
+        val selectJoin = """SELECT nested.transaction_id, nested.output_index, nested.pennies,
                         nested.total+nested.pennies as total_pennies, nested.lock_id
                        FROM
-                       (SELECT vs.transaction_id, vs.output_index, vs.contract_state, ccs.pennies,
+                       (SELECT vs.transaction_id, vs.output_index, ccs.pennies,
                        coalesce((SUM(ccs.pennies) OVER (PARTITION BY 1 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)), 0)
                        AS total, vs.lock_id
                         FROM vault_states AS vs, contract_cash_states AS ccs

--- a/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
@@ -37,4 +37,9 @@ class StateLoaderImpl(private val validatedTransactions: TransactionStorage) : S
         val stx = validatedTransactions.getTransaction(stateRef.txhash) ?: throw TransactionResolutionException(stateRef.txhash)
         return stx.resolveBaseTransaction(this).outputs[stateRef.index]
     }
+
+    @Throws(TransactionResolutionException::class)
+    override fun loadStates(stateRefs: Set<StateRef>): Set<TransactionState<*>> {
+        return (stateRefs.map { loadState(it) }).toSet()
+    }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/StartedNode.kt
@@ -1,8 +1,6 @@
 package net.corda.node.internal
 
-import net.corda.core.contracts.StateRef
-import net.corda.core.contracts.TransactionResolutionException
-import net.corda.core.contracts.TransactionState
+import net.corda.core.contracts.*
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
@@ -39,7 +37,8 @@ class StateLoaderImpl(private val validatedTransactions: TransactionStorage) : S
     }
 
     @Throws(TransactionResolutionException::class)
-    override fun loadStates(stateRefs: Set<StateRef>): Set<TransactionState<*>> {
-        return (stateRefs.map { loadState(it) }).toSet()
+    // TODO: future implementation to retrieve contract states from a Vault BLOB store
+    override fun loadStates(stateRefs: Set<StateRef>): Set<StateAndRef<ContractState>> {
+        return (stateRefs.map { StateAndRef(loadState(it), it) }).toSet()
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -29,7 +29,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
     @Table(name = "vault_states",
             indexes = arrayOf(Index(name = "state_status_idx", columnList = "state_status")))
     class VaultStates(
-            /** NOTE: serialized transaction state (including contract state) is now resolved from transaction store **/
+            /** NOTE: serialized transaction state (including contract state) is now resolved from transaction store */
+            // TODO: create a distinct table to hold serialized state data (once DBTransactionStore is encrypted)
 
             /** refers to the X500Name of the notary a state is attached to */
             @Column(name = "notary_name")

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -29,6 +29,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
     @Table(name = "vault_states",
             indexes = arrayOf(Index(name = "state_status_idx", columnList = "state_status")))
     class VaultStates(
+            /** NOTE: serialized transaction state (including contract state) is now resolved from transaction store **/
+
             /** refers to the X500Name of the notary a state is attached to */
             @Column(name = "notary_name")
             var notary: Party,
@@ -36,11 +38,6 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             /** references a concrete ContractState that is [QueryableState] and has a [MappedSchema] */
             @Column(name = "contract_state_class_name")
             var contractStateClassName: String,
-
-            /** refers to serialized transaction Contract State */
-            @Lob
-            @Column(name = "contract_state")
-            var contractState: ByteArray,
 
             /** state lifecycle: unconsumed, consumed */
             @Column(name = "state_status")

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -95,19 +95,16 @@ class VaultQueryTests {
     }
 
     private fun setUpDb(_database: CordaPersistence, delay: Long = 0) {
-        val (linearStatesJKL,linearStatesXYZ,dealStates) =
-            _database.transaction {
-                // create new states
-                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
-                val linearStatesXYZ = services.fillWithSomeTestLinearStates(1, "XYZ")
-                val linearStatesJKL = services.fillWithSomeTestLinearStates(2, "JKL")
-                services.fillWithSomeTestLinearStates(3, "ABC")
-                val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-                // Total unconsumed states = 10 + 1 + 2 + 3 + 3 = 19
-                sleep(delay)
-                Triple(linearStatesJKL,linearStatesXYZ,dealStates)
-            }
-         _database.transaction {
+        _database.transaction {
+            // create new states
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
+            val linearStatesXYZ = services.fillWithSomeTestLinearStates(1, "XYZ")
+            val linearStatesJKL = services.fillWithSomeTestLinearStates(2, "JKL")
+            services.fillWithSomeTestLinearStates(3, "ABC")
+            val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
+            // Total unconsumed states = 10 + 1 + 2 + 3 + 3 = 19
+            sleep(delay)
+
             // consume some states
             services.consumeLinearStates(linearStatesXYZ.states.toList(), DUMMY_NOTARY)
             services.consumeLinearStates(linearStatesJKL.states.toList(), DUMMY_NOTARY)
@@ -143,8 +140,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample1
             val result = vaultService.queryBy<ContractState>()
 
@@ -170,8 +166,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             val criteria = VaultQueryCriteria() // default is UNCONSUMED
             val result = vaultService.queryBy<ContractState>(criteria)
 
@@ -187,18 +182,15 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
-        database.transaction {
+
+            val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val resultsBeforeConsume = vaultService.queryBy<ContractState>(criteria, paging)
             assertThat(resultsBeforeConsume.states).hasSize(4)
             assertThat(resultsBeforeConsume.totalStatesAvailable).isEqualTo(4)
-        }
-        database.transaction {
+
             services.consumeCash(75.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        database.transaction {
+
             val consumedCriteria = VaultQueryCriteria(status = Vault.StateStatus.UNCONSUMED)
             val resultsAfterConsume = vaultService.queryBy<ContractState>(consumedCriteria, paging)
             assertThat(resultsAfterConsume.states).hasSize(1)
@@ -212,8 +204,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             val result = vaultService.queryBy<Cash.State>()
 
             assertThat(result.states).hasSize(3)
@@ -227,8 +218,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             val criteria = VaultQueryCriteria() // default is UNCONSUMED
             val result = vaultService.queryBy<Cash.State>(criteria)
 
@@ -250,8 +240,7 @@ class VaultQueryTests {
             val consumedStateRefs = spentStates.consumed.map { it.ref }.toList()
             val producedStateRefs = spentStates.produced.map { it.ref }.toList()
             stateRefs.addAll(consumedStateRefs.plus(producedStateRefs))
-        }
-        database.transaction {
+
             val sortAttribute = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF)
             val criteria = VaultQueryCriteria()
             val results = vaultService.queryBy<Cash.State>(criteria, Sort(setOf(Sort.SortColumn(sortAttribute, Sort.Direction.ASC))))
@@ -278,8 +267,7 @@ class VaultQueryTests {
         database.transaction {
             services.consumeCash(10.DOLLARS, notary = DUMMY_NOTARY).consumed.forEach { consumed += it.ref.txhash }
             services.consumeCash(10.DOLLARS, notary = DUMMY_NOTARY).consumed.forEach { consumed += it.ref.txhash }
-        }
-        database.transaction {
+
             val sortAttributeTxnId = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_TXN_ID)
             val sortAttributeIndex = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_INDEX)
             val sortBy = Sort(setOf(Sort.SortColumn(sortAttributeTxnId, Sort.Direction.ASC),
@@ -299,13 +287,11 @@ class VaultQueryTests {
 
     @Test
     fun `unconsumed states for state refs`() {
-        val stateRefs =
-                database.transaction {
-                    services.fillWithSomeTestLinearStates(8)
-                    val issuedStates = services.fillWithSomeTestLinearStates(2)
-                    issuedStates.states.map { it.ref }.toList()
-                }
         database.transaction {
+            services.fillWithSomeTestLinearStates(8)
+            val issuedStates = services.fillWithSomeTestLinearStates(2)
+            val stateRefs = issuedStates.states.map { it.ref }.toList()
+
             // DOCSTART VaultQueryExample2
             val sortAttribute = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF_TXN_ID)
             val criteria = VaultQueryCriteria(stateRefs = listOf(stateRefs.first(), stateRefs.last()))
@@ -326,8 +312,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             // default State.Status is UNCONSUMED
             // DOCSTART VaultQueryExample3
             val criteria = VaultQueryCriteria(contractStateTypes = setOf(Cash.State::class.java, DealState::class.java))
@@ -339,20 +324,16 @@ class VaultQueryTests {
 
     @Test
     fun `consumed states`() {
-        val (linearStates, dealStates) =
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 states with same externalId
             services.fillWithSomeTestLinearStates(8)
             val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-            Pair(linearStates,dealStates)
-        }
-        database.transaction {
+
             services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
             services.consumeDeals(dealStates.states.filter { it.state.data.linearId.externalId == "456" }, DUMMY_NOTARY)
             services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        database.transaction {
+
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val results = vaultService.queryBy<ContractState>(criteria)
             assertThat(results.states).hasSize(5)
@@ -366,18 +347,15 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(25.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
-        database.transaction {
+
+            val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val resultsBeforeConsume = vaultService.queryBy<ContractState>(criteria, paging)
             assertThat(resultsBeforeConsume.states).hasSize(4)
             assertThat(resultsBeforeConsume.totalStatesAvailable).isEqualTo(4)
-        }
-        database.transaction {
+
             services.consumeCash(75.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        database.transaction {
+
             val consumedCriteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val resultsAfterConsume = vaultService.queryBy<ContractState>(consumedCriteria, paging)
             assertThat(resultsAfterConsume.states).hasSize(3)
@@ -387,20 +365,16 @@ class VaultQueryTests {
 
     @Test
     fun `all states`() {
-        val (linearStates, dealStates) =
-            database.transaction {
-                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
-                val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 results with same UID
-                services.fillWithSomeTestLinearStates(8)
-                val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-                Pair(linearStates, dealStates)
-            }
         database.transaction {
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 results with same UID
+            services.fillWithSomeTestLinearStates(8)
+            val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
+
             services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
             services.consumeDeals(dealStates.states.filter { it.state.data.linearId.externalId == "456" }, DUMMY_NOTARY)
             services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY) // generates a new change state!
-        }
-        database.transaction {
+
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val results = vaultService.queryBy<ContractState>(criteria)
             assertThat(results.states).hasSize(17)
@@ -411,18 +385,16 @@ class VaultQueryTests {
     fun `all states with count`() {
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
-        val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
-        database.transaction {
+
+            val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
+            val paging = PageSpecification(DEFAULT_PAGE_NUM, 10)
+
             val resultsBeforeConsume = vaultService.queryBy<ContractState>(criteria, paging)
             assertThat(resultsBeforeConsume.states).hasSize(1)
             assertThat(resultsBeforeConsume.totalStatesAvailable).isEqualTo(1)
-        }
-        database.transaction {
+
             services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)    // consumed 100 (spent), produced 50 (change)
-        }
-        database.transaction {
+
             val resultsAfterConsume = vaultService.queryBy<ContractState>(criteria, paging)
             assertThat(resultsAfterConsume.states).hasSize(2)
             assertThat(resultsAfterConsume.totalStatesAvailable).isEqualTo(2)
@@ -435,8 +407,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample4
             val criteria = VaultQueryCriteria(notary = listOf(CASH_NOTARY))
             val results = vaultService.queryBy<ContractState>(criteria)
@@ -453,8 +424,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(2, "TEST", participants = listOf(MEGA_CORP, MINI_CORP))
             services.fillWithSomeTestDeals(listOf("456"), participants = listOf(MEGA_CORP, BIG_CORP))
             services.fillWithSomeTestDeals(listOf("123", "789"), participants = listOf(BIG_CORP))
-        }
-        database.transaction {
+
             val criteria = LinearStateQueryCriteria(participants = listOf(BIG_CORP))
             val results = vaultService.queryBy<ContractState>(criteria)
             assertThat(results.states).hasSize(3)
@@ -469,8 +439,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(2, "TEST", participants = listOf(MEGA_CORP, MINI_CORP))
             services.fillWithSomeTestDeals(listOf("456"), participants = listOf(MEGA_CORP, BIG_CORP))
             services.fillWithSomeTestDeals(listOf("123", "789"), participants = listOf(MEGA_CORP))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample5
             val criteria = LinearStateQueryCriteria(participants = listOf(BIG_CORP, MINI_CORP))
             val results = vaultService.queryBy<ContractState>(criteria)
@@ -482,17 +451,14 @@ class VaultQueryTests {
 
     @Test
     fun `unconsumed states with soft locking`() {
-        val (lockId1, lockId2) =
-                database.transaction {
-                    val issuedStates = services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 10, 10, Random(0L)).states.toList()
-                    vaultService.softLockReserve(UUID.randomUUID(), NonEmptySet.of(issuedStates[1].ref, issuedStates[2].ref, issuedStates[3].ref))
-                    val lockId1 = UUID.randomUUID()
-                    vaultService.softLockReserve(lockId1, NonEmptySet.of(issuedStates[4].ref, issuedStates[5].ref))
-                    val lockId2 = UUID.randomUUID()
-                    vaultService.softLockReserve(lockId2, NonEmptySet.of(issuedStates[6].ref))
-                    Pair(lockId1, lockId2)
-                }
         database.transaction {
+            val issuedStates = services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 10, 10, Random(0L)).states.toList()
+            vaultService.softLockReserve(UUID.randomUUID(), NonEmptySet.of(issuedStates[1].ref, issuedStates[2].ref, issuedStates[3].ref))
+            val lockId1 = UUID.randomUUID()
+            vaultService.softLockReserve(lockId1, NonEmptySet.of(issuedStates[4].ref, issuedStates[5].ref))
+            val lockId2 = UUID.randomUUID()
+            vaultService.softLockReserve(lockId2, NonEmptySet.of(issuedStates[6].ref))
+
             // excluding soft locked states
             val criteriaExclusive = VaultQueryCriteria(softLockingCondition = SoftLockingCondition(SoftLockingType.UNLOCKED_ONLY))
             val resultsExclusive = vaultService.queryBy<ContractState>(criteriaExclusive)
@@ -532,8 +498,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.equal(GBP.currencyCode) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -547,8 +512,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.notEqual(GBP.currencyCode) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -562,8 +526,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.greaterThan(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -577,8 +540,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.greaterThanOrEqual(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -592,8 +554,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.lessThan(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -607,8 +568,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.lessThanOrEqual(1000L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -622,8 +582,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(10.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::pennies.between(500L, 1500L) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -637,8 +596,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val currencies = listOf(CHF.currencyCode, GBP.currencyCode)
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.`in`(currencies) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -653,8 +611,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val currencies = listOf(CHF.currencyCode, GBP.currencyCode)
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.notIn(currencies) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -669,8 +626,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.like("%BP") }  // GPB
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -684,8 +640,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::currency.notLike("%BP") }  // GPB
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -699,8 +654,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::issuerPartyHash.isNull() }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -714,8 +668,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val logicalExpression = builder { CashSchemaV1.PersistentCashState::issuerPartyHash.notNull() }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
             val results = vaultService.queryBy<Cash.State>(criteria)
@@ -731,8 +684,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(300.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L))
             services.fillWithSomeTestCash(500.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample21
             val sum = builder { CashSchemaV1.PersistentCashState::pennies.sum() }
             val sumCriteria = VaultCustomQueryCriteria(sum)
@@ -773,8 +725,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(300.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L))
             services.fillWithSomeTestCash(500.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample22
             val sum = builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) }
             val sumCriteria = VaultCustomQueryCriteria(sum)
@@ -825,8 +776,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L), issuedBy = BOC.ref(1))
             services.fillWithSomeTestCash(300.POUNDS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L), issuedBy = DUMMY_CASH_ISSUER)
             services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L), issuedBy = BOC.ref(2))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample23
             val sum = builder {
                 CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::issuerPartyHash,
@@ -863,8 +813,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(2, "JKL")
             services.fillWithSomeTestLinearStates(3, "ABC")
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             // count fungible assets
             val count = builder { VaultSchemaV1.VaultStates::recordedTime.count() }
             val countCriteria = QueryCriteria.VaultCustomQueryCriteria(count)
@@ -883,18 +832,16 @@ class VaultQueryTests {
 
     @Test
     fun `aggregate functions count by contract type and state status`() {
-        val (linearStatesJKL, linearStatesXYZ, dealStates) =
-                database.transaction {
-                    // create new states
-                    services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
-                    val linearStatesXYZ = services.fillWithSomeTestLinearStates(1, "XYZ")
-                    val linearStatesJKL = services.fillWithSomeTestLinearStates(2, "JKL")
-                    services.fillWithSomeTestLinearStates(3, "ABC")
-                    val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-                    Triple(linearStatesJKL, linearStatesXYZ, dealStates)
-                }
-        val count = builder { VaultSchemaV1.VaultStates::recordedTime.count() }
         database.transaction {
+            // create new states
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 10, 10, Random(0L))
+            val linearStatesXYZ = services.fillWithSomeTestLinearStates(1, "XYZ")
+            val linearStatesJKL = services.fillWithSomeTestLinearStates(2, "JKL")
+            services.fillWithSomeTestLinearStates(3, "ABC")
+            val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
+
+            val count = builder { VaultSchemaV1.VaultStates::recordedTime.count() }
+
             // count fungible assets
             val countCriteria = QueryCriteria.VaultCustomQueryCriteria(count, Vault.StateStatus.ALL)
             val fungibleStateCount = vaultService.queryBy<FungibleAsset<*>>(countCriteria).otherResults.single() as Long
@@ -907,18 +854,15 @@ class VaultQueryTests {
             // count deal states
             val dealStateCount = vaultService.queryBy<DealState>(countCriteria).otherResults.single() as Long
             assertThat(dealStateCount).isEqualTo(3L)
-        }
-        val cashUpdates =
-                database.transaction {
-                    // consume some states
-                    services.consumeLinearStates(linearStatesXYZ.states.toList(), DUMMY_NOTARY)
-                    services.consumeLinearStates(linearStatesJKL.states.toList(), DUMMY_NOTARY)
-                    services.consumeDeals(dealStates.states.filter { it.state.data.linearId.externalId == "456" }, DUMMY_NOTARY)
-                    services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
 
-                    // UNCONSUMED states (default)
-                }
-        database.transaction {
+            // consume some states
+            services.consumeLinearStates(linearStatesXYZ.states.toList(), DUMMY_NOTARY)
+            services.consumeLinearStates(linearStatesJKL.states.toList(), DUMMY_NOTARY)
+            services.consumeDeals(dealStates.states.filter { it.state.data.linearId.externalId == "456" }, DUMMY_NOTARY)
+            val cashUpdates = services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
+
+            // UNCONSUMED states (default)
+
             // count fungible assets
             val countCriteriaUnconsumed = QueryCriteria.VaultCustomQueryCriteria(count, Vault.StateStatus.UNCONSUMED)
             val fungibleStateCountUnconsumed = vaultService.queryBy<FungibleAsset<*>>(countCriteriaUnconsumed).otherResults.single() as Long
@@ -955,8 +899,7 @@ class VaultQueryTests {
     fun `unconsumed states recorded between two time intervals`() {
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, CASH_NOTARY, 3, 3, Random(0L))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample6
             val start = TODAY
             val end = TODAY.plus(30, ChronoUnit.DAYS)
@@ -986,8 +929,7 @@ class VaultQueryTests {
         }
         database.transaction {
             services.consumeCash(100.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        database.transaction {
+
             val asOfDateTime = TODAY
             val consumedAfterExpression = TimeCondition(
                     QueryCriteria.TimeInstantType.CONSUMED, ColumnPredicate.BinaryComparison(BinaryComparisonOperator.GREATER_THAN_OR_EQUAL, asOfDateTime))
@@ -1004,8 +946,7 @@ class VaultQueryTests {
     fun `all states with paging specification - first page`() {
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 100, 100, Random(0L))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample7
             val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, 10)
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
@@ -1021,8 +962,7 @@ class VaultQueryTests {
     fun `all states with paging specification  - last`() {
         database.transaction {
             services.fillWithSomeTestCash(95.DOLLARS, notaryServices, DUMMY_NOTARY, 95, 95, Random(0L))
-        }
-        database.transaction {
+
             // Last page implies we need to perform a row count for the Query first,
             // and then re-query for a given offset defined by (count - pageSize)
             val pagingSpec = PageSpecification(10, 10)
@@ -1042,8 +982,7 @@ class VaultQueryTests {
 
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 100, 100, Random(0L))
-        }
-        database.transaction {
+
             val pagingSpec = PageSpecification(0, 10)
 
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
@@ -1059,8 +998,7 @@ class VaultQueryTests {
 
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 100, 100, Random(0L))
-        }
-        database.transaction {
+
             @Suppress("EXPECTED_CONDITION")
             val pagingSpec = PageSpecification(DEFAULT_PAGE_NUM, @Suppress("INTEGER_OVERFLOW") MAX_PAGE_SIZE + 1)  // overflow = -2147483648
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
@@ -1076,8 +1014,7 @@ class VaultQueryTests {
 
         database.transaction {
             services.fillWithSomeTestCash(201.DOLLARS, notaryServices, DUMMY_NOTARY, 201, 201, Random(0L))
-        }
-        database.transaction {
+
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
             vaultService.queryBy<ContractState>(criteria)
         }
@@ -1118,8 +1055,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestCommodity(Amount(100, Commodity.getInstance("FCOJ")!!), notaryServices)
             services.fillWithSomeTestLinearStates(10)
-        }
-        database.transaction {
+
             val results = vaultService.queryBy<FungibleAsset<*>>()
             assertThat(results.states).hasSize(4)
         }
@@ -1132,12 +1068,10 @@ class VaultQueryTests {
         }
         database.transaction {
             services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        database.transaction {
+
             services.fillWithSomeTestCommodity(Amount(100, Commodity.getInstance("FCOJ")!!), notaryServices)
             services.fillWithSomeTestLinearStates(10)
-        }
-        database.transaction {
+
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
             assertThat(results.states).hasSize(2)
@@ -1149,8 +1083,7 @@ class VaultQueryTests {
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
-        }
-        database.transaction {
+
             val results = vaultService.queryBy<Cash.State>()
             assertThat(results.states).hasSize(3)
         }
@@ -1163,9 +1096,7 @@ class VaultQueryTests {
         }
         database.transaction {
             services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        // should now have x2 CONSUMED + x2 UNCONSUMED (one spent + one change)
-        database.transaction {
+            // should now have x2 CONSUMED + x2 UNCONSUMED (one spent + one change)
             val results = vaultService.queryBy<Cash.State>(FungibleAssetQueryCriteria())
             assertThat(results.statesMetadata).hasSize(2)
             assertThat(results.states).hasSize(2)
@@ -1179,15 +1110,9 @@ class VaultQueryTests {
         }
         database.transaction {
             services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        val linearStates =
-                database.transaction {
-                    services.fillWithSomeTestLinearStates(10)
-                }
-        database.transaction {
+
+            val linearStates = services.fillWithSomeTestLinearStates(10)
             services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
-        }
-        database.transaction {
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val results = vaultService.queryBy<Cash.State>(criteria)
             assertThat(results.states).hasSize(2)
@@ -1200,8 +1125,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestLinearStates(10)
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             val results = vaultService.queryBy<LinearState>()
             assertThat(results.states).hasSize(13)
         }
@@ -1209,20 +1133,16 @@ class VaultQueryTests {
 
     @Test
     fun `consumed linear heads`() {
-        val (linearStates, dealStates) =
-            database.transaction {
-                services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
-                val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 states with same externalId
-                services.fillWithSomeTestLinearStates(8)
-                val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-                Pair(linearStates,dealStates)
-            }
         database.transaction {
+            services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
+            val linearStates = services.fillWithSomeTestLinearStates(2, "TEST") // create 2 states with same externalId
+            services.fillWithSomeTestLinearStates(8)
+            val dealStates = services.fillWithSomeTestDeals(listOf("123", "456", "789"))
+
             services.consumeLinearStates(linearStates.states.toList(), DUMMY_NOTARY)
             services.consumeDeals(dealStates.states.filter { it.state.data.linearId.externalId == "456" }, DUMMY_NOTARY)
             services.consumeCash(50.DOLLARS, notary = DUMMY_NOTARY)
-        }
-        database.transaction {
+
             val criteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
             val results = vaultService.queryBy<LinearState>(criteria)
             assertThat(results.states).hasSize(3)
@@ -1233,11 +1153,9 @@ class VaultQueryTests {
 
     @Test
     fun `unconsumed linear heads for linearId without external Id`() {
-        val issuedStates =
-                database.transaction {
-                    services.fillWithSomeTestLinearStates(10)
-                }
         database.transaction {
+            val issuedStates = services.fillWithSomeTestLinearStates(10)
+
             // DOCSTART VaultQueryExample8
             val linearIds = issuedStates.states.map { it.state.data.linearId }.toList()
             val criteria = LinearStateQueryCriteria(linearId = listOf(linearIds.first(), linearIds.last()))
@@ -1249,14 +1167,11 @@ class VaultQueryTests {
 
     @Test
     fun `unconsumed linear heads by linearId`() {
-        val (linearState1, linearState3) =
-                database.transaction {
-                    val linearState1 = services.fillWithSomeTestLinearStates(1, "ID1")
-                    services.fillWithSomeTestLinearStates(1, "ID2")
-                    val linearState3 = services.fillWithSomeTestLinearStates(1, "ID3")
-                    Pair(linearState1, linearState3)
-                }
         database.transaction {
+            val linearState1 = services.fillWithSomeTestLinearStates(1, "ID1")
+            services.fillWithSomeTestLinearStates(1, "ID2")
+            val linearState3 = services.fillWithSomeTestLinearStates(1, "ID3")
+
             val linearIds = listOf(linearState1.states.first().state.data.linearId, linearState3.states.first().state.data.linearId)
             val criteria = LinearStateQueryCriteria(linearId = linearIds)
             val results = vaultService.queryBy<LinearState>(criteria)
@@ -1266,14 +1181,11 @@ class VaultQueryTests {
 
     @Test
     fun `unconsumed linear heads for linearId by external Id`() {
-        val (linearState1, linearState3) =
-                database.transaction {
-                    val linearState1 = services.fillWithSomeTestLinearStates(1, "ID1")
-                    services.fillWithSomeTestLinearStates(1, "ID2")
-                    val linearState3 = services.fillWithSomeTestLinearStates(1, "ID3")
-                    Pair(linearState1, linearState3)
-                }
         database.transaction {
+            val linearState1 = services.fillWithSomeTestLinearStates(1, "ID1")
+            services.fillWithSomeTestLinearStates(1, "ID2")
+            val linearState3 = services.fillWithSomeTestLinearStates(1, "ID3")
+
             val externalIds = listOf(linearState1.states.first().state.data.linearId.externalId!!, linearState3.states.first().state.data.linearId.externalId!!)
             val criteria = LinearStateQueryCriteria(externalId = externalIds)
             val results = vaultService.queryBy<LinearState>(criteria)
@@ -1283,16 +1195,14 @@ class VaultQueryTests {
 
     @Test
     fun `all linear states for a given linear id`() {
-        val linearId =
-                database.transaction {
-                    val txns = services.fillWithSomeTestLinearStates(1, "TEST")
-                    val linearState = txns.states.first()
-                    services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
-                    services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
-                    services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
-                    linearState.state.data.linearId
-                }
         database.transaction {
+            val txns = services.fillWithSomeTestLinearStates(1, "TEST")
+            val linearState = txns.states.first()
+            services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
+            val linearId = linearState.state.data.linearId
+
             // should now have 1 UNCONSUMED & 3 CONSUMED state refs for Linear State with "TEST"
             // DOCSTART VaultQueryExample9
             val linearStateCriteria = LinearStateQueryCriteria(linearId = listOf(linearId), status = Vault.StateStatus.ALL)
@@ -1305,16 +1215,13 @@ class VaultQueryTests {
 
     @Test
     fun `all linear states for a given id sorted by uuid`() {
-        val linearStates =
-                database.transaction {
-                    val txns = services.fillWithSomeTestLinearStates(2, "TEST")
-                    val linearStates = txns.states.toList()
-                    services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
-                    services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
-                    services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
-                    linearStates
-                }
         database.transaction {
+            val txns = services.fillWithSomeTestLinearStates(2, "TEST")
+            val linearStates = txns.states.toList()
+            services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
+            services.evolveLinearStates(linearStates, DUMMY_NOTARY)  // consume current and produce new state reference
+
             // should now have 1 UNCONSUMED & 3 CONSUMED state refs for Linear State with "TEST"
             val linearStateCriteria = LinearStateQueryCriteria(uuid = linearStates.map { it.state.data.linearId.id }, status = Vault.StateStatus.ALL)
             val vaultCriteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
@@ -1332,8 +1239,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, externalId = "111")
             services.fillWithSomeTestLinearStates(2, externalId = "222")
             services.fillWithSomeTestLinearStates(3, externalId = "333")
-        }
-        database.transaction {
+
             val vaultCriteria = VaultQueryCriteria()
             val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Standard(Sort.LinearStateAttribute.EXTERNAL_ID), Sort.Direction.DESC)))
 
@@ -1345,13 +1251,11 @@ class VaultQueryTests {
 
     @Test
     fun `unconsumed deal states sorted`() {
-        val uid =
-                database.transaction {
-                    val linearStates = services.fillWithSomeTestLinearStates(10)
-                    services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-                    linearStates.states.first().state.data.linearId.id
-                }
         database.transaction {
+            val linearStates = services.fillWithSomeTestLinearStates(10)
+            services.fillWithSomeTestDeals(listOf("123", "456", "789"))
+            val uid = linearStates.states.first().state.data.linearId.id
+
             val linearStateCriteria = LinearStateQueryCriteria(uuid = listOf(uid))
             val dealStateCriteria = LinearStateQueryCriteria(externalId = listOf("123", "456", "789"))
             val compositeCriteria = linearStateCriteria or dealStateCriteria
@@ -1370,8 +1274,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, linearString = "111")
             services.fillWithSomeTestLinearStates(2, linearString = "222")
             services.fillWithSomeTestLinearStates(3, linearString = "333")
-        }
-        database.transaction {
+
             val vaultCriteria = VaultQueryCriteria()
             val sorting = Sort(setOf(Sort.SortColumn(SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearString"), Sort.Direction.DESC)))
 
@@ -1383,20 +1286,15 @@ class VaultQueryTests {
 
     @Test
     fun `return consumed linear states for a given linear id`() {
-        val txns = database.transaction {
-            services.fillWithSomeTestLinearStates(1, "TEST")
-        }
-        val linearState2 = database.transaction {
+        database.transaction {
+            val txns = services.fillWithSomeTestLinearStates(1, "TEST")
             val linearState = txns.states.first()
-            services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
-        }
-        val linearState3 = database.transaction {
-            services.evolveLinearState(linearState2, DUMMY_NOTARY)  // consume current and produce new state reference
-        }
-        database.transaction {
+
+            val linearState2 =services.evolveLinearState(linearState, DUMMY_NOTARY)  // consume current and produce new state reference
+            val linearState3 = services.evolveLinearState(linearState2, DUMMY_NOTARY)  // consume current and produce new state reference
+
             services.evolveLinearState(linearState3, DUMMY_NOTARY)  // consume current and produce new state reference
-        }
-        database.transaction {
+
             // should now have 1 UNCONSUMED & 3 CONSUMED state refs for Linear State with "TEST"
             val linearStateCriteria = LinearStateQueryCriteria(linearId = txns.states.map { it.state.data.linearId }, status = Vault.StateStatus.CONSUMED)
             val vaultCriteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
@@ -1413,8 +1311,7 @@ class VaultQueryTests {
     fun `unconsumed deals`() {
         database.transaction {
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             val results = vaultService.queryBy<DealState>()
             assertThat(results.states).hasSize(3)
         }
@@ -1424,8 +1321,7 @@ class VaultQueryTests {
     fun `unconsumed deals for ref`() {
         database.transaction {
             services.fillWithSomeTestDeals(listOf("123", "456", "789"))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample10
             val criteria = LinearStateQueryCriteria(externalId = listOf("456", "789"))
             val results = vaultService.queryBy<DealState>(criteria)
@@ -1441,8 +1337,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(2, "TEST")
             services.fillWithSomeTestDeals(listOf("456"))
             services.fillWithSomeTestDeals(listOf("123", "789"))
-        }
-        database.transaction {
+
             val all = vaultService.queryBy<DealState>()
             all.states.forEach { println(it.state) }
 
@@ -1459,8 +1354,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(2, "TEST")
             services.fillWithSomeTestDeals(listOf("456"), parties)
             services.fillWithSomeTestDeals(listOf("123", "789"))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample11
             val criteria = LinearStateQueryCriteria(participants = parties)
             val results = vaultService.queryBy<DealState>(criteria)
@@ -1481,8 +1375,6 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = BOC.ref(1))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = BOC.ref(2))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = BOC.ref(3))
-        }
-        database.transaction {
             val criteria = FungibleAssetQueryCriteria(issuer = listOf(BOC),
                     issuerRef = listOf(BOC.ref(1).reference, BOC.ref(2).reference))
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
@@ -1504,12 +1396,12 @@ class VaultQueryTests {
         val chfCashIssuerKey = entropyToKeyPair(BigInteger.valueOf(1003))
         val chfCashIssuer = Party(CordaX500Name(organisation = "Swiss Francs Cash Issuer", locality = "Zurich", country = "CH"), chfCashIssuerKey.public).ref(1)
         val chfCashIssuerServices = MockServices(cordappPackages, chfCashIssuerKey)
+
         database.transaction {
             services.fillWithSomeTestCash(100.POUNDS, gbpCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (gbpCashIssuer))
             services.fillWithSomeTestCash(100.DOLLARS, usdCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (usdCashIssuer))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, chfCashIssuerServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (chfCashIssuer))
-        }
-        database.transaction {
+
             val criteria = FungibleAssetQueryCriteria(issuer = listOf(gbpCashIssuer.party, usdCashIssuer.party))
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
             assertThat(results.states).hasSize(2)
@@ -1522,8 +1414,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = BOC.ref(1))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
                     issuedBy = MEGA_CORP.ref(0), ownedBy = (MINI_CORP))
-        }
-        database.transaction {
+
             val criteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP))
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
             assertThat(results.states).hasSize(1)   // can only be 1 owner of a node (MEGA_CORP in this MockServices setup)
@@ -1538,8 +1429,7 @@ class VaultQueryTests {
                     issuedBy = MEGA_CORP.ref(0), ownedBy = (MEGA_CORP))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L),
                     issuedBy = BOC.ref(0), ownedBy = (MINI_CORP))  // irrelevant to this vault
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample5.2
             val criteria = FungibleAssetQueryCriteria(owner = listOf(MEGA_CORP, BOC))
             val results = vaultService.queryBy<ContractState>(criteria)
@@ -1557,8 +1447,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample12
             val ccyIndex = builder { CashSchemaV1.PersistentCashState::currency.equal(USD.currencyCode) }
             val criteria = VaultCustomQueryCriteria(ccyIndex)
@@ -1574,8 +1463,7 @@ class VaultQueryTests {
         database.transaction {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(200.DOLLARS, notaryServices, DUMMY_NOTARY, 2, 2, Random(0L))
-        }
-        database.transaction {
+
             val sum = builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) }
             val sumCriteria = VaultCustomQueryCriteria(sum)
 
@@ -1599,8 +1487,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(400.POUNDS, notaryServices, DUMMY_NOTARY, 4, 4, Random(0L))
             services.fillWithSomeTestCash(500.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 5, 5, Random(0L))
             services.fillWithSomeTestCash(600.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 6, 6, Random(0L))
-        }
-        database.transaction {
+
             val ccyIndex = builder { CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency)) }
             val criteria = VaultCustomQueryCriteria(ccyIndex)
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
@@ -1622,8 +1509,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(25.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(50.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 3, 3, Random(0L))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample13
             val fungibleAssetCriteria = FungibleAssetQueryCriteria(quantity = builder { greaterThan(2500L) })
             val results = vaultService.queryBy<Cash.State>(fungibleAssetCriteria)
@@ -1640,8 +1526,7 @@ class VaultQueryTests {
 
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (DUMMY_CASH_ISSUER))
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L), issuedBy = (BOC.ref(1)))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample14
             val criteria = FungibleAssetQueryCriteria(issuer = listOf(BOC))
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
@@ -1658,8 +1543,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(50.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             val ccyIndex = builder { CashSchemaV1.PersistentCashState::currency.equal(GBP.currencyCode) }
             val customCriteria = VaultCustomQueryCriteria(ccyIndex)
             val fungibleAssetCriteria = FungibleAssetQueryCriteria(quantity = builder { greaterThan(5000L) })
@@ -1697,8 +1581,7 @@ class VaultQueryTests {
                         notaryServices.addSignature(stx, DUMMY_NOTARY_KEY.public)
                     }
             services.recordTransactions(commercialPaper2)
-        }
-        database.transaction {
+
             val ccyIndex = builder { CommercialPaperSchemaV1.PersistentCommercialPaperState::currency.equal(USD.currencyCode) }
             val criteria1 = QueryCriteria.VaultCustomQueryCriteria(ccyIndex)
 
@@ -1736,8 +1619,7 @@ class VaultQueryTests {
                     }
             commercialPaper2.verifyRequiredSignatures()
             services.recordTransactions(commercialPaper2)
-        }
-        database.transaction {
+
             val result = builder {
 
                 val ccyIndex = CommercialPaperSchemaV1.PersistentCommercialPaperState::currency.equal(USD.currencyCode)
@@ -1764,8 +1646,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.POUNDS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(100.SWISS_FRANCS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             // CashSchemaV3 NOT registered with NodeSchemaService
             val logicalExpression = builder { SampleCashSchemaV3.PersistentCashState::currency.equal(GBP.currencyCode) }
             val criteria = VaultCustomQueryCriteria(logicalExpression)
@@ -1786,8 +1667,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCash(100.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(10.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
             services.fillWithSomeTestCash(1.DOLLARS, notaryServices, DUMMY_NOTARY, 1, 1, Random(0L))
-        }
-        database.transaction {
+
             // DOCSTART VaultQueryExample20
             val generalCriteria = VaultQueryCriteria(Vault.StateStatus.ALL)
 
@@ -1819,8 +1699,6 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, "TEST")
 
             // 2 unconsumed states with same external ID
-        }
-        database.transaction {
             val recordedBetweenExpression = TimeCondition(TimeInstantType.RECORDED, builder { between(start, end) })
             val basicCriteria = VaultQueryCriteria(timeCondition = recordedBetweenExpression)
 
@@ -1836,8 +1714,7 @@ class VaultQueryTests {
         database.transaction {
             services.fillWithSomeTestLinearStates(1, "TEST1")
             services.fillWithSomeTestLinearStates(1, "TEST2")
-        }
-        database.transaction {
+
             // 2 unconsumed states with same external ID
             val externalIdCondition = builder { VaultSchemaV1.VaultLinearStates::externalId.equal("TEST2") }
             val externalIdCustomCriteria = VaultCustomQueryCriteria(externalIdCondition)
@@ -1859,8 +1736,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, "TEST2")
             sleep(1000)
             services.fillWithSomeTestLinearStates(1, "TEST3")
-        }
-        database.transaction {
+
             // 2 unconsumed states with same external ID
 
             val results = builder {
@@ -1881,16 +1757,13 @@ class VaultQueryTests {
     // specifying Query on Linear state attributes
     @Test
     fun `unconsumed linear heads for a given external id or uuid`() {
-        val uuid =
-                database.transaction {
-                    services.fillWithSomeTestLinearStates(1, "TEST1")
-                    val aState = services.fillWithSomeTestLinearStates(1, "TEST2").states
-                    services.consumeLinearStates(aState.toList(), DUMMY_NOTARY)
-                    services.fillWithSomeTestLinearStates(1, "TEST1").states.first().state.data.linearId.id
-
-                    // 2 unconsumed states with same external ID, 1 consumed with different external ID
-                }
         database.transaction {
+            services.fillWithSomeTestLinearStates(1, "TEST1")
+            val aState = services.fillWithSomeTestLinearStates(1, "TEST2").states
+            services.consumeLinearStates(aState.toList(), DUMMY_NOTARY)
+            val uuid = services.fillWithSomeTestLinearStates(1, "TEST1").states.first().state.data.linearId.id
+
+            // 2 unconsumed states with same external ID, 1 consumed with different external ID
             val results = builder {
                 val externalIdCondition = VaultSchemaV1.VaultLinearStates::externalId.equal("TEST1")
                 val externalIdCustomCriteria = VaultCustomQueryCriteria(externalIdCondition)
@@ -1913,8 +1786,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, "TEST1", listOf(ALICE))
             services.fillWithSomeTestLinearStates(1)
             services.fillWithSomeTestLinearStates(1, "TEST3")
-        }
-        database.transaction {
+
             val linearStateCriteria = LinearStateQueryCriteria(participants = listOf(ALICE))
             val results = vaultService.queryBy<LinearState>(linearStateCriteria)
 
@@ -1933,8 +1805,7 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, "TEST1", listOf(ALICE, BOB, CHARLIE))
             services.fillWithSomeTestLinearStates(1)
             services.fillWithSomeTestLinearStates(1, "TEST3")
-        }
-        database.transaction {
+
             val linearStateCriteria = LinearStateQueryCriteria(participants = listOf(ALICE, BOB, CHARLIE))
             val results = vaultService.queryBy<LinearState>(linearStateCriteria)
 
@@ -1951,8 +1822,6 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, "TEST3")
 
             // 3 unconsumed states (one without an external ID)
-        }
-        database.transaction {
             val results = builder {
                 val externalIdCondition = VaultSchemaV1.VaultLinearStates::externalId.isNull()
                 val externalIdCustomCriteria = VaultCustomQueryCriteria(externalIdCondition)
@@ -1971,8 +1840,6 @@ class VaultQueryTests {
             services.fillWithSomeTestLinearStates(1, "TEST3")
 
             // 3 unconsumed states (two with an external ID)
-        }
-        database.transaction {
             val results = builder {
                 val externalIdCondition = VaultSchemaV1.VaultLinearStates::externalId.notNull()
                 val externalIdCustomCriteria = VaultCustomQueryCriteria(externalIdCondition)
@@ -1990,9 +1857,7 @@ class VaultQueryTests {
             services.fillWithSomeTestCommodity(Amount(100, Commodity.getInstance("FCOJ")!!), notaryServices)
             services.fillWithSomeTestLinearStates(1, "ABC")
             services.fillWithSomeTestDeals(listOf("123"))
-        }
 
-        database.transaction {
             // Base criteria
             val baseCriteria = VaultQueryCriteria(notary = listOf(DUMMY_NOTARY),
                     status = Vault.StateStatus.CONSUMED)


### PR DESCRIPTION
Certain database providers have limitations on join table queries where LOB attributes are included in the select criteria. This PR removes the duplicated copy of the Transaction (Contract State) from the `VaultStates` table to prevent Vault Query failure.

Transaction contract state now resolved using `StateLoader` (from `DBTransactionStorage`).
An additional `loadStates(Set<StateRef>)` has also been added to the StateLoader interface.

