### PR TITLE
CORDA-1142: Fix explorer to support all transaction types

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
@@ -1,13 +1,14 @@
 package net.corda.client.jfx.model
 
 import javafx.beans.value.ObservableValue
+import javafx.collections.FXCollections
 import javafx.collections.ObservableMap
 import net.corda.client.jfx.utils.*
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.SecureHash
 import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.WireTransaction
 import org.fxmisc.easybind.EasyBind
 
 /**
@@ -17,7 +18,8 @@ import org.fxmisc.easybind.EasyBind
  */
 data class PartiallyResolvedTransaction(
         val transaction: SignedTransaction,
-        val inputs: List<ObservableValue<InputResolution>>) {
+        val inputs: List<ObservableValue<InputResolution>>,
+        val outputs: List<ObservableValue<out OutputResolution>>) {
     val id = transaction.id
 
     sealed class InputResolution {
@@ -29,21 +31,49 @@ data class PartiallyResolvedTransaction(
         }
     }
 
+    sealed class OutputResolution {
+        abstract val stateRef: StateRef
+
+        data class Unresolved(override val stateRef: StateRef) : OutputResolution()
+        data class Resolved(val stateAndRef: StateAndRef<ContractState>) : OutputResolution() {
+            override val stateRef: StateRef get() = stateAndRef.ref
+        }
+    }
+
     companion object {
         fun fromSignedTransaction(
                 transaction: SignedTransaction,
-                transactions: ObservableMap<SecureHash, SignedTransaction>
+                stateMap: ObservableMap<StateRef, StateAndRef<ContractState>>
         ) = PartiallyResolvedTransaction(
                 transaction = transaction,
-                inputs = transaction.tx.inputs.map { stateRef ->
-                    EasyBind.map(transactions.getObservableValue(stateRef.txhash)) {
+                inputs = transaction.inputs.map { stateRef ->
+                    EasyBind.map(stateMap.getObservableValue(stateRef)) {
                         if (it == null) {
                             InputResolution.Unresolved(stateRef)
                         } else {
-                            InputResolution.Resolved(it.tx.outRef(stateRef.index))
+                            InputResolution.Resolved(it)
+                        }
+                    }
+                },
+                outputs = if (transaction.coreTransaction is WireTransaction) {
+                    transaction.tx.outRefsOfType<ContractState>().map {
+                        OutputResolution.Resolved(it).lift()
+                    }
+                } else {
+                    // Transaction will have the same number of outputs as inputs
+                    val outputCount = transaction.coreTransaction.inputs.size
+                    val stateRefs = (0 until outputCount).map { StateRef(transaction.id, it) }
+                    stateRefs.map { stateRef ->
+                        EasyBind.map(stateMap.getObservableValue(stateRef)) {
+                            if (it == null) {
+                                OutputResolution.Unresolved(stateRef)
+                            } else {
+                                OutputResolution.Resolved(it)
+                            }
                         }
                     }
                 }
+
         )
     }
 }
@@ -54,9 +84,13 @@ data class PartiallyResolvedTransaction(
 class TransactionDataModel {
     private val transactions by observable(NodeMonitorModel::transactions)
     private val collectedTransactions = transactions.recordInSequence()
-    private val transactionMap = transactions.recordAsAssociation(SignedTransaction::id)
+    private val vaultUpdates by observable(NodeMonitorModel::vaultUpdates)
+    private val stateMap = vaultUpdates.fold(FXCollections.observableHashMap<StateRef, StateAndRef<ContractState>>()) { map, update ->
+        val states = update.consumed + update.produced
+        states.forEach { map[it.ref] = it }
+    }
 
     val partiallyResolvedTransactions = collectedTransactions.map {
-        PartiallyResolvedTransaction.fromSignedTransaction(it, transactionMap)
+        PartiallyResolvedTransaction.fromSignedTransaction(it, stateMap)
     }
 }

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/views/Network.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/views/Network.kt
@@ -30,6 +30,7 @@ import net.corda.client.jfx.utils.*
 import net.corda.core.contracts.ContractState
 import net.corda.core.identity.Party
 import net.corda.core.node.NodeInfo
+import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.toBase58String
 import net.corda.explorer.formatters.PartyNameFormatter
 import net.corda.explorer.model.CordaView
@@ -81,7 +82,11 @@ class Network : CordaView() {
                     .map { it as? PartiallyResolvedTransaction.InputResolution.Resolved }
                     .filterNotNull()
                     .map { it.stateAndRef.state.data }.getParties()
-            val outputParties = it.transaction.tx.outputStates.observable().getParties()
+            val outputParties = it.transaction.coreTransaction.let {
+                if (it is WireTransaction) it.outputStates.observable().getParties()
+                // For ContractUpgradeWireTransaction and NotaryChangeWireTransaction the output parties are the same as input parties
+                else inputParties
+            }
             val signingParties = it.transaction.sigs.map { it.by.toKnownParty() }
             // Input parties fire a bullets to all output parties, and to the signing parties. !! This is a rough guess of how the message moves in the network.
             // TODO : Expose artemis queue to get real message information.


### PR DESCRIPTION
NotaryChange and ContractUpgrade transactions don't contain the output states - they're recalculated on demand from the inputs. I changed the explorer logic to resolve transaction inputs and outputs from vault updates rather than from transactions directly.