### PR TITLE
[DO NOT MERGE] [CORDA-1178] Api scanner backport and update of api-current.txt

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -14,8 +14,6 @@
   public void setMessage(String)
   public void setOriginalExceptionClassName(String)
 ##
-public @interface net.corda.core.CordaInternal
-##
 public final class net.corda.core.CordaOID extends java.lang.Object
   @org.jetbrains.annotations.NotNull public static final String CORDA_PLATFORM = "1.3.6.1.4.1.50530.1"
   public static final net.corda.core.CordaOID INSTANCE
@@ -209,7 +207,7 @@ public static final class net.corda.core.context.Trace$InvocationId$Companion ex
 public static final class net.corda.core.context.Trace$SessionId$Companion extends java.lang.Object
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.contracts.AlwaysAcceptAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.AlwaysAcceptAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public static final net.corda.core.contracts.AlwaysAcceptAttachmentConstraint INSTANCE
 ##
@@ -284,14 +282,14 @@ public static final class net.corda.core.contracts.AmountTransfer$Companion exte
   @org.jetbrains.annotations.NotNull public abstract java.io.InputStream open()
   @org.jetbrains.annotations.NotNull public abstract jar.JarInputStream openAsJAR()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public interface net.corda.core.contracts.AttachmentConstraint
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.AttachmentConstraint
   public abstract boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
 ##
 @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHash()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.contracts.AutomaticHashConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.AutomaticHashConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public static final net.corda.core.contracts.AutomaticHashConstraint INSTANCE
 ##
@@ -372,7 +370,7 @@ public final class net.corda.core.contracts.ContractsDSL extends java.lang.Objec
   @org.jetbrains.annotations.NotNull public abstract Collection getExitKeys()
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.FungibleAsset withNewOwnerAndAmount(net.corda.core.contracts.Amount, net.corda.core.identity.AbstractParty)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.contracts.HashAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.HashAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public <init>(net.corda.core.crypto.SecureHash)
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
   @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.HashAttachmentConstraint copy(net.corda.core.crypto.SecureHash)
@@ -642,7 +640,7 @@ public static final class net.corda.core.contracts.UniqueIdentifier$Companion ex
 @net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.UpgradedContractWithLegacyConstraint extends net.corda.core.contracts.UpgradedContract
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public static final net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint INSTANCE
 ##
@@ -701,6 +699,7 @@ public static final class net.corda.core.crypto.CompositeKey$Builder extends jav
   public <init>()
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey$Builder addKey(java.security.PublicKey, int)
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey$Builder addKeys(List)
+  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.security.PublicKey...)
   @org.jetbrains.annotations.NotNull public final java.security.PublicKey build(Integer)
 ##
 public static final class net.corda.core.crypto.CompositeKey$Companion extends java.lang.Object
@@ -771,8 +770,8 @@ public static final class net.corda.core.crypto.CompositeSignaturesWithKeys$Comp
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeSignaturesWithKeys getEMPTY()
 ##
 public final class net.corda.core.crypto.CordaObjectIdentifier extends java.lang.Object
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_KEY
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_SIGNATURE
+  @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_KEY
+  @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_SIGNATURE
   public static final net.corda.core.crypto.CordaObjectIdentifier INSTANCE
 ##
 public final class net.corda.core.crypto.CordaSecurityProvider extends java.security.Provider
@@ -818,15 +817,15 @@ public final class net.corda.core.crypto.Crypto extends java.lang.Object
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final java.security.PrivateKey toSupportedPrivateKey(java.security.PrivateKey)
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final java.security.PublicKey toSupportedPublicKey(java.security.PublicKey)
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final java.security.PublicKey toSupportedPublicKey(org.bouncycastle.asn1.x509.SubjectPublicKeyInfo)
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme DEFAULT_SIGNATURE_SCHEME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256K1_SHA256
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256R1_SHA256
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme EDDSA_ED25519_SHA512
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme DEFAULT_SIGNATURE_SCHEME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256K1_SHA256
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256R1_SHA256
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme EDDSA_ED25519_SHA512
   public static final net.corda.core.crypto.Crypto INSTANCE
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme RSA_SHA256
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.DLSequence SHA512_256
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme SPHINCS256_SHA256
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme RSA_SHA256
+  @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.DLSequence SHA512_256
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme SPHINCS256_SHA256
 ##
 public final class net.corda.core.crypto.CryptoUtils extends java.lang.Object
   @org.jetbrains.annotations.NotNull public static final Set byKeys(Iterable)
@@ -1110,6 +1109,7 @@ public static final class net.corda.core.flows.AbstractStateReplacementFlow$Upgr
 ##
 @co.paralleluniverse.fibers.Suspendable public final class net.corda.core.flows.CollectSignatureFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, List)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, java.security.PublicKey...)
   @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public List call()
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
   @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowSession getSession()
@@ -1253,7 +1253,7 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public final void checkFlowPermission(String, Map)
   @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.Nullable public final net.corda.core.flows.FlowStackSnapshot flowStackSnapshot()
   @org.jetbrains.annotations.Nullable public static final net.corda.core.flows.FlowLogic getCurrentTopLevel()
-  @kotlin.Deprecated @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInfo getFlowInfo(net.corda.core.identity.Party)
+  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInfo getFlowInfo(net.corda.core.identity.Party)
   @org.jetbrains.annotations.NotNull public final org.slf4j.Logger getLogger()
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getOurIdentity()
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.PartyAndCertificate getOurIdentityAndCert()
@@ -1262,12 +1262,12 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   @org.jetbrains.annotations.NotNull public final net.corda.core.node.ServiceHub getServiceHub()
   @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.identity.Party)
   @co.paralleluniverse.fibers.Suspendable public final void persistFlowStackSnapshot()
-  @kotlin.Deprecated @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public net.corda.core.utilities.UntrustworthyData receive(Class, net.corda.core.identity.Party)
+  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated @org.jetbrains.annotations.NotNull public net.corda.core.utilities.UntrustworthyData receive(Class, net.corda.core.identity.Party)
   @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public List receiveAll(Class, List)
   @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public Map receiveAllMap(Map)
   public final void recordAuditEvent(String, String, Map)
-  @kotlin.Deprecated @co.paralleluniverse.fibers.Suspendable public void send(net.corda.core.identity.Party, Object)
-  @kotlin.Deprecated @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public net.corda.core.utilities.UntrustworthyData sendAndReceive(Class, net.corda.core.identity.Party, Object)
+  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated public void send(net.corda.core.identity.Party, Object)
+  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated @org.jetbrains.annotations.NotNull public net.corda.core.utilities.UntrustworthyData sendAndReceive(Class, net.corda.core.identity.Party, Object)
   @co.paralleluniverse.fibers.Suspendable @kotlin.jvm.JvmStatic public static final void sleep(java.time.Duration)
   @co.paralleluniverse.fibers.Suspendable public Object subFlow(net.corda.core.flows.FlowLogic)
   @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed track()
@@ -1281,9 +1281,11 @@ public static final class net.corda.core.flows.FlowLogic$Companion extends java.
   @org.jetbrains.annotations.Nullable public final net.corda.core.flows.FlowLogic getCurrentTopLevel()
   @co.paralleluniverse.fibers.Suspendable @kotlin.jvm.JvmStatic public final void sleep(java.time.Duration)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public interface net.corda.core.flows.FlowLogicRef
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public interface net.corda.core.flows.FlowLogicRef
 ##
 @net.corda.core.DoNotImplement public interface net.corda.core.flows.FlowLogicRefFactory
+  @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowLogicRef create(Class, Object...)
+  @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowLogicRef create(String, Object...)
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowLogic toFlowLogic(net.corda.core.flows.FlowLogicRef)
 ##
 @net.corda.core.DoNotImplement public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
@@ -1412,7 +1414,7 @@ public static final class net.corda.core.flows.NotarisationRequest$Companion ext
   public int hashCode()
   @org.jetbrains.annotations.NotNull public String toString()
   public static final net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion Companion
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.flows.NotaryError$TimeWindowInvalid INSTANCE
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.flows.NotaryError$TimeWindowInvalid INSTANCE
 ##
 public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion extends java.lang.Object
 ##
