### PR TITLE
allow cordapp developers to select fields from x500 names

### DIFF
--- a/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
@@ -105,10 +105,13 @@ data class CordaX500Name(val commonName: String?,
 
             val CN = attrsMap[BCStyle.CN]?.toString()
             val OU = attrsMap[BCStyle.OU]?.toString()
-            val O = attrsMap[BCStyle.O]?.toString() ?: throw IllegalArgumentException("Corda X.500 names must include an O attribute")
-            val L = attrsMap[BCStyle.L]?.toString() ?: throw IllegalArgumentException("Corda X.500 names must include an L attribute")
+            val O = attrsMap[BCStyle.O]?.toString()
+                    ?: throw IllegalArgumentException("Corda X.500 names must include an O attribute")
+            val L = attrsMap[BCStyle.L]?.toString()
+                    ?: throw IllegalArgumentException("Corda X.500 names must include an L attribute")
             val ST = attrsMap[BCStyle.ST]?.toString()
-            val C = attrsMap[BCStyle.C]?.toString() ?: throw IllegalArgumentException("Corda X.500 names must include an C attribute")
+            val C = attrsMap[BCStyle.C]?.toString()
+                    ?: throw IllegalArgumentException("Corda X.500 names must include an C attribute")
             return CordaX500Name(CN, OU, O, L, ST, C)
         }
 
@@ -120,9 +123,48 @@ data class CordaX500Name(val commonName: String?,
     private var _x500Principal: X500Principal? = null
 
     /** Return the [X500Principal] equivalent of this name. */
-    val x500Principal: X500Principal get() {
-        return _x500Principal ?: X500Principal(this.x500Name.encoded).also { _x500Principal = it }
-    }
+    val x500Principal: X500Principal
+        get() {
+            return _x500Principal ?: X500Principal(this.x500Name.encoded).also { _x500Principal = it }
+        }
 
     override fun toString(): String = x500Principal.toString()
+
+    fun toDisplayString(vararg selectors: CordaX500Name.NameSelector): String {
+        val nonNullElementsOfName = selectors.map { it.extract(this) }.filter { it != null }
+        return nonNullElementsOfName.joinToString ( ", " )
+    }
+
+    fun toDisplayString(): String {
+        return toDisplayString(
+                CordaX500Name.NameSelector.COMMON_NAME,
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY)
+    }
+
+    enum class NameSelector {
+        ORG {
+            override fun extract(x500name: CordaX500Name): String? {
+                return x500name.organisation
+            }
+        },
+        ORG_UNIT {
+            override fun extract(x500name: CordaX500Name): String? {
+                return x500name.organisationUnit
+            }
+        },
+        COMMON_NAME {
+            override fun extract(x500name: CordaX500Name): String? {
+                return x500name.commonName
+            }
+        },
+        COUNTRY {
+            override fun extract(x500name: CordaX500Name): String? {
+                return x500name.country
+            }
+        };
+
+        abstract fun extract(x500name: CordaX500Name): String?
+    }
 }

--- a/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
@@ -165,6 +165,6 @@ data class CordaX500Name(val commonName: String?,
             }
         };
 
