### PR TITLE
CORDA-939 Remove sslConfiguration from public constructor of CordaRPCClient

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3918,8 +3918,20 @@ public class net.corda.testing.node.MockNetwork extends java.lang.Object
   public <init>(List, net.corda.testing.node.MockNetworkParameters)
   public <init>(List, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, boolean, List, int)
   @org.jetbrains.annotations.NotNull public final java.nio.file.Path baseDirectory(int)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode()
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1, net.corda.node.VersionInfo)
   @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
   @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode()
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1)
+  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1, net.corda.node.VersionInfo)
   @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
   @org.jetbrains.annotations.NotNull public final List getCordappPackages()
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getDefaultNotaryIdentity()
@@ -4000,6 +4012,8 @@ public final class net.corda.testing.node.MockNodeParameters extends java.lang.O
   public String toString()
 ##
 public class net.corda.testing.node.MockServices extends java.lang.Object implements net.corda.core.node.StateLoader, net.corda.core.node.ServiceHub
+  public <init>()
+  public <init>(List)
   public <init>(List, net.corda.core.identity.CordaX500Name)
   public <init>(List, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
   public <init>(net.corda.core.identity.CordaX500Name)
@@ -4166,10 +4180,12 @@ public final class net.corda.testing.node.User extends java.lang.Object
 public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
   public <init>(net.corda.core.utilities.NetworkHostAndPort)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
-  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.nodeapi.internal.config.SSLConfiguration)
   @org.jetbrains.annotations.NotNull public final net.corda.client.rpc.CordaRPCConnection start(String, String)
   @org.jetbrains.annotations.NotNull public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
   public final Object use(String, String, kotlin.jvm.functions.Function1)
