### PR TITLE
Performance improvement: cache app classloaders

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -69,7 +69,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
         fun createDefault(baseDir: Path) = CordappLoader(getCordappsInDirectory(getCordappsPath(baseDir)))
 
         // Cache for CordappLoaders to avoid costly classpath scanning
-        private val cordappLoadersCache = LRUMap<Any, CordappLoader>(1000)
+        private val cordappLoadersCache = LRUMap<List<*>, CordappLoader>(1000)
 
         /**
          * Create a dev mode CordappLoader for test environments that creates and loads cordapps from the classpath

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -16,6 +16,7 @@ import net.corda.core.utilities.loggerFor
 import net.corda.node.internal.classloading.requireAnnotation
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.nodeapi.internal.serialization.DefaultWhitelist
+import org.apache.commons.collections4.map.LRUMap
 import java.io.File
 import java.io.FileOutputStream
 import java.lang.reflect.Modifier
@@ -68,6 +69,11 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
         fun createDefault(baseDir: Path) = CordappLoader(getCordappsInDirectory(getCordappsPath(baseDir)))
 
         /**
+         * Cache for CordappLoaders to avoid costly classpath scanning
+         */
+        private val cordappLoadersCache = LRUMap<Any, CordappLoader>(1000)
+
+        /**
          * Create a dev mode CordappLoader for test environments that creates and loads cordapps from the classpath
          * and cordapps directory. This is intended mostly for use by the driver.
          *
@@ -77,7 +83,8 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
         @VisibleForTesting
         fun createDefaultWithTestPackages(configuration: NodeConfiguration, testPackages: List<String>): CordappLoader {
             check(configuration.devMode) { "Package scanning can only occur in dev mode" }
-            return CordappLoader(getCordappsInDirectory(getCordappsPath(configuration.baseDirectory)) + testPackages.flatMap(this::createScanPackage))
+            val paths = getCordappsInDirectory(getCordappsPath(configuration.baseDirectory)) + testPackages.flatMap(this::createScanPackage)
+            return cordappLoadersCache.computeIfAbsent(paths, { CordappLoader(paths) })
         }
 
         /**
@@ -89,7 +96,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
          */
         @VisibleForTesting
         fun createWithTestPackages(testPackages: List<String>)
-                = CordappLoader(testPackages.flatMap(this::createScanPackage))
+                = cordappLoadersCache.computeIfAbsent(testPackages, { CordappLoader(testPackages.flatMap(this::createScanPackage)) })
 
         /**
          * Creates a dev mode CordappLoader intended only to be used in test environments
@@ -242,9 +249,12 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
         return scanResult.getClassesWithSuperclass(MappedSchema::class).toSet()
     }
 
+    private val cachedScanResult = LRUMap<RestrictedURL, RestrictedScanResult>(1000)
     private fun scanCordapp(cordappJarPath: RestrictedURL): RestrictedScanResult {
         logger.info("Scanning CorDapp in $cordappJarPath")
-        return RestrictedScanResult(FastClasspathScanner().addClassLoader(appClassLoader).overrideClasspath(cordappJarPath.url).scan(), cordappJarPath.qualifiedNamePrefix)
+        return cachedScanResult.computeIfAbsent(cordappJarPath, {
+            RestrictedScanResult(FastClasspathScanner().addClassLoader(appClassLoader).overrideClasspath(cordappJarPath.url).scan(), cordappJarPath.qualifiedNamePrefix)
+        })
     }
 
     private class FlowTypeHierarchyComparator(val initiatingFlow: Class<out FlowLogic<*>>) : Comparator<Class<out FlowLogic<*>>> {

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -68,9 +68,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
          */
         fun createDefault(baseDir: Path) = CordappLoader(getCordappsInDirectory(getCordappsPath(baseDir)))
 
-        /**
-         * Cache for CordappLoaders to avoid costly classpath scanning
-         */
+        // Cache for CordappLoaders to avoid costly classpath scanning
         private val cordappLoadersCache = LRUMap<Any, CordappLoader>(1000)
 
         /**


### PR DESCRIPTION
First Corda PR.

Reason:
- when running unit tests I noticed tests scanning the classpath repeatedly, which is usually very slow

Fix:
- I've added a cache, and it reduced the "node:test" time by about 15-20s (locally)  
- as a cache implementation I used a LRUMap with a max size to avoid memory issues
 