### PR TITLE
Updated node configuration documentation to contain quoted parameters

### DIFF
--- a/docs/source/node-database.rst
+++ b/docs/source/node-database.rst
@@ -40,9 +40,9 @@ Here is an example node configuration for PostgreSQL:
 
     dataSourceProperties = {
         dataSourceClassName = "org.postgresql.ds.PGSimpleDataSource"
-        dataSource.url = "jdbc:postgresql://[HOST]:[PORT]/postgres"
-        dataSource.user = [USER]
-        dataSource.password = [PASSWORD]
+        "dataSource.url" = "jdbc:postgresql://[HOST]:[PORT]/postgres"
+        "dataSource.user" = [USER]
+        "dataSource.password" = [PASSWORD]
     }
     database = {
         transactionIsolationLevel = READ_COMMITTED


### PR DESCRIPTION
Unquoted "dataSource.*" parameters may cause strange issues where reference.conf parameters override the ones specified in node.conf.

As confirmed by @szymonsztuka on Slack: 
> I suppose it more a feature of the HOCON, if reference.conf has a key name with a dot quoted and you override it by unquoted one, that the quoted take precedence (for HCOON these are different keys) a nd yes the example configuration for Postgress in docs is wrong then

Corresponding SO answer: https://stackoverflow.com/review/suggested-edits/19202559
