### PR TITLE
[CORDA-1098]: Fixed Artemis filters for flows draining mode.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -144,7 +144,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         }
 
         // Check attachment size first as they are most likely to go over the limit.
-        ltx.attachments.forEach { minus(it.size) }
+        ltx.attachments.associateBy(Attachment::id).values.forEach { minus(it.size) }
         minus(ltx.inputs.serialize().size)
         minus(ltx.commands.serialize().size)
         minus(ltx.outputs.serialize().size)

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
@@ -18,8 +18,9 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.test.fail
 
 class P2PFlowsDrainingModeTest {
@@ -28,7 +29,7 @@ class P2PFlowsDrainingModeTest {
     private val user = User("mark", "dadada", setOf(Permissions.all()))
     private val users = listOf(user)
 
-    private var executor: ExecutorService? = null
+    private var executor: ScheduledExecutorService? = null
 
     companion object {
         private val logger = loggerFor<P2PFlowsDrainingModeTest>()
@@ -36,7 +37,7 @@ class P2PFlowsDrainingModeTest {
 
     @Before
     fun setup() {
-        executor = Executors.newSingleThreadExecutor()
+        executor = Executors.newSingleThreadScheduledExecutor()
     }
 
     @After
@@ -59,11 +60,11 @@ class P2PFlowsDrainingModeTest {
             initiating.apply {
                 val flow = startFlow(::InitiateSessionFlow, counterParty)
                 // this should be really fast, for the flow has already started, so 5 seconds should never be a problem
-                executor!!.submit({
+                executor!!.schedule({
                     logger.info("Now disabling flows draining mode for $counterParty.")
                     shouldFail = false
                     initiated.setFlowsDrainingModeEnabled(false)
-                })
+                }, 5, TimeUnit.SECONDS)
                 flow.returnValue.map { result ->
                     if (shouldFail) {
                         fail("Shouldn't happen until flows draining mode is switched off.")

--- a/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
@@ -667,8 +667,8 @@ private class P2PMessagingConsumer(
         private val drainingModeWasChangedEvents: Observable<Pair<Boolean, Boolean>>) : LifecycleSupport {
 
     private companion object {
-        private const val initialSessionMessages = "${P2PMessagingHeaders.Type.KEY}=${P2PMessagingHeaders.Type.SESSION_INIT_VALUE}"
-        private const val existingSessionMessages = "${P2PMessagingHeaders.Type.KEY}<>${P2PMessagingHeaders.Type.SESSION_INIT_VALUE}"
+        private const val initialSessionMessages = "${P2PMessagingHeaders.Type.KEY}='${P2PMessagingHeaders.Type.SESSION_INIT_VALUE}'"
+        private const val existingSessionMessages = "${P2PMessagingHeaders.Type.KEY}<>'${P2PMessagingHeaders.Type.SESSION_INIT_VALUE}'"
     }
 
     private var startedFlag = false


### PR DESCRIPTION
@ags313 when we refactored `P2PFlowsDrainingModeTest` to use an `ExecutorService` instead of a `ScheduledExecutorService` we made that test useless (it was going green regardless, for a race condition).

When we refactored the `P2PMessagingClient` to use server-side filters, the feature got broken without us realising.