### PR TITLE
CORDA-1003: Fix duplicate detection on cache evict

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
@@ -57,6 +57,7 @@ abstract class AppendOnlyPersistentMapBase<K, V, E, out EK>(
             // Depending on 'store' method, this may insert without checking key duplication or it may avoid inserting a duplicated key.
             val existingInDb = store(key, value)
             if (existingInDb != null) { // Always reuse an existing value from the storage of a duplicated key.
+                isUnique = false
                 Optional.of(existingInDb)
             } else {
                 Optional.of(value)


### PR DESCRIPTION
This should fix https://r3-cev.atlassian.net/browse/SUP-103, the test reproduced a similar condition without the one-liner fix