### PR TITLE
[CORDA-1201] Remove a duplication of the kotlin introduction part, which is the same as "Note" section right below it

### DIFF
--- a/docs/source/hello-world-state.rst
+++ b/docs/source/hello-world-state.rst
@@ -24,17 +24,6 @@ interface is defined as follows:
             val participants: List<AbstractParty>
         }
 
-The first thing you'll probably notice about this interface declaration is that its not written in Java or another
-common language. The core Corda platform, including the interface declaration above, is entirely written in Kotlin.
-
-Learning some Kotlin will be very useful for understanding how Corda works internally, and usually only takes an
-experienced Java developer a day or so to pick up. However, learning Kotlin isn't essential. Because Kotlin code
-compiles down to JVM bytecode, CorDapps written in other JVM languages can interoperate with Corda.
-
-If you do want to dive into Kotlin, there's an official
-`getting started guide <https://kotlinlang.org/docs/tutorials/>`_, and a series of
-`Kotlin Koans <https://kotlinlang.org/docs/tutorials/koans.html>`_.
-
 We can see that the ``ContractState`` interface has a single field, ``participants``. ``participants`` is a list of the
 entities for which this state is relevant.
 


### PR DESCRIPTION
This change is removing a duplicated description of Kotlin, there is a same description in the "Note" section right below it, so remove this part and keep "Note" part.

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [NA] Have you run the unit, integration and smoke tests as described here? https://docs.corda.net/head/testing.html
- [NA] If you added/changed public APIs, did you write/update the JavaDocs?
- [NA] If the changes are of interest to application developers, have you added them to the changelog, and potentially release notes?
- [Yes] If you are contributing for the first time, please read the agreement in CONTRIBUTING.md now and add to this Pull Request that you agree to it.

Thanks for your code, it's appreciated! :)
