### PR TITLE
[CORDA-879] Generate node directories as part of bootstrapping

### DIFF
--- a/docs/source/setting-up-a-corda-network.rst
+++ b/docs/source/setting-up-a-corda-network.rst
@@ -67,7 +67,9 @@ The bootstrapper tool can be built with the command:
 
 The resulting jar can be found in ``tools/bootstrapper/build/libs/``.
 
-To use it, run the following command, specifying the root directory which hosts all the node directories as the argument:
+To use it, create a directory containing ``corda.jar`` (see the :doc:`corda-configuration-file` on how to build ``corda.jar``)
+and a list of config files for each node you want to create. The name of the config file will be used to create the name
+of the directory that will contain the node. Then run the following command:
 
 ``java -jar network-bootstrapper.jar <nodes-root-dir>``
 

--- a/docs/source/setting-up-a-corda-network.rst
+++ b/docs/source/setting-up-a-corda-network.rst
@@ -67,10 +67,20 @@ The bootstrapper tool can be built with the command:
 
 The resulting jar can be found in ``tools/bootstrapper/build/libs/``.
 
-To use it, create a directory containing a config file for each node you want to create. The name of the config file will be used to create the name
-of the directory that will contain the node. Then run the following command:
+To use it, create a directory containing a ``node.conf`` file for each node you want to create. Then run the following command:
 
 ``java -jar network-bootstrapper.jar <nodes-root-dir>``
+
+For example running the command on a directory containing these files :
+
+.. sourcecode:: none
+
+    .
+    ├── notary.conf             // The notary's node.conf file
+    ├── partya.conf             // Party A's node.conf file
+    └── partyb.conf             // Party B's node.conf file
+
+Would generate directories containing three nodes: notary, partya and partyb.
 
 Starting the nodes
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/setting-up-a-corda-network.rst
+++ b/docs/source/setting-up-a-corda-network.rst
@@ -67,8 +67,7 @@ The bootstrapper tool can be built with the command:
 
 The resulting jar can be found in ``tools/bootstrapper/build/libs/``.
 
