### PR TITLE
Fix VaultUpdate filtering in trackBy

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -52,19 +52,33 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
              */
             val type: UpdateType = UpdateType.GENERAL
     ) {
-        /** Checks whether the update contains a state of the specified type. */
-        inline fun <reified T : ContractState> containsType() = consumed.any { it.state.data is T } || produced.any { it.state.data is T }
+        /** Filters an update by [clazz]. */
+        fun <T : ContractState> filterByType(clazz: Class<T>) =
+                copy(
+                        consumed = consumed.filterTo(HashSet()) { clazz.isAssignableFrom(it.state.data.javaClass) },
+                        produced = produced.filterTo(HashSet()) { clazz.isAssignableFrom(it.state.data.javaClass) }
+                )
 
-        /** Checks whether the update contains a state of the specified type and state status */
-        fun <T : ContractState> containsType(clazz: Class<T>, status: StateStatus) =
+        /**
+         * Filters an update based on the query's [status] parameter.
+         * This only has an effect if [status]=[StateStatus.CONSUMED].
+         */
+        fun filterByStatus(status: StateStatus) =
                 when (status) {
-                    StateStatus.UNCONSUMED -> produced.any { clazz.isAssignableFrom(it.state.data.javaClass) }
-                    StateStatus.CONSUMED -> consumed.any { clazz.isAssignableFrom(it.state.data.javaClass) }
-                    else -> consumed.any { clazz.isAssignableFrom(it.state.data.javaClass) }
-                            || produced.any { clazz.isAssignableFrom(it.state.data.javaClass) }
+                    StateStatus.CONSUMED -> copy(produced = emptySet())
+                    else -> this
                 }
 
         fun isEmpty() = consumed.isEmpty() && produced.isEmpty()
+
+        /** Checks whether the update contains a state of the specified type and state status */
+        fun <T : ContractState> containsType(clazz: Class<T>, status: StateStatus) =
+            when (status) {
+                StateStatus.UNCONSUMED -> produced.any { clazz.isAssignableFrom(it.state.data.javaClass) }
+                StateStatus.CONSUMED -> consumed.any { clazz.isAssignableFrom(it.state.data.javaClass) }
+                else -> consumed.any { clazz.isAssignableFrom(it.state.data.javaClass) }
+                        || produced.any { clazz.isAssignableFrom(it.state.data.javaClass) }
+            }
 
         /**
          * Combine two updates into a single update with the combined inputs and outputs of the two updates but net

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -55,8 +55,8 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
         /** Filters an update by [clazz]. */
         fun <T : ContractState> filterByType(clazz: Class<T>) =
                 copy(
-                        consumed = consumed.filterTo(HashSet()) { clazz.isAssignableFrom(it.state.data.javaClass) },
-                        produced = produced.filterTo(HashSet()) { clazz.isAssignableFrom(it.state.data.javaClass) }
+                        consumed = consumed.filterTo(LinkedHashSet()) { clazz.isAssignableFrom(it.state.data.javaClass) },
+                        produced = produced.filterTo(LinkedHashSet()) { clazz.isAssignableFrom(it.state.data.javaClass) }
                 )
 
         /**

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -488,10 +488,21 @@ Behavioural notes
    is a separate SQL query on the underlying database, and it is entirely conceivable that state modifications are
    taking place in between and/or in parallel to paging requests. When using pagination, always check the value of the
    ``totalStatesAvailable`` (from the ``Vault.Page`` result) and adjust further paging requests appropriately.
-3. In case ``TrackBy`` is used the filters are applied to the initial query and subsequent updates will reflect the
-   diffs between such filtered queries. Note that this means that if a ``trackBy`` queries UNCONSUMED states the
-   returned snapshot will only contain UNCONSUMED states, however updates will contain both consumed and unconsumed
-   states related to the change in case a previously UNCONSUMED state got consumed.
+3. In the case where ``TrackBy`` is used, ``QueryCriteria`` filters are only applied to the initial snapshot query.
+   Subsequent updates reflect all changes since that initial filtered query.
+   For example if a ``trackBy`` queries UNCONSUMED states the returned snapshot will only contain UNCONSUMED states,
+   however updates will contain both consumed and unconsumed states related to the change in case a previously
+   UNCONSUMED state got consumed.
+
+   An example scenario:
+     Alice issues $1
+     Alice moves $1 to Bob
+     Bob moves $1 back to Alice
+   If Alice tracks the vault for UNCONSUMED states before this interchange then she will see:
+     Update($1 produced, nothing consumed)
+     Update(nothing produced, $1 consumed)
+     Update($1 produced, nothing consumed)
+   If we didn't send the second update Alice would think she has $2!
 
 Other use case scenarios
 ------------------------

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -488,6 +488,10 @@ Behavioural notes
    is a separate SQL query on the underlying database, and it is entirely conceivable that state modifications are
    taking place in between and/or in parallel to paging requests. When using pagination, always check the value of the
    ``totalStatesAvailable`` (from the ``Vault.Page`` result) and adjust further paging requests appropriately.
+3. In case ``TrackBy`` is used the filters are applied to the initial query and subsequent updates will reflect the
+   diffs between such filtered queries. Note that this means that if a ``trackBy`` queries UNCONSUMED states the
+   returned snapshot will only contain UNCONSUMED states, however updates will contain both consumed and unconsumed
+   states related to the change in case a previously UNCONSUMED state got consumed.
 
 Other use case scenarios
 ------------------------

--- a/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
@@ -51,7 +51,8 @@ class ArtemisTcpTransport {
                     // It does not use AMQP messages for its own messages e.g. topology and heartbeats.
                     // TODO further investigate how to ensure we use a well defined wire level protocol for Node to Node communications.
                     TransportConstants.PROTOCOLS_PROP_NAME to "CORE,AMQP",
-                    TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME to (nodeSerializationEnv != null)
+                    TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME to (nodeSerializationEnv != null),
+                    TransportConstants.REMOTING_THREADS_PROPNAME to (if (nodeSerializationEnv != null) -1 else 1)
             )
 
             if (config != null && enableSSL) {

--- a/node/src/integration-test/kotlin/net/corda/node/services/VaultServiceTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/VaultServiceTest.kt
@@ -1,0 +1,92 @@
+package net.corda.node.services
+
+import net.corda.core.contracts.withoutIssuer
+import net.corda.core.internal.concurrent.transpose
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.getOrThrow
+import net.corda.finance.DOLLARS
+import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.flows.CashIssueFlow
+import net.corda.finance.flows.CashPaymentFlow
+import net.corda.testing.driver.DriverDSL
+import net.corda.testing.driver.driver
+import net.corda.testing.expect
+import net.corda.testing.expectEvents
+import net.corda.testing.sequence
+import org.junit.Test
+
+class VaultServiceTest {
+    class Setup(driver: DriverDSL): DriverDSL by driver {
+        val aliceNode = driver.startNode()
+        val bobNode = driver.startNode()
+        val aliceRpc = aliceNode.getOrThrow().rpc
+        val bobRpc = bobNode.getOrThrow().rpc
+        val alice = aliceNode.getOrThrow().nodeInfo.legalIdentities.first()
+        val bob = bobNode.getOrThrow().nodeInfo.legalIdentities.first()
+        val aliceVaultUpdates = aliceRpc.vaultTrack(Cash.State::class.java).updates
+    }
+
+    fun setup(block: Setup.() -> Unit) {
+        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance")) {
+            Setup(this).block()
+        }
+    }
+
+    @Test
+    fun `Cash change updates arrive correctly`() {
+        setup {
+            aliceRpc.startFlow(::CashIssueFlow, 2.DOLLARS, OpaqueBytes.of(0), defaultNotaryHandle.identity).returnValue.getOrThrow()
+            aliceRpc.startFlow(::CashPaymentFlow, 1.DOLLARS, bob).returnValue.getOrThrow()
+            bobRpc.startFlow(::CashPaymentFlow, 1.DOLLARS, alice).returnValue.getOrThrow()
+            aliceVaultUpdates.expectEvents {
+                sequence(
+                        expect {
+                            require(it.consumed.size == 0)
+                            require(it.produced.size == 1)
+                            require(it.produced.first().state.data.amount.withoutIssuer() == 2.DOLLARS)
+                        },
+                        expect {
+                            require(it.consumed.size == 1)
+                            require(it.consumed.first().state.data.amount.withoutIssuer() == 2.DOLLARS)
+                            require(it.produced.size == 1)
+                            require(it.produced.first().state.data.amount.withoutIssuer() == 1.DOLLARS)
+                        },
+                        expect {
+                            require(it.consumed.size == 0)
+                            require(it.produced.size == 1)
+                            require(it.produced.first().state.data.amount.withoutIssuer() == 1.DOLLARS)
+                        }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Updates with nothing produced don't get lost`() {
+        setup {
+            aliceRpc.startFlow(::CashIssueFlow, 1.DOLLARS, OpaqueBytes.of(0), defaultNotaryHandle.identity).returnValue.getOrThrow()
+            aliceRpc.startFlow(::CashPaymentFlow, 1.DOLLARS, bob).returnValue.getOrThrow()
+            bobRpc.startFlow(::CashPaymentFlow, 1.DOLLARS, alice).returnValue.getOrThrow()
+            aliceVaultUpdates.expectEvents {
+                sequence(
+                        expect {
+                            require(it.consumed.size == 0)
+                            require(it.produced.size == 1)
+                            require(it.produced.first().state.data.amount.withoutIssuer() == 1.DOLLARS)
+                        },
+                        expect {
+                            require(it.consumed.size == 1)
+                            require(it.consumed.first().state.data.amount.withoutIssuer() == 1.DOLLARS)
+                            require(it.produced.size == 0)
+                        },
+                        expect {
+                            require(it.consumed.size == 0)
+                            require(it.produced.size == 1)
+                            require(it.produced.first().state.data.amount.withoutIssuer() == 1.DOLLARS)
+                        }
+                )
+            }
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -474,8 +474,10 @@ class NodeVaultService(
     override fun <T : ContractState> _trackBy(criteria: QueryCriteria, paging: PageSpecification, sorting: Sort, contractStateType: Class<out T>): DataFeed<Vault.Page<T>, Vault.Update<T>> {
         return mutex.locked {
             val snapshotResults = _queryBy(criteria, paging, sorting, contractStateType)
-            val updates: Observable<Vault.Update<T>> = uncheckedCast(_updatesPublisher.bufferUntilSubscribed().filter { it.containsType(contractStateType, snapshotResults.stateTypes) })
-            DataFeed(snapshotResults, updates)
+            val bufferedUpdates = _updatesPublisher.bufferUntilSubscribed()
+            val filteredUpdates = bufferedUpdates.map { it.filterByType(contractStateType).filterByStatus(snapshotResults.stateTypes) }
+            val nonEmptyFilteredUpdates = filteredUpdates.filter { !it.isEmpty() }
+            DataFeed(snapshotResults, uncheckedCast(nonEmptyFilteredUpdates))
         }
     }
 


### PR DESCRIPTION
This PR fixes the update filtering.

Previously when a user tracked UNCONSUMED states, updates with nothing produced were filtered out, making a local view of UNCONSUMED states inconsistent as updates that only consumed were swallowed.

Imo the reason for this inconsistency stems from using `VaultUpdate`s for two separate purposes:
1. As a datastructure describing what states were consumed and produced
2. As a datastructure describing *the diff between two vault query results*

I think 2 should be a different datastructure, e.g.
```kotlin
data class QueryResultDiff {
  val rowsAdded
  val rowsRemoved
}
```

The above would clarify what's going on. When the user `track`s, the stream should contain `QueryResultDiff`s rather than `VaultUpdate`s. The property of consumedness/producedness is orthogonal to a row being removed/added to a query result.
For example if the user queries CONSUMED states the diffs would always have `rowsRemoved` empty, as the set of CONSUMED states always grows.
If the user queries UNCONSUMED states then both `rowsAdded` and `rowsRemoved` may be non-empty, as the set of UNCONSUMED states may both grow and shrink.

Unfortunately the above would imply an API break, so in this PR I used `VaultUpdate`s as these diffs.
In the case of UNCONSUMED/ALL queries the updates are modified to only contain states of the queried type, but other than that the update stays the same.
In the case of CONSUMED queries the updates are additionally modified by clearing the `produced` set.

I left the old `containsType` function as is because it's public API (even though it isn't used by the filtering anymore).