### PR TITLE
Correct PostgreSQL types

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
@@ -63,13 +63,13 @@ class CashSelectionPostgreSQLImpl : AbstractCashSelection() {
             paramOffset += 1
         }
         if (onlyFromIssuerParties.isNotEmpty()) {
-            val issuerKeys = connection.createArrayOf("BYTEA", onlyFromIssuerParties.map
+            val issuerKeys = connection.createArrayOf("VARCHAR", onlyFromIssuerParties.map
             { it.owningKey.toBase58String() }.toTypedArray())
             statement.setArray(3 + paramOffset, issuerKeys)
             paramOffset += 1
         }
         if (withIssuerRefs.isNotEmpty()) {
-            val issuerRefs = connection.createArrayOf("VARCHAR", withIssuerRefs.map
+            val issuerRefs = connection.createArrayOf("BYTEA", withIssuerRefs.map
             { it.bytes }.toTypedArray())
             statement.setArray(3 + paramOffset, issuerRefs)
             paramOffset += 1
@@ -79,5 +79,4 @@ class CashSelectionPostgreSQLImpl : AbstractCashSelection() {
 
         return statement.executeQuery()
     }
-
 }


### PR DESCRIPTION
Issuer Reference has reverted back to being of type `BYTEA` (a previous PR changes this to VARCHAR).
Issuer Party should always be a VARCHAR.