### PR TITLE
CORDA-1300 Adding a unit test for SignedNodeInfo verification

### DIFF
--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/SignedNodeInfoTest.kt
@@ -1,6 +1,13 @@
 package net.corda.nodeapi.internal
 
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Crypto
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.node.NodeInfo
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.crypto.CertificateType
+import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
@@ -10,6 +17,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Rule
 import org.junit.Test
+import java.security.KeyPair
+import java.security.PrivateKey
+import java.security.PublicKey
 import java.security.SignatureException
 
 class SignedNodeInfoTest {
@@ -46,6 +56,19 @@ class SignedNodeInfoTest {
     }
 
     @Test
+    fun `verifying composite keys only`() {
+        val aliceKeyPair = generateKeyPair()
+        val bobKeyPair = generateKeyPair()
+        val identityKeyPair = generateKeyPair()
+        val compositeKey = CompositeKey.Builder().addKeys(aliceKeyPair.public, bobKeyPair.public).build(threshold = 1)
+        val nodeInfo = createNodeInfoWithSingleIdentity(ALICE_NAME, aliceKeyPair, compositeKey)
+        val signedNodeInfo = nodeInfo.signWith(listOf(identityKeyPair.private))
+        assertThatThrownBy { signedNodeInfo.verified() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("At least one identity with a non-composite key needs to be specified.")
+    }
+
+    @Test
     fun `verifying extra signature`() {
         val (_, aliceKey) = nodeInfoBuilder.addIdentity(ALICE_NAME)
         val nodeInfo = nodeInfoBuilder.build()
@@ -77,4 +100,26 @@ class SignedNodeInfoTest {
     }
 
     private fun generateKeyPair() = Crypto.generateKeyPair()
+
+    private fun createNodeInfoWithSingleIdentity(name: CordaX500Name, nodeKeyPair: KeyPair, identityCertPublicKey: PublicKey): NodeInfo {
+        val nodeCertificateAndKeyPair = createDevNodeCa(DEV_INTERMEDIATE_CA, name, nodeKeyPair)
+        val identityCert = X509Utilities.createCertificate(
+                CertificateType.LEGAL_IDENTITY,
+                nodeCertificateAndKeyPair.certificate,
+                nodeCertificateAndKeyPair.keyPair,
+                nodeCertificateAndKeyPair.certificate.subjectX500Principal,
+                identityCertPublicKey)
+        val certPath = X509Utilities.buildCertPath(
+                identityCert,
+                nodeCertificateAndKeyPair.certificate,
+                DEV_INTERMEDIATE_CA.certificate,
+                DEV_ROOT_CA.certificate)
+        val partyAndCertificate = PartyAndCertificate(certPath)
+        return NodeInfo(
+                listOf(NetworkHostAndPort("my.${partyAndCertificate.party.name.organisation}.com", 1234)),
+                listOf(partyAndCertificate),
+                1,
+                1
+        )
+    }
 }


### PR DESCRIPTION
This adds the test for the SignedNodeInfo verification. In particular the test focuses on verifying recently added composite check. 