### PR TITLE
CORDA-1008 Samples fail to run due to wrongly configured max transaction size in the network bootstrapper

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -165,7 +165,7 @@ class NetworkBootstrapper {
                 notaries = notaryInfos,
                 modifiedTime = Instant.now(),
                 maxMessageSize = 10485760,
-                maxTransactionSize = 40000,
+                maxTransactionSize = Int.MAX_VALUE,
                 epoch = 1
         ), overwriteFile = true)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -39,7 +39,7 @@ class NetworkMapServer(private val cacheTimeout: Duration,
                        private val myHostNameValue: String = "test.host.name",
                        vararg additionalServices: Any) : Closeable {
     companion object {
-        private val stubNetworkParameters = NetworkParameters(1, emptyList(), 10485760, 40000, Instant.now(), 10)
+        private val stubNetworkParameters = NetworkParameters(1, emptyList(), 10485760, Int.MAX_VALUE, Instant.now(), 10)
     }
 
     private val server: Server


### PR DESCRIPTION
master PR - https://github.com/corda/corda/pull/2509
jira - https://r3-cev.atlassian.net/browse/CORDA-1008