### PR TITLE
Revert bootstrap netcert

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt
@@ -15,6 +15,4 @@ interface SSLConfiguration {
 interface NodeSSLConfiguration : SSLConfiguration {
     val baseDirectory: Path
     override val certificatesDirectory: Path get() = baseDirectory / "certificates"
-    // TODO This will be removed. Instead we will just check against the truststore, which will be provided out-of-band, along with its password
-    val rootCertFile: Path get() = certificatesDirectory / "rootcert.pem"
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -27,18 +27,27 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
         val SELF_SIGNED_PRIVATE_KEY = "Self Signed Private Key"
     }
 
-    init {
-        require(config.rootCertFile.exists()) {
-            "${config.rootCertFile} does not exist. This file must contain the root CA cert of your compatibility zone. " +
-                    "Please contact your CZ operator."
-        }
-    }
-
     private val requestIdStore = config.certificatesDirectory / "certificate-request-id.txt"
     private val keystorePassword = config.keyStorePassword
     // TODO: Use different password for private key.
     private val privateKeyPassword = config.keyStorePassword
-    private val rootCert = X509Utilities.loadCertificateFromPEMFile(config.rootCertFile)
+    private val trustStore: KeyStore
+    private val rootCert: Certificate
+
+    init {
+        require(config.trustStoreFile.exists()) {
+            "${config.trustStoreFile} does not exist. This file must contain the root CA cert of your compatibility zone. " +
+                    "Please contact your CZ operator."
+        }
+        trustStore = loadKeyStore(config.trustStoreFile, config.trustStorePassword)
+        val rootCert = trustStore.getCertificate(CORDA_ROOT_CA)
+        require(rootCert != null) {
+            "${config.trustStoreFile} does not contain a certificate with the key $CORDA_ROOT_CA." +
+                    "This file must contain the root CA cert of your compatibility zone. " +
+                    "Please contact your CZ operator."
+        }
+        this.rootCert = rootCert
+    }
 
     /**
      * Ensure the initial keystore for a node is set up.
@@ -83,17 +92,13 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
             caKeyStore.addOrReplaceKey(CORDA_CLIENT_CA, keyPair.private, privateKeyPassword.toCharArray(), certificates)
             caKeyStore.deleteEntry(SELF_SIGNED_PRIVATE_KEY)
             caKeyStore.save(config.nodeKeystore, keystorePassword)
-
-            // Check the root certificate.
-            val returnedRootCa = certificates.last()
-            checkReturnedRootCaMatchesExpectedCa(returnedRootCa)
-
-            // Save root certificates to trust store.
-            val trustStore = loadOrCreateKeyStore(config.trustStoreFile, config.trustStorePassword)
-            // Assumes certificate chain always starts with client certificate and end with root certificate.
-            trustStore.addOrReplaceCertificate(CORDA_ROOT_CA, returnedRootCa)
-            trustStore.save(config.trustStoreFile, config.trustStorePassword)
             println("Node private key and certificate stored in ${config.nodeKeystore}.")
+
+            // Check that the root of the signed certificate matches the expected certificate in the truststore.
+            if (rootCert != certificates.last()) {
+                // Assumes certificate chain always starts with client certificate and end with root certificate.
+                throw WrongRootCertException(rootCert, certificates.last(), config.trustStoreFile)
+            }
 
             println("Generating SSL certificate for node messaging service.")
             val sslKey = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
@@ -108,16 +113,6 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
             requestIdStore.deleteIfExists()
         } else {
             println("Certificate already exists, Corda node will now terminate...")
-        }
-    }
-
-    /**
-     * Checks that the passed Certificate is the expected root CA.
-     * @throws WrongRootCertException if the certificates don't match.
-     */
-    private fun checkReturnedRootCaMatchesExpectedCa(returnedRootCa: Certificate) {
-        if (rootCert != returnedRootCa) {
-            throw WrongRootCertException(rootCert, returnedRootCa, config.rootCertFile)
         }
     }
 
@@ -177,7 +172,7 @@ class NetworkRegistrationHelper(private val config: NodeConfiguration, private v
 
 /**
  * Exception thrown when the doorman root certificate doesn't match the expected (out-of-band) root certificate.
- * This usually means the has been a Man-in-the-middle attack when contacting the doorman.
+ * This usually means that there has been a Man-in-the-middle attack when contacting the doorman.
  */
 class WrongRootCertException(expected: Certificate,
                              actual: Certificate,
@@ -186,5 +181,5 @@ class WrongRootCertException(expected: Certificate,
             The Root CA returned back from the registration process does not match the expected Root CA
             expected: $expected
             actual: $actual
-            the expected certificate is stored in: $expectedFilePath
+            the expected certificate is stored in: $expectedFilePath with alias $CORDA_ROOT_CA
             """.trimMargin())

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -1,28 +1,45 @@
 package net.corda.testing.driver
 
 import net.corda.core.concurrent.CordaFuture
+import net.corda.core.internal.copyTo
 import net.corda.core.internal.div
 import net.corda.core.internal.list
 import net.corda.core.internal.readLines
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
 import net.corda.node.internal.NodeStartup
+import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.crypto.getX509Certificate
+import net.corda.nodeapi.internal.crypto.loadOrCreateKeyStore
 import net.corda.testing.DUMMY_BANK_A
 import net.corda.testing.DUMMY_NOTARY
 import net.corda.testing.DUMMY_REGULATOR
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import net.corda.testing.http.HttpApi
+import net.corda.testing.internal.CompatibilityZoneParams
 import net.corda.testing.internal.addressMustBeBound
 import net.corda.testing.internal.addressMustNotBeBound
 import net.corda.testing.internal.internalDriver
 import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.network.NetworkMapServer
 import org.assertj.core.api.Assertions.assertThat
 import org.json.simple.JSONObject
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.net.URL
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import javax.ws.rs.GET
+import javax.ws.rs.POST
+import javax.ws.rs.Path
+import javax.ws.rs.core.Response
+import javax.ws.rs.core.Response.ok
+
 
 class DriverTests {
+
     companion object {
         private val executorService: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
 


### PR DESCRIPTION
Revert https://github.com/corda/corda/pull/2151
we decided not to ship/deliver a .cer file.
We will use the node truststore instead.