### PR TITLE
CORDA-1006: Undoing the wiring of maxMessageSize as it's not correctl…

### DIFF
--- a/docs/source/network-map.rst
+++ b/docs/source/network-map.rst
@@ -99,13 +99,20 @@ The current set of network parameters:
 
 :minimumPlatformVersion: The minimum platform version that the nodes must be running. Any node which is below this will
         not start.
+
 :notaries: List of identity and validation type (either validating or non-validating) of the notaries which are permitted
         in the compatibility zone.
-:maxMessageSize: Maximum allowed size in bytes of an individual message sent over the wire. Note that attachments are
+
+:maxMessageSize: (This is currently ignored. However, it will be wired up in a future release.)
+
+.. TODO Replace the above with this once wired: Maximum allowed size in bytes of an individual message sent over the wire. Note that attachments are
         a special case and may be fragmented for streaming transfer, however, an individual transaction or flow message
         may not be larger than this value.
+
 :maxTransactionSize: Maximum allowed size in bytes of a transaction. This is the size of the transaction object and its attachments.
+
 :modifiedTime: The time when the network parameters were last modified by the compatibility zone operator.
+
 :epoch: Version number of the network parameters. Starting from 1, this will always increment whenever any of the
         parameters change.
 :whitelistedContractImplementations: List of whitelisted versions of contract code.


### PR DESCRIPTION
…y implemented and updating the docs to clarify its status. (#2501)

The network parameter was just fed into Artemis' minLargeMessageSize property which isn't the same thing.

(cherry picked from commit 49f75da)
