### PR TITLE
Do not perform deep scan when assembling Dev Cordap Jar.

### DIFF
--- a/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
+++ b/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
@@ -11,6 +11,7 @@ import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.bufferUntilSubscribed
+import net.corda.core.internal.packageName
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.StateMachineTransactionMapping
 import net.corda.core.messaging.StateMachineUpdate
@@ -54,7 +55,7 @@ class NodeMonitorModelTest {
     private lateinit var newNode: (CordaX500Name) -> NodeInfo
 
     private fun setup(runTest: () -> Unit) {
-        driver(DriverParameters(extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name))) {
+        driver(DriverParameters(extraCordappPackagesToScan = listOf(Cash::class.packageName))) {
             val cashUser = User("user1", "test", permissions = setOf(
                     startFlow<CashIssueFlow>(),
                     startFlow<CashPaymentFlow>(),

--- a/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
+++ b/client/jfx/src/integration-test/kotlin/net/corda/client/jfx/NodeMonitorModelTest.kt
@@ -23,6 +23,7 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.DOLLARS
 import net.corda.finance.USD
+import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashExitFlow
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
@@ -53,7 +54,7 @@ class NodeMonitorModelTest {
     private lateinit var newNode: (CordaX500Name) -> NodeInfo
 
     private fun setup(runTest: () -> Unit) {
-        driver(DriverParameters(extraCordappPackagesToScan = listOf("net.corda.finance"))) {
+        driver(DriverParameters(extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name))) {
             val cashUser = User("user1", "test", permissions = setOf(
                     startFlow<CashIssueFlow>(),
                     startFlow<CashPaymentFlow>(),

--- a/core/src/main/kotlin/net/corda/core/internal/AttachmentWithContext.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AttachmentWithContext.kt
@@ -19,4 +19,8 @@ class AttachmentWithContext(
             "This AttachmentWithContext was not initialised properly"
         }
     }
+
+    override fun toString(): String {
+        return "ContractAttachment: $contractAttachment, stateContract: $stateContract, whitelistedContractImplementations: $whitelistedContractImplementations"
+    }
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -372,7 +372,7 @@ inline fun <reified T : ContractState> VaultService.trackBy(criteria: QueryCrite
     return _trackBy(criteria, paging, sorting, T::class.java)
 }
 
-class VaultQueryException(val description: String) : FlowException(description)
+class VaultQueryException(override val message: String) : FlowException(message)
 
 class StatesNotAvailableException(override val message: String?, override val cause: Throwable? = null) : FlowException(message, cause) {
     override fun toString() = "Soft locking error: $message"

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -372,7 +372,7 @@ inline fun <reified T : ContractState> VaultService.trackBy(criteria: QueryCrite
     return _trackBy(criteria, paging, sorting, T::class.java)
 }
 
-class VaultQueryException(description: String) : FlowException(description)
+class VaultQueryException(val description: String) : FlowException(description)
 
 class StatesNotAvailableException(override val message: String?, override val cause: Throwable? = null) : FlowException(message, cause) {
     override fun toString() = "Soft locking error: $message"

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -9,6 +9,7 @@ import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.Try
+import net.corda.core.utilities.contextLogger
 import java.util.*
 import java.util.function.Predicate
 
@@ -51,6 +52,9 @@ data class LedgerTransaction @JvmOverloads constructor(
     }
 
     private companion object {
+
+        private val logger = contextLogger()
+
         private fun contractClassFor(className: ContractClassName, classLoader: ClassLoader?): Try<Class<out Contract>> {
             return Try.on {
                 (classLoader ?: this::class.java.classLoader)
@@ -109,6 +113,7 @@ data class LedgerTransaction @JvmOverloads constructor(
             val contractAttachment = uniqueAttachmentsForStateContract.first()
             val constraintAttachment = AttachmentWithContext(contractAttachment, state.contract, networkParameters?.whitelistedContractImplementations)
             if (!state.constraint.isSatisfiedBy(constraintAttachment)) {
+                logger.warn("Constraint verification failed.\nState: $state\nAttachment: $constraintAttachment")
                 throw TransactionVerificationException.ContractConstraintRejection(id, state.contract)
             }
         }

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
@@ -50,7 +50,7 @@ fun main(args: Array<String>) {
             startFlow<CashExitFlow>(),
             invokeRpc(CordaRPCOps::nodeInfo)
     ))
-    driver(DriverParameters(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true)) {
+    driver(DriverParameters(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name), waitForAllNodesToFinish = true)) {
         val node = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).get()
         // END 1
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/ClientRpcTutorial.kt
@@ -4,6 +4,7 @@ package net.corda.docs
 
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.Amount
+import net.corda.core.internal.packageName
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.messaging.vaultQueryBy
@@ -50,7 +51,7 @@ fun main(args: Array<String>) {
             startFlow<CashExitFlow>(),
             invokeRpc(CordaRPCOps::nodeInfo)
     ))
-    driver(DriverParameters(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name), waitForAllNodesToFinish = true)) {
+    driver(DriverParameters(driverDirectory = baseDirectory, extraCordappPackagesToScan = listOf(Cash::class.packageName), waitForAllNodesToFinish = true)) {
         val node = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user)).get()
         // END 1
 

--- a/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/CommercialPaperTests.kt
@@ -4,6 +4,7 @@ import net.corda.core.contracts.*
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.internal.packageName
 import net.corda.core.node.services.Vault
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -88,7 +89,7 @@ class KotlinCommercialPaperLegacyTest : ICommercialPaperTestTemplate {
     override fun getContract() = CommercialPaper.CP_PROGRAM_ID
 }
 
-private val cordappPackages = listOf(Cash::class.java.`package`.name, CommercialPaper::class.java.`package`.name)
+private val cordappPackages = listOf(Cash::class.packageName, CommercialPaper::class.packageName)
 
 @RunWith(Parameterized::class)
 class CommercialPaperTestsGeneric {

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -6,6 +6,7 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.internal.concurrent.transpose
+import net.corda.core.internal.packageName
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
@@ -97,7 +98,7 @@ class NodePerformanceTests {
         internalDriver(
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, rpcUsers = listOf(user))),
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name)
+                extraCordappPackagesToScan = listOf(Cash::class.packageName)
         ) {
             val notary = defaultNotaryNode.getOrThrow() as InProcess
             val metricRegistry = startReporter(this.shutdownManager, notary.internalServices.monitoringService.metrics)

--- a/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodePerformanceTests.kt
@@ -11,6 +11,7 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.minutes
 import net.corda.finance.DOLLARS
+import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.startFlow
@@ -96,7 +97,7 @@ class NodePerformanceTests {
         internalDriver(
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, rpcUsers = listOf(user))),
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.finance")
+                extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name)
         ) {
             val notary = defaultNotaryNode.getOrThrow() as InProcess
             val metricRegistry = startReporter(this.shutdownManager, notary.internalServices.monitoringService.metrics)

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -4,6 +4,7 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.Amount
 import net.corda.core.identity.Party
 import net.corda.core.internal.bufferUntilSubscribed
+import net.corda.core.internal.packageName
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.StateMachineUpdate
 import net.corda.core.messaging.startFlow
@@ -43,7 +44,7 @@ class DistributedServiceTests {
                 invokeRpc(CordaRPCOps::stateMachinesFeed))
         )
         driver(DriverParameters(
-                extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name),
+                extraCordappPackagesToScan = listOf(Cash::class.packageName),
                 notarySpecs = listOf(
                         NotarySpec(
                                 DUMMY_NOTARY_NAME,

--- a/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/DistributedServiceTests.kt
@@ -10,6 +10,7 @@ import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.POUNDS
+import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
 import net.corda.node.services.Permissions.Companion.invokeRpc
@@ -42,7 +43,7 @@ class DistributedServiceTests {
                 invokeRpc(CordaRPCOps::stateMachinesFeed))
         )
         driver(DriverParameters(
-                extraCordappPackagesToScan = listOf("net.corda.finance.contracts"),
+                extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name),
                 notarySpecs = listOf(
                         NotarySpec(
                                 DUMMY_NOTARY_NAME,

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -3,6 +3,7 @@ package net.corda.node.utilities.registration
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.internal.logElapsedTime
+import net.corda.core.internal.packageName
 import net.corda.core.internal.readFully
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.*
@@ -89,7 +90,7 @@ class NodeRegistrationTest {
                 compatibilityZone = compatibilityZone,
                 initialiseSerialization = false,
                 notarySpecs = listOf(NotarySpec(notaryName)),
-                extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name)
+                extraCordappPackagesToScan = listOf(Cash::class.packageName)
         ) {
             val (alice, genevieve) = listOf(
                     startNode(providedName = aliceName),

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.internal.readFully
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.*
 import net.corda.finance.DOLLARS
+import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashIssueAndPaymentFlow
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.nodeapi.internal.crypto.CertificateType
@@ -88,7 +89,7 @@ class NodeRegistrationTest {
                 compatibilityZone = compatibilityZone,
                 initialiseSerialization = false,
                 notarySpecs = listOf(NotarySpec(notaryName)),
-                extraCordappPackagesToScan = listOf("net.corda.finance")
+                extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name)
         ) {
             val (alice, genevieve) = listOf(
                     startNode(providedName = aliceName),

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -133,7 +133,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
                 logger.info("Generating a test-only cordapp of classes discovered in $scanPackage at $cordappJAR")
                 JarOutputStream(cordappJAR.outputStream()).use { jos ->
                     val scanDir = url.toPath()
-                    scanDir.walk { it.forEach {
+                    scanDir.listFiles().filter { it.isFile }.forEach {
                         val entryPath = "$jarPackageName/${scanDir.relativize(it).toString().replace('\\', '/')}"
                         val time = FileTime.from(Instant.EPOCH)
                         val entry = ZipEntry(entryPath).setCreationTime(time).setLastAccessTime(time).setLastModifiedTime(time)
@@ -142,7 +142,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
                             it.copyTo(jos)
                         }
                         jos.closeEntry()
-                    } }
+                    }
                 }
                 cordappJAR.toUri()
             }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -2,9 +2,6 @@ package net.corda.node.internal.cordapp
 
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner
 import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult
-import net.corda.core.contracts.Contract
-import net.corda.core.contracts.UpgradedContract
-import net.corda.core.contracts.UpgradedContractWithLegacyConstraint
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.flows.*
 import net.corda.core.internal.*
@@ -133,7 +130,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
                 logger.info("Generating a test-only cordapp of classes discovered in $scanPackage at $cordappJAR")
                 JarOutputStream(cordappJAR.outputStream()).use { jos ->
                     val scanDir = url.toPath()
-                    scanDir.listFiles().filter { it.isFile }.forEach {
+                    scanDir.toFile().listFiles().filter { it.isFile }.map { it.toPath() }.forEach {
                         val entryPath = "$jarPackageName/${scanDir.relativize(it).toString().replace('\\', '/')}"
                         val time = FileTime.from(Instant.EPOCH)
                         val entry = ZipEntry(entryPath).setCreationTime(time).setLastAccessTime(time).setLastModifiedTime(time)

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
@@ -25,6 +25,10 @@ open class CordappProviderImpl(private val cordappLoader: CordappLoader,
 
     companion object {
         private val log = loggerFor<CordappProviderImpl>()
+
+        private data class CorDappLight(val contractClassNames: Set<String>, val jarPath: URL) {
+            constructor(corDapp: Cordapp) : this(corDapp.contractClassNames.toSet(), corDapp.jarPath)
+        }
     }
 
     private val contextCache = ConcurrentHashMap<Cordapp, CordappContext>()
@@ -33,6 +37,10 @@ open class CordappProviderImpl(private val cordappLoader: CordappLoader,
      * Current known CorDapps loaded on this node
      */
     override val cordapps get() = cordappLoader.cordapps
+
+    /**
+     * cordappAttachments.size <= cordapps.size since not all CorDapps have contracts
+     */
     private val cordappAttachments = HashBiMap.create(loadContractsIntoAttachmentStore(attachmentStorage))
 
     init {
@@ -71,7 +79,7 @@ open class CordappProviderImpl(private val cordappLoader: CordappLoader,
     }
 
     override fun getContractAttachmentID(contractClassName: ContractClassName): AttachmentId? {
-        return getCordappForClass(contractClassName)?.let(this::getCordappAttachmentId)
+        return cordappAttachments.entries.find { it.value.contractClassNames.contains(contractClassName) }?.key
     }
 
     /**
@@ -80,18 +88,53 @@ open class CordappProviderImpl(private val cordappLoader: CordappLoader,
      * @param cordapp The cordapp to get the attachment ID
      * @return An attachment ID if it exists, otherwise nothing
      */
-    fun getCordappAttachmentId(cordapp: Cordapp): SecureHash? = cordappAttachments.inverse().get(cordapp.jarPath)
+    fun getCordappAttachmentId(cordapp: Cordapp): SecureHash? = cordappAttachments.inverse().get(CorDappLight(cordapp))
 
-    private fun loadContractsIntoAttachmentStore(attachmentStorage: AttachmentStorage): Map<SecureHash, URL> =
-            cordapps.filter { !it.contractClassNames.isEmpty() }.map {
+    private fun loadContractsIntoAttachmentStore(attachmentStorage: AttachmentStorage): Map<SecureHash, CorDappLight> =
+            cordapps.filter { !it.contractClassNames.isEmpty() }.deDupeSameContractClassNames().map {
                 it.jarPath.openStream().use { stream ->
                     try {
                         attachmentStorage.importAttachment(stream, DEPLOYED_CORDAPP_UPLOADER, null)
                     } catch (faee: java.nio.file.FileAlreadyExistsException) {
                         AttachmentId.parse(faee.message!!)
                     }
-                } to it.jarPath
+                } to it
             }.toMap()
+
+
+    /**
+     * There might be cases when there are CorDapps that have the same contract classes. E.g. during Gradle unit test run the following been observed:
+     *
+     *     1. contractClassNames=[net.corda.finance.contracts.asset.Cash, net.corda.finance.contracts.asset.CommodityContract, net.corda.finance.contracts.asset.Obligation, net.corda.finance.contracts.asset.OnLedgerAsset] ->
+     *          jarPath=file:/Z:/corda/finance/build/tmp/generated-test-cordapps/net.corda.finance.contracts.asset-9562408e-b372-4194-8259-91dedaedc0ea.jar
+     *
+     *     2. contractClassNames=[net.corda.finance.contracts.asset.Cash, net.corda.finance.contracts.asset.CommodityContract, net.corda.finance.contracts.asset.Obligation, net.corda.finance.contracts.asset.OnLedgerAsset] ->
+     *          jarPath=file:/Z:/corda/finance/build/libs/corda-finance-corda-4.0-snapshot.jar
+     *
+     *  These will be represented as distinct attachments with different hashes. Since underlying storage is `HashBiMap` when look-up is the ordering is not guaranteed and given contract e.g. `net.corda.finance.contracts.asset.Cash`
+     *  can be found in either of the Jars which causes flakiness.
+     *
+     *  To mitigate that we de-dupe CorDapps based on the same `contractClassNames`.
+     */
+    private fun List<Cordapp>.deDupeSameContractClassNames(): List<CorDappLight> {
+
+        return this.map { CorDappLight(it) }.fold(Pair(ArrayList<CorDappLight>(), HashSet<String>())) { (acc, notedContracts), corDapp ->
+            if ((notedContracts - corDapp.contractClassNames).size == notedContracts.size) {
+                // Complete disconnect or "notedContracts" is empty.
+                acc += corDapp
+                notedContracts += corDapp.contractClassNames
+            } else if (notedContracts.containsAll(corDapp.contractClassNames)) {
+                log.warn("Skipping $corDapp as all of it is contracts already included")
+            } else {
+                val modifiedContractsList = corDapp.contractClassNames - notedContracts
+                val modifiedCordapp = corDapp.copy(contractClassNames = modifiedContractsList)
+                log.warn("Cordapp $corDapp has it contracts list modified to: $modifiedContractsList")
+                acc += modifiedCordapp
+                notedContracts += modifiedContractsList
+            }
+            Pair(acc, notedContracts)
+        }.first
+    }
 
     /**
      * Get the current cordapp context for the given CorDapp

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -29,7 +29,7 @@ class BankOfCordaRPCClientTest {
                 invokeRpc(CordaRPCOps::wellKnownPartyFromX500Name),
                 invokeRpc(CordaRPCOps::notaryIdentities)
         )
-        driver(DriverParameters(extraCordappPackagesToScan = listOf("net.corda.finance"), isDebug = true)) {
+        driver(DriverParameters(extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name), isDebug = true)) {
             val bocManager = User("bocManager", "password1", permissions = setOf(
                     startFlow<CashIssueAndPaymentFlow>()) + commonPermissions)
             val bigCorpCFO = User("bigCorpCFO", "password2", permissions = emptySet<String>() + commonPermissions)

--- a/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
+++ b/samples/bank-of-corda-demo/src/integration-test/kotlin/net/corda/bank/BankOfCordaRPCClientTest.kt
@@ -1,6 +1,7 @@
 package net.corda.bank
 
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.internal.packageName
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.node.services.Vault
@@ -29,7 +30,7 @@ class BankOfCordaRPCClientTest {
                 invokeRpc(CordaRPCOps::wellKnownPartyFromX500Name),
                 invokeRpc(CordaRPCOps::notaryIdentities)
         )
-        driver(DriverParameters(extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name), isDebug = true)) {
+        driver(DriverParameters(extraCordappPackagesToScan = listOf(Cash::class.packageName), isDebug = true)) {
             val bocManager = User("bocManager", "password1", permissions = setOf(
                     startFlow<CashIssueAndPaymentFlow>()) + commonPermissions)
             val bigCorpCFO = User("bigCorpCFO", "password2", permissions = emptySet<String>() + commonPermissions)

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.contracts.TransactionState
 import net.corda.core.flows.UnexpectedFlowEndException
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.internal.packageName
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.getOrThrow
@@ -49,7 +50,7 @@ class OracleNodeTearOffTests {
     @Before
     // DOCSTART 1
     fun setUp() {
-        mockNet = MockNetwork(cordappPackages = listOf(Cash::class.java.`package`.name, NodeInterestRates::class.java.`package`.name))
+        mockNet = MockNetwork(cordappPackages = listOf(Cash::class.packageName, NodeInterestRates::class.packageName))
         aliceNode = mockNet.createPartyNode(ALICE_NAME)
         oracleNode = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME)).apply {
             transaction {

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt
@@ -1,6 +1,5 @@
 package net.corda.irs.api
 
-import com.google.common.collect.testing.Helpers
 import com.google.common.collect.testing.Helpers.assertContains
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.TransactionState
@@ -50,7 +49,7 @@ class OracleNodeTearOffTests {
     @Before
     // DOCSTART 1
     fun setUp() {
-        mockNet = MockNetwork(cordappPackages = listOf("net.corda.finance.contracts", "net.corda.irs"))
+        mockNet = MockNetwork(cordappPackages = listOf(Cash::class.java.`package`.name, NodeInterestRates::class.java.`package`.name))
         aliceNode = mockNet.createPartyNode(ALICE_NAME)
         oracleNode = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME)).apply {
             transaction {

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -45,7 +45,7 @@ class SimmValuationTest {
 
     @Test
     fun `runs SIMM valuation demo`() {
-        driver(DriverParameters(isDebug = true, extraCordappPackagesToScan = listOf(IRSTradeFlow.javaClass.`package`.name, IRSState::class.java.`package`.name, "net.corda.vega.plugin.customserializers"))) {
+        driver(DriverParameters(isDebug = true, extraCordappPackagesToScan = listOf(IRSTradeFlow::class.packageName, IRSState::class.packageName, "net.corda.vega.plugin.customserializers"))) {
             val nodeAFuture = startNode(providedName = nodeALegalName)
             val nodeBFuture = startNode(providedName = nodeBLegalName)
             val (nodeA, nodeB) = listOf(nodeAFuture, nodeBFuture).map { it.getOrThrow() }

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -14,6 +14,8 @@ import net.corda.vega.api.PortfolioApi
 import net.corda.vega.api.PortfolioApiUtils
 import net.corda.vega.api.SwapDataModel
 import net.corda.vega.api.SwapDataView
+import net.corda.vega.contracts.IRSState
+import net.corda.vega.flows.IRSTradeFlow
 import net.corda.vega.plugin.customserializers.CurrencyParameterSensitivitiesSerializer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -43,7 +45,7 @@ class SimmValuationTest {
 
     @Test
     fun `runs SIMM valuation demo`() {
-        driver(DriverParameters(isDebug = true, extraCordappPackagesToScan = listOf("net.corda.vega.contracts", "net.corda.vega.plugin.customserializers"))) {
+        driver(DriverParameters(isDebug = true, extraCordappPackagesToScan = listOf(IRSTradeFlow.javaClass.`package`.name, IRSState::class.java.`package`.name, "net.corda.vega.plugin.customserializers"))) {
             val nodeAFuture = startNode(providedName = nodeALegalName)
             val nodeBFuture = startNode(providedName = nodeBLegalName)
             val (nodeA, nodeB) = listOf(nodeAFuture, nodeBFuture).map { it.getOrThrow() }

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -4,8 +4,11 @@ import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
 import net.corda.finance.DOLLARS
+import net.corda.finance.contracts.CommercialPaper
+import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
+import net.corda.finance.schemas.CashSchemaV1
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.services.Permissions.Companion.startFlow
 import net.corda.testing.core.BOC_NAME
@@ -33,7 +36,9 @@ class TraderDemoTest {
                 startFlow<CashPaymentFlow>(),
                 startFlow<CommercialPaperIssueFlow>(),
                 all()))
-        driver(DriverParameters(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance"))) {
+        driver(DriverParameters(startNodesInProcess = true,
+                extraCordappPackagesToScan = listOf(
+                        Cash::class.java.`package`.name, CommercialPaper::class.java.`package`.name, CashSchemaV1::class.java.`package`.name))) {
             val (nodeA, nodeB, bankNode) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
                     startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = listOf(demoUser)),

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -1,6 +1,7 @@
 package net.corda.traderdemo
 
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.internal.packageName
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
 import net.corda.finance.DOLLARS
@@ -38,7 +39,7 @@ class TraderDemoTest {
                 all()))
         driver(DriverParameters(startNodesInProcess = true,
                 extraCordappPackagesToScan = listOf(
-                        Cash::class.java.`package`.name, CommercialPaper::class.java.`package`.name, CashSchemaV1::class.java.`package`.name))) {
+                        Cash::class.packageName, CommercialPaper::class.packageName, CashSchemaV1::class.packageName))) {
             val (nodeA, nodeB, bankNode) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
                     startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = listOf(demoUser)),

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -39,7 +39,7 @@ class TraderDemoTest {
                 all()))
         driver(DriverParameters(startNodesInProcess = true,
                 extraCordappPackagesToScan = listOf(
-                        Cash::class.packageName, CommercialPaper::class.packageName, CashSchemaV1::class.packageName))) {
+                        Cash::class.packageName, CommercialPaper::class.packageName, CashSchemaV1::class.packageName, SellerFlow::class.packageName))) {
             val (nodeA, nodeB, bankNode) = listOf(
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
                     startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = listOf(demoUser)),

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -10,6 +10,7 @@ import net.corda.core.contracts.Amount
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.thenMatch
+import net.corda.core.internal.packageName
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.startFlow
@@ -63,7 +64,7 @@ class ExplorerSimulation(private val options: OptionSet) {
 
     private fun startDemoNodes() {
         val portAllocation = PortAllocation.Incremental(20000)
-        driver(DriverParameters(portAllocation = portAllocation, extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true))) {
+        driver(DriverParameters(portAllocation = portAllocation, extraCordappPackagesToScan = listOf(Cash::class.packageName), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true))) {
             // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user))
             val bob = startNode(providedName = BOB_NAME, rpcUsers = listOf(user))

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -63,7 +63,7 @@ class ExplorerSimulation(private val options: OptionSet) {
 
     private fun startDemoNodes() {
         val portAllocation = PortAllocation.Incremental(20000)
-        driver(DriverParameters(portAllocation = portAllocation, extraCordappPackagesToScan = listOf("net.corda.finance"), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true))) {
+        driver(DriverParameters(portAllocation = portAllocation, extraCordappPackagesToScan = listOf(Cash::class.java.`package`.name), waitForAllNodesToFinish = true, jmxPolicy = JmxPolicy(true))) {
             // TODO : Supported flow should be exposed somehow from the node instead of set of ServiceInfo.
             val alice = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user))
             val bob = startNode(providedName = BOB_NAME, rpcUsers = listOf(user))


### PR DESCRIPTION
Note: It is still possible to list every necessary package explicitly.
This is important as package name of the integration test is automatically included into list of packages to scan.
E.g. In case of integration test `DistributedServiceTests` the package is `net.corda.node.services` which is quite extensive, resulting big attachments (multiple MB) to be produced
and handled. This creates a notable delay in test execution.