### PR TITLE
[CORDA-824]: fix resource leak in Cash selection

### DIFF
--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt
@@ -45,7 +45,7 @@ object CustomVaultQuery {
             """
             log.info("SQL to execute: $nativeQuery")
             val session = services.jdbcSession()
-            session.prepareStatement(nativeQuery).use { prepStatement ->
+            return session.prepareStatement(nativeQuery).use { prepStatement ->
                 prepStatement.executeQuery().use { rs ->
                     val topUpLimits: MutableList<Amount<Currency>> = mutableListOf()
                     while (rs.next()) {
@@ -54,9 +54,9 @@ object CustomVaultQuery {
                         log.info("$currencyStr : $amount")
                         topUpLimits.add(Amount(amount, Currency.getInstance(currencyStr)))
                     }
+                    topUpLimits
                 }
             }
-            return topUpLimits
         }
     }
 }

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/CustomVaultQuery.kt
@@ -24,6 +24,7 @@ object CustomVaultQuery {
         private companion object {
             private val log = contextLogger()
         }
+
         fun rebalanceCurrencyReserves(): List<Amount<Currency>> {
             val nativeQuery = """
                 select
@@ -44,14 +45,16 @@ object CustomVaultQuery {
             """
             log.info("SQL to execute: $nativeQuery")
             val session = services.jdbcSession()
-            val prepStatement = session.prepareStatement(nativeQuery)
-            val rs = prepStatement.executeQuery()
-            val topUpLimits: MutableList<Amount<Currency>> = mutableListOf()
-            while (rs.next()) {
-                val currencyStr = rs.getString(1)
-                val amount = rs.getLong(2)
-                log.info("$currencyStr : $amount")
-                topUpLimits.add(Amount(amount, Currency.getInstance(currencyStr)))
+            session.prepareStatement(nativeQuery).use { prepStatement ->
+                prepStatement.executeQuery().use { rs ->
+                    val topUpLimits: MutableList<Amount<Currency>> = mutableListOf()
+                    while (rs.next()) {
+                        val currencyStr = rs.getString(1)
+                        val amount = rs.getLong(2)
+                        log.info("$currencyStr : $amount")
+                        topUpLimits.add(Amount(amount, Currency.getInstance(currencyStr)))
+                    }
+                }
             }
             return topUpLimits
         }
@@ -69,6 +72,7 @@ object TopupIssuerFlow {
     data class TopupRequest(val issueToParty: Party,
                             val issuerPartyRef: OpaqueBytes,
                             val notaryParty: Party)
+
     @InitiatingFlow
     @StartableByRPC
     class TopupIssuanceRequester(val issueToParty: Party,

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -30,9 +30,8 @@ class CashSelectionH2Impl : AbstractCashSelection() {
     //       2) H2 uses session variables to perform this accumulator function:
     //          http://www.h2database.com/html/functions.html#set
     //       3) H2 does not support JOIN's in FOR UPDATE (hence we are forced to execute 2 queries)
-    override fun executeQuery(connection: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?,
-                              onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>) : ResultSet {
-        connection.createStatement().execute("CALL SET(@t, CAST(0 AS BIGINT));")
+    override fun executeQuery(connection: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>, withResultSet: (ResultSet) -> Boolean): Boolean {
+        connection.createStatement().use { it.execute("CALL SET(@t, CAST(0 AS BIGINT));") }
 
         val selectJoin = """
                     SELECT vs.transaction_id, vs.output_index, ccs.pennies, SET(@t, ifnull(@t,0)+ccs.pennies) total_pennies, vs.lock_id
@@ -50,19 +49,22 @@ class CashSelectionH2Impl : AbstractCashSelection() {
                     " AND ccs.issuer_ref IN (?)" else "")
 
         // Use prepared statement for protection against SQL Injection (http://www.h2database.com/html/advanced.html#sql_injection)
-        val psSelectJoin = connection.prepareStatement(selectJoin)
-        var pIndex = 0
-        psSelectJoin.setString(++pIndex, amount.token.currencyCode)
-        psSelectJoin.setLong(++pIndex, amount.quantity)
-        psSelectJoin.setString(++pIndex, lockId.toString())
-        if (notary != null)
-            psSelectJoin.setString(++pIndex, notary.name.toString())
-        if (onlyFromIssuerParties.isNotEmpty())
-            psSelectJoin.setObject(++pIndex, onlyFromIssuerParties.map { it.owningKey.toStringShort() as Any}.toTypedArray() )
-        if (withIssuerRefs.isNotEmpty())
-            psSelectJoin.setObject(++pIndex, withIssuerRefs.map { it.bytes as Any }.toTypedArray())
-        log.debug { psSelectJoin.toString() }
+        connection.prepareStatement(selectJoin).use { psSelectJoin ->
+            var pIndex = 0
+            psSelectJoin.setString(++pIndex, amount.token.currencyCode)
+            psSelectJoin.setLong(++pIndex, amount.quantity)
+            psSelectJoin.setString(++pIndex, lockId.toString())
+            if (notary != null)
+                psSelectJoin.setString(++pIndex, notary.name.toString())
+            if (onlyFromIssuerParties.isNotEmpty())
+                psSelectJoin.setObject(++pIndex, onlyFromIssuerParties.map { it.owningKey.toStringShort() as Any }.toTypedArray())
+            if (withIssuerRefs.isNotEmpty())
+                psSelectJoin.setObject(++pIndex, withIssuerRefs.map { it.bytes as Any }.toTypedArray())
+            log.debug { psSelectJoin.toString() }
 
-        return psSelectJoin.executeQuery()
+            psSelectJoin.executeQuery().use { rs ->
+                return withResultSet(rs)
+            }
+        }
     }
 }

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionMySQLImpl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionMySQLImpl.kt
@@ -19,7 +19,7 @@ class CashSelectionMySQLImpl : AbstractCashSelection() {
         return metadata.driverName == JDBC_DRIVER_NAME
     }
 
-    override fun executeQuery(statement: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?, issuerKeysStr: Set<AbstractParty>, issuerRefsStr: Set<OpaqueBytes>): ResultSet {
+    override fun executeQuery(statement: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?, issuerKeysStr: Set<AbstractParty>, issuerRefsStr: Set<OpaqueBytes>, withResultSet: (ResultSet) -> Boolean): Boolean {
         TODO("MySQL cash selection not implemented")
     }
 


### PR DESCRIPTION
This fixes the leak by sending the business logic as a lambda to the executeQuery method that actually opens the PreparedStatement, and is responsible to close it.

Another non-disruptive option would be for the executeQuery to return some Tuple with a String and a List of parameters, and the abstract class to be responsible to create the PS and execute.
