### PR TITLE
Separate server contexts from shared contexts.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
@@ -36,20 +36,6 @@ val KRYO_STORAGE_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
         true,
         SerializationContext.UseCase.Storage)
 
-val KRYO_P2P_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
-        SerializationDefaults.javaClass.classLoader,
-        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.P2P)
-
-val KRYO_CHECKPOINT_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
-        SerializationDefaults.javaClass.classLoader,
-        QuasarWhitelist,
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.Checkpoint)
-
 
 val AMQP_STORAGE_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
         SerializationDefaults.javaClass.classLoader,
@@ -58,17 +44,9 @@ val AMQP_STORAGE_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
         true,
         SerializationContext.UseCase.Storage)
 
-val AMQP_P2P_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
-        SerializationDefaults.javaClass.classLoader,
-        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.P2P)
-
 val AMQP_RPC_SERVER_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
         SerializationDefaults.javaClass.classLoader,
         GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
         emptyMap(),
         true,
         SerializationContext.UseCase.RPCServer)
-

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SharedContexts.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SharedContexts.kt
@@ -1,0 +1,39 @@
+@file:JvmName("SharedContexts")
+
+package net.corda.nodeapi.internal.serialization
+
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationDefaults
+import net.corda.nodeapi.internal.serialization.amqp.AmqpHeaderV1_0
+import net.corda.nodeapi.internal.serialization.kryo.KryoHeaderV0_1
+
+/*
+ * Serialisation contexts shared by the server and client.
+ *
+ * NOTE: The [KRYO_STORAGE_CONTEXT] and [AMQP_STORAGE_CONTEXT]
+ * CANNOT always be instantiated outside of the server and so
+ * MUST be kept separate from these ones!
+ */
+
+val KRYO_P2P_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
+        SerializationDefaults.javaClass.classLoader,
+        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.P2P)
+
+val KRYO_CHECKPOINT_CONTEXT = SerializationContextImpl(KryoHeaderV0_1,
+        SerializationDefaults.javaClass.classLoader,
+        QuasarWhitelist,
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.Checkpoint)
+
+val AMQP_P2P_CONTEXT = SerializationContextImpl(AmqpHeaderV1_0,
+        SerializationDefaults.javaClass.classLoader,
+        GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
+        emptyMap(),
+        true,
+        SerializationContext.UseCase.P2P)
+
+


### PR DESCRIPTION
The `AllButBlacklisted` class is uninstantiable by the deterministic JVM, which knows nothing about SQL, networking etc. However, the JVM initialises the class file when it loads it, and hence instantiates all of the constants inside it. So we _must_ keep the server-specific serialisation contexts in a separate `.class` file from the serialisation contexts which the enclave will need to use.