### PR TITLE
Move classpath to system variable to avoid "Command too long" on Windows

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
@@ -44,8 +44,6 @@ object ProcessUtilities {
             if (maximumHeapSize != null) add("-Xmx$maximumHeapSize")
             add("-XX:+UseG1GC")
             addAll(extraJvmArguments)
-//            add("-cp")
-//            add(classpath)
             add(className)
             addAll(arguments)
         }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
@@ -44,12 +44,13 @@ object ProcessUtilities {
             if (maximumHeapSize != null) add("-Xmx$maximumHeapSize")
             add("-XX:+UseG1GC")
             addAll(extraJvmArguments)
-            add("-cp")
-            add(classpath)
+//            add("-cp")
+//            add(classpath)
             add(className)
             addAll(arguments)
         }
         return ProcessBuilder(command).apply {
+            environment().put("CLASSPATH", classpath)
             inheritIO()
             if (workingDirectory != null) {
                 redirectError((workingDirectory / "$className.stderr.log").toFile())


### PR DESCRIPTION
Windows is pretty sensitive when it comes to a path lengths, so some tests can fail if the user downloaded corda into "wrong" directory. Moving classpath to a system variable seems to overcome this problem.