### PR TITLE
Eliminate references to Java target "1.6"

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -156,8 +156,8 @@
       <module name="web_test" target="1.8" />
       <module name="webcapsule_main" target="1.6" />
       <module name="webcapsule_test" target="1.6" />
-      <module name="webserver-webcapsule_main" target="1.6" />
-      <module name="webserver-webcapsule_test" target="1.6" />
+      <module name="webserver-webcapsule_main" target="1.8" />
+      <module name="webserver-webcapsule_test" target="1.8" />
       <module name="webserver_integrationTest" target="1.8" />
       <module name="webserver_main" target="1.8" />
       <module name="webserver_test" target="1.8" />

--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -15,6 +15,14 @@ configurations {
     smokeTestRuntime.extendsFrom runtime
 }
 
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 sourceSets {
     integrationTest {
         kotlin {


### PR DESCRIPTION
Also for "client/rpc" explicitly specify "jvmTarget" (similar to what "experimental/behave" does) to avoid ambiguity.

Without this change the following compilation error been observed in IntelliJ:
```
Z:\corda\experimental\behave\src\main\kotlin\net\corda\behave\node\Node.kt
Error:(163, 44) Kotlin: Cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option
```
