### PR TITLE
Fix example-node.conf in docs

### DIFF
--- a/docs/source/example-code/src/main/resources/example-node.conf
+++ b/docs/source/example-code/src/main/resources/example-node.conf
@@ -12,7 +12,7 @@ rpcAddress : "my-corda-node:10003"
 webAddress : "localhost:10004"
 useHTTPS : false
 rpcUsers : [
-    { username=user1, password=letmein, permissions=[ StartProtocol.net.corda.protocols.CashProtocol ] }
+    { username=user1, password=letmein, permissions=[ StartFlow.net.corda.protocols.CashProtocol ] }
 ]
 devMode : true
 // certificateSigningService : "https://testnet.certificate.corda.net"


### PR DESCRIPTION
Minor fix: permission syntax used in example-node.conf 
