### PR TITLE
Update RpcExceptionHandlingTest tests introduced by CORDA-1264

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcExceptionHandlingTest.kt
@@ -9,6 +9,8 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.unwrap
 import net.corda.node.services.Permissions
 import net.corda.nodeapi.exceptions.InternalNodeException
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.NodeParameters
@@ -63,8 +65,8 @@ class RpcExceptionHandlingTest {
 
         driver(DriverParameters(startNodesInProcess = true)) {
 
-            val nodeA = startNode(NodeParameters(rpcUsers = users)).getOrThrow()
-            val nodeB = startNode(NodeParameters(rpcUsers = users)).getOrThrow()
+            val nodeA = startNode(NodeParameters(providedName = ALICE_NAME, rpcUsers = users)).getOrThrow()
+            val nodeB = startNode(NodeParameters(providedName = BOB_NAME, rpcUsers = users)).getOrThrow()
 
             assertThatCode { nodeA.rpc.startFlow(::InitFlow, nodeB.nodeInfo.singleIdentity()).returnValue.getOrThrow() }.isInstanceOfSatisfying(InternalNodeException::class.java) { exception ->
 


### PR DESCRIPTION
Add explicit node names in RpcExceptionHandlingTest for multi nodes tests (align with enterprise repo).
