### PR TITLE
Urgent bug fix for V1 to make sure the network map node rejects any n…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapService.kt
@@ -260,6 +260,12 @@ abstract class AbstractNetworkMapService(services: ServiceHubInternal,
             return RegistrationResponse("Minimum platform version requirement not met: $minimumPlatformVersion")
         }
 
+        val entryWithSameAddress = nodeRegistrations.entries.find { it.key != identity && it.value.reg.node.addresses.any { it in node.addresses } }
+        if (entryWithSameAddress != null) {
+            logger.warn("Registration from $node contains address of existing node $entryWithSameAddress")
+            return RegistrationResponse("Address already taken!")
+        }
+
         // Update the current value atomically, so that if multiple updates come
         // in on different threads, there is no risk of a race condition while checking
         // sequence numbers.


### PR DESCRIPTION
…ode registration containing an address already belonging to another node.

This is to prevent the duplicate address being propagated to the network, where the nodes have a DB constraint for address uniqueness, and thus they fall over when receiving the node with the duplicate address.
