### PR TITLE
SignedNetworkMap verification fix

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -67,7 +67,7 @@ class SignedNetworkMap(val raw: SerializedBytes<NetworkMap>, val sig: DigitalSig
     @Throws(SignatureException::class, CertPathValidatorException::class)
     fun verified(trustedRoot: X509Certificate): NetworkMap {
         sig.by.publicKey.verify(raw.bytes, sig)
-        // Assume network map cert is issued by the root.
+        // Assume network map cert is under the default trust root.
         X509Utilities.validateCertificateChain(trustedRoot, sig.by, trustedRoot)
         return raw.deserialize()
     }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/NetworkMap.kt
@@ -7,6 +7,7 @@ import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
+import net.corda.nodeapi.internal.crypto.X509Utilities
 import java.security.SignatureException
 import java.security.cert.CertPathValidatorException
 import java.security.cert.X509Certificate
@@ -63,9 +64,11 @@ class SignedNetworkMap(val raw: SerializedBytes<NetworkMap>, val sig: DigitalSig
      * @throws CertPathValidatorException if the certificate path is invalid.
      * @throws SignatureException if the signature is invalid.
      */
-    @Throws(SignatureException::class)
-    fun verified(): NetworkMap {
+    @Throws(SignatureException::class, CertPathValidatorException::class)
+    fun verified(trustedRoot: X509Certificate): NetworkMap {
         sig.by.publicKey.verify(raw.bytes, sig)
+        // Assume network map cert is issued by the root.
+        X509Utilities.validateCertificateChain(trustedRoot, sig.by, trustedRoot)
         return raw.deserialize()
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -47,9 +47,7 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val trustedRoot: X509C
     fun getNetworkMap(): NetworkMapResponse {
         val conn = networkMapUrl.openHttpConnection()
         val signedNetworkMap = conn.inputStream.use { it.readBytes() }.deserialize<SignedNetworkMap>()
-        val networkMap = signedNetworkMap.verified()
-        // Assume network map cert is issued by the root.
-        X509Utilities.validateCertificateChain(trustedRoot, signedNetworkMap.sig.by, trustedRoot)
+        val networkMap = signedNetworkMap.verified(trustedRoot)
         val timeout = CacheControl.parse(Headers.of(conn.headerFields.filterKeys { it != null }.mapValues { it.value.first() })).maxAgeSeconds().seconds
         return NetworkMapResponse(networkMap, timeout)
     }


### PR DESCRIPTION
SignedNetworkMap verification should also include cert path validation,
which was probably moved away by accident, because docs say about the
exception CertPathValidatorException.