### PR TITLE
Add config library and default config to webserver JAR

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -10,6 +10,12 @@ description 'Corda standalone node'
 
 configurations {
     runtimeArtifacts.extendsFrom runtime
+    capsuleRuntime
+}
+
+dependencies {
+    // TypeSafe Config: for simple and human friendly config files.
+    capsuleRuntime "com.typesafe:config:$typesafe_config_version"
 }
 
 // Force the Caplet to target Java 6. This ensures that running 'java -jar corda.jar' on any Java 6 VM upwards
@@ -28,13 +34,11 @@ task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').compileJava) {
             project(':node').jar,
             project(':node').sourceSets.main.java.outputDir.toString() + '/CordaCaplet.class',
             project(':node').sourceSets.main.java.outputDir.toString() + '/CordaCaplet$1.class',
-            "$rootDir/config/dev/log4j2.xml"
+            "$rootDir/config/dev/log4j2.xml",
+            "$rootDir/node/build/resources/main/reference.conf"
     )
     from 'NOTICE' // Copy CDDL notice
-    from { project(':node').configurations.runtime.allDependencies.matching { // Include config library JAR.
-        it.group.equals("com.typesafe") && it.name.equals("config")
-    }.collect { zipTree(project(':node').configurations.runtime.files(it).first()) } }
-    from { "$rootDir/node/build/resources/main/reference.conf" }
+    from configurations.capsuleRuntime.files.collect { zipTree(it) }
 
     capsuleManifest {
         applicationVersion = corda_release_version

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -10,6 +10,12 @@ description 'Corda node web server capsule'
 
 configurations {
     runtimeArtifacts
+    capsuleRuntime
+}
+
+dependencies {
+    // TypeSafe Config: for simple and human friendly config files.
+    capsuleRuntime "com.typesafe:config:$typesafe_config_version"
 }
 
 // Force the Caplet to target Java 6. This ensures that running 'java -jar corda.jar' on any Java 6 VM upwards
@@ -28,13 +34,11 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').compileJava
             project(':webserver').jar,
             project(':node').sourceSets.main.java.outputDir.toString() + '/CordaCaplet.class',
             project(':node').sourceSets.main.java.outputDir.toString() + '/CordaCaplet$1.class',
-            "$rootDir/config/dev/log4j2.xml"
+            "$rootDir/config/dev/log4j2.xml",
+            "$rootDir/node/build/resources/main/reference.conf"
     )
     from 'NOTICE' // Copy CDDL notice
-    from { project(':node').configurations.runtime.allDependencies.matching { // Include config library JAR.
-        it.group.equals("com.typesafe") && it.name.equals("config")
-    }.collect { zipTree(project(':node').configurations.runtime.files(it).first()) } }
-    from { "$rootDir/node/build/resources/main/reference.conf" }
+    from configurations.capsuleRuntime.files.collect { zipTree(it) }
 
     capsuleManifest {
         applicationVersion = corda_release_version

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -31,6 +31,10 @@ task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').compileJava
             "$rootDir/config/dev/log4j2.xml"
     )
     from 'NOTICE' // Copy CDDL notice
+    from { project(':node').configurations.runtime.allDependencies.matching { // Include config library JAR.
+        it.group.equals("com.typesafe") && it.name.equals("config")
+    }.collect { zipTree(project(':node').configurations.runtime.files(it).first()) } }
+    from { "$rootDir/node/build/resources/main/reference.conf" }
 
     capsuleManifest {
         applicationVersion = corda_release_version


### PR DESCRIPTION
Changes to make node.conf more powerful resulted in webserver capsule JAR throwing class not found exception due to missing config parsing library.  Also include default config to avoid error about missing default config.