@@ -1551,15 +1553,16 @@ public final class net.corda.core.flows.TransactionParts extends java.lang.Objec
   public <init>(String)
   public <init>(String, Throwable)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public abstract class net.corda.core.identity.AbstractParty extends java.lang.Object
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.identity.AbstractParty extends java.lang.Object
   public <init>(java.security.PublicKey)
   public boolean equals(Object)
   @org.jetbrains.annotations.NotNull public final java.security.PublicKey getOwningKey()
   public int hashCode()
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.CordaX500Name nameOrNull()
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PartyAndReference ref(byte...)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.identity.AnonymousParty extends net.corda.core.identity.AbstractParty
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.identity.AnonymousParty extends net.corda.core.identity.AbstractParty
   public <init>(java.security.PublicKey)
   @org.jetbrains.annotations.Nullable public net.corda.core.identity.CordaX500Name nameOrNull()
   @org.jetbrains.annotations.NotNull public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
@@ -1608,7 +1611,7 @@ public final class net.corda.core.identity.IdentityUtils extends java.lang.Objec
   @org.jetbrains.annotations.NotNull public static final Map groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, Collection)
   @org.jetbrains.annotations.NotNull public static final Map groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, Collection, boolean)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.identity.Party extends net.corda.core.identity.AbstractParty
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.identity.Party extends net.corda.core.identity.AbstractParty
   public <init>(java.security.cert.X509Certificate)
   public <init>(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.AnonymousParty anonymise()
@@ -1657,6 +1660,8 @@ public final class net.corda.core.identity.IdentityUtils extends java.lang.Objec
   @org.jetbrains.annotations.NotNull public abstract List queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
   @org.jetbrains.annotations.NotNull public abstract List registeredFlows()
   public abstract void setFlowsDrainingModeEnabled(boolean)
+  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowHandle startFlowDynamic(Class, Object...)
+  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowProgressHandle startTrackedFlowDynamic(Class, Object...)
   @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed stateMachineRecordedTransactionMappingFeed()
   @org.jetbrains.annotations.NotNull public abstract List stateMachineRecordedTransactionMappingSnapshot()
   @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed stateMachinesFeed()
@@ -1695,7 +1700,7 @@ public final class net.corda.core.messaging.CordaRPCOpsKt extends java.lang.Obje
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.StateMachineRunId getId()
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture getReturnValue()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowHandle
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowHandle
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture)
   public void close()
   @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId component1()
@@ -1713,7 +1718,7 @@ public final class net.corda.core.messaging.CordaRPCOpsKt extends java.lang.Obje
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.messaging.DataFeed getStepsTreeFeed()
   @org.jetbrains.annotations.Nullable public abstract net.corda.core.messaging.DataFeed getStepsTreeIndexFeed()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowProgressHandle
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowProgressHandle
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable)
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed)
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed, net.corda.core.messaging.DataFeed)
@@ -1888,7 +1893,9 @@ public @interface net.corda.core.messaging.RPCReturnsObservables
   @org.jetbrains.annotations.NotNull public abstract java.sql.Connection jdbcSession()
   public abstract void recordTransactions(Iterable)
   public abstract void recordTransactions(net.corda.core.node.StatesToRecord, Iterable)
+  public abstract void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public abstract void recordTransactions(boolean, Iterable)
+  public abstract void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public abstract void registerUnloadHandler(kotlin.jvm.functions.Function0)
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
   @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable)
@@ -2283,12 +2290,12 @@ public interface net.corda.core.node.services.vault.BaseQueryCriteriaParser
 public abstract class net.corda.core.node.services.vault.BaseSort extends java.lang.Object
   public <init>()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.node.services.vault.BinaryComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.BinaryComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
   protected <init>(String, int)
   public static net.corda.core.node.services.vault.BinaryComparisonOperator valueOf(String)
   public static net.corda.core.node.services.vault.BinaryComparisonOperator[] values()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.node.services.vault.BinaryLogicalOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.BinaryLogicalOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
   protected <init>(String, int)
   public static net.corda.core.node.services.vault.BinaryLogicalOperator valueOf(String)
   public static net.corda.core.node.services.vault.BinaryLogicalOperator[] values()
@@ -2360,7 +2367,7 @@ public abstract class net.corda.core.node.services.vault.BaseSort extends java.l
   @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression sum(kotlin.reflect.KProperty1, List, net.corda.core.node.services.vault.Sort$Direction)
   public static final net.corda.core.node.services.vault.Builder INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.node.services.vault.CollectionOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.CollectionOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
   protected <init>(String, int)
   public static net.corda.core.node.services.vault.CollectionOperator valueOf(String)
   public static net.corda.core.node.services.vault.CollectionOperator[] values()
@@ -2497,7 +2504,7 @@ public abstract class net.corda.core.node.services.vault.BaseSort extends java.l
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.node.services.vault.EqualityComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.EqualityComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
   protected <init>(String, int)
   public static net.corda.core.node.services.vault.EqualityComparisonOperator valueOf(String)
   public static net.corda.core.node.services.vault.EqualityComparisonOperator[] values()
@@ -2526,17 +2533,17 @@ public static interface net.corda.core.node.services.vault.GenericQueryCriteria$
   @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria)
   @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.node.services.vault.LikenessOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.LikenessOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
   protected <init>(String, int)
   public static net.corda.core.node.services.vault.LikenessOperator valueOf(String)
   public static net.corda.core.node.services.vault.LikenessOperator[] values()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.node.services.vault.NullOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.NullOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
   protected <init>(String, int)
   public static net.corda.core.node.services.vault.NullOperator valueOf(String)
   public static net.corda.core.node.services.vault.NullOperator[] values()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public interface net.corda.core.node.services.vault.Operator
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public interface net.corda.core.node.services.vault.Operator
 ##
 @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.PageSpecification extends java.lang.Object
   public <init>()
@@ -2718,9 +2725,9 @@ public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public static interface net.corda.core.node.services.vault.Sort$Attribute
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static interface net.corda.core.node.services.vault.Sort$Attribute
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public static final class net.corda.core.node.services.vault.Sort$CommonStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$CommonStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
   protected <init>(String, int, String, String)
   @org.jetbrains.annotations.Nullable public final String getAttributeChild()
   @org.jetbrains.annotations.NotNull public final String getAttributeParent()
@@ -2732,13 +2739,13 @@ public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends
   public static net.corda.core.node.services.vault.Sort$Direction valueOf(String)
   public static net.corda.core.node.services.vault.Sort$Direction[] values()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public static final class net.corda.core.node.services.vault.Sort$FungibleStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$FungibleStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
   protected <init>(String, int, String)
   @org.jetbrains.annotations.NotNull public final String getAttributeName()
   public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute valueOf(String)
   public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute[] values()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public static final class net.corda.core.node.services.vault.Sort$LinearStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$LinearStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
   protected <init>(String, int, String)
   @org.jetbrains.annotations.NotNull public final String getAttributeName()
   public static net.corda.core.node.services.vault.Sort$LinearStateAttribute valueOf(String)
@@ -2755,7 +2762,7 @@ public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public static final class net.corda.core.node.services.vault.Sort$VaultStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$VaultStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
   protected <init>(String, int, String)
   @org.jetbrains.annotations.NotNull public final String getAttributeName()
   public static net.corda.core.node.services.vault.Sort$VaultStateAttribute valueOf(String)
@@ -2993,7 +3000,7 @@ public static final class net.corda.core.serialization.SingletonSerializationTok
   @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getId()
   @org.jetbrains.annotations.NotNull public final String getReason()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.transactions.ContractUpgradeFilteredTransaction extends net.corda.core.transactions.CoreTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.ContractUpgradeFilteredTransaction extends net.corda.core.transactions.CoreTransaction
   public <init>(List, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash)
   @org.jetbrains.annotations.NotNull public final List component1()
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component2()
@@ -3037,8 +3044,9 @@ public static final class net.corda.core.serialization.SingletonSerializationTok
   public String toString()
   public void verifyRequiredSignatures()
   public void verifySignaturesExcept(Collection)
