### PR TITLE
[CORDA-2615]: Added description for configFile option in deployNodes Cordform Gradle task.

### DIFF
--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -120,10 +120,10 @@ nodes. Here is an example ``Cordform`` task called ``deployNodes`` that creates 
         }
     }
 
-To extend node configuration beyond properties defined in the ``deployNodes`` task use ``configFile`` property with the path (relative or absolute) set to an additional configuration file.
+To extend node configuration beyond the properties defined in the ``deployNodes`` task use the ``configFile`` property with the path (relative or absolute) set to an additional configuration file.
 This file should follow the standard format, as per node.conf. The properties from this file will be appended to the generated node configuration.
-Additionaly, the path to the file can also be added while running the Gradle task via the ``-PconfigFile`` command line option. However, the same file will be applied to all nodes.
-Following the previous example `PartyB` node will have additional configuration options added from a file `none-b.conf`:
+The path to the file can also be added while running the Gradle task via the ``-PconfigFile`` command line option. However, the same file will be applied to all nodes.
+Following the previous example ``PartyB`` node will have additional configuration options added from a file ``none-b.conf``:
 
 .. sourcecode:: groovy
 

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -120,6 +120,24 @@ nodes. Here is an example ``Cordform`` task called ``deployNodes`` that creates 
         }
     }
 
+To extend node configuration beyond properties defined in ``deployNodes`` task use ``configFile`` property with the path (relative or absolute) to an additional configuration file.
+The file should has a standard format as node.conf one. The properties from that file will be appended as it is to the resulting node configuration.
+The path to the file can also be added while running Gradle task via ``-PconfigFile`` command line option, however the same file will be added to all nodes.
+Following the previous example `PartyB` node will have additional configuration options added from a file `none-b.conf`:
+
+.. sourcecode:: groovy
+
+    task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
+        [...]
+        node {
+            name "O=PartyB,L=New York,C=US"
+            [...]
+            // Grants user1 the ability to start the MyFlow flow.
+            rpcUsers = [[ user: "user1", "password": "test", "permissions": ["StartFlow.net.corda.flows.MyFlow"]]]
+            configFile = "samples/trader-demo/src/main/resources/none-b.conf"
+        }
+    }
+
 Running this task will create three nodes in the ``build/nodes`` folder:
 
 * A ``NetworkMapAndNotary`` node that:

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -122,7 +122,7 @@ nodes. Here is an example ``Cordform`` task called ``deployNodes`` that creates 
 
 To extend node configuration beyond properties defined in the ``deployNodes`` task use ``configFile`` property with the path (relative or absolute) set to an additional configuration file.
 This file should have a standard format as node.conf one. The properties from that file will be appended as it is to the resulting node configuration.
-The path to the file can also be added while running Gradle task via ``-PconfigFile`` command line option. However the same file will be applied to all nodes.
+The path to the file can also be added while running Gradle task via ``-PconfigFile`` command line option. However, the same file will be applied to all nodes.
 Following the previous example `PartyB` node will have additional configuration options added from a file `none-b.conf`:
 
 .. sourcecode:: groovy

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -121,8 +121,8 @@ nodes. Here is an example ``Cordform`` task called ``deployNodes`` that creates 
     }
 
 To extend node configuration beyond properties defined in the ``deployNodes`` task use ``configFile`` property with the path (relative or absolute) set to an additional configuration file.
-This file should have a standard format as node.conf one. The properties from that file will be appended as it is to the resulting node configuration.
-The path to the file can also be added while running Gradle task via ``-PconfigFile`` command line option. However, the same file will be applied to all nodes.
+This file should follow the standard format, as per node.conf. The properties from this file will be appended to the generated node configuration.
+Additionaly, the path to the file can also be added while running the Gradle task via the ``-PconfigFile`` command line option. However, the same file will be applied to all nodes.
 Following the previous example `PartyB` node will have additional configuration options added from a file `none-b.conf`:
 
 .. sourcecode:: groovy

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -121,7 +121,7 @@ nodes. Here is an example ``Cordform`` task called ``deployNodes`` that creates 
     }
 
 To extend node configuration beyond the properties defined in the ``deployNodes`` task use the ``configFile`` property with the path (relative or absolute) set to an additional configuration file.
-This file should follow the standard format, as per node.conf. The properties from this file will be appended to the generated node configuration.
+This file should follow the standard :doc:`corda-configuration-file` format, as per node.conf. The properties from this file will be appended to the generated node configuration.
 The path to the file can also be added while running the Gradle task via the ``-PconfigFile`` command line option. However, the same file will be applied to all nodes.
 Following the previous example ``PartyB`` node will have additional configuration options added from a file ``none-b.conf``:
 

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -120,9 +120,9 @@ nodes. Here is an example ``Cordform`` task called ``deployNodes`` that creates 
         }
     }
 
-To extend node configuration beyond properties defined in ``deployNodes`` task use ``configFile`` property with the path (relative or absolute) to an additional configuration file.
-The file should has a standard format as node.conf one. The properties from that file will be appended as it is to the resulting node configuration.
-The path to the file can also be added while running Gradle task via ``-PconfigFile`` command line option, however the same file will be added to all nodes.
+To extend node configuration beyond properties defined in the ``deployNodes`` task use ``configFile`` property with the path (relative or absolute) set to an additional configuration file.
+This file should have a standard format as node.conf one. The properties from that file will be appended as it is to the resulting node configuration.
+The path to the file can also be added while running Gradle task via ``-PconfigFile`` command line option. However the same file will be applied to all nodes.
 Following the previous example `PartyB` node will have additional configuration options added from a file `none-b.conf`:
 
 .. sourcecode:: groovy


### PR DESCRIPTION
Added description for `configFile` option in `deployNodes` Cordform Gradle task.
The option is only used when generating a node configuration and it's not present in node.conf (so it was not added to https://docs.corda.net/head/corda-configuration-file.html ).

https://github.com/corda/corda/pull/2615