### PR TITLE
ENT-1670: update kdocs and unit test for better user experience

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -305,16 +305,21 @@ class RPCStabilityTests {
 
             var terminateHandlerCalled = false
             var errorHandlerCalled = false
+            var exceptionMessage: String? = null
             val subscription = client.subscribe()
                      .doOnTerminate{ terminateHandlerCalled = true }
                      .doOnError { errorHandlerCalled = true }
-                     .subscribe()
+                     .subscribe({}, {
+                         //log exception
+                         exceptionMessage = it.message
+                     })
 
             serverFollower.shutdown()
             Thread.sleep(100)
 
             assertTrue(terminateHandlerCalled)
             assertTrue(errorHandlerCalled)
+            assertEquals("Connection failure detected.", exceptionMessage)
             assertTrue(subscription.isUnsubscribed)
 
             clientFollower.shutdown() // Driver would do this after the new server, causing hang.

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -308,8 +308,8 @@ class RPCStabilityTests {
             var exceptionMessage: String? = null
             val subscription = client.subscribe()
                      .doOnTerminate{ terminateHandlerCalled = true }
-                     .doOnError { errorHandlerCalled = true }
                      .subscribe({}, {
+                         errorHandlerCalled = true
                          //log exception
                          exceptionMessage = it.message
                      })

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -89,6 +89,10 @@ interface CordaRPCClientConfiguration {
  * with an error, the observable is closed and you can't then re-subscribe again: you'll have to re-request a fresh
  * observable with another RPC.
  *
+ * In case of loss of connection to the server, the client will try to reconnect using the settings provided via
+ * [CordaRPCClientConfiguration]. While attempting failover, current and future RPC calls will throw
+ * [RPCException] and previously returned observables will call onError().
+ *
  * @param hostAndPort The network address to connect to.
  * @param configuration An optional configuration used to tweak client behaviour.
  * @param sslConfiguration An optional [SSLConfiguration] used to enable secure communication with the server.


### PR DESCRIPTION
With the recent RPCClient changes, the user is expected to provide error handlers when subscribing to observables. This was not being reflected in the kdocs. Also update a unit test with usage example.