### PR TITLE
CORDA-1006: Undoing the wiring of maxMessageSize as it's not correctly implemente…

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
@@ -9,7 +9,7 @@ import java.time.Instant
  * correctly interoperate with each other.
  * @property minimumPlatformVersion Minimum version of Corda platform that is required for nodes in the network.
  * @property notaries List of well known and trusted notary identities with information on validation type.
- * @property maxMessageSize Maximum P2P message sent over the wire in bytes.
+ * @property maxMessageSize This is currently ignored. However, it will be wired up in a future release.
  * @property maxTransactionSize Maximum permitted transaction size in bytes.
  * @property modifiedTime Last modification time of network parameters set.
  * @property epoch Version number of the network parameters. Starting from 1, this will always increment on each new set

--- a/docs/source/network-map.rst
+++ b/docs/source/network-map.rst
@@ -66,13 +66,20 @@ The current set of network parameters:
 
 :minimumPlatformVersion: The minimum platform version that the nodes must be running. Any node which is below this will
         not start.
+
 :notaries: List of identity and validation type (either validating or non-validating) of the notaries which are permitted
         in the compatibility zone.
-:maxMessageSize: Maximum allowed size in bytes of an individual message sent over the wire. Note that attachments are
+
+:maxMessageSize: (This is currently ignored. However, it will be wired up in a future release.)
+
+.. TODO Replace the above with this once wired: Maximum allowed size in bytes of an individual message sent over the wire. Note that attachments are
         a special case and may be fragmented for streaming transfer, however, an individual transaction or flow message
         may not be larger than this value.
+
 :maxTransactionSize: Maximum allowed size in bytes of a transaction. This is the size of the transaction object and its attachments.
+
 :modifiedTime: The time when the network parameters were last modified by the compatibility zone operator.
+
 :epoch: Version number of the network parameters. Starting from 1, this will always increment whenever any of the
         parameters change.
 


### PR DESCRIPTION
…d and updating the docs to clarify its status.

The network parameter was just fed into Artemis' minLargeMessageSize property which isn't the same thing.