### PR TITLE
Remove `errorLogPath` parameter which is not used anyway.

### DIFF
--- a/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
+++ b/samples/irs-demo/src/integration-test/kotlin/net/corda/test/spring/SpringDriver.kt
@@ -5,17 +5,13 @@ import net.corda.core.internal.concurrent.map
 import net.corda.core.utilities.contextLogger
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.NodeHandle
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.WebserverHandle
 import net.corda.testing.driver.internal.NodeHandleInternal
-import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.*
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.ConnectException
 import java.net.URL
-import java.nio.file.Path
-import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 fun <A> springDriver(
@@ -87,7 +83,6 @@ data class SpringBootDriverDSL(private val driverDSL: DriverDSLImpl) : InternalD
                 ),
                 classpath = ProcessUtilities.defaultClassPath,
                 workingDirectory = handle.baseDirectory,
-                errorLogPath = Paths.get("error.$className.log"),
                 arguments = listOf(
                         "--base-directory", handle.baseDirectory.toString(),
                         "--server.port=${(handle as NodeHandleInternal).webAddress.port}",

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -847,7 +847,6 @@ class DriverDSLImpl(
                     arguments = arguments,
                     jdwpPort = debugPort,
                     extraJvmArguments = extraJvmArguments + listOfNotNull(jolokiaAgent),
-                    errorLogPath = config.corda.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME / "error.log",
                     workingDirectory = config.corda.baseDirectory,
                     maximumHeapSize = maximumHeapSize
             )
@@ -864,7 +863,6 @@ class DriverDSLImpl(
                             "-Dname=node-${handle.p2pAddress}-webserver",
                             "-Djava.io.tmpdir=${System.getProperty("java.io.tmpdir")}" // Inherit from parent process
                     ),
-                    errorLogPath = Paths.get("error.$className.log"),
                     workingDirectory = null,
                     maximumHeapSize = maximumHeapSize
             )

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ProcessUtilities.kt
@@ -11,7 +11,7 @@ object ProcessUtilities {
             jdwpPort: Int? = null,
             extraJvmArguments: List<String> = emptyList()
     ): Process {
-        return startJavaProcessImpl(C::class.java.name, arguments, defaultClassPath, jdwpPort, extraJvmArguments, null, null, null)
+        return startJavaProcessImpl(C::class.java.name, arguments, defaultClassPath, jdwpPort, extraJvmArguments, null, null)
     }
 
     fun startCordaProcess(
@@ -19,13 +19,12 @@ object ProcessUtilities {
             arguments: List<String>,
             jdwpPort: Int?,
             extraJvmArguments: List<String>,
-            errorLogPath: Path?,
             workingDirectory: Path?,
             maximumHeapSize: String
     ): Process {
         // FIXME: Instead of hacking our classpath, use the correct classpath for className.
         val classpath = defaultClassPath.split(pathSeparator).filter { !(it / "log4j2-test.xml").exists() }.joinToString(pathSeparator)
-        return startJavaProcessImpl(className, arguments, classpath, jdwpPort, extraJvmArguments, errorLogPath, workingDirectory, maximumHeapSize)
+        return startJavaProcessImpl(className, arguments, classpath, jdwpPort, extraJvmArguments, workingDirectory, maximumHeapSize)
     }
 
     fun startJavaProcessImpl(
@@ -34,7 +33,6 @@ object ProcessUtilities {
             classpath: String,
             jdwpPort: Int?,
             extraJvmArguments: List<String>,
-            errorLogPath: Path?,
             workingDirectory: Path?,
             maximumHeapSize: String?
     ): Process {


### PR DESCRIPTION
StdErr is always written to working directory if such path specified.