### PR TITLE
Harmonises the names of the parameters across CashExitFlow constructors.

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
@@ -29,8 +29,8 @@ import java.util.*
 class CashExitFlow(private val amount: Amount<Currency>,
                    private val issuerRef: OpaqueBytes,
                    progressTracker: ProgressTracker) : AbstractCashFlow<AbstractCashFlow.Result>(progressTracker) {
-    constructor(amount: Amount<Currency>, issueRef: OpaqueBytes) : this(amount, issueRef, tracker())
-    constructor(request: ExitRequest) : this(request.amount, request.issueRef, tracker())
+    constructor(amount: Amount<Currency>, issuerRef: OpaqueBytes) : this(amount, issuerRef, tracker())
+    constructor(request: ExitRequest) : this(request.amount, request.issuerRef, tracker())
 
     companion object {
         fun tracker() = ProgressTracker(GENERATING_TX, SIGNING_TX, FINALISING_TX)
@@ -78,5 +78,5 @@ class CashExitFlow(private val amount: Amount<Currency>,
     }
 
     @CordaSerializable
-    class ExitRequest(amount: Amount<Currency>, val issueRef: OpaqueBytes) : AbstractRequest(amount)
+    class ExitRequest(amount: Amount<Currency>, val issuerRef: OpaqueBytes) : AbstractRequest(amount)
 }

--- a/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
@@ -21,7 +21,6 @@ import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.internal.config.User
 import net.corda.testing.chooseIdentity
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import org.junit.Assume.assumeFalse
 import org.junit.Test

--- a/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
@@ -21,6 +21,7 @@ import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.internal.config.User
 import net.corda.testing.chooseIdentity
+import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import org.junit.Assume.assumeFalse
 import org.junit.Test
@@ -74,7 +75,7 @@ class NodeStatePersistenceTests {
 
         val user = User("mark", "dadada", setOf(startFlow<SendMessageFlow>(), invokeRpc("vaultQuery")))
         val message = Message("Hello world!")
-        val stateAndRef: StateAndRef<MessageState>? = driver(isDebug = true, startNodesInProcess = isQuasarAgentSpecified()) {
+        val stateAndRef: StateAndRef<MessageState>? = driver(isDebug = true, portAllocation = PortAllocation.Incremental(300), startNodesInProcess = isQuasarAgentSpecified()) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name

--- a/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
@@ -75,7 +75,7 @@ class NodeStatePersistenceTests {
 
         val user = User("mark", "dadada", setOf(startFlow<SendMessageFlow>(), invokeRpc("vaultQuery")))
         val message = Message("Hello world!")
-        val stateAndRef: StateAndRef<MessageState>? = driver(isDebug = true, portAllocation = PortAllocation.Incremental(300), startNodesInProcess = isQuasarAgentSpecified()) {
+        val stateAndRef: StateAndRef<MessageState>? = driver(isDebug = true, startNodesInProcess = isQuasarAgentSpecified()) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -141,7 +141,7 @@ class ExplorerSimulation(private val options: OptionSet) {
                         it.startFlow(::CashIssueAndPaymentFlow, request).log(i, "${request.amount.token}Issuer")
                     }
                     is ExitRequest -> issuers[request.amount.token]?.let {
-                        println("${Instant.now()} [$i] EXITING ${request.amount} with ref ${request.issueRef}")
+                        println("${Instant.now()} [$i] EXITING ${request.amount} with ref ${request.issuerRef}")
                         it.startFlow(::CashExitFlow, request).log(i, "${request.amount.token}Exit")
                     }
                     else -> throw IllegalArgumentException("Unsupported command: $request")


### PR DESCRIPTION
Previously, one constructor used `issueRef`, and the other used `issuerRef`. This is confusing when starting the flow from the CRaSH shell and using named parameters.