### PR TITLE
Stop granting NODE_USER full RPC permissions

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -232,8 +232,6 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
         securityRoles["$INTERNAL_PREFIX#"] = setOf(nodeInternalRole)  // Do not add any other roles here as it's only for the node
         securityRoles[P2P_QUEUE] = setOf(nodeInternalRole, restrictedRole(PEER_ROLE, send = true))
         securityRoles[RPCApi.RPC_SERVER_QUEUE_NAME] = setOf(nodeInternalRole, restrictedRole(RPC_ROLE, send = true))
-        // TODO: remove the NODE_USER role below once the webserver doesn't need it anymore.
-        securityRoles["${RPCApi.RPC_CLIENT_QUEUE_NAME_PREFIX}.$NODE_USER.#"] = setOf(nodeInternalRole)
         // Each RPC user must have its own role and its own queue. This prevents users accessing each other's queues
         // and stealing RPC responses.
         for ((username) in userService.users) {

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
@@ -354,9 +354,6 @@ class RPCServer(
         observableMap.cleanUp()
     }
 
-    // TODO remove this User once webserver doesn't need it
-    private val nodeUser = User(NODE_USER, NODE_USER, setOf())
-
     private fun ClientMessage.context(sessionId: Trace.SessionId): RpcAuthContext {
         val trace = Trace.newInstance(sessionId = sessionId)
         val externalTrace = externalTrace()
@@ -369,15 +366,11 @@ class RPCServer(
         val validatedUser = message.getStringProperty(Message.HDR_VALIDATED_USER) ?: throw IllegalArgumentException("Missing validated user from the Artemis message")
         val targetLegalIdentity = message.getStringProperty(RPCApi.RPC_TARGET_LEGAL_IDENTITY)?.let(CordaX500Name.Companion::parse) ?: nodeLegalName
         // TODO switch userService based on targetLegalIdentity
-        val rpcUser = userService.getUser(validatedUser)
-        return if (rpcUser != null) {
-            Actor(Id(rpcUser.username), userService.id, targetLegalIdentity) to RpcPermissions(rpcUser.permissions)
-        } else if (CordaX500Name.parse(validatedUser) == nodeLegalName) {
-            // TODO remove this after Shell and WebServer will no longer need it
-            Actor(Id(nodeUser.username), userService.id, targetLegalIdentity) to RpcPermissions(nodeUser.permissions)
-        } else {
-            throw IllegalArgumentException("Validated user '$validatedUser' is not an RPC user nor the NODE user")
-        }
+        val rpcUser = userService.getUser(validatedUser) ?:
+                throw IllegalArgumentException("Validated user '$validatedUser' is not an RPC user nor the NODE user")
+        return Pair(
+            Actor(Id(rpcUser.username), userService.id, targetLegalIdentity),
+            RpcPermissions(rpcUser.permissions))
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
@@ -367,7 +367,7 @@ class RPCServer(
         val targetLegalIdentity = message.getStringProperty(RPCApi.RPC_TARGET_LEGAL_IDENTITY)?.let(CordaX500Name.Companion::parse) ?: nodeLegalName
         // TODO switch userService based on targetLegalIdentity
         val rpcUser = userService.getUser(validatedUser) ?:
-                throw IllegalArgumentException("Validated user '$validatedUser' is not an RPC user nor the NODE user")
+                throw IllegalArgumentException("Validated user '$validatedUser' is not an RPC user")
         return Pair(
             Actor(Id(rpcUser.username), userService.id, targetLegalIdentity),
             RpcPermissions(rpcUser.permissions))


### PR DESCRIPTION

Minor cleanup: stop giving full RPC permissions to NODE_USER.
This was previously required to authorize accesses from NodeWebServer and local Shell; in both cases we now use a different mechanism. 