+  public void verifySignaturesExcept(java.security.PublicKey...)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.transactions.ContractUpgradeWireTransaction extends net.corda.core.transactions.CoreTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.ContractUpgradeWireTransaction extends net.corda.core.transactions.CoreTransaction
   public <init>(List, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, String, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeFilteredTransaction buildFilteredTransaction()
   @org.jetbrains.annotations.NotNull public final List component1()
@@ -3061,7 +3069,7 @@ public static final class net.corda.core.serialization.SingletonSerializationTok
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, List)
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public abstract class net.corda.core.transactions.CoreTransaction extends net.corda.core.transactions.BaseTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.transactions.CoreTransaction extends net.corda.core.transactions.BaseTransaction
   public <init>()
   @org.jetbrains.annotations.NotNull public abstract List getInputs()
 ##
@@ -3080,7 +3088,7 @@ public static final class net.corda.core.serialization.SingletonSerializationTok
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.transactions.FilteredTransaction extends net.corda.core.transactions.TraversableTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.FilteredTransaction extends net.corda.core.transactions.TraversableTransaction
   public <init>(net.corda.core.crypto.SecureHash, List, List)
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, function.Predicate)
   public final void checkAllComponentsVisible(net.corda.core.contracts.ComponentGroupEnum)
@@ -3105,7 +3113,7 @@ public static final class net.corda.core.transactions.FilteredTransaction$Compan
   protected void checkBaseInvariants()
   @org.jetbrains.annotations.NotNull public abstract List getInputs()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
   public <init>(List, List, List, List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
   public <init>(List, List, List, List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
   @org.jetbrains.annotations.NotNull public final List commandsOfType(Class)
@@ -3188,8 +3196,9 @@ public static final class net.corda.core.transactions.LedgerTransaction$InOutGro
   public String toString()
   public void verifyRequiredSignatures()
   public void verifySignaturesExcept(Collection)
+  public void verifySignaturesExcept(java.security.PublicKey...)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.transactions.NotaryChangeWireTransaction extends net.corda.core.transactions.CoreTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.NotaryChangeWireTransaction extends net.corda.core.transactions.CoreTransaction
   public <init>(List, net.corda.core.identity.Party, net.corda.core.identity.Party)
   @org.jetbrains.annotations.NotNull public final List component1()
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component2()
@@ -3206,7 +3215,7 @@ public static final class net.corda.core.transactions.LedgerTransaction$InOutGro
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, List)
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.transactions.SignedTransaction extends java.lang.Object implements net.corda.core.transactions.TransactionWithSignatures
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.SignedTransaction extends java.lang.Object implements net.corda.core.transactions.TransactionWithSignatures
   public <init>(net.corda.core.serialization.SerializedBytes, List)
   public <init>(net.corda.core.transactions.CoreTransaction, List)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(function.Predicate)
@@ -3242,6 +3251,7 @@ public static final class net.corda.core.transactions.LedgerTransaction$InOutGro
   public final void verify(net.corda.core.node.ServiceHub, boolean)
   public void verifyRequiredSignatures()
   public void verifySignaturesExcept(Collection)
+  public void verifySignaturesExcept(java.security.PublicKey...)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(java.security.KeyPair, net.corda.core.crypto.SignatureMetadata)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(net.corda.core.crypto.TransactionSignature)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable)
@@ -3266,6 +3276,7 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addAttachment(net.corda.core.crypto.SecureHash)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.Command)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, List)
+  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.security.PublicKey...)
   @org.jetbrains.annotations.NotNull public net.corda.core.transactions.TransactionBuilder addInputState(net.corda.core.contracts.StateAndRef)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.contracts.AttachmentConstraint)
@@ -3297,6 +3308,7 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction toSignedTransaction(net.corda.core.node.services.KeyManagementService, java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.node.ServicesForResolution)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction toWireTransaction(net.corda.core.node.ServicesForResolution)
   public final void verify(net.corda.core.node.ServiceHub)
+  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder withItems(Object...)
 ##
 @net.corda.core.DoNotImplement public interface net.corda.core.transactions.TransactionWithSignatures extends net.corda.core.contracts.NamedByHash
   public abstract void checkSignaturesAreValid()
@@ -3306,8 +3318,9 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   @org.jetbrains.annotations.NotNull public abstract List getSigs()
   public abstract void verifyRequiredSignatures()
   public abstract void verifySignaturesExcept(Collection)
+  public abstract void verifySignaturesExcept(java.security.PublicKey...)
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public abstract class net.corda.core.transactions.TraversableTransaction extends net.corda.core.transactions.CoreTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.transactions.TraversableTransaction extends net.corda.core.transactions.CoreTransaction
   public <init>(List)
   @org.jetbrains.annotations.NotNull public final List getAttachments()
   @org.jetbrains.annotations.NotNull public final List getAvailableComponentGroups()
@@ -3318,7 +3331,7 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   @org.jetbrains.annotations.NotNull public List getOutputs()
   @org.jetbrains.annotations.Nullable public final net.corda.core.contracts.TimeWindow getTimeWindow()
 ##
