### PR TITLE
CORDA-1265: Upgrade to Kotlin language/API 1.2

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3214,7 +3214,7 @@ public static final class net.corda.core.transactions.FilteredTransaction$Compan
   @org.jetbrains.annotations.NotNull public final List inputsOfType(Class)
   public String toString()
   public final void verify()
-  public static final net.corda.core.transactions.LedgerTransaction$Companion Companion
+  @java.lang.Deprecated public static final net.corda.core.transactions.LedgerTransaction$Companion Companion
 ##
 public static final class net.corda.core.transactions.LedgerTransaction$InOutGroup extends java.lang.Object
   public <init>(List, List, Object)
@@ -3320,7 +3320,7 @@ public static final class net.corda.core.transactions.NotaryChangeWireTransactio
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(java.security.KeyPair, net.corda.core.crypto.SignatureMetadata)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(net.corda.core.crypto.TransactionSignature)
   @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable)
-  public static final net.corda.core.transactions.SignedTransaction$Companion Companion
+  @java.lang.Deprecated public static final net.corda.core.transactions.SignedTransaction$Companion Companion
 ##
 @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.transactions.SignedTransaction$SignaturesMissingException extends java.security.SignatureException implements net.corda.core.CordaThrowable, net.corda.core.contracts.NamedByHash
   public <init>(Set, List, net.corda.core.crypto.SecureHash)

--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ allprojects {
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
-            languageVersion = "1.1"
-            apiVersion = "1.1"
+            languageVersion = "1.2"
+            apiVersion = "1.2"
             jvmTarget = "1.8"
             javaParameters = true   // Useful for reflection.
         }


### PR DESCRIPTION
We are currently compiling against the old Kotlin 1.1 language/API definitions, despite using Kotlin 1.2.20 artifacts. Upgrade to use Kotlin 1.2 completely.