-To use it, create a directory containing ``corda.jar`` (see the :doc:`corda-configuration-file` on how to build ``corda.jar``)
-and a list of config files for each node you want to create. The name of the config file will be used to create the name
+To use it, create a directory containing a config file for each node you want to create. The name of the config file will be used to create the name
 of the directory that will contain the node. Then run the following command:
 
 ``java -jar network-bootstrapper.jar <nodes-root-dir>``

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -76,11 +76,11 @@ class NetworkBootstrapper {
         if (confFiles.isEmpty()) { return }
         println("Node config files found in the root directory - generating node directories")
         val cordaJar = extractCordaJarTo(directory)
-        confFiles.forEach {
-            val nodeName = it.fileName.toString().removeSuffix(".conf")
+        for(confFile in confFiles) {
+            val nodeName = confFile.fileName.toString().removeSuffix(".conf")
             println("Generating directory for $nodeName")
             val nodeDir = (directory / nodeName).createDirectory()
-            it.moveTo(nodeDir / "node.conf")
+            confFile.moveTo(nodeDir / "node.conf")
             Files.copy(cordaJar, (nodeDir / "corda.jar"))
         }
         Files.delete(cordaJar)
@@ -88,7 +88,7 @@ class NetworkBootstrapper {
 
     private fun extractCordaJarTo(directory: Path) : Path {
         val cordaJarPath = (directory / "corda.jar")
-        Files.copy(Thread.currentThread().contextClassLoader.getResourceAsStream("corda.jar"), cordaJarPath)
+        Thread.currentThread().contextClassLoader.getResourceAsStream("corda.jar").copyTo(cordaJarPath)
         return cordaJarPath
     }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -73,10 +73,10 @@ class NetworkBootstrapper {
 
     private fun generateDirectoriesIfNeeded(directory: Path) {
         val confFiles = directory.list { it.filter { it.toString().endsWith(".conf") }.toList() }
-        if (confFiles.isEmpty()) { return }
+        if (confFiles.isEmpty()) return
         println("Node config files found in the root directory - generating node directories")
         val cordaJar = extractCordaJarTo(directory)
-        for(confFile in confFiles) {
+        for (confFile in confFiles) {
             val nodeName = confFile.fileName.toString().removeSuffix(".conf")
             println("Generating directory for $nodeName")
             val nodeDir = (directory / nodeName).createDirectory()
@@ -86,7 +86,7 @@ class NetworkBootstrapper {
         Files.delete(cordaJar)
     }
 
-    private fun extractCordaJarTo(directory: Path) : Path {
+    private fun extractCordaJarTo(directory: Path): Path {
         val cordaJarPath = (directory / "corda.jar")
         Thread.currentThread().contextClassLoader.getResourceAsStream("corda.jar").copyTo(cordaJarPath)
         return cordaJarPath
@@ -159,10 +159,10 @@ class NetworkBootstrapper {
 
     private fun NodeInfo.notaryIdentity(): Party {
         return when (legalIdentities.size) {
-            // Single node notaries have just one identity like all other nodes. This identity is the notary identity
+        // Single node notaries have just one identity like all other nodes. This identity is the notary identity
             1 -> legalIdentities[0]
-            // Nodes which are part of a distributed notary have a second identity which is the composite identity of the
-            // cluster and is shared by all the other members. This is the notary identity.
+        // Nodes which are part of a distributed notary have a second identity which is the composite identity of the
+        // cluster and is shared by all the other members. This is the notary identity.
             2 -> legalIdentities[1]
             else -> throw IllegalArgumentException("Not sure how to get the notary identity in this scenerio: $this")
         }
@@ -184,6 +184,7 @@ class NetworkBootstrapper {
         override fun canDeserializeVersion(byteSequence: ByteSequence, target: SerializationContext.UseCase): Boolean {
             return byteSequence == KryoHeaderV0_1 && target == SerializationContext.UseCase.P2P
         }
+
         override fun rpcClientKryoPool(context: SerializationContext) = throw UnsupportedOperationException()
         override fun rpcServerKryoPool(context: SerializationContext) = throw UnsupportedOperationException()
     }

--- a/tools/bootstrapper/build.gradle
+++ b/tools/bootstrapper/build.gradle
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.slf4j:slf4j-api:$slf4j_version"
+    compile "org.slf4j:slf4j-nop:$slf4j_version"
 }
 
 task buildBootstrapperJar(type: FatCapsule, dependsOn: project(':node-api').compileJava) {

--- a/tools/bootstrapper/build.gradle
+++ b/tools/bootstrapper/build.gradle
@@ -6,7 +6,10 @@ configurations {
     runtimeArtifacts
 }
 
-// TODO Fix SLF4J warnings that occur when running the bootstrapper
+dependencies {
+    compile "org.slf4j:slf4j-api:$slf4j_version"
+}
+
 task buildBootstrapperJar(type: FatCapsule, dependsOn: project(':node-api').compileJava) {
     applicationClass 'net.corda.nodeapi.internal.network.NetworkBootstrapper'
     archiveName "network-bootstrapper.jar"
@@ -15,6 +18,9 @@ task buildBootstrapperJar(type: FatCapsule, dependsOn: project(':node-api').comp
         systemProperties['visualvm.display.name'] = 'Network Bootstrapper'
         minJavaVersion = '1.8.0'
         jvmArgs = ['-XX:+UseG1GC']
+    }
+    from(project(':node:capsule').tasks['buildCordaJAR']) {
+        rename 'corda-(.*)', 'corda.jar'
     }
     applicationSource = files(
             project(':node-api').configurations.runtime,


### PR DESCRIPTION
Give the bootstrapper a directory containing a list of .conf files and a corda.jar
Generate a node directory for each .conf file, using the name of the .conf file

The old method where the directories are already created will still work