### PR TITLE
Attach Jolokia agents in Node startup [ENT-1152]

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -34,6 +34,7 @@
       <module name="cordformation_main" target="1.8" />
       <module name="cordformation_runnodes" target="1.8" />
       <module name="cordformation_test" target="1.8" />
+      <module name="core_extraResource" target="1.8" />
       <module name="core_integrationTest" target="1.8" />
       <module name="core_main" target="1.8" />
       <module name="core_smokeTest" target="1.8" />
@@ -72,6 +73,7 @@
       <module name="irs-demo-web_test" target="1.8" />
       <module name="irs-demo_integrationTest" target="1.8" />
       <module name="irs-demo_main" target="1.8" />
+      <module name="irs-demo_systemTest" target="1.8" />
       <module name="irs-demo_test" target="1.8" />
       <module name="isolated_main" target="1.8" />
       <module name="isolated_test" target="1.8" />

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     // For sharing constants between builds
     Properties constants = new Properties()
     file("$projectDir/constants.properties").withInputStream { constants.load(it) }
+    file("${project(':node').projectDir}/src/main/resources/build.properties").withInputStream { constants.load(it) }
 
     // Our version: bump this on release.
     ext.corda_release_version = "3.0-SNAPSHOT"
@@ -69,6 +70,7 @@ buildscript {
     ext.docker_compose_rule_version = '0.33.0'
     ext.selenium_version = '3.8.1'
     ext.ghostdriver_version = '2.1.0'
+    ext.eaagentloader_version = '1.0.3'
 
     // Update 121 is required for ObjectInputFilter and at time of writing 131 was latest:
     ext.java8_minUpdateVersion = '131'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,9 @@ sourceSets {
             runtimeClasspath += main.output
             srcDir file('src/smoke-test/java')
         }
+        resources {
+            srcDir file('src/smoke-test/resources')
+        }
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,9 +43,6 @@ sourceSets {
             runtimeClasspath += main.output
             srcDir file('src/smoke-test/java')
         }
-        resources {
-            srcDir file('src/smoke-test/resources')
-        }
     }
 }
 

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -185,8 +185,8 @@ path to the node's base directory.
 
     :port: The port to start SSH server on
 
-:exportJMXTo: If set to ``http``, will enable JMX metrics reporting via the Jolokia HTTP/JSON agent.
-    Default Jolokia access url is http://127.0.0.1:7005/jolokia/
+:jmxMonitoringHttpPort: If set, will enable JMX metrics reporting via the Jolokia HTTP/JSON agent on the corresponding port.
+    Default Jolokia access url is http://127.0.0.1:port/jolokia/
 
 :transactionCacheSizeMegaBytes: Optionally specify how much memory should be used for caching of ledger transactions in memory.
             Otherwise defaults to 8MB plus 5% of all heap memory above 300MB.

--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -106,7 +106,7 @@ Here are a few ways to build dashboards and extract monitoring data for a node:
   It can bridge any data input to any output using their plugin system, for example, Telegraf can
   be configured to collect data from Jolokia and write to DataDog web api.
 
-The Node configuration parameter `exportJMXTo` should be set to ``http`` to ensure a Jolokia agent is instrumented with
+The Node configuration parameter `jmxMonitoringHttpPort` has to be present in order to ensure a Jolokia agent is instrumented with
 the JVM run-time.
 
 The following JMX statistics are exported:

