### PR TITLE
Add generation of network parameters to deployNodes task

### DIFF
--- a/gradle-plugins/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/gradle-plugins/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -31,5 +31,6 @@ class Cordformation : Plugin<Project> {
 
     override fun apply(project: Project) {
         Utils.createCompileConfiguration("cordapp", project)
+        project.dependencies.add("runtime", "${project.group}:corda-node:${project.rootProject.ext<String>("corda_release_version")}")
     }
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.common.internal
+package net.corda.nodeapi.internal
 
 import net.corda.core.crypto.SignedData
 import net.corda.core.crypto.entropyToKeyPair

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ParametersUtilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ParametersUtilities.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.common.internal
+package net.corda.nodeapi.internal
 
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -169,15 +169,30 @@ dependencies {
     testCompile "org.glassfish.jersey.containers:jersey-container-jetty-http:${jersey_version}"
 }
 
+task standaloneJar(type: Jar) {
+    // Create a fat jar by packing all deps into the output
+    from {
+        configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    with jar
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
+    exclude("META-INF/*.SF")
+    archiveName "corda-node.jar"
+}
+
 task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-jar {
-    baseName 'corda-node'
+artifacts {
+    publish standaloneJar {
+        classifier ""
+    }
 }
 
 publish {
-    name jar.baseName
+    disableDefaultJar = true
+    name 'corda-node'
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -27,8 +27,8 @@ import net.corda.node.services.transactions.minClusterSize
 import net.corda.node.services.transactions.minCorrectReplicas
 import net.corda.node.utilities.ServiceIdentityGenerator
 import net.corda.testing.chooseIdentity
-import net.corda.testing.common.internal.NetworkParametersCopier
-import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.nodeapi.internal.NetworkParametersCopier
+import net.corda.nodeapi.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.dummyCommand
 import net.corda.testing.node.MockNetwork

--- a/node/src/main/kotlin/net/corda/node/internal/networkParametersGenerator/NetworkParametersGenerator.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/networkParametersGenerator/NetworkParametersGenerator.kt
@@ -4,7 +4,6 @@ package net.corda.node.internal.networkParametersGenerator
 
 import joptsimple.OptionParser
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.identity.Party
 import net.corda.core.node.NotaryInfo
 import net.corda.core.serialization.internal.SerializationEnvironmentImpl
 import net.corda.core.serialization.internal.nodeSerializationEnv
@@ -36,7 +35,7 @@ class NetworkParametersGenerator {
             copier.install(baseDirectory) // Put the parameters just to this one node directory, the rest copy in gradle.
         }
 
-        // TODO Use JSON?
+        // TODO Use JSON
         // We need to know what are the notary node names and weather the notary is validating.
         private fun parseNotaries(option: String): Map<CordaX500Name, Boolean> {
             return option.split("#").map {

--- a/node/src/main/kotlin/net/corda/node/internal/networkParametersGenerator/NetworkParametersGenerator.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/networkParametersGenerator/NetworkParametersGenerator.kt
@@ -1,0 +1,63 @@
+@file:JvmName("NetworkParametersGenerator")
+
+package net.corda.node.internal.networkParametersGenerator
+
+import joptsimple.OptionParser
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.node.NotaryInfo
+import net.corda.core.serialization.internal.SerializationEnvironmentImpl
+import net.corda.core.serialization.internal.nodeSerializationEnv
+import net.corda.node.serialization.KryoServerSerializationScheme
+import net.corda.node.services.network.NodeInfoWatcher
+import net.corda.nodeapi.internal.NetworkParametersCopier
+import net.corda.nodeapi.internal.serialization.*
+import net.corda.nodeapi.internal.serialization.amqp.AMQPServerSerializationScheme
+import net.corda.nodeapi.internal.testNetworkParameters
+import java.nio.file.Path
+import java.nio.file.Paths
+
+// This class is used by deployNodes task to generate NetworkParameters in [Cordformation].
+class NetworkParametersGenerator {
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            initialiseSerialization()
+            require(args.isNotEmpty())
+            val optionParser = OptionParser()
+            val baseDirectoryArg = optionParser.accepts("base-directory").withRequiredArg()
+            val notariesArg = optionParser.accepts("notaries").withRequiredArg()
+            val optionSet = optionParser.parse(*args)
+            require(optionSet.has(baseDirectoryArg)) { "No node's base directory provided" }
+            val baseDirectory: Path = Paths.get(optionSet.valueOf(baseDirectoryArg))
+            val notaries = if (!optionSet.has(notariesArg)) emptyMap() else parseNotaries(optionSet.valueOf(notariesArg))
+            val notaryInfos = gatherNotaryInfos(baseDirectory, notaries)
+            val copier = NetworkParametersCopier(testNetworkParameters(notaryInfos))
+            copier.install(baseDirectory) // Put the parameters just to this one node directory, the rest copy in gradle.
+        }
+
+        // TODO Use JSON?
+        // We need to know what are the notary node names and weather the notary is validating.
+        private fun parseNotaries(option: String): Map<CordaX500Name, Boolean> {
+            return option.split("#").map {
+                val tuple = it.split(":")
+                require(tuple.size == 2)
+                Pair(CordaX500Name.parse(tuple[0]), tuple[1].toBoolean())
+            }.toMap()
+        }
+
+        private fun gatherNotaryInfos(baseDirectory: Path, notaries: Map<CordaX500Name, Boolean>): List<NotaryInfo> {
+            val nodeInfoSerializer = NodeInfoWatcher(baseDirectory)
+            return nodeInfoSerializer.loadAndGatherNotaryIdentities(notaries)
+        }
+
+        private fun initialiseSerialization() {
+            nodeSerializationEnv = SerializationEnvironmentImpl(
+                    SerializationFactoryImpl().apply {
+                        registerScheme(KryoServerSerializationScheme())
+                        registerScheme(AMQPServerSerializationScheme())
+                    },
+                    KRYO_P2P_CONTEXT)
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.network
 import net.corda.cordform.CordformNode
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.*
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.NotaryInfo

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -5,6 +5,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
 import net.corda.core.internal.*
 import net.corda.core.node.NodeInfo
+import net.corda.core.node.NotaryInfo
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.loggerFor
@@ -14,6 +15,7 @@ import rx.Observable
 import rx.Scheduler
 import rx.schedulers.Schedulers
 import java.io.IOException
+import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -89,6 +91,41 @@ class NodeInfoWatcher(private val nodePath: Path,
     }
 
     fun saveToFile(signedNodeInfo: SignedData<NodeInfo>) = Companion.saveToFile(nodePath, signedNodeInfo)
+
+    /**
+     * Loads all NodeInfo files stored in node's base directory and returns the [Party]s.
+     * Scans main directory and [CordformNode.NODE_INFO_DIRECTORY].
+     * Signatures are checked before returning a value. The latest value stored for a given name is returned.
+     *
+     * @return a list of [Party]s
+     */
+    fun loadAndGatherNotaryIdentities(notaries: Map<CordaX500Name, Boolean>): List<NotaryInfo> {
+        val nodeInfos = loadFromDirectory()
+        // NodeInfos are currently stored in 2 places: in [CordformNode.NODE_INFO_DIRECTORY] and in baseDirectory of the node.
+        val myFiles = Files.list(nodePath).filter { it.toString().contains("nodeInfo-") }.toList()
+        val myNodeInfos = myFiles.mapNotNull { processFile(it) }
+        val infosMap = mutableMapOf<CordaX500Name, NodeInfo>()
+        // Running deployNodes more than once produces new NodeInfos. We need to load the latest NodeInfos based on serial field.
+        for (info in nodeInfos + myNodeInfos) {
+            val name = info.legalIdentities.first().name
+            val prevInfo = infosMap[name]
+            if(prevInfo == null || prevInfo.serial < info.serial)
+                infosMap.put(name, info)
+        }
+        // Now get the notary identities based on names passed from Cordform configs. There is one problem, for distributed notaries
+        // Cordfom specifies in config only node's main name, the notary identity isn't passed there. It's read from keystore on
+        // node startup, so we have to look it up from node info as a second identity, which is ugly.
+        val notaryInfos = mutableSetOf<NotaryInfo>()
+        for (info in infosMap.values) {
+            // Here the ugliness happens.
+            // TODO Change Cordform definition so it specifies distributed notary identity.
+            if (info.legalIdentities[0].name in notaries.keys) {
+                val notaryId = if (info.legalIdentities.size == 2) info.legalIdentities[1] else info.legalIdentities[0]
+                notaryInfos.add(NotaryInfo(notaryId, notaries[info.legalIdentities[0].name]!!))
+            }
+        }
+        return notaryInfos.toList()
+    }
 
     /**
      * Loads all the files contained in a given path and returns the deserialized [NodeInfo]s.

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
@@ -16,7 +16,6 @@ import net.corda.core.node.services.NotaryService
 import net.corda.core.node.services.TimeWindowChecker
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.schemas.PersistentStateRef
-import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.FilteredTransaction

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -35,8 +35,8 @@ import net.corda.nodeapi.User
 import net.corda.nodeapi.config.toConfig
 import net.corda.nodeapi.internal.addShutdownHook
 import net.corda.testing.*
-import net.corda.testing.common.internal.NetworkParametersCopier
-import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.nodeapi.internal.NetworkParametersCopier
+import net.corda.nodeapi.internal.testNetworkParameters
 import net.corda.testing.setGlobalSerialization
 import net.corda.testing.internal.ProcessUtilities
 import net.corda.testing.node.ClusterSpec

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/NodeBasedTest.kt
@@ -16,8 +16,8 @@ import net.corda.node.services.config.parseAsNodeConfiguration
 import net.corda.node.services.config.plus
 import net.corda.nodeapi.User
 import net.corda.testing.SerializationEnvironmentRule
-import net.corda.testing.common.internal.NetworkParametersCopier
-import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.nodeapi.internal.NetworkParametersCopier
+import net.corda.nodeapi.internal.testNetworkParameters
 import net.corda.testing.driver.addressMustNotBeBoundFuture
 import net.corda.testing.getFreeLocalPorts
 import net.corda.testing.node.MockServices

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -37,8 +37,8 @@ import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.AffinityExecutor.ServiceAffinityExecutor
 import net.corda.node.utilities.ServiceIdentityGenerator
 import net.corda.testing.DUMMY_NOTARY
-import net.corda.testing.common.internal.NetworkParametersCopier
-import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.nodeapi.internal.NetworkParametersCopier
+import net.corda.nodeapi.internal.testNetworkParameters
 import net.corda.testing.setGlobalSerialization
 import net.corda.testing.node.MockServices.Companion.MOCK_VERSION_INFO
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties

--- a/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt
+++ b/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt
@@ -8,8 +8,8 @@ import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.loggerFor
-import net.corda.testing.common.internal.NetworkParametersCopier
-import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.nodeapi.internal.NetworkParametersCopier
+import net.corda.nodeapi.internal.testNetworkParameters
 import net.corda.testing.common.internal.asContextEnv
 import java.nio.file.Path
 import java.nio.file.Paths


### PR DESCRIPTION
Add utility NetworkParametersGenerator run during deployNodes task as a
separate process after generation of node infos.
Move NetworkParametersCopier to node-api/internal.