### PR TITLE
CORDA-1277 Remove double quotes from keys in reference.conf

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -34,6 +34,8 @@ from the previous milestone release.
 
 * Introduced a placeholder for custom properties within ``node.conf``; the property key is "custom".
 
+* Property keys with double quotes (e.g. `"key"`) in ``node.conf`` are no longer allowed, for rationale refer to :doc:`corda-configuration-file`.
+
 * java.math.BigInteger serialization support added.
 
 * java.security.cert.CRLReason added to the default Whitelist.

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -24,7 +24,7 @@ The Corda configuration file uses the HOCON format which is superset of JSON. Pl
 
 Please do NOT use double quotes (``"``) in configuration keys.
 
-Node will throw exception `Config files should not contain \" in property names. Please fix: [key]`
+Node setup will log `Config files should not contain \" in property names. Please fix: [key]` as error
 when it founds double quotes around keys.
 This prevents configuration errors when mixing keys containing ``.`` wrapped with double quotes and without them
 e.g.:

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -22,6 +22,8 @@ Format
 The Corda configuration file uses the HOCON format which is superset of JSON. Please visit
 `<https://github.com/typesafehub/config/blob/master/HOCON.md>`_ for further details.
 
+Please do NOT use double quotes in configuration keys.
+
 Defaults
 --------
 A set of default configuration options are loaded from the built-in resource file ``/node/src/main/resources/reference.conf``.

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -22,7 +22,14 @@ Format
 The Corda configuration file uses the HOCON format which is superset of JSON. Please visit
 `<https://github.com/typesafehub/config/blob/master/HOCON.md>`_ for further details.
 
-Please do NOT use double quotes in configuration keys.
+Please do NOT use double quotes (``"``) in configuration keys.
+
+Node will throw exception `Config files should not contain \" in property names. Please fix: [key]`
+when it founds double quotes around keys.
+This prevents configuration errors when mixing keys containing ``.`` wrapped with double quotes and without them
+e.g.:
+The property `"dataSourceProperties.dataSourceClassName" = "val"` in ``reference.conf``
+would be not overwritten by the property `dataSourceProperties.dataSourceClassName = "val2"` in ``node.conf``.
 
 Defaults
 --------

--- a/docs/source/example-code/src/main/resources/example-node.conf
+++ b/docs/source/example-code/src/main/resources/example-node.conf
@@ -3,9 +3,9 @@ keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
 dataSourceProperties : {
     dataSourceClassName : org.h2.jdbcx.JdbcDataSource
-    "dataSource.url" : "jdbc:h2:file:"${baseDirectory}"/persistence"
-    "dataSource.user" : sa
-    "dataSource.password" : ""
+    dataSource.url : "jdbc:h2:file:"${baseDirectory}"/persistence"
+    dataSource.user : sa
+    dataSource.password : ""
 }
 p2pAddress : "my-corda-node:10002"
 rpcSettings = {

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -10,6 +10,7 @@ import net.corda.core.internal.div
 import net.corda.core.internal.exists
 import net.corda.nodeapi.internal.*
 import net.corda.nodeapi.internal.config.SSLConfiguration
+import net.corda.nodeapi.internal.config.toProperties
 import net.corda.nodeapi.internal.crypto.X509KeyStore
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import net.corda.nodeapi.internal.crypto.save
@@ -35,7 +36,16 @@ object ConfigHelper {
                 .withFallback(appConfig)
                 .withFallback(defaultConfig)
                 .resolve()
+
+
         log.info("Config:\n${finalConfig.root().render(ConfigRenderOptions.defaults())}")
+
+        val entrySet = finalConfig.entrySet().filter { entry -> entry.key.contains("\"") }
+        for (mutableEntry in entrySet) {
+            val key = mutableEntry.key
+                log.error("Config files should not contain \" in property names. Please fix: ${key}")
+        }
+
         return finalConfig
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -10,7 +10,6 @@ import net.corda.core.internal.div
 import net.corda.core.internal.exists
 import net.corda.nodeapi.internal.*
 import net.corda.nodeapi.internal.config.SSLConfiguration
-import net.corda.nodeapi.internal.config.toProperties
 import net.corda.nodeapi.internal.crypto.X509KeyStore
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import net.corda.nodeapi.internal.crypto.save
@@ -43,7 +42,7 @@ object ConfigHelper {
         val entrySet = finalConfig.entrySet().filter { entry -> entry.key.contains("\"") }
         for (mutableEntry in entrySet) {
             val key = mutableEntry.key
-                log.error("Config files should not contain \" in property names. Please fix: ${key}")
+            log.error("Config files should not contain \" in property names. Please fix: ${key}")
         }
 
         return finalConfig

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -4,9 +4,9 @@ keyStorePassword = "cordacadevpass"
 trustStorePassword = "trustpass"
 dataSourceProperties = {
     dataSourceClassName = org.h2.jdbcx.JdbcDataSource
-    "dataSource.url" = "jdbc:h2:file:"${baseDirectory}"/persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=100;AUTO_SERVER_PORT="${h2port}
-    "dataSource.user" = sa
-    "dataSource.password" = ""
+    dataSource.url = "jdbc:h2:file:"${baseDirectory}"/persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=100;AUTO_SERVER_PORT="${h2port}
+    dataSource.user = sa
+    dataSource.password = ""
 }
 database = {
     transactionIsolationLevel = "REPEATABLE_READ"


### PR DESCRIPTION
Removing double quotes around keys from reference conf, added an error to ConfigParser if such quoted keys are detected.