### PR TITLE
CORDA-1319 Adding CRL checking for nodes

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -350,13 +350,14 @@ fun ExecutorService.join() {
     }
 }
 
-fun CertPath.validate(trustAnchor: TrustAnchor): PKIXCertPathValidatorResult {
-    val parameters = PKIXParameters(setOf(trustAnchor)).apply { isRevocationEnabled = false }
+// TODO: Currently the certificate revocation status is not handled here. Nowhere in the code the second parameter is used. Consider adding the support in the future.
+fun CertPath.validate(trustAnchor: TrustAnchor, checkRevocation: Boolean = false): PKIXCertPathValidatorResult {
+    val parameters = PKIXParameters(setOf(trustAnchor)).apply { isRevocationEnabled = checkRevocation }
     try {
         return CertPathValidator.getInstance("PKIX").validate(this, parameters) as PKIXCertPathValidatorResult
     } catch (e: CertPathValidatorException) {
         throw CertPathValidatorException(
-                """Cert path failed to validate against trust anchor.
+                """Cert path failed to validate.
 Reason: ${e.reason}
 Offending cert index: ${e.index}
 Cert path: $this

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -64,15 +64,10 @@ absolute path to the node's base directory.
 
     .. note:: Longer term these keys will be managed in secure hardware devices.
 
-:revocationCheckConfig:
-
-        :softFail: This is a boolean flag that when enabled (i.e. `true` value is set) the certificate revocation list (CRL) checking will use the soft fail mode.
-                   The soft fail mode allows the revocation check to succeed if the revocation status cannot be determined because of a network error.
-                   If this parameter is set to `false` the rigorous CRL checking takes place, meaning that each certificate in the
-                   certificate path being checked needs to have the CRL distribution point extension set and pointing to a URL serving a valid CRL.
-        :preferCrl: When set the CRL checking is preferred over the OCSP and OCSP is considered as a fallback mechanism unless the `noFallback` flag is set.
-                    The OCSP is not supported yet, therefore, this flag should always be set.
-        :noFallback: When set the fallback mechanism is disabled. The OCSP is not supported yet, therefore, this flag should always be set.
+:crlCheckSoftFail: This is a boolean flag that when enabled (i.e. `true` value is set) the certificate revocation list (CRL) checking will use the soft fail mode.
+                  The soft fail mode allows the revocation check to succeed if the revocation status cannot be determined because of a network error.
+                  If this parameter is set to `false` the rigorous CRL checking takes place, meaning that each certificate in the
+                  certificate path being checked needs to have the CRL distribution point extension set and pointing to a URL serving a valid CRL.
 
 :database: Database configuration:
 

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -64,6 +64,16 @@ absolute path to the node's base directory.
 
     .. note:: Longer term these keys will be managed in secure hardware devices.
 
+:revocationCheckConfig:
+
+        :softFail: This is a boolean flag that when enabled (i.e. `true` value is set) the certificate revocation list (CRL) checking will use the soft fail mode.
+                   The soft fail mode allows the revocation check to succeed if the revocation status cannot be determined because of a network error.
+                   If this parameter is set to `false` the rigorous CRL checking takes place, meaning that each certificate in the
+                   certificate path being checked needs to have the CRL distribution point extension set and pointing to a URL serving a valid CRL.
+        :preferCrl: When set the CRL checking is preferred over the OCSP and OCSP is considered as a fallback mechanism unless the `noFallback` flag is set.
+                    The OCSP is not supported yet, therefore, this flag should always be set.
+        :noFallback: When set the fallback mechanism is disabled. The OCSP is not supported yet, therefore, this flag should always be set.
+
 :database: Database configuration:
 
         :serverNameTablePrefix: Prefix string to apply to all the database tables. The default is no prefix.

--- a/docs/source/example-code/src/main/resources/example-node.conf
+++ b/docs/source/example-code/src/main/resources/example-node.conf
@@ -1,6 +1,11 @@
 myLegalName : "O=Bank A,L=London,C=GB"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
+revocationCheckConfig: {
+    preferCrl = true
+    noFallback = true
+    softFail = true
+}
 dataSourceProperties : {
     dataSourceClassName : org.h2.jdbcx.JdbcDataSource
     dataSource.url : "jdbc:h2:file:"${baseDirectory}"/persistence"

--- a/docs/source/example-code/src/main/resources/example-node.conf
+++ b/docs/source/example-code/src/main/resources/example-node.conf
@@ -1,11 +1,7 @@
 myLegalName : "O=Bank A,L=London,C=GB"
 keyStorePassword : "cordacadevpass"
 trustStorePassword : "trustpass"
-revocationCheckConfig: {
-    preferCrl = true
-    noFallback = true
-    softFail = true
-}
+crlCheckSoftFail: true
 dataSourceProperties : {
     dataSourceClassName : org.h2.jdbcx.JdbcDataSource
     dataSource.url : "jdbc:h2:file:"${baseDirectory}"/persistence"

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
@@ -8,6 +8,7 @@ import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.utilities.trace
 import net.corda.nodeapi.internal.config.NodeSSLConfiguration
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509KeyStore
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -35,6 +36,7 @@ object DevIdentityGenerator {
             override val baseDirectory = nodeDir
             override val keyStorePassword: String = "cordacadevpass"
             override val trustStorePassword get() = throw NotImplementedError("Not expected to be called")
+            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
         }
 
         nodeSslConfig.certificatesDirectory.createDirectories()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
@@ -8,7 +8,6 @@ import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.utilities.trace
 import net.corda.nodeapi.internal.config.NodeSSLConfiguration
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509KeyStore
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -36,7 +35,7 @@ object DevIdentityGenerator {
             override val baseDirectory = nodeDir
             override val keyStorePassword: String = "cordacadevpass"
             override val trustStorePassword get() = throw NotImplementedError("Not expected to be called")
-            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
+            override val crlCheckSoftFail: Boolean = true
         }
 
         nodeSslConfig.certificatesDirectory.createDirectories()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/AMQPBridgeManager.kt
@@ -16,7 +16,6 @@ import net.corda.nodeapi.internal.ArtemisMessagingComponent.RemoteInboxAddress.C
 import net.corda.nodeapi.internal.ArtemisSessionProvider
 import net.corda.nodeapi.internal.bridging.AMQPBridgeManager.AMQPBridge.Companion.getBridgeName
 import net.corda.nodeapi.internal.config.NodeSSLConfiguration
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.protonwrapper.messages.MessageStatus
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPClient
 import org.apache.activemq.artemis.api.core.SimpleString
@@ -47,7 +46,7 @@ class AMQPBridgeManager(config: NodeSSLConfiguration, val artemisMessageClientFa
     private val keyStorePrivateKeyPassword: String = config.keyStorePassword
     private val trustStore = config.loadTrustStore().internal
     private var artemis: ArtemisSessionProvider? = null
-    private val revocationCheckConfig: RevocationCheckConfig = config.revocationCheckConfig
+    private val crlCheckSoftFail: Boolean = config.crlCheckSoftFail
 
     constructor(config: NodeSSLConfiguration, p2pAddress: NetworkHostAndPort, maxMessageSize: Int) : this(config, { ArtemisMessagingClient(config, p2pAddress, maxMessageSize) })
 
@@ -69,7 +68,7 @@ class AMQPBridgeManager(config: NodeSSLConfiguration, val artemisMessageClientFa
                              keyStore: KeyStore,
                              keyStorePrivateKeyPassword: String,
                              trustStore: KeyStore,
-                             revocationCheckConfig: RevocationCheckConfig,
+                             crlCheckSoftFail: Boolean,
                              sharedEventGroup: EventLoopGroup,
                              private val artemis: ArtemisSessionProvider) {
         companion object {
@@ -78,7 +77,7 @@ class AMQPBridgeManager(config: NodeSSLConfiguration, val artemisMessageClientFa
 
         private val log = LoggerFactory.getLogger("$bridgeName:${legalNames.first()}")
 
-        val amqpClient = AMQPClient(listOf(target), legalNames, PEER_USER, PEER_USER, keyStore, keyStorePrivateKeyPassword, trustStore, revocationCheckConfig, sharedThreadPool = sharedEventGroup)
+        val amqpClient = AMQPClient(listOf(target), legalNames, PEER_USER, PEER_USER, keyStore, keyStorePrivateKeyPassword, trustStore, crlCheckSoftFail, sharedThreadPool = sharedEventGroup)
         val bridgeName: String get() = getBridgeName(queueName, target)
         private val lock = ReentrantLock() // lock to serialise session level access
         private var session: ClientSession? = null
@@ -172,7 +171,7 @@ class AMQPBridgeManager(config: NodeSSLConfiguration, val artemisMessageClientFa
         if (bridgeExists(getBridgeName(queueName, target))) {
             return
         }
-        val newBridge = AMQPBridge(queueName, target, legalNames, keyStore, keyStorePrivateKeyPassword, trustStore, revocationCheckConfig, sharedEventLoopGroup!!, artemis!!)
+        val newBridge = AMQPBridge(queueName, target, legalNames, keyStore, keyStorePrivateKeyPassword, trustStore, crlCheckSoftFail, sharedEventLoopGroup!!, artemis!!)
         lock.withLock {
             bridgeNameToBridgeMap[newBridge.bridgeName] = newBridge
         }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt
@@ -12,7 +12,7 @@ interface SSLConfiguration {
     // TODO This looks like it should be in NodeSSLConfiguration
     val nodeKeystore: Path get() = certificatesDirectory / "nodekeystore.jks"
     val trustStoreFile: Path get() = certificatesDirectory / "truststore.jks"
-    val revocationCheckConfig: RevocationCheckConfig
+    val crlCheckSoftFail: Boolean
 
     fun loadTrustStore(createNew: Boolean = false): X509KeyStore {
         return X509KeyStore.fromFile(trustStoreFile, trustStorePassword, createNew)
@@ -26,12 +26,6 @@ interface SSLConfiguration {
         return X509KeyStore.fromFile(sslKeystore, keyStorePassword, createNew)
     }
 }
-
-data class RevocationCheckConfig(
-        val preferCrl: Boolean = true,
-        val noFallback: Boolean = true,
-        val softFail: Boolean = true
-)
 
 interface NodeSSLConfiguration : SSLConfiguration {
     val baseDirectory: Path

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/config/SSLConfiguration.kt
@@ -12,6 +12,7 @@ interface SSLConfiguration {
     // TODO This looks like it should be in NodeSSLConfiguration
     val nodeKeystore: Path get() = certificatesDirectory / "nodekeystore.jks"
     val trustStoreFile: Path get() = certificatesDirectory / "truststore.jks"
+    val revocationCheckConfig: RevocationCheckConfig
 
     fun loadTrustStore(createNew: Boolean = false): X509KeyStore {
         return X509KeyStore.fromFile(trustStoreFile, trustStorePassword, createNew)
@@ -25,6 +26,12 @@ interface SSLConfiguration {
         return X509KeyStore.fromFile(sslKeystore, keyStorePassword, createNew)
     }
 }
+
+data class RevocationCheckConfig(
+        val preferCrl: Boolean = true,
+        val noFallback: Boolean = true,
+        val softFail: Boolean = true
+)
 
 interface NodeSSLConfiguration : SSLConfiguration {
     val baseDirectory: Path

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -148,7 +148,7 @@ object X509Utilities {
      * @param crlDistPoint CRL distribution point.
      * @param crlIssuer X500Name of the CRL issuer.
      */
-    private fun createPartialCertificate(certificateType: CertificateType,
+    fun createPartialCertificate(certificateType: CertificateType,
                                  issuer: X500Principal,
                                  issuerPublicKey: PublicKey,
                                  subject: X500Principal,

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt
@@ -12,6 +12,7 @@ import io.netty.util.internal.logging.Slf4JLoggerFactory
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.protonwrapper.messages.ReceivedMessage
 import net.corda.nodeapi.internal.protonwrapper.messages.SendableMessage
 import net.corda.nodeapi.internal.protonwrapper.messages.impl.SendableMessageImpl
@@ -38,6 +39,7 @@ class AMQPClient(val targets: List<NetworkHostAndPort>,
                  private val keyStore: KeyStore,
                  private val keyStorePrivateKeyPassword: String,
                  private val trustStore: KeyStore,
+                 private val revocationCheckConfig: RevocationCheckConfig,
                  private val trace: Boolean = false,
                  private val sharedThreadPool: EventLoopGroup? = null) : AutoCloseable {
     companion object {
@@ -102,7 +104,7 @@ class AMQPClient(val targets: List<NetworkHostAndPort>,
 
         init {
             keyManagerFactory.init(parent.keyStore, parent.keyStorePrivateKeyPassword.toCharArray())
-            trustManagerFactory.init(parent.trustStore)
+            trustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(parent.trustStore, parent.revocationCheckConfig))
         }
 
         override fun initChannel(ch: SocketChannel) {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
@@ -9,7 +9,6 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.node.serialization.KryoServerSerializationScheme
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.createDevKeyStores
 import net.corda.nodeapi.internal.serialization.AllWhitelist
@@ -184,7 +183,7 @@ class X509UtilitiesTest {
             override val certificatesDirectory = tempFolder.root.toPath()
             override val keyStorePassword = "serverstorepass"
             override val trustStorePassword = "trustpass"
-            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
+            override val crlCheckSoftFail: Boolean = true
         }
 
         val (rootCa, intermediateCa) = createDevIntermediateCaCertPath()
@@ -220,7 +219,7 @@ class X509UtilitiesTest {
             override val certificatesDirectory = tempFolder.root.toPath()
             override val keyStorePassword = "serverstorepass"
             override val trustStorePassword = "trustpass"
-            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
+            override val crlCheckSoftFail: Boolean = true
         }
 
         val (rootCa, intermediateCa) = createDevIntermediateCaCertPath()

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
@@ -9,6 +9,7 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.node.serialization.KryoServerSerializationScheme
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.createDevKeyStores
 import net.corda.nodeapi.internal.serialization.AllWhitelist
@@ -183,6 +184,7 @@ class X509UtilitiesTest {
             override val certificatesDirectory = tempFolder.root.toPath()
             override val keyStorePassword = "serverstorepass"
             override val trustStorePassword = "trustpass"
+            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
         }
 
         val (rootCa, intermediateCa) = createDevIntermediateCaCertPath()
@@ -218,6 +220,7 @@ class X509UtilitiesTest {
             override val certificatesDirectory = tempFolder.root.toPath()
             override val keyStorePassword = "serverstorepass"
             override val trustStorePassword = "trustpass"
+            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
         }
 
         val (rootCa, intermediateCa) = createDevIntermediateCaCertPath()

--- a/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
@@ -4,7 +4,6 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.internal.div
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.config.configureDevKeyAndTrustStores
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -35,7 +34,7 @@ class NodeKeystoreCheckTest {
                 override val keyStorePassword: String = keystorePassword
                 override val trustStorePassword: String = keystorePassword
                 override val certificatesDirectory: Path = baseDirectory(ALICE_NAME) / "certificates"
-                override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
+                override val crlCheckSoftFail: Boolean = true
             }
             config.configureDevKeyAndTrustStores(ALICE_NAME)
 

--- a/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
@@ -4,6 +4,7 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.internal.div
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.config.configureDevKeyAndTrustStores
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -34,6 +35,7 @@ class NodeKeystoreCheckTest {
                 override val keyStorePassword: String = keystorePassword
                 override val trustStorePassword: String = keystorePassword
                 override val certificatesDirectory: Path = baseDirectory(ALICE_NAME) / "certificates"
+                override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
             }
             config.configureDevKeyAndTrustStores(ALICE_NAME)
 

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
@@ -15,7 +15,6 @@ import net.corda.nodeapi.internal.ArtemisMessagingComponent
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2PMessagingHeaders
 import net.corda.nodeapi.internal.bridging.AMQPBridgeManager
 import net.corda.nodeapi.internal.bridging.BridgeManager
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPServer
 import net.corda.testing.core.*
 import net.corda.testing.internal.rigorousMock
@@ -174,7 +173,7 @@ class AMQPBridgeTest {
             doReturn(temporaryFolder.root.toPath() / "artemis").whenever(it).baseDirectory
             doReturn(ALICE_NAME).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
-            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
+            doReturn(true).whenever(it).crlCheckSoftFail
             doReturn("cordacadevpass").whenever(it).keyStorePassword
             doReturn(artemisAddress).whenever(it).p2pAddress
             doReturn(null).whenever(it).jmxMonitoringHttpPort
@@ -212,7 +211,7 @@ class AMQPBridgeTest {
                 serverConfig.loadSslKeyStore().internal,
                 serverConfig.keyStorePassword,
                 serverConfig.loadTrustStore().internal,
-                revocationCheckConfig = RevocationCheckConfig(),
+                crlCheckSoftFail = true,
                 trace = true
         )
     }

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
@@ -15,6 +15,7 @@ import net.corda.nodeapi.internal.ArtemisMessagingComponent
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2PMessagingHeaders
 import net.corda.nodeapi.internal.bridging.AMQPBridgeManager
 import net.corda.nodeapi.internal.bridging.BridgeManager
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPServer
 import net.corda.testing.core.*
 import net.corda.testing.internal.rigorousMock
@@ -77,7 +78,7 @@ class AMQPBridgeTest {
 
         fun formatMessage(expected: String, actual: Int, received: List<Int>): String {
             return "Expected message with id $expected, got $actual, previous message receive sequence: " +
-            "${received.joinToString(",  ", "[", "]")}."
+                    "${received.joinToString(",  ", "[", "]")}."
         }
 
         val received1 = receive.next()
@@ -173,6 +174,7 @@ class AMQPBridgeTest {
             doReturn(temporaryFolder.root.toPath() / "artemis").whenever(it).baseDirectory
             doReturn(ALICE_NAME).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
+            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
             doReturn("cordacadevpass").whenever(it).keyStorePassword
             doReturn(artemisAddress).whenever(it).p2pAddress
             doReturn(null).whenever(it).jmxMonitoringHttpPort
@@ -210,6 +212,7 @@ class AMQPBridgeTest {
                 serverConfig.loadSslKeyStore().internal,
                 serverConfig.keyStorePassword,
                 serverConfig.loadTrustStore().internal,
+                revocationCheckConfig = RevocationCheckConfig(),
                 trace = true
         )
     }

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -1,0 +1,474 @@
+package net.corda.node.amqp
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
+import net.corda.core.crypto.Crypto
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.internal.div
+import net.corda.core.toFuture
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.core.utilities.days
+import net.corda.core.utilities.minutes
+import net.corda.core.utilities.seconds
+import net.corda.node.services.config.NodeConfiguration
+import net.corda.node.services.config.configureWithDevSSLCertificate
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_PREFIX
+import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEER_USER
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
+import net.corda.nodeapi.internal.config.SSLConfiguration
+import net.corda.nodeapi.internal.crypto.*
+import net.corda.nodeapi.internal.protonwrapper.messages.MessageStatus
+import net.corda.nodeapi.internal.protonwrapper.netty.AMQPClient
+import net.corda.nodeapi.internal.protonwrapper.netty.AMQPServer
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.CHARLIE_NAME
+import net.corda.testing.core.freePort
+import net.corda.testing.internal.DEV_INTERMEDIATE_CA
+import net.corda.testing.internal.DEV_ROOT_CA
+import net.corda.testing.internal.rigorousMock
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.*
+import org.bouncycastle.cert.jcajce.JcaX509CRLConverter
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils
+import org.bouncycastle.cert.jcajce.JcaX509v2CRLBuilder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.handler.HandlerCollection
+import org.eclipse.jetty.servlet.ServletContextHandler
+import org.eclipse.jetty.servlet.ServletHolder
+import org.glassfish.jersey.server.ResourceConfig
+import org.glassfish.jersey.servlet.ServletContainer
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.Closeable
+import java.math.BigInteger
+import java.net.InetSocketAddress
+import java.security.KeyPair
+import java.security.PrivateKey
+import java.security.Security
+import java.security.cert.X509CRL
+import java.security.cert.X509Certificate
+import java.util.*
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.Response
+import kotlin.test.assertEquals
+
+class CertificateRevocationListNodeTests {
+    @Rule
+    @JvmField
+    val temporaryFolder = TemporaryFolder()
+
+    private val ROOT_CA = DEV_ROOT_CA
+    private lateinit var INTERMEDIATE_CA: CertificateAndKeyPair
+
+    private val serverPort = freePort()
+
+    private lateinit var server: CrlServer
+
+    private val revokedNodeCerts: MutableList<BigInteger> = mutableListOf()
+    private val revokedIntermediateCerts: MutableList<BigInteger> = mutableListOf()
+
+    private abstract class AbstractNodeConfiguration : NodeConfiguration
+
+    @Before
+    fun setUp() {
+        Security.addProvider(BouncyCastleProvider())
+        revokedNodeCerts.clear()
+        server = CrlServer(NetworkHostAndPort("localhost", 0))
+        server.start()
+        INTERMEDIATE_CA = CertificateAndKeyPair(replaceCrlDistPointCaCertificate(
+                DEV_INTERMEDIATE_CA.certificate,
+                CertificateType.INTERMEDIATE_CA,
+                ROOT_CA.keyPair,
+                "http://${server.hostAndPort}/crl/intermediate.crl"), DEV_INTERMEDIATE_CA.keyPair)
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+        revokedNodeCerts.clear()
+    }
+
+    @Test
+    fun `Simple AMPQ Client to Server connection works`() {
+        val revocationCheckConfig = RevocationCheckConfig()
+        val (amqpServer, _) = createServer(serverPort, revocationCheckConfig = revocationCheckConfig)
+        amqpServer.use {
+            amqpServer.start()
+            val receiveSubs = amqpServer.onReceive.subscribe {
+                assertEquals(BOB_NAME.toString(), it.sourceLegalName)
+                assertEquals(P2P_PREFIX + "Test", it.topic)
+                assertEquals("Test", String(it.payload))
+                it.complete(true)
+            }
+            val (amqpClient, _) = createClient(serverPort, revocationCheckConfig)
+            amqpClient.use {
+                val serverConnected = amqpServer.onConnection.toFuture()
+                val clientConnected = amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val serverConnect = serverConnected.get()
+                assertEquals(true, serverConnect.connected)
+                val clientConnect = clientConnected.get()
+                assertEquals(true, clientConnect.connected)
+                val msg = amqpClient.createMessage("Test".toByteArray(),
+                        P2P_PREFIX + "Test",
+                        ALICE_NAME.toString(),
+                        emptyMap())
+                amqpClient.write(msg)
+                assertEquals(MessageStatus.Acknowledged, msg.onComplete.get())
+                receiveSubs.unsubscribe()
+            }
+        }
+    }
+
+    @Test
+    fun `AMPQ Client to Server connection fails when client's certificate is revoked`() {
+        val revocationCheckConfig = RevocationCheckConfig()
+        val (amqpServer, _) = createServer(serverPort, revocationCheckConfig = revocationCheckConfig)
+        amqpServer.use {
+            amqpServer.start()
+            amqpServer.onReceive.subscribe {
+                it.complete(true)
+            }
+            val (amqpClient, clientCert) = createClient(serverPort, revocationCheckConfig)
+            revokedNodeCerts.add(clientCert.serialNumber)
+            amqpClient.use {
+                val serverConnected = amqpServer.onConnection.toFuture()
+                amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val serverConnect = serverConnected.get()
+                assertEquals(false, serverConnect.connected)
+            }
+        }
+    }
+
+    @Test
+    fun `AMPQ Client to Server connection fails when servers's certificate is revoked`() {
+        val revocationCheckConfig = RevocationCheckConfig()
+        val (amqpServer, serverCert) = createServer(serverPort, revocationCheckConfig = revocationCheckConfig)
+        revokedNodeCerts.add(serverCert.serialNumber)
+        amqpServer.use {
+            amqpServer.start()
+            amqpServer.onReceive.subscribe {
+                it.complete(true)
+            }
+            val (amqpClient, _) = createClient(serverPort, revocationCheckConfig)
+            amqpClient.use {
+                val serverConnected = amqpServer.onConnection.toFuture()
+                amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val serverConnect = serverConnected.get()
+                assertEquals(false, serverConnect.connected)
+            }
+        }
+    }
+
+    @Test
+    fun `AMPQ Client to Server connection fails when servers's certificate is revoked and soft fail is enabled`() {
+        val revocationCheckConfig = RevocationCheckConfig()
+        val (amqpServer, serverCert) = createServer(serverPort, revocationCheckConfig = revocationCheckConfig)
+        revokedNodeCerts.add(serverCert.serialNumber)
+        amqpServer.use {
+            amqpServer.start()
+            amqpServer.onReceive.subscribe {
+                it.complete(true)
+            }
+            val (amqpClient, _) = createClient(serverPort, revocationCheckConfig)
+            amqpClient.use {
+                val serverConnected = amqpServer.onConnection.toFuture()
+                amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val serverConnect = serverConnected.get()
+                assertEquals(false, serverConnect.connected)
+            }
+        }
+    }
+
+    @Test
+    fun `AMPQ Client to Server connection succeeds when CRL cannot be obtained and soft fail is enabled`() {
+        val revocationCheckConfig = RevocationCheckConfig()
+        val (amqpServer, serverCert) = createServer(
+                serverPort,
+                revocationCheckConfig = revocationCheckConfig,
+                nodeCrlDistPoint = "http://${server.hostAndPort}/crl/invalid.crl")
+        amqpServer.use {
+            amqpServer.start()
+            amqpServer.onReceive.subscribe {
+                it.complete(true)
+            }
+            val (amqpClient, _) = createClient(
+                    serverPort,
+                    revocationCheckConfig,
+                    nodeCrlDistPoint = "http://${server.hostAndPort}/crl/invalid.crl")
+            amqpClient.use {
+                val serverConnected = amqpServer.onConnection.toFuture()
+                amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val serverConnect = serverConnected.get()
+                assertEquals(true, serverConnect.connected)
+            }
+        }
+    }
+
+    @Test
+    fun `Revocation status chceck fails when the CRL distribution point is not set and soft fail is disabled`() {
+        val revocationCheckConfig = RevocationCheckConfig(softFail = false)
+        val (amqpServer, _) = createServer(
+                serverPort,
+                revocationCheckConfig = revocationCheckConfig,
+                tlsCrlDistPoint = null)
+        amqpServer.use {
+            amqpServer.start()
+            amqpServer.onReceive.subscribe {
+                it.complete(true)
+            }
+            val (amqpClient, _) = createClient(
+                    serverPort,
+                    revocationCheckConfig,
+                    tlsCrlDistPoint = null)
+            amqpClient.use {
+                val serverConnected = amqpServer.onConnection.toFuture()
+                amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val serverConnect = serverConnected.get()
+                assertEquals(false, serverConnect.connected)
+            }
+        }
+    }
+
+    @Test
+    fun `Revocation status chceck succeds when the CRL distribution point is not set and soft fail is enabled`() {
+        val revocationCheckConfig = RevocationCheckConfig()
+        val (amqpServer, _) = createServer(
+                serverPort,
+                revocationCheckConfig = revocationCheckConfig,
+                tlsCrlDistPoint = null)
+        amqpServer.use {
+            amqpServer.start()
+            amqpServer.onReceive.subscribe {
+                it.complete(true)
+            }
+            val (amqpClient, _) = createClient(
+                    serverPort,
+                    revocationCheckConfig,
+                    tlsCrlDistPoint = null)
+            amqpClient.use {
+                val serverConnected = amqpServer.onConnection.toFuture()
+                amqpClient.onConnection.toFuture()
+                amqpClient.start()
+                val serverConnect = serverConnected.get()
+                assertEquals(true, serverConnect.connected)
+            }
+        }
+    }
+
+    private fun createClient(targetPort: Int,
+                             revocationCheckConfig: RevocationCheckConfig,
+                             nodeCrlDistPoint: String = "http://${server.hostAndPort}/crl/node.crl",
+                             tlsCrlDistPoint: String? = "http://${server.hostAndPort}/crl/empty.crl"): Pair<AMQPClient, X509Certificate> {
+        val clientConfig = rigorousMock<AbstractNodeConfiguration>().also {
+            doReturn(temporaryFolder.root.toPath() / "client").whenever(it).baseDirectory
+            doReturn(BOB_NAME).whenever(it).myLegalName
+            doReturn("trustpass").whenever(it).trustStorePassword
+            doReturn("cordacadevpass").whenever(it).keyStorePassword
+            doReturn(revocationCheckConfig).whenever(it).revocationCheckConfig
+        }
+        clientConfig.configureWithDevSSLCertificate()
+        val nodeCert = clientConfig.recreateNodeCaAndTlsCertificates(nodeCrlDistPoint, tlsCrlDistPoint)
+        val clientTruststore = clientConfig.loadTrustStore().internal
+        val clientKeystore = clientConfig.loadSslKeyStore().internal
+        return Pair(AMQPClient(
+                listOf(NetworkHostAndPort("localhost", targetPort)),
+                setOf(ALICE_NAME, CHARLIE_NAME),
+                PEER_USER,
+                PEER_USER,
+                clientKeystore,
+                clientConfig.keyStorePassword,
+                clientTruststore,
+                revocationCheckConfig), nodeCert)
+    }
+
+    private fun createServer(port: Int, name: CordaX500Name = ALICE_NAME,
+                             revocationCheckConfig: RevocationCheckConfig,
+                             nodeCrlDistPoint: String = "http://${server.hostAndPort}/crl/node.crl",
+                             tlsCrlDistPoint: String? = "http://${server.hostAndPort}/crl/empty.crl"): Pair<AMQPServer, X509Certificate> {
+        val serverConfig = rigorousMock<AbstractNodeConfiguration>().also {
+            doReturn(temporaryFolder.root.toPath() / "server").whenever(it).baseDirectory
+            doReturn(name).whenever(it).myLegalName
+            doReturn("trustpass").whenever(it).trustStorePassword
+            doReturn("cordacadevpass").whenever(it).keyStorePassword
+            doReturn(revocationCheckConfig).whenever(it).revocationCheckConfig
+        }
+        serverConfig.configureWithDevSSLCertificate()
+        val nodeCert = serverConfig.recreateNodeCaAndTlsCertificates(nodeCrlDistPoint, tlsCrlDistPoint)
+        val serverTruststore = serverConfig.loadTrustStore().internal
+        val serverKeystore = serverConfig.loadSslKeyStore().internal
+        return Pair(AMQPServer(
+                "0.0.0.0",
+                port,
+                PEER_USER,
+                PEER_USER,
+                serverKeystore,
+                serverConfig.keyStorePassword,
+                serverTruststore,
+                revocationCheckConfig), nodeCert)
+    }
+
+    private fun SSLConfiguration.recreateNodeCaAndTlsCertificates(nodeCaCrlDistPoint: String, tlsCrlDistPoint: String?): X509Certificate {
+        val nodeKeyStore = loadNodeKeyStore()
+        val (nodeCert, nodeKeys) = nodeKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA)
+        val newNodeCert = replaceCrlDistPointCaCertificate(nodeCert, CertificateType.NODE_CA, INTERMEDIATE_CA.keyPair, nodeCaCrlDistPoint)
+        val nodeCertChain = listOf(newNodeCert, INTERMEDIATE_CA.certificate, *nodeKeyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_CA).drop(2).toTypedArray())
+        nodeKeyStore.internal.deleteEntry(X509Utilities.CORDA_CLIENT_CA)
+        nodeKeyStore.save()
+        nodeKeyStore.update {
+            setPrivateKey(X509Utilities.CORDA_CLIENT_CA, nodeKeys.private, nodeCertChain)
+        }
+        val sslKeyStore = loadSslKeyStore()
+        val (tlsCert, tlsKeys) = sslKeyStore.getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_TLS)
+        val newTlsCert = replaceCrlDistPointCaCertificate(tlsCert, CertificateType.TLS, nodeKeys, tlsCrlDistPoint, X500Name.getInstance(ROOT_CA.certificate.subjectX500Principal.encoded))
+        val sslCertChain = listOf(newTlsCert, newNodeCert, INTERMEDIATE_CA.certificate, *sslKeyStore.getCertificateChain(X509Utilities.CORDA_CLIENT_TLS).drop(3).toTypedArray())
+        sslKeyStore.internal.deleteEntry(X509Utilities.CORDA_CLIENT_TLS)
+        sslKeyStore.save()
+        sslKeyStore.update {
+            setPrivateKey(X509Utilities.CORDA_CLIENT_TLS, tlsKeys.private, sslCertChain)
+        }
+        return newNodeCert
+    }
+
+    private fun replaceCrlDistPointCaCertificate(currentCaCert: X509Certificate, certType: CertificateType, issuerKeyPair: KeyPair, crlDistPoint: String?, crlIssuer: X500Name? = null): X509Certificate {
+        val signatureScheme = Crypto.findSignatureScheme(issuerKeyPair.private)
+        val provider = Crypto.findProvider(signatureScheme.providerName)
+        val issuerSigner = ContentSignerBuilder.build(signatureScheme, issuerKeyPair.private, provider)
+        val builder = X509Utilities.createPartialCertificate(
+                certType,
+                currentCaCert.issuerX500Principal,
+                issuerKeyPair.public,
+                currentCaCert.subjectX500Principal,
+                currentCaCert.publicKey,
+                Pair(Date(System.currentTimeMillis() - 5.minutes.toMillis()), Date(System.currentTimeMillis() + 10.days.toMillis())),
+                null
+        )
+        crlDistPoint?.let {
+            val distPointName = DistributionPointName(GeneralNames(GeneralName(GeneralName.uniformResourceIdentifier, it)))
+            val crlIssuerGeneralNames = crlIssuer?.let {
+                GeneralNames(GeneralName(crlIssuer))
+            }
+            val distPoint = DistributionPoint(distPointName, null, crlIssuerGeneralNames)
+            builder.addExtension(Extension.cRLDistributionPoints, false, CRLDistPoint(arrayOf(distPoint)))
+        }
+        return builder.build(issuerSigner).toJca()
+    }
+
+    @Path("crl")
+    inner class CrlServlet(private val server: CrlServer) {
+
+        private val SIGNATURE_ALGORITHM = "SHA256withECDSA"
+        private val NODE_CRL = "node.crl"
+        private val INTEMEDIATE_CRL = "intermediate.crl"
+        private val EMPTY_CRL = "empty.crl"
+
+        @GET
+        @Path("node.crl")
+        @Produces("application/pkcs7-crl")
+        fun getNodeCRL(): Response {
+            return Response.ok(createRevocationList(
+                    INTERMEDIATE_CA.certificate,
+                    INTERMEDIATE_CA.keyPair.private,
+                    NODE_CRL,
+                    false,
+                    *revokedNodeCerts.toTypedArray()).encoded).build()
+        }
+
+        @GET
+        @Path("intermediate.crl")
+        @Produces("application/pkcs7-crl")
+        fun getIntermediateCRL(): Response {
+            return Response.ok(createRevocationList(
+                    ROOT_CA.certificate,
+                    ROOT_CA.keyPair.private,
+                    INTEMEDIATE_CRL,
+                    false,
+                    *revokedIntermediateCerts.toTypedArray()).encoded).build()
+        }
+
+        @GET
+        @Path("empty.crl")
+        @Produces("application/pkcs7-crl")
+        fun getEmptyCRL(): Response {
+            return Response.ok(createRevocationList(
+                    ROOT_CA.certificate,
+                    ROOT_CA.keyPair.private,
+                    EMPTY_CRL, true).encoded).build()
+        }
+
+        private fun createRevocationList(caCertificate: X509Certificate,
+                                         caPrivateKey: PrivateKey,
+                                         endpoint: String,
+                                         indirect: Boolean,
+                                         vararg serialNumbers: BigInteger): X509CRL {
+            println("Generating CRL for $endpoint")
+            val builder = JcaX509v2CRLBuilder(caCertificate.subjectX500Principal, Date(System.currentTimeMillis() - 1.minutes.toMillis()))
+            val extensionUtils = JcaX509ExtensionUtils()
+            builder.addExtension(Extension.authorityKeyIdentifier,
+                    false, extensionUtils.createAuthorityKeyIdentifier(caCertificate))
+            val issuingDistPointName = GeneralName(
+                    GeneralName.uniformResourceIdentifier,
+                    "http://${server.hostAndPort.host}:${server.hostAndPort.port}/crl/$endpoint")
+            // This is required and needs to match the certificate settings with respect to being indirect
+            val issuingDistPoint = IssuingDistributionPoint(DistributionPointName(GeneralNames(issuingDistPointName)), indirect, false)
+            builder.addExtension(Extension.issuingDistributionPoint, true, issuingDistPoint)
+            builder.setNextUpdate(Date(System.currentTimeMillis() + 1.seconds.toMillis()))
+            serialNumbers.forEach {
+                builder.addCRLEntry(it, Date(System.currentTimeMillis() - 10.minutes.toMillis()), ReasonFlags.certificateHold)
+            }
+            val signer = JcaContentSignerBuilder(SIGNATURE_ALGORITHM).setProvider(BouncyCastleProvider.PROVIDER_NAME).build(caPrivateKey)
+            return JcaX509CRLConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME).getCRL(builder.build(signer))
+        }
+    }
+
+    inner class CrlServer(hostAndPort: NetworkHostAndPort) : Closeable {
+
+        private val server: Server = Server(InetSocketAddress(hostAndPort.host, hostAndPort.port)).apply {
+            handler = HandlerCollection().apply {
+                addHandler(buildServletContextHandler())
+            }
+        }
+
+        val hostAndPort: NetworkHostAndPort
+            get() = server.connectors.mapNotNull { it as? ServerConnector }
+                    .map { NetworkHostAndPort(it.host, it.localPort) }
+                    .first()
+
+        override fun close() {
+            println("Shutting down network management web services...")
+            server.stop()
+            server.join()
+        }
+
+        fun start() {
+            server.start()
+            println("Network management web services started on $hostAndPort")
+        }
+
+        private fun buildServletContextHandler(): ServletContextHandler {
+            val crlServer = this
+            return ServletContextHandler().apply {
+                contextPath = "/"
+                val resourceConfig = ResourceConfig().apply {
+                    register(CrlServlet(crlServer))
+                }
+                val jerseyServlet = ServletHolder(ServletContainer(resourceConfig)).apply { initOrder = 0 }
+                addServlet(jerseyServlet, "/*")
+            }
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
@@ -15,7 +15,6 @@ import net.corda.node.services.messaging.ArtemisMessagingServer
 import net.corda.nodeapi.internal.ArtemisMessagingClient
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_PREFIX
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEER_USER
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.protonwrapper.messages.MessageStatus
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPClient
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPServer
@@ -225,7 +224,7 @@ class ProtonWrapperTests {
             doReturn(NetworkHostAndPort("0.0.0.0", artemisPort)).whenever(it).p2pAddress
             doReturn(null).whenever(it).jmxMonitoringHttpPort
             doReturn(emptyList<CertChainPolicyConfig>()).whenever(it).certificateChainCheckPolicies
-            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
+            doReturn(true).whenever(it).crlCheckSoftFail
         }
         artemisConfig.configureWithDevSSLCertificate()
 
@@ -242,7 +241,7 @@ class ProtonWrapperTests {
             doReturn(BOB_NAME).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
-            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
+            doReturn(true).whenever(it).crlCheckSoftFail
         }
         clientConfig.configureWithDevSSLCertificate()
 
@@ -258,7 +257,7 @@ class ProtonWrapperTests {
                 clientKeystore,
                 clientConfig.keyStorePassword,
                 clientTruststore,
-                RevocationCheckConfig())
+                true)
     }
 
     private fun createSharedThreadsClient(sharedEventGroup: EventLoopGroup, id: Int): AMQPClient {
@@ -267,7 +266,7 @@ class ProtonWrapperTests {
             doReturn(CordaX500Name(null, "client $id", "Corda", "London", null, "GB")).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
-            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
+            doReturn(true).whenever(it).crlCheckSoftFail
         }
         clientConfig.configureWithDevSSLCertificate()
 
@@ -281,7 +280,7 @@ class ProtonWrapperTests {
                 clientKeystore,
                 clientConfig.keyStorePassword,
                 clientTruststore,
-                RevocationCheckConfig(),
+                true,
                 sharedThreadPool = sharedEventGroup)
     }
 
@@ -291,7 +290,7 @@ class ProtonWrapperTests {
             doReturn(name).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
-            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
+            doReturn(true).whenever(it).crlCheckSoftFail
         }
         serverConfig.configureWithDevSSLCertificate()
 
@@ -305,6 +304,6 @@ class ProtonWrapperTests {
                 serverKeystore,
                 serverConfig.keyStorePassword,
                 serverTruststore,
-                revocationCheckConfig = RevocationCheckConfig())
+                crlCheckSoftFail = true)
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
@@ -15,6 +15,7 @@ import net.corda.node.services.messaging.ArtemisMessagingServer
 import net.corda.nodeapi.internal.ArtemisMessagingClient
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.P2P_PREFIX
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEER_USER
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.protonwrapper.messages.MessageStatus
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPClient
 import net.corda.nodeapi.internal.protonwrapper.netty.AMQPServer
@@ -224,6 +225,7 @@ class ProtonWrapperTests {
             doReturn(NetworkHostAndPort("0.0.0.0", artemisPort)).whenever(it).p2pAddress
             doReturn(null).whenever(it).jmxMonitoringHttpPort
             doReturn(emptyList<CertChainPolicyConfig>()).whenever(it).certificateChainCheckPolicies
+            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
         }
         artemisConfig.configureWithDevSSLCertificate()
 
@@ -240,6 +242,7 @@ class ProtonWrapperTests {
             doReturn(BOB_NAME).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
+            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
         }
         clientConfig.configureWithDevSSLCertificate()
 
@@ -247,14 +250,15 @@ class ProtonWrapperTests {
         val clientKeystore = clientConfig.loadSslKeyStore().internal
         return AMQPClient(
                 listOf(NetworkHostAndPort("localhost", serverPort),
-                NetworkHostAndPort("localhost", serverPort2),
-                NetworkHostAndPort("localhost", artemisPort)),
+                        NetworkHostAndPort("localhost", serverPort2),
+                        NetworkHostAndPort("localhost", artemisPort)),
                 setOf(ALICE_NAME, CHARLIE_NAME),
                 PEER_USER,
                 PEER_USER,
                 clientKeystore,
                 clientConfig.keyStorePassword,
-                clientTruststore, true)
+                clientTruststore,
+                RevocationCheckConfig())
     }
 
     private fun createSharedThreadsClient(sharedEventGroup: EventLoopGroup, id: Int): AMQPClient {
@@ -263,6 +267,7 @@ class ProtonWrapperTests {
             doReturn(CordaX500Name(null, "client $id", "Corda", "London", null, "GB")).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
+            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
         }
         clientConfig.configureWithDevSSLCertificate()
 
@@ -275,7 +280,9 @@ class ProtonWrapperTests {
                 PEER_USER,
                 clientKeystore,
                 clientConfig.keyStorePassword,
-                clientTruststore, true, sharedEventGroup)
+                clientTruststore,
+                RevocationCheckConfig(),
+                sharedThreadPool = sharedEventGroup)
     }
 
     private fun createServer(port: Int, name: CordaX500Name = ALICE_NAME): AMQPServer {
@@ -284,6 +291,7 @@ class ProtonWrapperTests {
             doReturn(name).whenever(it).myLegalName
             doReturn("trustpass").whenever(it).trustStorePassword
             doReturn("cordacadevpass").whenever(it).keyStorePassword
+            doReturn(RevocationCheckConfig()).whenever(it).revocationCheckConfig
         }
         serverConfig.configureWithDevSSLCertificate()
 
@@ -296,6 +304,7 @@ class ProtonWrapperTests {
                 PEER_USER,
                 serverKeystore,
                 serverConfig.keyStorePassword,
-                serverTruststore)
+                serverTruststore,
+                revocationCheckConfig = RevocationCheckConfig())
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
@@ -11,7 +11,6 @@ import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NODE_USER
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEER_USER
 import net.corda.nodeapi.internal.DEV_INTERMEDIATE_CA
 import net.corda.nodeapi.internal.DEV_ROOT_CA
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -89,7 +88,7 @@ class MQSecurityAsNodeTest : P2PMQSecurityTest() {
             override val certificatesDirectory = Files.createTempDirectory("certs")
             override val keyStorePassword: String get() = "cordacadevpass"
             override val trustStorePassword: String get() = "trustpass"
-            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
+            override val crlCheckSoftFail: Boolean = true
 
             init {
                 val legalName = CordaX500Name("MegaCorp", "London", "GB")

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityAsNodeTest.kt
@@ -11,6 +11,7 @@ import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NODE_USER
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.PEER_USER
 import net.corda.nodeapi.internal.DEV_INTERMEDIATE_CA
 import net.corda.nodeapi.internal.DEV_ROOT_CA
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -88,6 +89,7 @@ class MQSecurityAsNodeTest : P2PMQSecurityTest() {
             override val certificatesDirectory = Files.createTempDirectory("certs")
             override val keyStorePassword: String get() = "cordacadevpass"
             override val trustStorePassword: String get() = "trustpass"
+            override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
 
             init {
                 val legalName = CordaX500Name("MegaCorp", "London", "GB")

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -738,6 +738,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
     private fun makeIdentityService(identityCert: X509Certificate): PersistentIdentityService {
         val trustRoot = configuration.loadTrustStore().getCertificate(X509Utilities.CORDA_ROOT_CA)
         val nodeCa = configuration.loadNodeKeyStore().getCertificate(X509Utilities.CORDA_CLIENT_CA)
+
         return PersistentIdentityService(trustRoot, identityCert, nodeCa)
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -738,7 +738,6 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
     private fun makeIdentityService(identityCert: X509Certificate): PersistentIdentityService {
         val trustRoot = configuration.loadTrustStore().getCertificate(X509Utilities.CORDA_ROOT_CA)
         val nodeCa = configuration.loadNodeKeyStore().getCertificate(X509Utilities.CORDA_CLIENT_CA)
-
         return PersistentIdentityService(trustRoot, identityCert, nodeCa)
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -9,10 +9,7 @@ import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.seconds
 import net.corda.node.internal.artemis.CertificateChainCheckPolicy
 import net.corda.node.services.config.rpc.NodeRpcOptions
-import net.corda.nodeapi.internal.config.NodeSSLConfiguration
-import net.corda.nodeapi.internal.config.SSLConfiguration
-import net.corda.nodeapi.internal.config.User
-import net.corda.nodeapi.internal.config.parseAs
+import net.corda.nodeapi.internal.config.*
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.tools.shell.SSHDConfiguration
 import java.net.URL
@@ -130,6 +127,7 @@ data class NodeConfigurationImpl(
         override val emailAddress: String,
         override val keyStorePassword: String,
         override val trustStorePassword: String,
+        override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig(),
         override val dataSourceProperties: Properties,
         override val compatibilityZoneURL: URL? = null,
         override val rpcUsers: List<User>,
@@ -165,7 +163,7 @@ data class NodeConfigurationImpl(
         private val logger = loggerFor<NodeConfigurationImpl>()
     }
 
-    override val rpcOptions: NodeRpcOptions = initialiseRpcOptions(rpcAddress, rpcSettings, SslOptions(baseDirectory / "certificates", keyStorePassword, trustStorePassword))
+    override val rpcOptions: NodeRpcOptions = initialiseRpcOptions(rpcAddress, rpcSettings, SslOptions(baseDirectory / "certificates", keyStorePassword, trustStorePassword, revocationCheckConfig))
 
     private fun initialiseRpcOptions(explicitAddress: NetworkHostAndPort?, settings: NodeRpcSettings, fallbackSslOptions: SSLConfiguration): NodeRpcOptions {
         return when {

--- a/node/src/main/kotlin/net/corda/node/services/config/SslOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/SslOptions.kt
@@ -1,12 +1,24 @@
 package net.corda.node.services.config
 
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import java.nio.file.Path
 import java.nio.file.Paths
 
-data class SslOptions(override val certificatesDirectory: Path, override val keyStorePassword: String, override val trustStorePassword: String) : SSLConfiguration {
+// TODO: we use both SSL and Ssl for names. We should pick one of them, or even better change to TLS
+data class SslOptions(override val certificatesDirectory: Path,
+                      override val keyStorePassword: String,
+                      override val trustStorePassword: String,
+                      override val revocationCheckConfig: RevocationCheckConfig) : SSLConfiguration {
 
-    fun copy(certificatesDirectory: String = this.certificatesDirectory.toString(), keyStorePassword: String = this.keyStorePassword, trustStorePassword: String = this.trustStorePassword): SslOptions = copy(certificatesDirectory = certificatesDirectory.toAbsolutePath(), keyStorePassword = keyStorePassword, trustStorePassword = trustStorePassword)
+    fun copy(certificatesDirectory: String = this.certificatesDirectory.toString(),
+             keyStorePassword: String = this.keyStorePassword,
+             trustStorePassword: String = this.trustStorePassword,
+             revocationCheckConfig: RevocationCheckConfig = this.revocationCheckConfig): SslOptions = copy(
+            certificatesDirectory = certificatesDirectory.toAbsolutePath(),
+            keyStorePassword = keyStorePassword,
+            trustStorePassword = trustStorePassword,
+            revocationCheckConfig = revocationCheckConfig)
 }
 
 private fun String.toAbsolutePath() = Paths.get(this).toAbsolutePath()

--- a/node/src/main/kotlin/net/corda/node/services/config/SslOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/SslOptions.kt
@@ -1,6 +1,5 @@
 package net.corda.node.services.config
 
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -9,16 +8,16 @@ import java.nio.file.Paths
 data class SslOptions(override val certificatesDirectory: Path,
                       override val keyStorePassword: String,
                       override val trustStorePassword: String,
-                      override val revocationCheckConfig: RevocationCheckConfig) : SSLConfiguration {
+                      override val crlCheckSoftFail: Boolean) : SSLConfiguration {
 
     fun copy(certificatesDirectory: String = this.certificatesDirectory.toString(),
              keyStorePassword: String = this.keyStorePassword,
              trustStorePassword: String = this.trustStorePassword,
-             revocationCheckConfig: RevocationCheckConfig = this.revocationCheckConfig): SslOptions = copy(
+             crlCheckSoftFail: Boolean = this.crlCheckSoftFail): SslOptions = copy(
             certificatesDirectory = certificatesDirectory.toAbsolutePath(),
             keyStorePassword = keyStorePassword,
             trustStorePassword = trustStorePassword,
-            revocationCheckConfig = revocationCheckConfig)
+            crlCheckSoftFail = crlCheckSoftFail)
 }
 
 private fun String.toAbsolutePath() = Paths.get(this).toAbsolutePath()

--- a/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt
@@ -4,7 +4,6 @@ import net.corda.core.internal.div
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.services.Permissions
 import net.corda.node.services.config.NodeConfiguration
-import net.corda.node.services.config.shouldInitCrashShell
 import net.corda.nodeapi.internal.config.User
 import net.corda.tools.shell.ShellConfiguration
 import net.corda.tools.shell.ShellConfiguration.Companion.COMMANDS_DIR
@@ -22,7 +21,8 @@ fun NodeConfiguration.toShellConfig(): ShellConfiguration {
             ShellSslOptions(sslKeystore,
                     keyStorePassword,
                     trustStoreFile,
-                    trustStorePassword)
+                    trustStorePassword,
+                    revocationCheckConfig)
         }
     } else {
         null

--- a/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/shell/ShellConfig.kt
@@ -22,7 +22,7 @@ fun NodeConfiguration.toShellConfig(): ShellConfiguration {
                     keyStorePassword,
                     trustStoreFile,
                     trustStorePassword,
-                    revocationCheckConfig)
+                    crlCheckSoftFail)
         }
     } else {
         null

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -2,11 +2,7 @@ myLegalName = "Vast Global MegaCorp, Ltd"
 emailAddress = "admin@company.com"
 keyStorePassword = "cordacadevpass"
 trustStorePassword = "trustpass"
-revocationCheckConfig = {
-    preferCrl = true
-    noFallback = true
-    softFail = true
-}
+crlCheckSoftFail = true
 dataSourceProperties = {
     dataSourceClassName = org.h2.jdbcx.JdbcDataSource
     dataSource.url = "jdbc:h2:file:"${baseDirectory}"/persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=100;AUTO_SERVER_PORT="${h2port}

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -2,6 +2,11 @@ myLegalName = "Vast Global MegaCorp, Ltd"
 emailAddress = "admin@company.com"
 keyStorePassword = "cordacadevpass"
 trustStorePassword = "trustpass"
+revocationCheckConfig = {
+    preferCrl = true
+    noFallback = true
+    softFail = true
+}
 dataSourceProperties = {
     dataSourceClassName = org.h2.jdbcx.JdbcDataSource
     dataSource.url = "jdbc:h2:file:"${baseDirectory}"/persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=100;AUTO_SERVER_PORT="${h2port}

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -3,7 +3,6 @@ package net.corda.node.services.config
 import net.corda.core.internal.div
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.seconds
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
 import net.corda.tools.shell.SSHDConfiguration
@@ -63,7 +62,7 @@ class NodeConfigurationImplTest {
                 adminAddress = NetworkHostAndPort("localhost", 2),
                 standAloneBroker = false,
                 useSsl = false,
-                ssl = SslOptions(baseDirectory / "certificates", keyStorePassword, trustStorePassword, RevocationCheckConfig()))
+                ssl = SslOptions(baseDirectory / "certificates", keyStorePassword, trustStorePassword, true))
         return NodeConfigurationImpl(
                 baseDirectory = baseDirectory,
                 myLegalName = ALICE_NAME,
@@ -81,7 +80,7 @@ class NodeConfigurationImplTest {
                 devMode = true,
                 noLocalShell = false,
                 rpcSettings = rpcSettings,
-                revocationCheckConfig = RevocationCheckConfig()
+                crlCheckSoftFail = true
         )
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.config
 import net.corda.core.internal.div
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.seconds
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
 import net.corda.tools.shell.SSHDConfiguration
@@ -62,7 +63,7 @@ class NodeConfigurationImplTest {
                 adminAddress = NetworkHostAndPort("localhost", 2),
                 standAloneBroker = false,
                 useSsl = false,
-                ssl = SslOptions(baseDirectory / "certificates", keyStorePassword, trustStorePassword))
+                ssl = SslOptions(baseDirectory / "certificates", keyStorePassword, trustStorePassword, RevocationCheckConfig()))
         return NodeConfigurationImpl(
                 baseDirectory = baseDirectory,
                 myLegalName = ALICE_NAME,
@@ -79,7 +80,8 @@ class NodeConfigurationImplTest {
                 certificateChainCheckPolicies = emptyList(),
                 devMode = true,
                 noLocalShell = false,
-                rpcSettings = rpcSettings
+                rpcSettings = rpcSettings,
+                revocationCheckConfig = RevocationCheckConfig()
         )
     }
 }

--- a/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt
+++ b/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt
@@ -4,6 +4,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.createFile
 import net.corda.core.internal.deleteIfExists
 import net.corda.core.internal.div
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.crypto.*
 import org.apache.commons.io.FileUtils
@@ -76,9 +77,12 @@ class KeyStores(val keyStore: UnsafeKeyStore, val trustStore: UnsafeKeyStore) {
             }
         }
     }
-    data class TestSslOptions(override val certificatesDirectory: Path, override val keyStorePassword: String, override val trustStorePassword: String) : SSLConfiguration
+    data class TestSslOptions(override val certificatesDirectory: Path,
+                              override val keyStorePassword: String,
+                              override val trustStorePassword: String,
+                              override val revocationCheckConfig: RevocationCheckConfig) : SSLConfiguration
 
-    private fun sslConfiguration(directory: Path) = TestSslOptions(directory, keyStore.password, trustStore.password)
+    private fun sslConfiguration(directory: Path) = TestSslOptions(directory, keyStore.password, trustStore.password, RevocationCheckConfig())
 }
 
 interface AutoClosableSSLConfiguration : AutoCloseable {

--- a/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt
+++ b/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/UnsafeCertificatesFactory.kt
@@ -4,7 +4,6 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.createFile
 import net.corda.core.internal.deleteIfExists
 import net.corda.core.internal.div
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import net.corda.nodeapi.internal.crypto.*
 import org.apache.commons.io.FileUtils
@@ -77,12 +76,13 @@ class KeyStores(val keyStore: UnsafeKeyStore, val trustStore: UnsafeKeyStore) {
             }
         }
     }
+
     data class TestSslOptions(override val certificatesDirectory: Path,
                               override val keyStorePassword: String,
                               override val trustStorePassword: String,
-                              override val revocationCheckConfig: RevocationCheckConfig) : SSLConfiguration
+                              override val crlCheckSoftFail: Boolean) : SSLConfiguration
 
-    private fun sslConfiguration(directory: Path) = TestSslOptions(directory, keyStore.password, trustStore.password, RevocationCheckConfig())
+    private fun sslConfiguration(directory: Path) = TestSslOptions(directory, keyStore.password, trustStore.password, true)
 }
 
 interface AutoClosableSSLConfiguration : AutoCloseable {
@@ -125,6 +125,7 @@ data class UnsafeKeyStore(private val delegate: KeyStore, val password: String) 
 
 class TemporaryFile(fileName: String, val directory: Path) : AutoCloseable {
     val file: Path = (directory / fileName).createFile().toAbsolutePath()
+
     init {
         file.toFile().deleteOnExit()
     }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -10,7 +10,9 @@ import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.config.configureDevKeyAndTrustStores
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
+import net.corda.nodeapi.internal.config.toConfig
 import net.corda.nodeapi.internal.createDevNodeCa
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.nodeapi.internal.crypto.CertificateType
@@ -65,6 +67,7 @@ fun configureTestSSL(legalName: CordaX500Name): SSLConfiguration {
         override val certificatesDirectory = Files.createTempDirectory("certs")
         override val keyStorePassword: String get() = "cordacadevpass"
         override val trustStorePassword: String get() = "trustpass"
+        override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
 
         init {
             configureDevKeyAndTrustStores(legalName)
@@ -120,22 +123,24 @@ fun createDevNodeCaCertPath(
 /** Application of [doAnswer] that gets a value from the given [map] using the arg at [argIndex] as key. */
 fun doLookup(map: Map<*, *>, argIndex: Int = 0) = doAnswer { map[it.arguments[argIndex]] }
 
-fun SSLConfiguration.useSslRpcOverrides(): Map<String, String> {
+fun SSLConfiguration.useSslRpcOverrides(): Map<String, Any> {
     return mapOf(
             "rpcSettings.useSsl" to "true",
             "rpcSettings.ssl.certificatesDirectory" to certificatesDirectory.toString(),
             "rpcSettings.ssl.keyStorePassword" to keyStorePassword,
-            "rpcSettings.ssl.trustStorePassword" to trustStorePassword
+            "rpcSettings.ssl.trustStorePassword" to trustStorePassword,
+            "rpcSettings.ssl.revocationCheckConfig" to RevocationCheckConfig().toConfig().root().unwrapped()
     )
 }
 
-fun SSLConfiguration.noSslRpcOverrides(rpcAdminAddress: NetworkHostAndPort): Map<String, String> {
+fun SSLConfiguration.noSslRpcOverrides(rpcAdminAddress: NetworkHostAndPort): Map<String, Any> {
     return mapOf(
             "rpcSettings.adminAddress" to rpcAdminAddress.toString(),
             "rpcSettings.useSsl" to "false",
             "rpcSettings.ssl.certificatesDirectory" to certificatesDirectory.toString(),
             "rpcSettings.ssl.keyStorePassword" to keyStorePassword,
-            "rpcSettings.ssl.trustStorePassword" to trustStorePassword
+            "rpcSettings.ssl.trustStorePassword" to trustStorePassword,
+            "rpcSettings.ssl.revocationCheckConfig" to RevocationCheckConfig().toConfig().root().unwrapped()
     )
 }
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -10,9 +10,7 @@ import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.config.configureDevKeyAndTrustStores
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
-import net.corda.nodeapi.internal.config.toConfig
 import net.corda.nodeapi.internal.createDevNodeCa
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.nodeapi.internal.crypto.CertificateType
@@ -67,7 +65,7 @@ fun configureTestSSL(legalName: CordaX500Name): SSLConfiguration {
         override val certificatesDirectory = Files.createTempDirectory("certs")
         override val keyStorePassword: String get() = "cordacadevpass"
         override val trustStorePassword: String get() = "trustpass"
-        override val revocationCheckConfig: RevocationCheckConfig = RevocationCheckConfig()
+        override val crlCheckSoftFail: Boolean = true
 
         init {
             configureDevKeyAndTrustStores(legalName)
@@ -129,7 +127,7 @@ fun SSLConfiguration.useSslRpcOverrides(): Map<String, Any> {
             "rpcSettings.ssl.certificatesDirectory" to certificatesDirectory.toString(),
             "rpcSettings.ssl.keyStorePassword" to keyStorePassword,
             "rpcSettings.ssl.trustStorePassword" to trustStorePassword,
-            "rpcSettings.ssl.revocationCheckConfig" to RevocationCheckConfig().toConfig().root().unwrapped()
+            "rpcSettings.ssl.crlCheckSoftFail" to true
     )
 }
 
@@ -140,7 +138,7 @@ fun SSLConfiguration.noSslRpcOverrides(rpcAdminAddress: NetworkHostAndPort): Map
             "rpcSettings.ssl.certificatesDirectory" to certificatesDirectory.toString(),
             "rpcSettings.ssl.keyStorePassword" to keyStorePassword,
             "rpcSettings.ssl.trustStorePassword" to trustStorePassword,
-            "rpcSettings.ssl.revocationCheckConfig" to RevocationCheckConfig().toConfig().root().unwrapped()
+            "rpcSettings.ssl.crlCheckSoftFail" to true
     )
 }
 

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -8,7 +8,6 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions
 import net.corda.node.services.Permissions.Companion.all
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.testing.common.internal.withCertificates
 import net.corda.testing.common.internal.withKeyStores
 import net.corda.testing.core.ALICE_NAME
@@ -81,7 +80,7 @@ class InteractiveShellIntegrationTest {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
 
                         val sslConfiguration = ShellSslOptions(clientSslOptions.sslKeystore, clientSslOptions.keyStorePassword,
-                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.revocationCheckConfig)
+                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.crlCheckSoftFail)
                         val conf = ShellConfiguration(commandsDirectory = Files.createTempDir().toPath(),
                                 user = user.username, password = user.password,
                                 hostAndPort = node.rpcAddress,
@@ -118,7 +117,7 @@ class InteractiveShellIntegrationTest {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
 
                         val sslConfiguration = ShellSslOptions(clientSslOptions.sslKeystore, clientSslOptions.keyStorePassword,
-                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.revocationCheckConfig)
+                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.crlCheckSoftFail)
                         val conf = ShellConfiguration(commandsDirectory = Files.createTempDir().toPath(),
                                 user = user.username, password = user.password,
                                 hostAndPort = node.rpcAddress,
@@ -200,7 +199,7 @@ class InteractiveShellIntegrationTest {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
 
                         val sslConfiguration = ShellSslOptions(clientSslOptions.sslKeystore, clientSslOptions.keyStorePassword,
-                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.revocationCheckConfig)
+                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.crlCheckSoftFail)
                         val conf = ShellConfiguration(commandsDirectory = Files.createTempDir().toPath(),
                                 user = user.username, password = user.password,
                                 hostAndPort = node.rpcAddress,

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -8,6 +8,7 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions
 import net.corda.node.services.Permissions.Companion.all
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.testing.common.internal.withCertificates
 import net.corda.testing.common.internal.withKeyStores
 import net.corda.testing.core.ALICE_NAME
@@ -80,7 +81,7 @@ class InteractiveShellIntegrationTest {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
 
                         val sslConfiguration = ShellSslOptions(clientSslOptions.sslKeystore, clientSslOptions.keyStorePassword,
-                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword)
+                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.revocationCheckConfig)
                         val conf = ShellConfiguration(commandsDirectory = Files.createTempDir().toPath(),
                                 user = user.username, password = user.password,
                                 hostAndPort = node.rpcAddress,
@@ -117,7 +118,7 @@ class InteractiveShellIntegrationTest {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
 
                         val sslConfiguration = ShellSslOptions(clientSslOptions.sslKeystore, clientSslOptions.keyStorePassword,
-                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword)
+                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.revocationCheckConfig)
                         val conf = ShellConfiguration(commandsDirectory = Files.createTempDir().toPath(),
                                 user = user.username, password = user.password,
                                 hostAndPort = node.rpcAddress,
@@ -199,7 +200,7 @@ class InteractiveShellIntegrationTest {
                     startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
 
                         val sslConfiguration = ShellSslOptions(clientSslOptions.sslKeystore, clientSslOptions.keyStorePassword,
-                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword)
+                                clientSslOptions.trustStoreFile, clientSslOptions.trustStorePassword, clientSslOptions.revocationCheckConfig)
                         val conf = ShellConfiguration(commandsDirectory = Files.createTempDir().toPath(),
                                 user = user.username, password = user.password,
                                 hostAndPort = node.rpcAddress,

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/ShellConfiguration.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/ShellConfiguration.kt
@@ -1,6 +1,7 @@
 package net.corda.tools.shell
 
 import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -23,6 +24,12 @@ data class ShellConfiguration(
     }
 }
 
-data class ShellSslOptions(override val sslKeystore: Path, override val keyStorePassword: String, override val trustStoreFile:Path, override val trustStorePassword: String) : SSLConfiguration {
+//TODO: sslKeystore -> it's a path not the keystore itself.
+//TODO: trustStoreFile -> it's a path not the file itself.
+data class ShellSslOptions(override val sslKeystore: Path,
+                           override val keyStorePassword: String,
+                           override val trustStoreFile: Path,
+                           override val trustStorePassword: String,
+                           override val revocationCheckConfig: RevocationCheckConfig) : SSLConfiguration {
     override val certificatesDirectory: Path get() = Paths.get("")
 }

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/ShellConfiguration.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/ShellConfiguration.kt
@@ -1,7 +1,6 @@
 package net.corda.tools.shell
 
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.SSLConfiguration
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -30,6 +29,6 @@ data class ShellSslOptions(override val sslKeystore: Path,
                            override val keyStorePassword: String,
                            override val trustStoreFile: Path,
                            override val trustStorePassword: String,
-                           override val revocationCheckConfig: RevocationCheckConfig) : SSLConfiguration {
+                           override val crlCheckSoftFail: Boolean) : SSLConfiguration {
     override val certificatesDirectory: Path get() = Paths.get("")
 }

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShellArgsParser.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShellArgsParser.kt
@@ -6,7 +6,6 @@ import joptsimple.OptionParser
 import joptsimple.util.EnumConverter
 import net.corda.core.internal.div
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.parseAs
 import net.corda.tools.shell.ShellConfiguration.Companion.COMMANDS_DIR
 import org.slf4j.event.Level
@@ -28,10 +27,10 @@ class CommandLineOptionParser {
             .accepts("commands-directory", "The directory with additional CrAsH shell commands.")
             .withOptionalArg()
     private val hostArg = optionParser
-            .acceptsAll(listOf("h","host"), "The host of the Corda node.")
+            .acceptsAll(listOf("h", "host"), "The host of the Corda node.")
             .withRequiredArg()
     private val portArg = optionParser
-            .acceptsAll(listOf("p","port"), "The port of the Corda node.")
+            .acceptsAll(listOf("p", "port"), "The port of the Corda node.")
             .withRequiredArg()
     private val userArg = optionParser
             .accepts("user", "The RPC user name.")
@@ -211,11 +210,12 @@ private class ShellConfigurationFile {
                                 keyStorePassword = it.keystore.password,
                                 trustStoreFile = Paths.get(it.truststore.path),
                                 trustStorePassword = it.truststore.password,
-                                revocationCheckConfig = RevocationCheckConfig())
+                                crlCheckSoftFail = true)
                     }
 
             return ShellConfiguration(
-                    commandsDirectory = extensions?.commands?.let { Paths.get(it.path) } ?: Paths.get(".") / COMMANDS_DIR,
+                    commandsDirectory = extensions?.commands?.let { Paths.get(it.path) } ?: Paths.get(".")
+                    / COMMANDS_DIR,
                     cordappsDirectory = extensions?.cordapps?.let { Paths.get(it.path) },
                     user = node.user ?: "",
                     password = node.password ?: "",

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShellArgsParser.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/StandaloneShellArgsParser.kt
@@ -6,6 +6,7 @@ import joptsimple.OptionParser
 import joptsimple.util.EnumConverter
 import net.corda.core.internal.div
 import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import net.corda.nodeapi.internal.config.parseAs
 import net.corda.tools.shell.ShellConfiguration.Companion.COMMANDS_DIR
 import org.slf4j.event.Level
@@ -209,7 +210,8 @@ private class ShellConfigurationFile {
                                 sslKeystore = Paths.get(it.keystore.path),
                                 keyStorePassword = it.keystore.password,
                                 trustStoreFile = Paths.get(it.truststore.path),
-                                trustStorePassword = it.truststore.password)
+                                trustStorePassword = it.truststore.password,
+                                revocationCheckConfig = RevocationCheckConfig())
                     }
 
             return ShellConfiguration(

--- a/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt
+++ b/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt
@@ -2,7 +2,6 @@ package net.corda.tools.shell
 
 import net.corda.core.internal.toPath
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.slf4j.event.Level
@@ -109,7 +108,7 @@ class StandaloneShellArgsParserTest {
                 keyStorePassword = "pass1",
                 trustStoreFile = Paths.get("/x/y/truststore.jks"),
                 trustStorePassword = "pass2",
-                revocationCheckConfig = RevocationCheckConfig())
+                crlCheckSoftFail = true)
         val expectedConfig = ShellConfiguration(
                 commandsDirectory = Paths.get("/x/y/commands"),
                 cordappsDirectory = Paths.get("/x/y/cordapps"),
@@ -151,7 +150,7 @@ class StandaloneShellArgsParserTest {
                 keyStorePassword = "pass1",
                 trustStoreFile = Paths.get("/x/y/truststore.jks"),
                 trustStorePassword = "pass2",
-                revocationCheckConfig = RevocationCheckConfig())
+                crlCheckSoftFail = true)
         val expectedConfig = ShellConfiguration(
                 commandsDirectory = Paths.get("/x/y/commands"),
                 cordappsDirectory = Paths.get("/x/y/cordapps"),
@@ -191,7 +190,7 @@ class StandaloneShellArgsParserTest {
                 keyStorePassword = "pass1",
                 trustStoreFile = Paths.get("/x/y/truststore.jks"),
                 trustStorePassword = "pass2",
-                revocationCheckConfig = RevocationCheckConfig())
+                crlCheckSoftFail = true)
         val expectedConfig = ShellConfiguration(
                 commandsDirectory = Paths.get("/x/y/commands"),
                 cordappsDirectory = Paths.get("/x/y/cordapps"),

--- a/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt
+++ b/tools/shell/src/test/kotlin/net/corda/tools/shell/StandaloneShellArgsParserTest.kt
@@ -2,6 +2,7 @@ package net.corda.tools.shell
 
 import net.corda.core.internal.toPath
 import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.config.RevocationCheckConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.slf4j.event.Level
@@ -102,12 +103,13 @@ class StandaloneShellArgsParserTest {
                 trustStoreFile = Paths.get("/x/y/truststore.jks"),
                 keyStoreType = "dummy",
                 trustStoreType = "dummy"
-                )
+        )
 
         val expectedSsl = ShellSslOptions(sslKeystore = Paths.get("/x/y/keystore.jks"),
                 keyStorePassword = "pass1",
                 trustStoreFile = Paths.get("/x/y/truststore.jks"),
-                trustStorePassword = "pass2")
+                trustStorePassword = "pass2",
+                revocationCheckConfig = RevocationCheckConfig())
         val expectedConfig = ShellConfiguration(
                 commandsDirectory = Paths.get("/x/y/commands"),
                 cordappsDirectory = Paths.get("/x/y/cordapps"),
@@ -148,7 +150,8 @@ class StandaloneShellArgsParserTest {
         val expectedSsl = ShellSslOptions(sslKeystore = Paths.get("/x/y/keystore.jks"),
                 keyStorePassword = "pass1",
                 trustStoreFile = Paths.get("/x/y/truststore.jks"),
-                trustStorePassword = "pass2")
+                trustStorePassword = "pass2",
+                revocationCheckConfig = RevocationCheckConfig())
         val expectedConfig = ShellConfiguration(
                 commandsDirectory = Paths.get("/x/y/commands"),
                 cordappsDirectory = Paths.get("/x/y/cordapps"),
@@ -187,7 +190,8 @@ class StandaloneShellArgsParserTest {
         val expectedSsl = ShellSslOptions(sslKeystore = Paths.get("/x/y/cmd.jks"),
                 keyStorePassword = "pass1",
                 trustStoreFile = Paths.get("/x/y/truststore.jks"),
-                trustStorePassword = "pass2")
+                trustStorePassword = "pass2",
+                revocationCheckConfig = RevocationCheckConfig())
         val expectedConfig = ShellConfiguration(
                 commandsDirectory = Paths.get("/x/y/commands"),
                 cordappsDirectory = Paths.get("/x/y/cordapps"),

--- a/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt
@@ -2,7 +2,10 @@ package net.corda.webserver
 
 import com.typesafe.config.Config
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.nodeapi.internal.config.*
+import net.corda.nodeapi.internal.config.NodeSSLConfiguration
+import net.corda.nodeapi.internal.config.User
+import net.corda.nodeapi.internal.config.getValue
+import net.corda.nodeapi.internal.config.parseAs
 import java.nio.file.Path
 
 /**
@@ -11,7 +14,7 @@ import java.nio.file.Path
 class WebServerConfig(override val baseDirectory: Path, val config: Config) : NodeSSLConfiguration {
     override val keyStorePassword: String by config
     override val trustStorePassword: String by config
-    override val revocationCheckConfig: RevocationCheckConfig by config
+    override val crlCheckSoftFail: Boolean by config
     val useHTTPS: Boolean by config
     val myLegalName: String by config
     val rpcAddress: NetworkHostAndPort by lazy {

--- a/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/WebServerConfig.kt
@@ -2,10 +2,7 @@ package net.corda.webserver
 
 import com.typesafe.config.Config
 import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.nodeapi.internal.config.NodeSSLConfiguration
-import net.corda.nodeapi.internal.config.User
-import net.corda.nodeapi.internal.config.getValue
-import net.corda.nodeapi.internal.config.parseAs
+import net.corda.nodeapi.internal.config.*
 import java.nio.file.Path
 
 /**
@@ -14,6 +11,7 @@ import java.nio.file.Path
 class WebServerConfig(override val baseDirectory: Path, val config: Config) : NodeSSLConfiguration {
     override val keyStorePassword: String by config
     override val trustStorePassword: String by config
+    override val revocationCheckConfig: RevocationCheckConfig by config
     val useHTTPS: Boolean by config
     val myLegalName: String by config
     val rpcAddress: NetworkHostAndPort by lazy {


### PR DESCRIPTION
This PR enables the CRL checking on the node side. The node configuration is extended with a new parameter called `revocationCheckConfig`, which takes 3 boolean flags configuring the SSL-level revocation check mechanism.
 @mnesbit please let me know where else the SSL configuration change is required.

