### PR TITLE
CORDA-1042: Change the way how Jolokia library located on the classpath so that it work on Windows

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/JVMAgentRegistry.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/JVMAgentRegistry.kt
@@ -43,7 +43,7 @@ object JVMAgentRegistry {
         } else {
             (this::class.java.classLoader as? URLClassLoader)
                 ?.urLs
-                ?.map { Paths.get(it.path) }
+                ?.map { Paths.get(it.toURI()) }
                 ?.firstOrNull { it.fileName.toString() == jarFileName }
         }
     }


### PR DESCRIPTION
Old code failed with:
```
11:34:01.536 [main] ERROR net.corda.node.internal.Node - Exception during node startup
java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Program%20Files/JetBrains/IntelliJ%20IDEA%20Community%20Edition%202017.3.1/lib/idea_rt.jar
	at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182) ~[?:1.8.0_144]
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153) ~[?:1.8.0_144]
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77) ~[?:1.8.0_144]
	at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94) ~[?:1.8.0_144]
	at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255) ~[?:1.8.0_144]
	at java.nio.file.Paths.get(Paths.java:84) ~[?:1.8.0_144]
	at net.corda.node.utilities.JVMAgentRegistry.resolveAgentJar(JVMAgentRegistry.kt:46) ~[classes/:?]
	at net.corda.node.internal.AbstractNode.initialiseJVMAgents(AbstractNode.kt:785) ~[classes/:?]
	at net.corda.node.internal.AbstractNode.start(AbstractNode.kt:199) ~[classes/:?]
	at net.corda.node.internal.Node.start(Node.kt:335) ~[classes/:?]
	at net.corda.node.internal.NodeStartup.startNode(NodeStartup.kt:146) ~[classes/:?]
	at net.corda.node.internal.NodeStartup.run(NodeStartup.kt:120) [classes/:?]
	at net.corda.node.Corda.main(Corda.kt:16) [classes/:?]
```

this was exposed by `net.corda.testing.driver.DriverTests#monitoring mode enables jolokia exporting of JMX metrics via HTTP JSON` test.