### PR TITLE
Guice demo

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,8 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel target="1.8">
+      <module name="al-corda-project_main" target="1.8" />
+      <module name="al-corda-project_test" target="1.8" />
       <module name="api-scanner_main" target="1.8" />
       <module name="api-scanner_test" target="1.8" />
       <module name="attachment-demo_integrationTest" target="1.8" />
@@ -19,8 +21,15 @@
       <module name="corda-core_integrationTest" target="1.8" />
       <module name="corda-core_smokeTest" target="1.8" />
       <module name="corda-finance_integrationTest" target="1.8" />
+      <module name="corda-node_integrationTest" target="1.8" />
+      <module name="corda-node_main" target="1.8" />
+      <module name="corda-node_test" target="1.8" />
       <module name="corda-project_main" target="1.8" />
       <module name="corda-project_test" target="1.8" />
+      <module name="corda-samples_main" target="1.8" />
+      <module name="corda-samples_test" target="1.8" />
+      <module name="corda-tools_main" target="1.8" />
+      <module name="corda-tools_test" target="1.8" />
       <module name="corda-webserver_integrationTest" target="1.8" />
       <module name="corda-webserver_main" target="1.8" />
       <module name="corda-webserver_test" target="1.8" />
@@ -43,8 +52,6 @@
       <module name="docs_source_example-code_main" target="1.8" />
       <module name="docs_source_example-code_test" target="1.8" />
       <module name="docs_test" target="1.8" />
-      <module name="experimental-kryo-hook_main" target="1.8" />
-      <module name="experimental-kryo-hook_test" target="1.8" />
       <module name="example-code_integrationTest" target="1.8" />
       <module name="example-code_main" target="1.8" />
       <module name="example-code_test" target="1.8" />
@@ -109,6 +116,8 @@
       <module name="rpc_main" target="1.8" />
       <module name="rpc_smokeTest" target="1.8" />
       <module name="rpc_test" target="1.8" />
+      <module name="samples-network-visualiser_main" target="1.8" />
+      <module name="samples-network-visualiser_test" target="1.8" />
       <module name="samples_main" target="1.8" />
       <module name="samples_test" target="1.8" />
       <module name="sandbox_main" target="1.8" />
@@ -135,6 +144,8 @@
       <module name="testing-test-common_test" target="1.8" />
       <module name="testing-test-utils_main" target="1.8" />
       <module name="testing-test-utils_test" target="1.8" />
+      <module name="tools-explorer_main" target="1.8" />
+      <module name="tools-explorer_test" target="1.8" />
       <module name="tools_main" target="1.8" />
       <module name="tools_test" target="1.8" />
       <module name="trader-demo_integrationTest" target="1.8" />

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     compile project(":confidential-identities")
     compile project(':client:rpc')
     compile "net.corda.plugins:cordform-common:$gradle_plugins_version"
+    compile group: 'com.google.inject', name: 'guice', version: '4.0'
 
     compile "com.google.code.findbugs:jsr305:3.0.1"
 

--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -3,11 +3,22 @@
 
 package net.corda.node
 
+import com.google.inject.Guice
 import net.corda.node.internal.NodeStartup
+import net.corda.node.internal.NodeStartupArgumentsModule
+import net.corda.node.internal.VersionInfoModule
 
 fun main(args: Array<String>) {
     // Pass the arguments to the Node factory. In the Enterprise edition, this line is modified to point to a subclass.
     // It will exit the process in case of startup failure and is not intended to be used by embedders. If you want
     // to embed Node in your own container, instantiate it directly and set up the configuration objects yourself.
-    NodeStartup(args).run()
+    val modules = listOf(NodeStartupArgumentsModule(args), VersionInfoModule())
+
+    val injector = Guice.createInjector(modules)
+
+    val nodeStartup = injector.getInstance(NodeStartup::class.java)
+
+    nodeStartup.run()
 }
+
+

--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -12,11 +12,14 @@ fun main(args: Array<String>) {
     // Pass the arguments to the Node factory. In the Enterprise edition, this line is modified to point to a subclass.
     // It will exit the process in case of startup failure and is not intended to be used by embedders. If you want
     // to embed Node in your own container, instantiate it directly and set up the configuration objects yourself.
-    val modules = listOf(NodeStartupArgumentsModule(args), VersionInfoModule())
 
-    val injector = Guice.createInjector(modules)
+    /**
+     * List of installed modules.
+     */
+    val modules = listOf(NodeStartupArgumentsModule(args),
+            VersionInfoModule())
 
-    val nodeStartup = injector.getInstance(NodeStartup::class.java)
+    val nodeStartup = Guice.createInjector(modules).getInstance(NodeStartup::class.java)
 
     nodeStartup.run()
 }

