### PR TITLE
Minor refactoring of CordaRPCJavaClientTest to align with enterprise repo.

### DIFF
--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -55,7 +55,7 @@ public class CordaRPCJavaClientTest extends NodeBasedTest {
     }
 
     @Before
-    public void setUp() throws ExecutionException, InterruptedException {
+    public void setUp() throws Exception {
         node = startNode(ALICE_NAME, 1, singletonList(rpcUser));
         client = new CordaRPCClient(requireNonNull(node.getInternals().getConfiguration().getRpcAddress()));
     }
@@ -71,11 +71,11 @@ public class CordaRPCJavaClientTest extends NodeBasedTest {
     }
 
     @Test
-    public void testCashBalances() throws NoSuchFieldException, ExecutionException, InterruptedException {
+    public void testCashBalances() throws ExecutionException, InterruptedException {
         login(rpcUser.getUsername(), rpcUser.getPassword());
 
         FlowHandle<AbstractCashFlow.Result> flowHandle = rpcProxy.startFlowDynamic(CashIssueFlow.class,
-                DOLLARS(123), OpaqueBytes.of("1".getBytes()),
+                DOLLARS(123), OpaqueBytes.of((byte)0),
                 CoreTestUtils.chooseIdentity(node.getInfo()));
         System.out.println("Started issuing cash, waiting on result");
         flowHandle.getReturnValue().get();


### PR DESCRIPTION
* Align CordaRPCJavaClientTest with Kotlin version of the test (`(byte)0` instead of `"1".getBytes()`)
* Refactoring to align with enterprise repo (exceptions).