### PR TITLE
Adding CRL support in the generated certificates.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -8,12 +8,14 @@ import net.corda.core.internal.*
 import net.corda.core.utilities.days
 import net.corda.core.utilities.millis
 import org.bouncycastle.asn1.*
+import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x500.style.BCStyle
 import org.bouncycastle.asn1.x509.*
 import org.bouncycastle.asn1.x509.Extension
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.cert.X509v3CertificateBuilder
 import org.bouncycastle.cert.bc.BcX509ExtensionUtils
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.operator.ContentSigner
@@ -149,18 +151,25 @@ $trustedRoot""", e, certPath, e.index)
     /**
      * Build a partial X.509 certificate ready for signing.
      *
+     * @param certificateType type of the certificate.
      * @param issuer name of the issuing entity.
+     * @param issuerPublicKey public key of the issuing entity.
      * @param subject name of the certificate subject.
      * @param subjectPublicKey public key of the certificate subject.
      * @param validityWindow the time period the certificate is valid for.
      * @param nameConstraints any name constraints to impose on certificates signed by the generated certificate.
+     * @param crlDistPoint CRL distribution point.
+     * @param crlIssuer X500Name of the CRL issuer.
      */
-    fun createPartialCertificate(certificateType: CertificateType,
+    private fun createPartialCertificate(certificateType: CertificateType,
                                  issuer: X500Principal,
+                                 issuerPublicKey: PublicKey,
                                  subject: X500Principal,
                                  subjectPublicKey: PublicKey,
                                  validityWindow: Pair<Date, Date>,
-                                 nameConstraints: NameConstraints? = null): X509v3CertificateBuilder {
+                                 nameConstraints: NameConstraints? = null,
+                                 crlDistPoint: String? = null,
+                                 crlIssuer: X500Name? = null): X509v3CertificateBuilder {
         val serial = BigInteger.valueOf(random63BitValue())
         val keyPurposes = DERSequence(ASN1EncodableVector().apply { certificateType.purposes.forEach { add(it) } })
         val subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(subjectPublicKey.encoded))
@@ -171,10 +180,12 @@ $trustedRoot""", e, certPath, e.index)
                 .addExtension(Extension.basicConstraints, true, BasicConstraints(certificateType.isCA))
                 .addExtension(Extension.keyUsage, false, certificateType.keyUsage)
                 .addExtension(Extension.extendedKeyUsage, false, keyPurposes)
+                .addExtension(Extension.authorityKeyIdentifier, false, JcaX509ExtensionUtils().createAuthorityKeyIdentifier(issuerPublicKey))
 
         if (role != null) {
             builder.addExtension(ASN1ObjectIdentifier(CordaOID.X509_EXTENSION_CORDA_ROLE), false, role)
         }
+        addCrlInfo(builder, crlDistPoint, crlIssuer)
         if (nameConstraints != null) {
             builder.addExtension(Extension.nameConstraints, true, nameConstraints)
         }
@@ -185,11 +196,15 @@ $trustedRoot""", e, certPath, e.index)
     /**
      * Create a X509 v3 certificate using the given issuer certificate and key pair.
      *
+     * @param certificateType type of the certificate.
      * @param issuerCertificate The Public certificate of the root CA above this used to sign it.
      * @param issuerKeyPair The KeyPair of the root CA above this used to sign it.
      * @param subject subject of the generated certificate.
      * @param subjectPublicKey subject's public key.
      * @param validityWindow The certificate's validity window. Default to [DEFAULT_VALIDITY_WINDOW] if not provided.
+     * @param nameConstraints any name constraints to impose on certificates signed by the generated certificate.
+     * @param crlDistPoint CRL distribution point.
+     * @param crlIssuer X500Name of the CRL issuer.
      * @return A data class is returned containing the new intermediate CA Cert and its KeyPair for signing downstream certificates.
      * Note the generated certificate tree is capped at max depth of 1 below this to be in line with commercially available certificates.
      */
@@ -200,7 +215,9 @@ $trustedRoot""", e, certPath, e.index)
                           subject: X500Principal,
                           subjectPublicKey: PublicKey,
                           validityWindow: Pair<Duration, Duration> = DEFAULT_VALIDITY_WINDOW,
