### PR TITLE
CORDA-767: Raft Notary: remove snapshotting

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/transactions/DistributedImmutableMap.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/DistributedImmutableMap.kt
@@ -27,9 +27,9 @@ class DistributedImmutableMap<K : Any, V : Any, E, EK>(val db: CordaPersistence,
     object Commands {
         class PutAll<K, V>(val entries: Map<K, V>) : Command<Map<K, V>> {
             override fun compaction(): Command.CompactionMode {
-                // The SNAPSHOT compaction mode indicates that a command can be removed from the Raft log once
-                // a snapshot of the state machine has been written to disk
-                return Command.CompactionMode.SNAPSHOT
+                // The SEQUENTIAL compaction mode retains the command in the log until it has been stored and applied
+                // on all servers in the cluster.
+                return Command.CompactionMode.SEQUENTIAL
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/DistributedImmutableMap.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/DistributedImmutableMap.kt
@@ -19,7 +19,7 @@ import java.util.LinkedHashMap
  * to disk, and sharing them across the cluster. A new node joining the cluster will have to obtain and install a snapshot
  * containing the entire JDBC table contents.
  */
-class DistributedImmutableMap<K : Any, V : Any, E, EK>(val db: CordaPersistence, createMap: () -> AppendOnlyPersistentMap<K, V, E, EK>) : StateMachine(), Snapshottable {
+class DistributedImmutableMap<K : Any, V : Any, E, EK>(val db: CordaPersistence, createMap: () -> AppendOnlyPersistentMap<K, V, E, EK>) : StateMachine() {
     companion object {
         private val log = loggerFor<DistributedImmutableMap<*, *, *, *>>()
     }
@@ -68,31 +68,6 @@ class DistributedImmutableMap<K : Any, V : Any, E, EK>(val db: CordaPersistence,
     fun size(commit: Commit<Commands.Size>): Int {
         commit.use { _ ->
             return db.transaction { map.size }
-        }
-    }
-
-    /**
-     * Writes out all [map] entries to disk. Note that this operation does not load all entries into memory, as the
-     * [SnapshotWriter] is using a disk-backed buffer internally, and iterating map entries results in only a
-     * fixed number of recently accessed entries to ever be kept in memory.
-     */
-    override fun snapshot(writer: SnapshotWriter) {
-        db.transaction {
-            writer.writeInt(map.size)
-            map.allPersisted().forEach { writer.writeObject(it.first to it.second) }
-        }
-    }
-
-    /** Reads entries from disk and adds them to [map]. */
-    override fun install(reader: SnapshotReader) {
-        val size = reader.readInt()
-        db.transaction {
-            map.clear()
-            // TODO: read & put entries in batches
-            for (i in 1..size) {
-                val (key, value) = reader.readObject<Pair<K, V>>()
-                map[key] = value
-            }
         }
     }
 }


### PR DESCRIPTION
We remove snapshotting since it is not effective in our use case. We keep the Raft command log "forever" to allow new nodes to join the cluster and replay the commands.