### PR TITLE
Don't propagate internal notary service errors to the client

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -158,7 +158,7 @@ class NotaryFlow {
  */
 data class TransactionParts(val id: SecureHash, val inputs: List<StateRef>, val timestamp: TimeWindow?, val notary: Party?)
 
-class NotaryException(val error: NotaryError) : FlowException("Error response from Notary - $error")
+class NotaryException(val error: NotaryError) : FlowException("Unable to notarise: $error")
 
 @CordaSerializable
 sealed class NotaryError {
@@ -166,11 +166,16 @@ sealed class NotaryError {
         override fun toString() = "One or more input states for transaction $txId have been used in another transaction"
     }
 
-    /** Thrown if the time specified in the [TimeWindow] command is outside the allowed tolerance. */
+    /** Occurs when time specified in the [TimeWindow] command is outside the allowed tolerance. */
     object TimeWindowInvalid : NotaryError()
 
     data class TransactionInvalid(val cause: Throwable) : NotaryError() {
         override fun toString() = cause.toString()
+    }
+
+    /** Occurs when the notary service cannot connect to the internal data store. */
+    object ServiceUnavailable : NotaryError() {
+        override fun toString() = "Service unavailable, please try again later"
     }
 
     object WrongNotary : NotaryError()

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -173,10 +173,9 @@ sealed class NotaryError {
         override fun toString() = cause.toString()
     }
 
-    /** Occurs when the notary service cannot connect to the internal data store. */
-    object ServiceUnavailable : NotaryError() {
-        override fun toString() = "Service unavailable, please try again later"
-    }
-
     object WrongNotary : NotaryError()
+
+    data class General(val cause: String): NotaryError() {
+        override fun toString() = cause
+    }
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
@@ -80,7 +80,7 @@ abstract class TrustedAuthorityNotaryService : NotaryService() {
             }
         } catch (e: Exception) {
             log.error("Internal error", e)
-            throw NotaryException(NotaryError.ServiceUnavailable)
+            throw NotaryException(NotaryError.General("Service unavailable, please try again later"))
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
@@ -78,6 +78,9 @@ abstract class TrustedAuthorityNotaryService : NotaryService() {
                 log.warn("Notary conflicts for $txId: $conflicts")
                 throw notaryException(txId, e)
             }
+        } catch (e: Exception) {
+            log.error("Internal error", e)
+            throw NotaryException(NotaryError.ServiceUnavailable)
         }
     }
 


### PR DESCRIPTION
If the notary backend fails we should return a generic "service unavailable" error instead of propagating potentially cryptic implementation-specific exceptions. This should only be used when the issue can't be solved via internal retries.
