### PR TITLE
[CORDA-1262]: Fixed incorrect reference to column "issuer_key" in cash selection SQL for Postgres

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
@@ -43,7 +43,7 @@ class CashSelectionPostgreSQLImpl : AbstractCashSelection() {
                 (if (notary != null)
                     " AND vs.notary_name = ?" else "") +
                 (if (onlyFromIssuerParties.isNotEmpty())
-                    " AND ccs.issuer_key = ANY (?)" else "") +
+                    " AND ccs.issuer_key_hash = ANY (?)" else "") +
                 (if (withIssuerRefs.isNotEmpty())
                     " AND ccs.issuer_ref = ANY (?)" else "") +
                 """)


### PR DESCRIPTION
CORDA-1262: https://r3-cev.atlassian.net/browse/CORDA-1262