### PR TITLE
Update to latest jolokia with security fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
     ext.jackson_version = '2.9.3'
     ext.jetty_version = '9.4.7.v20170914'
     ext.jersey_version = '2.25'
-    ext.jolokia_version = '1.3.7'
+    ext.jolokia_version = '1.5.0'
     ext.assertj_version = '3.8.0'
     ext.slf4j_version = '1.7.25'
     ext.log4j_version = '2.9.1'


### PR DESCRIPTION
Update to Jolokia 1.5.0 - this version contains two security fixes. 
* The JMX proxy mode is now disabled by default
* XSS vulnerability has been fixed
