### PR TITLE
CORDA-1009 Remove X509EdDSAEngine dependency on X509Key

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt
@@ -27,12 +27,7 @@ class X509EdDSAEngine : Signature {
     override fun engineInitSign(privateKey: PrivateKey, random: SecureRandom) = engine.initSign(privateKey, random)
 
     override fun engineInitVerify(publicKey: PublicKey) {
-        val parsedKey = if (publicKey is sun.security.x509.X509Key) {
-            EdDSAPublicKey(X509EncodedKeySpec(publicKey.encoded))
-        } else {
-            publicKey
-        }
-
+        val parsedKey = publicKey as? EdDSAPublicKey ?: EdDSAPublicKey(X509EncodedKeySpec(publicKey.encoded))
         engine.initVerify(parsedKey)
     }
 

--- a/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/X509EdDSAEngine.kt
@@ -27,7 +27,11 @@ class X509EdDSAEngine : Signature {
     override fun engineInitSign(privateKey: PrivateKey, random: SecureRandom) = engine.initSign(privateKey, random)
 
     override fun engineInitVerify(publicKey: PublicKey) {
-        val parsedKey = publicKey as? EdDSAPublicKey ?: EdDSAPublicKey(X509EncodedKeySpec(publicKey.encoded))
+        val parsedKey = try {
+            publicKey as? EdDSAPublicKey ?: EdDSAPublicKey(X509EncodedKeySpec(publicKey.encoded))
+        } catch(e: Exception) {
+            throw (InvalidKeyException(e.message))
+        }
         engine.initVerify(parsedKey)
     }
 

--- a/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/X509EdDSAEngineTest.kt
@@ -114,4 +114,12 @@ class X509EdDSAEngineTest {
             engine.verify(signature)
         }
     }
+
+    /** Verify will fail if the input public key cannot be converted to EdDSA public key. */
+    @Test
+    fun `verify with non-supported key type fails`() {
+        val engine = EdDSAEngine()
+        val keyPair = Crypto.deriveKeyPairFromEntropy(Crypto.ECDSA_SECP256K1_SHA256, BigInteger.valueOf(SEED))
+        assertFailsWith<InvalidKeyException> { engine.initVerify(keyPair.public) }
+    }
 }


### PR DESCRIPTION
Required for the deterministic core, because `sun.security.x509.X509Key` isn't going to link as it uses an internal `sun.` class.

