### PR TITLE
CORDA-1197: Take into account last amount submitted when adding data points.

### DIFF
--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/cordapps/cash/CashViewer.kt
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList
 import javafx.geometry.Insets
 import javafx.scene.Parent
 import javafx.scene.chart.NumberAxis
+import javafx.scene.chart.XYChart
 import javafx.scene.control.*
 import javafx.scene.input.MouseButton
 import javafx.scene.layout.BorderPane
@@ -313,18 +314,39 @@ class CashViewer : CordaView("Cash") {
             linechart(null, xAxis, yAxis) {
                 series("USD") {
                     sumAmount.addListener { _, _, _ ->
+                        val lastAmount = data.last().value?.yValue
+                        val currAmount = sumAmount.value.toDecimal()
                         val lastTimeStamp = data.last().value?.xValue
-                        if (lastTimeStamp == null || System.currentTimeMillis() - lastTimeStamp.toLong() > 1.seconds.toMillis()) {
-                            data(System.currentTimeMillis(), sumAmount.value.quantity)
-                            runInFxApplicationThread {
-                                // Modify data in UI thread.
-                                if (data.size > 300) data.remove(0, 1)
+                        val currentTimeStamp = System.currentTimeMillis()
+
+                        // If amount is not the same - always add a data point.
+                        if (lastAmount == null || lastAmount != currAmount) {
+                            // If update arrived in very close succession to the previous one - kill the last point received to eliminate un-necessary noise on the graph.
+                            if(lastTimeStamp != null && currentTimeStamp - lastTimeStamp.toLong() < 1.seconds.toMillis()) {
+                                data.safelyTransition {
+                                    remove(size - 1, size)
+                                }
+                            }
+
+                            // Add a new data point.
+                            data(currentTimeStamp, currAmount)
+
+                            // Limit population of data points to make graph painting faster.
+                            data.safelyTransition {
+                                if (size > 300) remove(0, 1)
                             }
                         }
                     }
                 }
                 createSymbols = false
                 animated = false
+            }
+        }
+
+        private fun <X, Y> ObservableList<XYChart.Data<X, Y>>.safelyTransition(block: ObservableList<XYChart.Data<X, Y>>.() -> Unit) {
+            runInFxApplicationThread {
+                // Modify data in UI thread to properly propagate to GUI.
+                this.block()
             }
         }
     }


### PR DESCRIPTION
Current logic in `CashWidget` is not handling well updates done in close succession, i.e. less than 1 second.
And such frequent updates do indeed happen, e.g. from: `net.corda.client.jfx.model.ContractStateModel#cashStates`
where `list` is modified twice.

Also use `.toDecimal()` instead of `.quantity`to have amount represented in pounds rather than in pennies.