### PR TITLE
CORDA-1171: Fix potential privacy leak in notary double spend exceptions

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1373,12 +1373,10 @@ public static final class net.corda.core.flows.NotarisationRequest$Companion ext
 @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
 ##
 @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryError$Conflict extends net.corda.core.flows.NotaryError
-  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignedData)
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignedData component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError$Conflict copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignedData)
+  @org.jetbrains.annotations.NotNull public final Map component2()
+  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError$Conflict copy(net.corda.core.crypto.SecureHash, Map)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignedData getConflict()
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getTxId()
   public int hashCode()
   @org.jetbrains.annotations.NotNull public String toString()
@@ -1429,13 +1427,13 @@ public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid$Com
   public static final net.corda.core.flows.NotaryError$WrongNotary INSTANCE
 ##
 @net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.NotaryException extends net.corda.core.flows.FlowException
-  public <init>(net.corda.core.flows.NotaryError)
+  public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash)
   @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError getError()
 ##
 public final class net.corda.core.flows.NotaryFlow extends java.lang.Object
   public <init>()
 ##
-@net.corda.core.flows.InitiatingFlow public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.flows.FlowLogic
+@net.corda.core.flows.InitiatingFlow @net.corda.core.DoNotImplement public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
   @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public List call()

--- a/core/src/main/kotlin/net/corda/core/internal/NotaryUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/NotaryUtils.kt
@@ -1,0 +1,16 @@
+package net.corda.core.internal
+
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.isFulfilledBy
+import net.corda.core.flows.NotarisationResponse
+import net.corda.core.identity.Party
+
+/**
+ * Checks that there are sufficient signatures to satisfy the notary signing requirement and validates the signatures
+ * against the given transaction id.
+ */
+fun NotarisationResponse.validateSignatures(txId: SecureHash, notary: Party) {
+    val signingKeys = signatures.map { it.by }
+    require(notary.owningKey.isFulfilledBy(signingKeys)) { "Insufficient signatures to fulfill the notary signing requirement for $notary" }
+    signatures.forEach { it.verify(txId) }
+}

--- a/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
@@ -8,7 +8,6 @@ import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.node.ServiceHub
 import net.corda.core.serialization.SingletonSerializeAsToken
-import net.corda.core.serialization.serialize
 import net.corda.core.utilities.contextLogger
 import org.slf4j.Logger
 import java.security.PublicKey
@@ -30,18 +29,19 @@ abstract class NotaryService : SingletonSerializeAsToken() {
         }
 
         /**
-         * Checks if the current instant provided by the clock falls within the specified time window.
+         * Checks if the current instant provided by the clock falls within the specified time window. Should only be
+         * used by a notary service flow.
          *
-         * @throws NotaryException if current time is outside the specified time window. The exception contains
+         * @throws NotaryInternalException if current time is outside the specified time window. The exception contains
          *                         the [NotaryError.TimeWindowInvalid] error.
          */
         @JvmStatic
