### PR TITLE
Added "advertisedP2pAddress" in node.conf

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -423,8 +423,7 @@ abstract class AbstractNode(open val configuration: NodeConfiguration,
         myNotaryIdentity = getNotaryIdentity()
         val allIdentitiesList = mutableListOf(legalIdentity)
         myNotaryIdentity?.let { allIdentitiesList.add(it) }
-        val addresses = myAddresses() // TODO There is no support for multiple IP addresses yet.
-        return NodeInfo(addresses, allIdentitiesList, platformVersion, platformClock.instant().toEpochMilli())
+        return NodeInfo(listOf(configuration.advertisedP2pAddress), allIdentitiesList, platformVersion, platformClock.instant().toEpochMilli())
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -37,6 +37,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val bftSMaRt: BFTSMaRtConfiguration
     val notaryNodeAddress: NetworkHostAndPort?
     val notaryClusterAddresses: List<NetworkHostAndPort>
+    val advertisedP2pAddress: NetworkHostAndPort
 }
 
 data class FullNodeConfiguration(
@@ -58,6 +59,7 @@ data class FullNodeConfiguration(
         @OldConfig("artemisAddress")
         val p2pAddress: NetworkHostAndPort,
         val rpcAddress: NetworkHostAndPort?,
+        override val advertisedP2pAddress: NetworkHostAndPort,
         // TODO This field is slightly redundant as p2pAddress is sufficient to hold the address of the node's MQ broker.
         // Instead this should be a Boolean indicating whether that broker is an internal one started by the node or an external one
         val messagingServerAddress: NetworkHostAndPort?,


### PR DESCRIPTION
This serves the purpose of splitting two different behaviour of the nodes:
- The p2p address to bind on (i.e. p2pAddress)
- The p2p address other nodes need to know to talk to you properly (i.e. advertisedP2pAddress).

The advertisedP2pAddress is what goes into the NodeInfo sent to the NetworkMap, p2pAddress is used to bind on a local interface instead.