### PR TITLE
Integration test port binding exception fix

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
 class NodeKeystoreCheckTest {
     @Test
     fun `starting node in non-dev mode with no key store`() {
-        driver(startNodesInProcess = true) {
+        driver(startNodesInProcess = true, notarySpecs = emptyList()) {
             assertThatThrownBy {
                 startNode(customOverrides = mapOf("devMode" to false)).getOrThrow()
             }.hasMessageContaining("Identity certificate not found")
@@ -28,7 +28,7 @@ class NodeKeystoreCheckTest {
 
     @Test
     fun `node should throw exception if cert path doesn't chain to the trust root`() {
-        driver(startNodesInProcess = true) {
+        driver(startNodesInProcess = true, notarySpecs = emptyList()) {
             // Create keystores
             val keystorePassword = "password"
             val config = object : SSLConfiguration {

--- a/node/src/integration-test/kotlin/net/corda/node/SSHServerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/SSHServerTest.kt
@@ -4,27 +4,27 @@ import co.paralleluniverse.fibers.Suspendable
 import com.jcraft.jsch.ChannelExec
 import com.jcraft.jsch.JSch
 import com.jcraft.jsch.JSchException
-import net.corda.core.flows.*
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
+import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.nodeapi.internal.config.User
+import net.corda.testing.ALICE_NAME
 import net.corda.testing.driver.driver
+import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.util.io.Streams
 import org.junit.Test
-import net.corda.node.services.Permissions.Companion.startFlow
-import net.corda.testing.ALICE_NAME
 import java.net.ConnectException
+import java.util.regex.Pattern
 import kotlin.test.assertTrue
 import kotlin.test.fail
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
-import java.util.regex.Pattern
 
 class SSHServerTest {
 
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test()
     fun `ssh server does not start be default`() {
         val user = User("u", "p", setOf())
@@ -46,7 +46,6 @@ class SSHServerTest {
         }
     }
 
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `ssh server starts when configured`() {
         val user = User("u", "p", setOf())
@@ -66,8 +65,6 @@ class SSHServerTest {
         }
     }
 
-
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `ssh server verify credentials`() {
         val user = User("u", "p", setOf())
@@ -91,7 +88,6 @@ class SSHServerTest {
         }
     }
 
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `ssh respects permissions`() {
         val user = User("u", "p", setOf(startFlow<FlowICanRun>()))
@@ -122,7 +118,6 @@ class SSHServerTest {
         }
     }
 
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `ssh runs flows`() {
         val user = User("u", "p", setOf(startFlow<FlowICanRun>()))

--- a/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
@@ -20,15 +20,17 @@ import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.cordapp.CordappLoader
 import net.corda.node.internal.cordapp.CordappProviderImpl
-import net.corda.testing.*
+import net.corda.testing.DUMMY_BANK_A_NAME
+import net.corda.testing.DUMMY_NOTARY_NAME
+import net.corda.testing.SerializationEnvironmentRule
+import net.corda.testing.TestIdentity
 import net.corda.testing.driver.DriverDSL
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
+import net.corda.testing.internal.rigorousMock
 import net.corda.testing.internal.withoutTestSerialization
 import net.corda.testing.services.MockAttachmentStorage
-import net.corda.testing.internal.rigorousMock
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.net.URLClassLoader
@@ -100,7 +102,6 @@ class AttachmentLoadingTests {
         assertEquals(expected, actual)
     }
 
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `test that attachments retrieved over the network are not used for code`() = withoutTestSerialization {
         driver {
@@ -113,7 +114,6 @@ class AttachmentLoadingTests {
         Unit
     }
 
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `tests that if the attachment is loaded on both sides already that a flow can run`() = withoutTestSerialization {
         driver {

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -20,7 +20,6 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.ClusterSpec
 import net.corda.testing.node.NotarySpec
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import rx.Observable
 import java.util.*
@@ -74,7 +73,6 @@ class DistributedServiceTests {
 
     // TODO Use a dummy distributed service rather than a Raft Notary Service as this test is only about Artemis' ability
     // to handle distributed services
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `requests are distributed evenly amongst the nodes`() = setup {
         // Issue 100 pounds, then pay ourselves 50x2 pounds
@@ -103,7 +101,6 @@ class DistributedServiceTests {
     }
 
     // TODO This should be in RaftNotaryServiceTests
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `cluster survives if a notary is killed`() = setup {
         // Issue 100 pounds, then pay ourselves 10x5 pounds

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -20,7 +20,6 @@ import net.corda.testing.dummyCommand
 import net.corda.testing.node.ClusterSpec
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.startFlow
-import org.junit.Ignore
 import org.junit.Test
 import java.util.*
 import kotlin.test.assertEquals
@@ -29,7 +28,6 @@ import kotlin.test.assertFailsWith
 class RaftNotaryServiceTests {
     private val notaryName = CordaX500Name("RAFT Notary Service", "London", "GB")
 
-    @Ignore("Test has undeterministic capacity to hang, ignore till fixed")
     @Test
     fun `detect double spend`() {
         driver(

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ShutdownManager.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ShutdownManager.kt
@@ -41,14 +41,14 @@ class ShutdownManager(private val executorService: ExecutorService) {
             }
         }
 
-        val shutdowns = shutdownActionFutures.map { Try.on { it.getOrThrow(1.seconds) } }
+        val shutdowns = shutdownActionFutures.map { Try.on { it.getOrThrow(60.seconds) } }
         shutdowns.reversed().forEach {
             when (it) {
                 is Try.Success ->
                     try {
                         it.value()
                     } catch (t: Throwable) {
-                        log.warn("Exception while shutting down", t)
+                        log.warn("Exception while calling a shutdown action, this might create resource leaks", t)
                     }
                 is Try.Failure -> log.warn("Exception while getting shutdown method, disregarding", it.exception)
             }


### PR DESCRIPTION
Some of the recent integration test flakiness (namely port conflict exceptions) in CI was caused by leaked in process nodes. That seems to happen when the driver is shut down before the default notary node has started, and the notary node's 'dispose' future times out in the ShutdownManager (the timeout was set to 1s), so it never gets stopped.
