### PR TITLE
Raft notaries can share a single key pair for the service identity (i…

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
@@ -12,6 +12,9 @@ import net.corda.nodeapi.internal.config.NodeSSLConfiguration
 import net.corda.nodeapi.internal.crypto.*
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
+import java.security.KeyPair
+import java.security.PublicKey
+import java.security.cert.X509Certificate
 
 /**
  * Contains utility methods for generating identities for a node.
@@ -47,37 +50,56 @@ object DevIdentityGenerator {
         return identity.party
     }
 
-    fun generateDistributedNotaryIdentity(dirs: List<Path>, notaryName: CordaX500Name, threshold: Int = 1): Party {
+    fun generateDistributedNotaryCompositeIdentity(dirs: List<Path>, notaryName: CordaX500Name, threshold: Int = 1): Party {
         require(dirs.isNotEmpty())
 
-        log.trace { "Generating identity \"$notaryName\" for nodes: ${dirs.joinToString()}" }
-        val keyPairs = (1..dirs.size).map { generateKeyPair() }
-        val compositeKey = CompositeKey.Builder().addKeys(keyPairs.map { it.public }).build(threshold)
-
+        log.trace { "Generating composite identity \"$notaryName\" for nodes: ${dirs.joinToString()}" }
         val caKeyStore = loadKeyStore(javaClass.classLoader.getResourceAsStream("certificates/cordadevcakeys.jks"), "cordacadevpass")
         val intermediateCa = caKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_INTERMEDIATE_CA, "cordacadevkeypass")
-        val rootCert = caKeyStore.getCertificate(X509Utilities.CORDA_ROOT_CA)
+        val rootCert = caKeyStore.getX509Certificate(X509Utilities.CORDA_ROOT_CA)
 
+        val keyPairs = (1..dirs.size).map { generateKeyPair() }
+        val notaryKey = CompositeKey.Builder().addKeys(keyPairs.map { it.public }).build(threshold)
         keyPairs.zip(dirs) { keyPair, nodeDir ->
-            val (serviceKeyCert, compositeKeyCert) = listOf(keyPair.public, compositeKey).map { publicKey ->
-                X509Utilities.createCertificate(
-                        CertificateType.SERVICE_IDENTITY,
-                        intermediateCa.certificate,
-                        intermediateCa.keyPair,
-                        notaryName.x500Principal,
-                        publicKey)
-            }
-            val distServKeyStoreFile = (nodeDir / "certificates").createDirectories() / "distributedService.jks"
-            val keystore = loadOrCreateKeyStore(distServKeyStoreFile, "cordacadevpass")
-            keystore.setCertificateEntry("$DISTRIBUTED_NOTARY_ALIAS_PREFIX-composite-key", compositeKeyCert)
-            keystore.setKeyEntry(
-                    "$DISTRIBUTED_NOTARY_ALIAS_PREFIX-private-key",
-                    keyPair.private,
-                    "cordacadevkeypass".toCharArray(),
-                    arrayOf(serviceKeyCert, intermediateCa.certificate, rootCert))
-            keystore.save(distServKeyStoreFile, "cordacadevpass")
+            generateCertificates(keyPair, notaryKey, intermediateCa, notaryName, nodeDir, rootCert)
         }
 
-        return Party(notaryName, compositeKey)
+        return Party(notaryName, notaryKey)
+    }
+
+    fun generateDistributedNotarySingularIdentity(dirs: List<Path>, notaryName: CordaX500Name): Party {
+        require(dirs.isNotEmpty())
+
+        log.trace { "Generating singular identity \"$notaryName\" for nodes: ${dirs.joinToString()}" }
+        val caKeyStore = loadKeyStore(javaClass.classLoader.getResourceAsStream("certificates/cordadevcakeys.jks"), "cordacadevpass")
+        val intermediateCa = caKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_INTERMEDIATE_CA, "cordacadevkeypass")
+        val rootCert = caKeyStore.getX509Certificate(X509Utilities.CORDA_ROOT_CA)
+
+        val keyPair = generateKeyPair()
+        val notaryKey = keyPair.public
+        dirs.forEach { dir ->
+            generateCertificates(keyPair, notaryKey, intermediateCa, notaryName, dir, rootCert)
+        }
+        return Party(notaryName, notaryKey)
+    }
+
+    private fun generateCertificates(keyPair: KeyPair, notaryKey: PublicKey, intermediateCa: CertificateAndKeyPair, notaryName: CordaX500Name, nodeDir: Path, rootCert: X509Certificate) {
+        val (serviceKeyCert, compositeKeyCert) = listOf(keyPair.public, notaryKey).map { publicKey ->
+            X509Utilities.createCertificate(
+                    CertificateType.SERVICE_IDENTITY,
+                    intermediateCa.certificate,
+                    intermediateCa.keyPair,
+                    notaryName.x500Principal,
+                    publicKey)
+        }
+        val distServKeyStoreFile = (nodeDir / "certificates").createDirectories() / "distributedService.jks"
+        val keystore = loadOrCreateKeyStore(distServKeyStoreFile, "cordacadevpass")
+        keystore.setCertificateEntry("$DISTRIBUTED_NOTARY_ALIAS_PREFIX-composite-key", compositeKeyCert)
+        keystore.setKeyEntry(
+                "$DISTRIBUTED_NOTARY_ALIAS_PREFIX-private-key",
+                keyPair.private,
+                "cordacadevkeypass".toCharArray(),
+                arrayOf(serviceKeyCert, intermediateCa.certificate, rootCert))
+        keystore.save(distServKeyStoreFile, "cordacadevpass")
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -60,7 +60,7 @@ class BFTNotaryServiceTests {
         (Paths.get("config") / "currentView").deleteIfExists() // XXX: Make config object warn if this exists?
         val replicaIds = (0 until clusterSize)
 
-        notary = DevIdentityGenerator.generateDistributedNotaryIdentity(
+        notary = DevIdentityGenerator.generateDistributedNotaryCompositeIdentity(
                 replicaIds.map { mockNet.baseDirectory(mockNet.nextNodeId + it) },
                 CordaX500Name("BFT", "Zurich", "CH"))
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -16,6 +16,7 @@ import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.internal.config.User
 import net.corda.testing.*
 import net.corda.testing.driver.NodeHandle
+import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.DummyClusterSpec
@@ -45,7 +46,8 @@ class DistributedServiceTests {
                                 DUMMY_NOTARY_NAME,
                                 rpcUsers = listOf(testUser),
                                 cluster = DummyClusterSpec(clusterSize = 3, compositeServiceIdentity = compositeIdentity))
-                )
+                ),
+                portAllocation = PortAllocation.RandomFree
         ) {
             alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(testUser)).getOrThrow()
             raftNotaryIdentity = defaultNotaryIdentity

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -173,11 +173,11 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
     }
 
     private inline fun signNodeInfo(nodeInfo: NodeInfo, sign: (PublicKey, SerializedBytes<NodeInfo>) -> DigitalSignature): SignedNodeInfo {
-        // For now we assume the node has only one identity (excluding any composite ones)
-        val owningKey = nodeInfo.legalIdentities.single { it.owningKey !is CompositeKey }.owningKey
+        // For now we exclude any composite identities, see [SignedNodeInfo]
+        val owningKeys = nodeInfo.legalIdentities.map { it.owningKey }.filter { it !is CompositeKey }
         val serialised = nodeInfo.serialize()
-        val signature = sign(owningKey, serialised)
-        return SignedNodeInfo(serialised, listOf(signature))
+        val signatures = owningKeys.map { sign(it, serialised) }
+        return SignedNodeInfo(serialised, signatures)
     }
 
     open fun generateAndSaveNodeInfo(): NodeInfo {

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
@@ -62,7 +62,7 @@ class BFTNotaryCordform : CordformDefinition() {
     }
 
     override fun setup(context: CordformContext) {
-        DevIdentityGenerator.generateDistributedNotaryIdentity(
+        DevIdentityGenerator.generateDistributedNotaryCompositeIdentity(
                 notaryNames.map { context.baseDirectory(it.toString()) },
                 clusterName,
                 minCorrectReplicas(clusterSize)

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Notarise.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/Notarise.kt
@@ -1,6 +1,7 @@
 package net.corda.notarydemo
 
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.messaging.CordaRPCOps
@@ -38,7 +39,8 @@ private class NotaryDemoClientApi(val rpc: CordaRPCOps) {
 
     /** Makes calls to the node rpc to start transaction notarisation. */
     fun notarise(count: Int) {
-        println("Notary: \"${notary.name}\", with composite key: ${notary.owningKey.toStringShort()}")
+        val keyType = if (notary.owningKey is CompositeKey) "composite" else "public"
+        println("Notary: \"${notary.name}\", with $keyType key: ${notary.owningKey.toStringShort()}")
         val transactions = buildTransactions(count)
         println("Notarised ${transactions.size} transactions:")
         transactions.zip(notariseTransactions(transactions)).forEach { (tx, signersFuture) ->

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
@@ -58,7 +58,7 @@ class RaftNotaryCordform : CordformDefinition() {
     }
 
     override fun setup(context: CordformContext) {
-        DevIdentityGenerator.generateDistributedNotaryIdentity(
+        DevIdentityGenerator.generateDistributedNotarySingularIdentity(
                 notaryNames.map { context.baseDirectory(it.toString()) },
                 clusterName
         )

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NotarySpec.kt
@@ -14,10 +14,12 @@ data class NotarySpec(
 )
 
 @DoNotImplement
-sealed class ClusterSpec {
+abstract class ClusterSpec {
     abstract val clusterSize: Int
 
-    data class Raft(override val clusterSize: Int) : ClusterSpec() {
+    data class Raft(
+            override val clusterSize: Int
+    ) : ClusterSpec() {
         init {
             require(clusterSize > 0)
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DummyClusterSpec.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DummyClusterSpec.kt
@@ -1,0 +1,20 @@
+package net.corda.testing.node.internal
+
+import net.corda.testing.node.ClusterSpec
+
+/**
+ * Only used for testing the notary communication path. Can be configured to act as a Raft (singular identity),
+ * or a BFT (composite key identity) notary service.
+ */
+data class DummyClusterSpec(
+        override val clusterSize: Int,
+        /**
+         * If *true*, the cluster will use a shared composite public key for the service identity, with individual
+         * private keys. If *false*, the same "singular" key pair will be shared by all replicas.
+         */
+        val compositeServiceIdentity: Boolean = false
+) : ClusterSpec() {
+    init {
+        require(clusterSize > 0)
+    }
+}


### PR DESCRIPTION
…n contrast to a shared composite public key, and individual signing key pairs). This allows modifying the cluster size for a running notary service. 

Note that this does not apply to the BFT notary.