### PR TITLE
CORDA-1186 - Move ConstructorForDeserialization out of internal

### DIFF
--- a/node-api/src/main/kotlin/net/corda/core/serialization/ConstructorForDeserialization.kt
+++ b/node-api/src/main/kotlin/net/corda/core/serialization/ConstructorForDeserialization.kt
@@ -1,0 +1,8 @@
+package net.corda.core.serialization
+
+/**
+ * Annotation indicating a constructor to be used to reconstruct instances of a class during deserialization.
+ */
+@Target(AnnotationTarget.CONSTRUCTOR)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ConstructorForDeserialization

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationHelper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationHelper.kt
@@ -3,6 +3,7 @@ package net.corda.nodeapi.internal.serialization.amqp
 import com.google.common.primitives.Primitives
 import com.google.common.reflect.TypeToken
 import net.corda.core.serialization.ClassWhitelist
+import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationContext
 import org.apache.qpid.proton.codec.Data
@@ -17,13 +18,6 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaType
-
-/**
- * Annotation indicating a constructor to be used to reconstruct instances of a class during deserialization.
- */
-@Target(AnnotationTarget.CONSTRUCTOR)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class ConstructorForDeserialization
 
 /**
  * Code for finding the constructor we will use for deserialization.

--- a/node-api/src/test/java/net/corda/nodeapi/internal/serialization/amqp/JavaSerializationOutputTests.java
+++ b/node-api/src/test/java/net/corda/nodeapi/internal/serialization/amqp/JavaSerializationOutputTests.java
@@ -3,6 +3,7 @@ package net.corda.nodeapi.internal.serialization.amqp;
 import com.google.common.collect.ImmutableList;
 import net.corda.core.contracts.ContractState;
 import net.corda.core.identity.AbstractParty;
+import net.corda.core.serialization.ConstructorForDeserialization;
 import net.corda.nodeapi.internal.serialization.AllWhitelist;
 import net.corda.core.serialization.SerializedBytes;
 import org.apache.qpid.proton.codec.DecoderImpl;

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EvolvabilityTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EvolvabilityTests.kt
@@ -5,6 +5,7 @@ import net.corda.core.crypto.SignedData
 import net.corda.core.crypto.sign
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
+import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.serialization.SerializedBytes
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/PrivatePropertyTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/PrivatePropertyTests.kt
@@ -2,8 +2,7 @@ package net.corda.nodeapi.internal.serialization.amqp
 
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.assertEquals
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import net.corda.core.serialization.ConstructorForDeserialization
 import org.junit.Test
 import org.apache.qpid.proton.amqp.Symbol
 import org.assertj.core.api.Assertions

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationPropertyOrdering.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationPropertyOrdering.kt
@@ -1,5 +1,6 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
+import net.corda.core.serialization.ConstructorForDeserialization
 import org.junit.Test
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.assertEquals


### PR DESCRIPTION
Since it's a user facing object it shouldn't exist in an internal
package. Move to core to exist with the other serialization annotations