--- a/node/src/main/kotlin/net/corda/node/internal/ExampleModule.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/ExampleModule.kt
@@ -1,0 +1,30 @@
+package net.corda.node.internal
+
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import javax.inject.Qualifier
+
+
+@Qualifier
+annotation class SomeInteger
+
+@Qualifier
+annotation class AnotherInteger
+
+
+class QualifierExampleModule : AbstractModule() {
+
+    override fun configure() {
+        /**
+         * This will 'match' an "@SomeInteger i: Int"
+         */
+        bind(Int::class.java).annotatedWith(SomeInteger::class.java).to(14)
+    }
+
+    /**
+     * Same as above, different syntax.
+     */
+    @Provides
+    @AnotherInteger
+    fun provideAnoterInteger(): Int = 34
+}

--- a/node/src/main/kotlin/net/corda/node/internal/NodeArgumentParser.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeArgumentParser.kt
@@ -1,0 +1,46 @@
+package net.corda.node.internal
+
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import joptsimple.OptionException
+import net.corda.node.ArgsParser
+import net.corda.node.CmdLineOptions
+import kotlin.system.exitProcess
+
+interface NodeArgumentParser {
+    val argsParser: ArgsParser
+    val cmdLineOptions: CmdLineOptions
+}
+
+class NodeStartupArgumentsModule(val arguments: Array<String>): AbstractModule() {
+
+    @Provides
+    fun providerNodeArgumentParser() : NodeArgumentParser = NodeArgumentParserImpl(arguments)
+
+    @Provides
+    fun provideCmdLineOptions(nodeArgumentParser: NodeArgumentParser): CmdLineOptions = nodeArgumentParser.cmdLineOptions
+
+    @Provides
+    fun provideArgsParser(nodeArgumentParser: NodeArgumentParser): ArgsParser = nodeArgumentParser.argsParser
+
+    override fun configure() {  }
+}
+
+private class NodeArgumentParserImpl(val args: Array<String>): NodeArgumentParser {
+   override val argsParser: ArgsParser
+    override val cmdLineOptions: CmdLineOptions
+
+    init {
+        val argsParser = ArgsParser()
+        val cmdlineOptions = try {
+            argsParser.parse(*args)
+        } catch (ex: OptionException) {
+            println("Invalid command line arguments: ${ex.message}")
+            argsParser.printHelp(System.out)
+            exitProcess(1)
+        }
+        this.argsParser = argsParser
+        this.cmdLineOptions = cmdlineOptions
+    }
+}
+

--- a/node/src/main/kotlin/net/corda/node/internal/VerstionInfo.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/VerstionInfo.kt
@@ -1,0 +1,23 @@
+package net.corda.node.internal
+
+import com.google.inject.AbstractModule
+import com.jcabi.manifests.Manifests
+import net.corda.node.VersionInfo
+
+private fun getVersionInfo(): VersionInfo {
+    // Manifest properties are only available if running from the corda jar
+    fun manifestValue(name: String): String? = if (Manifests.exists(name)) Manifests.read(name) else null
+
+    return VersionInfo(
+            manifestValue("Corda-Platform-Version")?.toInt() ?: 1,
+            manifestValue("Corda-Release-Version") ?: "Unknown",
+            manifestValue("Corda-Revision") ?: "Unknown",
+            manifestValue("Corda-Vendor") ?: "Unknown"
+    )
+}
+
+class VersionInfoModule : AbstractModule() {
+    override fun configure() {
+        bind(VersionInfo::class.java).to(getVersionInfo())
+    }
+}


### PR DESCRIPTION
Minimal demo of adding Guice to corda.

I've added it in the top most part of the code.

This is a very minimal example which shows how one can remove code from a large class using dependency injection. 
3 dependencies of NodeStartup have been passed in as dependencies, and those are provided from modules.

Node that, unlike Spring, there isn't any scanning of classes to find dependencies, modules explicitly define all the mappings and each and every provided object.