### PR TITLE
CORDA-1092 secureRandomBytes should call getNextBytes, not generateSeed

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -168,7 +168,7 @@ fun KeyPair.verify(signatureData: ByteArray, clearData: ByteArray): Boolean = Cr
  * which should never happen and suggests an unusual JVM or non-standard Java library.
  */
 @Throws(NoSuchAlgorithmException::class)
-fun secureRandomBytes(numOfBytes: Int): ByteArray = newSecureRandom().generateSeed(numOfBytes)
+fun secureRandomBytes(numOfBytes: Int): ByteArray = ByteArray(numOfBytes).apply { newSecureRandom().nextBytes(this) }
 
 /**
  * Get an instance of [SecureRandom] to avoid blocking, due to waiting for additional entropy, when possible.

--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -78,7 +78,7 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
          * Generates a random SHA-256 value.
          */
         @JvmStatic
-        fun randomSHA256() = sha256(newSecureRandom().generateSeed(32))
+        fun randomSHA256() = sha256(secureRandomBytes(32))
 
         /**
          * A SHA-256 hash value consisting of 32 0x00 bytes.


### PR DESCRIPTION
`secureRandomBytes` should call `getNextBytes()`. It affects `SecureHash.randomSHA256()` as well.
