### PR TITLE
[CORDA-939] Remove exposure of internal hibernate configuration from mockservices

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -198,11 +198,10 @@ open class MockServices private constructor(
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
     val mockCordappProvider = MockCordappProvider(cordappLoader, attachments)
     override val cordappProvider: CordappProvider get() = mockCordappProvider
-    lateinit var hibernatePersister: HibernateObserver
 
-    fun makeVaultService(hibernateConfig: HibernateConfiguration, schemaService: SchemaService): VaultServiceInternal {
+    internal fun makeVaultService(hibernateConfig: HibernateConfiguration, schemaService: SchemaService): VaultServiceInternal {
         val vaultService = NodeVaultService(Clock.systemUTC(), keyManagementService, validatedTransactions, hibernateConfig)
-        hibernatePersister = HibernateObserver.install(vaultService.rawUpdates, hibernateConfig, schemaService)
+        HibernateObserver.install(vaultService.rawUpdates, hibernateConfig, schemaService)
         return vaultService
     }
 


### PR DESCRIPTION
The makeVaultService in MockServices asks for net.corda.nodeapi.internal.persistence.HibernateConfiguration to be passed in as a parameter.

It is only used internally by MockServices, and then in the HibernateConfigurationTest in the net.corda.node package. 

Since the HibernateConfigurationTest is specifically testing hibernate anyway, I've changed it to instantiate what it needs directly and made the makeVaultService function internal to MockServices, so the public API doesn't expose internal types.