### PR TITLE
1076 - Filters out structural steps when tracking a flow via RPC.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ProgressTracker.kt
@@ -1,3 +1,3 @@
 package net.corda.core.internal
 
-val STRUCTURAL_STEP_TEXT = "Structural step change in child of "
+val STRUCTURAL_STEP_PREFIX = "Structural step change in child of "

--- a/core/src/main/kotlin/net/corda/core/internal/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ProgressTracker.kt
@@ -1,0 +1,3 @@
+package net.corda.core.internal
+
+val STRUCTURAL_STEP_TEXT = "Structural step change in child of "

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -1,6 +1,6 @@
 package net.corda.core.utilities
 
-import net.corda.core.internal.STRUCTURAL_STEP_TEXT
+import net.corda.core.internal.STRUCTURAL_STEP_PREFIX
 import net.corda.core.serialization.CordaSerializable
 import rx.Observable
 import rx.Subscription
@@ -42,7 +42,7 @@ class ProgressTracker(vararg steps: Step) {
         }
 
         data class Structural(val tracker: ProgressTracker, val parent: Step) : Change(tracker) {
-            override fun toString() = STRUCTURAL_STEP_TEXT + parent.label
+            override fun toString() = STRUCTURAL_STEP_PREFIX + parent.label
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -1,5 +1,6 @@
 package net.corda.core.utilities
 
+import net.corda.core.internal.STRUCTURAL_STEP_TEXT
 import net.corda.core.serialization.CordaSerializable
 import rx.Observable
 import rx.Subscription
@@ -41,7 +42,7 @@ class ProgressTracker(vararg steps: Step) {
         }
 
         data class Structural(val tracker: ProgressTracker, val parent: Step) : Change(tracker) {
-            override fun toString() = "Structural step change in child of ${parent.label}"
+            override fun toString() = STRUCTURAL_STEP_TEXT + parent.label
         }
     }
 

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -329,12 +329,10 @@ Assuming all went well, you should see some activity in PartyA's web-server term
 
    >> Signing transaction with our private key.
    >> Gathering the counterparty's signature.
-   >> Structural step change in child of Gathering the counterparty's signature.
    >> Collecting signatures from counter-parties.
    >> Verifying collected signatures.
    >> Done
    >> Obtaining notary signature and recording transaction.
-   >> Structural step change in child of Obtaining notary signature and recording transaction.
    >> Requesting signature by notary service
    >> Broadcasting transaction to participants
    >> Done

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -14,6 +14,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.RPC_UPLOADER
+import net.corda.core.internal.STRUCTURAL_STEP_TEXT
 import net.corda.core.internal.sign
 import net.corda.core.messaging.*
 import net.corda.core.node.NodeInfo
@@ -154,7 +155,7 @@ internal class CordaRPCOpsImpl(
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
-                progress = stateMachine.logic.track()?.updates ?: Observable.empty(),
+                progress = stateMachine.logic.track()?.updates?.filter { !(it.contains(STRUCTURAL_STEP_TEXT)) } ?: Observable.empty(),
                 stepsTreeIndexFeed = stateMachine.logic.trackStepsTreeIndex(),
                 stepsTreeFeed = stateMachine.logic.trackStepsTree()
         )

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -14,7 +14,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.RPC_UPLOADER
-import net.corda.core.internal.STRUCTURAL_STEP_TEXT
+import net.corda.core.internal.STRUCTURAL_STEP_PREFIX
 import net.corda.core.internal.sign
 import net.corda.core.messaging.*
 import net.corda.core.node.NodeInfo
@@ -155,7 +155,7 @@ internal class CordaRPCOpsImpl(
         return FlowProgressHandleImpl(
                 id = stateMachine.id,
                 returnValue = stateMachine.resultFuture,
-                progress = stateMachine.logic.track()?.updates?.filter { !(it.contains(STRUCTURAL_STEP_TEXT)) } ?: Observable.empty(),
+                progress = stateMachine.logic.track()?.updates?.filter { !it.startsWith(STRUCTURAL_STEP_PREFIX) } ?: Observable.empty(),
                 stepsTreeIndexFeed = stateMachine.logic.trackStepsTreeIndex(),
                 stepsTreeFeed = stateMachine.logic.trackStepsTree()
         )


### PR DESCRIPTION
We can't filter out the structural steps by class, because `FlowLogic.track` is part of the public API and returns strings only.