-        abstract fun extract(x500name: CordaX500Name): String?
+         internal abstract fun extract(x500name: CordaX500Name): String?
     }
 }

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -319,9 +319,9 @@ interface CordaRPCOps : RPCOps {
 
     fun displayNameFromX500(x500Name: CordaX500Name) : String
 
-    fun displayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String
+    fun formatDisplayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String
 
-    fun displayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector) : String
+    fun formatDisplayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector) : String
 }
 
 inline fun <reified T : ContractState> CordaRPCOps.vaultQueryBy(criteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(),

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -318,10 +318,6 @@ interface CordaRPCOps : RPCOps {
     fun displayNameFromParty(party: Party): String
 
     fun displayNameFromX500(x500Name: CordaX500Name) : String
-
-    fun formatDisplayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String
-
-    fun formatDisplayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector) : String
 }
 
 inline fun <reified T : ContractState> CordaRPCOps.vaultQueryBy(criteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(),

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -314,6 +314,14 @@ interface CordaRPCOps : RPCOps {
 
     /** Clear all network map data from local node cache. */
     fun clearNetworkMapCache()
+
+    fun displayNameFromParty(party: Party): String
+
+    fun displayNameFromX500(x500Name: CordaX500Name) : String
+
+    fun displayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String
+
+    fun displayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector) : String
 }
 
 inline fun <reified T : ContractState> CordaRPCOps.vaultQueryBy(criteria: QueryCriteria = QueryCriteria.VaultQueryCriteria(),

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -315,8 +315,14 @@ interface CordaRPCOps : RPCOps {
     /** Clear all network map data from local node cache. */
     fun clearNetworkMapCache()
 
-    fun displayNameFromParty(party: Party): String
-
+    /** This will attempt to find a unique representation of an x500 name
+     * uniqueness is checked against the whole set of names within the network
+     * It will attempt to provide the shortest possible unique name by appending more fields till uniqueness is reached
+     * Extra fields are added in the order of CN,O,OU,C,L,S
+     * @param x500Name the name to get a representation of
+     * @return the shortest possible unique [String] representation of this name
+     * @throws [IllegalStateException] if no unique name is possible
+     */
     fun displayNameFromX500(x500Name: CordaX500Name) : String
 }
 

--- a/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
@@ -75,30 +75,56 @@ class CordaX500NameTest {
     }
 
     @Test
-    fun `default format should return a sensible display string`() {
-        val name = CordaX500Name.parse("CN=cName, OU=orgUnit, O=org, L=city, S=state, C=GB")
-        val displayString = name.toDisplayString()
-        assertEquals("cName, org, orgUnit, GB", displayString)
-    }
+    fun `should provide the shortest possible unique name given set of nodes and selectors`() {
+        val name1 = CordaX500Name.parse("O=blarg,   OU=unit,    C=GB,   L=city, CN=CommonName")
+        val name2 = CordaX500Name.parse("O=org,     OU=blarg,   C=GB,   L=city, CN=CommonName")
+        val name3 = CordaX500Name.parse("O=org,     OU=unit,    C=BL,   L=city, CN=CommonName")
+        val name4 = CordaX500Name.parse("O=org,     OU=unit,    C=US,   L=city, CN=Blaargh")
+        val name5 = CordaX500Name.parse("O=org,     OU=unit,    C=US,   L=city, CN=Blargh")
+        val outsiderName = CordaX500Name.parse("O=thisIs,  OU=unit,    C=BL,   L=city, CN=Blargh")
 
-    @Test
-    fun `default format should handle null name fields`() {
-        val name = CordaX500Name.parse("O=org, L=city, C=GB")
-        val displayString = name.toDisplayString()
-        assertEquals("org, GB", displayString)
-    }
+        val displayString1 = name1.toUniqueName(setOf(name1, name2, name3, name4, name5),
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY,
+                CordaX500Name.NameSelector.COMMON_NAME)
 
-    @Test
-    fun `custom format should return a sensible display string`() {
-        val name = CordaX500Name.parse("CN=cName, OU=orgUnit, O=org, L=city, S=state, C=GB")
-        val displayString = name.toDisplayString(CordaX500Name.NameSelector.ORG, CordaX500Name.NameSelector.COUNTRY, CordaX500Name.NameSelector.ORG_UNIT)
-        assertEquals("org, GB, orgUnit", displayString)
-    }
+        val displayString2 = name2.toUniqueName(setOf(name1, name2, name3, name4, name5),
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY,
+                CordaX500Name.NameSelector.COMMON_NAME)
 
-    @Test
-    fun `custom selectors should handle nullable fields`() {
-        val name = CordaX500Name.parse("O=org, L=city, C=GB")
-        val displayString = name.toDisplayString(CordaX500Name.NameSelector.ORG_UNIT, CordaX500Name.NameSelector.COMMON_NAME, CordaX500Name.NameSelector.COUNTRY)
-        assertEquals("GB", displayString)
+        val displayString3 = name3.toUniqueName(setOf(name1, name2, name3, name4, name5),
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY,
+                CordaX500Name.NameSelector.COMMON_NAME)
+
+        val displayString4 = name4.toUniqueName(setOf(name1, name2, name3, name4, name5),
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY,
+                CordaX500Name.NameSelector.COMMON_NAME)
+
+        val displayString5 = name5.toUniqueName(setOf(name1, name2, name3, name4, name5),
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY,
+                CordaX500Name.NameSelector.COMMON_NAME)
+
+        val displayString6 = outsiderName.toUniqueName(setOf(name1, name2, name3, name4, name5),
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY,
+                CordaX500Name.NameSelector.COMMON_NAME)
+
+        assertEquals("blarg", displayString1)
+        assertEquals("org, blarg", displayString2)
+        assertEquals("org, unit, BL", displayString3)
+        assertEquals("org, unit, US, Blaargh", displayString4)
+        assertEquals("org, unit, US, Blargh", displayString5)
+        assertEquals("thisIs", displayString6)
+
     }
 }

--- a/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
@@ -125,6 +125,18 @@ class CordaX500NameTest {
         assertEquals("org, unit, US, Blaargh", displayString4)
         assertEquals("org, unit, US, Blargh", displayString5)
         assertEquals("thisIs", displayString6)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `should throw exception if unable to produce unique name with given selectors`() {
+        val name1 = CordaX500Name.parse("O=org,   OU=unit,    C=GB,   L=LONDON, CN=CommonName")
+        val name2 = CordaX500Name.parse("O=org,     OU=unit,   C=GB,  L=NEW_YOURK, CN=CommonName")
+
+        println(name1.toUniqueName(setOf(name1, name2),
+                CordaX500Name.NameSelector.ORG,
+                CordaX500Name.NameSelector.ORG_UNIT,
+                CordaX500Name.NameSelector.COUNTRY,
+                CordaX500Name.NameSelector.COMMON_NAME))
 
     }
 }

--- a/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
@@ -73,4 +73,32 @@ class CordaX500NameTest {
             CordaX500Name.parse("O=Bank A, L=New York, C=US, SN=blah")
         }
     }