-@net.corda.core.serialization.CordaSerializable @net.corda.core.DoNotImplement public final class net.corda.core.transactions.WireTransaction extends net.corda.core.transactions.TraversableTransaction
+@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.WireTransaction extends net.corda.core.transactions.TraversableTransaction
   @kotlin.Deprecated public <init>(List, List, List, List, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
   public <init>(List, net.corda.core.contracts.PrivacySalt)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(function.Predicate)
@@ -3448,6 +3461,7 @@ public final class net.corda.core.utilities.NonEmptySet extends java.lang.Object
   public boolean isEmpty()
   @org.jetbrains.annotations.NotNull public Iterator iterator()
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NonEmptySet of(Object)
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NonEmptySet of(Object, Object, Object...)
   @org.jetbrains.annotations.NotNull public stream.Stream parallelStream()
   public boolean remove(Object)
   public boolean removeAll(Collection)
@@ -3462,6 +3476,7 @@ public final class net.corda.core.utilities.NonEmptySet extends java.lang.Object
 public static final class net.corda.core.utilities.NonEmptySet$Companion extends java.lang.Object
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NonEmptySet copyOf(Collection)
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NonEmptySet of(Object)
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NonEmptySet of(Object, Object, Object...)
 ##
 public static final class net.corda.core.utilities.NonEmptySet$iterator$1 extends java.lang.Object implements java.util.Iterator, kotlin.jvm.internal.markers.KMappedMarker
   public boolean hasNext()
@@ -3473,9 +3488,11 @@ public static final class net.corda.core.utilities.NonEmptySet$iterator$1 extend
   @org.jetbrains.annotations.NotNull public final byte[] getBytes()
   public int getOffset()
   public int getSize()
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.OpaqueBytes of(byte...)
   public static final net.corda.core.utilities.OpaqueBytes$Companion Companion
 ##
 public static final class net.corda.core.utilities.OpaqueBytes$Companion extends java.lang.Object
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.OpaqueBytes of(byte...)
 ##
 @net.corda.core.serialization.CordaSerializable public final class net.corda.core.utilities.OpaqueBytesSubSequence extends net.corda.core.utilities.ByteSequence
   public <init>(byte[], int, int)
@@ -3484,6 +3501,7 @@ public static final class net.corda.core.utilities.OpaqueBytes$Companion extends
   public int getSize()
 ##
 @net.corda.core.serialization.CordaSerializable public final class net.corda.core.utilities.ProgressTracker extends java.lang.Object
+  public <init>(net.corda.core.utilities.ProgressTracker$Step...)
   public final void endWithError(Throwable)
   @org.jetbrains.annotations.NotNull public final List getAllSteps()
   @org.jetbrains.annotations.NotNull public final List getAllStepsLabels()
@@ -4103,9 +4121,17 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public <init>()
   public <init>(List)
   public <init>(List, net.corda.core.identity.CordaX500Name)
+  public <init>(List, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
   public <init>(List, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(List, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(List, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  public <init>(List, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
+  public <init>(List, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
   public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
   public final void addMockCordapp(String)
   @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
   @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
@@ -4131,9 +4157,13 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @org.jetbrains.annotations.NotNull public net.corda.core.contracts.TransactionState loadState(net.corda.core.contracts.StateRef)
   @org.jetbrains.annotations.NotNull public Set loadStates(Set)
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final Properties makeTestDataSourceProperties(String)
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
   public void recordTransactions(Iterable)
   public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable)
+  public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public void recordTransactions(boolean, Iterable)
+  public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   @org.jetbrains.annotations.NotNull public Void registerUnloadHandler(kotlin.jvm.functions.Function0)
   @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
   @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable)
@@ -4143,6 +4173,8 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
 ##
 public static final class net.corda.testing.node.MockServices$Companion extends java.lang.Object
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final Properties makeTestDataSourceProperties(String)
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
 ##
 public static final class net.corda.testing.node.MockServices$Companion$makeTestDatabaseAndMockServices$mockService$1$1 extends net.corda.testing.node.MockServices
   @org.jetbrains.annotations.NotNull public net.corda.core.node.services.VaultService getVaultService()
@@ -4151,6 +4183,7 @@ public static final class net.corda.testing.node.MockServices$Companion$makeTest
 ##
 public final class net.corda.testing.node.MockServicesKt extends java.lang.Object
   @org.jetbrains.annotations.NotNull public static final net.corda.core.serialization.SerializeAsToken createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1)
+  @org.jetbrains.annotations.NotNull public static final net.corda.node.services.identity.InMemoryIdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
 ##
 public static final class net.corda.testing.node.MockServicesKt$createMockCordaService$MockAppServiceHubImpl extends java.lang.Object implements net.corda.core.node.AppServiceHub, net.corda.core.node.ServiceHub
   public <init>(net.corda.testing.node.MockServices, net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1)
@@ -4180,7 +4213,9 @@ public static final class net.corda.testing.node.MockServicesKt$createMockCordaS
   @org.jetbrains.annotations.NotNull public Set loadStates(Set)
   public void recordTransactions(Iterable)
   public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable)
+  public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public void recordTransactions(boolean, Iterable)
+  public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
   public void registerUnloadHandler(kotlin.jvm.functions.Function0)
   @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
   @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable)
@@ -4272,7 +4307,7 @@ public final class net.corda.client.rpc.CordaRPCClientConfiguration extends java
   public int hashCode()
   public String toString()
   public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
+  @org.jetbrains.annotations.NotNull public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
 ##
 public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
 ##
@@ -4309,6 +4344,7 @@ public final class net.corda.testing.contracts.DummyContract extends java.lang.O
   @org.jetbrains.annotations.Nullable public final Object component1()
   @org.jetbrains.annotations.NotNull public final net.corda.testing.contracts.DummyContract copy(Object)
   public boolean equals(Object)
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public static final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
   @org.jetbrains.annotations.Nullable public final Object getBlank()
   @org.jetbrains.annotations.NotNull public final String getPROGRAM_ID()
   public int hashCode()
@@ -4328,6 +4364,7 @@ public static final class net.corda.testing.contracts.DummyContract$Commands$Mov
   public <init>()
 ##
 public static final class net.corda.testing.contracts.DummyContract$Companion extends java.lang.Object
+  @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder move(List, net.corda.core.identity.AbstractParty)
   @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef, net.corda.core.identity.AbstractParty)
 ##
@@ -4466,8 +4503,10 @@ public final class net.corda.testing.core.ExpectKt extends java.lang.Object
   public static final void expectEvents(rx.Observable, boolean, kotlin.jvm.functions.Function0)
   public static final void genericExpectEvents(Object, boolean, kotlin.jvm.functions.Function2, kotlin.jvm.functions.Function0)
   @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose parallel(List)
+  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose parallel(net.corda.testing.core.ExpectCompose...)
   @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose replicate(int, kotlin.jvm.functions.Function1)
   @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose sequence(List)
+  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose sequence(net.corda.testing.core.ExpectCompose...)
 ##
 public static final class net.corda.testing.core.ExpectKt$expectEvents$1$lock$1 extends java.lang.Object
 ##
@@ -4486,14 +4525,15 @@ public static final class net.corda.testing.core.SerializationEnvironmentRule$ap
   public void evaluate()
 ##
 public final class net.corda.testing.core.TestConstants extends java.lang.Object
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name ALICE_NAME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name BOB_NAME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name BOC_NAME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
-  @kotlin.jvm.JvmField @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Command dummyCommand(java.security.PublicKey...)
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name ALICE_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name BOB_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name BOC_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
+  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
   public static final int MAX_MESSAGE_SIZE = 10485760
 ##
 public final class net.corda.testing.core.TestIdentity extends java.lang.Object
@@ -4505,6 +4545,7 @@ public final class net.corda.testing.core.TestIdentity extends java.lang.Object
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getName()
   @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getParty()
   @org.jetbrains.annotations.NotNull public final java.security.PublicKey getPublicKey()
+  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PartyAndReference ref(byte...)
   public static final net.corda.testing.core.TestIdentity$Companion Companion
 ##
 public static final class net.corda.testing.core.TestIdentity$Companion extends java.lang.Object
@@ -4647,6 +4688,7 @@ public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object
   @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1)
   public final void attachment(String)
   public void attachment(net.corda.core.crypto.SecureHash)
+  public final void attachments(String...)
   public final void command(java.security.PublicKey, net.corda.core.contracts.CommandData)
   public void command(List, net.corda.core.contracts.CommandData)
   @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails()

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=3.0.9
+gradlePluginsVersion=3.1.0
 kotlinVersion=1.1.60
 platformVersion=3
 guavaVersion=21.0

--- a/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
+++ b/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
@@ -7,6 +7,8 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.jvm.tasks.Jar;
 
