### PR TITLE
Corda-1155 - Jolokia logging via slf4j

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -60,5 +60,9 @@
         <Logger name="org.apache.activemq.artemis.core.server" level="error" additivity="false">
             <AppenderRef ref="RollingFile-Appender"/>
         </Logger>
+        <Logger name="org.jolokia" additivity="true" level="warn">
+            <AppenderRef ref="Console-Appender-Println"/>
+            <AppenderRef ref="RollingFile-Appender" />
+        </Logger>
     </Loggers>
 </Configuration>

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     testCompile "org.glassfish.jersey.containers:jersey-container-jetty-http:${jersey_version}"
 
     // Jolokia JVM monitoring agent
-    runtime "org.jolokia:jolokia-jvm:${jolokia_version}:agent"
+    compile "org.jolokia:jolokia-jvm:${jolokia_version}:agent"
 }
 
 task integrationTest(type: Test) {

--- a/node/src/main/kotlin/net/corda/node/JolokiaSlf4Adapter.kt
+++ b/node/src/main/kotlin/net/corda/node/JolokiaSlf4Adapter.kt
@@ -1,0 +1,35 @@
+package net.corda.node
+
+import org.jolokia.util.LogHandler
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class JolokiaSlf4Adapter : LogHandler {
+    val log: Logger = LoggerFactory.getLogger("org.jolokia")
+
+    override fun error(message: String?, t: Throwable?) {
+        if (message != null) {
+            if (t != null) {
+                log.error(message, t)
+            } else {
+                log.error(message)
+            }
+        } else if (t != null) {
+            log.error("Exception without a comment", t)
+        }
+    }
+
+    override fun debug(message: String?) {
+        if (message != null) {
+            log.debug(message)
+        }
+    }
+
+    override fun info(message: String?) {
+        if (message != null) {
+            log.info(message)
+        }
+    }
+
+
+}

--- a/webserver/src/main/kotlin/net/corda/webserver/JolokiaSlf4Adapter.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/JolokiaSlf4Adapter.kt
@@ -1,0 +1,35 @@
+package net.corda.webserver
+
+import org.jolokia.util.LogHandler
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class JolokiaSlf4Adapter : LogHandler {
+    val log: Logger = LoggerFactory.getLogger("org.jolokia")
+
+    override fun error(message: String?, t: Throwable?) {
+        if (message != null) {
+            if (t != null) {
+                log.error(message, t)
+            } else {
+                log.error(message)
+            }
+        } else if (t != null) {
+            log.error("Exception without a comment", t)
+        }
+    }
+
+    override fun debug(message: String?) {
+        if (message != null) {
+            log.debug(message)
+        }
+    }
+
+    override fun info(message: String?) {
+        if (message != null) {
+            log.info(message)
+        }
+    }
+
+
+}


### PR DESCRIPTION
Jolokia by default logs via StdOut. 
An adapter for slf4j has been added, however…
Webserver and Node are different packages, so it's the same code in two places.