### PR TITLE
[CORDA-1066] Remove internal test usage from finance package

### DIFF
--- a/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
@@ -9,11 +9,10 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.finance.DOLLARS
 import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
-import net.corda.node.internal.StartedNode
 import net.corda.testing.core.*
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
-import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.InternalMockNetwork.MockNode
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.StartedMockNode
 import net.corda.testing.node.startFlow
 import org.junit.After
 import org.junit.Before
@@ -22,16 +21,16 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class CashPaymentFlowTests {
-    private lateinit var mockNet: InternalMockNetwork
+    private lateinit var mockNet: MockNetwork
     private val initialBalance = 2000.DOLLARS
     private val ref = OpaqueBytes.of(0x01)
-    private lateinit var bankOfCordaNode: StartedNode<MockNode>
+    private lateinit var bankOfCordaNode: StartedMockNode
     private lateinit var bankOfCorda: Party
-    private lateinit var aliceNode: StartedNode<MockNode>
+    private lateinit var aliceNode: StartedMockNode
 
     @Before
     fun start() {
-        mockNet = InternalMockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance.contracts.asset"))
+        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance.contracts.asset"))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda = bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         aliceNode = mockNet.createPartyNode(ALICE_NAME)
@@ -50,7 +49,7 @@ class CashPaymentFlowTests {
         val expectedPayment = 500.DOLLARS
         val expectedChange = 1500.DOLLARS
 
-        bankOfCordaNode.database.transaction {
+        bankOfCordaNode.transaction {
             // Register for vault updates
             val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)
             val (_, vaultUpdatesBoc) = bankOfCordaNode.services.vaultService.trackBy<Cash.State>(criteria)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -112,6 +112,10 @@ class StartedMockNode private constructor(private val node: StartedNode<Internal
     /** Returns the currently live flows of type [flowClass], and their corresponding result future. */
     fun <F : FlowLogic<*>> findStateMachines(flowClass: Class<F>): List<Pair<F, CordaFuture<*>>> = node.smm.findStateMachines(flowClass)
 
+    /**
+     * Executes given statement in the scope of a transaction.
+     * @param statement to be executed in the scope of this transaction.
+     */
     fun <T> transaction(statement: () -> T): T {
         return node.database.transaction {
             statement()


### PR DESCRIPTION
Cherry-pick addressing @mikehearn's comments on PR https://github.com/corda/corda/pull/2534 in the v3 release branch