### PR TITLE
Rethrows a clearer error message when a test tx in a test ledger does not create a valid tx.

### DIFF
--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -236,7 +236,7 @@ data class TestLedgerDSLInterpreter private constructor(
         val wireTransaction = try {
             transactionInterpreter.toWireTransaction()
         } catch (e: IllegalStateException) {
-            throw IllegalStateException("A test transaction that is part of a test ledger must create a valid transaction.", e)
+            throw IllegalStateException("A transaction-DSL block that is part of a test ledger must return a valid transaction.", e)
         }
         // Record the output states
         transactionInterpreter.labelToIndexMap.forEach { label, index ->

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -236,7 +236,7 @@ data class TestLedgerDSLInterpreter private constructor(
         val wireTransaction = try {
             transactionInterpreter.toWireTransaction()
         } catch (e: IllegalStateException) {
-            throw IllegalStateException("A test transaction that is part of a test ledger must create a valid transaction.")
+            throw IllegalStateException("A test transaction that is part of a test ledger must create a valid transaction.", e)
         }
         // Record the output states
         transactionInterpreter.labelToIndexMap.forEach { label, index ->

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -233,7 +233,11 @@ data class TestLedgerDSLInterpreter private constructor(
         val transactionInterpreter = interpretTransactionDsl(transactionBuilder, dsl)
         if (fillTransaction) fillTransaction(transactionBuilder)
         // Create the WireTransaction
-        val wireTransaction = transactionInterpreter.toWireTransaction()
+        val wireTransaction = try {
+            transactionInterpreter.toWireTransaction()
+        } catch (e: IllegalStateException) {
+            throw IllegalStateException("A test transaction that is part of a test ledger must create a valid transaction.")
+        }
         // Record the output states
         transactionInterpreter.labelToIndexMap.forEach { label, index ->
             if (label in labelToOutputStateAndRefs) {


### PR DESCRIPTION
Currently, doing:

    @Test
    fun `test`() {
        ledgerServices.ledger(DUMMY_NOTARY) {
            transaction {
                tweak {
                    fails()
                }
                fails()
            }
        }
    }

Will throw an obscure error message (`java.lang.IllegalStateException: A transaction must contain at least one input or output state`), because a test tx that is party of a test ledger is expected to create a valid tx.