### PR TITLE
ENT-1665 - Update fast-classpath-scanner version to 2.12.3 (was 2.0.21)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,11 @@ Unreleased
 Here are brief summaries of what's changed between each snapshot release. This includes guidance on how to upgrade code
 from the previous milestone release.
 
+* Update the fast-classpath-scanner dependent library version from 2.0.21 to 2.12.3
+
+  .. note:: Whilst this is not the latest version of this library, that being 2.18.1 at time of writing, versions later
+  than 2.12.3 (including 2.12.4) exhibit a different issue.
+
 * Node can be shut down abruptly by ``shutdown`` function in `CordaRPCOps` or gracefully (draining flows first) through ``gracefulShutdown`` command from shell.
 
 * Parsing of ``NodeConfiguration`` will now fail if unknown configuration keys are found.

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile "org.apache.qpid:proton-j:0.21.0"
 
     // FastClasspathScanner: classpath scanning - needed for the NetworkBootstraper
-    compile 'io.github.lukehutch:fast-classpath-scanner:2.0.21'
+    compile 'io.github.lukehutch:fast-classpath-scanner:2.12.3'
 
     // Pure-Java Snappy compression
     compile 'org.iq80.snappy:snappy:0.4'


### PR DESCRIPTION
The problem manifests now that the classpath scanner is used by the
serialization framework in factory initialization to locate pluggable
serializers. The actual thrown error is

    java.lang.RuntimeException: Unknown constant pool tag

Given this is a known issue and a fixed bug it makes sense to move the
version forward. Unfortunately, at this time we cannot move beyond
2.12.3 as 2.12.4 and later versions (up to the latest 2.18.1) exhibit
some other error that needs investigating. Thus, move to the latest
version that is stable for our current set of use cases.

More information on the nature of the problem exhibited by moving beyond
2.12.3 can be found on the linked Jira (ENT-1665) as well as details on
reproducing the issue moving forward to 2.12.3 fixes.