+  public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
+##
+public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
 ##
 public final class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
   public <init>(java.time.Duration)

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -73,7 +73,7 @@ data class CordaRPCClientConfiguration(val connectionMaxRetryInterval: Duration)
 class CordaRPCClient private constructor(
         hostAndPort: NetworkHostAndPort,
         configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-        private var sslConfiguration: SSLConfiguration? = null
+        sslConfiguration: SSLConfiguration? = null
 ) {
     @JvmOverloads
     constructor(hostAndPort: NetworkHostAndPort, configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT) : this(hostAndPort, configuration, null)

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -72,9 +72,20 @@ data class CordaRPCClientConfiguration(val connectionMaxRetryInterval: Duration)
  */
 class CordaRPCClient @JvmOverloads constructor(
         hostAndPort: NetworkHostAndPort,
-        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
-        sslConfiguration: SSLConfiguration? = null
+        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
 ) {
+    companion object {
+        internal fun getClientWithSsl(
+                hostAndPort: NetworkHostAndPort,
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+                sslConfiguration: SSLConfiguration? = null
+        ) : CordaRPCClient{
+            return CordaRPCClient(hostAndPort, configuration).apply {
+                this.sslConfiguration = sslConfiguration
+            }
+        }
+    }
+
     init {
         try {
             effectiveSerializationEnv
@@ -86,6 +97,8 @@ class CordaRPCClient @JvmOverloads constructor(
             }
         }
     }
+
+    internal var sslConfiguration: SSLConfiguration? = null
 
     private val rpcClient = RPCClient<CordaRPCOps>(
             tcpTransport(ConnectionDirection.Outbound(), hostAndPort, config = sslConfiguration),

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -70,19 +70,21 @@ data class CordaRPCClientConfiguration(val connectionMaxRetryInterval: Duration)
  * @param configuration An optional configuration used to tweak client behaviour.
  * @param sslConfiguration An optional [SSLConfiguration] used to enable secure communication with the server.
  */
-class CordaRPCClient @JvmOverloads constructor(
+class CordaRPCClient private constructor(
         hostAndPort: NetworkHostAndPort,
-        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT
+        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+        private var sslConfiguration: SSLConfiguration? = null
 ) {
+    @JvmOverloads
+    constructor(hostAndPort: NetworkHostAndPort, configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT) : this(hostAndPort, configuration, null)
+
     companion object {
-        internal fun getClientWithSsl(
+        internal fun createWithSsl(
                 hostAndPort: NetworkHostAndPort,
                 configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
                 sslConfiguration: SSLConfiguration? = null
-        ) : CordaRPCClient{
-            return CordaRPCClient(hostAndPort, configuration).apply {
-                this.sslConfiguration = sslConfiguration
-            }
+        ): CordaRPCClient {
+            return CordaRPCClient(hostAndPort, configuration, sslConfiguration)
         }
     }
 
@@ -97,8 +99,6 @@ class CordaRPCClient @JvmOverloads constructor(
             }
         }
     }
-
-    internal var sslConfiguration: SSLConfiguration? = null
 
     private val rpcClient = RPCClient<CordaRPCOps>(
             tcpTransport(ConnectionDirection.Outbound(), hostAndPort, config = sslConfiguration),

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt
@@ -6,8 +6,8 @@ import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.nodeapi.internal.config.SSLConfiguration
 
 /** Utility which exposes the internal Corda RPC constructor to other internal Corda components */
-fun getCordaRPCClientWithSsl(
+fun createCordaRPCClientWithSsl(
         hostAndPort: NetworkHostAndPort,
         configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
         sslConfiguration: SSLConfiguration? = null
-) = CordaRPCClient.getClientWithSsl(hostAndPort, configuration, sslConfiguration)
+) = CordaRPCClient.createWithSsl(hostAndPort, configuration, sslConfiguration)

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt
@@ -1,0 +1,13 @@
+package net.corda.client.rpc.internal
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.CordaRPCClientConfiguration
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.config.SSLConfiguration
+
+/** Utility which exposes the internal Corda RPC constructor to other internal Corda components */
+fun getCordaRPCClientWithSsl(
+        hostAndPort: NetworkHostAndPort,
+        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT,
+        sslConfiguration: SSLConfiguration? = null
+) = CordaRPCClient.getClientWithSsl(hostAndPort, configuration, sslConfiguration)

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -1,5 +1,7 @@
 package net.corda.client.rpc.internal
 
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.CordaRPCClientConfiguration
 import net.corda.client.rpc.RPCConnection
 import net.corda.client.rpc.RPCException
 import net.corda.core.context.Actor

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services.rpc
 
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.internal.getCordaRPCClientWithSsl
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions.Companion.all
@@ -33,7 +34,7 @@ class RpcSslTest {
                 var successful = false
                 driver(isDebug = true, startNodesInProcess = true, portAllocation = PortAllocation.RandomFree) {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
-                        CordaRPCClient(node.rpcAddress, sslConfiguration = clientSslOptions).start(user.username, user.password).use { connection ->
+                        getCordaRPCClientWithSsl(node.rpcAddress, sslConfiguration = clientSslOptions).start(user.username, user.password).use { connection ->
                             connection.proxy.apply {
                                 nodeInfo()
                                 successful = true

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
@@ -1,7 +1,7 @@
 package net.corda.node.services.rpc
 
 import net.corda.client.rpc.CordaRPCClient
-import net.corda.client.rpc.internal.getCordaRPCClientWithSsl
+import net.corda.client.rpc.internal.createCordaRPCClientWithSsl
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions.Companion.all
@@ -34,7 +34,7 @@ class RpcSslTest {
                 var successful = false
                 driver(isDebug = true, startNodesInProcess = true, portAllocation = PortAllocation.RandomFree) {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
-                        getCordaRPCClientWithSsl(node.rpcAddress, sslConfiguration = clientSslOptions).start(user.username, user.password).use { connection ->
+                        createCordaRPCClientWithSsl(node.rpcAddress, sslConfiguration = clientSslOptions).start(user.username, user.password).use { connection ->
                             connection.proxy.apply {
                                 nodeInfo()
                                 successful = true

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -6,7 +6,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigRenderOptions
 import net.corda.client.rpc.CordaRPCClient
-import net.corda.client.rpc.internal.getCordaRPCClientWithSsl
+import net.corda.client.rpc.internal.createCordaRPCClientWithSsl
 import net.corda.cordform.CordformContext
 import net.corda.cordform.CordformNode
 import net.corda.core.concurrent.CordaFuture
@@ -151,7 +151,7 @@ class DriverDSLImpl(
     private fun establishRpc(config: NodeConfig, processDeathFuture: CordaFuture<out Process>): CordaFuture<CordaRPCOps> {
         val rpcAddress = config.corda.rpcOptions.address!!
         val client = if (config.corda.rpcOptions.useSsl) {
-            getCordaRPCClientWithSsl(rpcAddress, sslConfiguration = config.corda.rpcOptions.sslConfig)
+            createCordaRPCClientWithSsl(rpcAddress, sslConfiguration = config.corda.rpcOptions.sslConfig)
         } else {
             CordaRPCClient(rpcAddress)
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigRenderOptions
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.internal.getCordaRPCClientWithSsl
 import net.corda.cordform.CordformContext
 import net.corda.cordform.CordformNode
 import net.corda.core.concurrent.CordaFuture
@@ -150,7 +151,7 @@ class DriverDSLImpl(
     private fun establishRpc(config: NodeConfig, processDeathFuture: CordaFuture<out Process>): CordaFuture<CordaRPCOps> {
         val rpcAddress = config.corda.rpcOptions.address!!
         val client = if (config.corda.rpcOptions.useSsl) {
-            CordaRPCClient(rpcAddress, sslConfiguration = config.corda.rpcOptions.sslConfig)
+            getCordaRPCClientWithSsl(rpcAddress, sslConfiguration = config.corda.rpcOptions.sslConfig)
         } else {
             CordaRPCClient(rpcAddress)
         }


### PR DESCRIPTION
Remove the sslConfiguration paraemter from the public constructor of CordaRPCClient

Have created an internal factory method for initialising the sslConfiguration - and created an internal utility in net.corda.clienty.rpc.internal.CordaRPCClientUtils for other corda modules to get instances of CordaRPCClient. I considered making the constructor private but it seemed like it was used in so many places this broke the least things.