### PR TITLE
CORDA-1355: Introduce a dedicated property which controls what is going to be in scope for classpath scanning

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -53,6 +53,8 @@ Unreleased
 
 * java.math.BigInteger serialization support added.
 
+* Fix CORDA-1355: Reduce amount of classpath scanning during integration tests execution.
+
 .. _changelog_v3.1:
 
 Version 3.1

--- a/docs/source/cordapp-custom-serializers.rst
+++ b/docs/source/cordapp-custom-serializers.rst
@@ -17,11 +17,16 @@ Custom serializer classes should follow the rules for including classes found in
 Writing a Custom Serializer
 ---------------------------
 Serializers must
- * Inherit from net.corda.core.serialization.SerializationCustomSerializer
+ * Inherit from ``net.corda.core.serialization.SerializationCustomSerializer``
  * Provide a proxy class to transform the object to and from
  * Implement the ``toProxy`` and ``fromProxy`` methods
+ * Be either included into CorDapp Jar or made known to the running process via ``amqp.custom.serialization.scanSpec``
+system property.
+This system property may be necessary to be able to discover custom serializer in the classpath. At a minimum the value
+of the property should include comma separated set of packages where custom serializers located. Full syntax includes
+scanning specification as defined by: `<http://github.com/lukehutch/fast-classpath-scanner/wiki/2.-Constructor#scan-spec>`
 
-Serializers inheriting from SerializationCustomSerializer have to implement two methods and two types.
+Serializers inheriting from ``SerializationCustomSerializer`` have to implement two methods and two types.
 
 Example
 -------

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -2,6 +2,7 @@ package net.corda.vega
 
 import com.opengamma.strata.product.common.BuySell
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.internal.packageName
 import net.corda.core.utilities.getOrThrow
 import net.corda.nodeapi.internal.serialization.amqp.AbstractAMQPSerializationScheme
 import net.corda.testing.core.DUMMY_BANK_A_NAME
@@ -32,7 +33,7 @@ class SimmValuationTest {
 
     @Before
     fun setup() {
-        System.setProperty(AbstractAMQPSerializationScheme.SCAN_SPEC_PROP_NAME, CurrencyParameterSensitivitiesSerializer::class.java.`package`.name)
+        System.setProperty(AbstractAMQPSerializationScheme.SCAN_SPEC_PROP_NAME, CurrencyParameterSensitivitiesSerializer::class.packageName)
     }
 
     @After

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -3,6 +3,7 @@ package net.corda.vega
 import com.opengamma.strata.product.common.BuySell
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
+import net.corda.nodeapi.internal.serialization.amqp.AbstractAMQPSerializationScheme
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
 import net.corda.testing.driver.DriverParameters
@@ -12,7 +13,10 @@ import net.corda.vega.api.PortfolioApi
 import net.corda.vega.api.PortfolioApiUtils
 import net.corda.vega.api.SwapDataModel
 import net.corda.vega.api.SwapDataView
+import net.corda.vega.plugin.customserializers.CurrencyParameterSensitivitiesSerializer
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -24,6 +28,16 @@ class SimmValuationTest {
         val nodeALegalName = DUMMY_BANK_A_NAME
         val nodeBLegalName = DUMMY_BANK_B_NAME
         val testTradeId = "trade1"
+    }
+
+    @Before
+    fun setup() {
+        System.setProperty(AbstractAMQPSerializationScheme.SCAN_SPEC_PROP_NAME, CurrencyParameterSensitivitiesSerializer::class.java.`package`.name)
+    }
+
+    @After
+    fun tearDown() {
+        System.clearProperty(AbstractAMQPSerializationScheme.SCAN_SPEC_PROP_NAME)
     }
 
     @Test


### PR DESCRIPTION
This should help with execution performance of the integration tests and reduce the memory footprint used by `FastClasspathScanner`

I people like this change and will be thinking of approving it then I will update Corda documentation to explain the purpose of the newly introduced property.