### PR TITLE
Whitelisting CRLReason class

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/DefaultWhitelist.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/DefaultWhitelist.kt
@@ -7,6 +7,7 @@ import org.apache.activemq.artemis.api.core.SimpleString
 import rx.Notification
 import rx.exceptions.OnErrorNotImplementedException
 import sun.security.x509.X509CertImpl
+import java.security.cert.CRLReason
 import java.util.*
 
 /**
@@ -62,6 +63,7 @@ object DefaultWhitelist : SerializationWhitelist {
                     StackTraceElement::class.java,
 
                     // Implementation of X509Certificate.
-                    X509CertImpl::class.java
+                    X509CertImpl::class.java,
+                    CRLReason::class.java
                     )
 }


### PR DESCRIPTION
Adding CRLReason to the default whitelist. This class is needed for the certificate revocation list support.
