### PR TITLE
ENT-1732: Fixing SignedNodeInfo security issue

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/SignedNodeInfo.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/SignedNodeInfo.kt
@@ -25,7 +25,7 @@ class SignedNodeInfo(val raw: SerializedBytes<NodeInfo>, val signatures: List<Di
     fun verified(): NodeInfo {
         val nodeInfo = raw.deserialize()
         val identities = nodeInfo.legalIdentities.filterNot { it.owningKey is CompositeKey }
-
+        require(identities.isNotEmpty()) { "At least one identity with a non-composite key needs to be specified." }
         if (identities.size < signatures.size) {
             throw SignatureException("Extra signatures. Found ${signatures.size} expected ${identities.size}")
         }


### PR DESCRIPTION
This fixes the security vulnerability described in [ENT-1732](https://r3-cev.atlassian.net/browse/ENT-1732).
