### PR TITLE
ENT-1069 Allow for nodes to be started in registration mode

### DIFF
--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -81,7 +81,8 @@ class DriverTests {
         server.start()
 
         driver(compatibilityZoneURL = URL("http://localhost:$port")) {
-            startNode(providedName = DUMMY_BANK_A.name).get()
+            // Wait for the notary to have started.
+            notaryHandles.first().nodeHandles.get()
         }
 
         // We're getting:

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -17,6 +17,7 @@ import net.corda.testing.node.NotarySpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.net.InetSocketAddress
+import java.net.URL
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
@@ -72,14 +73,14 @@ class DriverTests {
         }
 
         val inetSocketAddress = InetSocketAddress(0)
-        val server = HttpServer.create(inetSocketAddress,  /* backlog */0)
+        val server = HttpServer.create(inetSocketAddress, 0)
         val port = server.address.port
         server.createContext("/", handler)
         server.executor = null // creates a default executor
         server.start()
 
         driver(portAllocation = PortAllocation.RandomFree) {
-            registerNode(providedName = DUMMY_BANK_A.name, compatibilityZoneURL = "http://localhost:${port}")
+            startNode(providedName = DUMMY_BANK_A.name, compatibilityZoneURL = URL("http://localhost:${port}"))
         }
 
         // We're getting a request to sign the certificate and one poll request to see if the request has been approved.

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -80,7 +80,7 @@ class DriverTests {
         server.executor = null // creates a default executor
         server.start()
 
-        driver(portAllocation = PortAllocation.RandomFree, startNodesInProcess = false) {
+        driver {
             startNode(providedName = DUMMY_BANK_A.name, compatibilityZoneURL = URL("http://localhost:$port"))
                     .get()
         }

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -80,9 +80,8 @@ class DriverTests {
         server.executor = null // creates a default executor
         server.start()
 
-        driver {
-            startNode(providedName = DUMMY_BANK_A.name, compatibilityZoneURL = URL("http://localhost:$port"))
-                    .get()
+        driver(compatibilityZoneURL = URL("http://localhost:$port")) {
+            startNode(providedName = DUMMY_BANK_A.name).get()
         }
 
         // We're getting:

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -80,7 +80,7 @@ class DriverTests {
         server.executor = null // creates a default executor
         server.start()
 
-        driver(portAllocation = PortAllocation.RandomFree) {
+        driver(portAllocation = PortAllocation.RandomFree, startNodesInProcess = false) {
             startNode(providedName = DUMMY_BANK_A.name, compatibilityZoneURL = URL("http://localhost:$port"))
                     .get()
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -689,7 +689,7 @@ class DriverDSL(
                         "myLegalName" to providedName.toString())
         )
         if (startNodesInProcess) {
-            // This is a bit cheating, we're not stating a full node, we're just calling the code nodes call
+            // This is a bit cheating, we're not starting a full node, we're just calling the code nodes call
             // when registering.
             val configuration = config.parseAsNodeConfiguration()
             NetworkRegistrationHelper(configuration, HTTPNetworkRegistrationService(compatibilityZoneURL))

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -895,6 +895,7 @@ class DriverDSL(
     private fun startNodeForRegistration(config: Config): CordaFuture<Unit> {
         val maximumHeapSize = "200m"
         val configuration = config.parseAsNodeConfiguration()
+        val baseDirectory = configuration.baseDirectory.createDirectories()
 
         val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
         val process = startOutOfProcessNode(configuration, config, quasarJarPath, debugPort,
@@ -1098,7 +1099,6 @@ class DriverDSL(
 
 fun writeConfig(path: Path, filename: String, config: Config) {
     val configString = config.root().render(ConfigRenderOptions.defaults())
-    path.createDirectories()
     configString.byteInputStream().copyTo(path / filename, REPLACE_EXISTING)
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -138,7 +138,6 @@ interface DriverDSLExposedInterface : CordformContext {
      *     in. If null the Driver-level value will be used.
      * @param compatibilityZoneURL if not null the node is started once in registration mode (which make the node quit
      *     once registration is complete) and then re-starts the node with the given parameters.
-     *     Note that the registration part is always ran as a separate process regardless of settings.
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available.
      */
     fun startNode(

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -895,7 +895,7 @@ class DriverDSL(
     private fun startNodeForRegistration(config: Config): CordaFuture<Unit> {
         val maximumHeapSize = "200m"
         val configuration = config.parseAsNodeConfiguration()
-        val baseDirectory = configuration.baseDirectory.createDirectories()
+        configuration.baseDirectory.createDirectories()
 
         val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
         val process = startOutOfProcessNode(configuration, config, quasarJarPath, debugPort,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
@@ -48,6 +48,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3
 import java.lang.reflect.Method
+import java.net.URL
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -236,6 +237,7 @@ fun <A> rpcDriver(
         extraCordappPackagesToScan: List<String> = emptyList(),
         notarySpecs: List<NotarySpec> = emptyList(),
         externalTrace: Trace? = null,
+        compatibilityZoneURL: URL? = null,
         dsl: RPCDriverExposedDSLInterface.() -> A
 ) = genericDriver(
         driverDsl = RPCDriverDSL(
@@ -249,7 +251,8 @@ fun <A> rpcDriver(
                         startNodesInProcess = startNodesInProcess,
                         waitForNodesToFinish = waitForNodesToFinish,
                         extraCordappPackagesToScan = extraCordappPackagesToScan,
-                        notarySpecs = notarySpecs
+                        notarySpecs = notarySpecs,
+                        compatibilityZoneURL = compatibilityZoneURL
                 ), externalTrace
         ),
         coerce = { it },

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -37,6 +37,7 @@ import org.apache.activemq.artemis.core.security.CheckType
 import org.apache.activemq.artemis.core.security.Role
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager
+import java.net.URL
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
@@ -85,6 +86,7 @@ fun <A> verifierDriver(
         waitForNodesToFinish: Boolean = false,
         extraCordappPackagesToScan: List<String> = emptyList(),
         notarySpecs: List<NotarySpec> = emptyList(),
+        compatibilityZoneURL: URL? = null,
         dsl: VerifierExposedDSLInterface.() -> A
 ) = genericDriver(
         driverDsl = VerifierDriverDSL(
@@ -98,7 +100,8 @@ fun <A> verifierDriver(
                         startNodesInProcess = startNodesInProcess,
                         waitForNodesToFinish = waitForNodesToFinish,
                         extraCordappPackagesToScan = extraCordappPackagesToScan,
-                        notarySpecs = notarySpecs
+                        notarySpecs = notarySpecs,
+                        compatibilityZoneURL = compatibilityZoneURL
                 )
         ),
         coerce = { it },


### PR DESCRIPTION
Let Driver start nodes in registration mode.

Added a simple test to verify that the started node hits a URL 