### PR TITLE
remove NodeState and nodeStateObservable remnants

### DIFF
--- a/node/src/main/kotlin/net/corda/node/shell/RPCOpsWithContext.kt
+++ b/node/src/main/kotlin/net/corda/node/shell/RPCOpsWithContext.kt
@@ -56,10 +56,6 @@ class RPCOpsWithContext(val cordaRPCOps: CordaRPCOps, val invocationContext:Invo
         return RPCContextRunner(invocationContext, rpcPermissions) { cordaRPCOps.queryAttachments(query, sorting) }.get().getOrThrow()
     }
 
-    override fun nodeStateObservable(): Observable<NodeState> {
-        return RPCContextRunner(invocationContext, rpcPermissions) { cordaRPCOps.nodeStateObservable() }.get().getOrThrow()
-    }
-
     override fun <T : ContractState> vaultTrackByWithSorting(contractStateType: Class<out T>, criteria: QueryCriteria, sorting: Sort): DataFeed<Vault.Page<T>, Vault.Update<T>> {
         return RPCContextRunner(invocationContext, rpcPermissions) { cordaRPCOps.vaultTrackByWithSorting(contractStateType, criteria, sorting) }.get().getOrThrow()
     }


### PR DESCRIPTION
Before merging the PR to rollback the node state RPC, another PR that used it was merged thus causing the build to fail. This PR removes the last uses of this RPC.