### PR TITLE
ENT-1249 - Downgrade Artemis from v2.4 to v2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.capsule_version = '1.0.1'
 
     ext.asm_version = '0.5.3'
-    ext.artemis_version = '2.4.0'
+    ext.artemis_version = '2.2.0'
     ext.jackson_version = '2.9.2'
     ext.jetty_version = '9.4.7.v20170914'
     ext.jersey_version = '2.25'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,22 @@ buildscript {
     ext.capsule_version = '1.0.1'
 
     ext.asm_version = '0.5.3'
-    ext.artemis_version = '2.2.0'
+
+    /*
+     * TODO Upgrade to version 2.4 for large message streaming support
+     *
+     * Due to a memory leak in the connection handling code in Artemis, we are
+     * temporarily downgrading to version 2.1.0 (version used prior to the 2.4
+     * bump).
+     *
+     * The memory leak essentially triggers an out-of-memory exception within
+     * less than 10 seconds and can take down a node if a non-TLS connection is
+     * attempted against the P2P port.
+     *
+     * The issue has been reported to upstream:
+     * https://issues.apache.org/jira/browse/ARTEMIS-1559
+     */
+    ext.artemis_version = '2.1.0'
     ext.jackson_version = '2.9.2'
     ext.jetty_version = '9.4.7.v20170914'
     ext.jersey_version = '2.25'

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
@@ -12,7 +12,7 @@ import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.testing.node.internal.RPCDriverDSL
 import net.corda.testing.node.internal.rpcDriver
 import net.corda.testing.internal.testThreadFactory
-import org.apache.activemq.artemis.utils.collections.ConcurrentHashSet
+import org.apache.activemq.artemis.utils.ConcurrentHashSet
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -46,7 +46,7 @@ import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
+import org.apache.activemq.artemis.spi.core.remoting.Connection
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3
 import java.lang.reflect.Method
 import java.nio.file.Path
@@ -131,13 +131,14 @@ fun <A> rpcDriver(
 }
 
 private class SingleUserSecurityManager(val rpcUser: User) : ActiveMQSecurityManager3 {
+
     override fun validateUser(user: String?, password: String?) = isValid(user, password)
     override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?) = isValid(user, password)
-    override fun validateUser(user: String?, password: String?, remotingConnection: RemotingConnection?): String? {
+    override fun validateUser(user: String?, password: String?, remotingConnection: Connection?): String? {
         return validate(user, password)
     }
 
-    override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?, address: String?, connection: RemotingConnection?): String? {
+    override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?, address: String?, connection: Connection?): String? {
         return validate(user, password)
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -46,12 +46,13 @@ import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
-import org.apache.activemq.artemis.spi.core.remoting.Connection
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3
 import java.lang.reflect.Method
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
+import javax.security.cert.X509Certificate
 
 inline fun <reified I : RPCOps> RPCDriverDSL.startInVmRpcClient(
         username: String = rpcTestUser.username,
@@ -131,14 +132,13 @@ fun <A> rpcDriver(
 }
 
 private class SingleUserSecurityManager(val rpcUser: User) : ActiveMQSecurityManager3 {
-
     override fun validateUser(user: String?, password: String?) = isValid(user, password)
     override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?) = isValid(user, password)
-    override fun validateUser(user: String?, password: String?, remotingConnection: Connection?): String? {
+    override fun validateUser(user: String?, password: String?, certificates: Array<out X509Certificate>?): String? {
         return validate(user, password)
     }
 
-    override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?, address: String?, connection: Connection?): String? {
+    override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?, address: String?, connection: RemotingConnection?): String? {
         return validate(user, password)
     }
 


### PR DESCRIPTION
Downgrade Artemis to version 2.1 to protect against rogue non-TLS connections causing OOM.
 * https://issues.apache.org/jira/browse/ARTEMIS-1559

![mem-leak](https://user-images.githubusercontent.com/5948145/33986237-eca24ac0-e0b4-11e7-842a-940370949b24.png)
![mem-leak-source](https://user-images.githubusercontent.com/5948145/33986238-ecb836a0-e0b4-11e7-9dd1-18d02a5c248c.png)
