### PR TITLE
Updates classloader to handle classes that implement interfaces or subclass classes in other cordapps.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -117,11 +117,9 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
                     .asSequence()
                     .map { path ->
                         if (path.protocol == "jar") {
-                            // When running tests from gradle this may be a corda module jar, so restrict to scanPackage:
                             RestrictedURL((path.openConnection() as JarURLConnection).jarFileURL, scanPackage)
                         } else {
-                            // No need to restrict as createDevCordappJar has already done that:
-                            RestrictedURL(createDevCordappJar(scanPackage, path, resource).toURL(), null)
+                            RestrictedURL(createDevCordappJar(scanPackage, path, resource).toURL(), scanPackage)
                         }
                     }
                     .toList()
@@ -190,18 +188,23 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
     }
 
     private fun loadCordapps(): List<Cordapp> {
-        return cordappJarPaths.map {
-            val scanResult = scanCordapp(it)
-            CordappImpl(findContractClassNames(scanResult),
-                    findInitiatedFlows(scanResult),
-                    findRPCFlows(scanResult),
-                    findServiceFlows(scanResult),
-                    findSchedulableFlows(scanResult),
-                    findServices(scanResult),
-                    findPlugins(it),
-                    findSerializers(scanResult),
-                    findCustomSchemas(scanResult),
-                    it.url)
+        return if (cordappJarPaths.isEmpty()) {
+            emptyList()
+        } else {
+            val scanResult = FastClasspathScanner().overrideClasspath(cordappJarPaths.map { it.url }).scan()
+            return cordappJarPaths.map {
+                val restrictedScanResult = scanCordapp(scanResult, it)
+                CordappImpl(findContractClassNames(restrictedScanResult),
+                        findInitiatedFlows(restrictedScanResult),
+                        findRPCFlows(restrictedScanResult),
+                        findServiceFlows(restrictedScanResult),
+                        findSchedulableFlows(restrictedScanResult),
+                        findServices(restrictedScanResult),
+                        findPlugins(it),
+                        findSerializers(restrictedScanResult),
+                        findCustomSchemas(restrictedScanResult),
+                        it.url)
+            }
         }
     }
 
@@ -258,12 +261,9 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
         return scanResult.getClassesWithSuperclass(MappedSchema::class).toSet()
     }
 
-    private val cachedScanResult = LRUMap<RestrictedURL, RestrictedScanResult>(1000)
-    private fun scanCordapp(cordappJarPath: RestrictedURL): RestrictedScanResult {
+    private fun scanCordapp(scanResult: ScanResult, cordappJarPath: RestrictedURL): RestrictedScanResult {
         logger.info("Scanning CorDapp in $cordappJarPath")
-        return cachedScanResult.computeIfAbsent(cordappJarPath, {
-            RestrictedScanResult(FastClasspathScanner().addClassLoader(appClassLoader).overrideClasspath(cordappJarPath.url).scan(), cordappJarPath.qualifiedNamePrefix)
-        })
+        return RestrictedScanResult(scanResult, cordappJarPath.qualifiedNamePrefix)
     }
 
     private class FlowTypeHierarchyComparator(val initiatingFlow: Class<out FlowLogic<*>>) : Comparator<Class<out FlowLogic<*>>> {

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappLoaderTest.kt
@@ -79,10 +79,11 @@ class CordappLoaderTest {
         // cannot happen. In gradle it will also pick up the node jar. 
         assertThat(actual.size == 4 || actual.size == 5).isTrue()
 
-        val actualCordapp = actual.single { !it.initiatedFlows.isEmpty() }
-        assertThat(actualCordapp.initiatedFlows).first().hasSameClassAs(DummyFlow::class.java)
-        assertThat(actualCordapp.rpcFlows).first().hasSameClassAs(DummyRPCFlow::class.java)
-        assertThat(actualCordapp.schedulableFlows).first().hasSameClassAs(DummySchedulableFlow::class.java)
+        actual.filter { !it.initiatedFlows.isEmpty() }.forEach { cordapp ->
+            assertThat(cordapp.initiatedFlows).first().hasSameClassAs(DummyFlow::class.java)
+            assertThat(cordapp.rpcFlows).first().hasSameClassAs(DummyRPCFlow::class.java)
+            assertThat(cordapp.schedulableFlows).first().hasSameClassAs(DummySchedulableFlow::class.java)
+        }
     }
 
     // This test exists because the appClassLoader is used by serialisation and we need to ensure it is the classloader


### PR DESCRIPTION
The old classloader couldn't handle cases such as the following:

1. X is defined in package 1 and implements Contract
2. Y is defined in package 2 and subclasses X

Y is a Contract, but because the classloader considered each CorDapp in isolation, it couldn't work this out.

Now, there is a single scan across all CorDapps at once, and then contracts, flows, etc. are assigned to their respective CorDapps based on their package names.

One potential issue is that if two CorDapps share a package name, all contracts, flows, etc. will be assigned to all of them. Is this an issue?