### PR TITLE
Consistent database tables naming convention.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
@@ -32,6 +32,7 @@ object NodeInfoSchemaV1 : MappedSchema(
 
             @Column(name = "addresses")
             @OneToMany(cascade = arrayOf(CascadeType.ALL), orphanRemoval = true)
+            @JoinColumn(name = "node_info_id")
             val addresses: List<NodeInfoSchemaV1.DBHostAndPort>,
 
             @Column(name = "legal_identities_certs")
@@ -69,6 +70,7 @@ object NodeInfoSchemaV1 : MappedSchema(
     ) : Serializable
 
     @Entity
+    @Table(name = "node_info_hosts")
     data class DBHostAndPort(
             @EmbeddedId
             private val pk: PKHostAndPort

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
@@ -95,7 +95,7 @@ class BFTNonValidatingNotaryService(override val services: ServiceHubInternal,
     }
 
     @Entity
-    @Table(name = "${NODE_DATABASE_PREFIX}bft_smart_notary_committed_states")
+    @Table(name = "${NODE_DATABASE_PREFIX}bft_committed_states")
     class PersistedCommittedState(id: PersistentStateRef, consumingTxHash: String, consumingIndex: Int, party: PersistentUniquenessProvider.PersistentParty)
         : PersistentUniquenessProvider.PersistentUniqueness(id, consumingTxHash, consumingIndex, party)
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftUniquenessProvider.kt
@@ -29,6 +29,7 @@ import net.corda.core.utilities.loggerFor
 import net.corda.node.services.config.RaftConfig
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.node.utilities.CordaPersistence
+import net.corda.node.utilities.NODE_DATABASE_PREFIX
 import net.corda.nodeapi.config.NodeSSLConfiguration
 import net.corda.nodeapi.config.SSLConfiguration
 import java.nio.file.Path
@@ -67,7 +68,7 @@ class RaftUniquenessProvider(private val transportConfiguration: NodeSSLConfigur
     }
 
     @Entity
-    @Table(name = "notary_committed_states")
+    @Table(name = "${NODE_DATABASE_PREFIX}raft_committed_states")
     class RaftState(
             @Id
             @Column(name = "id")

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -73,6 +73,10 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** X500Name of participant parties **/
             @ElementCollection
+            @CollectionTable(name = "vault_linear_states_parts",
+                    joinColumns = arrayOf(
+                            JoinColumn(name = "output_index", referencedColumnName = "output_index"),
+                            JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id")))
             @Column(name = "participants")
             var participants: MutableSet<AbstractParty>? = null,
             // Reason for not using Set is described here:
@@ -100,6 +104,10 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** X500Name of participant parties **/
             @ElementCollection
+            @CollectionTable(name = "vault_fungible_states_parts",
+                    joinColumns = arrayOf(
+                            JoinColumn(name = "output_index", referencedColumnName = "output_index"),
+                            JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id")))
             @Column(name = "participants")
             var participants: MutableSet<AbstractParty>? = null,
 
@@ -138,8 +146,7 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
     @Entity
     @Table(name = "vault_transaction_notes",
-            indexes = arrayOf(Index(name = "seq_no_index", columnList = "seq_no"),
-                    Index(name = "transaction_id_index", columnList = "transaction_id")))
+            indexes = arrayOf(Index(name = "transaction_id_index", columnList = "transaction_id")))
     class VaultTxnNote(
             @Id
             @GeneratedValue


### PR DESCRIPTION
* Added explicit table names (mostly for join tables).
* Shorten or alter 2 tables backing notaries.
* Change a compound index declaration to one column index.