### PR TITLE
CORDA-1064: Fix a hang in AMQP protocol code

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
@@ -168,12 +168,14 @@ internal class ConnectionStateMachine(serverMode: Boolean,
         val transport = event.transport
         log.debug { "Transport Head Closed $transport" }
         transport.close_tail()
+        onTransportInternal(transport)
     }
 
     override fun onTransportTailClosed(event: Event) {
         val transport = event.transport
         log.debug { "Transport Tail Closed $transport" }
         transport.close_head()
+        onTransportInternal(transport)
     }
 
     override fun onTransportClosed(event: Event) {
@@ -195,6 +197,7 @@ internal class ConnectionStateMachine(serverMode: Boolean,
         } else {
             log.info("Error (no description returned).")
         }
+        onTransportInternal(transport)
     }
 
     override fun onTransport(event: Event) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt
@@ -79,7 +79,10 @@ internal class EventProcessor(channel: Channel,
                 if ((connection.localState != EndpointState.CLOSED) && !connection.transport.isClosed) {
                     val now = System.currentTimeMillis()
                     val tickDelay = Math.max(0L, connection.transport.tick(now) - now)
-                    executor.schedule({ tick(connection) }, tickDelay, TimeUnit.MILLISECONDS)
+                    executor.schedule({
+                        tick(connection)
+                        processEvents()
+                    }, tickDelay, TimeUnit.MILLISECONDS)
                 }
             } catch (ex: Exception) {
                 connection.transport.close()


### PR DESCRIPTION
When debugging code with active AMQP connections it is possible for the proton-j state machine to become hung and not drop the bridging socket. This is due to timeout events not flushing through the events on the executor. This change ensures the events leading to close are always run.

Push to pre-release-V3