### PR TITLE
CORDA-1155 Removed a reference to an appender not present in tests

### DIFF
--- a/testing/test-common/src/main/resources/log4j2-test.xml
+++ b/testing/test-common/src/main/resources/log4j2-test.xml
@@ -27,7 +27,6 @@
         </Logger>
         <Logger name="org.jolokia" additivity="true" level="warn">
             <AppenderRef ref="Console-Appender-Println"/>
-            <AppenderRef ref="RollingFile-Appender" />
         </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Loggers in tests no longer reference a non-existent appender.