### PR TITLE
Remove jolokia war reference from webserver

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -42,7 +42,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').compileJava) {
 
     capsuleManifest {
         applicationVersion = corda_release_version
-        appClassPath = ["jolokia-war-${project.rootProject.ext.jolokia_version}.war"]
+
         // See experimental/quasar-hook/README.md for how to generate.
         def quasarExcludeExpression = "x(antlr**;bftsmart**;ch**;co.paralleluniverse**;com.codahale**;com.esotericsoftware**;com.fasterxml**;com.google**;com.ibm**;com.intellij**;com.jcabi**;com.nhaarman**;com.opengamma**;com.typesafe**;com.zaxxer**;de.javakaffee**;groovy**;groovyjarjarantlr**;groovyjarjarasm**;io.atomix**;io.github**;io.netty**;jdk**;joptsimple**;junit**;kotlin**;net.bytebuddy**;net.i2p**;org.apache**;org.assertj**;org.bouncycastle**;org.codehaus**;org.crsh**;org.dom4j**;org.fusesource**;org.h2**;org.hamcrest**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.junit**;org.mockito**;org.objectweb**;org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**;org.jolokia**)"
         javaAgents = ["quasar-core-${quasar_version}-jdk8.jar=${quasarExcludeExpression}"]

--- a/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
@@ -55,22 +55,6 @@ class NodeWebServer(val config: WebServerConfig) {
         // Note that the web server handlers will all run concurrently, and not on the node thread.
         val handlerCollection = HandlerCollection()
 
-        // Export JMX monitoring statistics and data over REST/JSON.
-        if (config.exportJMXto.split(',').contains("http")) {
-            val classpath = System.getProperty("java.class.path").split(System.getProperty("path.separator"))
-            val warpath = classpath.firstOrNull { it.contains("jolokia-war") && it.endsWith(".war") }
-            if (warpath != null) {
-                handlerCollection.addHandler(WebAppContext().apply {
-                    // Find the jolokia WAR file on the classpath.
-                    contextPath = "/monitoring/json"
-                    setInitParameter("mimeType", MediaType.APPLICATION_JSON)
-                    war = warpath
-                })
-            } else {
-                log.warn("Unable to locate Jolokia WAR on classpath")
-            }
-        }
-
         // API, data upload and download to services (attachments, rates oracles etc)
         handlerCollection.addHandler(buildServletContextHandler(localRpc))
 


### PR DESCRIPTION
* Removed the Jolokia endpoint from the node-webserver module. Jolokia (which provides access to JMX monitoring over HTTP) is not required on the webserver - because it is the corda node itself that would be the subject of any monitoring.
* Also removed the Jolokia WAR package from the node module, as it is an unused/unnecessary dependency. JMX monitoring is provided via the Node-Driver if required.
