### PR TITLE
[CORDA-1112] Explicit dependency on JS dep dir seems to eliminate race condition bug

### DIFF
--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -79,9 +79,9 @@ jar {
     from sourceSets.test.output
     dependsOn clientInstall
 
-	from("src/main/resources/static/js/bower_components") {
-		into "static/js/bower_components"
-	}
+    from("src/main/resources/static/js/bower_components") {
+        into "static/js/bower_components"
+    }
 }
 
 def docker_dir = file("$project.buildDir/docker")

--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -78,6 +78,10 @@ dependencies {
 jar {
     from sourceSets.test.output
     dependsOn clientInstall
+
+	from("src/main/resources/static/js/bower_components") {
+		into "static/js/bower_components"
+	}
 }
 
 def docker_dir = file("$project.buildDir/docker")


### PR DESCRIPTION
Content of ```bower_components``` folder is being downloaded by ```clientInstall``` step, directly into the source tree for easier development. This however seems to cause a problem with builds on fresh repos.