### PR TITLE
Vault Fungible Asset Query Criteria: removed incorrect reference in docs.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -129,8 +129,6 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
      *
      * Params
      *  [expression] refers to a (composable) type safe [CriteriaExpression]
-     *
-     * Refer to [CommercialPaper.State] for a concrete example.
      */
     data class VaultCustomQueryCriteria<L : PersistentState> @JvmOverloads constructor
     (val expression: CriteriaExpression<L, Boolean>,

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -107,11 +107,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
     }
 
     /**
-     * FungibleStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultFungibleState]
-     *
-     * Valid TokenType implementations defined by Amount<T> are
-     *   [Currency] as used in [Cash] contract state
-     *   [Commodity] as used in [CommodityContract] state
+     * FungibleStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultFungibleStates]
      */
     data class FungibleAssetQueryCriteria @JvmOverloads constructor(val participants: List<AbstractParty>? = null,
                                                                     val owner: List<AbstractParty>? = null,


### PR DESCRIPTION
Removed unresolvable documentation references to classes in `finance` package (not accessible from `core`)