### PR TITLE
Disable empty jar in top-level buildSrc project.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,3 +19,6 @@ dependencies {
         project(it.path)
     }
 }
+
+// Don't create an empty jar. The plugins are now in child projects.
+jar.enabled = false


### PR DESCRIPTION
There is no longer anything to build in the top-level project, so stop creating an empty jar.