### PR TITLE
Use single thread per netty eventgroup during testing

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
@@ -53,7 +53,8 @@ class ArtemisTcpTransport {
                     // It does not use AMQP messages for its own messages e.g. topology and heartbeats.
                     // TODO further investigate how to ensure we use a well defined wire level protocol for Node to Node communications.
                     TransportConstants.PROTOCOLS_PROP_NAME to "CORE,AMQP",
-                    TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME to (nodeSerializationEnv != null)
+                    TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME to (nodeSerializationEnv != null),
+                    TransportConstants.REMOTING_THREADS_PROPNAME to (if (nodeSerializationEnv != null) -1 else 1)
             )
 
             if (config != null && enableSSL) {


### PR DESCRIPTION
TLDR: This reduces the number of epoll fds created during testing which occasionally cause "too many open files" shenanigary and subsequent hangs like this: https://ci-master.corda.r3cev.com/viewLog.html?buildId=53620&buildTypeId=CordaEnterprise_PullRequests_IntegrationTests&tab=buildLog

Long story: with the GLOBAL_THREAD_POOL_THING switched off during testing, the number of threads used by netty to do stuff became linear with the number of remoting connections. Artemis for some reason defaults to using (processor count * 3) threads per such connection. On my setup this means 24. On linux each such thread creates 3 epoll fds, which means a single remoting connection (= bridge) creates 72 fds. not cool. Anyway this hardcodes the number of threads to 1 (during testing)/