### PR TITLE
Improve performance of NodeStatePersistenceTests

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
@@ -1,10 +1,10 @@
 package net.corda.node.modes.draining
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.MESSAGE_CONTRACT_PROGRAM_ID
-import net.corda.Message
-import net.corda.MessageContract
-import net.corda.MessageState
+import net.corda.testMessage.MESSAGE_CONTRACT_PROGRAM_ID
+import net.corda.testMessage.Message
+import net.corda.testMessage.MessageContract
+import net.corda.testMessage.MessageState
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.StateAndContract
 import net.corda.core.flows.*

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt
@@ -1,10 +1,10 @@
-package net.corda.node
+package net.corda.node.persistence
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.MESSAGE_CONTRACT_PROGRAM_ID
-import net.corda.Message
-import net.corda.MessageContract
-import net.corda.MessageState
+import net.corda.testMessage.MESSAGE_CONTRACT_PROGRAM_ID
+import net.corda.testMessage.Message
+import net.corda.testMessage.MessageContract
+import net.corda.testMessage.MessageState
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.StateAndContract
@@ -35,13 +35,10 @@ import kotlin.test.assertNotNull
 class NodeStatePersistenceTests {
     @Test
     fun `persistent state survives node restart`() {
-        // Temporary disable this test when executed on Windows. It is known to be sporadically failing.
-        // More investigation is needed to establish why.
-        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win"))
-
         val user = User("mark", "dadada", setOf(startFlow<SendMessageFlow>(), invokeRpc("vaultQuery")))
         val message = Message("Hello world!")
-        val stateAndRef: StateAndRef<MessageState>? = driver(DriverParameters(isDebug = true, startNodesInProcess = isQuasarAgentSpecified(), portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
+        val stateAndRef: StateAndRef<MessageState>? = driver(DriverParameters(isDebug = true, startNodesInProcess = isQuasarAgentSpecified(),
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
             val nodeName = {
                 val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
                 val nodeName = nodeHandle.nodeInfo.singleIdentity().name
@@ -104,7 +101,7 @@ class NodeStatePersistenceTests {
 
 fun isQuasarAgentSpecified(): Boolean {
     val jvmArgs = ManagementFactory.getRuntimeMXBean().inputArguments
-    return jvmArgs.any { it.startsWith("-javaagent:") && it.endsWith("quasar.jar") }
+    return jvmArgs.any { it.startsWith("-javaagent:") && it.contains("quasar") }
 }
 
 @StartableByRPC

--- a/node/src/integration-test/kotlin/net/corda/testMessage/MessageState.kt
+++ b/node/src/integration-test/kotlin/net/corda/testMessage/MessageState.kt
@@ -1,4 +1,4 @@
-package net.corda
+package net.corda.testMessage
 
 import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
@@ -48,7 +48,7 @@ object MessageSchemaV1 : MappedSchema(
     ) : PersistentState()
 }
 
-const val MESSAGE_CONTRACT_PROGRAM_ID = "net.corda.MessageContract"
+const val MESSAGE_CONTRACT_PROGRAM_ID = "net.corda.testMessage.MessageContract"
 
 open class MessageContract : Contract {
     override fun verify(tx: LedgerTransaction) {

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -218,8 +218,11 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
             identityService.loadIdentities(nodeInfo.legalIdentitiesAndCerts)
             val metrics = MetricRegistry()
             val transactionStorage = makeTransactionStorage(database, configuration.transactionCacheSizeBytes)
+            log.debug("Transaction storage created")
             attachments = NodeAttachmentService(metrics, configuration.attachmentContentCacheSizeBytes, configuration.attachmentCacheBound)
+            log.debug("Attachment service created")
             val cordappProvider = CordappProviderImpl(cordappLoader, CordappConfigFileProvider(), attachments, networkParameters.whitelistedContractImplementations)
+            log.debug("Cordapp provider created")
             val servicesForResolution = ServicesForResolutionImpl(identityService, attachments, cordappProvider, networkParameters, transactionStorage)
             val nodeProperties = NodePropertiesPersistentStore(StubbedNodeUniqueIdProvider::value, database)
             val nodeServices = makeServices(

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -110,6 +110,7 @@ class PersistentIdentityService(override val trustRoot: X509Certificate,
         confidentialIdentities.forEach {
             principalToParties.addWithDuplicatesAllowed(it.name, mapToKey(it), false)
         }
+        log.debug("Identities loaded")
     }
 
     @Throws(CertificateExpiredException::class, CertificateNotYetValidException::class, InvalidAlgorithmParameterException::class)


### PR DESCRIPTION
Packages re-jig was meant to reduce the size of the jars that are being produced by the
node driver. E.g. previously `MessageState` was in package `net.corda` which resulted in jar file
of around 2MB to be created multiple times. Same for `NodeStatePersistenceTests` which was in `net.corda.node`.

This change alone saves couple of minutes in build time.
Please compare this build without change:
https://ci-master.corda.r3cev.com/viewLog.html?currentGroup=test&scope=%23teamcity%23net.corda.node%23teamcity%23NodeStatePersistenceTests&pager.currentPage=1&order=DURATION_DESC&recordsPerPage=20&filterText=&status=&buildTypeId=Corda_CordaBuild&buildId=75021&tab=testsInfo
with:
https://ci-master.corda.r3cev.com/viewLog.html?currentGroup=test&scope=%23teamcity%23net.corda.node.persistence%23teamcity%23NodeStatePersistenceTests&pager.currentPage=1&order=DURATION_DESC&recordsPerPage=20&filterText=NodeStatePersistenceTests&status=&buildTypeId=Corda_Build_PullRequests_IntegrationTests&buildId=75135&tab=testsInfo