+import javax.annotation.Nonnull;
+
 public class ApiScanner implements Plugin<Project> {
 
     /**
@@ -16,7 +18,7 @@ public class ApiScanner implements Plugin<Project> {
      * @param p Current project.
      */
     @Override
-    public void apply(Project p) {
+    public void apply(@Nonnull Project p) {
         p.getLogger().info("Applying API scanner to {}", p.getName());
 
         ScannerExtension extension = p.getExtensions().create("scanApi", ScannerExtension.class);

--- a/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/gradle-plugins/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -1,18 +1,12 @@
 package net.corda.plugins;
 
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
-import io.github.lukehutch.fastclasspathscanner.scanner.ClassInfo;
-import io.github.lukehutch.fastclasspathscanner.scanner.FieldInfo;
-import io.github.lukehutch.fastclasspathscanner.scanner.MethodInfo;
-import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
+import io.github.lukehutch.fastclasspathscanner.scanner.*;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.tasks.CompileClasspath;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.OutputFiles;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.Console;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
@@ -33,14 +27,24 @@ import static java.util.stream.Collectors.*;
 public class ScanApi extends DefaultTask {
     private static final int CLASS_MASK = Modifier.classModifiers();
     private static final int INTERFACE_MASK = Modifier.interfaceModifiers() & ~Modifier.ABSTRACT;
-    private static final int METHOD_MASK = Modifier.methodModifiers();
+    /**
+     * The VARARG modifier for methods has the same value as the TRANSIENT modifier for fields.
+     * Unfortunately, {@link Modifier#methodModifiers() methodModifiers} doesn't include this
+     * flag, and so we need to add it back ourselves.
+     * @link https://docs.oracle.com/javase/specs/jls/se8/html/index.html
+     */
+    private static final int METHOD_MASK = Modifier.methodModifiers() | Modifier.TRANSIENT;
     private static final int FIELD_MASK = Modifier.fieldModifiers();
     private static final int VISIBILITY_MASK = Modifier.PUBLIC | Modifier.PROTECTED;
 
+    private static final String INTERNAL_ANNOTATION_NAME = ".CordaInternal";
+    private static final String DEFAULT_INTERNAL_ANNOTATION = "net.corda.core" + INTERNAL_ANNOTATION_NAME;
     private static final Set<String> ANNOTATION_BLACKLIST;
     static {
        Set<String> blacklist = new LinkedHashSet<>();
+       blacklist.add("kotlin.jvm.JvmField");
        blacklist.add("kotlin.jvm.JvmOverloads");
+       blacklist.add(DEFAULT_INTERNAL_ANNOTATION);
        ANNOTATION_BLACKLIST = unmodifiableSet(blacklist);
     }
 
@@ -65,6 +69,7 @@ public class ScanApi extends DefaultTask {
         outputDir = new File(getProject().getBuildDir(), "api");
     }
 
+    @SkipWhenEmpty
     @InputFiles
     public FileCollection getSources() {
         return sources;
@@ -103,6 +108,7 @@ public class ScanApi extends DefaultTask {
         );
     }
 
+    @Console
     public boolean isVerbose() {
         return verbose;
     }
@@ -112,7 +118,7 @@ public class ScanApi extends DefaultTask {
     }
 
     private File toTarget(File source) {
-        return new File(outputDir, source.getName().replaceAll(".jar$", ".txt"));
+        return new File(outputDir, source.getName().replaceAll("\\.jar$", ".txt"));
     }
 
     @TaskAction
@@ -130,10 +136,13 @@ public class ScanApi extends DefaultTask {
         private final URLClassLoader classpathLoader;
         private final Class<? extends Annotation> metadataClass;
         private final Method classTypeMethod;
+        private Collection<String> internalAnnotations;
+        private Collection<String> invisibleAnnotations;
 
         @SuppressWarnings("unchecked")
         Scanner(URLClassLoader classpathLoader) {
             this.classpathLoader = classpathLoader;
+            this.invisibleAnnotations = ANNOTATION_BLACKLIST;
 
             Class<? extends Annotation> kClass;
             Method kMethod;
@@ -160,6 +169,7 @@ public class ScanApi extends DefaultTask {
 
         void scan(File source) {
             File target = toTarget(source);
+            getLogger().info("API file: {}", target.getAbsolutePath());
             try (
                 URLClassLoader appLoader = new URLClassLoader(new URL[]{ toURL(source) }, classpathLoader);
                 PrintWriter writer = new PrintWriter(target, "UTF-8")
@@ -180,6 +190,7 @@ public class ScanApi extends DefaultTask {
                 .enableFieldInfo()
                 .verbose(verbose)
                 .scan();
+            loadAnnotationCaches(result);
             writeApis(writer, result);
         }
 
@@ -193,6 +204,21 @@ public class ScanApi extends DefaultTask {
                 spec[i++] = '-' + excludeClass;
             }
             return spec;
+        }
+
+        private void loadAnnotationCaches(ScanResult result) {
+            Set<String> internal = result.getNamesOfAllAnnotationClasses().stream()
+                .filter(s -> s.endsWith(INTERNAL_ANNOTATION_NAME))
+                .collect(toCollection(LinkedHashSet::new));
+            internal.add(DEFAULT_INTERNAL_ANNOTATION);
+            internalAnnotations = unmodifiableSet(internal);
+
+            Set<String> invisible = internalAnnotations.stream()
+                .flatMap(a -> result.getNamesOfAnnotationsWithMetaAnnotation(a).stream())
+                .collect(toCollection(LinkedHashSet::new));
+            invisible.addAll(ANNOTATION_BLACKLIST);
+            invisible.addAll(internal);
+            invisibleAnnotations = unmodifiableSet(invisible);
         }
 
         private void writeApis(PrintWriter writer, ScanResult result) {
@@ -213,6 +239,12 @@ public class ScanApi extends DefaultTask {
                 ClassInfo classInfo = allInfo.get(className);
                 if (classInfo.getClassLoaders() == null) {
                     // Ignore classes that belong to one of our target ClassLoader's parents.
+                    return;
+                }
+
+                if (classInfo.isAnnotation() && !isVisibleAnnotation(className)) {
+                    // Exclude these annotations from the output,
+                    // e.g. because they're internal to Kotlin or Corda.
                     return;
                 }
 
@@ -246,9 +278,9 @@ public class ScanApi extends DefaultTask {
                 /*
                  * Class declaration.
                  */
-                List<String> annotationNames = toNames(readClassAnnotationsFor(classInfo));
-                if (!annotationNames.isEmpty()) {
-                    writer.append(asAnnotations(annotationNames));
+                Names annotationNames = toNames(readClassAnnotationsFor(classInfo));
+                if (!annotationNames.visible.isEmpty()) {
+                    writer.append(asAnnotations(annotationNames.visible));
                 }
                 writer.append(Modifier.toString(modifiers & CLASS_MASK));
                 writer.append(" class ").print(classInfo);
@@ -264,9 +296,9 @@ public class ScanApi extends DefaultTask {
                 /*
                  * Interface declaration.
                  */
-                List<String> annotationNames = toNames(readInterfaceAnnotationsFor(classInfo));
-                if (!annotationNames.isEmpty()) {
-                    writer.append(asAnnotations(annotationNames));
+                Names annotationNames = toNames(readInterfaceAnnotationsFor(classInfo));
+                if (!annotationNames.visible.isEmpty()) {
+                    writer.append(asAnnotations(annotationNames.visible));
                 }
                 writer.append(Modifier.toString(modifiers & INTERFACE_MASK));
                 writer.append(" interface ").print(classInfo);
@@ -283,7 +315,7 @@ public class ScanApi extends DefaultTask {
             for (MethodInfo method : methods) {
                 if (isVisible(method.getAccessFlags()) // Only public and protected methods
                         && isValid(method.getAccessFlags(), METHOD_MASK) // Excludes bridge and synthetic methods
-                        && !hasCordaInternal(method.getAnnotationNames()) // Excludes methods annotated as @CordaInternal
+                        && !hasInternalAnnotation(method.getAnnotationNames()) // Excludes methods annotated as @CordaInternal
                         && !isKotlinInternalScope(method)) {
                     writer.append("  ").println(filterAnnotationsFor(method));
                 }
@@ -293,8 +325,10 @@ public class ScanApi extends DefaultTask {
         private void writeFields(PrintWriter output, List<FieldInfo> fields) {
             sort(fields);
             for (FieldInfo field : fields) {
-                if (isVisible(field.getAccessFlags()) && isValid(field.getAccessFlags(), FIELD_MASK)) {
-                    output.append("  ").println(field);
+                if (isVisible(field.getAccessFlags())
+                        && isValid(field.getAccessFlags(), FIELD_MASK)
+                        && !hasInternalAnnotation(field.getAnnotationNames())) {
+                    output.append("  ").println(filterAnnotationsFor(field));
                 }
             }
         }
@@ -313,11 +347,12 @@ public class ScanApi extends DefaultTask {
             return 0;
         }
 
-        private List<String> toNames(Collection<ClassInfo> classes) {
-            return classes.stream()
+        private Names toNames(Collection<ClassInfo> classes) {
+            Map<Boolean, List<String>> partitioned = classes.stream()
                 .map(ClassInfo::toString)
                 .filter(ScanApi::isApplicationClass)
-                .collect(toList());
+                .collect(partitioningBy(this::isVisibleAnnotation, toCollection(ArrayList::new)));
+            return new Names(ordering(partitioned.get(true)), ordering(partitioned.get(false)));
         }
 
         private Set<ClassInfo> readClassAnnotationsFor(ClassInfo classInfo) {
@@ -350,22 +385,42 @@ public class ScanApi extends DefaultTask {
                 method.getAccessFlags(),
                 method.getTypeDescriptor(),
                 method.getAnnotationNames().stream()
-                    .filter(ScanApi::isVisibleAnnotation)
+                    .filter(this::isVisibleAnnotation)
+                    .sorted()
                     .collect(toList())
             );
         }
+
+        private FieldInfo filterAnnotationsFor(FieldInfo field) {
+            return new FieldInfo(
+                field.getClassName(),
+                field.getFieldName(),
+                field.getAccessFlags(),
+                field.getTypeDescriptor(),
+                field.getConstFinalValue(),
+                field.getAnnotationNames().stream()
+                    .filter(this::isVisibleAnnotation)
+                    .sorted()
+                    .collect(toList())
+            );
+        }
+
+        private boolean isVisibleAnnotation(String annotationName) {
+            return !invisibleAnnotations.contains(annotationName);
+        }
+
+        private boolean hasInternalAnnotation(Collection<String> annotationNames) {
+            return annotationNames.stream().anyMatch(internalAnnotations::contains);
+        }
     }
 
-    private static boolean isVisibleAnnotation(String annotationName) {
-        return !ANNOTATION_BLACKLIST.contains(annotationName);
+    private static <T extends Comparable<? super T>> List<T> ordering(List<T> list) {
+        sort(list);
+        return list;
     }
 
     private static boolean isKotlinInternalScope(MethodInfo method) {
         return method.getMethodName().indexOf('$') >= 0;
-    }
-
-    private static boolean hasCordaInternal(Collection<String> annotationNames) {
-        return annotationNames.contains("net.corda.core.CordaInternal");
     }
 
     private static boolean isValid(int modifiers, int mask) {
@@ -398,5 +453,19 @@ public class ScanApi extends DefaultTask {
             urls.add(toURL(file));
         }
         return urls.toArray(new URL[urls.size()]);
+    }
+}
+
+class Names {
+    List<String> visible;
+    @SuppressWarnings("WeakerAccess") List<String> hidden;
+
+    Names(List<String> visible, List<String> hidden) {
+        this.visible = unmodifiable(visible);
+        this.hidden = unmodifiable(hidden);
+    }
+
+    private static <T> List<T> unmodifiable(List<T> list) {
+        return list.isEmpty() ? emptyList() : unmodifiableList(new ArrayList<>(list));
     }
 }

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class AnnotatedClassTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("annotated-class/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testAnnotatedClass() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-class.txt");
+        assertThat(api.toFile()).isFile();
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object",
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
+        );
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import static org.junit.Assert.*;
+
+public class AnnotatedFieldTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("annotated-field/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testAnnotatedField() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-field.txt");
+        assertThat(api.toFile()).isFile();
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "public class net.corda.example.HasAnnotatedField extends java.lang.Object",
+            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public static final String ANNOTATED_FIELD = \"<string-value>\""
+        );
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class AnnotatedInterfaceTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("annotated-interface/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testAnnotatedInterface() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
+        assertThat(api.toFile()).isFile();
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public interface net.corda.example.HasInheritedAnnotation",
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
+        );
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class AnnotatedMethodTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("annotated-method/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testAnnotatedMethod() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-method.txt");
+        assertThat(api.toFile()).isFile();
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object",
+            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()"
+        );
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
@@ -1,0 +1,50 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class BasicAnnotationTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("basic-annotation/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testBasicAnnotation() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "basic-annotation.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public @interface net.corda.example.BasicAnnotation\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class BasicClassTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("basic-class/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testBasicClass() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "basic-class.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public class net.corda.example.BasicClass extends java.lang.Object\n" +
+            "  public <init>(String)\n" +
+            "  public String getName()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
@@ -1,0 +1,51 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class BasicInterfaceTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("basic-interface/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testBasicInterface() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "basic-interface.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public interface net.corda.example.BasicInterface\n" +
+            "  public abstract java.math.BigInteger getBigNumber()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class ClassWithInternalAnnotationTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("class-internal-annotation/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testClassWithInternalAnnotation() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        assertThat(output).contains("net.corda.example.InvisibleAnnotation");
+
+        Path api = pathOf(testProjectDir, "build", "api", "class-internal-annotation.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public class net.corda.example.AnnotatedClass extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
@@ -1,0 +1,49 @@
+package net.corda.plugins;
+
+import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardCopyOption.*;
+
+public final class CopyUtils {
+    private static final String testGradleUserHome = System.getProperty("test.gradle.user.home", "");
+
+    private CopyUtils() {
+    }
+
+    public static long copyResourceTo(String resourceName, Path target) throws IOException {
+        try (InputStream input = CopyUtils.class.getClassLoader().getResourceAsStream(resourceName)) {
+            return Files.copy(input, target, REPLACE_EXISTING);
+        }
+    }
+
+    public static long copyResourceTo(String resourceName, File target) throws IOException {
+        return copyResourceTo(resourceName, target.toPath());
+    }
+
+    public static String toString(Path file) throws IOException {
+        return new String(Files.readAllBytes(file), UTF_8);
+    }
+
+    public static Path pathOf(TemporaryFolder folder, String... elements) {
+        return Paths.get(folder.getRoot().getAbsolutePath(), elements);
+    }
+
+    public static List<String> getGradleArgsForTasks(String... taskNames) {
+        List<String> args = new ArrayList<>(taskNames.length + 3);
+        Collections.addAll(args, taskNames);
+        args.add("--info");
+        if (!testGradleUserHome.isEmpty()) {
+            Collections.addAll(args,"-g", testGradleUserHome);
+        }
+        return args;
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
@@ -1,0 +1,51 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class ExtendedClassTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("extended-class/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testExtendedClass() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "extended-class.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public class net.corda.example.ExtendedClass extends java.io.FilterInputStream\n" +
+            "  public <init>(java.io.InputStream)\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class ExtendedInterfaceTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("extended-interface/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testExtendedInterface() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "extended-interface.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public interface net.corda.example.ExtendedInterface extends java.util.concurrent.Future\n" +
+            "  public abstract String getName()\n" +
+            "  public abstract void setName(String)\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
@@ -1,0 +1,55 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import static org.junit.Assert.*;
+
+public class FieldWithInternalAnnotationTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("field-internal-annotation/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testFieldWithInternalAnnotations() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        assertThat(output)
+            .contains("net.corda.example.field.InvisibleAnnotation")
+            .contains("net.corda.example.field.LocalInvisibleAnnotation");
+
+        Path api = pathOf(testProjectDir, "build", "api", "field-internal-annotation.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public class net.corda.example.field.HasVisibleField extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  public String hasInvisibleAnnotations\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
@@ -1,0 +1,52 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class InternalAnnotationTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("internal-annotation/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testInternalAnnotations() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        assertThat(output)
+            .contains("net.corda.core.CordaInternal")
+            .contains("net.corda.example.CordaInternal");
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "internal-annotation.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
@@ -1,0 +1,51 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import static org.junit.Assert.*;
+
+public class InternalFieldTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("internal-field/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testInternalField() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "internal-field.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public class net.corda.example.WithInternalField extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
@@ -1,0 +1,50 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class InternalMethodTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("internal-method/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testInternalMethod() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "internal-method.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public class net.corda.example.WithInternalMethod extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
@@ -1,0 +1,53 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class InternalPackageTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("internal-package/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testInternalPackageIsIgnored() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        assertThat(output).contains("net.corda.internal.InvisibleClass");
+
+        Path api = pathOf(testProjectDir, "build", "api", "internal-package.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+    "public class net.corda.VisibleClass extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -1,0 +1,69 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class KotlinAnnotationsTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("kotlin-annotations/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testKotlinAnnotations() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public final class net.corda.example.HasJvmField extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  @org.jetbrains.annotations.NotNull public final String stringValue = \"Hello World\"\n" +
+            "##\n" +
+            "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  @kotlin.jvm.JvmStatic public static final void doThing(String)\n" +
+            "  public static final net.corda.example.HasJvmStaticFunction$Companion Companion\n" +
+            "##\n" +
+            "public static final class net.corda.example.HasJvmStaticFunction$Companion extends java.lang.Object\n" +
+            "  @kotlin.jvm.JvmStatic public final void doThing(String)\n" +
+            "##\n" +
+            "public final class net.corda.example.HasOverloadedConstructor extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  public <init>(String)\n" +
+            "  public <init>(String, String)\n" +
+            "  public <init>(String, String, int)\n" +
+            "  @org.jetbrains.annotations.NotNull public final String getNotNullable()\n" +
+            "  @org.jetbrains.annotations.Nullable public final String getNullable()\n" +
+            "  public final int getNumber()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -1,0 +1,53 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.Assert.*;
+
+public class KotlinInternalAnnotationTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("kotlin-internal-annotation/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testKotlinInternalAnnotation() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        assertThat(output).contains("net.corda.example.kotlin.CordaInternal");
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals(
+            "public final class net.corda.example.kotlin.AnnotatedClass extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
@@ -1,0 +1,53 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class KotlinLambdasTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("kotlin-lambdas/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testKotlinLambdas() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        assertThat(output).contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1");
+
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-lambdas.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public final class net.corda.example.LambdaExpressions extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  public final void testing(kotlin.Unit)\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
@@ -1,0 +1,48 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.Assert.*;
+
+public class KotlinVarargMethodTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("kotlin-vararg-method/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testKotlinVarargMethod() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-vararg-method.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public interface net.corda.example.KotlinVarargMethod\n" +
+            "  public abstract void action(Object...)\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
@@ -1,0 +1,55 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class MethodWithInternalAnnotationTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("method-internal-annotation/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testMethodWithInternalAnnotations() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        assertThat(output)
+            .contains("net.corda.example.method.InvisibleAnnotation")
+            .contains("net.corda.example.method.LocalInvisibleAnnotation");
+
+        Path api = pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public class net.corda.example.method.HasVisibleMethod extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  public void hasInvisibleAnnotations()\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
+++ b/gradle-plugins/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
@@ -1,0 +1,48 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.Assert.*;
+
+public class VarargMethodTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("vararg-method/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testVarargMethod() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArgsForTasks("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "vararg-method.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public interface net.corda.example.VarargMethod\n" +
+            "  public abstract void action(Object...)\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-class/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-class/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test annotation inheritance across classes'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/annotated-class/java")
+        }
+    }
+}
+
+jar {
+    baseName = "annotated-class"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/AlsoInherited.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/AlsoInherited.java
@@ -1,0 +1,14 @@
+package net.corda.example;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@Inherited
+public @interface AlsoInherited {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/HasInheritedAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/HasInheritedAnnotation.java
@@ -1,0 +1,7 @@
+package net.corda.example;
+
+@NotInherited
+@IsInherited
+@AlsoInherited
+public class HasInheritedAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/InheritingAnnotations.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/InheritingAnnotations.java
@@ -1,0 +1,4 @@
+package net.corda.example;
+
+public class InheritingAnnotations extends HasInheritedAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/IsInherited.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/IsInherited.java
@@ -1,0 +1,14 @@
+package net.corda.example;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@Inherited
+public @interface IsInherited {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/NotInherited.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-class/java/net/corda/example/NotInherited.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface NotInherited {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-field/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-field/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test annotation behaviour for a field'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/annotated-field/java",
+                "../resources/test/common-annotations/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "annotated-field"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-field/java/net/corda/example/HasAnnotatedField.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-field/java/net/corda/example/HasAnnotatedField.java
@@ -1,0 +1,6 @@
+package net.corda.example;
+
+public class HasAnnotatedField {
+    @B @C @A
+    public static final String ANNOTATED_FIELD = "<string-value>";
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-interface/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-interface/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test annotation inheritance across interfaces'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/annotated-interface/java")
+        }
+    }
+}
+
+jar {
+    baseName = "annotated-interface"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/AlsoInherited.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/AlsoInherited.java
@@ -1,0 +1,14 @@
+package net.corda.example;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@Inherited
+public @interface AlsoInherited {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/HasInheritedAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/HasInheritedAnnotation.java
@@ -1,0 +1,7 @@
+package net.corda.example;
+
+@NotInherited
+@IsInherited
+@AlsoInherited
+public interface HasInheritedAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/InheritingAnnotations.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/InheritingAnnotations.java
@@ -1,0 +1,4 @@
+package net.corda.example;
+
+public interface InheritingAnnotations extends HasInheritedAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/IsInherited.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/IsInherited.java
@@ -1,0 +1,14 @@
+package net.corda.example;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@Inherited
+public @interface IsInherited {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/NotInherited.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/NotInherited.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface NotInherited {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-method/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-method/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test annotation behaviour for a method'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/annotated-method/java",
+                "../resources/test/common-annotations/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "annotated-method"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/annotated-method/java/net/corda/example/HasAnnotatedMethod.java
+++ b/gradle-plugins/api-scanner/src/test/resources/annotated-method/java/net/corda/example/HasAnnotatedMethod.java
@@ -1,0 +1,8 @@
+package net.corda.example;
+
+public class HasAnnotatedMethod {
+    @B @C @A
+    public void hasAnnotation() {
+        System.out.println("VISIBLE ANNOTATIONS");
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/basic-annotation/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/basic-annotation/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of a basic Java annotation'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/basic-annotation/java")
+        }
+    }
+}
+
+jar {
+    baseName = "basic-annotation"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/basic-annotation/java/net/corda/example/BasicAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/basic-annotation/java/net/corda/example/BasicAnnotation.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface BasicAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/basic-class/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/basic-class/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of a basic Java class'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/basic-class/java")
+        }
+    }
+}
+
+jar {
+    baseName = "basic-class"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/basic-class/java/net/corda/example/BasicClass.java
+++ b/gradle-plugins/api-scanner/src/test/resources/basic-class/java/net/corda/example/BasicClass.java
@@ -1,0 +1,13 @@
+package net.corda.example;
+
+public class BasicClass {
+    private final String name;
+
+    public BasicClass(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/basic-interface/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/basic-interface/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of a basic Java interface'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/basic-interface/java")
+        }
+    }
+}
+
+jar {
+    baseName = "basic-interface"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/basic-interface/java/net/corda/example/BasicInterface.java
+++ b/gradle-plugins/api-scanner/src/test/resources/basic-interface/java/net/corda/example/BasicInterface.java
@@ -1,0 +1,7 @@
+package net.corda.example;
+
+import java.math.BigInteger;
+
+public interface BasicInterface {
+    BigInteger getBigNumber();
+}

--- a/gradle-plugins/api-scanner/src/test/resources/class-internal-annotation/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/class-internal-annotation/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of internal annotations on classes'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/class-internal-annotation/java",
+                "../resources/test/common-internal/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "class-internal-annotation"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/AnnotatedClass.java
+++ b/gradle-plugins/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/AnnotatedClass.java
@@ -1,0 +1,5 @@
+package net.corda.example;
+
+@InvisibleAnnotation
+public class AnnotatedClass {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/InvisibleAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/InvisibleAnnotation.java
@@ -1,0 +1,14 @@
+package net.corda.example;
+
+import net.corda.core.CordaInternal;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@CordaInternal
+public @interface InvisibleAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/common-annotations/java/net/corda/example/A.java
+++ b/gradle-plugins/api-scanner/src/test/resources/common-annotations/java/net/corda/example/A.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(CLASS)
+public @interface A {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/common-annotations/java/net/corda/example/B.java
+++ b/gradle-plugins/api-scanner/src/test/resources/common-annotations/java/net/corda/example/B.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(CLASS)
+public @interface B {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/common-annotations/java/net/corda/example/C.java
+++ b/gradle-plugins/api-scanner/src/test/resources/common-annotations/java/net/corda/example/C.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(CLASS)
+public @interface C {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/common-internal/java/net/corda/core/CordaInternal.java
+++ b/gradle-plugins/api-scanner/src/test/resources/common-internal/java/net/corda/core/CordaInternal.java
@@ -1,0 +1,12 @@
+package net.corda.core;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/extended-class/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/extended-class/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of an extended Java class'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/extended-class/java")
+        }
+    }
+}
+
+jar {
+    baseName = "extended-class"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/extended-class/java/net/corda/example/ExtendedClass.java
+++ b/gradle-plugins/api-scanner/src/test/resources/extended-class/java/net/corda/example/ExtendedClass.java
@@ -1,0 +1,10 @@
+package net.corda.example;
+
+import java.io.InputStream;
+import java.io.FilterInputStream;
+
+public class ExtendedClass extends FilterInputStream {
+    public ExtendedClass(InputStream input) {
+        super(input);
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/extended-interface/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/extended-interface/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of an extended Java interface'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/extended-interface/java")
+        }
+    }
+}
+
+jar {
+    baseName = "extended-interface"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/extended-interface/java/net/corda/example/ExtendedInterface.java
+++ b/gradle-plugins/api-scanner/src/test/resources/extended-interface/java/net/corda/example/ExtendedInterface.java
@@ -1,0 +1,8 @@
+package net.corda.example;
+
+import java.util.concurrent.Future;
+
+public interface ExtendedInterface<T> extends Future<T> {
+    String getName();
+    void setName(String name);
+}

--- a/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of internal annotations on fields'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/field-internal-annotation/java",
+                "../resources/test/common-internal/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "field-internal-annotation"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/CordaInternal.java
+++ b/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/CordaInternal.java
@@ -1,0 +1,12 @@
+package net.corda.example.field;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, FIELD})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/HasVisibleField.java
+++ b/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/HasVisibleField.java
@@ -1,0 +1,7 @@
+package net.corda.example.field;
+
+public class HasVisibleField {
+    @InvisibleAnnotation
+    @LocalInvisibleAnnotation
+    public String hasInvisibleAnnotations;
+}

--- a/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/InvisibleAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/InvisibleAnnotation.java
@@ -1,0 +1,14 @@
+package net.corda.example.field;
+
+import net.corda.core.CordaInternal;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, FIELD})
+@Retention(CLASS)
+@CordaInternal
+public @interface InvisibleAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/LocalInvisibleAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/LocalInvisibleAnnotation.java
@@ -1,0 +1,13 @@
+package net.corda.example.field;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, FIELD})
+@Retention(CLASS)
+@CordaInternal
+public @interface LocalInvisibleAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-annotation/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-annotation/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of @CordaInternal annotations'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/internal-annotation/java",
+                "../resources/test/common-internal/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "internal-annotation"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-annotation/java/net/corda/example/CordaInternal.java
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-annotation/java/net/corda/example/CordaInternal.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-field/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-field/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of @CordaInternal annotation on fields'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/internal-field/java",
+                "../resources/test/common-internal/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "internal-field"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-field/java/net/corda/example/WithInternalField.java
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-field/java/net/corda/example/WithInternalField.java
@@ -1,0 +1,8 @@
+package net.corda.example;
+
+import net.corda.core.CordaInternal;
+
+public class WithInternalField {
+    @CordaInternal
+    public static final String INTERNAL_FIELD = "<secret value>";
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-method/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-method/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of @CordaInternal annotation on methods'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/internal-method/java",
+                "../resources/test/common-internal/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "internal-method"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-method/java/net/corda/example/WithInternalMethod.java
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-method/java/net/corda/example/WithInternalMethod.java
@@ -1,0 +1,10 @@
+package net.corda.example;
+
+import net.corda.core.CordaInternal;
+
+public class WithInternalMethod {
+    @CordaInternal
+    public void internalMethod() {
+        System.out.println("INTERNAL METHOD");
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-package/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-package/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of an internal package'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/internal-package/java")
+        }
+    }
+}
+
+jar {
+    baseName = "internal-package"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-package/java/net/corda/VisibleClass.java
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-package/java/net/corda/VisibleClass.java
@@ -1,0 +1,4 @@
+package net.corda;
+
+public class VisibleClass {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/internal-package/java/net/corda/internal/InvisibleClass.java
+++ b/gradle-plugins/api-scanner/src/test/resources/internal-package/java/net/corda/internal/InvisibleClass.java
@@ -1,0 +1,13 @@
+package net.corda.internal;
+
+public class InvisibleClass {
+    private final String name;
+
+    public InvisibleClass(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'net.corda.plugins.api-scanner'
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+}
+
+description 'Test appearance of Kotlin-specific annotations'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir file("../resources/test/kotlin-annotations/kotlin")
+        }
+    }
+}
+
+dependencies {
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version'
+    compile 'org.jetbrains.kotlin:kotlin-reflect:$kotlin_version'
+}
+
+jar {
+    baseName = "kotlin-annotations"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasJvmField.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasJvmField.kt
@@ -1,0 +1,6 @@
+package net.corda.example
+
+class HasJvmField {
+    @JvmField
+    val stringValue = "Hello World"
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasJvmStaticFunction.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasJvmStaticFunction.kt
@@ -1,0 +1,8 @@
+package net.corda.example
+
+class HasJvmStaticFunction {
+    companion object {
+        @JvmStatic
+        fun doThing(message: String) = println(message)
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasOverloadedConstructor.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasOverloadedConstructor.kt
@@ -1,0 +1,7 @@
+package net.corda.example
+
+class HasOverloadedConstructor @JvmOverloads constructor (
+    val notNullable: String = "defaultName",
+    val nullable: String? = null,
+    val number: Int = 0
+)

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'net.corda.plugins.api-scanner'
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+}
+
+description 'Test appearance of internal Corda annotations in Kotlin'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir file("../resources/test/kotlin-internal-annotation/kotlin")
+        }
+    }
+}
+
+dependencies {
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version'
+    compile 'org.jetbrains.kotlin:kotlin-reflect:$kotlin_version'
+}
+
+jar {
+    baseName = "kotlin-internal-annotation"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/AnnotatedClass.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/AnnotatedClass.kt
@@ -1,0 +1,4 @@
+package net.corda.example.kotlin
+
+@InvisibleAnnotation
+class AnnotatedClass

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/CordaInternal.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/CordaInternal.kt
@@ -1,0 +1,8 @@
+package net.corda.example.kotlin
+
+import kotlin.annotation.AnnotationRetention.*
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(FILE, CLASS, FUNCTION, ANNOTATION_CLASS)
+@Retention(BINARY)
+annotation class CordaInternal

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/InvisibleAnnotation.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/InvisibleAnnotation.kt
@@ -1,0 +1,9 @@
+package net.corda.example.kotlin
+
+import kotlin.annotation.AnnotationRetention.*
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(FILE, CLASS, FUNCTION)
+@Retention(BINARY)
+@CordaInternal
+annotation class InvisibleAnnotation

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'net.corda.plugins.api-scanner'
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+}
+
+description 'Test appearance of Kotlin lambdas'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir file("../resources/test/kotlin-lambdas/kotlin")
+        }
+    }
+}
+
+dependencies {
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version'
+    compile 'org.jetbrains.kotlin:kotlin-reflect:$kotlin_version'
+}
+
+jar {
+    baseName = "kotlin-lambdas"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-lambdas/kotlin/net/corda/example/LambdaExpressions.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-lambdas/kotlin/net/corda/example/LambdaExpressions.kt
@@ -1,0 +1,14 @@
+package net.corda.example
+
+import java.util.*
+import kotlin.concurrent.schedule
+
+class LambdaExpressions {
+    private val timer: Timer = Timer()
+
+    fun testing(block: Unit) {
+        timer.schedule(Random().nextLong()) {
+            block
+        }
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'net.corda.plugins.api-scanner'
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+}
+
+description 'Test appearance of Kotlin vararg functions'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir file("../resources/test/kotlin-vararg-method/kotlin")
+        }
+    }
+}
+
+dependencies {
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version'
+    compile 'org.jetbrains.kotlin:kotlin-reflect:$kotlin_version'
+}
+
+jar {
+    baseName = "kotlin-vararg-method"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/kotlin-vararg-method/kotlin/net/corda/example/KotlinVarargMethod.kt
+++ b/gradle-plugins/api-scanner/src/test/resources/kotlin-vararg-method/kotlin/net/corda/example/KotlinVarargMethod.kt
@@ -1,0 +1,5 @@
+package net.corda.example
+
+interface KotlinVarargMethod {
+    fun action(vararg arg: Any?)
+}

--- a/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of internal annotations on methods'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/method-internal-annotation/java",
+                "../resources/test/common-internal/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "method-internal-annotation"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/CordaInternal.java
+++ b/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/CordaInternal.java
@@ -1,0 +1,12 @@
+package net.corda.example.method;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/HasVisibleMethod.java
+++ b/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/HasVisibleMethod.java
@@ -1,0 +1,9 @@
+package net.corda.example.method;
+
+public class HasVisibleMethod {
+    @InvisibleAnnotation
+    @LocalInvisibleAnnotation
+    public void hasInvisibleAnnotations() {
+        System.out.println("VISIBLE METHOD, INVISIBLE ANNOTATIONS");
+    }
+}

--- a/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/InvisibleAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/InvisibleAnnotation.java
@@ -1,0 +1,14 @@
+package net.corda.example.method;
+
+import net.corda.core.CordaInternal;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@CordaInternal
+public @interface InvisibleAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/LocalInvisibleAnnotation.java
+++ b/gradle-plugins/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/LocalInvisibleAnnotation.java
@@ -1,0 +1,13 @@
+package net.corda.example.method;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@CordaInternal
+public @interface LocalInvisibleAnnotation {
+}

--- a/gradle-plugins/api-scanner/src/test/resources/vararg-method/build.gradle
+++ b/gradle-plugins/api-scanner/src/test/resources/vararg-method/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'net.corda.plugins.api-scanner'
+    id 'java'
+}
+
+description 'Test appearance of Java vararg functions'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/vararg-method/java")
+        }
+    }
+}
+
+jar {
+    baseName = "vararg-method"
+}
+
+scanApi {
+    verbose = true
+}

--- a/gradle-plugins/api-scanner/src/test/resources/vararg-method/java/net/corda/example/VarargMethod.java
+++ b/gradle-plugins/api-scanner/src/test/resources/vararg-method/java/net/corda/example/VarargMethod.java
@@ -1,0 +1,5 @@
+package net.corda.example;
+
+public interface VarargMethod {
+    void action(Object... arg);
+}


### PR DESCRIPTION
The api-scanner in the gradle-plugins repo has been modified, which adds extra elements to the api-current.txt file. By porting the version of the api-scanner in gradle-plugins to the v3 release branch, we can align the api-current.txt file between the release branch and live, which will help diagnose api compatibility breakages.

Since the 3.0 release has been cut, we will have this as the first commit in 3.1.