-                          nameConstraints: NameConstraints? = null): X509Certificate {
+                          nameConstraints: NameConstraints? = null,
+                          crlDistPoint: String? = null,
+                          crlIssuer: X500Name? = null): X509Certificate {
         val window = getCertificateValidityWindow(validityWindow.first, validityWindow.second, issuerCertificate)
         return createCertificate(
                 certificateType,
@@ -209,28 +226,36 @@ $trustedRoot""", e, certPath, e.index)
                 subject,
                 subjectPublicKey,
                 window,
-                nameConstraints
+                nameConstraints,
+                crlDistPoint,
+                crlIssuer
         )
     }
 
     /**
      * Build and sign an X.509 certificate with the given signer.
      *
+     * @param certificateType type of the certificate.
      * @param issuer name of the issuing entity.
      * @param issuerSigner content signer to sign the certificate with.
      * @param subject name of the certificate subject.
      * @param subjectPublicKey public key of the certificate subject.
      * @param validityWindow the time period the certificate is valid for.
      * @param nameConstraints any name constraints to impose on certificates signed by the generated certificate.
+     * @param crlDistPoint CRL distribution point.
+     * @param crlIssuer X500Name of the CRL issuer.
      */
     fun createCertificate(certificateType: CertificateType,
                           issuer: X500Principal,
+                          issuerPublicKey: PublicKey,
                           issuerSigner: ContentSigner,
                           subject: X500Principal,
                           subjectPublicKey: PublicKey,
                           validityWindow: Pair<Date, Date>,
-                          nameConstraints: NameConstraints? = null): X509Certificate {
-        val builder = createPartialCertificate(certificateType, issuer, subject, subjectPublicKey, validityWindow, nameConstraints)
+                          nameConstraints: NameConstraints? = null,
+                          crlDistPoint: String? = null,
+                          crlIssuer: X500Name? = null): X509Certificate {
+        val builder = createPartialCertificate(certificateType, issuer, issuerPublicKey, subject, subjectPublicKey, validityWindow, nameConstraints, crlDistPoint, crlIssuer)
         return builder.build(issuerSigner).run {
             require(isValidOn(Date()))
             toJca()
@@ -240,6 +265,7 @@ $trustedRoot""", e, certPath, e.index)
     /**
      * Build and sign an X.509 certificate with CA cert private key.
      *
+     * @param certificateType type of the certificate.
      * @param issuer name of the issuing entity.
      * @param issuerKeyPair the public & private key to sign the certificate with.
      * @param subject name of the certificate subject.
@@ -253,11 +279,21 @@ $trustedRoot""", e, certPath, e.index)
                           subject: X500Principal,
                           subjectPublicKey: PublicKey,
                           validityWindow: Pair<Date, Date>,
-                          nameConstraints: NameConstraints? = null): X509Certificate {
+                          nameConstraints: NameConstraints? = null,
+                          crlDistPoint: String? = null,
+                          crlIssuer: X500Name? = null): X509Certificate {
         val signatureScheme = Crypto.findSignatureScheme(issuerKeyPair.private)
         val provider = Crypto.findProvider(signatureScheme.providerName)
         val signer = ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
-        val builder = createPartialCertificate(certificateType, issuer, subject, subjectPublicKey, validityWindow, nameConstraints)
+        val builder = createPartialCertificate(
+                certificateType,
+                issuer,
+                issuerKeyPair.public,
+                subject, subjectPublicKey,
+                validityWindow,
+                nameConstraints,
+                crlDistPoint,
+                crlIssuer)
         return builder.build(signer).run {
             require(isValidOn(Date()))
             require(isSignatureValid(JcaContentVerifierProviderBuilder().build(issuerKeyPair.public)))
@@ -301,6 +337,21 @@ $trustedRoot""", e, certPath, e.index)
 
     fun buildCertPath(certificates: List<X509Certificate>): CertPath {
         return X509CertificateFactory().generateCertPath(certificates)
+    }
+
+    private fun addCrlInfo(builder: X509v3CertificateBuilder, crlDistPoint: String?, crlIssuer: X500Name?) {
+        if (crlDistPoint != null) {
+            val distPointName = DistributionPointName(GeneralNames(GeneralName(GeneralName.uniformResourceIdentifier, crlDistPoint)))
+            val crlIssuerGeneralNames = crlIssuer?.let {
+                GeneralNames(GeneralName(crlIssuer))
+            }
+            // The second argument is flag that allows you to define what reason of certificate revocation is served by this distribution point see [ReasonFlags].
+            // The idea is that you have different revocation per revocation reason. Since we won't go into such a granularity, we can skip that parameter.
+            // The third argument allows you to specify the name of the CRL issuer, it needs to be consistent with the crl (IssuingDistributionPoint) extension and the idp argument.
+            // If idp == true, set it, if idp == false, leave it null as done here.
+            val distPoint = DistributionPoint(distPointName, null, crlIssuerGeneralNames)
+            builder.addExtension(Extension.cRLDistributionPoints, false, CRLDistPoint(arrayOf(distPoint)))
+        }
     }
 }
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
@@ -20,9 +20,7 @@ import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.internal.createDevIntermediateCaCertPath
 import org.assertj.core.api.Assertions.assertThat
-import org.bouncycastle.asn1.x509.BasicConstraints
-import org.bouncycastle.asn1.x509.Extension
-import org.bouncycastle.asn1.x509.KeyUsage
+import org.bouncycastle.asn1.x509.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -100,6 +98,28 @@ class X509UtilitiesTest {
             val keyUsage = KeyUsage.getInstance(getExtension(Extension.keyUsage).parsedValue)
             assertFalse { keyUsage.hasUsages(5) } // Bit 5 == keyCertSign according to ASN.1 spec (see full comment on KeyUsage property)
             assertNull(basicConstraints.pathLenConstraint) // Non-CA certificate
+        }
+    }
+
+    @Test
+    fun `create valid server certificate chain includes CRL info`() {
+        val caKey = generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
+        val caCert = X509Utilities.createSelfSignedCACertificate(X500Principal("CN=Test CA Cert,O=R3 Ltd,L=London,C=GB"), caKey)
+        val caSubjectKeyIdentifier = SubjectKeyIdentifier.getInstance(caCert.toBc().getExtension(Extension.subjectKeyIdentifier).parsedValue)
+        val keyPair = generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
+        val crlDistPoint = "http://test.com"
+        val serverCert = X509Utilities.createCertificate(
+                CertificateType.TLS,
+                caCert,
+                caKey,
+                X500Principal("CN=Server Cert,O=R3 Ltd,L=London,C=GB"),
+                keyPair.public,
+                crlDistPoint = crlDistPoint)
+        serverCert.toBc().run {
+            val certCrlDistPoint = CRLDistPoint.getInstance(getExtension(Extension.cRLDistributionPoints).parsedValue)
+            assertTrue(certCrlDistPoint.distributionPoints.first().distributionPoint.toString().contains(crlDistPoint))
+            val certCaAuthorityKeyIdentifier = AuthorityKeyIdentifier.getInstance(getExtension(Extension.authorityKeyIdentifier).parsedValue)
+            assertTrue(Arrays.equals(caSubjectKeyIdentifier.keyIdentifier, certCaAuthorityKeyIdentifier.keyIdentifier))
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/KMSUtils.kt
@@ -40,6 +40,7 @@ fun freshCertificate(identityService: IdentityService,
     val ourCertificate = X509Utilities.createCertificate(
             CertificateType.CONFIDENTIAL_LEGAL_IDENTITY,
             issuerCert.subjectX500Principal,
+            issuerCert.publicKey,
             issuerSigner,
             issuer.name.x500Principal,
             subjectPublicKey,


### PR DESCRIPTION
This PR adds the CRL support for the generated certificates in the X509Utilities class.
Here is the certificate snippet:

[
[
  Version: V3
  Subject: CN=Server Cert, O=R3 Ltd, L=London, C=GB
  Signature Algorithm: SHA256withECDSA, params unparsed, OID = 1.2.840.10045.4.3.2

  Key:  Sun EC public key, 256 bits
  public x coord: 4480091252781703195661860073149098197905970789947759358848305764737974351635
  public y coord: 91515947767866989687528832609777756360177875523811291720844490776224837881690
  parameters: secp256r1 [NIST P-256, X9.62 prime256v1] (1.2.840.10045.3.1.7)
  Validity: [From: Thu Apr 05 01:00:00 BST 2018,
               To: Sun Apr 02 01:00:00 BST 2028]
  Issuer: CN=Test CA Cert, O=R3 Ltd, L=London, C=GB
  SerialNumber: [    74820859 611c7975]

Certificate Extensions: 7
[1]: ObjectId: 1.3.6.1.4.1.50530.1.1 Criticality=false
Extension unknown: DER encoded OCTET string =
0000: 04 03 02 01 05                                     .....


[2]: ObjectId: 2.5.29.35 Criticality=false
AuthorityKeyIdentifier [
KeyIdentifier [
0000: C4 3D 94 DD 33 65 9C 52   0B A8 18 A9 1E D5 94 D4  .=..3e.R........
0010: EA E1 F3 7C                                        ....
]
]

[3]: ObjectId: 2.5.29.19 Criticality=true
BasicConstraints:[
  CA:false
  PathLen: undefined
]

[4]: ObjectId: 2.5.29.31 Criticality=false
CRLDistributionPoints [
  [DistributionPoint:
     [URIName: http://test.com]
]]

[5]: ObjectId: 2.5.29.37 Criticality=false
ExtendedKeyUsages [
  serverAuth
  clientAuth
  anyExtendedKeyUsage
]

[6]: ObjectId: 2.5.29.15 Criticality=false
KeyUsage [
  DigitalSignature
  Key_Encipherment
  Key_Agreement
]

[7]: ObjectId: 2.5.29.14 Criticality=false
SubjectKeyIdentifier [
KeyIdentifier [
0000: D3 DE E8 52 0C 84 64 5F   77 61 25 58 2A AB 02 C2  ...R..d_wa%X*...
0010: 2C 4D 15 D4                                        ,M..
]
]

]
  Algorithm: [SHA256withECDSA, params unparsed]
  Signature:
0000: 30 45 02 20 77 33 47 29   C7 90 49 37 A0 80 5B CF  0E. w3G)..I7..[.
0010: 05 89 C0 FE 4B 87 94 58   1C BD BD AF 43 B3 0C E5  ....K..X....C...
0020: D3 77 10 4A 02 21 00 D4   B3 86 1E 6B 8F CA 65 C9  .w.J.!.....k..e.
0030: FC 49 C1 AF 77 4E EF 97   49 DF 99 7B 35 04 4C 00  .I..wN..I...5.L.
0040: 11 A4 6F 3B AC 16 19                               ..o;...

]

