### PR TITLE
Remove superfluous @JvmStatic annotation.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -51,7 +51,6 @@ data class LedgerTransaction @JvmOverloads constructor(
     }
 
     private companion object {
-        @JvmStatic
         private fun createContractFor(className: ContractClassName, classLoader: ClassLoader?): Try<Contract> {
             return Try.on {
                 (classLoader ?: this::class.java.classLoader)


### PR DESCRIPTION
Remove `@JvmStatic` to stop generating an extra function we don't need.