### PR TITLE
Trying to improve stability of `RPCStabilityTests.client reconnects to rebooted server`

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -173,6 +173,7 @@ class RPCClientProxyHandler(
     private val deduplicationSequenceNumber = AtomicLong(0)
 
     private val lock = ReentrantReadWriteLock()
+    @Volatile
     private var sendingEnabled = true
 
     /**


### PR DESCRIPTION
Prior to this change it was intermittently failing with:
```
net.corda.client.rpc.RPCException: RPC server is not available.
    at net.corda.client.rpc.internal.RPCClientProxyHandler.invoke(RPCClientProxyHandler.kt:222)
    at com.sun.proxy.$Proxy79.ping(Unknown Source)
    at net.corda.client.rpc.RPCStabilityTests$client reconnects to rebooted server$1$pingFuture$1.invoke(RPCStabilityTests.kt:251)
    at net.corda.client.rpc.RPCStabilityTests$client reconnects to rebooted server$1$pingFuture$1.invoke(RPCStabilityTests.kt:36)
    at net.corda.core.internal.concurrent.ValueOrException$DefaultImpls.capture(CordaFutureImpl.kt:107)
    at net.corda.core.internal.concurrent.OpenFuture$DefaultImpls.capture(CordaFutureImpl.kt:65535)
    at net.corda.core.internal.concurrent.CordaFutureImpl.capture(CordaFutureImpl.kt:119)
    at net.corda.core.internal.concurrent.CordaFutureImplKt$fork$$inlined$also$lambda$1.run(CordaFutureImpl.kt:22)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:748)
```

This is related to PR #2812