### PR TITLE
CORDA-986 and CORDA-985 CompositeKey and Signature verification performance fixes

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -144,7 +144,7 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
             return if (weight == other.weight)
                 node.encoded.sequence().compareTo(other.node.encoded.sequence())
             else
-                -weight.compareTo(other.weight) // Descending ordering.
+                -weight.compareTo(other.weight) // Descending order.
         }
 
         override fun toASN1Primitive(): ASN1Primitive {

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -62,7 +62,7 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
     }
 
     /**
-     * Τhe order of the children may not be the same to what was provided in the constructor.
+     * Τhe order of the children may not be the same to what was provided in the builder.
      */
     val children: List<NodeAndWeight> = children.sortedWith(descWeightComparator)
 

--- a/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CompositeKey.kt
@@ -52,17 +52,17 @@ class CompositeKey private constructor(val threshold: Int, children: List<NodeAn
             }
             return builder.build(threshold)
         }
-        // Required for sorting [children] list.
+        // Required for sorting [children] list. To ensure a deterministic way of adding children required for equality
+        // checking, [children] list is sorted during construction. A DESC ordering in the [NodeAndWeight.weight] field
+        // will improve efficiency, because keys with bigger "weights" are the first to be checked and thus the
+        // threshold requirement might be met earlier without requiring a full [children] scan.
         // TODO: node.encoded.sequence() might be expensive, consider a faster deterministic compareTo implementation
         //      for public keys in general.
         private val descWeightComparator = compareBy<NodeAndWeight>({ -it.weight }, { it.node.encoded.sequence() })
     }
 
     /**
-     * To ensure a deterministic way of adding children required for equality checking, [children] list is sorted
-     * during construction. A DESC ordering in the [NodeAndWeight.weight] field will improve efficiency, because keys
-     * with bigger "weights" are the first to be checked and thus the threshold requirement might be met earlier without
-     * requiring a full [children] scan.
+     * Τhe order of the children may not be the same to what was provided in the constructor.
      */
     val children: List<NodeAndWeight> = children.sortedWith(descWeightComparator)
 

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -37,7 +37,7 @@ import java.util.function.Predicate
 data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
                              override val sigs: List<TransactionSignature>
 ) : TransactionWithSignatures {
-    // DOCEND 1.
+    // DOCEND 1
     constructor(ctx: CoreTransaction, sigs: List<TransactionSignature>) : this(ctx.serialize(), sigs) {
         cachedTransaction = ctx
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -163,22 +163,22 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     @Throws(SignatureException::class, AttachmentResolutionException::class, TransactionResolutionException::class, TransactionVerificationException::class)
     fun verify(services: ServiceHub, checkSufficientSignatures: Boolean = true) {
         if (isNotaryChangeTransaction()) {
-            verifyNotaryChangeTransaction(checkSufficientSignatures, services)
+            verifyNotaryChangeTransaction(services, checkSufficientSignatures)
         } else {
-            verifyRegularTransaction(checkSufficientSignatures, services)
+            verifyRegularTransaction(services, checkSufficientSignatures)
         }
     }
 
     // TODO: Verify contract constraints here as well as in LedgerTransaction to ensure that anything being deserialised
     // from the attachment is trusted. This will require some partial serialisation work to not load the ContractState
     // objects from the TransactionState.
-    private fun verifyRegularTransaction(checkSufficientSignatures: Boolean, services: ServiceHub) {
+    private fun verifyRegularTransaction(services: ServiceHub, checkSufficientSignatures: Boolean) {
         val ltx = toLedgerTransaction(services, checkSufficientSignatures)
         // TODO: allow non-blocking verification.
         services.transactionVerifierService.verify(ltx).getOrThrow()
     }
 
-    private fun verifyNotaryChangeTransaction(checkSufficientSignatures: Boolean, services: ServiceHub) {
+    private fun verifyNotaryChangeTransaction(services: ServiceHub, checkSufficientSignatures: Boolean) {
         val ntx = resolveNotaryChangeTransaction(services)
         if (checkSufficientSignatures) ntx.verifyRequiredSignatures()
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -167,7 +167,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     // objects from the TransactionState.
     private fun verifyRegularTransaction(checkSufficientSignatures: Boolean, services: ServiceHub) {
         val ltx = toLedgerTransaction(services, checkSufficientSignatures)
-        // TODO: allow non-blocking verification
+        // TODO: allow non-blocking verification.
         services.transactionVerifierService.verify(ltx).getOrThrow()
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -134,8 +134,11 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     @JvmOverloads
     @Throws(SignatureException::class, AttachmentResolutionException::class, TransactionResolutionException::class)
     fun toLedgerTransaction(services: ServiceHub, checkSufficientSignatures: Boolean = true): LedgerTransaction {
-        checkSignaturesAreValid()
-        if (checkSufficientSignatures) verifyRequiredSignatures()
+        if (checkSufficientSignatures) {
+            verifyRequiredSignatures() // It internally invokes checkSignaturesAreValid().
+        } else {
+            checkSignaturesAreValid()
+        }
         return tx.toLedgerTransaction(services)
     }
 
@@ -165,8 +168,11 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
      * objects from the TransactionState.
      */
     private fun verifyRegularTransaction(checkSufficientSignatures: Boolean, services: ServiceHub) {
-        checkSignaturesAreValid()
-        if (checkSufficientSignatures) verifyRequiredSignatures()
+        if (checkSufficientSignatures) {
+            verifyRequiredSignatures() // It internally invokes checkSignaturesAreValid().
+        } else {
+            checkSignaturesAreValid()
+        }
         val ltx = tx.toLedgerTransaction(services)
         // TODO: allow non-blocking verification
         services.transactionVerifierService.verify(ltx).getOrThrow()

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -37,7 +37,7 @@ import java.util.function.Predicate
 data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
                              override val sigs: List<TransactionSignature>
 ) : TransactionWithSignatures {
-    // DOCEND 1
+    // DOCEND 1.
     constructor(ctx: CoreTransaction, sigs: List<TransactionSignature>) : this(ctx.serialize(), sigs) {
         cachedTransaction = ctx
     }
@@ -68,15 +68,15 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
      */
     fun buildFilteredTransaction(filtering: Predicate<Any>) = tx.buildFilteredTransaction(filtering)
 
-    /** Helper to access the inputs of the contained transaction */
+    /** Helper to access the inputs of the contained transaction. */
     val inputs: List<StateRef> get() = transaction.inputs
-    /** Helper to access the notary of the contained transaction */
+    /** Helper to access the notary of the contained transaction. */
     val notary: Party? get() = transaction.notary
 
     override val requiredSigningKeys: Set<PublicKey> get() = tx.requiredSigningKeys
 
     override fun getKeyDescriptions(keys: Set<PublicKey>): ArrayList<String> {
-        // TODO: We need a much better way of structuring this data
+        // TODO: We need a much better way of structuring this data.
         val descriptions = ArrayList<String>()
         this.tx.commands.forEach { command ->
             if (command.signers.any { it in keys })
@@ -162,18 +162,11 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
         }
     }
 
-    /**
-     * TODO: Verify contract constraints here as well as in LedgerTransaction to ensure that anything being deserialised
-     * from the attachment is trusted. This will require some partial serialisation work to not load the ContractState
-     * objects from the TransactionState.
-     */
+    // TODO: Verify contract constraints here as well as in LedgerTransaction to ensure that anything being deserialised
+    // from the attachment is trusted. This will require some partial serialisation work to not load the ContractState
+    // objects from the TransactionState.
     private fun verifyRegularTransaction(checkSufficientSignatures: Boolean, services: ServiceHub) {
-        if (checkSufficientSignatures) {
-            verifyRequiredSignatures() // It internally invokes checkSignaturesAreValid().
-        } else {
-            checkSignaturesAreValid()
-        }
-        val ltx = tx.toLedgerTransaction(services)
+        val ltx = toLedgerTransaction(services, checkSufficientSignatures)
         // TODO: allow non-blocking verification
         services.transactionVerifierService.verify(ltx).getOrThrow()
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -134,6 +134,13 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     @JvmOverloads
     @Throws(SignatureException::class, AttachmentResolutionException::class, TransactionResolutionException::class)
     fun toLedgerTransaction(services: ServiceHub, checkSufficientSignatures: Boolean = true): LedgerTransaction {
+        // TODO: We could probably optimise the below by
+        // a) not throwing if threshold is eventually satisfied, but some of the rest of the signatures are failing.
+        // b) omit verifying signatures when threshold requirement is met.
+        // c) omit verifying signatures from keys not included in [requiredSigningKeys].
+        // For the above to work, [checkSignaturesAreValid] should take the [requiredSigningKeys] as input
+        // and probably combine logic from signature validation and key-fulfilment
+        // in [TransactionWithSignatures.verifySignaturesExcept].
         if (checkSufficientSignatures) {
             verifyRequiredSignatures() // It internally invokes checkSignaturesAreValid().
         } else {

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -181,6 +181,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
     private fun verifyNotaryChangeTransaction(services: ServiceHub, checkSufficientSignatures: Boolean) {
         val ntx = resolveNotaryChangeTransaction(services)
         if (checkSufficientSignatures) ntx.verifyRequiredSignatures()
+        else checkSignaturesAreValid()
     }
 
     fun isNotaryChangeTransaction() = transaction is NotaryChangeWireTransaction

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -66,7 +66,6 @@ interface TransactionWithSignatures : NamedByHash {
     @Throws(SignatureException::class)
     fun verifySignaturesExcept(allowedToBeMissing: Collection<PublicKey>) {
         checkSignaturesAreValid()
-
         val needed = getMissingSigners() - allowedToBeMissing
         if (needed.isNotEmpty())
             throw SignaturesMissingException(needed.toNonEmptySet(), getKeyDescriptions(needed), id)

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -11,7 +11,7 @@ import java.security.PublicKey
 import java.security.SignatureException
 import java.util.*
 
-/** An interface for transactions containing signatures, with logic for signature verification */
+/** An interface for transactions containing signatures, with logic for signature verification. */
 @DoNotImplement
 interface TransactionWithSignatures : NamedByHash {
     /**
@@ -21,7 +21,7 @@ interface TransactionWithSignatures : NamedByHash {
      */
     val sigs: List<TransactionSignature>
 
-    /** Specifies all the public keys that require signatures for the transaction to be valid */
+    /** Specifies all the public keys that require signatures for the transaction to be valid. */
     val requiredSigningKeys: Set<PublicKey>
 
     /**
@@ -65,10 +65,10 @@ interface TransactionWithSignatures : NamedByHash {
      */
     @Throws(SignatureException::class)
     fun verifySignaturesExcept(allowedToBeMissing: Collection<PublicKey>) {
-        checkSignaturesAreValid()
         val needed = getMissingSigners() - allowedToBeMissing
         if (needed.isNotEmpty())
             throw SignaturesMissingException(needed.toNonEmptySet(), getKeyDescriptions(needed), id)
+        checkSignaturesAreValid()
     }
 
     /**


### PR DESCRIPTION
- Fix double sig verification issue in  `toLedgerTransaction` and `verifyRegularTransaction`. The problem was that `checkSignaturesAreValid` was called twice.
- `CompositeKey.checkFulfilledBy` returns right after the threshold requirement is met. Previously, it required a full scan of signing keys.
- checkValidity() "knows" if it ran before; not required any more to externally check `if (!validated)`
- we now first check for missing signers, then validate signatures.
- fixed missing `checkSignaturesAreValid` from `verifyNotaryChangeTransaction
- some comments and `method signature consistency fixes (private methods)