### PR TITLE
CORDA-1336: Turn off direct delivery in Artemis via config

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
@@ -65,7 +65,8 @@ class ArtemisTcpTransport {
                     // TODO further investigate how to ensure we use a well defined wire level protocol for Node to Node communications.
                     TransportConstants.PROTOCOLS_PROP_NAME to "CORE,AMQP",
                     TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME to (nodeSerializationEnv != null),
-                    TransportConstants.REMOTING_THREADS_PROPNAME to (if (nodeSerializationEnv != null) -1 else 1)
+                    TransportConstants.REMOTING_THREADS_PROPNAME to (if (nodeSerializationEnv != null) -1 else 1),
+                    TransportConstants.DIRECT_DELIVER to false
             )
 
             if (config != null && enableSSL) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
@@ -66,6 +66,8 @@ class ArtemisTcpTransport {
                     TransportConstants.PROTOCOLS_PROP_NAME to "CORE,AMQP",
                     TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME to (nodeSerializationEnv != null),
                     TransportConstants.REMOTING_THREADS_PROPNAME to (if (nodeSerializationEnv != null) -1 else 1),
+                    // turn off direct delivery in Artemis - this is latency optimisation that can lead to
+                    //hick-ups under high load (CORDA-1336)
                     TransportConstants.DIRECT_DELIVER to false
             )
 


### PR DESCRIPTION
 this can deadlock when the server gets busy and switches back and forth between
direct and async delivery if it can't keep up.