--- a/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/gradle-plugins/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -80,19 +80,15 @@ private abstract class JavaCommand(
         init: MutableList<String>.() -> Unit, args: List<String>,
         jvmArgs: List<String>
 ) {
-    private val jolokiaJar by lazy {
-        File("$dir/drivers").listFiles { _, filename ->
-            filename.matches("jolokia-jvm-.*-agent\\.jar$".toRegex())
-        }.first().name
-    }
-
     internal val command: List<String> = mutableListOf<String>().apply {
         add(getJavaPath())
         addAll(jvmArgs)
         add("-Dname=$nodeName")
+        if (monitoringPort != null) {
+            add("-Dcorda.config.jmxMonitoringHttpPort=$monitoringPort")
+        }
         val jvmArgs: MutableList<String> = mutableListOf()
         null != debugPort && jvmArgs.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$debugPort")
-        null != monitoringPort && jvmArgs.add("-javaagent:drivers/$jolokiaJar=port=$monitoringPort")
         if (jvmArgs.isNotEmpty()) {
             add("-Dcapsule.jvm.args=${jvmArgs.joinToString(separator = " ")}")
         }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -172,6 +172,9 @@ dependencies {
     // Jsh: Testing SSH server
     integrationTestCompile group: 'com.jcraft', name: 'jsch', version: '0.1.54'
 
+    // AgentLoader: dynamic loading of JVM agents
+    compile group: 'com.ea.agentloader', name: 'ea-agent-loader', version: "${eaagentloader_version}"
+
     // Jetty dependencies for NetworkMapClient test.
     // Web stuff: for HTTP[S] servlets
     testCompile "org.eclipse.jetty:jetty-servlet:${jetty_version}"
@@ -183,7 +186,6 @@ dependencies {
     testCompile "org.glassfish.jersey.containers:jersey-container-servlet-core:${jersey_version}"
     testCompile "org.glassfish.jersey.containers:jersey-container-jetty-http:${jersey_version}"
 
-    // Jolokia JVM monitoring agent
     runtime "org.jolokia:jolokia-jvm:${jolokia_version}:agent"
 }
 

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
@@ -138,7 +138,7 @@ class AMQPBridgeTest {
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
             doReturn(artemisAddress).whenever(it).p2pAddress
-            doReturn("").whenever(it).exportJMXto
+            doReturn(null).whenever(it).jmxMonitoringHttpPort
             doReturn(emptyList<CertChainPolicyConfig>()).whenever(it).certificateChainCheckPolicies
         }
         artemisConfig.configureWithDevSSLCertificate()

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
@@ -222,7 +222,7 @@ class ProtonWrapperTests {
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
             doReturn(NetworkHostAndPort("0.0.0.0", artemisPort)).whenever(it).p2pAddress
-            doReturn("").whenever(it).exportJMXto
+            doReturn(null).whenever(it).jmxMonitoringHttpPort
             doReturn(emptyList<CertChainPolicyConfig>()).whenever(it).certificateChainCheckPolicies
         }
         artemisConfig.configureWithDevSSLCertificate()

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -186,9 +186,9 @@ open class Node(configuration: NodeConfiguration,
                 val rpcBrokerDirectory: Path = baseDirectory / "brokers" / "rpc"
                 with(rpcOptions) {
                     rpcBroker = if (useSsl) {
-                        ArtemisRpcBroker.withSsl(this.address!!, sslConfig, securityManager, certificateChainCheckPolicies, networkParameters.maxMessageSize, exportJMXto.isNotEmpty(), rpcBrokerDirectory)
+                        ArtemisRpcBroker.withSsl(this.address!!, sslConfig, securityManager, certificateChainCheckPolicies, networkParameters.maxMessageSize, jmxMonitoringHttpPort != null, rpcBrokerDirectory)
                     } else {
-                        ArtemisRpcBroker.withoutSsl(this.address!!, adminAddress!!, sslConfig, securityManager, certificateChainCheckPolicies, networkParameters.maxMessageSize, exportJMXto.isNotEmpty(), rpcBrokerDirectory)
+                        ArtemisRpcBroker.withoutSsl(this.address!!, adminAddress!!, sslConfig, securityManager, certificateChainCheckPolicies, networkParameters.maxMessageSize, jmxMonitoringHttpPort != null, rpcBrokerDirectory)
                     }
                 }
                 return rpcBroker!!.addresses

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -28,12 +28,22 @@ object ConfigHelper {
         val parseOptions = ConfigParseOptions.defaults()
         val defaultConfig = ConfigFactory.parseResources("reference.conf", parseOptions.setAllowMissing(false))
         val appConfig = ConfigFactory.parseFile(configFile.toFile(), parseOptions.setAllowMissing(allowMissingConfig))
+
+        // Inject overrides from system properties
+        val overridesFromProperties = System.getProperties().mapNotNull {
+            val (key, value) = it
+            if (key is String && key.startsWith("corda.config.")) {
+                Pair(key.drop("corda.config.".length), value)
+            } else null
+        }.toMap()
+
         val finalConfig = configOf(
                 // Add substitution values here
                 "baseDirectory" to baseDirectory.toString())
                 .withFallback(configOverrides)
                 .withFallback(appConfig)
                 .withFallback(defaultConfig)
+                .withFallback(ConfigFactory.parseMap(overridesFromProperties))
                 .resolve()
         log.info("Config:\n${finalConfig.root().render(ConfigRenderOptions.defaults())}")
         return finalConfig

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -24,7 +24,7 @@ val Int.MB: Long get() = this * 1024L * 1024L
 interface NodeConfiguration : NodeSSLConfiguration {
     val myLegalName: CordaX500Name
     val emailAddress: String
-    val exportJMXto: String
+    val jmxMonitoringHttpPort: Int?
     val dataSourceProperties: Properties
     val rpcUsers: List<User>
     val security: SecurityConfiguration?
@@ -115,6 +115,7 @@ data class NodeConfigurationImpl(
         /** This is not retrieved from the config file but rather from a command line argument. */
         override val baseDirectory: Path,
         override val myLegalName: CordaX500Name,
+        override val jmxMonitoringHttpPort: Int? = null,
         override val emailAddress: String,
         override val keyStorePassword: String,
         override val trustStorePassword: String,
@@ -181,7 +182,6 @@ data class NodeConfigurationImpl(
         return errors
     }
 
-    override val exportJMXto: String get() = "http"
     override val transactionCacheSizeBytes: Long
         get() = transactionCacheSizeMegaBytes?.MB ?: super.transactionCacheSizeBytes
     override val attachmentContentCacheSizeBytes: Long

--- a/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/ArtemisMessagingServer.kt
@@ -144,7 +144,7 @@ class ArtemisMessagingServer(private val config: NodeConfiguration,
         managementNotificationAddress = SimpleString(NOTIFICATIONS_ADDRESS)
 
         // JMX enablement
-        if (config.exportJMXto.isNotEmpty()) {
+        if (config.jmxMonitoringHttpPort != null) {
             isJMXManagementEnabled = true
             isJMXUseBrokerName = true
         }

--- a/node/src/main/kotlin/net/corda/node/utilities/JVMAgentRegistry.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JVMAgentRegistry.kt
@@ -1,0 +1,50 @@
+package net.corda.node.utilities
+
+import com.ea.agentloader.AgentLoader
+import net.corda.core.internal.exists
+import net.corda.core.internal.isRegularFile
+import java.net.URLClassLoader
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Helper class for loading JVM agents dynamically
+ */
+object JVMAgentRegistry {
+
+    /**
+     * Names and options of loaded agents
+     */
+    val loadedAgents = ConcurrentHashMap<String, String>()
+
+    /**
+     * Load and attach agent located at given [jar], unless [loadedAgents]
+     * indicate that one of its instance has been already loaded.
+     */
+    fun attach(agentName: String, options: String, jar: Path) {
+        loadedAgents.computeIfAbsent(agentName.toLowerCase()) {
+            AgentLoader.loadAgent(jar.toString(), options)
+            options
+        }
+    }
+
+    /**
+     * Attempt finding location of jar for given agent by first searching into
+     * "drivers" directory of [nodeBaseDirectory] and then falling back to
+     * classpath. Returns null if no match is found.
+     */
+    fun resolveAgentJar(jarFileName: String, driversDir: Path): Path? {
+        require(jarFileName.endsWith(".jar")) { "jarFileName does not have .jar suffix" }
+
+        val path = Paths.get(driversDir.toString(), jarFileName)
+        return if (path.exists() && path.isRegularFile()) {
+            path
+        } else {
+            (this::class.java.classLoader as? URLClassLoader)
+                ?.urLs
+                ?.map { Paths.get(it.path) }
+                ?.firstOrNull { it.fileName.toString() == jarFileName }
+        }
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/utilities/NodeBuildProperties.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NodeBuildProperties.kt
@@ -1,0 +1,27 @@
+package net.corda.node.utilities
+
+import java.util.*
+
+/**
+ * Expose properties defined in top-level 'constants.properties' file.
+ */
+object NodeBuildProperties {
+
+    // Note: initialization order is important
+    private val data by lazy {
+        Properties().apply {
+            NodeBuildProperties::class.java.getResourceAsStream("/build.properties")
+                    ?.let { load(it) }
+        }
+    }
+
+    /**
+     * Jolokia dependency version
+     */
+    val JOLOKIA_AGENT_VERSION = get("jolokiaAgentVersion")
+
+    /**
+     * Get property value by name
+     */
+    fun get(key: String): String? = data.getProperty(key)
+}

--- a/node/src/main/resources/build.properties
+++ b/node/src/main/resources/build.properties
@@ -1,0 +1,5 @@
+# Build constants exported as resource file to make them visible in Node program
+# Note: sadly, due to present limitation of IntelliJ-IDEA in processing resource files, these constants cannot be
+# imported from top-level 'constants.properties' file
+
+jolokiaAgentVersion=1.3.7

--- a/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
@@ -66,7 +66,7 @@ class ArtemisMessagingTest {
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
             doReturn(NetworkHostAndPort("0.0.0.0", serverPort)).whenever(it).p2pAddress
-            doReturn("").whenever(it).exportJMXto
+            doReturn(null).whenever(it).jmxMonitoringHttpPort
             doReturn(emptyList<CertChainPolicyConfig>()).whenever(it).certificateChainCheckPolicies
             doReturn(5).whenever(it).messageRedeliveryDelaySeconds
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNode.kt
@@ -504,7 +504,7 @@ private fun mockNodeConfiguration(): NodeConfiguration {
         doReturn(null).whenever(it).notary
         doReturn(DatabaseConfig()).whenever(it).database
         doReturn("").whenever(it).emailAddress
-        doReturn("").whenever(it).exportJMXto
+        doReturn(null).whenever(it).jmxMonitoringHttpPort
         doReturn(true).whenever(it).devMode
         doReturn(null).whenever(it).compatibilityZoneURL
         doReturn(emptyList<CertChainPolicyConfig>()).whenever(it).certificateChainCheckPolicies


### PR DESCRIPTION
More surgery to remove runtime dependencies on Capsule:

    Jolokia agents are loaded dynamically if configured
    Renamed exportJmxTo to jmxMonitoringHttpPort and expose it as config variable
    Updated documentation and tests
