### PR TITLE
CORDA-880 Make contractsdsl java interop functions behave same as inline functions

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
@@ -12,7 +12,6 @@ import java.util.*
  * Defines a simple domain specific language for the specification of financial contracts. Currently covers:
  *
  *  - Some utilities for working with commands.
- *  - An Amount type that represents a positive quantity of a specific token.
  *  - A simple language extension for specifying requirements in English, along with logic to enforce them.
  */
 
@@ -38,7 +37,7 @@ inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>
                 filter { if (party == null) true else party in it.signingParties }.
                 map { CommandWithParties(it.signers, it.signingParties, it.value as T) }
 
-/** Filters the command list by type, parties and public keys all at once. */
+/** Filters the command list by type, party and public key all at once. */
 fun <C : CommandData> Collection<CommandWithParties<CommandData>>.select(klass: Class<C>,
                                                                          signer: PublicKey? = null,
                                                                          party: AbstractParty? = null) =

--- a/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
@@ -32,10 +32,7 @@ inline fun <R> requireThat(body: Requirements.() -> R) = Requirements.body()
 /** Filters the command list by type, party and public key all at once. */
 inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>.select(signer: PublicKey? = null,
                                                                                         party: AbstractParty? = null) =
-        filter { it.value is T }.
-                filter { if (signer == null) true else signer in it.signers }.
-                filter { if (party == null) true else party in it.signingParties }.
-                map { CommandWithParties(it.signers, it.signingParties, it.value as T) }
+        select(T::class.java, signer, party)
 
 /** Filters the command list by type, party and public key all at once. */
 fun <C : CommandData> Collection<CommandWithParties<CommandData>>.select(klass: Class<C>,
@@ -49,10 +46,7 @@ fun <C : CommandData> Collection<CommandWithParties<CommandData>>.select(klass: 
 /** Filters the command list by type, parties and public keys all at once. */
 inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>.select(signers: Collection<PublicKey>?,
                                                                                         parties: Collection<Party>?) =
-        filter { it.value is T }.
-                filter { if (signers == null) true else it.signers.containsAll(signers) }.
-                filter { if (parties == null) true else it.signingParties.containsAll(parties) }.
-                map { CommandWithParties(it.signers, it.signingParties, it.value as T) }
+        select(T::class.java, signers, parties)
 
 /** Filters the command list by type, parties and public keys all at once. */
 fun <C : CommandData> Collection<CommandWithParties<CommandData>>.select(klass: Class<C>,

--- a/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
@@ -30,8 +30,6 @@ inline fun <R> requireThat(body: Requirements.() -> R) = Requirements.body()
 
 //// Authenticated commands ///////////////////////////////////////////////////////////////////////////////////////////
 
-// TODO: Provide a version of select that interops with Java
-
 /** Filters the command list by type, party and public key all at once. */
 inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>.select(signer: PublicKey? = null,
                                                                                         party: AbstractParty? = null) =
@@ -40,7 +38,14 @@ inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>
                 filter { if (party == null) true else party in it.signingParties }.
                 map { CommandWithParties(it.signers, it.signingParties, it.value as T) }
 
-// TODO: Provide a version of select that interops with Java
+/** Filters the command list by type, parties and public keys all at once. */
+fun <C : CommandData> Collection<CommandWithParties<CommandData>>.select(klass: Class<C>,
+                                                                         signer: PublicKey? = null,
+                                                                         party: AbstractParty? = null) =
+        mapNotNull { if (klass.isInstance(it.value)) uncheckedCast<CommandWithParties<CommandData>, CommandWithParties<C>>(it) else null }.
+                filter { if (signer == null) true else signer in it.signers }.
+                filter { if (party == null) true else party in it.signingParties }.
+                map { CommandWithParties(it.signers, it.signingParties, it.value) }
 
 /** Filters the command list by type, parties and public keys all at once. */
 inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>.select(signers: Collection<PublicKey>?,
@@ -50,6 +55,15 @@ inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>
                 filter { if (parties == null) true else it.signingParties.containsAll(parties) }.
                 map { CommandWithParties(it.signers, it.signingParties, it.value as T) }
 
+/** Filters the command list by type, parties and public keys all at once. */
+fun <C : CommandData> Collection<CommandWithParties<CommandData>>.select(klass: Class<C>,
+                                                                         signers: Collection<PublicKey>?,
+                                                                         parties: Collection<Party>?) =
+        mapNotNull { if (klass.isInstance(it.value)) uncheckedCast<CommandWithParties<CommandData>, CommandWithParties<C>>(it) else null }.
+                filter { if (signers == null) true else it.signers.containsAll(signers) }.
+                filter { if (parties == null) true else it.signingParties.containsAll(parties) }.
+                map { CommandWithParties(it.signers, it.signingParties, it.value) }
+
 /** Ensures that a transaction has only one command that is of the given type, otherwise throws an exception. */
 inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>.requireSingleCommand() = try {
     select<T>().single()
@@ -58,8 +72,11 @@ inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>
 }
 
 /** Ensures that a transaction has only one command that is of the given type, otherwise throws an exception. */
-fun <C : CommandData> Collection<CommandWithParties<CommandData>>.requireSingleCommand(klass: Class<C>) =
-        mapNotNull { if (klass.isInstance(it.value)) uncheckedCast<CommandWithParties<CommandData>, CommandWithParties<C>>(it) else null }.single()
+fun <C : CommandData> Collection<CommandWithParties<CommandData>>.requireSingleCommand(klass: Class<C>) = try {
+    select(klass).single()
+} catch (e: NoSuchElementException) {
+    throw IllegalStateException("Required ${klass.kotlin.qualifiedName} command")   // Better error message.
+}
 
 /**
  * Simple functionality for verifying a move command. Verifies that each input has a signature from its owning key.

--- a/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
@@ -58,11 +58,7 @@ fun <C : CommandData> Collection<CommandWithParties<CommandData>>.select(klass: 
                 map { CommandWithParties(it.signers, it.signingParties, it.value) }
 
 /** Ensures that a transaction has only one command that is of the given type, otherwise throws an exception. */
-inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>.requireSingleCommand() = try {
-    select<T>().single()
-} catch (e: NoSuchElementException) {
-    throw IllegalStateException("Required ${T::class.qualifiedName} command")   // Better error message.
-}
+inline fun <reified T : CommandData> Collection<CommandWithParties<CommandData>>.requireSingleCommand() = requireSingleCommand(T::class.java)
 
 /** Ensures that a transaction has only one command that is of the given type, otherwise throws an exception. */
 fun <C : CommandData> Collection<CommandWithParties<CommandData>>.requireSingleCommand(klass: Class<C>) = try {

--- a/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
@@ -2,7 +2,7 @@ package net.corda.core.identity
 
 import com.google.common.collect.ImmutableSet
 import net.corda.core.internal.LegalNameValidator
-import net.corda.core.internal.VisibleForTesting
+import net.corda.core.internal.unspecifiedCountry
 import net.corda.core.internal.x500Name
 import net.corda.core.serialization.CordaSerializable
 import org.bouncycastle.asn1.ASN1Encodable
@@ -81,8 +81,6 @@ data class CordaX500Name(val commonName: String?,
         const val MAX_LENGTH_ORGANISATION_UNIT = 64
         const val MAX_LENGTH_COMMON_NAME = 64
         private val supportedAttributes = setOf(BCStyle.O, BCStyle.C, BCStyle.L, BCStyle.CN, BCStyle.ST, BCStyle.OU)
-        @VisibleForTesting
-        val unspecifiedCountry = "ZZ"
         private val countryCodes: Set<String> = ImmutableSet.copyOf(Locale.getISOCountries() + unspecifiedCountry)
         @JvmStatic
         fun build(principal: X500Principal): CordaX500Name {

--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -5,6 +5,7 @@ package net.corda.core.internal
 import net.corda.core.cordapp.CordappProvider
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.transactions.TransactionBuilder
@@ -318,3 +319,8 @@ fun ExecutorService.join() {
         // Try forever. Do not give up, tests use this method to assert the executor has no more tasks.
     }
 }
+
+@Suppress("unused")
+@VisibleForTesting
+val CordaX500Name.Companion.unspecifiedCountry
+    get() = "ZZ"

--- a/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt
@@ -1,0 +1,190 @@
+package net.corda.core.contracts
+
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.testing.TestIdentity
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.security.PublicKey
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+
+class ContractsDSLTests {
+    class UnwantedCommand : CommandData
+
+    interface TestCommands : CommandData {
+        class CommandOne : TypeOnlyCommandData(), TestCommands
+        class CommandTwo : TypeOnlyCommandData(), TestCommands
+    }
+
+    private companion object {
+
+        val MEGA_CORP = TestIdentity(CordaX500Name("MegaCorp", "London", "GB"))
+        val MEGA_CORP_PARTY get() = MEGA_CORP.party
+        val MEGA_CORP_KEY get() = MEGA_CORP.publicKey
+        val MINI_CORP = TestIdentity(CordaX500Name("MiniCorp", "London", "GB"))
+        val MINI_CORP_PARTY get() = MINI_CORP.party
+        val MINI_CORP_KEY get() = MINI_CORP.publicKey
+
+        val VALID_COMMAND_ONE = CommandWithParties(listOf(MEGA_CORP_KEY, MINI_CORP_KEY), listOf(MEGA_CORP_PARTY, MINI_CORP_PARTY), TestCommands.CommandOne())
+        val VALID_COMMAND_TWO = CommandWithParties(listOf(MEGA_CORP_KEY), listOf(MEGA_CORP_PARTY), TestCommands.CommandTwo())
+        val INVALID_COMMAND = CommandWithParties(emptyList(), emptyList(), UnwantedCommand())
+
+    }
+
+    @RunWith(Parameterized::class)
+    class RequireSingleCommandTests(private val testFunction: (Collection<CommandWithParties<CommandData>>) -> CommandWithParties<CommandData>, description: String) {
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "{1}")
+            fun data(): Collection<Array<Any>> = listOf(
+                    arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>> -> commands.requireSingleCommand<TestCommands>() }, "Inline version"),
+                    arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>> -> commands.requireSingleCommand(TestCommands::class.java) }, "Interop version")
+            )
+        }
+
+        @Test
+        fun `check function returns one value`() {
+            val commands = listOf(VALID_COMMAND_ONE, INVALID_COMMAND)
+            val returnedCommand = testFunction(commands)
+            assertEquals(returnedCommand, VALID_COMMAND_ONE, "they should be the same")
+        }
+
+        @Test(expected = IllegalArgumentException::class)
+        fun `check error is thrown if more than one valid command`() {
+            val commands = listOf(VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            testFunction(commands)
+        }
+
+        @Test
+        fun `check error is thrown when command is of wrong type`() {
+            val commands = listOf(INVALID_COMMAND)
+            try {
+                testFunction(commands)
+            } catch (e: IllegalStateException) {
+                assertEquals(e.message, "Required net.corda.core.contracts.ContractsDSLTests.TestCommands command")
+                return
+            }
+            fail("Should have returned an exception")
+        }
+    }
+
+    @RunWith(Parameterized::class)
+    class SelectWithSingleInputsTests(private val testFunction: (Collection<CommandWithParties<CommandData>>, PublicKey?, AbstractParty?) -> Iterable<CommandWithParties<CommandData>>, description: String) {
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "{1}")
+            fun data(): Collection<Array<Any>> = listOf(
+                    arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signer: PublicKey?, party: AbstractParty? -> commands.select<TestCommands>(signer, party) }, "Inline version"),
+                    arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signer: PublicKey?, party: AbstractParty? -> commands.select(TestCommands::class.java, signer, party) }, "Interop version")
+            )
+        }
+
+        @Test
+        fun `check that function returns all values`() {
+            val commands = listOf (VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            testFunction(commands, null, null)
+            assertEquals(2, commands.size)
+            assertTrue(commands.contains(VALID_COMMAND_ONE))
+            assertTrue(commands.contains(VALID_COMMAND_TWO))
+        }
+
+        @Test
+        fun `check that function does not return invalid command types`() {
+            val commands = listOf(VALID_COMMAND_ONE, INVALID_COMMAND)
+            val filteredCommands = testFunction(commands, null, null).toList()
+            assertEquals(1, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertFalse(filteredCommands.contains(INVALID_COMMAND))
+        }
+
+        @Test
+        fun `check that function returns commands from valid signers`() {
+            val commands = listOf(VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            val filteredCommands = testFunction(commands, MINI_CORP_KEY, null).toList()
+            assertEquals(1, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertFalse(filteredCommands.contains(VALID_COMMAND_TWO))
+        }
+
+        @Test
+        fun `check that function returns commands from valid parties`() {
+            val commands = listOf(VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            val filteredCommands = testFunction(commands, null, MINI_CORP_PARTY).toList()
+            assertEquals(1, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertFalse(filteredCommands.contains(VALID_COMMAND_TWO))
+        }
+    }
+
+    @RunWith(Parameterized::class)
+    class SelectWithMultipleInputsTests(private val testFunction: (Collection<CommandWithParties<CommandData>>, Collection<PublicKey>?, Collection<Party>?) -> Iterable<CommandWithParties<CommandData>>, description: String) {
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "{1}")
+            fun data(): Collection<Array<Any>> = listOf(
+                    arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signers: Collection<PublicKey>?, party: Collection<Party>? -> commands.select<TestCommands>(signers, party) }, "Inline version"),
+                    arrayOf<Any>({ commands: Collection<CommandWithParties<CommandData>>, signers: Collection<PublicKey>?, party: Collection<Party>? -> commands.select(TestCommands::class.java, signers, party) }, "Interop version")
+            )
+        }
+
+        @Test
+        fun `check that function returns all values`() {
+            val commands = listOf (VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            testFunction(commands, null, null)
+            assertEquals(2, commands.size)
+            assertTrue(commands.contains(VALID_COMMAND_ONE))
+            assertTrue(commands.contains(VALID_COMMAND_TWO))
+        }
+
+        @Test
+        fun `check that function does not return invalid command types`() {
+            val commands = listOf(VALID_COMMAND_ONE, INVALID_COMMAND)
+            val filteredCommands = testFunction(commands, null, null).toList()
+            assertEquals(1, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertFalse(filteredCommands.contains(INVALID_COMMAND))
+        }
+
+        @Test
+        fun `check that function returns commands from valid signers`() {
+            val commands = listOf(VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            val filteredCommands = testFunction(commands, listOf(MEGA_CORP_KEY), null).toList()
+            assertEquals(2, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertTrue(filteredCommands.contains(VALID_COMMAND_TWO))
+        }
+
+        @Test
+        fun `check that function returns commands from all valid signers`() {
+            val commands = listOf(VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            val filteredCommands = testFunction(commands, listOf(MINI_CORP_KEY, MEGA_CORP_KEY), null).toList()
+            assertEquals(1, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertFalse(filteredCommands.contains(VALID_COMMAND_TWO))
+        }
+
+        @Test
+        fun `check that function returns commands from valid parties`() {
+            val commands = listOf(VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            val filteredCommands = testFunction(commands, null, listOf(MEGA_CORP_PARTY)).toList()
+            assertEquals(2, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertTrue(filteredCommands.contains(VALID_COMMAND_TWO))
+        }
+
+        @Test
+        fun `check that function returns commands from all valid parties`() {
+            val commands = listOf(VALID_COMMAND_ONE, VALID_COMMAND_TWO)
+            val filteredCommands = testFunction(commands, null, listOf(MINI_CORP_PARTY, MEGA_CORP_PARTY)).toList()
+            assertEquals(1, filteredCommands.size)
+            assertTrue(filteredCommands.contains(VALID_COMMAND_ONE))
+            assertFalse(filteredCommands.contains(VALID_COMMAND_TWO))
+        }
+    }
+}

--- a/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/ContractsDSLTests.kt
@@ -59,7 +59,7 @@ class ContractsDSLTests {
             val commands = listOf(invalidCommand)
             Assertions.assertThatThrownBy { testFunction(commands) }
                     .isInstanceOf(IllegalStateException::class.java)
-                    .withFailMessage("Required net.corda.core.contracts.ContractsDSLTests.TestCommands command")
+                    .hasMessage("Required net.corda.core.contracts.ContractsDSLTests.TestCommands command")
         }
     }
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/CoreTestUtils.kt
@@ -10,6 +10,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.cert
+import net.corda.core.internal.unspecifiedCountry
 import net.corda.core.internal.x500Name
 import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort


### PR DESCRIPTION
* Made ContractsDSL.requireSingleCommand behave the same way for the inline function and the java version (thrown error messages were different)
* Added java compatible implementations of the ContractsDSL.single
* Added tests for the above functions to make sure both signatures work the same way
