### PR TITLE
Docs update: instructions to enable service

### DIFF
--- a/docs/source/deploying-a-node.rst
+++ b/docs/source/deploying-a-node.rst
@@ -212,7 +212,7 @@ at boot, and means the Corda service stays running with no users connected to th
 
       nssm install cordanode1 C:\ProgramData\Oracle\Java\javapath\java.exe
       nssm set cordanode1 AppDirectory C:\Corda
-      nssm set cordanode1 AppParameters "-jar corda.jar -Xmx2048m --config-file=C:\corda\node.conf"
+      nssm set cordanode1 AppParameters "-Xmx2048m -jar corda.jar --config-file=C:\corda\node.conf"
       nssm set cordanode1 AppStdout C:\Corda\service.log
       nssm set cordanode1 AppStderr C:\Corda\service.log
       nssm set cordanode1 Description Corda Node - Bank of Breakfast Tea

--- a/docs/source/deploying-a-node.rst
+++ b/docs/source/deploying-a-node.rst
@@ -126,11 +126,11 @@ handling, and ensures the Corda service is run at boot.
 9. Provision the required certificates to your node. Contact the network permissioning service or see
    :doc:`permissioning`
 
-10. You can now start a node and its webserver by running the following ``systemctl`` commands:
+10. You can now start a node and its webserver and set the services to start on boot by running the following ``systemctl`` commands:
 
    * ``sudo systemctl daemon-reload``
-   * ``sudo systemctl corda start``
-   * ``sudo systemctl corda-webserver start``
+   * ``sudo systemctl enable --now corda``
+   * ``sudo systemctl enable --now corda-webserver``
 
 You can run multiple nodes by creating multiple directories and Corda services, modifying the ``node.conf`` and
 ``service`` files so they are unique.
@@ -216,6 +216,7 @@ at boot, and means the Corda service stays running with no users connected to th
       nssm set cordanode1 AppStdout C:\Corda\service.log
       nssm set cordanode1 AppStderr C:\Corda\service.log
       nssm set cordanode1 Description Corda Node - Bank of Breakfast Tea
+      nssm set cordanode1 Start SERVICE_AUTO_START
       sc start cordanode1
 
 9. Modify the batch file:

--- a/docs/source/running-a-node.rst
+++ b/docs/source/running-a-node.rst
@@ -22,6 +22,12 @@ Start the nodes with ``runnodes`` by running the following command from the root
 .. warn:: On macOS, do not click/change focus until all the node terminal windows have opened, or some processes may
    fail to start.
 
+If you receive an ``OutOfMemoryError`` exception when interacting with the nodes, you need to increase the amount of
+Java heap memory available to them, which you can do when running them individually. See
+:ref:`starting-an-individual-corda-node`.
+
+.. _starting-an-individual-corda-node:
+
 Starting an individual Corda node
 ---------------------------------
 Run the node by opening a terminal window in the node's folder and running:
@@ -30,9 +36,18 @@ Run the node by opening a terminal window in the node's folder and running:
 
    java -jar corda.jar
 
-.. warning:: By default, the node will look for a configuration file called ``node.conf`` and a CorDapps folder called
-   ``cordapps`` in the current working directory. You can override the configuration file and workspace paths on the
-   command line (e.g. ``./corda.jar --config-file=test.conf --base-directory=/opt/r3corda/nodes/test``).
+By default, the node will look for a configuration file called ``node.conf`` and a CorDapps folder called ``cordapps``
+in the current working directory. You can override the configuration file and workspace paths on the command line (e.g.
+``./corda.jar --config-file=test.conf --base-directory=/opt/corda/nodes/test``).
+
+You can increase the amount of Java heap memory available to the node using the ``-Xmx`` command line argument. For
+example, the following would run the node with a heap size of 2048MB:
+
+.. code-block:: shell
+
+   java -jar corda.jar -Xmx2048m
+
+You should do this if you receive an ``OutOfMemoryError`` exception when interacting with the node.
 
 Optionally run the node's webserver as well by opening a terminal window in the node's folder and running:
 

--- a/docs/source/running-a-node.rst
+++ b/docs/source/running-a-node.rst
@@ -45,7 +45,7 @@ example, the following would run the node with a heap size of 2048MB:
 
 .. code-block:: shell
 
-   java -jar corda.jar -Xmx2048m
+   java -Xmx2048m -jar corda.jar
 
 You should do this if you receive an ``OutOfMemoryError`` exception when interacting with the node.
 


### PR DESCRIPTION
Change to docs to fix systemctl syntax and enable services to start on boot.
