### PR TITLE
Remove debug logging left over from earlier AMQP development.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
@@ -428,7 +428,6 @@ internal class ConnectionStateMachine(serverMode: Boolean,
     }
 
     fun transportWriteMessage(msg: SendableMessageImpl) {
-        log.debug { "Queue application message write uuid: ${msg.applicationProperties["_AMQ_DUPL_ID"]} ${javax.xml.bind.DatatypeConverter.printHexBinary(msg.payload)}" }
         msg.buf = encodePayloadBytes(msg)
         val messageQueue = messageQueues.getOrPut(msg.topic, { LinkedList() })
         messageQueue.offer(msg)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPChannelHandler.kt
@@ -103,7 +103,6 @@ internal class AMQPChannelHandler(private val serverMode: Boolean,
 
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
         try {
-            log.debug { "Received $msg" }
             if (msg is ByteBuf) {
                 eventProcessor!!.transportProcessInput(msg)
             }
@@ -116,7 +115,6 @@ internal class AMQPChannelHandler(private val serverMode: Boolean,
     override fun write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise) {
         try {
             try {
-                log.debug { "Sent $msg" }
                 when (msg) {
                 // Transfers application packet into the AMQP engine.
                     is SendableMessageImpl -> {


### PR DESCRIPTION
This PR removes some excessive binary logging from the AMQP protocol wrappers, which was useful only during the initial development and is now just spam.