### PR TITLE
Wire part of network parameters

### DIFF
--- a/docs/source/network-map.rst
+++ b/docs/source/network-map.rst
@@ -2,7 +2,7 @@ Network Map
 ===========
 
 The network map stores a collection of ``NodeInfo`` objects, each representing another node with which the node can interact.
-There two sources from which a Corda node can retrieve ``NodeInfo`` objects:
+There are two sources from which a Corda node can retrieve ``NodeInfo`` objects:
 
 1. the REST protocol with the network map service, which also provides a publishing API,
 
@@ -25,7 +25,7 @@ Node side network map update protocol:
 
 * The Corda node will query the network map service periodically according to the ``Expires`` attribute in the HTTP header.
 
-* The network map service returns a signed ``NetworkMap`` object, containing list of node info hashes and the network parameters hashes.
+* The network map service returns a signed ``NetworkMap`` object, containing list of node info hashes and the network parameters hash.
 
 * The node updates its local copy of ``NodeInfos`` if it is different from the newly downloaded ``NetworkMap``.
 
@@ -36,7 +36,7 @@ Network Map service REST API:
 +================+===================================+========================================================================================================================================================+
 | POST           | /api/network-map/publish          | Publish new ``NodeInfo`` to the network map service, the legal identity in ``NodeInfo`` must match with the identity registered with the doorman.      |
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| GET            | /api/network-map                  | Retrieve ``NetworkMap`` from the server, the ``NetworkMap`` object contains list of node info hashes and NetworkParameters hash.                       |
+| GET            | /api/network-map                  | Retrieve ``NetworkMap`` from the server, the ``NetworkMap`` object contains list of node info hashes and ``NetworkParameters`` hash.                   |
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 | GET            | /api/network-map/node-info/{hash} | Retrieve ``NodeInfo`` object with the same hash.                                                                                                       |
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -55,3 +55,19 @@ Nodes expect to find a serialized ``SignedData<NodeInfo>`` object, the same obje
 Whenever a node starts it writes on disk a file containing its own ``NodeInfo``, this file is called ``nodeInfo-XXX`` where ``XXX`` is a long string.
 
 Hence if an operator wants node A to see node B they can pick B's ``NodeInfo`` file from B base directory and drop it into A's ``additional-node-infos`` directory.
+
+
+Network parameters
+------------------
+Network parameters are constants that every node participating in the network needs to agree on and use for interop purposes.
+The structure is distributed as a file containing serialized ``SignedData<NetworkParameters>`` with a signature from the
+network operator. Network map advertises the hash of currently used network parameters.
+The ``NetworkParameters`` structure contains:
+ * ``minimumPlatformVersion`` -  minimum version of Corda platform that is required for nodes in the network.
+ * ``notaries`` - list of well known and trusted notary identities with information on validation type.
+ * ``maxMessageSize`` - maximum P2P message size sent over the wire in bytes.
+ * ``maxTransactionSize`` - maximum permitted transaction size in bytes.
+ * ``modifiedTime``
+ * ``epoch`` - version number of the network parameters. Starting from 1, this will always increment on each new set of parameters.
+
+The set of parameters is still under development and we may find the need to add additional fields.

--- a/docs/source/network-map.rst
+++ b/docs/source/network-map.rst
@@ -34,13 +34,13 @@ Network Map service REST API:
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Request method | Path                              | Description                                                                                                                                            |
 +================+===================================+========================================================================================================================================================+
-| POST           | /api/network-map/publish          | Publish new ``NodeInfo`` to the network map service, the legal identity in ``NodeInfo`` must match with the identity registered with the doorman.      |
+| POST           | /network-map/publish              | Publish new ``NodeInfo`` to the network map service, the legal identity in ``NodeInfo`` must match with the identity registered with the doorman.      |
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| GET            | /api/network-map                  | Retrieve ``NetworkMap`` from the server, the ``NetworkMap`` object contains list of node info hashes and ``NetworkParameters`` hash.                   |
+| GET            | /network-map                      | Retrieve ``NetworkMap`` from the server, the ``NetworkMap`` object contains list of node info hashes and ``NetworkParameters`` hash.                   |
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| GET            | /api/network-map/node-info/{hash} | Retrieve ``NodeInfo`` object with the same hash.                                                                                                       |
+| GET            | /network-map/node-info/{hash}     | Retrieve ``NodeInfo`` object with the same hash.                                                                                                       |
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| GET            | /api/network-map/parameters/{hash}| Retrieve ``NetworkParameters`` object with the same hash.                                                                                              |
+| GET            | /network-map/parameters/{hash}    | Retrieve ``NetworkParameters`` object with the same hash.                                                                                              |
 +----------------+-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 TODO: Access control of the network map will be added in the future.

--- a/docs/source/network-map.rst
+++ b/docs/source/network-map.rst
@@ -25,7 +25,18 @@ Node side network map update protocol:
 
 * The Corda node will query the network map service periodically according to the ``Expires`` attribute in the HTTP header.
 
-* The network map service returns a signed ``NetworkMap`` object, containing list of node info hashes and the network parameters hash.
+* The network map service returns a signed ``NetworkMap`` object which looks as follows:
+
+.. container:: codeset
+
+   .. sourcecode:: kotlin
+
+        data class NetworkMap {
+            val nodeInfoHashes: List<SecureHash>,
+            val networkParametersHash: SecureHash
+        }
+
+The object contains list of node info hashes and hash of the network parameters data structure (without the signatures).
 
 * The node updates its local copy of ``NodeInfos`` if it is different from the newly downloaded ``NetworkMap``.
 
@@ -60,14 +71,14 @@ Hence if an operator wants node A to see node B they can pick B's ``NodeInfo`` f
 Network parameters
 ------------------
 Network parameters are constants that every node participating in the network needs to agree on and use for interop purposes.
-The structure is distributed as a file containing serialized ``SignedData<NetworkParameters>`` with a signature from the
-network operator. Network map advertises the hash of currently used network parameters.
+The structure is distributed as a file containing serialized ``SignedData<NetworkParameters>`` with a signature from
+a sub-key of the compatibility zone root cert. Network map advertises the hash of currently used network parameters.
 The ``NetworkParameters`` structure contains:
  * ``minimumPlatformVersion`` -  minimum version of Corda platform that is required for nodes in the network.
  * ``notaries`` - list of well known and trusted notary identities with information on validation type.
  * ``maxMessageSize`` - maximum P2P message size sent over the wire in bytes.
  * ``maxTransactionSize`` - maximum permitted transaction size in bytes.
- * ``modifiedTime``
+ * ``modifiedTime`` - the time the network parameters were created by the CZ operator.
  * ``epoch`` - version number of the network parameters. Starting from 1, this will always increment on each new set of parameters.
 
 The set of parameters is still under development and we may find the need to add additional fields.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -13,6 +13,7 @@ import java.security.cert.X509Certificate
 import java.time.Duration
 import java.time.Instant
 
+const val NETWORK_PARAM_FILE_PREFIX = "network-parameters"
 // TODO: Need more discussion on rather we should move this class out of internal.
 /**
  * Data class containing hash of [NetworkParameters] and network participant's [NodeInfo] hashes.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -21,21 +21,21 @@ import java.time.Instant
 data class NetworkMap(val nodeInfoHashes: List<SecureHash>, val networkParameterHash: SecureHash)
 
 /**
- * @property minimumPlatformVersion
- * @property notaries
- * @property eventHorizon
+ * @property minimumPlatformVersion Minimal version of Corda platform that is required for nodes in the network.
+ * @property notaries List of well known and trusted notary identities with information on validation type.
  * @property maxMessageSize Maximum P2P message sent over the wire in bytes.
  * @property maxTransactionSize Maximum permitted transaction size in bytes.
  * @property modifiedTime
  * @property epoch Version number of the network parameters. Starting from 1, this will always increment on each new set
  * of parameters.
  */
