### PR TITLE
Try to improve stability of `NodeRegistrationTest`

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -37,6 +37,8 @@ import java.security.KeyPair
 import java.security.cert.CertPath
 import java.security.cert.Certificate
 import java.security.cert.X509Certificate
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListSet
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import javax.ws.rs.*
@@ -119,8 +121,8 @@ class NodeRegistrationTest {
 
 @Path("certificate")
 class RegistrationHandler(private val rootCertAndKeyPair: CertificateAndKeyPair) {
-    private val certPaths = HashMap<String, CertPath>()
-    val idsPolled = HashSet<String>()
+    private val certPaths = ConcurrentHashMap<String, CertPath>()
+    val idsPolled = ConcurrentSkipListSet<String>()
 
     companion object {
         val log = loggerFor<RegistrationHandler>()


### PR DESCRIPTION
Since we are running web-server and different handling methods will be called from
different threads, it is more appropriate to use concurrent data structures
for exchanging information between threads.

Prior to this change I observed the following exception which is likely to be due `certPaths` not synchronized between threads:
```
Caused by: kotlin.KotlinNullPointerException
    at net.corda.node.utilities.registration.RegistrationHandler$reply$1.invoke(NodeRegistrationTest.kt:151) ~[integrationTest/:?]
    at net.corda.node.utilities.registration.RegistrationHandler$reply$1.invoke(NodeRegistrationTest.kt:122) ~[integrationTest/:?]
    at net.corda.core.internal.InternalUtils.logElapsedTime(InternalUtils.kt:221) ~[corda-core-corda-4.0-snapshot.jar:?]
    at net.corda.core.internal.InternalUtils.logElapsedTime(InternalUtils.kt:213) ~[corda-core-corda-4.0-snapshot.jar:?]
    at net.corda.node.utilities.registration.RegistrationHandler.reply(NodeRegistrationTest.kt:149) ~[integrationTest/:?]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_161]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_161]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_161]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_161]
 ```