### PR TITLE
Rename Artemis Queue Addresses to allow future broker agility

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -29,7 +29,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.nodeapi.ArtemisConsumer
 import net.corda.nodeapi.ArtemisProducer
 import net.corda.nodeapi.RPCApi
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration
+import org.apache.activemq.artemis.api.core.RoutingType
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient.DEFAULT_ACK_BATCH_SIZE
 import org.apache.activemq.artemis.api.core.client.ClientMessage
@@ -194,7 +194,7 @@ class RPCClientProxyHandler(
                 TimeUnit.MILLISECONDS
         )
         sessionAndProducerPool.run {
-            it.session.createTemporaryQueue(clientAddress, ActiveMQDefaultConfiguration.getDefaultRoutingType(), clientAddress)
+            it.session.createTemporaryQueue(clientAddress, RoutingType.ANYCAST, clientAddress)
         }
         val sessionFactory = serverLocator.createSessionFactory()
         val session = sessionFactory.createSession(rpcUsername, rpcPassword, false, true, true, false, DEFAULT_ACK_BATCH_SIZE)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -141,6 +141,13 @@ UNRELEASED
 * Peer-to-peer communications is now via AMQP 1.0 as default.
   Although the legacy Artemis CORE bridging can still be used by setting the ``useAMQPBridges`` configuration property to false.
 
+* The Artemis topics used for peer-to-peer communication have been changed to be more consistent with future cryptographic
+  agility and to open up the future possibility of sharing brokers between nodes. This is a breaking wire level change
+  as it means that nodes after this change will not be able to communicate correctly with nodes running the previous version.
+  Also, any pending enqueued messages in the Artemis message store will not be delivered correctly to their original target.
+  However, assuming a clean reset of the artemis data and that the nodes are consistent versions,
+  data persisted via the AMQP serializer will be forward compatible.
+
 .. _changelog_v1:
 
 Release 1.0

--- a/docs/source/messaging.rst
+++ b/docs/source/messaging.rst
@@ -46,7 +46,7 @@ Message queues
 The node makes use of various queues for its operation. The more important ones are described below. Others are used
 for maintenance and other minor purposes.
 
-:``p2p.inbound``:
+:``p2p.inbound.$identity``:
    The node listens for messages sent from other peer nodes on this queue. Only clients who are authenticated to be
    nodes on the same network are given permission to send. Messages which are routed internally are also sent to this
    queue (e.g. two flows on the same node communicating with each other).
@@ -54,7 +54,7 @@ for maintenance and other minor purposes.
 :``internal.peers.$identity``:
    These are a set of private queues only available to the node which it uses to route messages destined to other peers.
    The queue name ends in the base 58 encoding of the peer's identity key. There is at most one queue per peer. The broker
-   creates a bridge from this queue to the peer's ``p2p.inbound`` queue, using the network map service to lookup the
+           creates a bridge from this queue to the peer's ``p2p.inbound.$identity`` queue, using the network map service to lookup the
    peer's network address.
 
 :``internal.services.$identity``:
@@ -86,7 +86,7 @@ Clients attempting to connect to the node's broker fall in one of four groups:
 #. Anyone connecting with the username ``SystemUsers/Peer`` is treated as a peer on the same Corda network as the node. Their
    TLS root CA must be the same as the node's root CA - the root CA is the doorman of the network and having the same root CA
    implies we've been let in by the same doorman. If they are part of the same network then they are only given permission
