### PR TITLE
ENT-1226 Improve Network client Error Handling

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -43,7 +43,6 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val trustedRoot: X509C
             if (responseCode != 200) {
                 throw IOException("Response Code $responseCode: ${IOUtils.toString(errorStream)}")
             }
-            inputStream.close()
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -18,9 +18,11 @@ import net.corda.nodeapi.internal.network.SignedNetworkMap
 import net.corda.nodeapi.internal.SignedNodeInfo
 import okhttp3.CacheControl
 import okhttp3.Headers
+import org.apache.commons.io.IOUtils
 import rx.Subscription
 import java.io.BufferedReader
 import java.io.Closeable
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.security.cert.X509Certificate
@@ -33,15 +35,16 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val trustedRoot: X509C
 
     fun publish(signedNodeInfo: SignedNodeInfo) {
         val publishURL = URL("$networkMapUrl/publish")
-        val conn = publishURL.openHttpConnection()
-        conn.doOutput = true
-        conn.requestMethod = "POST"
-        conn.setRequestProperty("Content-Type", "application/octet-stream")
-        conn.outputStream.use { signedNodeInfo.serialize().open().copyTo(it) }
-
-        // This will throw IOException if the response code is not HTTP 200.
-        // This gives a much better exception then reading the error stream.
-        conn.inputStream.close()
+        publishURL.openHttpConnection().apply {
+            doOutput = true
+            requestMethod = "POST"
+            setRequestProperty("Content-Type", "application/octet-stream")
+            outputStream.use { signedNodeInfo.serialize().open().copyTo(it) }
+            if (responseCode != 200) {
+                throw IOException("Response Code $responseCode: ${IOUtils.toString(errorStream)}")
+            }
+            inputStream.close()
+        }
     }
 
     fun getNetworkMap(): NetworkMapResponse {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -60,10 +60,10 @@ class NetworkMapServer(cacheTimeout: Duration,
 
     private val server: Server
     var networkParameters: NetworkParameters = stubNetworkParameters
-      set(networkParameters) {
-          check(field == stubNetworkParameters) { "Network parameters can be set only once" }
-          field = networkParameters
-      }
+        set(networkParameters) {
+            check(field == stubNetworkParameters) { "Network parameters can be set only once" }
+            field = networkParameters
+        }
     private val serializedParameters get() = networkParameters.serialize()
     private val service = InMemoryNetworkMapService(cacheTimeout, networkMapKeyAndCert(rootCa))
 
@@ -110,9 +110,11 @@ class NetworkMapServer(cacheTimeout: Duration,
                                           private val networkMapKeyAndCert: CertificateAndKeyPair) {
         private val nodeInfoMap = mutableMapOf<SecureHash, SignedNodeInfo>()
         private val parametersHash by lazy { serializedParameters.hash }
-        private val signedParameters by lazy { SignedData(
-                serializedParameters,
-                DigitalSignature.WithKey(networkMapKeyAndCert.keyPair.public, Crypto.doSign(networkMapKeyAndCert.keyPair.private, serializedParameters.bytes))) }
+        private val signedParameters by lazy {
+            SignedData(
+                    serializedParameters,
+                    DigitalSignature.WithKey(networkMapKeyAndCert.keyPair.public, Crypto.doSign(networkMapKeyAndCert.keyPair.private, serializedParameters.bytes)))
+        }
 
         @POST
         @Path("publish")
@@ -124,8 +126,8 @@ class NetworkMapServer(cacheTimeout: Duration,
                 val nodeInfoHash = nodeInfo.serialize().sha256()
                 nodeInfoMap.put(nodeInfoHash, registrationData)
                 ok()
-            } catch (e: Exception){
-                when(e) {
+            } catch (e: Exception) {
+                when (e) {
                     is SignatureException -> status(Response.Status.FORBIDDEN).entity(e.message)
                     else -> status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.message)
                 }


### PR DESCRIPTION
Pull through the error responses that are returned from the network map server, to aid the user in debugging. Currently returned response code is shown but any message is lost. 