### PR TITLE
Speed-up `NodeRegistrationTest`

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -47,7 +47,7 @@ class NodeRegistrationTest {
         private val notaryName = CordaX500Name("NotaryService", "Zurich", "CH")
         private val aliceName = CordaX500Name("Alice", "London", "GB")
         private val genevieveName = CordaX500Name("Genevieve", "London", "GB")
-        private val log = loggerFor<NodeRegistrationTest>()
+        private val log = contextLogger()
     }
 
     @Rule
@@ -62,7 +62,7 @@ class NodeRegistrationTest {
     @Before
     fun startServer() {
         server = NetworkMapServer(
-                responseValidityDuration = 1.seconds,
+                pollInterval = 1.seconds,
                 hostAndPort = portAllocation.nextHostAndPort(),
                 myHostNameValue = "localhost",
                 additionalServices = registrationHandler)

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -62,7 +62,7 @@ class NodeRegistrationTest {
     @Before
     fun startServer() {
         server = NetworkMapServer(
-                cacheTimeout = 1.minutes,
+                responseValidityDuration = 1.seconds,
                 hostAndPort = portAllocation.nextHostAndPort(),
                 myHostNameValue = "localhost",
                 additionalServices = registrationHandler)

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -47,6 +47,7 @@ class NodeRegistrationTest {
         private val notaryName = CordaX500Name("NotaryService", "Zurich", "CH")
         private val aliceName = CordaX500Name("Alice", "London", "GB")
         private val genevieveName = CordaX500Name("Genevieve", "London", "GB")
+        private val log = loggerFor<NodeRegistrationTest>()
     }
 
     @Rule
@@ -91,6 +92,9 @@ class NodeRegistrationTest {
                     startNode(providedName = genevieveName),
                     defaultNotaryNode
             ).transpose().getOrThrow()
+
+            log.info("Nodes started")
+
             val (alice, genevieve) = nodes
 
             assertThat(registrationHandler.idsPolled).containsOnly(

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -73,6 +73,7 @@ import java.time.Instant
 import java.time.ZoneOffset.UTC
 import java.time.format.DateTimeFormatter
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -101,7 +102,7 @@ class DriverDSLImpl(
     override val shutdownManager get() = _shutdownManager!!
     private val cordappPackages = extraCordappPackagesToScan + getCallerPackage()
     // Map from a nodes legal name to an observable emitting the number of nodes in its network map.
-    private val countObservables = mutableMapOf<CordaX500Name, Observable<Int>>()
+    private val countObservables = ConcurrentHashMap<CordaX500Name, Observable<Int>>()
     private val nodeNames = mutableSetOf<CordaX500Name>()
     /**
      * Future which completes when the network map is available, whether a local one or one from the CZ. This future acts
@@ -575,15 +576,17 @@ class DriverDSLImpl(
     }
 
     /**
+     * @nodeName the name of the node which performs counting
      * @param initial number of nodes currently in the network map of a running node.
      * @param networkMapCacheChangeObservable an observable returning the updates to the node network map.
      * @return a [ConnectableObservable] which emits a new [Int] every time the number of registered nodes changes
      *   the initial value emitted is always [initial]
      */
-    private fun nodeCountObservable(initial: Int, networkMapCacheChangeObservable: Observable<NetworkMapCache.MapChange>):
+    private fun nodeCountObservable(nodeName: CordaX500Name, initial: Int, networkMapCacheChangeObservable: Observable<NetworkMapCache.MapChange>):
             ConnectableObservable<Int> {
         val count = AtomicInteger(initial)
         return networkMapCacheChangeObservable.map {
+            log.debug("nodeCountObservable for '$nodeName' received '$it'")
             when (it) {
                 is NetworkMapCache.MapChange.Added -> count.incrementAndGet()
                 is NetworkMapCache.MapChange.Removed -> count.decrementAndGet()
@@ -599,8 +602,9 @@ class DriverDSLImpl(
      */
     private fun allNodesConnected(rpc: CordaRPCOps): CordaFuture<Int> {
         val (snapshot, updates) = rpc.networkMapFeed()
-        val counterObservable = nodeCountObservable(snapshot.size, updates)
-        countObservables[rpc.nodeInfo().legalIdentities[0].name] = counterObservable
+        val nodeName = rpc.nodeInfo().legalIdentities[0].name
+        val counterObservable = nodeCountObservable(nodeName, snapshot.size, updates)
+        countObservables[nodeName] = counterObservable
         /* TODO: this might not always be the exact number of nodes one has to wait for,
          * for example in the following sequence
          * 1 start 3 nodes in order, A, B, C.
@@ -611,6 +615,7 @@ class DriverDSLImpl(
 
         // This is an observable which yield the minimum number of nodes in each node network map.
         val smallestSeenNetworkMapSize = Observable.combineLatest(countObservables.values.toList()) { args: Array<Any> ->
+            log.debug("smallestSeenNetworkMapSize for '$nodeName' is: ${args.toList()}")
             args.map { it as Int }.min() ?: 0
         }
         val future = smallestSeenNetworkMapSize.filter { it >= requiredNodes }.toFuture()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -701,7 +701,8 @@ class DriverDSLImpl(
                         if (it == processDeathFuture) {
                             throw ListenProcessDeathException(config.corda.p2pAddress, process)
                         }
-                        processDeathFuture.cancel(false)
+                        // Will interrupt polling for process death as this is no longer relevant since the process been successfully started and reflected itself in the NetworkMap.
+                        processDeathFuture.cancel(true)
                         log.info("Node handle is ready. NodeInfo: ${rpc.nodeInfo()}, WebAddress: $webAddress")
                         OutOfProcessImpl(rpc.nodeInfo(), rpc, config.corda, webAddress, useHTTPS, debugPort, process, onNodeExit)
                     }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -2,6 +2,7 @@ package net.corda.testing.node.internal.network
 
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.SignedData
+import net.corda.core.internal.logElapsedTime
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
@@ -10,6 +11,7 @@ import net.corda.nodeapi.internal.SignedNodeInfo
 import net.corda.nodeapi.internal.createDevNetworkMapCa
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.core.node.NetworkParameters
+import net.corda.core.utilities.loggerFor
 import net.corda.nodeapi.internal.network.NetworkMap
 import net.corda.nodeapi.internal.network.ParametersUpdate
 import org.eclipse.jetty.server.Server
@@ -39,6 +41,7 @@ class NetworkMapServer(private val cacheTimeout: Duration,
                        vararg additionalServices: Any) : Closeable {
     companion object {
         private val stubNetworkParameters = NetworkParameters(1, emptyList(), 10485760, Int.MAX_VALUE, Instant.now(), 10, emptyMap())
+        private val log = loggerFor<NetworkMapServer>()
     }
 
     private val server: Server
@@ -85,12 +88,6 @@ class NetworkMapServer(private val cacheTimeout: Duration,
         parametersUpdate = ParametersUpdate(nextParameters.serialize().hash, description, updateDeadline)
     }
 
-    fun advertiseNewParameters() {
-        networkParameters = checkNotNull(nextNetworkParameters) { "Schedule parameters update first" }
-        nextNetworkParameters = null
-        parametersUpdate = null
-    }
-
     fun latestParametersAccepted(publicKey: PublicKey): SecureHash? {
         return service.latestAcceptedParametersMap[publicKey]
     }
@@ -108,36 +105,38 @@ class NetworkMapServer(private val cacheTimeout: Duration,
         @POST
         @Path("publish")
         @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-        fun publishNodeInfo(input: InputStream): Response {
-            return try {
-                val signedNodeInfo = input.readBytes().deserialize<SignedNodeInfo>()
-                signedNodeInfo.verified()
-                nodeInfoMap[signedNodeInfo.raw.hash] = signedNodeInfo
-                ok()
-            } catch (e: Exception) {
-                when (e) {
-                    is SignatureException -> status(Response.Status.FORBIDDEN).entity(e.message)
-                    else -> status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.message)
-                }
-            }.build()
-        }
+        fun publishNodeInfo(input: InputStream): Response =
+            log.logElapsedTime("Publish") {
+                try {
+                    val signedNodeInfo = input.readBytes().deserialize<SignedNodeInfo>()
+                    signedNodeInfo.verified()
+                    nodeInfoMap[signedNodeInfo.raw.hash] = signedNodeInfo
+                    ok()
+                } catch (e: Exception) {
+                    when (e) {
+                        is SignatureException -> status(Response.Status.FORBIDDEN).entity(e.message)
+                        else -> status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.message)
+                    }
+                }.build()
+            }
 
         @POST
         @Path("ack-parameters")
         @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-        fun ackNetworkParameters(input: InputStream): Response {
-            val signedParametersHash = input.readBytes().deserialize<SignedData<SecureHash>>()
-            val hash = signedParametersHash.verified()
-            latestAcceptedParametersMap[signedParametersHash.sig.by] = hash
-            return ok().build()
-        }
+        fun ackNetworkParameters(input: InputStream): Response =
+            log.logElapsedTime("Ack parameters") {
+                val signedParametersHash = input.readBytes().deserialize<SignedData<SecureHash>>()
+                val hash = signedParametersHash.verified()
+                latestAcceptedParametersMap[signedParametersHash.sig.by] = hash
+                ok().build()
+            }
 
         @GET
         @Produces(MediaType.APPLICATION_OCTET_STREAM)
-        fun getNetworkMap(): Response {
+        fun getNetworkMap(): Response = log.logElapsedTime("Get NetworkMap") {
             val networkMap = NetworkMap(nodeInfoMap.keys.toList(), signedNetParams.raw.hash, parametersUpdate)
             val signedNetworkMap = networkMapCertAndKeyPair.sign(networkMap)
-            return Response.ok(signedNetworkMap.serialize().bytes).header("Cache-Control", "max-age=${cacheTimeout.seconds}").build()
+            Response.ok(signedNetworkMap.serialize().bytes).header("Cache-Control", "max-age=${cacheTimeout.seconds}").build()
         }
 
         // Remove nodeInfo for testing.
@@ -148,9 +147,9 @@ class NetworkMapServer(private val cacheTimeout: Duration,
         @GET
         @Path("node-info/{var}")
         @Produces(MediaType.APPLICATION_OCTET_STREAM)
-        fun getNodeInfo(@PathParam("var") nodeInfoHash: String): Response {
+        fun getNodeInfo(@PathParam("var") nodeInfoHash: String): Response = log.logElapsedTime("NodeInfo by hash") {
             val signedNodeInfo = nodeInfoMap[SecureHash.parse(nodeInfoHash)]
-            return if (signedNodeInfo != null) {
+            if (signedNodeInfo != null) {
                 Response.ok(signedNodeInfo.serialize().bytes)
             } else {
                 Response.status(Response.Status.NOT_FOUND)
@@ -160,7 +159,7 @@ class NetworkMapServer(private val cacheTimeout: Duration,
         @GET
         @Path("network-parameters/{var}")
         @Produces(MediaType.APPLICATION_OCTET_STREAM)
-        fun getNetworkParameter(@PathParam("var") hash: String): Response {
+        fun getNetworkParameter(@PathParam("var") hash: String): Response = log.logElapsedTime("NetworkParams by hash") {
             val requestedHash = SecureHash.parse(hash)
             val requestedParameters = if (requestedHash == signedNetParams.raw.hash) {
                 signedNetParams
@@ -170,11 +169,13 @@ class NetworkMapServer(private val cacheTimeout: Duration,
                 null
             }
             requireNotNull(requestedParameters)
-            return Response.ok(requestedParameters!!.serialize().bytes).build()
+            Response.ok(requestedParameters!!.serialize().bytes).build()
         }
 
         @GET
         @Path("my-hostname")
-        fun getHostName(): Response = Response.ok(myHostNameValue).build()
+        fun getHostName(): Response = logElapsedTime("My hostname") {
+            Response.ok(myHostNameValue).build()
+        }
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -34,7 +34,7 @@ import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.ok
 import javax.ws.rs.core.Response.status
 
-class NetworkMapServer(private val cacheTimeout: Duration,
+class NetworkMapServer(private val responseValidityDuration: Duration,
                        hostAndPort: NetworkHostAndPort,
                        private val networkMapCertAndKeyPair: CertificateAndKeyPair = createDevNetworkMapCa(),
                        private val myHostNameValue: String = "test.host.name",
@@ -142,7 +142,7 @@ class NetworkMapServer(private val cacheTimeout: Duration,
         fun getNetworkMap(): Response = log.logElapsedTime("Get NetworkMap") {
             val networkMap = NetworkMap(nodeInfoMap.keys.toList(), signedNetParams.raw.hash, parametersUpdate)
             val signedNetworkMap = networkMapCertAndKeyPair.sign(networkMap)
-            Response.ok(signedNetworkMap.serialize().bytes).header("Cache-Control", "max-age=${cacheTimeout.seconds}").build()
+            Response.ok(signedNetworkMap.serialize().bytes).header("Cache-Control", "max-age=${responseValidityDuration.seconds}").build()
         }
 
         // Remove nodeInfo for testing.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/network/NetworkMapServer.kt
@@ -92,6 +92,12 @@ class NetworkMapServer(private val cacheTimeout: Duration,
         return service.latestAcceptedParametersMap[publicKey]
     }
 
+    fun advertiseNewParameters() {
+        networkParameters = checkNotNull(nextNetworkParameters) { "Schedule parameters update first" }
+        nextNetworkParameters = null
+        parametersUpdate = null
+    }
+
     override fun close() {
         server.stop()
     }


### PR DESCRIPTION
There was a problem identified with `NetworkMapServer` where response cache interval has not been correctly set for it.
This resulted delay of 1 minute in all the nodes discovering each other on the NetworkMap.

After the changes the test running time is down to 55 seconds from around 2 minutes previously.