-   to send to our ``p2p.inbound`` queue, otherwise they are rejected.
+   to send to our ``p2p.inbound.$identity`` queue, otherwise they are rejected.
 
 #. Every other username is treated as a RPC user and authenticated against the node's list of valid RPC users. If that
    is successful then they are only given sufficient permission to perform RPC, otherwise they are rejected.

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -5,6 +5,7 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.client.rpc.CordaRPCConnection
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.crypto.random63BitValue
+import net.corda.core.crypto.toStringShort
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
@@ -14,14 +15,13 @@ import net.corda.core.identity.Party
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
-import net.corda.core.utilities.toBase58String
 import net.corda.core.utilities.unwrap
 import net.corda.node.internal.Node
 import net.corda.node.internal.StartedNode
 import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.INTERNAL_PREFIX
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NOTIFICATIONS_ADDRESS
-import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_QUEUE
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_PREFIX
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEERS_PREFIX
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.testing.ALICE_NAME
@@ -71,30 +71,30 @@ abstract class MQSecurityTest : NodeBasedTest() {
 
     @Test
     fun `consume message from P2P queue`() {
-        assertConsumeAttackFails(P2P_QUEUE)
+        assertConsumeAttackFails("$P2P_PREFIX${alice.info.chooseIdentity().owningKey.toStringShort()}")
     }
 
     @Test
     fun `consume message from peer queue`() {
         val bobParty = startBobAndCommunicateWithAlice()
-        assertConsumeAttackFails("$PEERS_PREFIX${bobParty.owningKey.toBase58String()}")
+        assertConsumeAttackFails("$PEERS_PREFIX${bobParty.owningKey.toStringShort()}")
     }
 
     @Test
     fun `send message to address of peer which has been communicated with`() {
         val bobParty = startBobAndCommunicateWithAlice()
-        assertSendAttackFails("$PEERS_PREFIX${bobParty.owningKey.toBase58String()}")
+        assertSendAttackFails("$PEERS_PREFIX${bobParty.owningKey.toStringShort()}")
     }
 
     @Test
     fun `create queue for peer which has not been communicated with`() {
         val bob = startNode(BOB_NAME)
-        assertAllQueueCreationAttacksFail("$PEERS_PREFIX${bob.info.chooseIdentity().owningKey.toBase58String()}")
+        assertAllQueueCreationAttacksFail("$PEERS_PREFIX${bob.info.chooseIdentity().owningKey.toStringShort()}")
     }
 
     @Test
     fun `create queue for unknown peer`() {
-        val invalidPeerQueue = "$PEERS_PREFIX${generateKeyPair().public.toBase58String()}"
+        val invalidPeerQueue = "$PEERS_PREFIX${generateKeyPair().public.toStringShort()}"
         assertAllQueueCreationAttacksFail(invalidPeerQueue)
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -40,6 +40,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rx.Scheduler
 import rx.schedulers.Schedulers
+import java.security.PublicKey
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
 import javax.management.ObjectName
@@ -166,11 +167,14 @@ open class Node(configuration: NodeConfiguration,
             VerifierType.OutOfProcess -> VerifierMessagingClient(configuration, serverAddress, services.monitoringService.metrics, networkParameters.maxMessageSize)
             VerifierType.InMemory -> null
         }
+        require(info.legalIdentities.size in 1..2) { "Currently nodes must have a primary address and optionally one serviced address" }
+        val serviceIdentity: PublicKey? = if (info.legalIdentities.size == 1) null else info.legalIdentities[1].owningKey
         return P2PMessagingClient(
                 configuration,
                 versionInfo,
                 serverAddress,
                 info.legalIdentities[0].owningKey,
+                serviceIdentity,
                 serverThread,
                 database,
                 advertisedAddress,

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -29,6 +29,10 @@ interface NetworkMapCacheBaseInternal : NetworkMapCacheBase {
 
     fun getNodeByHash(nodeHash: SecureHash): NodeInfo?
 
+    /** Find nodes from the [PublicKey] toShortString representation.
+     * This is used for Artemis bridge lookup process. */
+    fun getNodesByOwningKeyIndex(identityKeyIndex: String): List<NodeInfo>
+
     /** Adds a node to the local cache (generally only used for adding ourselves). */
     fun addNode(node: NodeInfo)
 

--- a/node/src/main/kotlin/net/corda/node/services/messaging/AMQPBridgeManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/AMQPBridgeManager.kt
@@ -12,8 +12,8 @@ import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.messaging.AMQPBridgeManager.AMQPBridge.Companion.getBridgeName
 import net.corda.nodeapi.internal.ArtemisMessagingComponent
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NODE_USER
-import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_QUEUE
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEER_USER
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.RemoteInboxAddress.Companion.translateLocalQueueToInboxAddress
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient.DEFAULT_ACK_BATCH_SIZE
@@ -132,7 +132,8 @@ internal class AMQPBridgeManager(val config: NodeConfiguration, val p2pAddress: 
                     properties[key.toString()] = value
                 }
                 log.debug { "Bridged Send to ${legalNames.first()} uuid: ${artemisMessage.getObjectProperty("_AMQ_DUPL_ID")}" }
-                val sendableMessage = amqpClient.createMessage(data, P2P_QUEUE,
+                val peerInbox = translateLocalQueueToInboxAddress(queueName)
+                val sendableMessage = amqpClient.createMessage(data, peerInbox,
                         legalNames.first().toString(),
                         properties)
                 sendableMessage.onComplete.then {

--- a/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
@@ -21,7 +21,6 @@ import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.node.utilities.PersistentMap
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.*
-import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_QUEUE
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
 import org.apache.activemq.artemis.api.core.ActiveMQObjectClosedException
@@ -55,21 +54,28 @@ import javax.persistence.Lob
  * invoke methods on the provided implementation. There is more documentation on this in the docsite and the
  * CordaRPCClient class.
  *
- * @param serverAddress The address of the broker instance to connect to (might be running in the same process).
- * @param myIdentity The public key to be used as the ArtemisMQ address and queue name for the node.
- * @param nodeExecutor An executor to run received message tasks upon.
- * @param advertisedAddress The node address for inbound connections, advertised to the network map service and peers.
- * If not provided, will default to [serverAddress].
+ * @param config The configuration of the node, which is used for controlling the message redelivery options.
+ * @param versionInfo All messages from the node carry the version info and received messages are checked against this for compatibility.
+ * @param serverAddress The host and port of the Artemis broker.
+ * @param myIdentity The primary identity of the node, which defines the messaging address for externally received messages.
+ * It is also used to construct the myAddress field, which is ultimately advertised in the network map.
+ * @param serviceIdentity An optional second identity if the node is also part of a group address, for example a notary.
+ * @param nodeExecutor The received messages are marshalled onto the server executor to prevent Netty buffers leaking during fiber suspends.
+ * @param database The nodes database, which is used to deduplicate messages.
+ * @param advertisedAddress The externally advertised version of the Artemis broker address used to construct myAddress and included
+ * in the network map data.
+ * @param maxMessageSize A bound applied to the message size.
  */
 @ThreadSafe
 class P2PMessagingClient(config: NodeConfiguration,
                          private val versionInfo: VersionInfo,
                          serverAddress: NetworkHostAndPort,
                          private val myIdentity: PublicKey,
+                         private val serviceIdentity: PublicKey?,
                          private val nodeExecutor: AffinityExecutor.ServiceAffinityExecutor,
                          private val database: CordaPersistence,
                          advertisedAddress: NetworkHostAndPort = serverAddress,
-                         private val maxMessageSize: Int
+                         maxMessageSize: Int
 ) : SingletonSerializeAsToken(), MessagingService {
     companion object {
         private val log = contextLogger()
@@ -128,6 +134,7 @@ class P2PMessagingClient(config: NodeConfiguration,
     private class InnerState {
         var running = false
         var p2pConsumer: ClientConsumer? = null
+        var serviceConsumer: ClientConsumer? = null
     }
 
     private val messagesToRedeliver = database.transaction {
@@ -183,8 +190,23 @@ class P2PMessagingClient(config: NodeConfiguration,
     fun start() {
         state.locked {
             val session = artemis.start().session
+            val inbox = RemoteInboxAddress(myIdentity).queueName
             // Create a queue, consumer and producer for handling P2P network messages.
-            p2pConsumer = session.createConsumer(P2P_QUEUE)
+            createQueueIfAbsent(inbox)
+            p2pConsumer = session.createConsumer(inbox)
+            if (serviceIdentity != null) {
+                val serviceAddress = RemoteInboxAddress(serviceIdentity).queueName
+                createQueueIfAbsent(serviceAddress)
+                val serviceHandler = session.createConsumer(serviceAddress)
+                serviceHandler.setMessageHandler { msg ->
+                    val message: ReceivedMessage? = artemisToCordaMessage(msg)
+                    if (message != null)
+                        deliver(message)
+                    state.locked {
+                        msg.individualAcknowledge()
+                    }
+                }
+            }
         }
 
         resumeMessageRedelivery()
@@ -261,7 +283,7 @@ class P2PMessagingClient(config: NodeConfiguration,
             val platformVersion = message.required(platformVersionProperty) { getIntProperty(it) }
             // Use the magic deduplication property built into Artemis as our message identity too
             val uuid = message.required(HDR_DUPLICATE_DETECTION_ID) { UUID.fromString(message.getStringProperty(it)) }
-            log.trace { "Received message from: ${message.address} user: $user topic: $topic sessionID: $sessionID uuid: $uuid" }
+            log.info("Received message from: ${message.address} user: $user topic: $topic sessionID: $sessionID uuid: $uuid")
 
             return ArtemisReceivedMessage(TopicSession(topic, sessionID), CordaX500Name.parse(user), platformVersion, uuid, message)
         } catch (e: Exception) {
@@ -346,6 +368,13 @@ class P2PMessagingClient(config: NodeConfiguration,
                 // Ignore it: this can happen if the server has gone away before we do.
             }
             p2pConsumer = null
+            val s = serviceConsumer
+            try {
+                s?.close()
+            } catch (e: ActiveMQObjectClosedException) {
+                // Ignore it: this can happen if the server has gone away before we do.
+            }
+            serviceConsumer = null
             prevRunning
         }
         if (running && !nodeExecutor.isOnThread) {
@@ -446,7 +475,7 @@ class P2PMessagingClient(config: NodeConfiguration,
     private fun getMQAddress(target: MessageRecipients): String {
         return if (target == myAddress) {
             // If we are sending to ourselves then route the message directly to our P2P queue.
-            P2P_QUEUE
+            RemoteInboxAddress(myIdentity).queueName
         } else {
             // Otherwise we send the message to an internal queue for the target residing on our broker. It's then the
             // broker's job to route the message to the target's P2P queue.
@@ -463,7 +492,7 @@ class P2PMessagingClient(config: NodeConfiguration,
             val queueQuery = session.queueQuery(SimpleString(queueName))
             if (!queueQuery.isExists) {
                 log.info("Create fresh queue $queueName bound on same address")
-                session.createQueue(queueName, RoutingType.MULTICAST, queueName, true)
+                session.createQueue(queueName, RoutingType.ANYCAST, queueName, true)
             }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/VerifierMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/VerifierMessagingClient.kt
@@ -7,15 +7,15 @@ import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.transactions.OutOfProcessTransactionVerifierService
-import net.corda.node.utilities.*
+import net.corda.node.utilities.AffinityExecutor
 import net.corda.nodeapi.VerifierApi
 import net.corda.nodeapi.VerifierApi.VERIFICATION_REQUESTS_QUEUE_NAME
 import net.corda.nodeapi.VerifierApi.VERIFICATION_RESPONSES_QUEUE_NAME_PREFIX
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import org.apache.activemq.artemis.api.core.RoutingType
 import org.apache.activemq.artemis.api.core.SimpleString
-import org.apache.activemq.artemis.api.core.client.*
-import java.util.concurrent.*
+import org.apache.activemq.artemis.api.core.client.ClientConsumer
+import java.util.concurrent.TimeUnit
 
 class VerifierMessagingClient(config: SSLConfiguration, serverAddress: NetworkHostAndPort, metrics: MetricRegistry, private val maxMessageSize: Int) : SingletonSerializeAsToken() {
     companion object {
@@ -40,7 +40,7 @@ class VerifierMessagingClient(config: SSLConfiguration, serverAddress: NetworkHo
             val queueQuery = session.queueQuery(SimpleString(queueName))
             if (!queueQuery.isExists) {
                 log.info("Create fresh queue $queueName bound on same address")
-                session.createQueue(queueName, RoutingType.MULTICAST, queueName, true)
+                session.createQueue(queueName, RoutingType.ANYCAST, queueName, true)
             }
         }
         createQueueIfAbsent(VERIFICATION_REQUESTS_QUEUE_NAME)

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTests.kt
@@ -173,6 +173,7 @@ class ArtemisMessagingTests {
                     MOCK_VERSION_INFO.copy(platformVersion = platformVersion),
                     server,
                     identity.public,
+                    null,
                     ServiceAffinityExecutor("ArtemisMessagingTests", 1),
                     database,
                     maxMessageSize = maxMessageSize).apply {


### PR DESCRIPTION
This PR renames the outgoing and inbox queue addresses to enhance broker agility.

First, by using a hash of the public key of the nodes in the address construction we reduce the length of the addresses to a range supported by more brokers. Also, with post-quantum keys this will drastically reduce the size of the string.

Also, by changing the name of the inbox to a topic tied to the node identity we disambiguate the identity and potentially in the future we will be able share the broker between nodes for performance and HA purposes.