### PR TITLE
CORDA-840: Gradle plugins are now able to be published to artifactory…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ buildscript {
     ext.beanutils_version = '1.9.3'
     ext.crash_version = 'faba68332800f21278c5b600bf14ad55cef5989e'
     ext.jsr305_version = constants.getProperty("jsr305Version")
+    ext.artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')
 
     // Update 121 is required for ObjectInputFilter and at time of writing 131 was latest:
     ext.java8_minUpdateVersion = '131'
@@ -72,6 +73,7 @@ buildscript {
         classpath "org.ajoberstar:grgit:1.1.0"
         classpath "net.i2p.crypto:eddsa:$eddsa_version" // Needed for ServiceIdentityGenerator in the build environment.
         classpath "org.owasp:dependency-check-gradle:${dependency_checker_version}"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:$artifactory_plugin_version"
     }
 }
 
@@ -80,7 +82,6 @@ plugins {
     // but the DSL has some restrictions e.g can't be used on the allprojects section. So we should revisit this if there are improvements in Gradle.
     // Version 1.0.2 of this plugin uses capsule:1.0.1
     id "us.kirchmeier.capsule" version "1.0.2"
-    id "com.jfrog.artifactory" version "4.4.18"
 }
 
 ext {
@@ -92,6 +93,7 @@ apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'net.corda.plugins.cordformation'
 apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
 
 // We need the following three lines even though they're inside an allprojects {} block below because otherwise
 // IntelliJ gets confused when importing the project and ends up erasing and recreating the .idea directory, along

--- a/constants.properties
+++ b/constants.properties
@@ -5,3 +5,4 @@ guavaVersion=21.0
 bouncycastleVersion=1.57
 typesafeConfigVersion=1.3.1
 jsr305Version=3.0.2
+artifactoryPluginVersion=4.4.18

--- a/gradle-plugins/api-scanner/build.gradle
+++ b/gradle-plugins/api-scanner/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 description "Generates a summary of the artifact's public API"
 

--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -7,11 +7,14 @@ buildscript {
     file("$projectDir/../constants.properties").withInputStream { constants.load(it) }
 
     // If you bump this version you must re-bootstrap the codebase. See the README for more information.
-    ext.gradle_plugins_version = constants.getProperty("gradlePluginsVersion")
-    ext.bouncycastle_version = constants.getProperty("bouncycastleVersion")
-    ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
-    ext.jsr305_version = constants.getProperty("jsr305Version")
-    ext.kotlin_version = constants.getProperty("kotlinVersion")
+    ext {
+        gradle_plugins_version = constants.getProperty("gradlePluginsVersion")
+        bouncycastle_version = constants.getProperty("bouncycastleVersion")
+        typesafe_config_version = constants.getProperty("typesafeConfigVersion")
+        jsr305_version = constants.getProperty("jsr305Version")
+        kotlin_version = constants.getProperty("kotlinVersion")
+        artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')
+    }
 
     repositories {
         mavenLocal()
@@ -22,10 +25,12 @@ buildscript {
         classpath "net.corda.plugins:publish-utils:$gradle_plugins_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:$artifactory_plugin_version"
     }
 }
 
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 allprojects {
     version gradle_plugins_version
@@ -52,5 +57,27 @@ bintrayConfig {
         id = 'R3'
         name = 'R3'
         email = 'dev@corda.net'
+    }
+}
+
+artifactory {
+    publish {
+        contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
+        repository {
+            repoKey = 'corda-dev'
+            username = 'teamcity'
+            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+        }
+
+        defaults {
+            // Publish utils does not have a publish block because it would be circular for it to apply it's own
+            // extensions to itself
+            if(project.name == 'publish-utils') {
+                publications('publishUtils')
+            // Root project applies the plugin (for this block) but does not need to be published
+            } else if(project != rootProject) {
+                publications(project.extensions.publish.name())
+            }
+        }
     }
 }

--- a/gradle-plugins/cordapp/build.gradle
+++ b/gradle-plugins/cordapp/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 description 'Turns a project into a cordapp project that produces cordapp fat JARs'
 

--- a/gradle-plugins/cordform-common/build.gradle
+++ b/gradle-plugins/cordform-common/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 repositories {
     mavenCentral()

--- a/gradle-plugins/cordformation/build.gradle
+++ b/gradle-plugins/cordformation/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 description 'A small gradle plugin for adding some basic Quasar tasks and configurations to reduce build.gradle bloat.'
 

--- a/gradle-plugins/publish-utils/build.gradle
+++ b/gradle-plugins/publish-utils/build.gradle
@@ -1,13 +1,17 @@
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.jfrog.artifactory'
 
 // Used for bootstrapping project
 buildscript {
     Properties constants = new Properties()
     file("../../constants.properties").withInputStream { constants.load(it) }
 
-    ext.gradle_plugins_version = constants.getProperty("gradlePluginsVersion")
+    ext {
+        gradle_plugins_version = constants.getProperty("gradlePluginsVersion")
+        artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')
+    }
 
     repositories {
         jcenter()
@@ -15,6 +19,7 @@ buildscript {
 
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:$artifactory_plugin_version"
     }
 }
 

--- a/gradle-plugins/quasar-utils/build.gradle
+++ b/gradle-plugins/quasar-utils/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 description 'A small gradle plugin for adding some basic Quasar tasks and configurations to reduce build.gradle bloat.'
 


### PR DESCRIPTION
…. (#2203)

Gradle plugins are now able to be published to artifactory.

This is already on master. It will enable you to use the new artifactory publish on TC to make it easier to distribute the custom gradle plugins version. 