### PR TITLE
[CORDA-843] ECDSA full support and entropyToKeyPair

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -117,18 +117,19 @@ fun Iterable<TransactionSignature>.byKeys() = map { it.by }.toSet()
 
 // Allow Kotlin destructuring:
 // val (private, public) = keyPair
-/* The [PrivateKey] of this [KeyPair] .*/
+/* The [PrivateKey] of this [KeyPair]. */
 operator fun KeyPair.component1(): PrivateKey = this.private
-/* The [PublicKey] of this [KeyPair] .*/
+/* The [PublicKey] of this [KeyPair]. */
 operator fun KeyPair.component2(): PublicKey = this.public
 
-/** A simple wrapper that will make it easier to swap out the EC algorithm we use in future. */
+/** A simple wrapper that will make it easier to swap out the signature algorithm we use in future. */
 fun generateKeyPair(): KeyPair = Crypto.generateKeyPair()
 
 /**
  * Returns a key pair derived from the given private key entropy. This is useful for unit tests and other cases where
  * you want hard-coded private keys.
- * This currently works for the default signature scheme EdDSA ed25519 only.
+ * @param entropy a [BigInteger] value.
+ * @return a deterministically generated [KeyPair] for the [Crypto.DEFAULT_SIGNATURE_SCHEME].
  */
 fun entropyToKeyPair(entropy: BigInteger): KeyPair = Crypto.deriveKeyPairFromEntropy(entropy)
 

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -24,6 +24,7 @@ import net.corda.testing.node.startFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import java.time.Instant
 import java.util.*
@@ -99,6 +100,7 @@ class NotaryServiceTests {
         assertThat(ex.error).isInstanceOf(NotaryError.TimeWindowInvalid::class.java)
     }
 
+    @Ignore("Only applies to deterministic signature schemes (e.g. EdDSA) and when deterministic metadata is attached (no timestamps or nonces)")
     @Test
     fun `should sign identical transaction multiple times (signing is idempotent)`() {
         val stx = run {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.DoNotImplement
 import net.corda.core.crypto.entropyToKeyPair
+import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
@@ -325,7 +326,8 @@ open class MockNetwork(private val cordappPackages: List<String>,
         // This is not thread safe, but node construction is done on a single thread, so that should always be fine
         override fun generateKeyPair(): KeyPair {
             counter = counter.add(BigInteger.ONE)
-            return entropyToKeyPair(counter)
+            // The MockNode specifically uses EdDSA keys as they are fixed and stored in json files for some tests (e.g IRSSimulation).
+            return Crypto.deriveKeyPairFromEntropy(Crypto.EDDSA_ED25519_SHA512, counter)
         }
 
         /**


### PR DESCRIPTION
Fully supporting ECDSA (both R1 and K1) in case they are set as the default signature schemes.
This work includes:

- Ignoring a test that assumes signature idempotency (ECDSA is randomised and not deterministic)

- IRS demo uses keys via MockNode and will still use EdDSA (even if we ever change the default) as the keys are fixed in json files.

- Support entropyToKeyPair for ECDSA R1 and K1

- Unit tests for both EdDSA and ECDSA (eg EdDSA trims the entropy to the first 256 bytes, while ECDSA uses hash(entropy) if it is out of range)

- The default algorithm is still EdDSA, but this PR will allow for easier transition to ECDSA when and if required.