### PR TITLE
Test driver default parameters removal

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3641,7 +3641,6 @@ public static final class net.corda.client.jackson.StringToMethodCallParser$Unpa
 ##
 public final class net.corda.testing.driver.Driver extends java.lang.Object
   public static final Object driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1)
-  public static final Object driver(net.corda.testing.driver.DriverParameters, boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, Map, boolean, boolean, boolean, boolean, List, List, net.corda.testing.driver.JmxPolicy, int, kotlin.jvm.functions.Function1)
 ##
 @net.corda.core.DoNotImplement public interface net.corda.testing.driver.DriverDSL
   @org.jetbrains.annotations.NotNull public abstract java.nio.file.Path baseDirectory(net.corda.core.identity.CordaX500Name)

--- a/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
+++ b/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
@@ -29,6 +29,7 @@ import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.*
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import org.junit.Test
@@ -51,7 +52,7 @@ class NodeMonitorModelTest {
     private lateinit var newNode: (CordaX500Name) -> NodeInfo
 
     private fun setup(runTest: () -> Unit) {
-        driver(extraCordappPackagesToScan = listOf("net.corda.finance")) {
+        driver(DriverParameters(extraCordappPackagesToScan = listOf("net.corda.finance"))) {
             val cashUser = User("user1", "test", permissions = setOf(
                     startFlow<CashIssueFlow>(),
                     startFlow<CashPaymentFlow>(),

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/BlacklistKotlinClosureTest.kt
@@ -8,6 +8,7 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
@@ -28,7 +29,7 @@ class BlacklistKotlinClosureTest {
 
     @Test
     fun `closure sent via RPC`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val rpc = startNode(providedName = ALICE_NAME).getOrThrow().rpc
             val packet = Packet { EVIL }
             assertThatExceptionOfType(KryoException::class.java)

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
@@ -11,6 +11,7 @@ import net.corda.node.internal.StartedNode
 import net.corda.node.services.Permissions
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.testing.core.*
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
@@ -29,7 +30,7 @@ class FlowsExecutionModeRpcTest {
         assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win"))
 
         val user = User("mark", "dadada", setOf(invokeRpc("setFlowsDrainingModeEnabled"), invokeRpc("isFlowsDrainingModeEnabled")))
-        driver(isDebug = true, startNodesInProcess = true) {
+        driver(DriverParameters(isDebug = true, startNodesInProcess = true)) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/IntegrationTestingTutorial.kt
@@ -15,6 +15,7 @@ import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.*
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import org.junit.Test
@@ -24,8 +25,8 @@ class IntegrationTestingTutorial {
     @Test
     fun `alice bob cash exchange example`() {
         // START 1
-        driver(startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.finance.contracts.asset")) {
+        driver(DriverParameters(startNodesInProcess = true,
+                extraCordappPackagesToScan = listOf("net.corda.finance.contracts.asset"))) {
             val aliceUser = User("aliceUser", "testPassword1", permissions = setOf(
                     startFlow<CashIssueFlow>(),
                     startFlow<CashPaymentFlow>(),

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
@@ -19,6 +19,7 @@ import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.node.User
 import net.corda.testing.driver.driver
 import org.graphstream.graph.Edge
@@ -49,7 +50,7 @@ fun main(args: Array<String>) {
             startFlow<CashExitFlow>(),
             invokeRpc(CordaRPCOps::nodeInfo)
     ))
-    driver(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true) {
+    driver(DriverParameters(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true)) {
         val node = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).get()
         // END 1
 

--- a/node/src/integration-test/kotlin/net/corda/node/BootTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/BootTests.kt
@@ -12,6 +12,7 @@ import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.node.User
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -36,7 +37,7 @@ class BootTests {
     fun `double node start doesn't write into log file`() {
         val logConfigFile = projectRootDir / "config" / "dev" / "log4j2.xml"
         assertThat(logConfigFile).isRegularFile()
-        driver(isDebug = true, systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())) {
+        driver(DriverParameters(isDebug = true, systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()))) {
             val alice = startNode(providedName = ALICE_NAME).get()
             val logFolder = alice.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
             val logFile = logFolder.toFile().listFiles { _, name -> name.endsWith(".log") }.single()

--- a/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
@@ -8,6 +8,7 @@ import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -17,7 +18,7 @@ import javax.security.auth.x500.X500Principal
 class NodeKeystoreCheckTest {
     @Test
     fun `starting node in non-dev mode with no key store`() {
-        driver(startNodesInProcess = true, notarySpecs = emptyList()) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             assertThatThrownBy {
                 startNode(customOverrides = mapOf("devMode" to false)).getOrThrow()
             }.hasMessageContaining("Identity certificate not found")
@@ -26,7 +27,7 @@ class NodeKeystoreCheckTest {
 
     @Test
     fun `node should throw exception if cert path doesn't chain to the trust root`() {
-        driver(startNodesInProcess = true, notarySpecs = emptyList()) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             // Create keystores
             val keystorePassword = "password"
             val config = object : SSLConfiguration {

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -15,6 +15,7 @@ import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.InProcess
 import net.corda.testing.node.User
 import net.corda.testing.driver.driver
@@ -47,7 +48,7 @@ class NodePerformanceTests {
 
     @Test
     fun `empty flow per second`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val a = startNode(rpcUsers = listOf(User("A", "A", setOf(startFlow<EmptyFlow>())))).get()
 
             CordaRPCClient(a.rpcAddress).use("A", "A") { connection ->

--- a/node/src/integration-test/kotlin/net/corda/node/NodeUnloadHandlerTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeUnloadHandlerTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.core.DUMMY_BANK_A_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import org.junit.Assert
 import org.junit.Test
@@ -20,7 +21,7 @@ class NodeUnloadHandlerTests {
 
     @Test
     fun `should be able to register run on stop lambda`() {
-        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.node"), isDebug = true) {
+        driver(DriverParameters(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.node"), isDebug = true)) {
             startNode(providedName = DUMMY_BANK_A_NAME).getOrThrow()
             // just want to fall off the end of this for the mo...
         }

--- a/node/src/integration-test/kotlin/net/corda/node/SSHServerTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/SSHServerTest.kt
@@ -13,6 +13,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.node.User
 import net.corda.testing.driver.driver
 import org.assertj.core.api.Assertions.assertThat
@@ -92,7 +93,7 @@ class SSHServerTest {
     fun `ssh respects permissions`() {
         val user = User("u", "p", setOf(startFlow<FlowICanRun>()))
         // The driver will automatically pick up the annotated flows below
-        driver(isDebug = true) {
+        driver(DriverParameters(isDebug = true)) {
             val node = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user),
                     customOverrides = mapOf("sshd" to mapOf("port" to 2222)))
             node.getOrThrow()
@@ -122,7 +123,7 @@ class SSHServerTest {
     fun `ssh runs flows`() {
         val user = User("u", "p", setOf(startFlow<FlowICanRun>()))
         // The driver will automatically pick up the annotated flows below
-        driver(isDebug = true) {
+        driver(DriverParameters(isDebug = true)) {
             val node = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user),
                     customOverrides = mapOf("sshd" to mapOf("port" to 2222)))
             node.getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
@@ -10,6 +10,7 @@ import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.unwrap
 import net.corda.node.services.Permissions
 import net.corda.testing.core.chooseIdentity
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
@@ -46,7 +47,7 @@ class P2PFlowsDrainingModeTest {
     @Test
     fun `flows draining mode suspends consumption of initial session messages`() {
 
-        driver(isDebug = true, startNodesInProcess = false, portAllocation = portAllocation) {
+        driver(DriverParameters(isDebug = true, startNodesInProcess = false, portAllocation = portAllocation)) {
             val initiatedNode = startNode().getOrThrow()
             val initiating = startNode(rpcUsers = users).getOrThrow().rpc
             val counterParty = initiatedNode.nodeInfo.chooseIdentity()

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions
 import net.corda.nodeapi.exceptions.RejectedCommandException
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
@@ -23,7 +24,7 @@ class RpcFlowsDrainingModeTest {
     @Test
     fun `flows draining mode rejects start flows commands through rpc`() {
 
-        driver(isDebug = true, startNodesInProcess = false, portAllocation = portAllocation) {
+        driver(DriverParameters(isDebug = true, startNodesInProcess = false, portAllocation = portAllocation)) {
 
             startNode(rpcUsers = users).getOrThrow().rpc.apply {
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -15,6 +15,7 @@ import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.*
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.OutOfProcess
 import net.corda.testing.driver.driver
@@ -40,7 +41,7 @@ class DistributedServiceTests {
                 invokeRpc(CordaRPCOps::nodeInfo),
                 invokeRpc(CordaRPCOps::stateMachinesFeed))
         )
-        driver(
+        driver(DriverParameters(
                 extraCordappPackagesToScan = listOf("net.corda.finance.contracts"),
                 notarySpecs = listOf(
                         NotarySpec(
@@ -48,7 +49,7 @@ class DistributedServiceTests {
                                 rpcUsers = listOf(testUser),
                                 cluster = DummyClusterSpec(clusterSize = 3, compositeServiceIdentity = compositeIdentity))
                 )
-        ) {
+        )) {
             alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(testUser)).getOrThrow()
             raftNotaryIdentity = defaultNotaryIdentity
             notaryNodes = defaultNotaryHandle.nodeHandles.getOrThrow().map { it as OutOfProcess }

--- a/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/RaftNotaryServiceTests.kt
@@ -15,6 +15,7 @@ import net.corda.testing.core.chooseIdentity
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.driver.driver
 import net.corda.testing.core.dummyCommand
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.InProcess
 import net.corda.testing.node.ClusterSpec
 import net.corda.testing.node.NotarySpec
@@ -29,11 +30,11 @@ class RaftNotaryServiceTests {
 
     @Test
     fun `detect double spend`() {
-        driver(
+        driver(DriverParameters(
                 startNodesInProcess = true,
                 extraCordappPackagesToScan = listOf("net.corda.testing.contracts"),
                 notarySpecs = listOf(NotarySpec(notaryName, cluster = ClusterSpec.Raft(clusterSize = 3)))
-        ) {
+        )) {
             val bankA = startNode(providedName = DUMMY_BANK_A_NAME).map { (it as InProcess) }.getOrThrow()
             val inputState = issueState(bankA, defaultNotaryIdentity)
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
@@ -6,6 +6,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.testsupport.withCertificates
 import net.corda.node.testsupport.withKeyStores
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import net.corda.testing.internal.useSslRpcOverrides
@@ -31,7 +32,7 @@ class RpcSslTest {
 
             withKeyStores(server, client) { nodeSslOptions, clientSslOptions ->
                 var successful = false
-                driver(isDebug = true, startNodesInProcess = true, portAllocation = PortAllocation.RandomFree) {
+                driver(DriverParameters(isDebug = true, startNodesInProcess = true, portAllocation = PortAllocation.RandomFree)) {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
                         CordaRPCClient(node.rpcAddress, sslConfiguration = clientSslOptions).start(user.username, user.password).use { connection ->
                             connection.proxy.apply {
@@ -50,7 +51,7 @@ class RpcSslTest {
     fun rpc_client_not_using_ssl() {
         val user = User("mark", "dadada", setOf(all()))
         var successful = false
-        driver(isDebug = true, startNodesInProcess = true, portAllocation = PortAllocation.RandomFree) {
+        driver(DriverParameters(isDebug = true, startNodesInProcess = true, portAllocation = PortAllocation.RandomFree)) {
             startNode(rpcUsers = listOf(user)).getOrThrow().use { node ->
                 CordaRPCClient(node.rpcAddress).start(user.username, user.password).use { connection ->
                     connection.proxy.apply {

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -12,6 +12,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyState
 import net.corda.testing.core.*
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
@@ -71,7 +72,7 @@ class LargeTransactionsTest {
         val bigFile2 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 1)
         val bigFile3 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 2)
         val bigFile4 = InputStreamAndHash.createInMemoryTestZip(1024 * 1024 * 3, 3)
-        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.testing.contracts"), portAllocation = PortAllocation.RandomFree) {
+        driver(DriverParameters(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.testing.contracts"), portAllocation = PortAllocation.RandomFree)) {
             val rpcUser = User("admin", "admin", setOf("ALL"))
             val (alice, _) = listOf(ALICE_NAME, BOB_NAME).map { startNode(providedName = it, rpcUsers = listOf(rpcUser)) }.transpose().getOrThrow()
             CordaRPCClient(alice.rpcAddress).use(rpcUser.username, rpcUser.password) {

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/P2PMessagingTest.kt
@@ -18,6 +18,7 @@ import net.corda.node.services.messaging.send
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.chooseIdentity
 import net.corda.testing.driver.DriverDSL
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.InProcess
 import net.corda.testing.driver.driver
 import net.corda.testing.node.ClusterSpec
@@ -110,7 +111,7 @@ class P2PMessagingTest {
 
 
     private fun startDriverWithDistributedService(dsl: DriverDSL.(List<InProcess>) -> Unit) {
-        driver(startNodesInProcess = true, notarySpecs = listOf(NotarySpec(DISTRIBUTED_SERVICE_NAME, cluster = ClusterSpec.Raft(clusterSize = 2)))) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = listOf(NotarySpec(DISTRIBUTED_SERVICE_NAME, cluster = ClusterSpec.Raft(clusterSize = 2))))) {
             dsl(defaultNotaryHandle.nodeHandles.getOrThrow().map { (it as InProcess) })
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/test/node/NodeStatePersistenceTests.kt
@@ -22,6 +22,7 @@ import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.node.User
 import net.corda.testing.core.chooseIdentity
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import org.junit.Assume.assumeFalse
@@ -42,7 +43,7 @@ class ONodeStatePersistenceTests {
 
         val user = User("mark", "dadada", setOf(startFlow<SendMessageFlow>(), invokeRpc("vaultQuery")))
         val message = Message("Hello world!")
-        val stateAndRef: StateAndRef<MessageState>? = driver(isDebug = true, startNodesInProcess = isQuasarAgentSpecified(), portAllocation = PortAllocation.RandomFree) {
+        val stateAndRef: StateAndRef<MessageState>? = driver(DriverParameters(isDebug = true, startNodesInProcess = isQuasarAgentSpecified(), portAllocation = PortAllocation.RandomFree)) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name
@@ -76,7 +77,7 @@ class ONodeStatePersistenceTests {
 
         val user = User("mark", "dadada", setOf(startFlow<SendMessageFlow>(), invokeRpc("vaultQuery")))
         val message = Message("Hello world!")
-        val stateAndRef: StateAndRef<MessageState>? = driver(isDebug = true, startNodesInProcess = isQuasarAgentSpecified(), portAllocation = PortAllocation.RandomFree) {
+        val stateAndRef: StateAndRef<MessageState>? = driver(DriverParameters(isDebug = true, startNodesInProcess = isQuasarAgentSpecified(), portAllocation = PortAllocation.RandomFree)) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.chooseIdentity().name

--- a/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/schema/NodeSchemaServiceTest.kt
@@ -11,6 +11,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.schema.NodeSchemaService.NodeCoreV1
 import net.corda.node.services.schema.NodeSchemaService.NodeNotaryV1
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.InProcess
 import net.corda.testing.driver.driver
 import net.corda.testing.internal.vault.DummyLinearStateSchemaV1
@@ -68,7 +69,7 @@ class NodeSchemaServiceTest {
      */
     @Test
     fun `auto scanning of custom schemas for testing with Driver`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val result = defaultNotaryNode.getOrThrow().rpc.startFlow(::MappedSchemasFlow)
             val mappedSchemas = result.returnValue.getOrThrow()
             assertTrue(mappedSchemas.contains(TestSchema.name))
@@ -78,7 +79,7 @@ class NodeSchemaServiceTest {
     @Test
     fun `custom schemas are loaded eagerly`() {
         val expected = setOf("PARENTS", "CHILDREN")
-        val tables = driver(startNodesInProcess = true) {
+        val tables = driver(DriverParameters(startNodesInProcess = true)) {
             (defaultNotaryNode.getOrThrow() as InProcess).database.transaction {
                 session.createNativeQuery("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES").list()
             }
@@ -91,7 +92,7 @@ class NodeSchemaServiceTest {
     fun `check node runs with minimal core schema set using driverDSL`() {
         // TODO: driver limitation: cannot restrict CorDapps that get automatically created by default,
         //       can ONLY specify additional ones using `extraCordappPackagesToScan` constructor argument.
-        driver(startNodesInProcess = true, notarySpecs = emptyList()) {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             val node = startNode().getOrThrow()
             val result = node.rpc.startFlow(::MappedSchemasFlow)
             val mappedSchemas = result.returnValue.getOrThrow()
@@ -104,7 +105,7 @@ class NodeSchemaServiceTest {
 
     @Test
     fun `check node runs inclusive of notary node schema set using driverDSL`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val notaryNode = defaultNotaryNode.getOrThrow().rpc.startFlow(::MappedSchemasFlow)
             val mappedSchemas = notaryNode.returnValue.getOrThrow()
             // check against NodeCore + NodeNotary Schemas

--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -7,6 +7,7 @@ import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.node.User
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
@@ -19,7 +20,7 @@ class AttachmentDemoTest {
     @Test
     fun `attachment demo using a 10MB zip file`() {
         val numOfExpectedBytes = 10_000_000
-        driver(isDebug = true, portAllocation = PortAllocation.Incremental(20000)) {
+        driver(DriverParameters(isDebug = true, portAllocation = PortAllocation.Incremental(20000))) {
             val demoUser = listOf(User("demo", "demo", setOf(
                     startFlow<AttachmentDemoFlow>(),
                     invokeRpc(CordaRPCOps::attachmentExists),

--- a/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
+++ b/samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/Main.kt
@@ -3,6 +3,7 @@ package net.corda.attachmentdemo
 import net.corda.core.internal.div
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.node.User
 import net.corda.testing.driver.driver
 
@@ -12,7 +13,7 @@ import net.corda.testing.driver.driver
  */
 fun main(args: Array<String>) {
     val demoUser = listOf(User("demo", "demo", setOf("StartFlow.net.corda.flows.FinalityFlow")))
-    driver(isDebug = true, driverDirectory = "build" / "attachment-demo-nodes", waitForAllNodesToFinish = true) {
+    driver(DriverParameters(isDebug = true, driverDirectory = "build" / "attachment-demo-nodes", waitForAllNodesToFinish = true)) {
         startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = demoUser)
         startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = demoUser)
     }

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -16,6 +16,7 @@ import net.corda.testing.core.BOC_NAME
 import net.corda.testing.core.expect
 import net.corda.testing.core.expectEvents
 import net.corda.testing.core.sequence
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import org.junit.Test
@@ -28,7 +29,7 @@ class BankOfCordaRPCClientTest {
                 invokeRpc(CordaRPCOps::wellKnownPartyFromX500Name),
                 invokeRpc(CordaRPCOps::notaryIdentities)
         )
-        driver(extraCordappPackagesToScan = listOf("net.corda.finance"), isDebug = true) {
+        driver(DriverParameters(extraCordappPackagesToScan = listOf("net.corda.finance"), isDebug = true)) {
             val bocManager = User("bocManager", "password1", permissions = setOf(
                     startFlow<CashIssueAndPaymentFlow>()) + commonPermissions)
             val bigCorpCFO = User("bigCorpCFO", "password2", permissions = emptySet<String>() + commonPermissions)

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/Main.kt
@@ -4,6 +4,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 
 /**
@@ -11,7 +12,7 @@ import net.corda.testing.driver.driver
  * Do not use in a production environment.
  */
 fun main(args: Array<String>) {
-    driver(useTestClock = true, isDebug = true, waitForAllNodesToFinish = true) {
+    driver(DriverParameters(useTestClock = true, isDebug = true, waitForAllNodesToFinish = true)) {
         val (nodeA, nodeB) = listOf(
                 startNode(providedName = DUMMY_BANK_A_NAME),
                 startNode(providedName = DUMMY_BANK_B_NAME),

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/irs/IRSDemoTest.kt
@@ -28,6 +28,7 @@ import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.chooseIdentity
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.http.HttpApi
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.User
@@ -50,12 +51,12 @@ class IRSDemoTest {
 
     @Test
     fun `runs IRS demo`() {
-        springDriver(
+        springDriver(DriverParameters(
                 useTestClock = true,
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, rpcUsers = rpcUsers)),
                 isDebug = true,
                 extraCordappPackagesToScan = listOf("net.corda.irs")
-        ) {
+        )) {
             val (nodeA, nodeB) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = rpcUsers),
                     startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = rpcUsers),

--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
@@ -20,33 +20,11 @@ import java.util.concurrent.TimeUnit
 
 fun <A> springDriver(
         defaultParameters: DriverParameters = DriverParameters(),
-        isDebug: Boolean = defaultParameters.isDebug,
-        driverDirectory: Path = defaultParameters.driverDirectory,
-        portAllocation: PortAllocation = defaultParameters.portAllocation,
-        debugPortAllocation: PortAllocation = defaultParameters.debugPortAllocation,
-        systemProperties: Map<String, String> = defaultParameters.systemProperties,
-        useTestClock: Boolean = defaultParameters.useTestClock,
-        initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
-        startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
-        notarySpecs: List<NotarySpec> = defaultParameters.notarySpecs,
-        extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
-        maxTransactionSize: Int = defaultParameters.maxTransactionSize,
         dsl: SpringBootDriverDSL.() -> A
 ): A {
     return genericDriver(
             defaultParameters = defaultParameters,
-            isDebug = isDebug,
-            driverDirectory = driverDirectory,
-            portAllocation = portAllocation,
-            debugPortAllocation = debugPortAllocation,
-            systemProperties = systemProperties,
-            useTestClock = useTestClock,
-            initialiseSerialization = initialiseSerialization,
-            startNodesInProcess = startNodesInProcess,
-            extraCordappPackagesToScan = extraCordappPackagesToScan,
-            notarySpecs = notarySpecs,
             driverDslWrapper = { driverDSL: DriverDSLImpl -> SpringBootDriverDSL(driverDSL) },
-            maxTransactionSize = maxTransactionSize,
             coerce = { it }, dsl = dsl
     )
 }

--- a/samples/irs-demo/src/system-test/kotlin/IRSDemoDockerTest.kt
+++ b/samples/irs-demo/src/system-test/kotlin/IRSDemoDockerTest.kt
@@ -72,9 +72,15 @@ class IRSDemoDockerTest {
 
         //Wait for deals to appear in a rows table
         val dealsList = driverWait.until<WebElement>({
+            makeScreenshot(driver, "second")
             it?.findElement(By.cssSelector("table#deal-list tbody tr"))
         })
 
         assertNotNull(dealsList)
+    }
+
+    private fun makeScreenshot(driver: PhantomJSDriver, name: String) {
+        val screenshotAs = driver.getScreenshotAs(OutputType.FILE)
+        Files.copy(screenshotAs.toPath(), Paths.get("/Users", "maksymilianpawlak", "phantomjs", name + System.currentTimeMillis() + ".png"), StandardCopyOption.REPLACE_EXISTING)
     }
 }

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -5,6 +5,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.http.HttpApi
 import net.corda.vega.api.PortfolioApi
@@ -27,7 +28,7 @@ class SimmValuationTest {
 
     @Test
     fun `runs SIMM valuation demo`() {
-        driver(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.vega.contracts", "net.corda.vega.plugin.customserializers")) {
+        driver(DriverParameters(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.vega.contracts", "net.corda.vega.plugin.customserializers"))) {
             val nodeAFuture = startNode(providedName = nodeALegalName)
             val nodeBFuture = startNode(providedName = nodeBLegalName)
             val (nodeA, nodeB) = listOf(nodeAFuture, nodeBFuture).map { it.getOrThrow() }

--- a/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
+++ b/samples/simm-valuation-demo/src/test/kotlin/net/corda/vega/Main.kt
@@ -4,6 +4,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
 import net.corda.testing.core.DUMMY_BANK_C_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 
 /**
@@ -12,7 +13,7 @@ import net.corda.testing.driver.driver
  * via the web api.
  */
 fun main(args: Array<String>) {
-    driver(isDebug = true, waitForAllNodesToFinish = true) {
+    driver(DriverParameters(isDebug = true, waitForAllNodesToFinish = true)) {
         val (nodeA, nodeB, nodeC) = listOf(
                 startNode(providedName = DUMMY_BANK_A_NAME),
                 startNode(providedName = DUMMY_BANK_B_NAME),

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -12,6 +12,7 @@ import net.corda.testing.core.BOC_NAME
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
 import net.corda.testing.core.chooseIdentity
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.InProcess
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
@@ -32,7 +33,7 @@ class TraderDemoTest {
                 startFlow<CashPaymentFlow>(),
                 startFlow<CommercialPaperIssueFlow>(),
                 all()))
-        driver(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance")) {
+        driver(DriverParameters(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance"))) {
             val (nodeA, nodeB, bankNode) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
                     startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = listOf(demoUser)),

--- a/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt
+++ b/samples/trader-demo/src/test/kotlin/net/corda/traderdemo/Main.kt
@@ -7,6 +7,7 @@ import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.BOC_NAME
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.node.User
 import net.corda.testing.driver.driver
 import net.corda.traderdemo.flow.CommercialPaperIssueFlow
@@ -22,7 +23,7 @@ fun main(args: Array<String>) {
             startFlow<SellerFlow>(),
             all())
     val demoUser = listOf(User("demo", "demo", permissions))
-    driver(driverDirectory = "build" / "trader-demo-nodes", isDebug = true, waitForAllNodesToFinish = true) {
+    driver(DriverParameters(driverDirectory = "build" / "trader-demo-nodes", isDebug = true, waitForAllNodesToFinish = true)) {
         val user = User("user1", "test", permissions = setOf(startFlow<CashIssueFlow>(),
                 startFlow<CommercialPaperIssueFlow>(),
                 startFlow<SellerFlow>()))

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -69,7 +69,7 @@ class DriverTests {
 
     @Test
     fun `random free port allocation`() {
-        val nodeHandle = driver(portAllocation = PortAllocation.RandomFree) {
+        val nodeHandle = driver(DriverParameters(portAllocation = PortAllocation.RandomFree)) {
             val nodeInfo = startNode(providedName = DUMMY_BANK_A_NAME)
             nodeMustBeUp(nodeInfo)
         }
@@ -81,7 +81,7 @@ class DriverTests {
         // Make sure we're using the log4j2 config which writes to the log file
         val logConfigFile = projectRootDir / "config" / "dev" / "log4j2.xml"
         assertThat(logConfigFile).isRegularFile()
-        driver(isDebug = true, systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString())) {
+        driver(DriverParameters(isDebug = true, systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()))) {
             val baseDirectory = startNode(providedName = DUMMY_BANK_A_NAME).getOrThrow().baseDirectory
             val logFile = (baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).list { it.sorted().findFirst().get() }
             val debugLinesPresent = logFile.readLines { lines -> lines.anyMatch { line -> line.startsWith("[DEBUG]") } }
@@ -91,7 +91,7 @@ class DriverTests {
 
     @Test
     fun `monitoring mode enables jolokia exporting of JMX metrics via HTTP JSON`() {
-        driver(jmxPolicy = JmxPolicy(true)) {
+        driver(DriverParameters(jmxPolicy = JmxPolicy(true))) {
             // start another node so we gain access to node JMX metrics
             startNode(providedName = DUMMY_REGULATOR_NAME).getOrThrow()
             val webAddress = NetworkHostAndPort("localhost", 7006)

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/node/FlowStackSnapshotTest.kt
@@ -10,6 +10,7 @@ import net.corda.core.internal.read
 import net.corda.core.messaging.startFlow
 import net.corda.core.serialization.CordaSerializable
 import net.corda.node.services.Permissions.Companion.startFlow
+import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import org.junit.Ignore
 import org.junit.Test
@@ -227,7 +228,7 @@ fun assertFrame(expectedMethod: String, expectedEmpty: Boolean, frame: StackSnap
 class FlowStackSnapshotTest {
     @Test
     fun `flowStackSnapshot contains full frames when methods with side effects are called`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val a = startNode(rpcUsers = listOf(User(Constants.USER, Constants.PASSWORD, setOf(startFlow<SideEffectFlow>())))).get()
             CordaRPCClient(a.rpcAddress).use(Constants.USER, Constants.PASSWORD) { connection ->
                 val stackSnapshotFrames = connection.proxy.startFlow(::SideEffectFlow).returnValue.get()
@@ -242,7 +243,7 @@ class FlowStackSnapshotTest {
 
     @Test
     fun `flowStackSnapshot contains empty frames when methods with no side effects are called`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val a = startNode(rpcUsers = listOf(User(Constants.USER, Constants.PASSWORD, setOf(startFlow<NoSideEffectFlow>())))).get()
             CordaRPCClient(a.rpcAddress).use(Constants.USER, Constants.PASSWORD) { connection ->
                 val stackSnapshotFrames = connection.proxy.startFlow(::NoSideEffectFlow).returnValue.get()
@@ -257,7 +258,7 @@ class FlowStackSnapshotTest {
 
     @Test
     fun `persistFlowStackSnapshot persists empty frames to a file when methods with no side effects are called`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val a = startNode(rpcUsers = listOf(User(Constants.USER, Constants.PASSWORD, setOf(startFlow<PersistingNoSideEffectFlow>())))).get()
             CordaRPCClient(a.rpcAddress).use(Constants.USER, Constants.PASSWORD) { connection ->
                 val flowId = connection.proxy.startFlow(::PersistingNoSideEffectFlow).returnValue.get()
@@ -273,7 +274,7 @@ class FlowStackSnapshotTest {
 
     @Test
     fun `persistFlowStackSnapshot persists multiple snapshots in different files`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val a = startNode(rpcUsers = listOf(User(Constants.USER, Constants.PASSWORD, setOf(startFlow<MultiplePersistingSideEffectFlow>())))).get()
 
             CordaRPCClient(a.rpcAddress).use(Constants.USER, Constants.PASSWORD) { connection ->
@@ -304,7 +305,7 @@ class FlowStackSnapshotTest {
 
     @Test
     fun `persistFlowStackSnapshot stack traces are aligned with stack objects`() {
-        driver(startNodesInProcess = true) {
+        driver(DriverParameters(startNodesInProcess = true)) {
             val a = startNode(rpcUsers = listOf(User(Constants.USER, Constants.PASSWORD, setOf(startFlow<PersistingSideEffectFlow>())))).get()
 
             CordaRPCClient(a.rpcAddress).use(Constants.USER, Constants.PASSWORD) { connection ->

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -11,9 +11,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.internal.Node
-import net.corda.node.internal.StartedNode
 import net.corda.node.services.api.StartedNodeServices
-import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.VerifierType
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.testing.core.DUMMY_NOTARY_NAME
@@ -152,55 +150,28 @@ data class JmxPolicy(val startJmxHttpServer: Boolean = false,
  */
 fun <A> driver(
         defaultParameters: DriverParameters = DriverParameters(),
-        isDebug: Boolean = defaultParameters.isDebug,
-        driverDirectory: Path = defaultParameters.driverDirectory,
-        portAllocation: PortAllocation = defaultParameters.portAllocation,
-        debugPortAllocation: PortAllocation = defaultParameters.debugPortAllocation,
-        systemProperties: Map<String, String> = defaultParameters.systemProperties,
-        useTestClock: Boolean = defaultParameters.useTestClock,
-        initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
-        startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
-        waitForAllNodesToFinish: Boolean = defaultParameters.waitForAllNodesToFinish,
-        notarySpecs: List<NotarySpec> = defaultParameters.notarySpecs,
-        extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
-        jmxPolicy: JmxPolicy = defaultParameters.jmxPolicy,
-        maxTransactionSize: Int = defaultParameters.maxTransactionSize,
         dsl: DriverDSL.() -> A
 ): A {
     return genericDriver(
             driverDsl = DriverDSLImpl(
-                    portAllocation = portAllocation,
-                    debugPortAllocation = debugPortAllocation,
-                    systemProperties = systemProperties,
-                    driverDirectory = driverDirectory.toAbsolutePath(),
-                    useTestClock = useTestClock,
-                    isDebug = isDebug,
-                    startNodesInProcess = startNodesInProcess,
-                    waitForNodesToFinish = waitForAllNodesToFinish,
-                    notarySpecs = notarySpecs,
-                    extraCordappPackagesToScan = extraCordappPackagesToScan,
-                    jmxPolicy = jmxPolicy,
+                    portAllocation = defaultParameters.portAllocation,
+                    debugPortAllocation = defaultParameters.debugPortAllocation,
+                    systemProperties = defaultParameters.systemProperties,
+                    driverDirectory = defaultParameters.driverDirectory.toAbsolutePath(),
+                    useTestClock = defaultParameters.useTestClock,
+                    isDebug = defaultParameters.isDebug,
+                    startNodesInProcess = defaultParameters.startNodesInProcess,
+                    waitForAllNodesToFinish = defaultParameters.waitForAllNodesToFinish,
+                    notarySpecs = defaultParameters.notarySpecs,
+                    extraCordappPackagesToScan = defaultParameters.extraCordappPackagesToScan,
+                    jmxPolicy = defaultParameters.jmxPolicy,
                     compatibilityZone = null,
-                    maxTransactionSize = maxTransactionSize
+                    maxTransactionSize = defaultParameters.maxTransactionSize
             ),
             coerce = { it },
             dsl = dsl,
-            initialiseSerialization = initialiseSerialization
+            initialiseSerialization = defaultParameters.initialiseSerialization
     )
-}
-
-/**
- * Helper function for starting a [driver] with custom parameters from Java.
- *
- * @param parameters The default parameters for the driver.
- * @param dsl The dsl itself.
- * @return The value returned in the [dsl] closure.
- */
-fun <A> driver(
-        parameters: DriverParameters,
-        dsl: DriverDSL.() -> A
-): A {
-    return driver(defaultParameters = parameters, dsl = dsl)
 }
 
 /** Helper builder for configuring a [driver] from Java. */

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -86,7 +86,7 @@ class DriverDSLImpl(
         val useTestClock: Boolean,
         val isDebug: Boolean,
         val startNodesInProcess: Boolean,
-        val waitForNodesToFinish: Boolean,
+        val waitForAllNodesToFinish: Boolean,
         extraCordappPackagesToScan: List<String>,
         val jmxPolicy: JmxPolicy,
         val notarySpecs: List<NotarySpec>,
@@ -138,7 +138,7 @@ class DriverDSLImpl(
     }
 
     override fun shutdown() {
-        if (waitForNodesToFinish) {
+        if (waitForAllNodesToFinish) {
             state.locked {
                 processes.forEach { it.waitFor() }
             }
@@ -665,7 +665,7 @@ class DriverDSLImpl(
             val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
             val monitorPort = if (jmxPolicy.startJmxHttpServer) jmxPolicy.jmxHttpServerPortAllocation?.nextPort() else null
             val process = startOutOfProcessNode(config, quasarJarPath, debugPort, jolokiaJarPath, monitorPort, systemProperties, cordappPackages, maximumHeapSize)
-            if (waitForNodesToFinish) {
+            if (waitForAllNodesToFinish) {
                 state.locked {
                     processes += process
                 }
@@ -947,38 +947,25 @@ fun <DI : DriverDSL, D : InternalDriverDSL, A> genericDriver(
  */
 fun <DI : DriverDSL, D : InternalDriverDSL, A> genericDriver(
         defaultParameters: DriverParameters = DriverParameters(),
-        isDebug: Boolean = defaultParameters.isDebug,
-        driverDirectory: Path = defaultParameters.driverDirectory,
-        portAllocation: PortAllocation = defaultParameters.portAllocation,
-        debugPortAllocation: PortAllocation = defaultParameters.debugPortAllocation,
-        systemProperties: Map<String, String> = defaultParameters.systemProperties,
-        useTestClock: Boolean = defaultParameters.useTestClock,
-        initialiseSerialization: Boolean = defaultParameters.initialiseSerialization,
-        waitForNodesToFinish: Boolean = defaultParameters.waitForAllNodesToFinish,
-        startNodesInProcess: Boolean = defaultParameters.startNodesInProcess,
-        notarySpecs: List<NotarySpec>,
-        extraCordappPackagesToScan: List<String> = defaultParameters.extraCordappPackagesToScan,
-        jmxPolicy: JmxPolicy = JmxPolicy(),
-        maxTransactionSize: Int,
         driverDslWrapper: (DriverDSLImpl) -> D,
         coerce: (D) -> DI, dsl: DI.() -> A
 ): A {
-    val serializationEnv = setGlobalSerialization(initialiseSerialization)
+    val serializationEnv = setGlobalSerialization(defaultParameters.initialiseSerialization)
     val driverDsl = driverDslWrapper(
             DriverDSLImpl(
-                    portAllocation = portAllocation,
-                    debugPortAllocation = debugPortAllocation,
-                    systemProperties = systemProperties,
-                    driverDirectory = driverDirectory.toAbsolutePath(),
-                    useTestClock = useTestClock,
-                    isDebug = isDebug,
-                    startNodesInProcess = startNodesInProcess,
-                    waitForNodesToFinish = waitForNodesToFinish,
-                    extraCordappPackagesToScan = extraCordappPackagesToScan,
-                    jmxPolicy = jmxPolicy,
-                    notarySpecs = notarySpecs,
+                    portAllocation = defaultParameters.portAllocation,
+                    debugPortAllocation = defaultParameters.debugPortAllocation,
+                    systemProperties = defaultParameters.systemProperties,
+                    driverDirectory = defaultParameters.driverDirectory.toAbsolutePath(),
+                    useTestClock = defaultParameters.useTestClock,
+                    isDebug = defaultParameters.isDebug,
+                    startNodesInProcess = defaultParameters.startNodesInProcess,
+                    waitForAllNodesToFinish = defaultParameters.waitForAllNodesToFinish,
+                    extraCordappPackagesToScan = defaultParameters.extraCordappPackagesToScan,
+                    jmxPolicy = defaultParameters.jmxPolicy,
+                    notarySpecs = defaultParameters.notarySpecs,
                     compatibilityZone = null,
-                    maxTransactionSize = maxTransactionSize
+                    maxTransactionSize = defaultParameters.maxTransactionSize
             )
     )
     val shutdownHook = addShutdownHook(driverDsl::shutdown)
@@ -1033,7 +1020,7 @@ fun <A> internalDriver(
                     useTestClock = useTestClock,
                     isDebug = isDebug,
                     startNodesInProcess = startNodesInProcess,
-                    waitForNodesToFinish = waitForAllNodesToFinish,
+                    waitForAllNodesToFinish = waitForAllNodesToFinish,
                     notarySpecs = notarySpecs,
                     extraCordappPackagesToScan = extraCordappPackagesToScan,
                     jmxPolicy = jmxPolicy,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -119,7 +119,7 @@ fun <A> rpcDriver(
                             useTestClock = useTestClock,
                             isDebug = isDebug,
                             startNodesInProcess = startNodesInProcess,
-                            waitForNodesToFinish = waitForNodesToFinish,
+                            waitForAllNodesToFinish = waitForNodesToFinish,
                             extraCordappPackagesToScan = extraCordappPackagesToScan,
                             notarySpecs = notarySpecs,
                             jmxPolicy = jmxPolicy,

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -24,11 +24,8 @@ import net.corda.finance.flows.CashIssueAndPaymentFlow.IssueAndPaymentRequest
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
+import net.corda.testing.driver.*
 import net.corda.testing.node.User
-import net.corda.testing.driver.JmxPolicy
-import net.corda.testing.driver.NodeHandle
-import net.corda.testing.driver.PortAllocation
-import net.corda.testing.driver.driver
 import java.time.Instant
 import java.util.*
 
@@ -66,7 +63,7 @@ class ExplorerSimulation(private val options: OptionSet) {
 
     private fun startDemoNodes() {
         val portAllocation = PortAllocation.Incremental(20000)
-        driver(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true)) {
+        driver(DriverParameters(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true))) {
             // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user))
             val bob = startNode(providedName = BOB_NAME, rpcUsers = listOf(user))

--- a/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
+++ b/verifier/src/integration-test/kotlin/net/corda/verifier/VerifierDriver.kt
@@ -76,7 +76,7 @@ fun <A> verifierDriver(
                         useTestClock = useTestClock,
                         isDebug = isDebug,
                         startNodesInProcess = startNodesInProcess,
-                        waitForNodesToFinish = waitForNodesToFinish,
+                        waitForAllNodesToFinish = waitForNodesToFinish,
                         extraCordappPackagesToScan = extraCordappPackagesToScan,
                         notarySpecs = notarySpecs,
                         jmxPolicy = jmxPolicy,


### PR DESCRIPTION
In order to simplify future API changes, parameters-overload version of ```driver()``` method was removed. Now the full ```DriverParameters``` object is expected