### PR TITLE
CORDA-1038 Update verifySignaturesExcept in api-transactions.rst

### DIFF
--- a/docs/source/api-transactions.rst
+++ b/docs/source/api-transactions.rst
@@ -615,8 +615,8 @@ which the signatures are allowed to be missing:
        :end-before: DOCEND 36
        :dedent: 16
 
-There is also an overload of ``SignedTransaction.verifySignaturesExcept``, which takes a ``Collection`` of the public keys for
-which the signatures are allowed to be missing:
+There is also an overload of ``SignedTransaction.verifySignaturesExcept``, which takes a ``Collection`` of the
+public keys for which the signatures are allowed to be missing:
 
 .. container:: codeset
 

--- a/docs/source/api-transactions.rst
+++ b/docs/source/api-transactions.rst
@@ -615,6 +615,24 @@ which the signatures are allowed to be missing:
        :end-before: DOCEND 36
        :dedent: 16
 
+There is also an overload of ``SignedTransaction.verifySignaturesExcept``, which takes a ``Collection`` of the public keys for
+which the signatures are allowed to be missing:
+
+.. container:: codeset
+
+    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+       :language: kotlin
+       :start-after: DOCSTART 54
+       :end-before: DOCEND 54
+       :dedent: 8
+
+    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+       :language: java
+       :start-after: DOCSTART 54
+       :end-before: DOCEND 54
+       :dedent: 16
+
+
 If the transaction is missing any signatures without the corresponding public keys being passed in, a
 ``SignaturesMissingException`` is thrown.
 

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -28,7 +28,6 @@ import java.security.GeneralSecurityException;
 import java.security.PublicKey;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -28,6 +28,7 @@ import java.security.GeneralSecurityException;
 import java.security.PublicKey;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -540,11 +541,20 @@ public class FlowCookbookJava {
                 // DOCEND 35
 
                 // If the transaction is only partially signed, we have to pass in
-                // a list of the public keys corresponding to the missing
+                // a vararg of the public keys corresponding to the missing
                 // signatures, explicitly telling the system not to check them.
                 // DOCSTART 36
                 onceSignedTx.verifySignaturesExcept(counterpartyPubKey);
                 // DOCEND 36
+
+                // There is also an overload of ``verifySignaturesExcept`` which accepts
+                // a ``Collection`` of the public keys corresponding to the missing
+                // signatures. In the example below, we could also use
+                // ``Arrays.asList(counterpartyPubKey)`` instead of
+                // ``Collections.singletonList(counterpartyPubKey)``.
+                // DOCSTART 54
+                onceSignedTx.verifySignaturesExcept(Collections.singletonList(counterpartyPubKey));
+                // DOCEND 54
 
                 // We can also choose to only check the signatures that are
                 // present. BE VERY CAREFUL - this function provides no guarantees

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
@@ -522,11 +522,18 @@ class InitiatorFlow(val arg1: Boolean, val arg2: Int, private val counterparty: 
         // DOCEND 35
 
         // If the transaction is only partially signed, we have to pass in
-        // a list of the public keys corresponding to the missing
+        // a vararg of the public keys corresponding to the missing
         // signatures, explicitly telling the system not to check them.
         // DOCSTART 36
         onceSignedTx.verifySignaturesExcept(counterpartyPubKey)
         // DOCEND 36
+
+        // There is also an overload of ``verifySignaturesExcept`` which accepts
+        // a ``Collection`` of the public keys corresponding to the missing
+        // signatures.
+        // DOCSTART 54
+        onceSignedTx.verifySignaturesExcept(listOf(counterpartyPubKey))
+        // DOCEND 54
 
         // We can also choose to only check the signatures that are
         // present. BE VERY CAREFUL - this function provides no guarantees


### PR DESCRIPTION
Update [api-transactions.rst](https://docs.corda.net/head/api-transactions.html#verifying-the-transaction-s-signatures) to reflect new ``TransactionWithSignatures.verifySignaturesExcept`` which takes in a ``Collection`` of ``PublicKey``s.