### PR TITLE
ENT-1125 bootstrap root certificate

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/config/SSLConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/config/SSLConfiguration.kt
@@ -10,6 +10,7 @@ interface SSLConfiguration {
     val sslKeystore: Path get() = certificatesDirectory / "sslkeystore.jks"
     val nodeKeystore: Path get() = certificatesDirectory / "nodekeystore.jks"
     val trustStoreFile: Path get() = certificatesDirectory / "truststore.jks"
+    val rootCaCertFile: Path get() = certificatesDirectory / "rootCaCert.cer"
 }
 
 interface NodeSSLConfiguration : SSLConfiguration {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/config/SSLConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/config/SSLConfiguration.kt
@@ -10,10 +10,10 @@ interface SSLConfiguration {
     val sslKeystore: Path get() = certificatesDirectory / "sslkeystore.jks"
     val nodeKeystore: Path get() = certificatesDirectory / "nodekeystore.jks"
     val trustStoreFile: Path get() = certificatesDirectory / "truststore.jks"
-    val rootCaCertFile: Path get() = certificatesDirectory / "rootCaCert.cer"
 }
 
 interface NodeSSLConfiguration : SSLConfiguration {
     val baseDirectory: Path
     override val certificatesDirectory: Path get() = baseDirectory / "certificates"
+    val rootCaCertFile: Path get() = certificatesDirectory / "rootcacert.cer"
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -315,7 +315,7 @@ class X509CertificateFactory {
     }
 
     // TODO migrate calls to [CertificateFactory#generateCertPath] to call this instead.
-    fun buildCertPath(vararg certificates: Certificate): CertPath {
+    fun generateCertPath(vararg certificates: Certificate): CertPath {
         return delegate.generateCertPath(certificates.asList())
     }
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -313,6 +313,10 @@ class X509CertificateFactory {
     fun generateCertificate(input: InputStream): X509Certificate {
         return delegate.generateCertificate(input) as X509Certificate
     }
+
+    fun buildCertPath(vararg certificates: Certificate): CertPath {
+        return delegate.generateCertPath(certificates.asList())
+    }
 }
 
 enum class CertificateType(val keyUsage: KeyUsage, vararg val purposes: KeyPurposeId, val isCA: Boolean) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -314,6 +314,7 @@ class X509CertificateFactory {
         return delegate.generateCertificate(input) as X509Certificate
     }
 
+    // TODO migrate calls to [CertificateFactory#generateCertPath] to call this instead.
     fun buildCertPath(vararg certificates: Certificate): CertPath {
         return delegate.generateCertPath(certificates.asList())
     }

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -68,8 +68,8 @@ class NetworkRegistrationHelperDriverTest {
         driver(portAllocation = portAllocation,
                 compatibilityZoneURL = compatibilityZoneUrl,
                 startNodesInProcess = true,
-                rootCertificate = rootCert) {
-
+                rootCertificate = rootCert
+        ) {
             // Wait for the node to have started.
             startNode(providedName = ALICE_NAME, initialRegistration = true).get()
         }
@@ -85,8 +85,8 @@ class NetworkRegistrationHelperDriverTest {
     fun `node registration without root cert`() {
         driver(portAllocation = portAllocation,
                 compatibilityZoneURL = compatibilityZoneUrl,
-                startNodesInProcess = true) {
-
+                startNodesInProcess = true
+        ) {
             assertThatThrownBy {
                 startNode(providedName = ALICE_NAME, initialRegistration = true).get()
             }.isInstanceOf(java.nio.file.NoSuchFileException::class.java)
@@ -98,8 +98,8 @@ class NetworkRegistrationHelperDriverTest {
         driver(portAllocation = portAllocation,
                 compatibilityZoneURL = compatibilityZoneUrl,
                 startNodesInProcess = true,
-                rootCertificate = createSelfKeyAndSelfSignedCertificate().certificate) {
-
+                rootCertificate = createSelfKeyAndSelfSignedCertificate().certificate
+        ) {
             assertThatThrownBy {
                 startNode(providedName = ALICE_NAME, initialRegistration = true).get()
             }.isInstanceOf(WrongRootCaCertificateException::class.java)
@@ -147,7 +147,7 @@ private fun createSignedClientCertificate(certificationRequest: PKCS10Certificat
             CordaX500Name.parse(request.subject.toString()).copy(commonName = X509Utilities.CORDA_CLIENT_CA_CN),
             request.publicKey,
             nameConstraints = null)
-    return x509CertificateFactory.buildCertPath(x509CertificateHolder.cert, *caCertPath)
+    return x509CertificateFactory.generateCertPath(x509CertificateHolder.cert, *caCertPath)
 }
 
 // TODO this logic is shared with doorman itself, refactor this to be somewhere where both doorman and these tests

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -9,6 +9,8 @@ import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509CertificateFactory
 import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_CLIENT_CA
+import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_INTERMEDIATE_CA
 import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_ROOT_CA
 import net.corda.testing.ALICE_NAME
 import net.corda.testing.driver.PortAllocation
@@ -157,7 +159,7 @@ private fun buildDoormanReply(certificates: Array<Certificate>): Response {
     val baos = ByteArrayOutputStream()
     ZipOutputStream(baos).use { zip ->
         // Client certificate must come first and root certificate should come last.
-        listOf(X509Utilities.CORDA_CLIENT_CA, CORDA_ROOT_CA).zip(certificates).forEach {
+        listOf(CORDA_CLIENT_CA, CORDA_INTERMEDIATE_CA, CORDA_ROOT_CA).zip(certificates).forEach {
             zip.putNextEntry(ZipEntry("${it.first}.cer"))
             zip.write(it.second.encoded)
             zip.closeEntry()

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -3,8 +3,6 @@ package net.corda.node.utilities.registration
 import net.corda.core.crypto.Crypto
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.cert
-import net.corda.core.internal.createDirectories
-import net.corda.core.internal.div
 import net.corda.core.internal.toX509CertHolder
 import net.corda.core.utilities.minutes
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
@@ -18,7 +16,6 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.network.NetworkMapServer
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest
 import org.junit.After
@@ -70,9 +67,8 @@ class NetworkRegistrationHelperDriverTest {
     fun `node registration correct root cert`() {
         driver(portAllocation = portAllocation,
                 compatibilityZoneURL = compatibilityZoneUrl,
-                startNodesInProcess = true) {
-
-            writeRootCaCertificateForNode(baseDirectory(ALICE_NAME.toString()), rootCert)
+                startNodesInProcess = true,
+                rootCertificate = rootCert) {
 
             // Wait for the node to have started.
             startNode(providedName = ALICE_NAME, initialRegistration = true).get()
@@ -101,10 +97,8 @@ class NetworkRegistrationHelperDriverTest {
     fun `node registration wrong root cert`() {
         driver(portAllocation = portAllocation,
                 compatibilityZoneURL = compatibilityZoneUrl,
-                startNodesInProcess = true) {
-
-            writeRootCaCertificateForNode(baseDirectory(ALICE_NAME.toString()),
-                    createSelfKeyAndSelfSignedCertificate().certificate)
+                startNodesInProcess = true,
+                rootCertificate = createSelfKeyAndSelfSignedCertificate().certificate) {
 
             assertThatThrownBy {
                 startNode(providedName = ALICE_NAME, initialRegistration = true).get()
@@ -181,10 +175,4 @@ private fun createSelfKeyAndSelfSignedCertificate(): CertificateAndKeyPair {
                     organisation = "R3 Ltd", locality = "London",
                     country = "GB"), rootCAKey)
     return CertificateAndKeyPair(rootCACert, rootCAKey)
-}
-
-fun writeRootCaCertificateForNode(path: java.nio.file.Path, caRootCertificate: X509CertificateHolder) {
-    val fullPath = path / "certificates" / "rootcacert.cer"
-    fullPath.parent.createDirectories()
-    X509Utilities.saveCertificateAsPEMFile(caRootCertificate, fullPath)
 }

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -71,7 +71,7 @@ class NetworkRegistrationHelperDriverTest {
         driver(portAllocation = portAllocation,
                 compatibilityZoneURL = compatibilityZoneUrl,
                 startNodesInProcess = true) {
-            
+
             writeRootCaCertificateForNode(baseDirectory(ALICE_NAME.toString()), rootCert)
 
             // Wait for the node to have started.

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -1,0 +1,181 @@
+package net.corda.node.utilities.registration
+
+import net.corda.core.crypto.Crypto
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.internal.cert
+import net.corda.core.internal.toX509CertHolder
+import net.corda.core.utilities.minutes
+import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
+import net.corda.nodeapi.internal.crypto.CertificateType
+import net.corda.nodeapi.internal.crypto.X509CertificateFactory
+import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_ROOT_CA
+import net.corda.testing.ALICE_NAME
+import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.driver
+import net.corda.testing.node.network.NetworkMapServer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.URL
+import java.security.KeyPair
+import java.security.cert.CertPath
+import java.security.cert.Certificate
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.ws.rs.*
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+
+private const val REQUEST_ID = "requestId"
+
+private val x509CertificateFactory = X509CertificateFactory()
+private val portAllocation = PortAllocation.Incremental(10000)
+
+/**
+ * Driver based tests for [NetworkRegistrationHelper]
+ */
+class NetworkRegistrationHelperDriverTest {
+    val certificateAndKeyPair = createSelfKeyAndSelfSignedCertificate()
+    val caRootCertificate = certificateAndKeyPair.certificate
+    val handler = RegistrationHandler(certificateAndKeyPair)
+    lateinit var server: NetworkMapServer
+    lateinit var host: String
+    var port: Int = 0
+    val compatibilityZoneUrl get() = URL("http", host, port, "")
+
+    @Before
+    fun startServer() {
+        server = NetworkMapServer(1.minutes, portAllocation.nextHostAndPort(), handler)
+        val (host, port) = server.start()
+        this.host = host
+        this.port = port
+    }
+
+    @After
+    fun stopServer() {
+        server.close()
+    }
+
+    @Test
+    fun `node registration correct root cert`() {
+        driver(portAllocation = portAllocation,
+                compatibilityZoneURL = compatibilityZoneUrl,
+                startNodesInProcess = true) {
+
+            writeRootCaCertificateForNode(ALICE_NAME, caRootCertificate)
+
+            // Wait for the node to have started.
+            startNode(providedName = ALICE_NAME, initialRegistration = true).get()
+        }
+
+        // We're getting:
+        //   a request to sign the certificate then
+        //   at least one poll request to see if the request has been approved.
+        //   all the network map registration and download.
+        assertThat(handler.requests).startsWith("/certificate", "/certificate/" + REQUEST_ID)
+    }
+
+    @Test
+    fun `node registration without root cert`() {
+        driver(portAllocation = portAllocation,
+                compatibilityZoneURL = compatibilityZoneUrl,
+                startNodesInProcess = true) {
+
+            assertThatThrownBy {
+                startNode(providedName = ALICE_NAME, initialRegistration = true).get()
+            }.isInstanceOf(NoSuchFileException::class.java)
+        }
+    }
+
+    @Test
+    fun `node registration wrong root cert`() {
+        driver(portAllocation = portAllocation,
+                compatibilityZoneURL = compatibilityZoneUrl,
+                startNodesInProcess = true) {
+
+            writeRootCaCertificateForNode(ALICE_NAME, createSelfKeyAndSelfSignedCertificate().certificate)
+
+            assertThatThrownBy {
+                startNode(providedName = ALICE_NAME, initialRegistration = true).get()
+            }.isInstanceOf(WrongRootCaCertificateException::class.java)
+        }
+    }
+}
+
+
+/**
+ * Simple registration handler which can handle a single request, which will be given request id [REQUEST_ID].
+ */
+@Path("certificate")
+class RegistrationHandler(
+        private val certificateAndKeyPair: CertificateAndKeyPair) {
+    val requests = mutableListOf<String>()
+    lateinit var certificationRequest: JcaPKCS10CertificationRequest
+
+    @POST
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    @Produces(MediaType.TEXT_PLAIN)
+    fun registration(input: InputStream): Response {
+        requests += "/certificate"
+        certificationRequest = input.use { JcaPKCS10CertificationRequest(it.readBytes()) }
+        return Response.ok(REQUEST_ID).build()
+    }
+
+    @GET
+    @Path(REQUEST_ID)
+    fun reply(): Response {
+        requests += "/certificate/" + REQUEST_ID
+        val certPath = createSignedClientCertificate(certificationRequest,
+                certificateAndKeyPair.keyPair, arrayOf(certificateAndKeyPair.certificate.cert))
+        return buildDoormanReply(certPath.certificates.toTypedArray())
+    }
+}
+
+// TODO this logic is shared with doorman itself, refactor this to be somewhere where both doorman and these tests
+// can depend on
+private fun createSignedClientCertificate(certificationRequest: PKCS10CertificationRequest,
+                                          caKeyPair: KeyPair,
+                                          caCertPath: Array<Certificate>): CertPath {
+    val request = JcaPKCS10CertificationRequest(certificationRequest)
+    val x509CertificateHolder = X509Utilities.createCertificate(CertificateType.CLIENT_CA,
+            caCertPath.first().toX509CertHolder(),
+            caKeyPair,
+            CordaX500Name.parse(request.subject.toString()).copy(commonName = X509Utilities.CORDA_CLIENT_CA_CN),
+            request.publicKey,
+            nameConstraints = null)
+    return x509CertificateFactory.buildCertPath(x509CertificateHolder.cert, *caCertPath)
+}
+
+// TODO this logic is shared with doorman itself, refactor this to be somewhere where both doorman and these tests
+// can depend on
+private fun buildDoormanReply(certificates: Array<Certificate>): Response {
+    // Write certificate chain to a zip stream and extract the bit array output.
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zip ->
+        // Client certificate must come first and root certificate should come last.
+        listOf(X509Utilities.CORDA_CLIENT_CA, CORDA_ROOT_CA).zip(certificates).forEach {
+            zip.putNextEntry(ZipEntry("${it.first}.cer"))
+            zip.write(it.second.encoded)
+            zip.closeEntry()
+        }
+    }
+    return Response.ok(baos.toByteArray())
+            .type("application/zip")
+            .header("Content-Disposition", "attachment; filename=\"certificates.zip\"").build()
+}
+
+private fun createSelfKeyAndSelfSignedCertificate(): CertificateAndKeyPair {
+    val rootCAKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
+    val rootCACert = X509Utilities.createSelfSignedCACertificate(
+            CordaX500Name(commonName = "Integration Test Corda Node Root CA",
+                    organisation = "R3 Ltd", locality = "London",
+                    country = "GB"), rootCAKey)
+    return CertificateAndKeyPair(rootCACert, rootCAKey)
+}

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -4,6 +4,7 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.cert
 import net.corda.core.internal.toX509CertHolder
+import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.minutes
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.nodeapi.internal.crypto.CertificateType
@@ -29,6 +30,8 @@ import java.net.URL
 import java.security.KeyPair
 import java.security.cert.CertPath
 import java.security.cert.Certificate
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import javax.ws.rs.*
@@ -72,7 +75,6 @@ class NetworkRegistrationHelperDriverTest {
                 startNodesInProcess = true,
                 rootCertificate = rootCert
         ) {
-            // Wait for the node to have started.
             startNode(providedName = ALICE_NAME, initialRegistration = true).get()
         }
 

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -41,7 +41,7 @@ import javax.ws.rs.core.Response
 private const val REQUEST_ID = "requestId"
 
 private val x509CertificateFactory = X509CertificateFactory()
-private val portAllocation = PortAllocation.Incremental(10000)
+private val portAllocation = PortAllocation.Incremental(11000)
 
 /**
  * Driver based tests for [NetworkRegistrationHelper]

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperDriverTest.kt
@@ -41,7 +41,7 @@ import javax.ws.rs.core.Response
 private const val REQUEST_ID = "requestId"
 
 private val x509CertificateFactory = X509CertificateFactory()
-private val portAllocation = PortAllocation.Incremental(11000)
+private val portAllocation = PortAllocation.Incremental(13000)
 
 /**
  * Driver based tests for [NetworkRegistrationHelper]

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -75,10 +75,15 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
             caKeyStore.addOrReplaceKey(CORDA_CLIENT_CA, keyPair.private, privateKeyPassword.toCharArray(), certificates)
             caKeyStore.deleteEntry(SELF_SIGNED_PRIVATE_KEY)
             caKeyStore.save(config.nodeKeystore, keystorePassword)
+
+            // Check the root certificate.
+            val returnedRootCa = certificates.last()
+            checkReturnedRootCaMatchesExpectedCa(returnedRootCa)
+
             // Save root certificates to trust store.
             val trustStore = loadOrCreateKeyStore(config.trustStoreFile, config.trustStorePassword)
             // Assumes certificate chain always starts with client certificate and end with root certificate.
-            trustStore.addOrReplaceCertificate(CORDA_ROOT_CA, certificates.last())
+            trustStore.addOrReplaceCertificate(CORDA_ROOT_CA, returnedRootCa)
             trustStore.save(config.trustStoreFile, config.trustStorePassword)
             println("Node private key and certificate stored in ${config.nodeKeystore}.")
 
@@ -95,6 +100,17 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
             requestIdStore.deleteIfExists()
         } else {
             println("Certificate already exists, Corda node will now terminate...")
+        }
+    }
+
+    /**
+     * Checks that the passed Certificate is the expected root CA.
+     * @throws WrongRootCaCertificateException if the certificates don't match.
+     */
+    private fun checkReturnedRootCaMatchesExpectedCa(returnedRootCa: Certificate) {
+        val expected = X509Utilities.loadCertificateFromPEMFile(config.rootCaCertFile).cert
+        if (expected != returnedRootCa) {
+            throw WrongRootCaCertificateException()
         }
     }
 
@@ -151,3 +167,9 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
         }
     }
 }
+
+/**
+ * Exception thrown when the doorman root certificate doesn't match the expected (out-of-band) root certificate.
+ * This usually means the has been a Man-in-the-middle attack when contacting the doorman.
+ */
+class WrongRootCaCertificateException: Exception()

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -12,6 +12,7 @@ import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_ROOT_CA
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.util.io.pem.PemObject
 import java.io.StringWriter
+import java.nio.file.Path
 import java.security.KeyPair
 import java.security.KeyStore
 import java.security.cert.Certificate
@@ -110,7 +111,7 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
     private fun checkReturnedRootCaMatchesExpectedCa(returnedRootCa: Certificate) {
         val expected = X509Utilities.loadCertificateFromPEMFile(config.rootCaCertFile).cert
         if (expected != returnedRootCa) {
-            throw WrongRootCaCertificateException()
+            throw WrongRootCaCertificateException(expected, returnedRootCa, config.rootCaCertFile)
         }
     }
 
@@ -172,4 +173,12 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
  * Exception thrown when the doorman root certificate doesn't match the expected (out-of-band) root certificate.
  * This usually means the has been a Man-in-the-middle attack when contacting the doorman.
  */
-class WrongRootCaCertificateException: Exception()
+class WrongRootCaCertificateException(expected: Certificate,
+                                      actual: Certificate,
+                                      expectedFilePath: Path):
+        Exception("""
+            The Root CA returned back from the registration process does not match the expected Root CA
+            expected: $expected
+            actual: $actual
+            expected is stored in: $expectedFilePath
+            """.trimMargin())

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -180,5 +180,5 @@ class WrongRootCaCertificateException(expected: Certificate,
             The Root CA returned back from the registration process does not match the expected Root CA
             expected: $expected
             actual: $actual
-            expected is stored in: $expectedFilePath
+            the expected certificate is stored in: $expectedFilePath
             """.trimMargin())

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkisRegistrationHelperTest.kt
@@ -46,6 +46,9 @@ class NetworkRegistrationHelperTest {
                 baseDirectory = tempFolder.root.toPath(),
                 myLegalName = ALICE.name)
 
+        config.rootCaCertFile.parent.createDirectories()
+        X509Utilities.saveCertificateAsPEMFile(certs.last().toX509CertHolder(), config.rootCaCertFile)
+
         assertFalse(config.nodeKeystore.exists())
         assertFalse(config.sslKeystore.exists())
         assertFalse(config.trustStoreFile.exists())

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
@@ -78,6 +78,7 @@ fun testNodeConfiguration(
         doCallRealMethod().whenever(it).trustStoreFile
         doCallRealMethod().whenever(it).sslKeystore
         doCallRealMethod().whenever(it).nodeKeystore
+        doCallRealMethod().whenever(it).rootCaCertFile
     }
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -876,12 +876,14 @@ class DriverDSL(
                 ServiceIdentityGenerator.generateToDisk(
                         dirs = listOf(baseDirectory(spec.name)),
                         serviceName = spec.name,
+                        rootCertertificate = rootCertificate,
                         serviceId = "identity"
                 )
             } else {
                 ServiceIdentityGenerator.generateToDisk(
                         dirs = generateNodeNames(spec).map { baseDirectory(it) },
                         serviceName = spec.name,
+                        rootCertertificate = rootCertificate,
                         serviceId = NotaryService.constructId(
                                 validating = spec.validating,
                                 raft = spec.cluster is ClusterSpec.Raft

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -345,9 +345,11 @@ data class NodeParameters(
  * available from [DriverDSLExposedInterface.notaryHandles]. Defaults to a simple validating notary.
  * @param compatibilityZoneURL if not null each node is started once in registration mode (which makes the node register and quit),
  *     and then re-starts the node with the given parameters.
+ * @param rootCertificate if not null every time a node is started for registration that certificate is written on disk   
  * @param dsl The dsl itself.
  * @return The value returned in the [dsl] closure.
  */
+// TODO: make the registration testing parameters internal.
 fun <A> driver(
         defaultParameters: DriverParameters = DriverParameters(),
         isDebug: Boolean = defaultParameters.isDebug,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -41,6 +41,7 @@ import net.corda.nodeapi.config.parseAs
 import net.corda.nodeapi.config.toConfig
 import net.corda.nodeapi.internal.NotaryInfo
 import net.corda.nodeapi.internal.addShutdownHook
+import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.testing.*
 import net.corda.nodeapi.internal.NetworkParametersCopier
 import net.corda.testing.common.internal.testNetworkParameters
@@ -51,6 +52,7 @@ import net.corda.testing.node.MockServices.Companion.MOCK_VERSION_INFO
 import net.corda.testing.node.NotarySpec
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.bouncycastle.cert.X509CertificateHolder
 import org.slf4j.Logger
 import rx.Observable
 import rx.observables.ConnectableObservable
@@ -209,6 +211,8 @@ interface DriverDSLExposedInterface : CordformContext {
     }
 
     val shutdownManager: ShutdownManager
+
+    fun writeRootCaCertificateForNode(nodeName: CordaX500Name, caRootCertificate: X509CertificateHolder)
 }
 
 interface DriverDSLInternalInterface : DriverDSLExposedInterface {
@@ -1198,6 +1202,13 @@ class DriverDSL(
         private fun Map<String, Any>.removeResolvedClasspath(): Map<String, Any> {
             return filterNot { it.key == "java.class.path" }
         }
+    }
+
+    override fun writeRootCaCertificateForNode(nodeName: CordaX500Name, caRootCertificate: X509CertificateHolder) {
+        val path = baseDirectory(nodeName.toString())
+        (path / "certificates").createDirectories()
+        val fullPath = path / "certificates" / "rootCaCert.cer"
+        X509Utilities.saveCertificateAsPEMFile(caRootCertificate, fullPath)
     }
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -211,8 +211,6 @@ interface DriverDSLExposedInterface : CordformContext {
     }
 
     val shutdownManager: ShutdownManager
-
-    fun writeRootCaCertificateForNode(nodeName: CordaX500Name, caRootCertificate: X509CertificateHolder)
 }
 
 interface DriverDSLInternalInterface : DriverDSLExposedInterface {
@@ -1202,13 +1200,6 @@ class DriverDSL(
         private fun Map<String, Any>.removeResolvedClasspath(): Map<String, Any> {
             return filterNot { it.key == "java.class.path" }
         }
-    }
-
-    override fun writeRootCaCertificateForNode(nodeName: CordaX500Name, caRootCertificate: X509CertificateHolder) {
-        val path = baseDirectory(nodeName.toString())
-        (path / "certificates").createDirectories()
-        val fullPath = path / "certificates" / "rootCaCert.cer"
-        X509Utilities.saveCertificateAsPEMFile(caRootCertificate, fullPath)
     }
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
@@ -47,6 +47,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3
+import org.bouncycastle.cert.X509CertificateHolder
 import java.lang.reflect.Method
 import java.net.URL
 import java.nio.file.Path
@@ -237,6 +238,7 @@ fun <A> rpcDriver(
         notarySpecs: List<NotarySpec> = emptyList(),
         externalTrace: Trace? = null,
         compatibilityZoneURL: URL? = null,
+        rootCertificate: X509CertificateHolder? = null,
         dsl: RPCDriverExposedDSLInterface.() -> A
 ) = genericDriver(
         driverDsl = RPCDriverDSL(
@@ -251,7 +253,8 @@ fun <A> rpcDriver(
                         waitForNodesToFinish = waitForNodesToFinish,
                         extraCordappPackagesToScan = extraCordappPackagesToScan,
                         notarySpecs = notarySpecs,
-                        compatibilityZoneURL = compatibilityZoneURL
+                        compatibilityZoneURL = compatibilityZoneURL,
+                        rootCertificate = rootCertificate
                 ), externalTrace
         ),
         coerce = { it },

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -37,6 +37,7 @@ import org.apache.activemq.artemis.core.security.CheckType
 import org.apache.activemq.artemis.core.security.Role
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager
+import org.bouncycastle.cert.X509CertificateHolder
 import java.net.URL
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -87,6 +88,7 @@ fun <A> verifierDriver(
         extraCordappPackagesToScan: List<String> = emptyList(),
         notarySpecs: List<NotarySpec> = emptyList(),
         compatibilityZoneURL: URL? = null,
+        rootCertificate: X509CertificateHolder? = null,
         dsl: VerifierExposedDSLInterface.() -> A
 ) = genericDriver(
         driverDsl = VerifierDriverDSL(
@@ -101,7 +103,8 @@ fun <A> verifierDriver(
                         waitForNodesToFinish = waitForNodesToFinish,
                         extraCordappPackagesToScan = extraCordappPackagesToScan,
                         notarySpecs = notarySpecs,
-                        compatibilityZoneURL = compatibilityZoneURL
+                        compatibilityZoneURL = compatibilityZoneURL,
+                        rootCertificate = rootCertificate
                 )
         ),
         coerce = { it },


### PR DESCRIPTION
During the node registration process make nodes check that the root of the certificate is an expected certificate stored under /certificates/rootCaCert.cer

Note this PR makes the registration FAIL if there is no such file, we might want to relax that for testing/dev purposes.

Also this borrows some code from doorman (to craft a fake doorman reply), all that code should be put in the OS repo so that both doorman & tests can use it.