+
+    @Test
+    fun `default format should return a sensible display string`() {
+        val name = CordaX500Name.parse("CN=cName, OU=orgUnit, O=org, L=city, S=state, C=GB")
+        val displayString = name.toDisplayString()
+        assertEquals("cName, org, orgUnit, GB", displayString)
+    }
+
+    @Test
+    fun `default format should handle null name fields`() {
+        val name = CordaX500Name.parse("O=org, L=city, C=GB")
+        val displayString = name.toDisplayString()
+        assertEquals("org, GB", displayString)
+    }
+
+    @Test
+    fun `custom format should return a sensible display string`() {
+        val name = CordaX500Name.parse("CN=cName, OU=orgUnit, O=org, L=city, S=state, C=GB")
+        val displayString = name.toDisplayString(CordaX500Name.NameSelector.ORG, CordaX500Name.NameSelector.COUNTRY, CordaX500Name.NameSelector.ORG_UNIT)
+        assertEquals("org, GB, orgUnit", displayString)
+    }
+
+    @Test
+    fun `custom selectors should handle nullable fields`() {
+        val name = CordaX500Name.parse("O=org, L=city, C=GB")
+        val displayString = name.toDisplayString(CordaX500Name.NameSelector.ORG_UNIT, CordaX500Name.NameSelector.COMMON_NAME, CordaX500Name.NameSelector.COUNTRY)
+        assertEquals("GB", displayString)
+    }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -42,6 +42,22 @@ internal class CordaRPCOpsImpl(
         private val database: CordaPersistence,
         private val flowStarter: FlowStarter
 ) : CordaRPCOps {
+    override fun displayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
+        return displayNameFromX500(party.name, *selectors);
+    }
+
+    override fun displayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
+        return x500Name.toDisplayString(*selectors)
+    }
+
+    override fun displayNameFromParty(party: Party): String {
+        return displayNameFromX500(party.name)
+    }
+
+    override fun displayNameFromX500(x500Name: CordaX500Name): String {
+        return x500Name.toDisplayString();
+    }
+
     override fun networkMapSnapshot(): List<NodeInfo> {
         val (snapshot, updates) = networkMapFeed()
         updates.notUsed()
@@ -175,7 +191,7 @@ internal class CordaRPCOpsImpl(
         }
     }
 
