### PR TITLE
Internal driver now also does the registration for the notaries.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
@@ -14,7 +14,6 @@ import net.corda.nodeapi.internal.config.NodeSSLConfiguration
 import net.corda.nodeapi.internal.crypto.*
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
-import java.security.cert.X509Certificate
 
 /**
  * Contains utility methods for generating identities for a node.
@@ -29,11 +28,8 @@ object DevIdentityGenerator {
     const val NODE_IDENTITY_ALIAS_PREFIX = "identity"
     const val DISTRIBUTED_NOTARY_ALIAS_PREFIX = "distributed-notary"
 
-    /**
-     * Install a node key store for the given node directory using the given legal name and an optional root cert. If no
-     * root cert is specified then the default one in certificates/cordadevcakeys.jks is used.
-     */
-    fun installKeyStoreWithNodeIdentity(nodeDir: Path, legalName: CordaX500Name, customRootCert: X509Certificate? = null): Party {
+    /** Install a node key store for the given node directory using the given legal name. */
+    fun installKeyStoreWithNodeIdentity(nodeDir: Path, legalName: CordaX500Name): Party {
         val nodeSslConfig = object : NodeSSLConfiguration {
             override val baseDirectory = nodeDir
             override val keyStorePassword: String = "cordacadevpass"
@@ -43,8 +39,7 @@ object DevIdentityGenerator {
         // TODO The passwords for the dev key stores are spread everywhere and should be constants in a single location
         val caKeyStore = loadKeyStore(javaClass.classLoader.getResourceAsStream("certificates/cordadevcakeys.jks"), "cordacadevpass")
         val intermediateCa = caKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_INTERMEDIATE_CA, "cordacadevkeypass")
-        // TODO If using a custom root cert, then the intermidate cert needs to be generated from it as well, and not taken from the default
-        val rootCert = customRootCert ?: caKeyStore.getCertificate(X509Utilities.CORDA_ROOT_CA)
+        val rootCert = caKeyStore.getCertificate(X509Utilities.CORDA_ROOT_CA)
 
         nodeSslConfig.certificatesDirectory.createDirectories()
         nodeSslConfig.createDevKeyStores(rootCert.toX509CertHolder(), intermediateCa, legalName)
@@ -54,7 +49,7 @@ object DevIdentityGenerator {
         return identity.party
     }
 
-    fun generateDistributedNotaryIdentity(dirs: List<Path>, notaryName: CordaX500Name, threshold: Int = 1, customRootCert: X509Certificate? = null): Party {
+    fun generateDistributedNotaryIdentity(dirs: List<Path>, notaryName: CordaX500Name, threshold: Int = 1): Party {
         require(dirs.isNotEmpty())
 
         log.trace { "Generating identity \"$notaryName\" for nodes: ${dirs.joinToString()}" }
@@ -63,8 +58,7 @@ object DevIdentityGenerator {
 
         val caKeyStore = loadKeyStore(javaClass.classLoader.getResourceAsStream("certificates/cordadevcakeys.jks"), "cordacadevpass")
         val intermediateCa = caKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_INTERMEDIATE_CA, "cordacadevkeypass")
-        // TODO If using a custom root cert, then the intermidate cert needs to be generated from it as well, and not taken from the default
-        val rootCert = customRootCert ?: caKeyStore.getCertificate(X509Utilities.CORDA_ROOT_CA)
+        val rootCert = caKeyStore.getCertificate(X509Utilities.CORDA_ROOT_CA)
 
         keyPairs.zip(dirs) { keyPair, nodeDir ->
             val (serviceKeyCert, compositeKeyCert) = listOf(keyPair.public, compositeKey).map { publicKey ->

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -4,12 +4,8 @@ import net.corda.core.CordaOID
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SignatureScheme
 import net.corda.core.crypto.random63BitValue
-import net.corda.core.internal.CertRole
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.internal.cert
-import net.corda.core.internal.reader
-import net.corda.core.internal.writer
-import net.corda.core.internal.x500Name
+import net.corda.core.internal.*
 import net.corda.core.utilities.days
 import net.corda.core.utilities.millis
 import org.bouncycastle.asn1.*
@@ -43,6 +39,7 @@ object X509Utilities {
     val DEFAULT_IDENTITY_SIGNATURE_SCHEME = Crypto.EDDSA_ED25519_SHA512
     val DEFAULT_TLS_SIGNATURE_SCHEME = Crypto.ECDSA_SECP256R1_SHA256
 
+    // TODO This class is more of a general purpose utility class and as such these constants belong elsewhere
     // Aliases for private keys and certificates.
     const val CORDA_ROOT_CA = "cordarootca"
     const val CORDA_INTERMEDIATE_CA = "cordaintermediateca"

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
@@ -170,10 +170,10 @@ class X509UtilitiesTest {
             override val trustStorePassword = "trustpass"
         }
 
-        val (rootCert, intermediateCa) = createDevIntermediateCaCertPath()
+        val (rootCa, intermediateCa) = createDevIntermediateCaCertPath()
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        sslConfig.createDevKeyStores(rootCert.certificate, intermediateCa, MEGA_CORP.name)
+        sslConfig.createDevKeyStores(rootCa.certificate, intermediateCa, MEGA_CORP.name)
 
         // Load back server certificate
         val serverKeyStore = loadKeyStore(sslConfig.nodeKeystore, sslConfig.keyStorePassword)
@@ -206,11 +206,11 @@ class X509UtilitiesTest {
             override val trustStorePassword = "trustpass"
         }
 
-        val (rootCert, intermediateCa) = createDevIntermediateCaCertPath()
+        val (rootCa, intermediateCa) = createDevIntermediateCaCertPath()
 
         // Generate server cert and private key and populate another keystore suitable for SSL
-        sslConfig.createDevKeyStores(rootCert.certificate, intermediateCa, MEGA_CORP.name)
-        sslConfig.createTrustStore(rootCert.certificate.cert)
+        sslConfig.createDevKeyStores(rootCa.certificate, intermediateCa, MEGA_CORP.name)
+        sslConfig.createTrustStore(rootCa.certificate.cert)
 
         val keyStore = loadKeyStore(sslConfig.sslKeystore, sslConfig.keyStorePassword)
         val trustStore = loadKeyStore(sslConfig.trustStoreFile, sslConfig.trustStorePassword)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -180,13 +180,13 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
         return SignedNodeInfo(serialised, listOf(signature))
     }
 
-    open fun generateNodeInfo() {
+    open fun generateAndSaveNodeInfo(): NodeInfo {
         check(started == null) { "Node has already been started" }
         log.info("Generating nodeInfo ...")
         initCertificate()
         val schemaService = NodeSchemaService(cordappLoader.cordappSchemas)
         val (identity, identityKeyPair) = obtainIdentity(notaryConfig = null)
-        initialiseDatabasePersistence(schemaService,  makeIdentityService(identity.certificate)) { database ->
+        return initialiseDatabasePersistence(schemaService,  makeIdentityService(identity.certificate)) { database ->
             // TODO The fact that we need to specify an empty list of notaries just to generate our node info looks like
             // a code smell.
             val persistentNetworkMapCache = PersistentNetworkMapCache(database, notaries = emptyList())
@@ -196,6 +196,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
                 privateKey.sign(serialised.bytes)
             }
             NodeInfoWatcher.saveToFile(configuration.baseDirectory, signedNodeInfo)
+            info
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -19,7 +19,9 @@ import net.corda.node.internal.cordapp.CordappLoader
 import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.serialization.KryoServerSerializationScheme
 import net.corda.node.services.api.SchemaService
-import net.corda.node.services.config.*
+import net.corda.node.services.config.NodeConfiguration
+import net.corda.node.services.config.SecurityConfiguration
+import net.corda.node.services.config.VerifierType
 import net.corda.node.services.messaging.*
 import net.corda.node.services.transactions.InMemoryTransactionVerifierService
 import net.corda.node.utilities.AddressUtils
@@ -32,6 +34,7 @@ import net.corda.nodeapi.internal.serialization.*
 import net.corda.nodeapi.internal.serialization.amqp.AMQPServerSerializationScheme
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import rx.Scheduler
 import rx.schedulers.Schedulers
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
@@ -264,15 +267,13 @@ open class Node(configuration: NodeConfiguration,
     private val _startupComplete = openFuture<Unit>()
     val startupComplete: CordaFuture<Unit> get() = _startupComplete
 
-    override fun generateNodeInfo() {
+    override fun generateAndSaveNodeInfo(): NodeInfo {
         initialiseSerialization()
-        super.generateNodeInfo()
+        return super.generateAndSaveNodeInfo()
     }
 
     override fun start(): StartedNode<Node> {
-        if (initialiseSerialization) {
-            initialiseSerialization()
-        }
+        initialiseSerialization()
         val started: StartedNode<Node> = uncheckedCast(super.start())
         nodeReadyFuture.thenMatch({
             serverThread.execute {
@@ -305,8 +306,10 @@ open class Node(configuration: NodeConfiguration,
         return started
     }
 
-    override fun getRxIoScheduler() = Schedulers.io()!!
+    override fun getRxIoScheduler(): Scheduler = Schedulers.io()
+
     private fun initialiseSerialization() {
+        if (!initialiseSerialization) return
         val classloader = cordappLoader.appClassLoader
         nodeSerializationEnv = SerializationEnvironmentImpl(
                 SerializationFactoryImpl().apply {

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -1,7 +1,6 @@
 package net.corda.node.internal
 
 import com.jcabi.manifests.Manifests
-import com.typesafe.config.ConfigException
 import joptsimple.OptionException
 import net.corda.core.internal.*
 import net.corda.core.internal.concurrent.thenMatch
@@ -126,7 +125,7 @@ open class NodeStartup(val args: Array<String>) {
         val node = createNode(conf, versionInfo)
         if (cmdlineOptions.justGenerateNodeInfo) {
             // Perform the minimum required start-up logic to be able to write a nodeInfo to disk
-            node.generateNodeInfo()
+            node.generateAndSaveNodeInfo()
             return
         }
         val startedNode = node.start()

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapClientTest.kt
@@ -5,7 +5,10 @@ import net.corda.core.crypto.sha256
 import net.corda.core.internal.cert
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.seconds
-import net.corda.testing.*
+import net.corda.testing.ALICE_NAME
+import net.corda.testing.BOB_NAME
+import net.corda.testing.DEV_TRUST_ROOT
+import net.corda.testing.SerializationEnvironmentRule
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.internal.createNodeInfoAndSigned
 import net.corda.testing.node.internal.network.NetworkMapServer
@@ -30,7 +33,7 @@ class NetworkMapClientTest {
 
     @Before
     fun setUp() {
-        server = NetworkMapServer(cacheTimeout, PortAllocation.Incremental(10000).nextHostAndPort(), root_ca = ROOT_CA)
+        server = NetworkMapServer(cacheTimeout, PortAllocation.Incremental(10000).nextHostAndPort())
         val hostAndPort = server.start()
         networkMapClient = NetworkMapClient(URL("http://${hostAndPort.host}:${hostAndPort.port}"), DEV_TRUST_ROOT.cert)
     }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -14,11 +14,11 @@ import net.corda.node.internal.StartedNode
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.VerifierType
 import net.corda.nodeapi.internal.config.User
+import net.corda.testing.DUMMY_NOTARY_NAME
+import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.DriverDSLImpl
 import net.corda.testing.node.internal.genericDriver
 import net.corda.testing.node.internal.getTimestampAsDirectoryName
-import net.corda.testing.DUMMY_NOTARY_NAME
-import net.corda.testing.node.NotarySpec
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.nio.file.Path
@@ -193,8 +193,7 @@ fun <A> driver(
                     notarySpecs = notarySpecs,
                     extraCordappPackagesToScan = extraCordappPackagesToScan,
                     jmxPolicy = jmxPolicy,
-                    compatibilityZone = null,
-                    onNetworkParametersGeneration = { }
+                    compatibilityZone = null
             ),
             coerce = { it },
             dsl = dsl,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -121,8 +121,7 @@ fun <A> rpcDriver(
                             extraCordappPackagesToScan = extraCordappPackagesToScan,
                             notarySpecs = notarySpecs,
                             jmxPolicy = jmxPolicy,
-                            compatibilityZone = null,
-                            onNetworkParametersGeneration = {}
+                            compatibilityZone = null
                     ), externalTrace
             ),
             coerce = { it },

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response.ok
 
 class NetworkMapServer(cacheTimeout: Duration,
                        hostAndPort: NetworkHostAndPort,
-                       root_ca: CertificateAndKeyPair = ROOT_CA, // Default to ROOT_CA for testing.
+                       rootCa: CertificateAndKeyPair = ROOT_CA, // Default to ROOT_CA for testing.
                        private val myHostNameValue: String = "test.host.name",
                        vararg additionalServices: Any) : Closeable {
     companion object {
@@ -64,7 +64,7 @@ class NetworkMapServer(cacheTimeout: Duration,
           field = networkParameters
       }
     private val serializedParameters get() = networkParameters.serialize()
-    private val service = InMemoryNetworkMapService(cacheTimeout, networkMapKeyAndCert(root_ca))
+    private val service = InMemoryNetworkMapService(cacheTimeout, networkMapKeyAndCert(rootCa))
 
 
     init {

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -76,8 +76,7 @@ fun <A> verifierDriver(
                         extraCordappPackagesToScan = extraCordappPackagesToScan,
                         notarySpecs = notarySpecs,
                         jmxPolicy = jmxPolicy,
-                        compatibilityZone = null,
-                        onNetworkParametersGeneration = { }
+                        compatibilityZone = null
                 )
         ),
         coerce = { it },


### PR DESCRIPTION
Using the --just-generate-node-info flag for the notary nodes so that their identities can be submitted to the network map server, which does the network parameters generation.