### PR TITLE
CORDA-1170: Define and whitelist the Artemis/AMQP application headers that are accepted by Corda

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisMessagingComponent.kt
@@ -7,7 +7,6 @@ import net.corda.core.messaging.MessageRecipients
 import net.corda.core.messaging.SingleMessageRecipient
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2PMessagingHeaders.Type.KEY
 import org.apache.activemq.artemis.api.core.Message
 import org.apache.activemq.artemis.api.core.SimpleString
 import java.security.PublicKey
@@ -63,14 +62,14 @@ class ArtemisMessagingComponent {
                 const val SESSION_INIT_VALUE = "session_init"
             }
 
-            val whiteListedHeaders: Set<String> = setOf(topicProperty.toString(),
+            val whitelistedHeaders: Set<String> = setOf(topicProperty.toString(),
                     cordaVendorProperty.toString(),
                     releaseVersionProperty.toString(),
                     platformVersionProperty.toString(),
                     senderUUID.toString(),
                     senderSeqNo.toString(),
                     bridgedCertificateSubject.toString(),
-                    KEY,
+                    Type.KEY,
                     Message.HDR_DUPLICATE_DETECTION_ID.toString(),
                     Message.HDR_VALIDATED_USER.toString())
         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
@@ -129,7 +129,7 @@ class AMQPBridgeManager(config: NodeSSLConfiguration, val artemisMessageClientFa
         private fun clientArtemisMessageHandler(artemisMessage: ClientMessage) {
             val data = ByteArray(artemisMessage.bodySize).apply { artemisMessage.bodyBuffer.readBytes(this) }
             val properties = HashMap<Any?, Any?>()
-            for (key in P2PMessagingHeaders.whiteListedHeaders) {
+            for (key in P2PMessagingHeaders.whitelistedHeaders) {
                 if (artemisMessage.containsProperty(key)) {
                     var value = artemisMessage.getObjectProperty(key)
                     if (value is SimpleString) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
@@ -10,6 +10,7 @@ import net.corda.core.utilities.debug
 import net.corda.nodeapi.internal.ArtemisMessagingClient
 import net.corda.nodeapi.internal.ArtemisMessagingComponent
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NODE_USER
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2PMessagingHeaders
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEER_USER
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.RemoteInboxAddress.Companion.translateLocalQueueToInboxAddress
 import net.corda.nodeapi.internal.ArtemisSessionProvider
@@ -128,12 +129,14 @@ class AMQPBridgeManager(config: NodeSSLConfiguration, val artemisMessageClientFa
         private fun clientArtemisMessageHandler(artemisMessage: ClientMessage) {
             val data = ByteArray(artemisMessage.bodySize).apply { artemisMessage.bodyBuffer.readBytes(this) }
             val properties = HashMap<Any?, Any?>()
-            for (key in artemisMessage.propertyNames) {
-                var value = artemisMessage.getObjectProperty(key)
-                if (value is SimpleString) {
-                    value = value.toString()
+            for (key in P2PMessagingHeaders.whiteListedHeaders) {
+                if (artemisMessage.containsProperty(key)) {
+                    var value = artemisMessage.getObjectProperty(key)
+                    if (value is SimpleString) {
+                        value = value.toString()
+                    }
+                    properties[key] = value
                 }
-                properties[key.toString()] = value
             }
             log.debug { "Bridged Send to ${legalNames.first()} uuid: ${artemisMessage.getObjectProperty("_AMQ_DUPL_ID")}" }
             val peerInbox = translateLocalQueueToInboxAddress(queueName)

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
@@ -12,6 +12,7 @@ import net.corda.node.services.config.configureWithDevSSLCertificate
 import net.corda.node.services.messaging.ArtemisMessagingServer
 import net.corda.nodeapi.internal.ArtemisMessagingClient
 import net.corda.nodeapi.internal.ArtemisMessagingComponent
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2PMessagingHeaders
 import net.corda.nodeapi.internal.bridging.AMQPBridgeManager
 import net.corda.nodeapi.internal.bridging.BridgeManager
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPServer
@@ -56,7 +57,7 @@ class AMQPBridgeTest {
         val artemis = artemisClient.started!!
         for (i in 0 until 3) {
             val artemisMessage = artemis.session.createMessage(true).apply {
-                putIntProperty("CountProp", i)
+                putIntProperty(P2PMessagingHeaders.senderUUID, i)
                 writeBodyBufferBytes("Test$i".toByteArray())
                 // Use the magic deduplication property built into Artemis as our message identity too
                 putStringProperty(HDR_DUPLICATE_DETECTION_ID, SimpleString(UUID.randomUUID().toString()))
@@ -80,7 +81,7 @@ class AMQPBridgeTest {
         }
 
         val received1 = receive.next()
-        val messageID1 = received1.applicationProperties["CountProp"] as Int
+        val messageID1 = received1.applicationProperties[P2PMessagingHeaders.senderUUID.toString()] as Int
         assertArrayEquals("Test$messageID1".toByteArray(), received1.payload)
         assertEquals(0, messageID1)
         dedupeSet += received1.applicationProperties[HDR_DUPLICATE_DETECTION_ID.toString()] as String
@@ -89,7 +90,7 @@ class AMQPBridgeTest {
         atNodeSequence += messageID1
 
         val received2 = receive.next()
-        val messageID2 = received2.applicationProperties["CountProp"] as Int
+        val messageID2 = received2.applicationProperties[P2PMessagingHeaders.senderUUID.toString()] as Int
         assertArrayEquals("Test$messageID2".toByteArray(), received2.payload)
         assertEquals(1, messageID2, formatMessage("1", messageID2, receivedSequence))
         received2.complete(false) // Reject message and don't add to dedupe
@@ -98,7 +99,7 @@ class AMQPBridgeTest {
         // drop things until we get back to the replay
         while (true) {
             val received3 = receive.next()
-            val messageID3 = received3.applicationProperties["CountProp"] as Int
+            val messageID3 = received3.applicationProperties[P2PMessagingHeaders.senderUUID.toString()] as Int
             assertArrayEquals("Test$messageID3".toByteArray(), received3.payload)
             receivedSequence += messageID3
             if (messageID3 != 1) { // keep rejecting any batched items following rejection
@@ -117,7 +118,7 @@ class AMQPBridgeTest {
         // start receiving again, but discarding duplicates
         while (true) {
             val received4 = receive.next()
-            val messageID4 = received4.applicationProperties["CountProp"] as Int
+            val messageID4 = received4.applicationProperties[P2PMessagingHeaders.senderUUID.toString()] as Int
             assertArrayEquals("Test$messageID4".toByteArray(), received4.payload)
             receivedSequence += messageID4
             val messageId = received4.applicationProperties[HDR_DUPLICATE_DETECTION_ID.toString()] as String
@@ -133,7 +134,7 @@ class AMQPBridgeTest {
 
         // Send a fresh item and check receive
         val artemisMessage = artemis.session.createMessage(true).apply {
-            putIntProperty("CountProp", 3)
+            putIntProperty(P2PMessagingHeaders.senderUUID, 3)
             writeBodyBufferBytes("Test3".toByteArray())
             // Use the magic deduplication property built into Artemis as our message identity too
             putStringProperty(HDR_DUPLICATE_DETECTION_ID, SimpleString(UUID.randomUUID().toString()))
@@ -144,7 +145,7 @@ class AMQPBridgeTest {
         // start receiving again, discarding duplicates
         while (true) {
             val received5 = receive.next()
-            val messageID5 = received5.applicationProperties["CountProp"] as Int
+            val messageID5 = received5.applicationProperties[P2PMessagingHeaders.senderUUID.toString()] as Int
             assertArrayEquals("Test$messageID5".toByteArray(), received5.payload)
             receivedSequence += messageID5
             val messageId = received5.applicationProperties[HDR_DUPLICATE_DETECTION_ID.toString()] as String

--- a/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/Messaging.kt
@@ -147,10 +147,3 @@ object TopicStringValidator {
     fun check(tag: String) = require(regex.matcher(tag).matches())
 }
 
-object P2PMessagingHeaders {
-
-    object Type {
-        const val KEY = "corda_p2p_message_type"
-        const val SESSION_INIT_VALUE = "session_init"
-    }
-}

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -19,12 +19,8 @@ import net.corda.core.flows.FlowInfo
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
-import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.ThreadBox
-import net.corda.core.internal.bufferUntilSubscribed
-import net.corda.core.internal.castIfPossible
+import net.corda.core.internal.*
 import net.corda.core.internal.concurrent.doneFuture
-import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.DataFeed
 import net.corda.core.serialization.SerializationDefaults.CHECKPOINT_CONTEXT
 import net.corda.core.serialization.SerializationDefaults.SERIALIZATION_FACTORY
@@ -40,10 +36,10 @@ import net.corda.node.services.api.Checkpoint
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.config.shouldCheckCheckpoints
-import net.corda.node.services.messaging.P2PMessagingHeaders
 import net.corda.node.services.messaging.ReceivedMessage
 import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.newNamedSingleThreadExecutor
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2PMessagingHeaders
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.bufferUntilDatabaseCommit
 import net.corda.nodeapi.internal.persistence.wrapWithDatabaseTransaction


### PR DESCRIPTION
Currently, we have defined in several places headers that we use in Artemis messages and we blindly copy all headers over the bridges. During review of my out of process bridge work on ENT it was pointed out that we should whitelist control these. Therefore this pushes the constants into nodeapi internal and only copies the defined headers across the AMQP bridges.