### PR TITLE
Remove superfluous registerInitiatedFlow calls from tutorial and example tests

### DIFF
--- a/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
+++ b/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
@@ -1,6 +1,7 @@
 package net.corda.core.flows;
 
 import co.paralleluniverse.fibers.Suspendable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 import net.corda.core.identity.Party;
 import net.corda.testing.core.TestConstants;
@@ -13,13 +14,12 @@ import org.junit.Test;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static java.util.Collections.emptyList;
 import static net.corda.testing.core.TestUtils.singleIdentity;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.fail;
 
 public class FlowsInJavaTest {
-    private final MockNetwork mockNet = new MockNetwork(emptyList());
+    private final MockNetwork mockNet = new MockNetwork(ImmutableList.of("net.corda.core.flows"));
     private StartedMockNode aliceNode;
     private StartedMockNode bobNode;
     private Party bob;
@@ -38,7 +38,6 @@ public class FlowsInJavaTest {
 
     @Test
     public void suspendableActionInsideUnwrap() throws Exception {
-        bobNode.registerInitiatedFlow(SendHelloAndThenReceive.class);
         Future<String> result = aliceNode.startFlow(new SendInUnwrapFlow(bob));
         mockNet.runNetwork();
         assertThat(result.get()).isEqualTo("Hello");

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -41,7 +41,7 @@ class CollectSignaturesFlowTests {
 
     @Before
     fun setup() {
-        mockNet = InternalMockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
+        mockNet = InternalMockNetwork(cordappPackages = listOf("net.corda.testing.contracts", "net.corda.core.flows"))
         aliceNode = mockNet.createPartyNode(ALICE_NAME)
         bobNode = mockNet.createPartyNode(BOB_NAME)
         charlieNode = mockNet.createPartyNode(CHARLIE_NAME)
@@ -54,12 +54,6 @@ class CollectSignaturesFlowTests {
     @After
     fun tearDown() {
         mockNet.stopNodes()
-    }
-
-    private fun registerFlowOnAllNodes(flowClass: KClass<out FlowLogic<*>>) {
-        listOf(aliceNode, bobNode, charlieNode).forEach {
-            it.registerInitiatedFlow(flowClass.java)
-        }
     }
 
     // With this flow, the initiator starts the "CollectTransactionFlow". It is then the responders responsibility to
@@ -110,7 +104,6 @@ class CollectSignaturesFlowTests {
             // Normally this is handled by TransactionKeyFlow, but here we have to manually let A know about the identity
             aliceNode.services.identityService.verifyAndRegisterIdentity(bConfidentialIdentity)
         }
-        registerFlowOnAllNodes(TestFlow.Responder::class)
         val magicNumber = 1337
         val parties = listOf(alice, bConfidentialIdentity.party, charlie)
         val state = DummyContract.MultiOwnerState(magicNumber, parties)

--- a/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
@@ -38,12 +38,10 @@ class ResolveTransactionsFlowTest {
 
     @Before
     fun setup() {
-        mockNet = InternalMockNetwork(cordappPackages = listOf("net.corda.testing.contracts"))
+        mockNet = InternalMockNetwork(cordappPackages = listOf("net.corda.testing.contracts", "net.corda.core.internal"))
         notaryNode = mockNet.defaultNotaryNode
         megaCorpNode = mockNet.createPartyNode(CordaX500Name("MegaCorp", "London", "GB"))
         miniCorpNode = mockNet.createPartyNode(CordaX500Name("MiniCorp", "London", "GB"))
-        megaCorpNode.registerInitiatedFlow(TestResponseFlow::class.java)
-        miniCorpNode.registerInitiatedFlow(TestResponseFlow::class.java)
         notary = mockNet.defaultNotaryIdentity
         megaCorp = megaCorpNode.info.singleIdentity()
         miniCorp = miniCorpNode.info.singleIdentity()

--- a/docs/source/api-testing.rst
+++ b/docs/source/api-testing.rst
@@ -165,24 +165,6 @@ Nodes are created on the ``MockNetwork`` using:
             }
         }
 
-Registering a node's initiated flows
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Regular Corda nodes automatically register any response flows defined in their installed CorDapps. When using a
-``MockNetwork``, each ``StartedMockNode`` must manually register any responder flows it wishes to use.
-
-Responder flows are registered as follows:
-
-.. container:: codeset
-
-   .. sourcecode:: kotlin
-
-        nodeA.registerInitiatedFlow(ExampleFlow.Acceptor::class.java)
-
-   .. sourcecode:: java
-
-        nodeA.registerInitiatedFlow(ExampleFlow.Acceptor.class);
-
 Running the network
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/tutorial/mocknetwork/TutorialMockNetwork.kt
@@ -1,6 +1,7 @@
 package net.corda.docs.tutorial.mocknetwork
 
 import co.paralleluniverse.fibers.Suspendable
+import com.google.common.collect.ImmutableList
 import net.corda.core.contracts.requireThat
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
@@ -62,10 +63,9 @@ class TutorialMockNetwork {
 
     @Before
     fun setUp() {
-        mockNet = MockNetwork(emptyList())
+        mockNet = MockNetwork(ImmutableList.of("net.corda.docs.tutorial.mocknetwork"))
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
-        nodeB.registerInitiatedFlow(FlowB::class.java)
     }
 
     @After

--- a/docs/source/flow-testing.rst
+++ b/docs/source/flow-testing.rst
@@ -61,10 +61,6 @@ transactions are valid) inside a ``database.transaction``.  All node flows run w
 nodes themselves, but any time we need to use the database directly from a unit test, you need to provide a database
 transaction as shown here.
 
-With regards to initiated flows (see :doc:`flow-state-machines` for information on initiated and initiating flows), the
-full node automatically registers them by scanning the CorDapp jars. In a unit test environment this is not possible so
-``MockNode`` has the ``registerInitiatedFlow`` method to manually register an initiated flow.
-
 .. MockNetwork message manipulation
 .. --------------------------------
 .. The MockNetwork has the ability to manipulate message streams. You can use this to test your flows behaviour on corrupted,

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -39,7 +39,6 @@ class TraderDemoTest {
                     startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = listOf(demoUser)),
                     startNode(providedName = BOC_NAME, rpcUsers = listOf(bankUser))
             ).map { (it.getOrThrow() as InProcess) }
-            nodeA.registerInitiatedFlow(BuyerFlow::class.java)
             val (nodeARpc, nodeBRpc) = listOf(nodeA, nodeB).map {
                 val client = CordaRPCClient(it.rpcAddress)
                 client.start(demoUser.username, demoUser.password).proxy


### PR DESCRIPTION
The use of registerInitiatedFlow is no longer needed in tests - MockNetwork scans the supplied packages for flows and registers them automatically, so I've removed that part from the tutorial and example tests to reduce confusion.