### PR TITLE
ENT-1634 Fix value generation for PK column of node_notary_request_log table

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -41,8 +41,8 @@ class PersistentUniquenessProvider(val clock: Clock) : UniquenessProvider, Singl
     @CordaSerializable
     class Request(
             @Id
-            @GeneratedValue(strategy = GenerationType.AUTO)
-            val id: Int = 0,
+            @GeneratedValue
+            val id: Int? = null,
 
             @Column(name = "consuming_transaction_id")
             val consumingTxHash: String,


### PR DESCRIPTION
Don't assign a value as it's auto generated.
Remove redundant default value for GeneratedValue strategy.