-// TODO Wire up the parameters
+// TODO Add eventHorizon - how many days a node can be offline before being automatically ejected from the network.
+//  It needs separate design.
+// TODO Currently both maxTransactionSize and modifiedTime are not wired.
 @CordaSerializable
 data class NetworkParameters(
         val minimumPlatformVersion: Int,
         val notaries: List<NotaryInfo>,
-        val eventHorizon: Duration,
         val maxMessageSize: Int,
         val maxTransactionSize: Int,
         val modifiedTime: Instant,

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -10,7 +10,6 @@ import net.corda.core.serialization.deserialize
 import java.security.SignatureException
 import java.security.cert.CertPathValidatorException
 import java.security.cert.X509Certificate
-import java.time.Duration
 import java.time.Instant
 
 const val NETWORK_PARAM_FILE_PREFIX = "network-parameters"

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -22,7 +22,7 @@ const val NETWORK_PARAM_FILE_PREFIX = "network-parameters"
 data class NetworkMap(val nodeInfoHashes: List<SecureHash>, val networkParameterHash: SecureHash)
 
 /**
- * @property minimumPlatformVersion Minimal version of Corda platform that is required for nodes in the network.
+ * @property minimumPlatformVersion Minimum version of Corda platform that is required for nodes in the network.
  * @property notaries List of well known and trusted notary identities with information on validation type.
  * @property maxMessageSize Maximum P2P message sent over the wire in bytes.
  * @property maxTransactionSize Maximum permitted transaction size in bytes.
@@ -46,6 +46,8 @@ data class NetworkParameters(
         require(minimumPlatformVersion > 0) { "minimumPlatformVersion must be at least 1" }
         require(notaries.distinctBy { it.identity } == notaries) { "Duplicate notary identities" }
         require(epoch > 0) { "epoch must be at least 1" }
+        require(maxMessageSize > 0 ) { "maxMessageSize must be at least 1" }
+        require(maxTransactionSize > 0 ) { "maxTransactionSize must be at least 1" }
     }
 }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -45,8 +45,8 @@ data class NetworkParameters(
         require(minimumPlatformVersion > 0) { "minimumPlatformVersion must be at least 1" }
         require(notaries.distinctBy { it.identity } == notaries) { "Duplicate notary identities" }
         require(epoch > 0) { "epoch must be at least 1" }
-        require(maxMessageSize > 0 ) { "maxMessageSize must be at least 1" }
-        require(maxTransactionSize > 0 ) { "maxTransactionSize must be at least 1" }
+        require(maxMessageSize > 0) { "maxMessageSize must be at least 1" }
+        require(maxTransactionSize > 0) { "maxTransactionSize must be at least 1" }
     }
 }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -12,7 +12,7 @@ import java.security.cert.CertPathValidatorException
 import java.security.cert.X509Certificate
 import java.time.Instant
 
-const val NETWORK_PARAM_FILE_PREFIX = "network-parameters"
+const val NETWORK_PARAMS_FILE_NAME = "network-parameters"
 // TODO: Need more discussion on rather we should move this class out of internal.
 /**
  * Data class containing hash of [NetworkParameters] and network participant's [NodeInfo] hashes.
@@ -31,7 +31,7 @@ data class NetworkMap(val nodeInfoHashes: List<SecureHash>, val networkParameter
  */
 // TODO Add eventHorizon - how many days a node can be offline before being automatically ejected from the network.
 //  It needs separate design.
-// TODO Currently both maxTransactionSize and modifiedTime are not wired.
+// TODO Currently maxTransactionSize is not wired.
 @CordaSerializable
 data class NetworkParameters(
         val minimumPlatformVersion: Int,

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
@@ -22,9 +22,9 @@ class NetworkParametersCopier(networkParameters: NetworkParameters) {
         SignedData(serialize, signature).serialize()
     }
 
-    fun install(dir: Path) {
+    fun install(dir: Path, paramsFile: String = "network-parameters") {
         try {
-            serializedNetworkParameters.open().copyTo(dir / "network-parameters")
+            serializedNetworkParameters.open().copyTo(dir / paramsFile)
         } catch (e: FileAlreadyExistsException) {
             // Leave the file untouched if it already exists
         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
@@ -22,7 +22,7 @@ class NetworkParametersCopier(networkParameters: NetworkParameters) {
         SignedData(serialize, signature).serialize()
     }
 
-    fun install(dir: Path, paramsFile: String = "network-parameters") {
+    fun install(dir: Path, paramsFile: String = NETWORK_PARAM_FILE_PREFIX) {
         try {
             serializedNetworkParameters.open().copyTo(dir / paramsFile)
         } catch (e: FileAlreadyExistsException) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersCopier.kt
@@ -6,7 +6,6 @@ import net.corda.core.crypto.sign
 import net.corda.core.internal.copyTo
 import net.corda.core.internal.div
 import net.corda.core.serialization.serialize
-import net.corda.nodeapi.internal.NetworkParameters
 import java.math.BigInteger
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Path
@@ -22,9 +21,9 @@ class NetworkParametersCopier(networkParameters: NetworkParameters) {
         SignedData(serialize, signature).serialize()
     }
 
-    fun install(dir: Path, paramsFile: String = NETWORK_PARAM_FILE_PREFIX) {
+    fun install(dir: Path) {
         try {
-            serializedNetworkParameters.open().copyTo(dir / paramsFile)
+            serializedNetworkParameters.open().copyTo(dir / NETWORK_PARAMS_FILE_NAME)
         } catch (e: FileAlreadyExistsException) {
             // Leave the file untouched if it already exists
         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersGenerator.kt
@@ -45,7 +45,7 @@ class NetworkParametersGenerator {
                     maxTransactionSize = 40000,
                     epoch = 1
             ))
-            nodesDirs.forEach { copier.install(it) }
+            nodesDirs.forEach(copier::install)
         } finally {
             _contextSerializationEnv.set(null)
         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersGenerator.kt
@@ -45,7 +45,7 @@ class NetworkParametersGenerator {
                     maxTransactionSize = 40000,
                     epoch = 1
             ))
-            nodesDirs.forEach(copier::install)
+            nodesDirs.forEach { copier.install(it) }
         } finally {
             _contextSerializationEnv.set(null)
         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkParametersGenerator.kt
@@ -41,7 +41,6 @@ class NetworkParametersGenerator {
                     minimumPlatformVersion = 1,
                     notaries = notaryInfos,
                     modifiedTime = Instant.now(),
-                    eventHorizon = 10000.days,
                     maxMessageSize = 40000,
                     maxTransactionSize = 40000,
                     epoch = 1

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NetworkParametersTest {
@@ -37,6 +38,7 @@ class NetworkParametersTest {
     fun `choose highest epoch`() {
         var alice = mockNet.createPartyNode(ALICE.name)
         val aliceDirectory = alice.internals.configuration.baseDirectory
+        // Epoch is not exposed by node, so we are checking notaries instead.
         assertEquals(DUMMY_NOTARY.name, alice.services.networkMapCache.notaryIdentities[0].name)
         alice.dispose()
         // Make parameters with higher epoch and different notary so it's easier to check them.
@@ -83,9 +85,9 @@ class NetworkParametersTest {
             val notary = NotaryConfig(false)
             doReturn(notary).whenever(it).notary}))
         val fakeNotaryId = fakeNotary.info.chooseIdentity()
-        assert(fakeNotary.internals.configuration.notary != null)
+        assertFalse(fakeNotary.internals.configuration.notary == null)
         val alice = mockNet.createPartyNode(ALICE_NAME)
-        assert(fakeNotaryId !in alice.services.networkMapCache.notaryIdentities)
+        assertFalse(fakeNotaryId in alice.services.networkMapCache.notaryIdentities)
         assertFails {
             alice.services.startFlow(CashIssueFlow(500.DOLLARS, OpaqueBytes.of(0x01), fakeNotaryId)).resultFuture.getOrThrow()
         }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
@@ -1,0 +1,98 @@
+package net.corda.nodeapi.internal
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
+import net.corda.core.internal.deleteIfExists
+import net.corda.core.internal.div
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.getOrThrow
+import net.corda.finance.DOLLARS
+import net.corda.finance.flows.CashIssueFlow
+import net.corda.node.services.config.NotaryConfig
+import net.corda.testing.*
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
+import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.node.MockServices
+import org.junit.After
+import org.junit.Test
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+class NetworkParametersTest {
+    private val mockNet= MockNetwork(
+            MockNetworkParameters(networkSendManuallyPumped = true),
+            notarySpecs = listOf(MockNetwork.NotarySpec(DUMMY_NOTARY.name)))
+
+    @After
+    fun tearDown() {
+        mockNet.stopNodes()
+    }
+
+    // Epoch tests
+    @Test
+    fun `choose highest epoch`() {
+        var alice = mockNet.createPartyNode(ALICE.name)
+        val aliceDirectory = alice.internals.configuration.baseDirectory
+        assertEquals(DUMMY_NOTARY.name, alice.services.networkMapCache.notaryIdentities[0].name)
+        alice.dispose()
+        // Make parameters with higher epoch and different notary so it's easier to check them.
+        val secondParams = testNetworkParameters(notaries = listOf(NotaryInfo(DUMMY_BANK_A, true)), epoch = 10)
+        dropParametersToDir(aliceDirectory, "network-parameters-2", secondParams)
+        alice = mockNet.createNode(MockNodeParameters(alice.internals.id))
+        assertEquals(1, alice.services.networkMapCache.notaryIdentities.size)
+        assertEquals(DUMMY_BANK_A, alice.services.networkMapCache.notaryIdentities[0])
+        alice.dispose()
+        // Remove the params, and check that old ones were read in correctly.
+        assertTrue((aliceDirectory / "network-parameters-2").deleteIfExists())
+        alice = mockNet.createNode(MockNodeParameters(alice.internals.id))
+        assertEquals(1, alice.services.networkMapCache.notaryIdentities.size)
+        assertEquals(mockNet.defaultNotaryIdentity, alice.services.networkMapCache.notaryIdentities[0])
+    }
+
+    // Minimum Platform Version tests
+    @Test
+    fun `node shutdowns when on lower platform version than network`() {
+        val alice = mockNet.createUnstartedNode(MockNodeParameters(legalName = ALICE.name, forcedID = 100, version = MockServices.MOCK_VERSION_INFO.copy(platformVersion = 1)))
+        val aliceDirectory = mockNet.baseDirectory(100)
+        val netParams = testNetworkParameters(
+                notaries = listOf(NotaryInfo(mockNet.defaultNotaryIdentity, true)),
+                minimumPlatformVersion = 2)
+        dropParametersToDir(aliceDirectory, "network-parameters", netParams)
+        assertFails { alice.start() }
+    }
+
+    @Test
+    fun `node works fine when on higher platform version`() {
+        val alice = mockNet.createUnstartedNode(MockNodeParameters(legalName = ALICE.name, forcedID = 100, version = MockServices.MOCK_VERSION_INFO.copy(platformVersion = 2)))
+        val aliceDirectory = mockNet.baseDirectory(100)
+        val netParams = testNetworkParameters(
+                notaries = listOf(NotaryInfo(mockNet.defaultNotaryIdentity, true)),
+                minimumPlatformVersion = 1)
+        dropParametersToDir(aliceDirectory, "network-parameters", netParams)
+        alice.start()
+    }
+
+    // Notaries tests
+    @Test
+    fun `choosing notary not specified in network parameters will fail`() {
+        val fakeNotary = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME, configOverrides = {
+            val notary = NotaryConfig(false)
+            doReturn(notary).whenever(it).notary})) // TODO what?
+        val fakeNotaryId = fakeNotary.info.chooseIdentity()
+        assert(fakeNotary.internals.configuration.notary != null)
+        val alice = mockNet.createPartyNode(ALICE_NAME)
+        assert(fakeNotaryId !in alice.services.networkMapCache.notaryIdentities)
+        assertFails {
+            alice.services.startFlow(CashIssueFlow(500.DOLLARS, OpaqueBytes.of(0x01), fakeNotaryId)).resultFuture.getOrThrow()
+        }
+    }
+
+    // Helpers
+    private fun dropParametersToDir(dir: Path, filename: String, params: NetworkParameters) {
+        NetworkParametersCopier(params).install(dir, filename)
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
@@ -81,7 +81,7 @@ class NetworkParametersTest {
     fun `choosing notary not specified in network parameters will fail`() {
         val fakeNotary = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME, configOverrides = {
             val notary = NotaryConfig(false)
-            doReturn(notary).whenever(it).notary})) // TODO what?
+            doReturn(notary).whenever(it).notary}))
         val fakeNotaryId = fakeNotary.info.chooseIdentity()
         assert(fakeNotary.internals.configuration.notary != null)
         val alice = mockNet.createPartyNode(ALICE_NAME)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/NetworkParametersTest.kt
@@ -29,17 +29,6 @@ class NetworkParametersTest {
         mockNet.stopNodes()
     }
 
-    @Test
-    fun `only one network parameters file allowed in base directory`() {
-        val alice = mockNet.createUnstartedNode(MockNodeParameters(legalName = ALICE.name, forcedID = 100))
-        val aliceDirectory = mockNet.baseDirectory(100)
-        val firstParams = testNetworkParameters(notaries = listOf(NotaryInfo(DUMMY_NOTARY, true)), epoch = 10)
-        val secondParams = testNetworkParameters(notaries = listOf(NotaryInfo(DUMMY_BANK_A, true)), epoch = 10)
-        dropParametersToDir(aliceDirectory, "network-parameters", firstParams)
-        dropParametersToDir(aliceDirectory, "network-parameters-1", secondParams)
-        assertFails { alice.start() }
-    }
-
     // Minimum Platform Version tests
     @Test
     fun `node shutdowns when on lower platform version than network`() {
@@ -48,7 +37,7 @@ class NetworkParametersTest {
         val netParams = testNetworkParameters(
                 notaries = listOf(NotaryInfo(mockNet.defaultNotaryIdentity, true)),
                 minimumPlatformVersion = 2)
-        dropParametersToDir(aliceDirectory, "network-parameters", netParams)
+        dropParametersToDir(aliceDirectory, netParams)
         assertFails { alice.start() }
     }
 
@@ -59,7 +48,7 @@ class NetworkParametersTest {
         val netParams = testNetworkParameters(
                 notaries = listOf(NotaryInfo(mockNet.defaultNotaryIdentity, true)),
                 minimumPlatformVersion = 1)
-        dropParametersToDir(aliceDirectory, "network-parameters", netParams)
+        dropParametersToDir(aliceDirectory, netParams)
         alice.start()
     }
 
@@ -79,7 +68,7 @@ class NetworkParametersTest {
     }
 
     // Helpers
-    private fun dropParametersToDir(dir: Path, filename: String, params: NetworkParameters) {
-        NetworkParametersCopier(params).install(dir, filename)
+    private fun dropParametersToDir(dir: Path, params: NetworkParameters) {
+        NetworkParametersCopier(params).install(dir)
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
@@ -51,8 +51,8 @@ class NetworkMapTest {
     @Test
     fun `node correctly downloads and saves network parameters file on startup`() {
         internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone, initialiseSerialization = false) {
-            val aliceDir = baseDirectory(ALICE.name)
-            startNode(providedName = ALICE.name).getOrThrow()
+            val aliceDir = baseDirectory(ALICE_NAME)
+            startNode(providedName = ALICE_NAME).getOrThrow()
             val networkParameters = Files.list(aliceDir).toList().single { NETWORK_PARAMS_FILE_NAME == it.fileName.toString() }
                     .readAll().deserialize<SignedData<NetworkParameters>>().verified()
             assertEquals(NetworkMapServer.stubNetworkParameter, networkParameters)

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
@@ -4,6 +4,7 @@ import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.seconds
 import net.corda.testing.node.internal.CompatibilityZoneParams
 import net.corda.testing.ALICE_NAME
+import net.corda.testing.SerializationEnvironmentRule
 import net.corda.testing.BOB_NAME
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.PortAllocation
@@ -12,10 +13,14 @@ import net.corda.testing.node.network.NetworkMapServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import java.net.URL
 
 class NetworkMapTest {
+    @Rule
+    @JvmField
+    val testSerialization = SerializationEnvironmentRule(true)
     private val cacheTimeout = 1.seconds
     private val portAllocation = PortAllocation.Incremental(10000)
 
@@ -36,7 +41,7 @@ class NetworkMapTest {
 
     @Test
     fun `nodes can see each other using the http network map`() {
-        internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone) {
+        internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone, initialiseSerialization = false) {
             val alice = startNode(providedName = ALICE_NAME)
             val bob = startNode(providedName = BOB_NAME)
             val notaryNode = defaultNotaryNode.get()
@@ -51,7 +56,7 @@ class NetworkMapTest {
 
     @Test
     fun `nodes process network map add updates correctly when adding new node to network map`() {
-        internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone) {
+        internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone, initialiseSerialization = false) {
             val alice = startNode(providedName = ALICE_NAME)
             val notaryNode = defaultNotaryNode.get()
             val aliceNode = alice.get()
@@ -72,7 +77,7 @@ class NetworkMapTest {
 
     @Test
     fun `nodes process network map remove updates correctly`() {
-        internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone) {
+        internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone, initialiseSerialization = false) {
             val alice = startNode(providedName = ALICE_NAME)
             val bob = startNode(providedName = BOB_NAME)
             val notaryNode = defaultNotaryNode.get()

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
@@ -49,15 +49,16 @@ class NetworkMapTest {
     }
 
     @Test
-    fun `node corectly downloads and saves network parameters file on startup`() {
+    fun `node correctly downloads and saves network parameters file on startup`() {
         internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone, initialiseSerialization = false) {
             val aliceDir = baseDirectory(ALICE.name)
             startNode(providedName = ALICE.name).getOrThrow()
-            val networkParameters = Files.list(aliceDir).filter { NETWORK_PARAMS_FILE_NAME == it.fileName.toString() }.toList()[0]
+            val networkParameters = Files.list(aliceDir).toList().single { NETWORK_PARAMS_FILE_NAME == it.fileName.toString() }
                     .readAll().deserialize<SignedData<NetworkParameters>>().verified()
             assertEquals(NetworkMapServer.stubNetworkParameter, networkParameters)
         }
     }
+
     @Test
     fun `nodes can see each other using the http network map`() {
         internalDriver(portAllocation = portAllocation, compatibilityZone = compatibilityZone, initialiseSerialization = false) {

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -52,7 +52,7 @@ class NodeRegistrationTest {
 
     @Before
     fun startServer() {
-        server = NetworkMapServer(1.minutes, portAllocation.nextHostAndPort(), registrationHandler)
+        server = NetworkMapServer(1.minutes, portAllocation.nextHostAndPort(), rootCertAndKeyPair, registrationHandler)
         serverHostAndPort = server.start()
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -14,6 +14,7 @@ import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_CLIENT_CA
 import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_INTERMEDIATE_CA
 import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_ROOT_CA
+import net.corda.testing.SerializationEnvironmentRule
 import net.corda.testing.node.internal.CompatibilityZoneParams
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.node.internal.internalDriver
@@ -24,6 +25,7 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -38,6 +40,9 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 class NodeRegistrationTest {
+    @Rule
+    @JvmField
+    val testSerialization = SerializationEnvironmentRule(true)
     private val portAllocation = PortAllocation.Incremental(13000)
     private val rootCertAndKeyPair = createSelfKeyAndSelfSignedCertificate()
     private val registrationHandler = RegistrationHandler(rootCertAndKeyPair)
@@ -64,7 +69,8 @@ class NodeRegistrationTest {
         internalDriver(
                 portAllocation = portAllocation,
                 notarySpecs = emptyList(),
-                compatibilityZone = compatibilityZone
+                compatibilityZone = compatibilityZone,
+                initialiseSerialization = false
         ) {
             startNode(providedName = CordaX500Name("Alice", "London", "GB")).getOrThrow()
             assertThat(registrationHandler.idsPolled).contains("Alice")

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -12,7 +12,6 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
-import net.corda.core.crypto.sha256
 import net.corda.core.crypto.sign
 import net.corda.core.flows.*
 import net.corda.core.identity.CordaX500Name
@@ -245,8 +244,8 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
         val networkMapUpdater = NetworkMapUpdater(services.networkMapCache,
                 NodeInfoWatcher(configuration.baseDirectory, getRxIoScheduler(), Duration.ofMillis(configuration.additionalNodeInfoPollingFrequencyMsec)),
                 networkMapClient,
-                currentParametersHash)
-        networkMapUpdater.parametersUpdates.subscribe { handleNetworkParametersUpdate(it) }
+                networkParameters.serialize().hash)
+        networkMapUpdater.parametersUpdates.subscribe({handleNetworkParametersUpdate(it)})
         runOnStop += networkMapUpdater::close
 
         networkMapUpdater.updateNodeInfo(services.myInfo) {
@@ -278,8 +277,9 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
 
     // TODO NetworkParameters updates are not implemented yet. This handling is not ideal, because we simply shutdown node, which can cause some problems.
     private fun handleNetworkParametersUpdate(newParametersHash: SecureHash) {
-        throw IllegalArgumentException("Network map is advertising different parametersHash than the ones node is currently using.\n" +
-                "New hash: $newParametersHash. Please update parameters file.")
+        log.error("Network map is advertising different parametersHash than the ones node is currently using.\n" +
+                "Our hash: ${ networkParameters.serialize().hash }, new hash: $newParametersHash. Please update parameters file.")
+        stop()
     }
 
     open fun startShell(rpcOps: CordaRPCOps) {
@@ -646,28 +646,24 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
         return PersistentKeyManagementService(identityService, keyPairs)
     }
 
-    private fun readNetworkParameters(): SecureHash {
+    private fun readNetworkParameters() {
         var latestEpoch = 0
         var latestParams: NetworkParameters? = null
-        var latestParamsHash: SecureHash? = null
         // Load network parameters with the latest known epoch.
         for (paramFile in Files.list(configuration.baseDirectory)) {
             if ("network-parameters" !in paramFile.toString())
                 continue
-            val contents = paramFile.readAll()
-            val params = contents.deserialize<SignedData<NetworkParameters>>().verified()
+            val params = paramFile.readAll().deserialize<SignedData<NetworkParameters>>().verified()
             val epoch = params.epoch
             if (latestEpoch < epoch) {
                 latestEpoch = epoch
                 latestParams = params
-                latestParamsHash = contents.sha256()
             }
         }
         checkNotNull(latestParams) { "Couldn't find network parameters file" }
         networkParameters = latestParams!!
         log.info("Loaded the latest known version of network parameters $latestParams")
         check(networkParameters.minimumPlatformVersion <= versionInfo.platformVersion) { "Node is too old for the network" }
-        return latestParamsHash!!
     }
 
     private fun makeCoreNotaryService(notaryConfig: NotaryConfig, database: CordaPersistence): NotaryService {

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -144,9 +144,9 @@ open class Node(configuration: NodeConfiguration,
         val advertisedAddress = info.addresses.single()
 
         printBasicNodeInfo("Incoming connection address", advertisedAddress.toString())
-        rpcMessagingClient = RPCMessagingClient(configuration, serverAddress)
+        rpcMessagingClient = RPCMessagingClient(configuration, serverAddress, networkParameters.maxMessageSize)
         verifierMessagingClient = when (configuration.verifierType) {
-            VerifierType.OutOfProcess -> VerifierMessagingClient(configuration, serverAddress, services.monitoringService.metrics)
+            VerifierType.OutOfProcess -> VerifierMessagingClient(configuration, serverAddress, services.monitoringService.metrics, networkParameters.maxMessageSize)
             VerifierType.InMemory -> null
         }
         return P2PMessagingClient(
@@ -156,12 +156,13 @@ open class Node(configuration: NodeConfiguration,
                 info.legalIdentities[0].owningKey,
                 serverThread,
                 database,
-                advertisedAddress)
+                advertisedAddress,
+                networkParameters.maxMessageSize)
     }
 
     private fun makeLocalMessageBroker(): NetworkHostAndPort {
         with(configuration) {
-            messageBroker = ArtemisMessagingServer(this, p2pAddress.port, rpcAddress?.port, services.networkMapCache, securityManager)
+            messageBroker = ArtemisMessagingServer(this, p2pAddress.port, rpcAddress?.port, services.networkMapCache, securityManager, networkParameters.maxMessageSize)
             return NetworkHostAndPort("localhost", p2pAddress.port)
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingClient.kt
@@ -30,7 +30,7 @@ class ArtemisMessagingClient(private val config: SSLConfiguration, private val s
             // would be the default and the two lines below can be deleted.
             connectionTTL = -1
             clientFailureCheckPeriod = -1
-            minLargeMessageSize = maxMessageSize // TODO check that option!
+            minLargeMessageSize = maxMessageSize
             isUseGlobalPools = nodeSerializationEnv != null
         }
         val sessionFactory = locator.createSessionFactory()

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingClient.kt
@@ -10,7 +10,7 @@ import net.corda.nodeapi.internal.config.SSLConfiguration
 import org.apache.activemq.artemis.api.core.client.*
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient.DEFAULT_ACK_BATCH_SIZE
 
-class ArtemisMessagingClient(private val config: SSLConfiguration, private val serverAddress: NetworkHostAndPort) {
+class ArtemisMessagingClient(private val config: SSLConfiguration, private val serverAddress: NetworkHostAndPort, private val maxMessageSize: Int) {
     companion object {
         private val log = loggerFor<ArtemisMessagingClient>()
     }
@@ -30,7 +30,7 @@ class ArtemisMessagingClient(private val config: SSLConfiguration, private val s
             // would be the default and the two lines below can be deleted.
             connectionTTL = -1
             clientFailureCheckPeriod = -1
-            minLargeMessageSize = ArtemisMessagingServer.MAX_FILE_SIZE
+            minLargeMessageSize = maxMessageSize // TODO check that option!
             isUseGlobalPools = nodeSerializationEnv != null
         }
         val sessionFactory = locator.createSessionFactory()

--- a/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
@@ -68,7 +68,8 @@ class P2PMessagingClient(config: NodeConfiguration,
                          private val myIdentity: PublicKey,
                          private val nodeExecutor: AffinityExecutor.ServiceAffinityExecutor,
                          private val database: CordaPersistence,
-                         advertisedAddress: NetworkHostAndPort = serverAddress
+                         advertisedAddress: NetworkHostAndPort = serverAddress,
+                         private val maxMessageSize: Int
 ) : SingletonSerializeAsToken(), MessagingService {
     companion object {
         private val log = contextLogger()
@@ -146,7 +147,7 @@ class P2PMessagingClient(config: NodeConfiguration,
 
     override val myAddress: SingleMessageRecipient = NodeAddress(myIdentity, advertisedAddress)
     private val messageRedeliveryDelaySeconds = config.messageRedeliveryDelaySeconds.toLong()
-    private val artemis = ArtemisMessagingClient(config, serverAddress)
+    private val artemis = ArtemisMessagingClient(config, serverAddress, maxMessageSize)
     private val state = ThreadBox(InnerState())
     private val handlers = CopyOnWriteArrayList<Handler>()
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RPCMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RPCMessagingClient.kt
@@ -12,8 +12,8 @@ import net.corda.nodeapi.internal.crypto.getX509Certificate
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
 
-class RPCMessagingClient(private val config: SSLConfiguration, serverAddress: NetworkHostAndPort) : SingletonSerializeAsToken() {
-    private val artemis = ArtemisMessagingClient(config, serverAddress)
+class RPCMessagingClient(private val config: SSLConfiguration, serverAddress: NetworkHostAndPort, private val maxMessageSize: Int) : SingletonSerializeAsToken() {
+    private val artemis = ArtemisMessagingClient(config, serverAddress, maxMessageSize)
     private var rpcServer: RPCServer? = null
 
     fun start(rpcOps: RPCOps, securityManager: RPCSecurityManager) = synchronized(this) {

--- a/node/src/main/kotlin/net/corda/node/services/messaging/VerifierMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/VerifierMessagingClient.kt
@@ -17,13 +17,13 @@ import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.client.*
 import java.util.concurrent.*
 
-class VerifierMessagingClient(config: SSLConfiguration, serverAddress: NetworkHostAndPort, metrics: MetricRegistry) : SingletonSerializeAsToken() {
+class VerifierMessagingClient(config: SSLConfiguration, serverAddress: NetworkHostAndPort, metrics: MetricRegistry, private val maxMessageSize: Int) : SingletonSerializeAsToken() {
     companion object {
         private val log = loggerFor<VerifierMessagingClient>()
         private val verifierResponseAddress = "$VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX.${random63BitValue()}"
     }
 
-    private val artemis = ArtemisMessagingClient(config, serverAddress)
+    private val artemis = ArtemisMessagingClient(config, serverAddress, maxMessageSize)
     /** An executor for sending messages */
     private val messagingExecutor = AffinityExecutor.ServiceAffinityExecutor("Messaging", 1)
     private var verificationResponseConsumer: ClientConsumer? = null

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -68,7 +68,7 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val trustedRoot: X509C
         }
     }
 
-    fun getNetworkParameter(networkParameterHash: SecureHash): NetworkParameters? {
+    fun getNetworkParameter(networkParameterHash: SecureHash): SignedData<NetworkParameters>? {
         val conn = URL("$networkMapUrl/network-parameter/$networkParameterHash").openHttpConnection()
         return if (conn.responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
             null

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -18,9 +18,7 @@ import net.corda.nodeapi.internal.SignedNetworkMap
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import okhttp3.CacheControl
 import okhttp3.Headers
-import rx.Observable
 import rx.Subscription
-import rx.subjects.PublishSubject
 import java.io.BufferedReader
 import java.io.Closeable
 import java.net.HttpURLConnection
@@ -99,8 +97,6 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
     private val executor = Executors.newSingleThreadScheduledExecutor(NamedThreadFactory("Network Map Updater Thread", Executors.defaultThreadFactory()))
     private var fileWatcherSubscription: Subscription? = null
 
-    val parametersUpdates: PublishSubject<SecureHash> = PublishSubject.create<SecureHash>()
-
     override fun close() {
         fileWatcherSubscription?.unsubscribe()
         MoreExecutors.shutdownAndAwaitTermination(executor, 50, TimeUnit.SECONDS)
@@ -136,7 +132,7 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
                     if (currentParametersHash != networkMap.networkParameterHash) {
                         logger.error("Node is using parameters with hash: $currentParametersHash but network map is advertising: ${networkMap.networkParameterHash}.\n" +
                                 "Please update node to use correct network parameters file.\"")
-                        parametersUpdates.onNext(networkMap.networkParameterHash)
+                        System.exit(1)
                     }
                     val currentNodeHashes = networkMapCache.allNodeHashes
                     val hashesFromNetworkMap = networkMap.nodeInfoHashes

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -207,9 +207,6 @@ open class PersistentNetworkMapCache(
             getAllInfos(session).map { it.toNodeInfo() }
         }
 
-    // Changes related to NetworkMap redesign
-    // TODO It will be properly merged into network map cache after services removal.
-
     private fun getAllInfos(session: Session): List<NodeInfoSchemaV1.PersistentNodeInfo> {
         val criteria = session.criteriaBuilder.createQuery(NodeInfoSchemaV1.PersistentNodeInfo::class.java)
         criteria.select(criteria.from(NodeInfoSchemaV1.PersistentNodeInfo::class.java))

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -289,7 +289,6 @@ open class PersistentNetworkMapCache(
         else result.map { it.toNodeInfo() }.singleOrNull() ?: throw IllegalStateException("More than one node with the same host and port")
     }
 
-
     /** Object Relational Mapping support. */
     private fun generateMappedObject(nodeInfo: NodeInfo): NodeInfoSchemaV1.PersistentNodeInfo {
         return NodeInfoSchemaV1.PersistentNodeInfo(

--- a/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
@@ -12,10 +12,7 @@ import net.corda.nodeapi.internal.NetworkParametersCopier
 import net.corda.nodeapi.internal.NotaryInfo
 import net.corda.testing.*
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.node.MockNetwork
-import net.corda.testing.node.MockNetworkParameters
-import net.corda.testing.node.MockNodeParameters
-import net.corda.testing.node.MockServices
+import net.corda.testing.node.*
 import org.junit.After
 import org.junit.Test
 import java.nio.file.Path
@@ -25,7 +22,7 @@ import org.assertj.core.api.Assertions.*
 class NetworkParametersTest {
     private val mockNet = MockNetwork(
             MockNetworkParameters(networkSendManuallyPumped = true),
-            notarySpecs = listOf(MockNetwork.NotarySpec(DUMMY_NOTARY.name)))
+            notarySpecs = listOf(MockNetwork.NotarySpec(DUMMY_NOTARY_NAME)))
 
     @After
     fun tearDown() {
@@ -35,7 +32,7 @@ class NetworkParametersTest {
     // Minimum Platform Version tests
     @Test
     fun `node shutdowns when on lower platform version than network`() {
-        val alice = mockNet.createUnstartedNode(MockNodeParameters(legalName = ALICE.name, forcedID = 100, version = MockServices.MOCK_VERSION_INFO.copy(platformVersion = 1)))
+        val alice = mockNet.createUnstartedNode(MockNodeParameters(legalName = ALICE_NAME, forcedID = 100, version = MockServices.MOCK_VERSION_INFO.copy(platformVersion = 1)))
         val aliceDirectory = mockNet.baseDirectory(100)
         val netParams = testNetworkParameters(
                 notaries = listOf(NotaryInfo(mockNet.defaultNotaryIdentity, true)),
@@ -46,7 +43,7 @@ class NetworkParametersTest {
 
     @Test
     fun `node works fine when on higher platform version`() {
-        val alice = mockNet.createUnstartedNode(MockNodeParameters(legalName = ALICE.name, forcedID = 100, version = MockServices.MOCK_VERSION_INFO.copy(platformVersion = 2)))
+        val alice = mockNet.createUnstartedNode(MockNodeParameters(legalName = ALICE_NAME, forcedID = 100, version = MockServices.MOCK_VERSION_INFO.copy(platformVersion = 2)))
         val aliceDirectory = mockNet.baseDirectory(100)
         val netParams = testNetworkParameters(
                 notaries = listOf(NotaryInfo(mockNet.defaultNotaryIdentity, true)),

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -163,7 +163,7 @@ class ArtemisMessagingTests {
         return Pair(messagingClient, receivedMessages)
     }
 
-    private fun createMessagingClient(server: NetworkHostAndPort = NetworkHostAndPort("localhost", serverPort), platformVersion: Int = 1): P2PMessagingClient {
+    private fun createMessagingClient(server: NetworkHostAndPort = NetworkHostAndPort("localhost", serverPort), platformVersion: Int = 1, maxMessageSize: Int = MAX_MESSAGE_SIZE): P2PMessagingClient {
         return database.transaction {
             P2PMessagingClient(
                     config,
@@ -171,16 +171,16 @@ class ArtemisMessagingTests {
                     server,
                     identity.public,
                     ServiceAffinityExecutor("ArtemisMessagingTests", 1),
-                    database
-            ).apply {
+                    database,
+                    maxMessageSize = maxMessageSize).apply {
                 config.configureWithDevSSLCertificate()
                 messagingClient = this
             }
         }
     }
 
-    private fun createMessagingServer(local: Int = serverPort, rpc: Int = rpcPort): ArtemisMessagingServer {
-        return ArtemisMessagingServer(config, local, rpc, networkMapCache, securityManager).apply {
+    private fun createMessagingServer(local: Int = serverPort, rpc: Int = rpcPort, maxMessageSize: Int = MAX_MESSAGE_SIZE): ArtemisMessagingServer {
+        return ArtemisMessagingServer(config, local, rpc, networkMapCache, securityManager, maxMessageSize).apply {
             config.configureWithDevSSLCertificate()
             messagingServer = this
         }

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
@@ -6,9 +6,7 @@ import net.corda.core.internal.cert
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.seconds
 import net.corda.node.services.network.TestNodeInfoFactory.createNodeInfo
-import net.corda.testing.DEV_CA
 import net.corda.testing.DEV_TRUST_ROOT
-import net.corda.testing.ROOT_CA
 import net.corda.testing.SerializationEnvironmentRule
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.node.network.NetworkMapServer

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
@@ -69,7 +69,7 @@ class NetworkMapClientTest {
     @Test
     fun `download NetworkParameter correctly`() {
         // The test server returns same network parameter for any hash.
-        val networkParameter = networkMapClient.getNetworkParameter(SecureHash.randomSHA256())
+        val networkParameter = networkMapClient.getNetworkParameter(SecureHash.randomSHA256())?.verified()
         assertNotNull(networkParameter)
         assertEquals(NetworkMapServer.stubNetworkParameter, networkParameter)
     }

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -53,7 +53,7 @@ class NetworkMapUpdaterTest {
 
         val scheduler = TestScheduler()
         val fileWatcher = NodeInfoWatcher(baseDir, scheduler)
-        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, networkMapClient)
+        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, networkMapClient, SecureHash.randomSHA256())
 
         // Publish node info for the first time.
         updater.updateNodeInfo(nodeInfo1) { signedNodeInfo }
@@ -88,6 +88,7 @@ class NetworkMapUpdaterTest {
         val nodeInfo3 = TestNodeInfoFactory.createNodeInfo("Info 3")
         val nodeInfo4 = TestNodeInfoFactory.createNodeInfo("Info 4")
         val fileNodeInfo = TestNodeInfoFactory.createNodeInfo("Info from file")
+        val parametersHash = SecureHash.randomSHA256()
         val networkMapCache = getMockNetworkMapCache()
 
         val nodeInfoMap = ConcurrentHashMap<SecureHash, SignedData<NodeInfo>>()
@@ -96,13 +97,13 @@ class NetworkMapUpdaterTest {
                 val signedNodeInfo: SignedData<NodeInfo> = uncheckedCast(it.arguments.first())
                 nodeInfoMap.put(signedNodeInfo.verified().serialize().hash, signedNodeInfo)
             }
-            on { getNetworkMap() }.then { NetworkMapResponse(NetworkMap(nodeInfoMap.keys.toList(), SecureHash.randomSHA256()), 100.millis) }
+            on { getNetworkMap() }.then { NetworkMapResponse(NetworkMap(nodeInfoMap.keys.toList(), parametersHash), 100.millis) }
             on { getNodeInfo(any()) }.then { nodeInfoMap[it.arguments.first()]?.verified() }
         }
 
         val scheduler = TestScheduler()
         val fileWatcher = NodeInfoWatcher(baseDir, scheduler)
-        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, networkMapClient)
+        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, networkMapClient, parametersHash)
 
         // Test adding new node.
         networkMapClient.publish(nodeInfo1)
@@ -142,6 +143,7 @@ class NetworkMapUpdaterTest {
         val nodeInfo3 = TestNodeInfoFactory.createNodeInfo("Info 3")
         val nodeInfo4 = TestNodeInfoFactory.createNodeInfo("Info 4")
         val fileNodeInfo = TestNodeInfoFactory.createNodeInfo("Info from file")
+        val parametersHash = SecureHash.randomSHA256()
         val networkMapCache = getMockNetworkMapCache()
 
         val nodeInfoMap = ConcurrentHashMap<SecureHash, SignedData<NodeInfo>>()
@@ -150,13 +152,13 @@ class NetworkMapUpdaterTest {
                 val signedNodeInfo: SignedData<NodeInfo> = uncheckedCast(it.arguments.first())
                 nodeInfoMap.put(signedNodeInfo.verified().serialize().hash, signedNodeInfo)
             }
-            on { getNetworkMap() }.then { NetworkMapResponse(NetworkMap(nodeInfoMap.keys.toList(), SecureHash.randomSHA256()), 100.millis) }
+            on { getNetworkMap() }.then { NetworkMapResponse(NetworkMap(nodeInfoMap.keys.toList(), parametersHash), 100.millis) }
             on { getNodeInfo(any()) }.then { nodeInfoMap[it.arguments.first()]?.verified() }
         }
 
         val scheduler = TestScheduler()
         val fileWatcher = NodeInfoWatcher(baseDir, scheduler)
-        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, networkMapClient)
+        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, networkMapClient, parametersHash)
 
         // Add all nodes.
         NodeInfoWatcher.saveToFile(baseDir / CordformNode.NODE_INFO_DIRECTORY, fileNodeInfo)
@@ -200,7 +202,7 @@ class NetworkMapUpdaterTest {
 
         val scheduler = TestScheduler()
         val fileWatcher = NodeInfoWatcher(baseDir, scheduler)
-        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, null)
+        val updater = NetworkMapUpdater(networkMapCache, fileWatcher, null, SecureHash.randomSHA256())
 
         // Not subscribed yet.
         verify(networkMapCache, times(0)).addNode(any())

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -28,14 +28,15 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 
 class NetworkMapUpdaterTest {
+    companion object {
+        val NETWORK_PARAMS_HASH = SecureHash.randomSHA256()
+    }
+
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule(true)
     private val jimFs = Jimfs.newFileSystem(Configuration.unix())
     private val baseDir = jimFs.getPath("/node")
-    companion object {
-        val NETWORK_PARAMS_HASH = SecureHash.randomSHA256()
-    }
 
     @Test
     fun `publish node info`() {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -22,6 +22,7 @@ import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SerializationWhitelist
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
+import net.corda.node.VersionInfo
 import net.corda.core.utilities.seconds
 import net.corda.node.internal.AbstractNode
 import net.corda.node.internal.StartedNode
@@ -91,7 +92,8 @@ data class MockNodeParameters(
         val forcedID: Int? = null,
         val legalName: CordaX500Name? = null,
         val entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
-        val configOverrides: (NodeConfiguration) -> Any? = {}) {
+        val configOverrides: (NodeConfiguration) -> Any? = {},
+        val version: VersionInfo = MOCK_VERSION_INFO) {
     fun setForcedID(forcedID: Int?) = copy(forcedID = forcedID)
     fun setLegalName(legalName: CordaX500Name?) = copy(legalName = legalName)
     fun setEntropyRoot(entropyRoot: BigInteger) = copy(entropyRoot = entropyRoot)
@@ -102,7 +104,8 @@ data class MockNodeArgs(
         val config: NodeConfiguration,
         val network: MockNetwork,
         val id: Int,
-        val entropyRoot: BigInteger
+        val entropyRoot: BigInteger,
+        val version: VersionInfo = MOCK_VERSION_INFO
 )
 
 /**
@@ -241,7 +244,7 @@ class MockNetwork(defaultParameters: MockNetworkParameters = MockNetworkParamete
     open class MockNode(args: MockNodeArgs) : AbstractNode(
             args.config,
             TestClock(Clock.systemUTC()),
-            MOCK_VERSION_INFO,
+            args.version,
             CordappLoader.createDefaultWithTestPackages(args.config, args.network.cordappPackages),
             args.network.busyLatch
     ) {
@@ -392,7 +395,7 @@ class MockNetwork(defaultParameters: MockNetworkParameters = MockNetworkParamete
             doReturn(makeTestDataSourceProperties("node_${id}_net_$networkId")).whenever(it).dataSourceProperties
             parameters.configOverrides(it)
         }
-        val node = nodeFactory(MockNodeArgs(config, this, id, parameters.entropyRoot))
+        val node = nodeFactory(MockNodeArgs(config, this, id, parameters.entropyRoot, parameters.version))
         _nodes += node
         if (start) {
             node.start()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -245,6 +245,7 @@ class DriverDSLImpl(
     }
 
     internal fun startCordformNodes(cordforms: List<CordformNode>): CordaFuture<*> {
+        check(compatibilityZone == null) { "Cordform nodes should be run without compatibilityZone configuration" }
         val clusterNodes = HashMultimap.create<ClusterType, CordaX500Name>()
         val notaryInfos = ArrayList<NotaryInfo>()
 
@@ -354,7 +355,7 @@ class DriverDSLImpl(
         }
         val notaryInfos = generateNotaryIdentities()
         // The network parameters must be serialised before starting any of the nodes
-        networkParameters = NetworkParametersCopier(testNetworkParameters(notaryInfos))
+        if (compatibilityZone == null) networkParameters = NetworkParametersCopier(testNetworkParameters(notaryInfos))
         val nodeHandles = startNotaries()
         _notaries = notaryInfos.zip(nodeHandles) { (identity, validating), nodes -> NotaryHandle(identity, validating, nodes) }
     }
@@ -519,7 +520,7 @@ class DriverDSLImpl(
         val configuration = config.parseAsNodeConfiguration()
         val baseDirectory = configuration.baseDirectory.createDirectories()
         nodeInfoFilesCopier?.addConfig(baseDirectory)
-        networkParameters!!.install(baseDirectory)
+        networkParameters?.install(baseDirectory)
         val onNodeExit: () -> Unit = {
             nodeInfoFilesCopier?.removeConfig(baseDirectory)
             countObservables.remove(configuration.myLegalName)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -25,6 +25,7 @@ import net.corda.nodeapi.ConnectionDirection
 import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.internal.config.User
 import net.corda.nodeapi.internal.serialization.KRYO_RPC_CLIENT_CONTEXT
+import net.corda.testing.MAX_MESSAGE_SIZE
 import net.corda.testing.driver.JmxPolicy
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.node.NotarySpec
@@ -430,7 +431,7 @@ data class RPCDriverDSL(
             brokerHandle: RpcBrokerHandle
     ): RpcServerHandle {
         val locator = ActiveMQClient.createServerLocatorWithoutHA(brokerHandle.clientTransportConfiguration).apply {
-            minLargeMessageSize = ArtemisMessagingServer.MAX_FILE_SIZE
+            minLargeMessageSize = MAX_MESSAGE_SIZE
             isUseGlobalPools = false
         }
         val rpcSecurityManager = RPCSecurityManagerImpl.fromUserList(users = listOf(rpcUser), id = AuthServiceId("TEST_SECURITY_MANAGER"))

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -227,8 +227,8 @@ data class RPCDriverDSL(
     fun <I : RPCOps> startInVmRpcServer(
             rpcUser: User = rpcTestUser,
             nodeLegalName: CordaX500Name = fakeNodeLegalName,
-            maxFileSize: Int = ArtemisMessagingServer.MAX_FILE_SIZE,
-            maxBufferedBytesPerClient: Long = 10L * ArtemisMessagingServer.MAX_FILE_SIZE,
+            maxFileSize: Int = MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Long = 10L * MAX_MESSAGE_SIZE,
             configuration: RPCServerConfiguration = RPCServerConfiguration.default,
             ops: I
     ): CordaFuture<RpcServerHandle> {
@@ -295,8 +295,8 @@ data class RPCDriverDSL(
             serverName: String = "driver-rpc-server-${random63BitValue()}",
             rpcUser: User = rpcTestUser,
             nodeLegalName: CordaX500Name = fakeNodeLegalName,
-            maxFileSize: Int = ArtemisMessagingServer.MAX_FILE_SIZE,
-            maxBufferedBytesPerClient: Long = 10L * ArtemisMessagingServer.MAX_FILE_SIZE,
+            maxFileSize: Int = MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Long = 10L * MAX_MESSAGE_SIZE,
             configuration: RPCServerConfiguration = RPCServerConfiguration.default,
             customPort: NetworkHostAndPort? = null,
             ops: I
@@ -378,8 +378,8 @@ data class RPCDriverDSL(
     fun startRpcBroker(
             serverName: String = "driver-rpc-server-${random63BitValue()}",
             rpcUser: User = rpcTestUser,
-            maxFileSize: Int = ArtemisMessagingServer.MAX_FILE_SIZE,
-            maxBufferedBytesPerClient: Long = 10L * ArtemisMessagingServer.MAX_FILE_SIZE,
+            maxFileSize: Int = MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Long = 10L * MAX_MESSAGE_SIZE,
             customPort: NetworkHostAndPort? = null
     ): CordaFuture<RpcBrokerHandle> {
         val hostAndPort = customPort ?: driverDSL.portAllocation.nextHostAndPort()
@@ -402,8 +402,8 @@ data class RPCDriverDSL(
 
     fun startInVmRpcBroker(
             rpcUser: User = rpcTestUser,
-            maxFileSize: Int = ArtemisMessagingServer.MAX_FILE_SIZE,
-            maxBufferedBytesPerClient: Long = 10L * ArtemisMessagingServer.MAX_FILE_SIZE
+            maxFileSize: Int = MAX_MESSAGE_SIZE,
+            maxBufferedBytesPerClient: Long = 10L * MAX_MESSAGE_SIZE
     ): CordaFuture<RpcBrokerHandle> {
         return driverDSL.executorService.fork {
             val artemisConfig = createInVmRpcServerArtemisConfig(maxFileSize, maxBufferedBytesPerClient)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/network/NetworkMapServer.kt
@@ -97,12 +97,7 @@ class NetworkMapServer(cacheTimeout: Duration,
     @Path("network-map")
     class InMemoryNetworkMapService(private val cacheTimeout: Duration, private val networkMapKeyAndCert: CertificateAndKeyPair) {
         private val nodeInfoMap = mutableMapOf<SecureHash, SignedData<NodeInfo>>()
-        private val serializedParameters = {
-            val serialize = stubNetworkParameter.serialize()
-            val signature = networkMapKeyAndCert.keyPair.sign(serialize)
-            SignedData(serialize, signature).serialize()
-        }()
-        private val parametersHash = serializedParameters.hash
+        private val parametersHash = stubNetworkParameter.serialize().hash
 
         @POST
         @Path("publish")

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/network/NetworkMapServer.kt
@@ -36,6 +36,7 @@ import javax.ws.rs.core.Response.ok
 
 class NetworkMapServer(cacheTimeout: Duration,
                        hostAndPort: NetworkHostAndPort,
+                       root_ca: CertificateAndKeyPair = ROOT_CA, // Default to ROOT_CA for testing.
                        vararg additionalServices: Any) : Closeable {
     companion object {
         val stubNetworkParameter = NetworkParameters(1, emptyList(), 40000, 40000, Instant.now(), 10)
@@ -53,9 +54,7 @@ class NetworkMapServer(cacheTimeout: Duration,
     }
 
     private val server: Server
-    // Default to ROOT_CA for testing.
-    // TODO: make this configurable?
-    private val service = InMemoryNetworkMapService(cacheTimeout, networkMapKeyAndCert(ROOT_CA))
+    private val service = InMemoryNetworkMapService(cacheTimeout, networkMapKeyAndCert(root_ca))
 
     init {
         server = Server(InetSocketAddress(hostAndPort.host, hostAndPort.port)).apply {

--- a/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
+++ b/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
@@ -1,18 +1,23 @@
 package net.corda.testing.common.internal
 
-import net.corda.core.utilities.days
 import net.corda.nodeapi.internal.NetworkParameters
 import net.corda.nodeapi.internal.NotaryInfo
 import java.time.Instant
 
-fun testNetworkParameters(notaries: List<NotaryInfo>): NetworkParameters {
+fun testNetworkParameters(
+        notaries: List<NotaryInfo>,
+        minimumPlatformVersion: Int = 1,
+        modifiedTime: Instant = Instant.now(),
+        maxMessageSize: Int = 40000,
+        maxTransactionSize: Int = 40000,
+        epoch: Int = 1
+): NetworkParameters {
     return NetworkParameters(
-            minimumPlatformVersion = 1,
+            minimumPlatformVersion = minimumPlatformVersion,
             notaries = notaries,
-            modifiedTime = Instant.now(),
-            eventHorizon = 10000.days,
-            maxMessageSize = 40000,
-            maxTransactionSize = 40000,
-            epoch = 1
+            modifiedTime = modifiedTime,
+            maxMessageSize = maxMessageSize,
+            maxTransactionSize = maxTransactionSize,
+            epoch = epoch
     )
 }

--- a/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
+++ b/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
@@ -8,7 +8,7 @@ fun testNetworkParameters(
         notaries: List<NotaryInfo>,
         minimumPlatformVersion: Int = 1,
         modifiedTime: Instant = Instant.now(),
-        maxMessageSize: Int = 40000,
+        maxMessageSize: Int = 1048576,
         maxTransactionSize: Int = 40000,
         epoch: Int = 1
 ): NetworkParameters {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
@@ -44,4 +44,4 @@ fun dummyCommand(vararg signers: PublicKey = arrayOf(generateKeyPair().public)) 
 object DummyCommandData : TypeOnlyCommandData()
 
 /** Maximum artemis message size. 10 MiB maximum allowed file size for attachments, including message headers. */
-val MAX_MESSAGE_SIZE: Int = 1048576
+const val MAX_MESSAGE_SIZE: Int = 1048576

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/TestConstants.kt
@@ -42,3 +42,6 @@ val DEV_TRUST_ROOT: X509CertificateHolder by lazy {
 fun dummyCommand(vararg signers: PublicKey = arrayOf(generateKeyPair().public)) = Command<TypeOnlyCommandData>(DummyCommandData, signers.toList())
 
 object DummyCommandData : TypeOnlyCommandData()
+
+/** Maximum artemis message size. 10 MiB maximum allowed file size for attachments, including message headers. */
+val MAX_MESSAGE_SIZE: Int = 1048576

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeController.kt
@@ -143,7 +143,6 @@ class NodeController(check: atRuntime = ::checkExists) : Controller() {
                 minimumPlatformVersion = 1,
                 notaries = listOf(NotaryInfo(identity, config.nodeConfig.notary!!.validating)),
                 modifiedTime = Instant.now(),
-                eventHorizon = 10000.days,
                 maxMessageSize = 40000,
                 maxTransactionSize = 40000,
                 epoch = 1


### PR DESCRIPTION
Added handling of the situation when network map is advertising different parameters hash - for now we stop the node.
Added wiring of maxMessageSize (in fact we already had that, now it's just taken from network parameters), also handling of epoch on node startup.
