### PR TITLE
CORDA-716 Inline testNodeConfiguration

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -30,6 +30,7 @@ import net.corda.node.services.statemachine.StateMachineManagerImpl
 import net.corda.node.services.vault.NodeVaultService
 import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.internal.configureDatabase
+import net.corda.node.services.config.NodeConfiguration
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.*
@@ -42,7 +43,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.nio.file.Paths
 import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
@@ -97,7 +97,10 @@ class NodeSchedulerServiceTest : SingletonSerializeAsToken() {
         database = configureDatabase(dataSourceProps, DatabaseConfig(), rigorousMock())
         val identityService = makeTestIdentityService()
         kms = MockKeyManagementService(identityService, ALICE_KEY)
-        val configuration = testNodeConfiguration(Paths.get("."), CordaX500Name("Alice", "London", "GB"))
+        val configuration = rigorousMock<NodeConfiguration>().also {
+            doReturn(true).whenever(it).devMode
+            doReturn(null).whenever(it).devModeOptions
+        }
         val validatedTransactions = MockTransactionStorage()
         database.transaction {
             services = rigorousMock<Services>().also {

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -15,7 +15,6 @@ import net.corda.nodeapi.internal.crypto.getX509Certificate
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import net.corda.testing.ALICE_NAME
 import net.corda.testing.rigorousMock
-import net.corda.testing.node.testNodeConfiguration
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Rule
@@ -45,7 +44,14 @@ class NetworkRegistrationHelperTest {
 
     @Before
     fun init() {
-        config = testNodeConfiguration(baseDirectory = tempFolder.root.toPath(), myLegalName = ALICE_NAME)
+        abstract class AbstractNodeConfiguration : NodeConfiguration
+        config = rigorousMock<AbstractNodeConfiguration>().also {
+            doReturn(tempFolder.root.toPath()).whenever(it).baseDirectory
+            doReturn("trustpass").whenever(it).trustStorePassword
+            doReturn("cordacadevpass").whenever(it).keyStorePassword
+            doReturn(ALICE_NAME).whenever(it).myLegalName
+            doReturn("").whenever(it).emailAddress
+        }
     }
 
     @Test

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt
@@ -2,8 +2,6 @@
 
 package net.corda.testing.node
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.context.Actor
 import net.corda.core.context.AuthServiceId
 import net.corda.core.context.InvocationContext
@@ -15,16 +13,8 @@ import net.corda.core.internal.FlowStateMachine
 import net.corda.core.node.ServiceHub
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
-import net.corda.core.utilities.seconds
 import net.corda.node.services.api.StartedNodeServices
-import net.corda.node.services.config.CertChainPolicyConfig
-import net.corda.nodeapi.internal.persistence.DatabaseConfig
-import net.corda.node.services.config.NodeConfiguration
-import net.corda.node.services.config.VerifierType
-import net.corda.nodeapi.internal.config.User
 import net.corda.testing.*
-import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
-import java.nio.file.Path
 
 /**
  * Creates and tests a ledger built by the passed in dsl.
@@ -46,31 +36,6 @@ fun ServiceHub.transaction(
         dsl: TransactionDSL<TransactionDSLInterpreter>.() -> EnforceVerifyOrFail
 ) = ledger(notary) {
     dsl(TransactionDSL(TestTransactionDSLInterpreter(interpreter, TransactionBuilder(notary)), notary))
-}
-
-fun testNodeConfiguration(
-        baseDirectory: Path,
-        myLegalName: CordaX500Name): NodeConfiguration {
-    abstract class MockableNodeConfiguration : NodeConfiguration // Otherwise Mockito is defeated by val getters.
-    return rigorousMock<MockableNodeConfiguration>().also {
-        doReturn(baseDirectory).whenever(it).baseDirectory
-        doReturn(myLegalName).whenever(it).myLegalName
-        doReturn("cordacadevpass").whenever(it).keyStorePassword
-        doReturn("trustpass").whenever(it).trustStorePassword
-        doReturn(emptyList<User>()).whenever(it).rpcUsers
-        doReturn(null).whenever(it).notary
-        doReturn(makeTestDataSourceProperties(myLegalName.organisation)).whenever(it).dataSourceProperties
-        doReturn(DatabaseConfig()).whenever(it).database
-        doReturn("").whenever(it).emailAddress
-        doReturn("").whenever(it).exportJMXto
-        doReturn(true).whenever(it).devMode
-        doReturn(null).whenever(it).compatibilityZoneURL
-        doReturn(emptyList<CertChainPolicyConfig>()).whenever(it).certificateChainCheckPolicies
-        doReturn(VerifierType.InMemory).whenever(it).verifierType
-        doReturn(5).whenever(it).messageRedeliveryDelaySeconds
-        doReturn(5.seconds.toMillis()).whenever(it).additionalNodeInfoPollingFrequencyMsec
-        doReturn(null).whenever(it).devModeOptions
-    }
 }
 
 fun testActor(owningLegalIdentity: CordaX500Name = CordaX500Name("Test Company Inc.", "London", "GB")) = Actor(Actor.Id("Only For Testing"), AuthServiceId("TEST"), owningLegalIdentity)


### PR DESCRIPTION
shouldn't be api, and only MockNode needs most of the fields