### PR TITLE
Make `extraCordappPackagesToScan` on Node Driver a Set.

### DIFF
--- a/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
+++ b/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
@@ -51,7 +51,7 @@ class NodeMonitorModelTest {
     private lateinit var newNode: (CordaX500Name) -> NodeInfo
 
     private fun setup(runTest: () -> Unit) {
-        driver(extraCordappPackagesToScan = listOf("net.corda.finance")) {
+        driver(extraCordappPackagesToScan = setOf("net.corda.finance")) {
             val cashUser = User("user1", "test", permissions = setOf(
                     startFlow<CashIssueFlow>(),
                     startFlow<CashPaymentFlow>(),

--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -1,5 +1,6 @@
 package net.corda.client.rpc;
 
+import com.google.common.collect.Sets;
 import net.corda.core.contracts.Amount;
 import net.corda.core.messaging.CordaRPCOps;
 import net.corda.core.messaging.FlowHandle;
@@ -32,7 +33,7 @@ import static net.corda.testing.TestConstants.getALICE;
 
 public class CordaRPCJavaClientTest extends NodeBasedTest {
     public CordaRPCJavaClientTest() {
-        super(Arrays.asList("net.corda.finance.contracts", CashSchemaV1.class.getPackage().getName()));
+        super(Sets.newHashSet("net.corda.finance.contracts", CashSchemaV1.class.getPackage().getName()));
     }
 
     private List<String> perms = Arrays.asList(

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance.contracts", CashSchemaV1::class.packageName)) {
+class CordaRPCClientTest : NodeBasedTest(setOf("net.corda.finance.contracts", CashSchemaV1::class.packageName)) {
     private val rpcUser = User("user1", "test", permissions = setOf(
             startFlow<CashIssueFlow>(),
             startFlow<CashPaymentFlow>(),

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
@@ -32,7 +32,7 @@ class IdentitySyncFlowTests {
         mockNet = MockNetwork(
                 networkSendManuallyPumped = false,
                 threadPerNode = true,
-                cordappPackages = listOf("net.corda.finance.contracts.asset")
+                cordappPackages = setOf("net.corda.finance.contracts.asset")
         )
     }
 

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -33,7 +33,7 @@ class CollectSignaturesFlowTests {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
+        mockNet = MockNetwork(cordappPackages = setOf("net.corda.testing.contracts"))
         aliceNode = mockNet.createPartyNode(ALICE.name)
         bobNode = mockNet.createPartyNode(BOB.name)
         charlieNode = mockNet.createPartyNode(CHARLIE.name)
@@ -129,7 +129,7 @@ class CollectSignaturesFlowTests {
     @Test
     fun `fails when not signed by initiator`() {
         val onePartyDummyContract = DummyContract.generateInitial(1337, notary, alice.ref(1))
-        val miniCorpServices = MockServices(listOf("net.corda.testing.contracts"), rigorousMock(), MINI_CORP.name, MINI_CORP_KEY)
+        val miniCorpServices = MockServices(setOf("net.corda.testing.contracts"), rigorousMock(), MINI_CORP.name, MINI_CORP_KEY)
         val ptx = miniCorpServices.signInitialTransaction(onePartyDummyContract)
         val flow = aliceNode.services.startFlow(CollectSignaturesFlow(ptx, emptySet()))
         mockNet.runNetwork()

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -49,7 +49,7 @@ class ContractUpgradeFlowTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset", "net.corda.core.flows"))
+        mockNet = MockNetwork(cordappPackages = setOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset", "net.corda.core.flows"))
         aliceNode = mockNet.createPartyNode(ALICE_NAME)
         bobNode = mockNet.createPartyNode(BOB_NAME)
         notary = mockNet.defaultNotaryIdentity

--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -25,7 +25,7 @@ class FinalityFlowTests {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.finance.contracts.asset"))
+        mockNet = MockNetwork(cordappPackages = setOf("net.corda.finance.contracts.asset"))
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)
         val bobNode = mockNet.createPartyNode(BOB_NAME)
         aliceServices = aliceNode.services

--- a/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
@@ -38,7 +38,7 @@ class ResolveTransactionsFlowTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
+        mockNet = MockNetwork(cordappPackages = setOf("net.corda.testing.contracts"))
         notaryNode = mockNet.defaultNotaryNode
         megaCorpNode = mockNet.createPartyNode(MEGA_CORP.name)
         miniCorpNode = mockNet.createPartyNode(MINI_CORP.name)

--- a/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/serialization/TransactionSerializationTests.kt
@@ -50,8 +50,8 @@ class TransactionSerializationTests {
     val inputState = StateAndRef(TransactionState(TestCash.State(depositRef, 100.POUNDS, MEGA_CORP), TEST_CASH_PROGRAM_ID, DUMMY_NOTARY), fakeStateRef)
     val outputState = TransactionState(TestCash.State(depositRef, 600.POUNDS, MEGA_CORP), TEST_CASH_PROGRAM_ID, DUMMY_NOTARY)
     val changeState = TransactionState(TestCash.State(depositRef, 400.POUNDS, MEGA_CORP), TEST_CASH_PROGRAM_ID, DUMMY_NOTARY)
-    val megaCorpServices = MockServices(listOf("net.corda.core.serialization"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
-    val notaryServices = MockServices(listOf("net.corda.core.serialization"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
+    val megaCorpServices = MockServices(setOf("net.corda.core.serialization"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
+    val notaryServices = MockServices(setOf("net.corda.core.serialization"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
     lateinit var tx: TransactionBuilder
 
     @Before

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -24,7 +24,7 @@ class IntegrationTestingTutorial {
     fun `alice bob cash exchange example`() {
         // START 1
         driver(startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.finance.contracts.asset")) {
+                extraCordappPackagesToScan = setOf("net.corda.finance.contracts.asset")) {
             val aliceUser = User("aliceUser", "testPassword1", permissions = setOf(
                     startFlow<CashIssueFlow>(),
                     startFlow<CashPaymentFlow>(),

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
@@ -48,7 +48,7 @@ fun main(args: Array<String>) {
             startFlow<CashExitFlow>(),
             invokeRpc(CordaRPCOps::nodeInfo)
     ))
-    driver(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true) {
+    driver(driverDirectory = baseDirectory, extraCordappPackagesToScan = setOf("net.corda.finance"), waitForAllNodesToFinish = true) {
         val node = startNode(providedName = ALICE.name, rpcUsers = listOf(user)).get()
         // END 1
 

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
@@ -25,7 +25,7 @@ class CustomVaultQueryTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance", "net.corda.docs"))
+        mockNet = MockNetwork(threadPerNode = true, cordappPackages = setOf("net.corda.finance", "net.corda.docs"))
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
         nodeA.registerInitiatedFlow(TopupIssuerFlow.TopupIssuer::class.java)

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/FxTransactionBuildTutorialTest.kt
@@ -24,7 +24,7 @@ class FxTransactionBuildTutorialTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance"))
+        mockNet = MockNetwork(threadPerNode = true, cordappPackages = setOf("net.corda.finance"))
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
         nodeB.registerInitiatedFlow(ForeignExchangeRemoteFlow::class.java)

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
@@ -32,7 +32,7 @@ class WorkflowTransactionBuildTutorialTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.docs"))
+        mockNet = MockNetwork(threadPerNode = true, cordappPackages = setOf("net.corda.docs"))
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)
         val bobNode = mockNet.createPartyNode(BOB_NAME)
         aliceNode.registerInitiatedFlow(RecordCompletionFlow::class.java)

--- a/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt
+++ b/experimental/src/test/kotlin/net/corda/finance/contracts/universal/Cap.kt
@@ -12,7 +12,7 @@ import java.time.Instant
 import java.time.LocalDate
 
 fun transaction(script: TransactionDSL<TransactionDSLInterpreter>.() -> EnforceVerifyOrFail) = run {
-    net.corda.testing.transaction(cordappPackages = listOf("net.corda.finance.contracts.universal"), dsl = script)
+    net.corda.testing.transaction(cordappPackages = setOf("net.corda.finance.contracts.universal"), dsl = script)
 }
 
 class Cap {

--- a/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt
@@ -224,14 +224,14 @@ class CommercialPaperTestsGeneric {
     private lateinit var aliceVaultService: VaultService
     private lateinit var alicesVault: Vault<ContractState>
     private val notaryServices = MockServices(rigorousMock(), MEGA_CORP.name, DUMMY_NOTARY_KEY)
-    private val issuerServices = MockServices(listOf("net.corda.finance.contracts"), rigorousMock(), MEGA_CORP.name, DUMMY_CASH_ISSUER_KEY)
+    private val issuerServices = MockServices(setOf("net.corda.finance.contracts"), rigorousMock(), MEGA_CORP.name, DUMMY_CASH_ISSUER_KEY)
     private lateinit var moveTX: SignedTransaction
     @Test
     fun `issue move and then redeem`() {
         val aliceDatabaseAndServices = makeTestDatabaseAndMockServices(
                 listOf(ALICE_KEY),
                 makeTestIdentityService(listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)),
-                listOf("net.corda.finance.contracts"),
+                setOf("net.corda.finance.contracts"),
                 MEGA_CORP.name)
         val databaseAlice = aliceDatabaseAndServices.first
         aliceServices = aliceDatabaseAndServices.second
@@ -244,7 +244,7 @@ class CommercialPaperTestsGeneric {
         val bigCorpDatabaseAndServices = makeTestDatabaseAndMockServices(
                 listOf(BIG_CORP_KEY),
                 makeTestIdentityService(listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)),
-                listOf("net.corda.finance.contracts"),
+                setOf("net.corda.finance.contracts"),
                 MEGA_CORP.name)
         val databaseBigCorp = bigCorpDatabaseAndServices.first
         bigCorpServices = bigCorpDatabaseAndServices.second

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -69,15 +69,15 @@ class CashTests {
     @Before
     fun setUp() {
         LogHelper.setLevel(NodeVaultService::class)
-        megaCorpServices = MockServices(listOf("net.corda.finance.contracts.asset"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
-        miniCorpServices = MockServices(listOf("net.corda.finance.contracts.asset"), rigorousMock<IdentityServiceInternal>().also {
+        megaCorpServices = MockServices(setOf("net.corda.finance.contracts.asset"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
+        miniCorpServices = MockServices(setOf("net.corda.finance.contracts.asset"), rigorousMock<IdentityServiceInternal>().also {
             doNothing().whenever(it).justVerifyAndRegisterIdentity(argThat { name == MINI_CORP.name })
         }, MINI_CORP.name, MINI_CORP_KEY)
-        val notaryServices = MockServices(listOf("net.corda.finance.contracts.asset"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
+        val notaryServices = MockServices(setOf("net.corda.finance.contracts.asset"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
         val databaseAndServices = makeTestDatabaseAndMockServices(
                 listOf(generateKeyPair()),
                 makeTestIdentityService(listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)),
-                listOf("net.corda.finance.contracts.asset"),
+                setOf("net.corda.finance.contracts.asset"),
                 CordaX500Name("Me", "London", "GB"))
         database = databaseAndServices.first
         ourServices = databaseAndServices.second
@@ -776,7 +776,7 @@ class CashTests {
     // Double spend.
     @Test
     fun chainCashDoubleSpendFailsWith() {
-        val mockService = MockServices(listOf("net.corda.finance.contracts.asset"), rigorousMock<IdentityServiceInternal>().also {
+        val mockService = MockServices(setOf("net.corda.finance.contracts.asset"), rigorousMock<IdentityServiceInternal>().also {
             doReturn(MEGA_CORP).whenever(it).partyFromKey(MEGA_CORP_PUBKEY)
         }, MEGA_CORP.name, MEGA_CORP_KEY)
         ledger(mockService) {

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt
@@ -54,9 +54,9 @@ class ObligationTests {
             beneficiary = CHARLIE
     )
     private val outState = inState.copy(beneficiary = AnonymousParty(BOB_PUBKEY))
-    private val miniCorpServices = MockServices(listOf("net.corda.finance.contracts.asset"), rigorousMock(), MINI_CORP.name, MINI_CORP_KEY)
+    private val miniCorpServices = MockServices(setOf("net.corda.finance.contracts.asset"), rigorousMock(), MINI_CORP.name, MINI_CORP_KEY)
     private val notaryServices = MockServices(rigorousMock(), MEGA_CORP.name, DUMMY_NOTARY_KEY)
-    private val mockService = MockServices(listOf("net.corda.finance.contracts.asset"), rigorousMock<IdentityServiceInternal>().also {
+    private val mockService = MockServices(setOf("net.corda.finance.contracts.asset"), rigorousMock<IdentityServiceInternal>().also {
         doReturn(null).whenever(it).partyFromKey(ALICE_PUBKEY)
         doReturn(null).whenever(it).partyFromKey(BOB_PUBKEY)
         doReturn(MEGA_CORP).whenever(it).partyFromKey(MEGA_CORP_PUBKEY)

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 import java.util.Collections.nCopies
 
 class CashSelectionH2ImplTest {
-    private val mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance"))
+    private val mockNet = MockNetwork(threadPerNode = true, cordappPackages = setOf("net.corda.finance"))
 
     @After
     fun cleanUp() {

--- a/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
@@ -29,7 +29,7 @@ class CashExitFlowTests {
     @Before
     fun start() {
         mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(),
-                cordappPackages = listOf("net.corda.finance.contracts.asset"))
+                cordappPackages = setOf("net.corda.finance.contracts.asset"))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda = bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         notary = mockNet.defaultNotaryIdentity

--- a/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt
@@ -26,7 +26,7 @@ class CashIssueFlowTests {
 
     @Before
     fun start() {
-        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance.contracts.asset"))
+        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = setOf("net.corda.finance.contracts.asset"))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda =  bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         notary = mockNet.defaultNotaryIdentity

--- a/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
@@ -30,7 +30,7 @@ class CashPaymentFlowTests {
 
     @Before
     fun start() {
-        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance.contracts.asset"))
+        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = setOf("net.corda.finance.contracts.asset"))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda = bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         aliceNode = mockNet.createPartyNode(ALICE_NAME)

--- a/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformDefinition.java
+++ b/gradle-plugins/cordform-common/src/main/java/net/corda/cordform/CordformDefinition.java
@@ -4,13 +4,15 @@ import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public abstract class CordformDefinition {
     private Path nodesDirectory = Paths.get("build", "nodes");
     private final List<Consumer<CordformNode>> nodeConfigurers = new ArrayList<>();
-    private final List<String> cordappPackages = new ArrayList<>();
+    private final Set<String> cordappPackages = new HashSet<>();
 
     public Path getNodesDirectory() {
         return nodesDirectory;
@@ -28,7 +30,7 @@ public abstract class CordformDefinition {
         nodeConfigurers.add(configurer);
     }
 
-    public List<String> getCordappPackages() {
+    public Set<String> getCordappPackages() {
         return cordappPackages;
     }
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
@@ -49,7 +49,7 @@ class AttachmentsClassLoaderStaticContractTests {
     }
 
     private val serviceHub = rigorousMock<ServicesForResolution>().also {
-        doReturn(CordappProviderImpl(CordappLoader.createWithTestPackages(listOf("net.corda.nodeapi.internal")), MockAttachmentStorage())).whenever(it).cordappProvider
+        doReturn(CordappProviderImpl(CordappLoader.createWithTestPackages(setOf("net.corda.nodeapi.internal")), MockAttachmentStorage())).whenever(it).cordappProvider
     }
 
     @Test

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -107,7 +107,7 @@ class NodePerformanceTests {
         driver(
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name, rpcUsers = listOf(user))),
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.finance")
+                extraCordappPackagesToScan = setOf("net.corda.finance")
         ) {
             val notary = defaultNotaryNode.getOrThrow() as NodeHandle.InProcess
             val metricRegistry = startReporter((this as InternalDriverDSL).shutdownManager, notary.node.services.monitoringService.metrics)

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -41,7 +41,7 @@ class DistributedServiceTests {
         )
 
         driver(
-                extraCordappPackagesToScan = listOf("net.corda.finance.contracts"),
+                extraCordappPackagesToScan = setOf("net.corda.finance.contracts"),
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name.copy(commonName = RaftValidatingNotaryService.id), rpcUsers = listOf(testUser), cluster = ClusterSpec.Raft(clusterSize = 3))))
         {
             alice = startNode(providedName = ALICE.name, rpcUsers = listOf(testUser)).getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -33,7 +33,7 @@ class RaftNotaryServiceTests {
     fun `detect double spend`() {
         driver(
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.testing.contracts"),
+                extraCordappPackagesToScan = setOf("net.corda.testing.contracts"),
                 notarySpecs = listOf(NotarySpec(notaryName, cluster = ClusterSpec.Raft(clusterSize = 3))))
         {
             val bankA = startNode(providedName = DUMMY_BANK_A.name).map { (it as NodeHandle.InProcess).node }.getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -64,7 +64,7 @@ class LargeTransactionsTest {
         val bigFile2 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 1)
         val bigFile3 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 2)
         val bigFile4 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 3)
-        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.testing.contracts")) {
+        driver(startNodesInProcess = true, extraCordappPackagesToScan = setOf("net.corda.testing.contracts")) {
             val rpcUser = User("admin", "admin", setOf("ALL"))
             val (alice, _) = listOf(ALICE_NAME, BOB_NAME).map { startNode(providedName = it, rpcUsers = listOf(rpcUser)) }.transpose().getOrThrow()
             alice.rpcClientToNode().use(rpcUser.username, rpcUser.password) {

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -76,7 +76,7 @@ open class Node(configuration: NodeConfiguration,
         val scanPackagesSeparator = ","
         private fun makeCordappLoader(configuration: NodeConfiguration): CordappLoader {
             return System.getProperty(scanPackagesSystemProperty)?.let { scanPackages ->
-                CordappLoader.createDefaultWithTestPackages(configuration, scanPackages.split(scanPackagesSeparator))
+                CordappLoader.createDefaultWithTestPackages(configuration, scanPackages.split(scanPackagesSeparator).toSet())
             } ?: CordappLoader.createDefault(configuration.baseDirectory)
         }
     }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -80,11 +80,11 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
          * @param testPackages See [createWithTestPackages.testPackages]
          */
         @VisibleForTesting
-        fun createDefaultWithTestPackages(configuration: NodeConfiguration, testPackages: List<String>): CordappLoader {
+        fun createDefaultWithTestPackages(configuration: NodeConfiguration, testPackages: Set<String>): CordappLoader {
             if (!configuration.devMode) {
                 logger.warn("Package scanning should only occur in dev mode!")
             }
-            val paths = getCordappsInDirectory(getCordappsPath(configuration.baseDirectory)) + testPackages.flatMap(this::createScanPackage)
+            val paths = getCordappsInDirectory(getCordappsPath(configuration.baseDirectory)) + testPackages.flatMap(this::createScanPackage).toList()
             return cordappLoadersCache.computeIfAbsent(paths, { CordappLoader(paths) })
         }
 
@@ -96,8 +96,8 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
          * CorDapps.
          */
         @VisibleForTesting
-        fun createWithTestPackages(testPackages: List<String>): CordappLoader {
-            return cordappLoadersCache.computeIfAbsent(testPackages, { CordappLoader(testPackages.flatMap(this::createScanPackage)) })
+        fun createWithTestPackages(testPackages: Set<String>): CordappLoader {
+            return cordappLoadersCache.computeIfAbsent(testPackages.toList(), { CordappLoader(testPackages.flatMap(this::createScanPackage)) })
         }
 
         /**

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -1,6 +1,7 @@
 package net.corda.node.services.vault;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import kotlin.Pair;
 import kotlin.Triple;
 import net.corda.core.contracts.*;
@@ -60,7 +61,7 @@ public class VaultQueryJavaTests {
 
     @Before
     public void setUp() throws CertificateException, InvalidAlgorithmParameterException {
-        List<String> cordappPackages = Arrays.asList("net.corda.testing.contracts", "net.corda.finance.contracts.asset", CashSchemaV1.class.getPackage().getName());
+        Set<String> cordappPackages = Sets.newHashSet("net.corda.testing.contracts", "net.corda.finance.contracts.asset", CashSchemaV1.class.getPackage().getName());
         IdentityServiceInternal identitySvc = makeTestIdentityService(Arrays.asList(getMEGA_CORP_IDENTITY(), getDUMMY_CASH_ISSUER_IDENTITY(), getDUMMY_NOTARY_IDENTITY()));
         Pair<CordaPersistence, MockServices> databaseAndServices = makeTestDatabaseAndMockServices(
                 Arrays.asList(getMEGA_CORP_KEY(), getDUMMY_NOTARY_KEY()),

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -75,7 +75,7 @@ class CordaRPCOpsImplTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.finance.contracts.asset"))
+        mockNet = MockNetwork(cordappPackages = setOf("net.corda.finance.contracts.asset"))
         aliceNode = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         rpc = SecureCordaRPCOps(aliceNode.services, aliceNode.smm, aliceNode.database, aliceNode.services)
         CURRENT_RPC_CONTEXT.set(RpcAuthContext(InvocationContext.rpc(testActor()), buildSubject("TEST_USER", emptySet())))

--- a/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/CordaServiceTest.kt
@@ -79,7 +79,7 @@ class CordaServiceTest {
 
     @Before
     fun start() {
-        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.node.internal","net.corda.finance"))
+        mockNet = MockNetwork(threadPerNode = true, cordappPackages = setOf("net.corda.node.internal","net.corda.finance"))
         nodeA = mockNet.createNode()
         mockNet.startNodes()
     }

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt
@@ -36,7 +36,7 @@ class DummyRPCFlow : FlowLogic<Unit>() {
 
 class CordappLoaderTest {
     private companion object {
-        val testScanPackages = listOf("net.corda.node.internal.cordapp")
+        val testScanPackages = setOf("net.corda.node.internal.cordapp")
         val isolatedContractId = "net.corda.finance.contracts.isolated.AnotherDummyContract"
         val isolatedFlowName = "net.corda.finance.contracts.isolated.IsolatedDummyFlow\$Initiator"
     }

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -68,7 +68,7 @@ import kotlin.test.assertTrue
 @RunWith(Parameterized::class)
 class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
     companion object {
-        private val cordappPackages = listOf("net.corda.finance.contracts")
+        private val cordappPackages = setOf("net.corda.finance.contracts")
         @JvmStatic
         @Parameterized.Parameters(name = "Anonymous = {0}")
         fun data(): Collection<Boolean> = listOf(true, false)

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -45,7 +45,7 @@ class NotaryChangeTests {
         val oldNotaryName = DUMMY_NOTARY.name.copy(organisation = "Old Dummy Notary")
         mockNet = MockNetwork(
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name), NotarySpec(oldNotaryName)),
-                cordappPackages = listOf("net.corda.testing.contracts")
+                cordappPackages = setOf("net.corda.testing.contracts")
         )
         clientNodeA = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         clientNodeB = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))

--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -103,7 +103,7 @@ class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
                 doReturn(NetworkMapCacheImpl(MockNetworkMapCache(database), identityService)).whenever(it).networkMapCache
                 doReturn(myInfo).whenever(it).myInfo
                 doReturn(kms).whenever(it).keyManagementService
-                doReturn(CordappProviderImpl(CordappLoader.createWithTestPackages(listOf("net.corda.testing.contracts")), MockAttachmentStorage())).whenever(it).cordappProvider
+                doReturn(CordappProviderImpl(CordappLoader.createWithTestPackages(setOf("net.corda.testing.contracts")), MockAttachmentStorage())).whenever(it).cordappProvider
                 doReturn(NodeVaultService(testClock, kms, validatedTransactions, database.hibernateConfig)).whenever(it).vaultService
                 doReturn(this@NodeSchedulerServiceTest).whenever(it).testReference
 

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -97,7 +97,7 @@ class ScheduledFlowTests {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.testing.contracts"))
+        mockNet = MockNetwork(threadPerNode = true, cordappPackages = setOf("net.corda.testing.contracts"))
         aliceNode = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         bobNode = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))
         notary = mockNet.defaultNotaryIdentity

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -83,7 +83,7 @@ class HibernateConfigurationTest {
 
     @Before
     fun setUp() {
-        val cordappPackages = listOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset")
+        val cordappPackages = setOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset")
         bankServices = MockServices(cordappPackages, rigorousMock(), BOC.name, BOC_KEY)
         issuerServices = MockServices(cordappPackages, rigorousMock(), DUMMY_CASH_ISSUER_NAME, DUMMY_CASH_ISSUER_KEY)
         notaryServices = MockServices(cordappPackages, rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)

--- a/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt
@@ -26,7 +26,7 @@ class NodeSchemaServiceTest {
      */
     @Test
     fun `registering custom schemas for testing with MockNode`() {
-        val mockNet = MockNetwork(cordappPackages = listOf(DummyLinearStateSchemaV1::class.packageName))
+        val mockNet = MockNetwork(cordappPackages = setOf(DummyLinearStateSchemaV1::class.packageName))
         val mockNode = mockNet.createNode()
         val schemaService = mockNode.services.schemaService
         assertTrue(schemaService.schemaOptions.containsKey(DummyLinearStateSchemaV1))

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -76,7 +76,7 @@ class FlowFrameworkTests {
     fun start() {
         mockNet = MockNetwork(
                 servicePeerAllocationStrategy = RoundRobin(),
-                cordappPackages = listOf("net.corda.finance.contracts", "net.corda.testing.contracts")
+                cordappPackages = setOf("net.corda.finance.contracts", "net.corda.testing.contracts")
         )
         aliceNode = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         bobNode = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -39,7 +39,7 @@ class NotaryServiceTests {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
+        mockNet = MockNetwork(cordappPackages = setOf("net.corda.testing.contracts"))
         aliceServices = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME)).services
         notaryServices = mockNet.defaultNotaryNode.services //TODO get rid of that
         notary = mockNet.defaultNotaryIdentity

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -36,7 +36,7 @@ class ValidatingNotaryServiceTests {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
+        mockNet = MockNetwork(cordappPackages = setOf("net.corda.testing.contracts"))
         val aliceNode = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         notaryServices = mockNet.defaultNotaryNode.services
         aliceServices = aliceNode.services

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -60,7 +60,7 @@ import kotlin.test.assertTrue
 
 class NodeVaultServiceTest {
     companion object {
-        private val cordappPackages = listOf("net.corda.finance.contracts.asset", CashSchemaV1::class.packageName)
+        private val cordappPackages = setOf("net.corda.finance.contracts.asset", CashSchemaV1::class.packageName)
     }
 
     @Rule

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -59,7 +59,7 @@ class VaultQueryTests {
     @JvmField
     val expectedEx: ExpectedException = ExpectedException.none()
 
-    private val cordappPackages = mutableListOf(
+    private val cordappPackages = mutableSetOf(
             "net.corda.testing.contracts",
             "net.corda.finance.contracts",
             CashSchemaV1::class.packageName,

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -81,7 +81,7 @@ class VaultSoftLockManagerTest {
     private val mockVault = rigorousMock<VaultServiceInternal>().also {
         doNothing().whenever(it).softLockRelease(any(), anyOrNull())
     }
-    private val mockNet = MockNetwork(cordappPackages = listOf(ContractImpl::class.packageName), defaultFactory = { args ->
+    private val mockNet = MockNetwork(cordappPackages = setOf(ContractImpl::class.packageName), defaultFactory = { args ->
         object : MockNetwork.MockNode(args) {
             override fun makeVaultService(keyManagementService: KeyManagementService, stateLoader: StateLoader, hibernateConfig: HibernateConfiguration): VaultServiceInternal {
                 val realVault = super.makeVaultService(keyManagementService, stateLoader, hibernateConfig)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -44,7 +44,7 @@ import kotlin.test.fail
 
 class VaultWithCashTest {
     companion object {
-        private val cordappPackages = listOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset", CashSchemaV1::class.packageName)
+        private val cordappPackages = setOf("net.corda.testing.contracts", "net.corda.finance.contracts.asset", CashSchemaV1::class.packageName)
     }
 
     @Rule

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -23,7 +23,7 @@ class BankOfCordaRPCClientTest {
                 invokeRpc(CordaRPCOps::wellKnownPartyFromX500Name),
                 invokeRpc(CordaRPCOps::notaryIdentities)
         )
-        driver(extraCordappPackagesToScan = listOf("net.corda.finance"), isDebug = true) {
+        driver(extraCordappPackagesToScan = setOf("net.corda.finance"), isDebug = true) {
             val bocManager = User("bocManager", "password1", permissions = setOf(
                     startFlow<CashIssueAndPaymentFlow>()) + commonPermissions)
             val bigCorpCFO = User("bigCorpCFO", "password2", permissions = emptySet<String>() + commonPermissions)

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt
@@ -47,7 +47,7 @@ class NodeInterestRatesTest {
 
     private val DUMMY_CASH_ISSUER_KEY = generateKeyPair()
     private val DUMMY_CASH_ISSUER = Party(CordaX500Name(organisation = "Cash issuer", locality = "London", country = "GB"), DUMMY_CASH_ISSUER_KEY.public)
-    private val services = MockServices(listOf("net.corda.finance.contracts.asset"), rigorousMock(), DUMMY_CASH_ISSUER.name, DUMMY_CASH_ISSUER_KEY, MEGA_CORP_KEY)
+    private val services = MockServices(setOf("net.corda.finance.contracts.asset"), rigorousMock(), DUMMY_CASH_ISSUER.name, DUMMY_CASH_ISSUER_KEY, MEGA_CORP_KEY)
     // This is safe because MockServices only ever have a single identity
     private val identity = services.myInfo.singleIdentity()
 
@@ -203,7 +203,7 @@ class NodeInterestRatesTest {
 
     @Test
     fun `network tearoff`() = withoutTestSerialization {
-        val mockNet = MockNetwork(cordappPackages = listOf("net.corda.finance.contracts", "net.corda.irs"))
+        val mockNet = MockNetwork(cordappPackages = setOf("net.corda.finance.contracts", "net.corda.irs"))
         val aliceNode = mockNet.createPartyNode(ALICE_NAME)
         val oracleNode = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME)).apply {
             registerInitiatedFlow(NodeInterestRates.FixQueryHandler::class.java)

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt
@@ -219,9 +219,10 @@ class IRSTests {
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
-    private val megaCorpServices = MockServices(listOf("net.corda.irs.contract"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
-    private val miniCorpServices = MockServices(listOf("net.corda.irs.contract"), rigorousMock(), MINI_CORP.name, MINI_CORP_KEY)
-    private val notaryServices = MockServices(listOf("net.corda.irs.contract"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
+    private val megaCorpServices = MockServices(setOf("net.corda.irs.contract"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
+    private val miniCorpServices = MockServices(setOf("net.corda.irs.contract"), rigorousMock(), MINI_CORP.name, MINI_CORP_KEY)
+    private val notaryServices = MockServices(setOf("net.corda.irs.contract"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
+
     @Test
     fun ok() {
         trade().verifies()
@@ -317,7 +318,7 @@ class IRSTests {
      */
     @Test
     fun generateIRSandFixSome() {
-        val services = MockServices(listOf("net.corda.irs.contract"), rigorousMock<IdentityServiceInternal>().also {
+        val services = MockServices(setOf("net.corda.irs.contract"), rigorousMock<IdentityServiceInternal>().also {
             listOf(MEGA_CORP, MINI_CORP).forEach { party ->
                 doReturn(party).whenever(it).partyFromKey(party.owningKey)
             }

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -49,7 +49,7 @@ class IRSDemoTest {
                 useTestClock = true,
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name, rpcUsers = rpcUsers)),
                 isDebug = true,
-                extraCordappPackagesToScan = listOf("net.corda.irs")
+                extraCordappPackagesToScan = setOf("net.corda.irs")
         ) {
             val (nodeA, nodeB) = listOf(
                     startNode(providedName = DUMMY_BANK_A.name, rpcUsers = rpcUsers),

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
@@ -28,7 +28,7 @@ fun <A> springDriver(
         initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
         startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
         notarySpecs: List<NotarySpec>,
-        extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
+        extraCordappPackagesToScan: Set<String> = defaultParameters.extraCordappPackagesToScan,
         dsl: SpringBootDriverDSL.() -> A
 ): A {
     return genericDriver(

--- a/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
+++ b/samples/network-visualiser/src/main/kotlin/net/corda/netmap/simulation/Simulation.kt
@@ -69,7 +69,7 @@ abstract class Simulation(val networkSendManuallyPumped: Boolean,
     val mockNet = MockNetwork(
             networkSendManuallyPumped = networkSendManuallyPumped,
             threadPerNode = runAsync,
-            cordappPackages = listOf("net.corda.finance.contract", "net.corda.irs"))
+            cordappPackages = setOf("net.corda.finance.contract", "net.corda.irs"))
     // TODO: Regulatory nodes don't actually exist properly, this is a last minute demo request.
     //       So we just fire a message at a node that doesn't know how to handle it, and it'll ignore it.
     //       But that's fine for visualisation purposes.

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -27,7 +27,7 @@ class SimmValuationTest {
 
     @Test
     fun `runs SIMM valuation demo`() {
-        driver(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.vega.contracts")) {
+        driver(isDebug = true, extraCordappPackagesToScan = setOf("net.corda.vega.contracts")) {
             val nodeAFuture = startNode(providedName = nodeALegalName)
             val nodeBFuture = startNode(providedName = nodeBLegalName)
             val (nodeA, nodeB) = listOf(nodeAFuture, nodeBFuture).map { it.getOrThrow() }

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -32,7 +32,7 @@ class TraderDemoTest {
                 startFlow<CashPaymentFlow>(),
                 startFlow<CommercialPaperIssueFlow>(),
                 all()))
-        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance")) {
+        driver(startNodesInProcess = true, extraCordappPackagesToScan = setOf("net.corda.finance")) {
             val (nodeA, nodeB, bankNode) = listOf(
                     startNode(providedName = DUMMY_BANK_A.name, rpcUsers = listOf(demoUser)),
                     startNode(providedName = DUMMY_BANK_B.name, rpcUsers = listOf(demoUser)),

--- a/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt
+++ b/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/TransactionGraphSearchTests.kt
@@ -36,8 +36,8 @@ class TransactionGraphSearchTests {
      * @param signer signer for the two transactions and their commands.
      */
     fun buildTransactions(command: CommandData): GraphTransactionStorage {
-        val megaCorpServices = MockServices(listOf("net.corda.testing.contracts"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
-        val notaryServices = MockServices(listOf("net.corda.testing.contracts"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
+        val megaCorpServices = MockServices(setOf("net.corda.testing.contracts"), rigorousMock(), MEGA_CORP.name, MEGA_CORP_KEY)
+        val notaryServices = MockServices(setOf("net.corda.testing.contracts"), rigorousMock(), DUMMY_NOTARY.name, DUMMY_NOTARY_KEY)
         val originBuilder = TransactionBuilder(DUMMY_NOTARY)
                 .addOutputState(DummyState(random31BitValue()), DummyContract.PROGRAM_ID)
                 .addCommand(command, MEGA_CORP_PUBKEY)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/NodeTestUtils.kt
@@ -46,7 +46,7 @@ fun ledger(
 @JvmOverloads
 fun transaction(
         transactionBuilder: TransactionBuilder = TransactionBuilder(notary = DUMMY_NOTARY),
-        cordappPackages: List<String> = emptyList(),
+        cordappPackages: Set<String> = emptySet(),
         dsl: TransactionDSL<TransactionDSLInterpreter>.() -> EnforceVerifyOrFail
 ) = ledger(services = MockServices(cordappPackages, makeTestIdentityService(listOf(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY)), MEGA_CORP.name)) {
     dsl(TransactionDSL(TestTransactionDSLInterpreter(this.interpreter, transactionBuilder)))

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -162,6 +162,7 @@ data class JmxPolicy(val startJmxHttpServer: Boolean = false,
  * @param jmxPolicy Used to specify whether to expose JMX metrics via Jolokia HHTP/JSON. Defines two attributes:
  *      startJmxHttpServer: indicates whether the spawned nodes should start with a Jolokia JMX agent to enable remote JMX monitoring using HTTP/JSON.
  *      jmxHttpServerPortAllocation: the port allocation strategy to use for remote Jolokia/JMX monitoring over HTTP. Defaults to incremental.
+ * @param extraCordappPackagesToScan Additional names of the packages that will be used for construction of [CordappLoader] for a given node.
  * @param dsl The dsl itself.
  * @return The value returned in the [dsl] closure.
  */
@@ -177,7 +178,7 @@ fun <A> driver(
         startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
         waitForAllNodesToFinish: Boolean = defaultParameters.waitForAllNodesToFinish,
         notarySpecs: List<NotarySpec> = defaultParameters.notarySpecs,
-        extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
+        extraCordappPackagesToScan: Set<String> = defaultParameters.extraCordappPackagesToScan,
         jmxPolicy: JmxPolicy = JmxPolicy(),
         dsl: DriverDSL.() -> A
 ): A {
@@ -228,9 +229,8 @@ data class DriverParameters(
         val startNodesInProcess: Boolean = false,
         val waitForAllNodesToFinish: Boolean = false,
         val notarySpecs: List<NotarySpec> = listOf(NotarySpec(DUMMY_NOTARY.name)),
-        val extraCordappPackagesToScan: List<String> = emptyList(),
+        val extraCordappPackagesToScan: Set<String> = emptySet(),
         val jmxPolicy: JmxPolicy = JmxPolicy()
-
 ) {
     fun setIsDebug(isDebug: Boolean) = copy(isDebug = isDebug)
     fun setDriverDirectory(driverDirectory: Path) = copy(driverDirectory = driverDirectory)
@@ -241,7 +241,7 @@ data class DriverParameters(
     fun setInitialiseSerialization(initialiseSerialization: Boolean) = copy(initialiseSerialization = initialiseSerialization)
     fun setStartNodesInProcess(startNodesInProcess: Boolean) = copy(startNodesInProcess = startNodesInProcess)
     fun setWaitForAllNodesToFinish(waitForAllNodesToFinish: Boolean) = copy(waitForAllNodesToFinish = waitForAllNodesToFinish)
-    fun setExtraCordappPackagesToScan(extraCordappPackagesToScan: List<String>) = copy(extraCordappPackagesToScan = extraCordappPackagesToScan)
+    fun setExtraCordappPackagesToScan(extraCordappPackagesToScan: Set<String>) = copy(extraCordappPackagesToScan = extraCordappPackagesToScan)
     fun setNotarySpecs(notarySpecs: List<NotarySpec>) = copy(notarySpecs = notarySpecs)
     fun setJmxPolicy(jmxPolicy: JmxPolicy) = copy(jmxPolicy = jmxPolicy)
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/DriverDSLImpl.kt
@@ -71,7 +71,7 @@ class DriverDSLImpl(
         val isDebug: Boolean,
         val startNodesInProcess: Boolean,
         val waitForNodesToFinish: Boolean,
-        extraCordappPackagesToScan: List<String>,
+        extraCordappPackagesToScan: Set<String>,
         val jmxPolicy: JmxPolicy,
         val notarySpecs: List<NotarySpec>
 ) : InternalDriverDSL {
@@ -467,7 +467,7 @@ class DriverDSLImpl(
                 executorService: ScheduledExecutorService,
                 nodeConf: NodeConfiguration,
                 config: Config,
-                cordappPackages: List<String>
+                cordappPackages: Set<String>
         ): CordaFuture<Pair<StartedNode<Node>, Thread>> {
             return executorService.fork {
                 log.info("Starting in-process Node ${nodeConf.myLegalName.organisation}")
@@ -492,7 +492,7 @@ class DriverDSLImpl(
                 jolokiaJarPath: String,
                 monitorPort: Int?,
                 overriddenSystemProperties: Map<String, String>,
-                cordappPackages: List<String>,
+                cordappPackages: Set<String>,
                 maximumHeapSize: String
         ): Process {
             log.info("Starting out-of-process Node ${nodeConf.myLegalName.organisation}, debug port is " + (debugPort ?: "not enabled") + ", jolokia monitoring port is " + (monitorPort ?: "not enabled"))
@@ -659,7 +659,7 @@ fun <DI : DriverDSL, D : InternalDriverDSL, A> genericDriver(
         waitForNodesToFinish: Boolean = defaultParameters.waitForAllNodesToFinish,
         startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
         notarySpecs: List<NotarySpec>,
-        extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
+        extraCordappPackagesToScan: Set<String> = defaultParameters.extraCordappPackagesToScan,
         jmxPolicy: JmxPolicy = JmxPolicy(),
         driverDslWrapper: (DriverDSLImpl) -> D,
         coerce: (D) -> DI, dsl: DI.() -> A

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/NodeBasedTest.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.Executors
 import kotlin.concurrent.thread
 
 // TODO Some of the logic here duplicates what's in the driver
-abstract class NodeBasedTest(private val cordappPackages: List<String> = emptyList()) {
+abstract class NodeBasedTest(private val cordappPackages: Set<String> = emptySet()) {
     companion object {
         private val WHITESPACE = "\\s++".toRegex()
     }
@@ -113,7 +113,7 @@ abstract class NodeBasedTest(private val cordappPackages: List<String> = emptyLi
 }
 
 class InProcessNode(
-        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: List<String>) : Node(
+        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: Set<String>) : Node(
         configuration, versionInfo, false, CordappLoader.createDefaultWithTestPackages(configuration, cordappPackages)) {
     override fun getRxIoScheduler() = CachedThreadScheduler(testThreadFactory()).also { runOnStop += it::shutdown }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/internal/RPCDriver.kt
@@ -99,7 +99,7 @@ fun <A> rpcDriver(
         useTestClock: Boolean = false,
         startNodesInProcess: Boolean = false,
         waitForNodesToFinish: Boolean = false,
-        extraCordappPackagesToScan: List<String> = emptyList(),
+        extraCordappPackagesToScan: Set<String> = emptySet(),
         notarySpecs: List<NotarySpec> = emptyList(),
         externalTrace: Trace? = null,
         jmxPolicy: JmxPolicy = JmxPolicy(),

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -67,13 +67,13 @@ data class MockNetworkParameters(
         val servicePeerAllocationStrategy: InMemoryMessagingNetwork.ServicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.Random(),
         val defaultFactory: (MockNodeArgs) -> MockNetwork.MockNode = MockNetwork::MockNode,
         val initialiseSerialization: Boolean = true,
-        val cordappPackages: List<String> = emptyList()) {
+        val cordappPackages: Set<String> = emptySet()) {
     fun setNetworkSendManuallyPumped(networkSendManuallyPumped: Boolean) = copy(networkSendManuallyPumped = networkSendManuallyPumped)
     fun setThreadPerNode(threadPerNode: Boolean) = copy(threadPerNode = threadPerNode)
     fun setServicePeerAllocationStrategy(servicePeerAllocationStrategy: InMemoryMessagingNetwork.ServicePeerAllocationStrategy) = copy(servicePeerAllocationStrategy = servicePeerAllocationStrategy)
     fun setDefaultFactory(defaultFactory: (MockNodeArgs) -> MockNetwork.MockNode) = copy(defaultFactory = defaultFactory)
     fun setInitialiseSerialization(initialiseSerialization: Boolean) = copy(initialiseSerialization = initialiseSerialization)
-    fun setCordappPackages(cordappPackages: List<String>) = copy(cordappPackages = cordappPackages)
+    fun setCordappPackages(cordappPackages: Set<String>) = copy(cordappPackages = cordappPackages)
 }
 
 /**
@@ -123,7 +123,7 @@ class MockNetwork(defaultParameters: MockNetworkParameters = MockNetworkParamete
                   private val defaultFactory: (MockNodeArgs) -> MockNode = defaultParameters.defaultFactory,
                   initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
                   private val notarySpecs: List<NotarySpec> = listOf(NotarySpec(DUMMY_NOTARY.name)),
-                  private val cordappPackages: List<String> = defaultParameters.cordappPackages) {
+                  private val cordappPackages: Set<String> = defaultParameters.cordappPackages) {
     /** Helper constructor for creating a [MockNetwork] with custom parameters from Java. */
     constructor(parameters: MockNetworkParameters) : this(defaultParameters = parameters)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -84,7 +84,7 @@ open class MockServices private constructor(
         @JvmStatic
         fun makeTestDatabaseAndMockServices(keys: List<KeyPair>,
                                             identityService: IdentityServiceInternal,
-                                            cordappPackages: List<String> = emptyList(),
+                                            cordappPackages: Set<String> = emptySet(),
                                             initialIdentityName: CordaX500Name): Pair<CordaPersistence, MockServices> {
             val cordappLoader = CordappLoader.createWithTestPackages(cordappPackages)
             val dataSourceProps = makeTestDataSourceProperties()
@@ -108,8 +108,8 @@ open class MockServices private constructor(
     }
 
     private constructor(cordappLoader: CordappLoader, identityService: IdentityServiceInternal, initialIdentityName: CordaX500Name, vararg keys: KeyPair) : this(cordappLoader, MockTransactionStorage(), identityService, initialIdentityName, *keys)
-    constructor(cordappPackages: List<String>, identityService: IdentityServiceInternal, initialIdentityName: CordaX500Name, vararg keys: KeyPair) : this(CordappLoader.createWithTestPackages(cordappPackages), identityService, initialIdentityName, *keys)
-    constructor(identityService: IdentityServiceInternal, initialIdentityName: CordaX500Name, vararg keys: KeyPair) : this(emptyList(), identityService, initialIdentityName, *keys)
+    constructor(cordappPackages: Set<String>, identityService: IdentityServiceInternal, initialIdentityName: CordaX500Name, vararg keys: KeyPair) : this(CordappLoader.createWithTestPackages(cordappPackages), identityService, initialIdentityName, *keys)
+    constructor(identityService: IdentityServiceInternal, initialIdentityName: CordaX500Name, vararg keys: KeyPair) : this(emptySet(), identityService, initialIdentityName, *keys)
     constructor(identityService: IdentityServiceInternal, initialIdentityName: CordaX500Name) : this(identityService, initialIdentityName, generateKeyPair())
 
     val key: KeyPair get() = keys.first()

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -65,7 +65,7 @@ class ExplorerSimulation(private val options: OptionSet) {
 
     private fun startDemoNodes() {
         val portAllocation = PortAllocation.Incremental(20000)
-        driver(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true)) {
+        driver(portAllocation = portAllocation, extraCordappPackagesToScan = setOf("net.corda.finance"), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true)) {
             // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
             val alice = startNode(providedName = ALICE.name, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to "true"))
             val bob = startNode(providedName = BOB.name, rpcUsers = listOf(user))

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -58,7 +58,7 @@ fun <A> verifierDriver(
         useTestClock: Boolean = false,
         startNodesInProcess: Boolean = false,
         waitForNodesToFinish: Boolean = false,
-        extraCordappPackagesToScan: List<String> = emptyList(),
+        extraCordappPackagesToScan: Set<String> = emptySet(),
         notarySpecs: List<NotarySpec> = emptyList(),
         jmxPolicy: JmxPolicy = JmxPolicy(),
         dsl: VerifierDriverDSL.() -> A

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierTests.kt
@@ -43,7 +43,7 @@ class VerifierTests {
 
     @Test
     fun `single verifier works with requestor`() {
-        verifierDriver(extraCordappPackagesToScan = listOf("net.corda.finance.contracts")) {
+        verifierDriver(extraCordappPackagesToScan = setOf("net.corda.finance.contracts")) {
             val aliceFuture = startVerificationRequestor(ALICE.name)
             val transactions = generateTransactions(100)
             val alice = aliceFuture.get()
@@ -60,7 +60,7 @@ class VerifierTests {
 
     @Test
     fun `single verification fails`() {
-        verifierDriver(extraCordappPackagesToScan = listOf("net.corda.finance.contracts")) {
+        verifierDriver(extraCordappPackagesToScan = setOf("net.corda.finance.contracts")) {
             val aliceFuture = startVerificationRequestor(ALICE.name)
             // Generate transactions as per usual, but then remove attachments making transaction invalid.
             val transactions = generateTransactions(1).map { it.copy(attachments = emptyList()) }
@@ -136,7 +136,7 @@ class VerifierTests {
     @Test
     fun `single verifier works with a node`() {
         verifierDriver(
-                extraCordappPackagesToScan = listOf("net.corda.finance.contracts"),
+                extraCordappPackagesToScan = setOf("net.corda.finance.contracts"),
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY.name, verifierType = VerifierType.OutOfProcess))
         ) {
             val aliceNode = startNode(providedName = ALICE.name).getOrThrow()


### PR DESCRIPTION
This is probably not the most exciting change, but having `List` feels a bit awkward when it is not the order, but rather the content that counts and passing duplicates doesn't quite make sense.