### PR TITLE
CORDA-978 - Only consider getters that accpet zero parameters

### DIFF
--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/PrivatePropertyTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/PrivatePropertyTests.kt
@@ -86,7 +86,7 @@ class PrivatePropertyTests {
     @Test
     fun testMultiArgSetter() {
         @Suppress("UNUSED")
-        data class C(private var a: Int, val b: Int) {
+        data class C(private var a: Int, var b: Int) {
             // This will force the serialization engine to use getter / setter
             // instantiation for the object rather than construction
             @ConstructorForDeserialization
@@ -97,10 +97,9 @@ class PrivatePropertyTests {
         }
 
         val c1 = C(33, 44)
-        Assertions.assertThatThrownBy {
-            SerializationOutput(factory).serialize(c1)
-        }.isInstanceOf(NotSerializableException::class.java).hasMessageContaining(
-                "Defined setter for parameter a takes too many arguments")
+        val c2 = DeserializationInput(factory).deserialize(SerializationOutput(factory).serialize(c1))
+        assertEquals(0, c2.getA())
+        assertEquals(44, c2.b)
     }
 
     @Test

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationOutputTests.kt
@@ -1080,4 +1080,33 @@ class SerializationOutputTests {
             serdes(obj, factory, factory2, expectedEqual = false, expectDeserializedEqual = false)
         }.isInstanceOf(MissingAttachmentsException::class.java)
     }
+
+    //
+    // java.lang.IllegalArgumentException:
+    //      net.corda.core.contracts.TransactionState ->
+    //      data(net.corda.core.contracts.ContractState) ->
+    //      net.corda.finance.contracts.asset.Cash$State ->
+    //      amount(net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<java.util.Currency>>) ->
+    //      net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<java.util.Currency>> ->
+    //      displayTokenSize(java.math.BigDecimal) ->
+    //      wrong number of arguments
+    //
+    @Test
+    fun invokeFailure() {
+        data class C (val a: Amount<Currency>)
+
+        val factory = testDefaultFactoryNoEvolution()
+        factory.register(net.corda.nodeapi.internal.serialization.amqp.custom.BigDecimalSerializer)
+        factory.register(net.corda.nodeapi.internal.serialization.amqp.custom.CurrencySerializer)
+
+        val c = C(Amount<Currency>(100, BigDecimal("1.5"), Currency.getInstance("USD")))
+
+        SerializationOutput(factory).serialize(c)
+        /*
+
+        var deserializedC = DeserializationInput(sf1).deserialize(
+        assertEquals('c', deserializedC.c)
+        */
+
+    }
 }


### PR DESCRIPTION
Because of inheritance, we have to consider multiple getters existing on a class for a property, however in that, we weren't excluding getters that take parameters, something we're unable to provide, so depending no the returned order sometimes we select the wrong one and it all goes terribley wrong.