### PR TITLE
Include `buildSrc` into the main build

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -47,3 +47,5 @@ include 'samples:simm-valuation-demo'
 include 'samples:notary-demo'
 include 'samples:bank-of-corda-demo'
 include 'samples:cordapp-configuration'
+// TODO: Remove this "project" once https://youtrack.jetbrains.com/issue/IDEA-187904 is fixed.
+include 'buildSrc'


### PR DESCRIPTION
Or else on Windows when built from IntelliJ using Gradle the following error is observed:
```
Caused by: org.gradle.api.UnknownProjectException: Project with path ':canonicalizer:' could not be found in root project 'corda-project'.
	at org.gradle.api.internal.project.DefaultProject.project(DefaultProject.java:602)
	at org.gradle.api.internal.project.ProjectInternal$project$1.call(Unknown Source)
	at ijinit52_8nlsl8rhxhf1kemvqfi7ln8o8$_run_closure46.doCall(C:\Users\Viktor\AppData\Local\Temp\ijinit52.gradle:273)
	at org.gradle.listener.ClosureBackedMethodInvocationDispatch.dispatch(ClosureBackedMethodInvocationDispatch.java:40)
	at org.gradle.listener.ClosureBackedMethodInvocationDispatch.dispatch(ClosureBackedMethodInvocationDispatch.java:25)
	at org.gradle.internal.event.AbstractBroadcastDispatch.dispatch(AbstractBroadcastDispatch.java:42)
	at org.gradle.internal.event.BroadcastDispatch$SingletonDispatch.dispatch(BroadcastDispatch.java:230)
	at org.gradle.internal.event.BroadcastDispatch$SingletonDispatch.dispatch(BroadcastDispatch.java:149)
	at org.gradle.internal.event.AbstractBroadcastDispatch.dispatch(AbstractBroadcastDispatch.java:58)
	at org.gradle.internal.event.BroadcastDispatch$CompositeDispatch.dispatch(BroadcastDispatch.java:324)
	at org.gradle.internal.event.BroadcastDispatch$CompositeDispatch.dispatch(BroadcastDispatch.java:234)
	at org.gradle.internal.event.ListenerBroadcast.dispatch(ListenerBroadcast.java:140)
	at org.gradle.internal.event.ListenerBroadcast.dispatch(ListenerBroadcast.java:37)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
	at com.sun.proxy.$Proxy17.projectsEvaluated(Unknown Source)
	at org.gradle.initialization.DefaultGradleLauncher.projectsEvaluated(DefaultGradleLauncher.java:329)
	at org.gradle.initialization.DefaultGradleLauncher.access$1200(DefaultGradleLauncher.java:46)
	at org.gradle.initialization.DefaultGradleLauncher$ConfigureBuild.run(DefaultGradleLauncher.java:252)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:336)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:328)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:199)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:110)
	at org.gradle.initialization.DefaultGradleLauncher.configureBuild(DefaultGradleLauncher.java:167)
	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:126)
	... 62 more
```