### PR TITLE
Refactor database properties in mock services

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -400,7 +400,7 @@ open class MockNetwork(private val cordappPackages: List<String>,
         val config = mockNodeConfiguration().also {
             doReturn(baseDirectory(id).createDirectories()).whenever(it).baseDirectory
             doReturn(parameters.legalName ?: CordaX500Name("Mock Company $id", "London", "GB")).whenever(it).myLegalName
-            doReturn(makeTestDataSourceProperties("node_${id}_net_$networkId")).whenever(it).dataSourceProperties
+            doReturn(makeTestDataSourceProperties("node_$id", "net_$networkId")).whenever(it).dataSourceProperties
             parameters.configOverrides(it)
         }
         val node = nodeFactory(MockNodeArgs(config, this, id, parameters.entropyRoot, parameters.version))

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -251,8 +251,8 @@ fun inMemoryH2DataSourceConfig(nodeName: String? = null, postfix: String? = null
     val h2InstanceName = if (postfix != null) nodeName + "_" + postfix else nodeName
 
     return ConfigFactory.parseMap(mapOf(
-            "dataSourceClassName" to "org.h2.jdbcx.JdbcDataSource",
-            "dataSource.url" to "jdbc:h2:mem:${h2InstanceName}_persistence;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE",
-            "dataSource.user" to "sa",
-            "dataSource.password" to ""))
+            "dataSourceProperties.dataSourceClassName" to "org.h2.jdbcx.JdbcDataSource",
+            "dataSourceProperties.dataSource.url" to "jdbc:h2:mem:${h2InstanceName}_persistence;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE",
+            "dataSourceProperties.dataSource.user" to "sa",
+            "dataSourceProperties.dataSource.password" to ""))
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -66,13 +66,14 @@ open class MockServices private constructor(
          * Make properties appropriate for creating a DataSource for unit tests.
          *
          * @param nodeName Reflects the "instance" of the in-memory database or database username/schema.  Defaults to a random string.
-         * @param nameExtension Provides additional name extension for the "instance" of in-memory database to provide uniqueness when running integration unit tests against H2.
+         * @param nodeNameExtension Provides additional name extension for the "instance" of in-memory database to provide uniqueness when running unit tests against H2 db.
+         * @param configSupplier returns [Config] with dataSourceProperties entry.
          */
         // TODO: Can we use an X509 principal generator here?
         @JvmStatic
-        fun makeTestDataSourceProperties(nodeName: String = SecureHash.randomSHA256().toString(), nameExtension: String? = null,
+        fun makeTestDataSourceProperties(nodeName: String = SecureHash.randomSHA256().toString(), nodeNameExtension: String? = null,
                                          configSupplier: (String, String?) -> Config = ::inMemoryH2DataSourceConfig): Properties {
-            val config = configSupplier(nodeName, nameExtension)
+            val config = configSupplier(nodeName, nodeNameExtension)
             val props = Properties()
             props.setProperty("dataSourceClassName", config.getString("dataSourceProperties.dataSourceClassName"))
             props.setProperty("dataSource.url", config.getString("dataSourceProperties.dataSource.url"))

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/database/DataSourcePropertiesUtil.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/database/DataSourcePropertiesUtil.kt
@@ -1,0 +1,47 @@
+package net.corda.testing.database
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import net.corda.testing.database.DataSourceProperties.CONFIG_ENTRY
+import net.corda.testing.database.DataSourceProperties.DATA_SOURCE_CLASSNAME
+import net.corda.testing.database.DataSourceProperties.DATA_SOURCE_PASSWORD
+import net.corda.testing.database.DataSourceProperties.DATA_SOURCE_URL
+import net.corda.testing.database.DataSourceProperties.DATA_SOURCE_USER
+import java.util.*
+
+internal object DataSourceProperties {
+    /** Entry name in [Config] containing datasource properties. */
+    const val CONFIG_ENTRY = "dataSourceProperties."
+    const val DATA_SOURCE_URL = "dataSource.url"
+    const val DATA_SOURCE_CLASSNAME = "dataSourceClassName"
+    const val DATA_SOURCE_USER = "dataSource.user"
+    const val DATA_SOURCE_PASSWORD = "dataSource.password"
+}
+
+/**
+ * Retrieves JDBC Data Source properties for HikariConfig from dataSourceProperties [Config] entry.
+ * Use when [Config] is created manually without use of auto binding by NodeConfiguration.
+ */
+fun Config.toDataSourceProperties(): Properties {
+    val props = Properties()
+    props.setProperty(DATA_SOURCE_CLASSNAME, this.getString(CONFIG_ENTRY + DATA_SOURCE_CLASSNAME))
+    props.setProperty(DATA_SOURCE_URL, this.getString(CONFIG_ENTRY + DATA_SOURCE_URL))
+    props.setProperty(DATA_SOURCE_USER, this.getString(CONFIG_ENTRY + DATA_SOURCE_USER))
+    props.setProperty(DATA_SOURCE_PASSWORD, this.getString(CONFIG_ENTRY + DATA_SOURCE_PASSWORD))
+    return props
+}
+
+/**
+ * Creates a dataSourceProperties entry of [Config].
+ * @param url JDBC connection string, value for dataSource.url key
+ * @param driverClass JDBC Driver class name, value for dataSource.url key
+ * @param user database login, value for dataSource.user key
+ * @param password database password, value for dataSource.password key
+ */
+fun dataSourceConfig(url: String, driverClass: String, user: String, password: String) : Config {
+    return ConfigFactory.parseMap(mapOf(
+            CONFIG_ENTRY + DATA_SOURCE_URL to url,
+            CONFIG_ENTRY + DATA_SOURCE_CLASSNAME to driverClass,
+            CONFIG_ENTRY + DATA_SOURCE_USER to user,
+            CONFIG_ENTRY + DATA_SOURCE_PASSWORD to password))
+}


### PR DESCRIPTION
* Align the use of parameters for `makeTestDataSourceProperties` method with one in Enterprise repo.
* Move database constants (the properties names in config file) from MockServices to a separate encapsulating Util class.