### PR TITLE
Change how mock notary identity is extracted

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -169,7 +169,7 @@ class MockNetwork(defaultParameters: MockNetworkParameters = MockNetworkParamete
      * @see defaultNotaryNode
      */
     val defaultNotaryIdentityAndCert: PartyAndCertificate get() {
-        return defaultNotaryNode.info.legalIdentitiesAndCerts.singleOrNull() ?: throw IllegalStateException("Default notary has multiple identities")
+        return defaultNotaryNode.info.legalIdentitiesAndCerts[1] // TODO Resolve once network parameters is merged back in
     }
 
     /**


### PR DESCRIPTION
Change how mock notary identity is extracted, to match reversion in commit 3bb018a5