### PR TITLE
CORDA-1117 Fix non deterministic port allocation issue in ExplorerSimulation

### DIFF
--- a/docs/source/node-explorer.rst
+++ b/docs/source/node-explorer.rst
@@ -63,11 +63,11 @@ The Demo Nodes can be started in one of two modes:
 
 .. note:: 5 Corda nodes will be created on the following port on localhost by default.
 
-   * Notary -> 20003            (Does not accept logins)
-   * Alice -> 20006
-   * Bob -> 20009
-   * UK Bank Plc -> 20012       (*Issuer node*)
-   * USA Bank Corp -> 20015     (*Issuer node*)
+   * Alice -> 20001
+   * Bob -> 20005
+   * UK Bank Plc -> 20009       (*Issuer node*)
+   * USA Bank Corp -> 20013     (*Issuer node*)
+   * Notary -> 20017            (Does not accept logins)
 
 Explorer login credentials to the Issuer nodes are defaulted to ``manager`` and ``test``.
 Explorer login credentials to the Participants nodes are defaulted to ``user1`` and ``test``.

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -126,6 +126,7 @@ interface FlowStarter {
 
     /**
      * Starts an already constructed flow. Note that you must be on the server thread to call this method.
+     * @param logic the [FlowLogic] to start.
      * @param context indicates who started the flow, see: [InvocationContext].
      */
     fun <T> startFlow(logic: FlowLogic<T>, context: InvocationContext): CordaFuture<FlowStateMachine<T>>

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -184,7 +184,7 @@ class DriverDSLImpl(
             startInSameProcess: Boolean?,
             maximumHeapSize: String
     ): CordaFuture<NodeHandle> {
-        val p2pAddress = portAllocation.nextHostAndPort()
+        val p2pAddress = portAllocation.nextHostAndPort(Pair(providedName, "p2p"))
         // TODO: Derive name from the full picked name, don't just wrap the common name
         val name = providedName ?: CordaX500Name("${oneOf(names).organisation}-${p2pAddress.port}", "London", "GB")
         synchronized(nodeNames) {
@@ -215,10 +215,10 @@ class DriverDSLImpl(
                                     customOverrides: Map<String, Any?>,
                                     startInSameProcess: Boolean? = null,
                                     maximumHeapSize: String = "200m",
-                                    p2pAddress: NetworkHostAndPort = portAllocation.nextHostAndPort()): CordaFuture<NodeHandle> {
-        val rpcAddress = portAllocation.nextHostAndPort()
-        val rpcAdminAddress = portAllocation.nextHostAndPort()
-        val webAddress = portAllocation.nextHostAndPort()
+                                    p2pAddress: NetworkHostAndPort = portAllocation.nextHostAndPort(Pair(name, "p2p"))): CordaFuture<NodeHandle> {
+        val rpcAddress = portAllocation.nextHostAndPort(Pair(name, "rpc"))
+        val rpcAdminAddress = portAllocation.nextHostAndPort(Pair(name, "rpcAdmin"))
+        val webAddress = portAllocation.nextHostAndPort(Pair(name, "web"))
         val users = rpcUsers.map { it.copy(permissions = it.permissions + DRIVER_REQUIRED_PERMISSIONS) }
         val czUrlConfig = if (compatibilityZone != null) mapOf("compatibilityZoneURL" to compatibilityZone.url.toString()) else emptyMap()
         val config = NodeConfig(ConfigHelper.loadConfig(

--- a/tools/explorer/README.md
+++ b/tools/explorer/README.md
@@ -34,11 +34,11 @@ The Participant nodes are only able to spend cash (eg. move cash).
 
 **These Corda nodes will be created on the following port on localhost.**
 
-   * Notary -> 20005            (Does not accept logins)
-   * UK Bank Plc -> 20011       (*Issuer node*)
-   * USA Bank Corp -> 20008     (*Issuer node*)
-   * Alice -> 20017
-   * Bob -> 20014
+   * Alice -> 20001
+   * Bob -> 20005
+   * UK Bank Plc -> 20009       (*Issuer node*)
+   * USA Bank Corp -> 20013     (*Issuer node*)
+   * Notary -> 20017            (Does not accept logins)
 
 Explorer login credentials to the Issuer nodes are defaulted to ``manager`` and ``test``.
 Explorer login credentials to the Participants nodes are defaulted to ``user1`` and ``test``.

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/Main.kt
@@ -118,8 +118,8 @@ class Main : App(MainView::class) {
 }
 
 /**
- * This main method will starts 5 nodes (Notary, USA Bank, UK Bank, Bob and Alice) locally for UI testing,
- * they will be on localhost ports 20005, 20008, 20011, 20014 and 20017 respectively.
+ * This main method will starts 5 nodes (Alice, Bob, UK Bank, USA Bank and Notary) locally for UI testing,
+ * they will be on localhost ports 20001, 20005, 20009, 20013 and 20017 respectively.
  *
  * The simulation start with pre-allocating chunks of cash to each of the party in 2 currencies (USD, GBP), then it enter a loop to generate random events.
  * On each iteration, the issuers will execute a Cash Issue or Cash Exit flow (at a 9:1 ratio) and a random party will execute a move of cash to another random party.


### PR DESCRIPTION
Port allocation in `ExplorerSimulation` is using Driver and previous implementation was not deterministic regarding port allocation.
A fix by implementing a custom [PortAllocation] has been applied.
Docs and readme files have been updated with the correct fixed ports.
