### PR TITLE
ENT-1389 persist transaction by schema

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/HibernateObserver.kt
@@ -10,10 +10,17 @@ import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
 import net.corda.node.services.api.SchemaService
-import net.corda.nodeapi.internal.persistence.HibernateConfiguration
 import net.corda.nodeapi.internal.persistence.DatabaseTransactionManager
+import net.corda.nodeapi.internal.persistence.HibernateConfiguration
 import org.hibernate.FlushMode
 import rx.Observable
+
+
+/**
+ * Small data class bundling together a ContractState and a StateRef (as opposed to a TransactionState and StateRef
+ * in StateAndRef)
+ */
+data class ContractStateAndRef(val state: ContractState, val ref: StateRef)
 
 /**
  * A vault observer that extracts Object Relational Mappings for contract states that support it, and persists them with Hibernate.
@@ -30,27 +37,33 @@ class HibernateObserver private constructor(private val config: HibernateConfigu
     }
 
     private fun persist(produced: Set<StateAndRef<ContractState>>) {
-        produced.forEach { persistState(it) }
-    }
-
-    private fun persistState(stateAndRef: StateAndRef<ContractState>) {
-        val state = stateAndRef.state.data
-        log.debug { "Asked to persist state ${stateAndRef.ref}" }
-        schemaService.selectSchemas(state).forEach { persistStateWithSchema(state, stateAndRef.ref, it) }
+        val stateBySchema: MutableMap<MappedSchema, MutableList<ContractStateAndRef>> = mutableMapOf()
+        // map all states by their referenced schemas
+        produced.forEach {
+            val contractStateAndRef = ContractStateAndRef(it.state.data, it.ref)
+            log.debug { "Asked to persist state ${it.ref}" }
+            schemaService.selectSchemas(contractStateAndRef.state).forEach {
+                stateBySchema.getOrPut(it) { mutableListOf() }.add(contractStateAndRef)
+            }
+        }
+        // then persist all states for each schema
+        stateBySchema.forEach { persistStatesWithSchema(it.value, it.key) }
     }
 
     @VisibleForTesting
-    internal fun persistStateWithSchema(state: ContractState, stateRef: StateRef, schema: MappedSchema) {
+    internal fun persistStatesWithSchema(statesAndRefs: List<ContractStateAndRef>, schema: MappedSchema) {
         val sessionFactory = config.sessionFactoryForSchemas(setOf(schema))
         val session = sessionFactory.withOptions().
                 connection(DatabaseTransactionManager.current().connection).
                 flushMode(FlushMode.MANUAL).
                 openSession()
-        session.use {
-            val mappedObject = schemaService.generateMappedObject(state, schema)
-            mappedObject.stateRef = PersistentStateRef(stateRef)
-            it.persist(mappedObject)
-            it.flush()
+        session.use { thisSession ->
+            statesAndRefs.forEach {
+                val mappedObject = schemaService.generateMappedObject(it.state, schema)
+                mappedObject.stateRef = PersistentStateRef(it.ref)
+                thisSession.persist(mappedObject)
+            }
+            thisSession.flush()
         }
     }
 }


### PR DESCRIPTION
Modify the HibernateObserver to persist states by schema (and only create a session per schema, not one per state per schema)

