### PR TITLE
ENT-1668: Don't crash on node startup when network map is not available

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -10,6 +10,7 @@ import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 import net.corda.nodeapi.internal.network.NETWORK_PARAMS_UPDATE_FILE_NAME
 import net.corda.nodeapi.internal.network.SignedNetworkParameters
 import net.corda.nodeapi.internal.network.verifiedNetworkMapCert
+import java.net.ConnectException
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.security.cert.X509Certificate
@@ -26,7 +27,13 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
     val networkParameters by lazy { retrieveNetworkParameters() }
 
     private fun retrieveNetworkParameters(): NetworkParameters {
-        val advertisedParametersHash = networkMapClient?.getNetworkMap()?.payload?.networkParameterHash
+        val advertisedParametersHash = try {
+            networkMapClient?.getNetworkMap()?.payload?.networkParameterHash
+        } catch(e: ConnectException) {
+            logger.info("Couldn't connect to NetworkMap")
+            // If NetworkMap is down while restarting the node, we should be still able to continue with parameters from file
+            null
+        }
         val signedParametersFromFile = if (networkParamsFile.exists()) {
             networkParamsFile.readObject<SignedNetworkParameters>()
         } else {
@@ -44,7 +51,7 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
                 readParametersUpdate(advertisedParametersHash, signedParametersFromFile.raw.hash).verifiedNetworkMapCert(trustRoot)
             }
         } else { // No compatibility zone configured. Node should proceed with parameters from file.
-            signedParametersFromFile?.verifiedNetworkMapCert(trustRoot) ?: throw IllegalArgumentException("Couldn't find network parameters file and compatibility zone wasn't configured")
+            signedParametersFromFile?.verifiedNetworkMapCert(trustRoot) ?: throw IllegalArgumentException("Couldn't find network parameters file and compatibility zone wasn't configured/isn't reachable")
         }
         logger.info("Loaded network parameters: $parameters")
         return parameters

--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -29,8 +29,8 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
     private fun retrieveNetworkParameters(): NetworkParameters {
         val advertisedParametersHash = try {
             networkMapClient?.getNetworkMap()?.payload?.networkParameterHash
-        } catch(e: ConnectException) {
-            logger.info("Couldn't connect to NetworkMap")
+        } catch (e: ConnectException) {
+            logger.info("Couldn't connect to NetworkMap", e)
             // If NetworkMap is down while restarting the node, we should be still able to continue with parameters from file
             null
         }


### PR DESCRIPTION
Don't crash on node startup when network map is not available