### PR TITLE
CORDA-806 Show origin test in ThreadLeakException

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt
@@ -16,7 +16,7 @@ interface SerializationEnvironment {
     val checkpointContext: SerializationContext
 }
 
-class SerializationEnvironmentImpl(
+open class SerializationEnvironmentImpl(
         override val serializationFactory: SerializationFactory,
         override val p2pContext: SerializationContext,
         rpcServerContext: SerializationContext? = null,

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/SerializationTestHelpers.kt
@@ -15,10 +15,13 @@ import org.junit.runners.model.Statement
 
 /** @param inheritable whether new threads inherit the environment, use sparingly. */
 class SerializationEnvironmentRule(private val inheritable: Boolean = false) : TestRule {
-    val env: SerializationEnvironment = createTestSerializationEnv()
-    override fun apply(base: Statement, description: Description?) = object : Statement() {
-        override fun evaluate() = env.asContextEnv(inheritable) {
-            base.evaluate()
+    lateinit var env: SerializationEnvironment
+    override fun apply(base: Statement, description: Description): Statement {
+        env = createTestSerializationEnv(description.toString())
+        return object : Statement() {
+            override fun evaluate() = env.asContextEnv(inheritable) {
+                base.evaluate()
+            }
         }
     }
 }
@@ -30,7 +33,7 @@ interface GlobalSerializationEnvironment : SerializationEnvironment {
 
 /** @param inheritable whether new threads inherit the environment, use sparingly. */
 fun <T> withTestSerialization(inheritable: Boolean = false, callable: (SerializationEnvironment) -> T): T {
-    return createTestSerializationEnv().asContextEnv(inheritable, callable)
+    return createTestSerializationEnv("<context>").asContextEnv(inheritable, callable)
 }
 
 /**
@@ -53,7 +56,7 @@ fun <T> withoutTestSerialization(callable: () -> T): T {
  */
 fun setGlobalSerialization(armed: Boolean): GlobalSerializationEnvironment {
     return if (armed) {
-        object : GlobalSerializationEnvironment, SerializationEnvironment by createTestSerializationEnv() {
+        object : GlobalSerializationEnvironment, SerializationEnvironment by createTestSerializationEnv("<global>") {
             override fun unset() {
                 _globalSerializationEnv.set(null)
             }
@@ -67,7 +70,7 @@ fun setGlobalSerialization(armed: Boolean): GlobalSerializationEnvironment {
     }
 }
 
-private fun createTestSerializationEnv() = SerializationEnvironmentImpl(
+private fun createTestSerializationEnv(label: String) = object : SerializationEnvironmentImpl(
         SerializationFactoryImpl().apply {
             registerScheme(KryoClientSerializationScheme())
             registerScheme(KryoServerSerializationScheme())
@@ -78,7 +81,9 @@ private fun createTestSerializationEnv() = SerializationEnvironmentImpl(
         KRYO_RPC_SERVER_CONTEXT,
         KRYO_RPC_CLIENT_CONTEXT,
         if (isAmqpEnabled()) AMQP_STORAGE_CONTEXT else KRYO_STORAGE_CONTEXT,
-        KRYO_CHECKPOINT_CONTEXT)
+        KRYO_CHECKPOINT_CONTEXT) {
+    override fun toString() = "testSerializationEnv($label)"
+}
 
 private const val AMQP_ENABLE_PROP_NAME = "net.corda.testing.amqp.enable"
 


### PR DESCRIPTION
for debugging, exceptions now look like:
````
net.corda.core.internal.ThreadLeakException: Leaked thread 'pool-2-thread-1' detected, value was: testSerializationEnv(inherited values are poisoned on clear(net.corda.core.internal.ToggleFieldTest))
````