### PR TITLE
Expose two static fields on SecureHash for Java.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SecureHash.kt
@@ -82,13 +82,31 @@ sealed class SecureHash(bytes: ByteArray) : OpaqueBytes(bytes) {
 
         /**
          * A SHA-256 hash value consisting of 32 0x00 bytes.
+         * This field provides more intuitive access from Java.
          */
-        val zeroHash = SecureHash.SHA256(ByteArray(32, { 0.toByte() }))
+        @JvmField
+        val zeroHash: SHA256 = SecureHash.SHA256(ByteArray(32, { 0.toByte() }))
+
+        /**
+         * A SHA-256 hash value consisting of 32 0x00 bytes.
+         * This function is provided for API stability.
+         */
+        @Suppress("Unused")
+        fun getZeroHash(): SHA256 = zeroHash
 
         /**
          * A SHA-256 hash value consisting of 32 0xFF bytes.
+         * This field provides more intuitive access from Java.
          */
-        val allOnesHash = SecureHash.SHA256(ByteArray(32, { 255.toByte() }))
+        @JvmField
+        val allOnesHash: SHA256 = SecureHash.SHA256(ByteArray(32, { 255.toByte() }))
+
+        /**
+         * A SHA-256 hash value consisting of 32 0xFF bytes.
+         * This function is provided for API stability.
+         */
+        @Suppress("Unused")
+        fun getAllOnesHash(): SHA256 = allOnesHash
     }
 
     // In future, maybe SHA3, truncated hashes etc.


### PR DESCRIPTION
The `SecureHash.zeroHash` and `SecureHash.allOnesHash` properties must currently be accessed from Java as:
```java
SecureHash.Companion.getZeroHash()
```
and
```java
SecureHash.Companion.getAllOnesHash()
```
Make these more "Java friendly" by using `@JvmField`, and preserve API compatibility by adding explicit getter functions.