### PR TITLE
This prevents log4j2 shutting down logging using a shutdown hook

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="info">
+<Configuration status="info" shutdownHook="disable">
 
     <Properties>
         <Property name="log-path">logs</Property>


### PR DESCRIPTION
At the minute the log4j2 logging is registering a shutdown hook, which cleans up when invoked. Unfortunately, Corda uses shutdown hooks to run its own shutdown tasks, so we stop logging partly way through close.