-        @Throws(NotaryException::class)
+        @Throws(NotaryInternalException::class)
         fun validateTimeWindow(clock: Clock, timeWindow: TimeWindow?) {
             if (timeWindow == null) return
             val currentTime = clock.instant()
             if (currentTime !in timeWindow) {
-                throw NotaryException(
+                throw NotaryInternalException(
                         NotaryError.TimeWindowInvalid(currentTime, timeWindow)
                 )
             }
@@ -82,26 +82,22 @@ abstract class TrustedAuthorityNotaryService : NotaryService() {
     fun commitInputStates(inputs: List<StateRef>, txId: SecureHash, caller: Party) {
         try {
             uniquenessProvider.commit(inputs, txId, caller)
-        } catch (e: UniquenessException) {
-            val conflicts = inputs.filterIndexed { i, stateRef ->
-                val consumingTx = e.error.stateHistory[stateRef]
-                consumingTx != null && consumingTx != UniquenessProvider.ConsumingTx(txId, i, caller)
-            }
-            if (conflicts.isNotEmpty()) {
-                // TODO: Create a new UniquenessException that only contains the conflicts filtered above.
-                log.warn("Notary conflicts for $txId: $conflicts")
-                throw notaryException(txId, e)
-            }
+        } catch (e: NotaryInternalException) {
+            if (e.error is NotaryError.Conflict) {
+                val conflicts = inputs.filterIndexed { _, stateRef ->
+                    val cause = e.error.consumedStates[stateRef]
+                    cause != null && cause.hashOfTransactionId != txId.sha256()
+                }
+                if (conflicts.isNotEmpty()) {
+                    // TODO: Create a new UniquenessException that only contains the conflicts filtered above.
+                    log.info("Notary conflicts for $txId: $conflicts")
+                    throw e
+                }
+            } else throw e
         } catch (e: Exception) {
             log.error("Internal error", e)
-            throw NotaryException(NotaryError.General(Exception("Service unavailable, please try again later")))
+            throw NotaryInternalException(NotaryError.General(Exception("Service unavailable, please try again later")))
         }
-    }
-
-    private fun notaryException(txId: SecureHash, e: UniquenessException): NotaryException {
-        val conflictData = e.error.serialize()
-        val signedConflict = SignedData(conflictData, sign(conflictData.bytes))
-        return NotaryException(NotaryError.Conflict(txId, signedConflict))
     }
 
     /** Sign a [ByteArray] input. */
@@ -117,6 +113,8 @@ abstract class TrustedAuthorityNotaryService : NotaryService() {
 
     // TODO: Sign multiple transactions at once by building their Merkle tree and then signing over its root.
 
-    @Deprecated("This property is no longer used") @Suppress("DEPRECATION")
-    protected open val timeWindowChecker: TimeWindowChecker get() = throw UnsupportedOperationException("No default implementation, need to override")
+    @Deprecated("This property is no longer used")
+    @Suppress("DEPRECATION")
+    protected open val timeWindowChecker: TimeWindowChecker
+        get() = throw UnsupportedOperationException("No default implementation, need to override")
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/UniquenessProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/UniquenessProvider.kt
@@ -13,24 +13,22 @@ import net.corda.core.serialization.CordaSerializable
  * A uniqueness provider is expected to be used from within the context of a flow.
  */
 interface UniquenessProvider {
-    /** Commits all input states of the given transaction */
+    /** Commits all input states of the given transaction. */
     fun commit(states: List<StateRef>, txId: SecureHash, callerIdentity: Party)
 
-    /** Specifies the consuming transaction for every conflicting state */
+    /** Specifies the consuming transaction for every conflicting state. */
     @CordaSerializable
+    @Deprecated("No longer used due to potential privacy leak")
     data class Conflict(val stateHistory: Map<StateRef, ConsumingTx>)
 
     /**
      * Specifies the transaction id, the position of the consumed state in the inputs, and
      * the caller identity requesting the commit.
-     *
-     * TODO: need to do more design work to prevent privacy problems: knowing the id of a
-     *       transaction, by the rules of our system the party can obtain it and see its contents.
-     *       This allows a party to just submit invalid transactions with outputs it was aware of and
-     *       find out where exactly they were spent.
      */
     @CordaSerializable
     data class ConsumingTx(val id: SecureHash, val inputIndex: Int, val requestingParty: Party)
 }
 
+@Deprecated("No longer used due to potential privacy leak")
+@Suppress("DEPRECATION")
 class UniquenessException(val error: UniquenessProvider.Conflict) : CordaException(UniquenessException::class.java.name)

--- a/docs/source/tutorial-custom-notary.rst
+++ b/docs/source/tutorial-custom-notary.rst
@@ -3,9 +3,10 @@
 Writing a custom notary service (experimental)
 ==============================================
 
-.. warning:: Customising a notary service is still an experimental feature and not recommended for most use-cases. Currently,
-   customising Raft or BFT notaries is not yet fully supported. If you want to write your own Raft notary you will have to
-   implement a custom database connector (or use a separate database for the notary), and use a custom configuration file.
+.. warning:: Customising a notary service is still an experimental feature and not recommended for most use-cases. The APIs
+   for writing a custom notary may change in the future. Additionally, customising Raft or BFT notaries is not yet
+   fully supported. If you want to write your own Raft notary you will have to implement a custom database connector
+   (or use a separate database for the notary), and use a custom configuration file.
 
 Similarly to writing an oracle service, the first step is to create a service class in your CorDapp and annotate it
 with ``@CordaService``. The Corda node scans for any class with this annotation and initialises them. The custom notary

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.CompositeKey
+import net.corda.core.crypto.sha256
 import net.corda.core.flows.NotaryError
 import net.corda.core.flows.NotaryException
 import net.corda.core.flows.NotaryFlow
@@ -13,6 +14,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.deleteIfExists
 import net.corda.core.internal.div
+import net.corda.core.node.NotaryInfo
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.NetworkHostAndPort
@@ -25,11 +27,10 @@ import net.corda.node.services.transactions.minClusterSize
 import net.corda.node.services.transactions.minCorrectReplicas
 import net.corda.nodeapi.internal.DevIdentityGenerator
 import net.corda.nodeapi.internal.network.NetworkParametersCopier
-import net.corda.core.node.NotaryInfo
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
-import net.corda.testing.core.singleIdentity
 import net.corda.testing.core.dummyCommand
+import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNetwork.MockNode
 import net.corda.testing.node.internal.InternalMockNodeParameters
@@ -142,13 +143,12 @@ class BFTNotaryServiceTests {
             }.single()
             spendTxs.zip(results).forEach { (tx, result) ->
                 if (result is Try.Failure) {
-                    val error = (result.exception as NotaryException).error as NotaryError.Conflict
+                    val exception = result.exception as NotaryException
+                    val error = exception.error as NotaryError.Conflict
                     assertEquals(tx.id, error.txId)
-                    val (stateRef, consumingTx) = error.conflict.verified().stateHistory.entries.single()
+                    val (stateRef, cause) = error.consumedStates.entries.single()
                     assertEquals(StateRef(issueTx.id, 0), stateRef)
-                    assertEquals(spendTxs[successfulIndex].id, consumingTx.id)
-                    assertEquals(0, consumingTx.inputIndex)
-                    assertEquals(info.singleIdentity(), consumingTx.requestingParty)
+                    assertEquals(spendTxs[successfulIndex].id.sha256(), cause.hashOfTransactionId)
                 }
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
@@ -37,7 +37,7 @@ class ValidatingNotaryFlow(otherSideSession: FlowSession, service: TrustedAuthor
         } catch (e: Exception) {
             throw when (e) {
                 is TransactionVerificationException,
-                is SignatureException -> NotaryException(NotaryError.TransactionInvalid(e))
+                is SignatureException -> NotaryInternalException(NotaryError.TransactionInvalid(e))
                 else -> e
             }
         }
@@ -67,7 +67,7 @@ class ValidatingNotaryFlow(otherSideSession: FlowSession, service: TrustedAuthor
         try {
             tx.verifySignaturesExcept(service.notaryIdentityKey)
         } catch (e: SignatureException) {
-            throw NotaryException(NotaryError.TransactionInvalid(e))
+            throw NotaryInternalException(NotaryError.TransactionInvalid(e))
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt
@@ -1,8 +1,10 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.sha256
+import net.corda.core.flows.NotaryInternalException
+import net.corda.core.flows.NotaryError
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.node.services.UniquenessException
 import net.corda.node.internal.configureDatabase
 import net.corda.node.services.schema.NodeSchemaService
 import net.corda.nodeapi.internal.persistence.CordaPersistence
@@ -60,12 +62,11 @@ class PersistentUniquenessProviderTests {
             val inputs = listOf(inputState)
             provider.commit(inputs, txID, identity)
 
-            val ex = assertFailsWith<UniquenessException> { provider.commit(inputs, txID, identity) }
+            val ex = assertFailsWith<NotaryInternalException> { provider.commit(inputs, txID, identity) }
+            val error = ex.error as NotaryError.Conflict
 
-            val consumingTx = ex.error.stateHistory[inputState]!!
-            assertEquals(consumingTx.id, txID)
-            assertEquals(consumingTx.inputIndex, inputs.indexOf(inputState))
-            assertEquals(consumingTx.requestingParty, identity)
+            val conflictCause = error.consumedStates[inputState]!!
+            assertEquals(conflictCause.hashOfTransactionId, txID.sha256())
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -14,7 +14,6 @@ import net.corda.core.node.ServiceHub
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
-import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.issueInvalidState
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
@@ -80,14 +79,13 @@ class ValidatingNotaryServiceTests {
             aliceNode.services.signInitialTransaction(tx)
         }
 
-        val ex = assertFailsWith(NotaryException::class) {
+        // Expecting SignaturesMissingException instead of NotaryException, since the exception should originate from
+        // the client flow.
+        val ex = assertFailsWith<SignedTransaction.SignaturesMissingException> {
             val future = runClient(stx)
             future.getOrThrow()
         }
-        val notaryError = ex.error as NotaryError.TransactionInvalid
-        assertThat(notaryError.cause).isInstanceOf(SignedTransaction.SignaturesMissingException::class.java)
-
-        val missingKeys = (notaryError.cause as SignedTransaction.SignaturesMissingException).missing
+        val missingKeys = ex.missing
         assertEquals(setOf(expectedMissingKey), missingKeys)
     }
 

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt
@@ -4,14 +4,11 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.flows.*
-import net.corda.core.flows.NotarisationPayload
-import net.corda.core.flows.NotarisationRequest
 import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.internal.validateRequest
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.node.services.TrustedAuthorityNotaryService
-import net.corda.core.transactions.CoreTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionWithSignatures
 import net.corda.core.transactions.WireTransaction
@@ -58,7 +55,7 @@ class MyValidatingNotaryFlow(otherSide: FlowSession, service: MyCustomValidating
         } catch (e: Exception) {
             throw when (e) {
                 is TransactionVerificationException,
-                is SignatureException -> NotaryException(NotaryError.TransactionInvalid(e))
+                is SignatureException -> NotaryInternalException(NotaryError.TransactionInvalid(e))
                 else -> e
             }
         }
@@ -89,7 +86,7 @@ class MyValidatingNotaryFlow(otherSide: FlowSession, service: MyCustomValidating
         try {
             tx.verifySignaturesExcept(service.notaryIdentityKey)
         } catch (e: SignatureException) {
-            throw NotaryException(NotaryError.TransactionInvalid(e))
+            throw NotaryInternalException(NotaryError.TransactionInvalid(e))
         }
     }
 


### PR DESCRIPTION
When a double-spend occurs, do not send the consuming transaction id and requesting party back to the client - this might lead to privacy leak. Only the transaction id hash is now returned.