### PR TITLE
ENT-1463: Instantiate all contract classes before verifying any of them.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -119,17 +119,24 @@ data class LedgerTransaction @JvmOverloads constructor(
      * If any contract fails to verify, the whole transaction is considered to be invalid.
      */
     private fun verifyContracts() {
+        val contractInstances = ArrayList<Contract>(contracts.size)
         for ((key, result) in contracts) {
             when (result) {
                 is Try.Failure -> throw TransactionVerificationException.ContractCreationError(id, key, result.exception)
                 is Try.Success -> {
                     try {
-                        val contract = result.value.newInstance()
-                        contract.verify(this)
+                        contractInstances.add(result.value.newInstance())
                     } catch (e: Throwable) {
-                        throw TransactionVerificationException.ContractRejection(id, result.value.name, e)
+                        throw TransactionVerificationException.ContractCreationError(id, result.value.name, e)
                     }
                 }
+            }
+        }
+        contractInstances.forEach { contract ->
+            try {
+                contract.verify(this)
+            } catch (e: Throwable) {
+                throw TransactionVerificationException.ContractRejection(id, contract, e)
             }
         }
     }


### PR DESCRIPTION
To reduce the possibility of any side effect from aborting half-way through, we instantiate all of the contract classes before calling any of their verify methods.
We still load the contract classes when we create the `LedgerTransaction` object because the `ClassLoader` class may not be available to the JVM during verification.