### PR TITLE
Database schema changes

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/schemas/CommercialPaperSchemaV1.kt
+++ b/finance/src/main/kotlin/net/corda/finance/schemas/CommercialPaperSchemaV1.kt
@@ -33,6 +33,7 @@ object CommercialPaperSchemaV1 : MappedSchema(schemaFamily = CommercialPaperSche
             var issuancePartyHash: String,
 
             @Column(name = "issuance_ref")
+            @Type(type = "corda-wrapper-binary")
             var issuanceRef: ByteArray,
 
             @Column(name = "owner_key_hash", length = MAX_HASH_HEX_SIZE)

--- a/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV1.kt
+++ b/finance/src/test/kotlin/net/corda/finance/schemas/SampleCommercialPaperSchemaV1.kt
@@ -31,6 +31,7 @@ object SampleCommercialPaperSchemaV1 : MappedSchema(schemaFamily = CommercialPap
             var issuancePartyHash: String,
 
             @Column(name = "issuance_ref")
+            @Type(type = "corda-wrapper-binary")
             var issuanceRef: ByteArray,
 
             @Column(name = "owner_key_hash", length = MAX_HASH_HEX_SIZE)

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -13,6 +13,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.contextLogger
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
+import org.hibernate.annotations.Type
 import java.io.Serializable
 import java.util.*
 import javax.annotation.concurrent.ThreadSafe
@@ -43,6 +44,7 @@ class PersistentUniquenessProvider : UniquenessProvider, SingletonSerializeAsTok
             var name: String = "",
 
             @Column(name = "requesting_party_key", length = 255)
+            @Type(type = "corda-wrapper-binary")
             var owningKey: ByteArray = ByteArray(0)
     ) : Serializable
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -151,7 +151,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
     @Entity
     @Table(name = "vault_transaction_notes",
-            indexes = arrayOf(Index(name = "transaction_id_index", columnList = "transaction_id")))
+            indexes = arrayOf(Index(name = "seq_no_index", columnList = "seq_no"),
+                    Index(name = "transaction_id_index", columnList = "transaction_id")))
     class VaultTxnNote(
             @Id
             @GeneratedValue

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -745,24 +745,18 @@ class VaultQueryTests {
             // DOCEND VaultQueryExample22
 
             assertThat(results.otherResults).hasSize(15)
-            /** CHF */
-            assertThat(results.otherResults[0]).isEqualTo(50000L)
-            assertThat(results.otherResults[1]).isEqualTo(10274L)
-            assertThat(results.otherResults[2]).isEqualTo(9481L)
-            assertThat(results.otherResults[3]).isEqualTo(10000.0)
-            assertThat(results.otherResults[4]).isEqualTo("CHF")
-            /** GBP */
-            assertThat(results.otherResults[5]).isEqualTo(40000L)
-            assertThat(results.otherResults[6]).isEqualTo(10343L)
-            assertThat(results.otherResults[7]).isEqualTo(9351L)
-            assertThat(results.otherResults[8]).isEqualTo(10000.0)
-            assertThat(results.otherResults[9]).isEqualTo("GBP")
-            /** USD */
-            assertThat(results.otherResults[10]).isEqualTo(60000L)
-            assertThat(results.otherResults[11]).isEqualTo(11298L)
-            assertThat(results.otherResults[12]).isEqualTo(8702L)
-            assertThat(results.otherResults[13]).isEqualTo(10000.0)
-            assertThat(results.otherResults[14]).isEqualTo("USD")
+            // the order of rows not guaranteed, a row has format 'NUM, NUM, NUM, CURRENCY_CODE'
+            val actualRows = mapOf(results.otherResults[4] as String to results.otherResults.subList(0,4),
+                    results.otherResults[9] as String to results.otherResults.subList(5,9),
+                    results.otherResults[14] as String to results.otherResults.subList(10,14))
+
+            val expectedRows = mapOf("CHF" to listOf(50000L, 10274L, 9481L, 10000.0),
+                    "GBP" to listOf(40000L, 10343L, 9351L, 10000.0),
+                    "USD" to listOf(60000L, 11298L, 8702L, 10000.0))
+
+            assertThat(expectedRows["CHF"]).isEqualTo(actualRows["CHF"])
+            assertThat(expectedRows["GBP"]).isEqualTo(actualRows["GBP"])
+            assertThat(expectedRows["USD"]).isEqualTo(actualRows["USD"])
         }
     }
 
@@ -1454,12 +1448,14 @@ class VaultQueryTests {
             val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
 
             assertThat(results.otherResults).hasSize(6)
-            assertThat(results.otherResults[0]).isEqualTo(110000L)
-            assertThat(results.otherResults[1]).isEqualTo("CHF")
-            assertThat(results.otherResults[2]).isEqualTo(70000L)
-            assertThat(results.otherResults[3]).isEqualTo("GBP")
-            assertThat(results.otherResults[4]).isEqualTo(30000L)
-            assertThat(results.otherResults[5]).isEqualTo("USD")
+            // the order of rows not guaranteed
+            val actualTotals = mapOf(results.otherResults[1] as String to results.otherResults[0] as Long,
+                    results.otherResults[3] as String to results.otherResults[2] as Long,
+                    results.otherResults[5] as String to results.otherResults[4] as Long)
+            val expectedTotals = mapOf("CHF" to 110000L, "GBP" to 70000L, "USD" to 30000L)
+            assertThat(expectedTotals["CHF"]).isEqualTo(actualTotals["CHF"])
+            assertThat(expectedTotals["GBP"]).isEqualTo(actualTotals["GBP"])
+            assertThat(expectedTotals["USD"]).isEqualTo(actualTotals["USD"])
         }
     }
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealStateSchemaV1.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyDealStateSchemaV1.kt
@@ -22,7 +22,7 @@ object DummyDealStateSchemaV1 : MappedSchema(schemaFamily = DummyDealStateSchema
             /** parent attributes */
             @ElementCollection
             @Column(name = "participants")
-            @CollectionTable(name = "dummy_deal_states_participants", joinColumns = arrayOf(
+            @CollectionTable(name = "dummy_deal_states_parts", joinColumns = arrayOf(
                     JoinColumn(name = "output_index", referencedColumnName = "output_index"),
                     JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id")))
             override var participants: MutableSet<AbstractParty>? = null,

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV2.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/DummyLinearStateSchemaV2.kt
@@ -18,7 +18,7 @@ object DummyLinearStateSchemaV2 : MappedSchema(schemaFamily = DummyLinearStateSc
 
             @ElementCollection
             @Column(name = "participants")
-            @CollectionTable(name = "dummy_linear_states_v2_participants", joinColumns = arrayOf(
+            @CollectionTable(name = "dummy_linear_states_v2_parts", joinColumns = arrayOf(
                     JoinColumn(name = "output_index", referencedColumnName = "output_index"),
                     JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id")))
             override var participants: MutableSet<AbstractParty>? = null,


### PR DESCRIPTION
Changes compatible with R3.Corda (ENT-794):
* Added Hibernate corda-wrapper-binary to CommercialPaperSchema/issuanceRef column, and PersistentUniqnessProvider/requesting_party_key column.
* Shorten names of tables in dummy schemas used in tests.
* Undo removal of compound index of VaultTxnNote (https://github.com/corda/corda/commit/b423fea537077c3336501a300c31dddf3be02c7a).
* Assertions for 2 vault tests don't rely on order of rows.