### PR TITLE
Remove primary key constraint on DBHostAndPort

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/schemas/NodeInfoSchema.kt
@@ -63,26 +63,24 @@ object NodeInfoSchemaV1 : MappedSchema(
         }
     }
 
-    @Embeddable
-    data class PKHostAndPort(
-            val host: String? = null,
-            val port: Int? = null
-    ) : Serializable
-
     @Entity
     @Table(name = "node_info_hosts")
     data class DBHostAndPort(
-            @EmbeddedId
-            private val pk: PKHostAndPort
+            @Id
+            @GeneratedValue
+            @Column(name = "hosts_id")
+            var id: Int,
+            val host: String? = null,
+            val port: Int? = null
     ) {
         companion object {
             fun fromHostAndPort(hostAndPort: NetworkHostAndPort) = DBHostAndPort(
-                    PKHostAndPort(hostAndPort.host, hostAndPort.port)
+                    0, hostAndPort.host, hostAndPort.port
             )
         }
 
         fun toHostAndPort(): NetworkHostAndPort {
-            return NetworkHostAndPort(this.pk.host!!, this.pk.port!!)
+            return NetworkHostAndPort(host!!, port!!)
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -74,8 +74,13 @@ interface NetworkMapCacheBase {
      */
     fun getNodeByLegalName(name: CordaX500Name): NodeInfo?
 
+    // TODO We don't want to end up with two functions of this kind. Should I deprecate this one? On the other hand, we shouldn't allow to have
+    //  two different parites to advertise the same address?
     /** Look up the node info for a host and port. */
     fun getNodeByAddress(address: NetworkHostAndPort): NodeInfo?
+
+    /** Look up the node infos for a host and port. */
+    fun getNodesByAddress(address: NetworkHostAndPort): List<NodeInfo>
 
     /**
      * Look up a well known identity (including certificate path) of a legal name. This should be used in preference

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkMapCache.kt
@@ -74,13 +74,8 @@ interface NetworkMapCacheBase {
      */
     fun getNodeByLegalName(name: CordaX500Name): NodeInfo?
 
-    // TODO We don't want to end up with two functions of this kind. Should I deprecate this one? On the other hand, we shouldn't allow to have
-    //  two different parites to advertise the same address?
     /** Look up the node info for a host and port. */
     fun getNodeByAddress(address: NetworkHostAndPort): NodeInfo?
-
-    /** Look up the node infos for a host and port. */
-    fun getNodesByAddress(address: NetworkHostAndPort): List<NodeInfo>
 
     /**
      * Look up a well known identity (including certificate path) of a legal name. This should be used in preference

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -1,20 +1,19 @@
 package net.corda.node.services.network
 
+import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.internal.Node
 import net.corda.node.internal.StartedNode
-import net.corda.testing.ALICE_NAME
-import net.corda.testing.BOB_NAME
-import net.corda.testing.TestIdentity
-import net.corda.testing.chooseIdentity
+import net.corda.testing.*
 import net.corda.testing.node.internal.NodeBasedTest
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
+// TODO Clean up these tests, they were written with old network map design in place.
 class PersistentNetworkMapCacheTest : NodeBasedTest() {
     private companion object {
         val ALICE = TestIdentity(ALICE_NAME, 70).party
@@ -56,6 +55,19 @@ class PersistentNetworkMapCacheTest : NodeBasedTest() {
             val res = netCache.getNodeByAddress(alice.info.addresses[0])
             assertEquals(alice.info, res)
         }
+    }
+
+    // This test has to be done as normal node not mock, because MockNodes don't have addresses.
+    @Test
+    fun `insert two node infos with the same host and port`() {
+        val aliceNode = startNode(ALICE_NAME)
+        val charliePartyCert = getTestPartyAndCertificate(CHARLIE_NAME, generateKeyPair().public)
+        val aliceCache = aliceNode.services.networkMapCache
+        aliceCache.addNode(aliceNode.info.copy(legalIdentitiesAndCerts = listOf(charliePartyCert)))
+        val res = aliceNode.database.transaction {
+            aliceCache.getNodesByAddress(aliceNode.info.addresses[0])
+        }
+        assertEquals(2, res.size)
     }
 
     @Test

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -65,7 +65,7 @@ class PersistentNetworkMapCacheTest : NodeBasedTest() {
         val aliceCache = aliceNode.services.networkMapCache
         aliceCache.addNode(aliceNode.info.copy(legalIdentitiesAndCerts = listOf(charliePartyCert)))
         val res = aliceNode.database.transaction {
-            aliceCache.getNodesByAddress(aliceNode.info.addresses[0])
+            aliceCache.allNodes.filter { aliceNode.info.addresses[0] in it.addresses }
         }
         assertEquals(2, res.size)
     }

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -149,9 +149,7 @@ open class PersistentNetworkMapCache(
     override fun getNodesByLegalIdentityKey(identityKey: PublicKey): List<NodeInfo> =
             database.transaction { queryByIdentityKey(session, identityKey) }
 
-    override fun getNodeByAddress(address: NetworkHostAndPort): NodeInfo? = database.transaction { queryByAddress(session, address).singleOrNull() }
-
-    override fun getNodesByAddress(address: NetworkHostAndPort): List<NodeInfo> = database.transaction { queryByAddress(session, address) }
+    override fun getNodeByAddress(address: NetworkHostAndPort): NodeInfo? = database.transaction { queryByAddress(session, address).firstOrNull() }
 
     override fun getPeerCertificateByLegalName(name: CordaX500Name): PartyAndCertificate? = database.transaction { queryIdentityByLegalName(session, name) }
 

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapCacheTest.kt
@@ -1,8 +1,10 @@
 package net.corda.node.services.network
 
+import net.corda.core.crypto.generateKeyPair
 import net.corda.core.node.services.NetworkMapCache
 import net.corda.testing.ALICE_NAME
 import net.corda.testing.BOB_NAME
+import net.corda.testing.getTestPartyAndCertificate
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNodeParameters
 import net.corda.testing.singleIdentity
@@ -76,5 +78,15 @@ class NetworkMapCacheTest {
             assertThat(bobCache.getNodeByLegalIdentity(bob) != null)
             assertThat(bobCache.getNodeByLegalName(alice.name) == null)
         }
+    }
+
+    @Test
+    fun `add two nodes the same name different keys`() {
+        val aliceNode = mockNet.createPartyNode(ALICE_NAME)
+        val aliceCache = aliceNode.services.networkMapCache
+        val alicePartyAndCert2 = getTestPartyAndCertificate(ALICE_NAME, generateKeyPair().public)
+        aliceCache.addNode(aliceNode.info.copy(legalIdentitiesAndCerts = listOf(alicePartyAndCert2)))
+        // This is correct behaviour as we may have distributed service nodes.
+        assertEquals(2, aliceCache.getNodesByLegalName(ALICE_NAME).size)
     }
 }


### PR DESCRIPTION
I think we should avoid advertising this kind of node infos on network map level though.
