### PR TITLE
Move the CommercialPaperTest examples

### DIFF
--- a/docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+++ b/docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
@@ -2,6 +2,7 @@ package net.corda.docs.java.tutorial.testdsl;
 
 import kotlin.Unit;
 import net.corda.core.contracts.PartyAndReference;
+import net.corda.core.contracts.TransactionVerificationException;
 import net.corda.core.identity.CordaX500Name;
 import net.corda.finance.contracts.ICommercialPaperState;
 import net.corda.finance.contracts.JavaCommercialPaper;
@@ -43,7 +44,8 @@ public class CommercialPaperTest {
     // DOCEND 1
 
     // DOCSTART 2
-    @Test
+    // This example test will fail with this exception.
+    @Test(expected = IllegalStateException.class)
     public void simpleCP() {
         ICommercialPaperState inState = getPaper();
         ledger(ledgerServices, l -> {
@@ -58,7 +60,8 @@ public class CommercialPaperTest {
     // DOCEND 2
 
     // DOCSTART 3
-    @Test
+    // This example test will fail with this exception.
+    @Test(expected = TransactionVerificationException.ContractRejection.class)
     public void simpleCPMove() {
         ICommercialPaperState inState = getPaper();
         ledger(ledgerServices, l -> {

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
@@ -2,6 +2,7 @@ package net.corda.docs.tutorial.testdsl
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
+import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.days
@@ -53,7 +54,8 @@ class CommercialPaperTest {
     // DOCEND 1
 
     // DOCSTART 2
-    @Test
+    // This example test will fail with this exception.
+    @Test(expected = IllegalStateException::class)
     fun simpleCP() {
         val inState = getPaper()
         ledgerServices.ledger(DUMMY_NOTARY) {
@@ -67,7 +69,8 @@ class CommercialPaperTest {
     // DOCEND 2
 
     // DOCSTART 3
-    @Test
+    // This example test will fail with this exception.
+    @Test(expected = TransactionVerificationException.ContractRejection::class)
     fun simpleCPMove() {
         val inState = getPaper()
         ledgerServices.ledger(DUMMY_NOTARY) {

--- a/docs/source/tutorial-test-dsl.rst
+++ b/docs/source/tutorial-test-dsl.rst
@@ -55,13 +55,13 @@ We will start with defining helper function that returns a ``CommercialPaper`` s
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 1
         :end-before: DOCEND 1
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 1
         :end-before: DOCEND 1
@@ -122,13 +122,13 @@ last line of ``transaction``:
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 2
         :end-before: DOCEND 2
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 2
         :end-before: DOCEND 2
@@ -138,13 +138,13 @@ Let's take a look at a transaction that fails.
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 3
         :end-before: DOCEND 3
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 3
         :end-before: DOCEND 3
@@ -167,13 +167,13 @@ However we can specify that this is an intended behaviour by changing ``verifies
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 4
         :end-before: DOCEND 4
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 4
         :end-before: DOCEND 4
@@ -183,13 +183,13 @@ We can continue to build the transaction until it ``verifies``:
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 5
         :end-before: DOCEND 5
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 5
         :end-before: DOCEND 5
@@ -206,13 +206,13 @@ What should we do if we wanted to test what happens when the wrong party signs t
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 6
         :end-before: DOCEND 6
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 6
         :end-before: DOCEND 6
@@ -227,13 +227,13 @@ ledger with a single transaction:
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 7
         :end-before: DOCEND 7
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 7
         :end-before: DOCEND 7
@@ -246,13 +246,13 @@ Now that we know how to define a single transaction, let's look at how to define
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 8
         :end-before: DOCEND 8
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 8
         :end-before: DOCEND 8
@@ -273,13 +273,13 @@ To do so let's create a simple example that uses the same input twice:
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 9
         :end-before: DOCEND 9
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 9
         :end-before: DOCEND 9
@@ -290,13 +290,13 @@ verification (``fails()`` at the end). As in previous examples we can use ``twea
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
+    .. literalinclude:: ../../docs/source/example-code/src/test/kotlin/net/corda/docs/tutorial/testdsl/TutorialTestDSL.kt
         :language: kotlin
         :start-after: DOCSTART 10
         :end-before: DOCEND 10
         :dedent: 4
 
-    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/test/java/net/corda/docs/java/tutorial/testdsl/CommercialPaperTest.java
         :language: java
         :start-after: DOCSTART 10
         :end-before: DOCEND 10


### PR DESCRIPTION
Move the CommercialPaperTest examples to a location where it'll be run by gradle/ci. Make sure the tests pass, even the example tests that are intended to fail, so these files are kept up to date as the code changes.