-    override fun uploadAttachmentWithMetadata(jar: InputStream, uploader:String, filename:String): SecureHash {
+    override fun uploadAttachmentWithMetadata(jar: InputStream, uploader: String, filename: String): SecureHash {
         // TODO: this operation should not require an explicit transaction
         return database.transaction {
             services.attachments.importAttachment(jar, uploader, filename)
@@ -286,7 +302,8 @@ internal class CordaRPCOpsImpl(
         val principal = origin.principal().name
         return when (origin) {
             is Origin.RPC -> FlowInitiator.RPC(principal)
-            is Origin.Peer -> services.identityService.wellKnownPartyFromX500Name((origin as Origin.Peer).party)?.let { FlowInitiator.Peer(it) } ?: throw IllegalStateException("Unknown peer with name ${(origin as Origin.Peer).party}.")
+            is Origin.Peer -> services.identityService.wellKnownPartyFromX500Name((origin as Origin.Peer).party)?.let { FlowInitiator.Peer(it) }
+                    ?: throw IllegalStateException("Unknown peer with name ${(origin as Origin.Peer).party}.")
             is Origin.Service -> FlowInitiator.Service(principal)
             is Origin.Shell -> FlowInitiator.Shell
             is Origin.Scheduled -> FlowInitiator.Scheduled((origin as Origin.Scheduled).scheduledState)

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -42,11 +42,11 @@ internal class CordaRPCOpsImpl(
         private val database: CordaPersistence,
         private val flowStarter: FlowStarter
 ) : CordaRPCOps {
-    override fun displayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
-        return displayNameFromX500(party.name, *selectors);
+    override fun formatDisplayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
+        return formatDisplayNameFromX500(party.name, *selectors);
     }
 
-    override fun displayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
+    override fun formatDisplayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
         return x500Name.toDisplayString(*selectors)
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -44,7 +44,7 @@ internal class CordaRPCOpsImpl(
 ) : CordaRPCOps {
 
 
-    override fun displayNameFromParty(party: Party): String {
+    fun displayNameFromParty(party: Party): String {
         return displayNameFromX500(party.name)
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -42,20 +42,14 @@ internal class CordaRPCOpsImpl(
         private val database: CordaPersistence,
         private val flowStarter: FlowStarter
 ) : CordaRPCOps {
-    override fun formatDisplayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
-        return formatDisplayNameFromX500(party.name, *selectors);
-    }
 
-    override fun formatDisplayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
-        return x500Name.toDisplayString(*selectors)
-    }
 
     override fun displayNameFromParty(party: Party): String {
         return displayNameFromX500(party.name)
     }
 
     override fun displayNameFromX500(x500Name: CordaX500Name): String {
-        return x500Name.toDisplayString();
+        return x500Name.toUniqueDisplayName(services.networkMapCache.allNodes.map { it.legalIdentities.first().name }.toSet());
     }
 
     override fun networkMapSnapshot(): List<NodeInfo> {

--- a/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
@@ -28,12 +28,12 @@ class RpcAuthorisationProxy(private val implementation: CordaRPCOps, private val
         return implementation.displayNameFromX500(x500Name)
     }
 
-    override fun displayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
-        return implementation.displayNameFromParty(party, *selectors)
+    override fun formatDisplayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
+        return implementation.formatDisplayNameFromParty(party, *selectors)
     }
 
-    override fun displayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
-        return implementation.displayNameFromX500(x500Name, *selectors)
+    override fun formatDisplayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
+        return implementation.formatDisplayNameFromX500(x500Name, *selectors)
     }
 
     override fun uploadAttachmentWithMetadata(jar: InputStream, uploader: String, filename: String): SecureHash = guard("uploadAttachmentWithMetadata") {

--- a/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
@@ -20,6 +20,21 @@ import java.security.PublicKey
 
 // TODO change to KFunction reference after Kotlin fixes https://youtrack.jetbrains.com/issue/KT-12140
 class RpcAuthorisationProxy(private val implementation: CordaRPCOps, private val context: () -> RpcAuthContext) : CordaRPCOps {
+    override fun displayNameFromParty(party: Party): String {
+        return implementation.displayNameFromParty(party)
+    }
+
+    override fun displayNameFromX500(x500Name: CordaX500Name): String {
+        return implementation.displayNameFromX500(x500Name)
+    }
+
+    override fun displayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
+        return implementation.displayNameFromParty(party, *selectors)
+    }
+
+    override fun displayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
+        return implementation.displayNameFromX500(x500Name, *selectors)
+    }
 
     override fun uploadAttachmentWithMetadata(jar: InputStream, uploader: String, filename: String): SecureHash = guard("uploadAttachmentWithMetadata") {
         implementation.uploadAttachmentWithMetadata(jar, uploader, filename)
@@ -157,11 +172,10 @@ class RpcAuthorisationProxy(private val implementation: CordaRPCOps, private val
     private inline fun <RESULT> guard(methodName: String, action: () -> RESULT) = guard(methodName, emptyList(), action)
 
     // TODO change to KFunction reference after Kotlin fixes https://youtrack.jetbrains.com/issue/KT-12140
-    private inline fun <RESULT> guard(methodName: String, args: List<Class<*>>, action: () -> RESULT) : RESULT {
+    private inline fun <RESULT> guard(methodName: String, args: List<Class<*>>, action: () -> RESULT): RESULT {
         if (!context().isPermitted(methodName, *(args.map { it.name }.toTypedArray()))) {
             throw PermissionException("User not authorized to perform RPC call $methodName with target $args")
-        }
-        else {
+        } else {
             return action()
         }
     }

--- a/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
@@ -28,14 +28,6 @@ class RpcAuthorisationProxy(private val implementation: CordaRPCOps, private val
         return implementation.displayNameFromX500(x500Name)
     }
 
-    override fun formatDisplayNameFromParty(party: Party, vararg selectors: CordaX500Name.NameSelector): String {
-        return implementation.formatDisplayNameFromParty(party, *selectors)
-    }
-
-    override fun formatDisplayNameFromX500(x500Name: CordaX500Name, vararg selectors: CordaX500Name.NameSelector): String {
-        return implementation.formatDisplayNameFromX500(x500Name, *selectors)
-    }
-
     override fun uploadAttachmentWithMetadata(jar: InputStream, uploader: String, filename: String): SecureHash = guard("uploadAttachmentWithMetadata") {
         implementation.uploadAttachmentWithMetadata(jar, uploader, filename)
     }

--- a/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/RpcAuthorisationProxy.kt
@@ -19,10 +19,8 @@ import java.io.InputStream
 import java.security.PublicKey
 
 // TODO change to KFunction reference after Kotlin fixes https://youtrack.jetbrains.com/issue/KT-12140
+// TODO implement this using reflective proxy or K-Delegation
 class RpcAuthorisationProxy(private val implementation: CordaRPCOps, private val context: () -> RpcAuthContext) : CordaRPCOps {
-    override fun displayNameFromParty(party: Party): String {
-        return implementation.displayNameFromParty(party)
-    }
 
     override fun displayNameFromX500(x500Name: CordaX500Name): String {
         return implementation.displayNameFromX500(x500Name)


### PR DESCRIPTION
This a simple way for cordapp developers to select a sensible way to display a x500 cert or a Corda Identity (Party)
