### PR TITLE
ENT-1775: reworked client to handle failover in HA mode instead of Artemis

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -326,6 +326,96 @@ class RPCStabilityTests {
         }
     }
 
+    interface ServerOps : RPCOps {
+        fun serverId(): String
+    }
+
+    @Test
+    fun `client connects to first available server`() {
+        rpcDriver {
+            val ops = object : ServerOps {
+                override val protocolVersion = 0
+                override fun serverId() = "server"
+            }
+            val serverFollower = shutdownManager.follower()
+            val serverAddress = startRpcServer<RPCOps>(ops = ops).getOrThrow().broker.hostAndPort!!
+            serverFollower.unfollow()
+
+            val clientFollower = shutdownManager.follower()
+            val client = startRpcClient<ServerOps>(listOf(NetworkHostAndPort("localhost", 12345), serverAddress, NetworkHostAndPort("localhost", 54321))).getOrThrow()
+            clientFollower.unfollow()
+
+            assertEquals("server", client.serverId())
+
+            clientFollower.shutdown() // Driver would do this after the new server, causing hang.
+        }
+    }
+
+    @Test
+    fun `3 server failover`() {
+        rpcDriver {
+            val ops1 = object : ServerOps {
+                override val protocolVersion = 0
+                override fun serverId() = "server1"
+            }
+            val ops2 = object : ServerOps {
+                override val protocolVersion = 0
+                override fun serverId() = "server2"
+            }
+            val ops3 = object : ServerOps {
+                override val protocolVersion = 0
+                override fun serverId() = "server3"
+            }
+            val serverFollower1 = shutdownManager.follower()
+            val server1 = startRpcServer<RPCOps>(ops = ops1).getOrThrow()
+            serverFollower1.unfollow()
+
+            val serverFollower2 = shutdownManager.follower()
+            val server2 = startRpcServer<RPCOps>(ops = ops2).getOrThrow()
+            serverFollower2.unfollow()
+
+            val serverFollower3 = shutdownManager.follower()
+            val server3 = startRpcServer<RPCOps>(ops = ops3).getOrThrow()
+            serverFollower3.unfollow()
+            val servers = mutableMapOf("server1" to serverFollower1, "server2" to serverFollower2, "server3" to serverFollower3)
+
+            val clientFollower = shutdownManager.follower()
+            val client = startRpcClient<ServerOps>(listOf(server1.broker.hostAndPort!!, server2.broker.hostAndPort!!, server3.broker.hostAndPort!!)).getOrThrow()
+            clientFollower.unfollow()
+
+            var response = client.serverId()
+            assertTrue(servers.containsKey(response))
+            servers[response]!!.shutdown()
+            servers.remove(response)
+
+            //failover will take some time
+            while (true) {
+                try {
+                    response = client.serverId()
+                    break
+                } catch (e: RPCException) {}
+            }
+            assertTrue(servers.containsKey(response))
+            servers[response]!!.shutdown()
+            servers.remove(response)
+
+            while (true) {
+                try {
+                    response = client.serverId()
+                    break
+                } catch (e: RPCException) {}
+            }
+            assertTrue(servers.containsKey(response))
+            servers[response]!!.shutdown()
+            servers.remove(response)
+
+            assertTrue(servers.isEmpty())
+
+            clientFollower.shutdown() // Driver would do this after the new server, causing hang.
+
+        }
+    }
+
     interface TrackSubscriberOps : RPCOps {
         fun subscribe(): Observable<Unit>
     }

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -388,7 +388,7 @@ class RPCStabilityTests {
             servers[response]!!.shutdown()
             servers.remove(response)
 
-            //failover will take some time
+            // Failover will take some time.
             while (true) {
                 try {
                     response = client.serverId()

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -93,18 +93,33 @@ interface CordaRPCClientConfiguration {
  * [CordaRPCClientConfiguration]. While attempting failover, current and future RPC calls will throw
  * [RPCException] and previously returned observables will call onError().
  *
+ * If the client was created using a list of hosts, automatic failover will occur(the servers have to be started in HA mode)
+ *
  * @param hostAndPort The network address to connect to.
  * @param configuration An optional configuration used to tweak client behaviour.
  * @param sslConfiguration An optional [SSLConfiguration] used to enable secure communication with the server.
+ * @param haAddressPool A list of [NetworkHostAndPort] representing the addresses of servers in HA mode.
+ * The client will attempt to connect to a live server by trying each address in the list. If the servers are not in
+ * HA mode, the client will round-robin from the beginning of the list and try all servers.
  */
 class CordaRPCClient private constructor(
-        hostAndPort: NetworkHostAndPort,
-        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
-        sslConfiguration: SSLConfiguration? = null,
-        classLoader: ClassLoader? = null
+        private val hostAndPort: NetworkHostAndPort,
+        private val configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+        private val sslConfiguration: SSLConfiguration? = null,
+        private val classLoader: ClassLoader? = null,
+        private val haAddressPool: List<NetworkHostAndPort> = emptyList()
 ) {
     @JvmOverloads
     constructor(hostAndPort: NetworkHostAndPort, configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default()) : this(hostAndPort, configuration, null)
+
+    /**
+     * @param haAddressPool A list of [NetworkHostAndPort] representing the addresses of servers in HA mode.
+     * The client will attempt to connect to a live server by trying each address in the list. If the servers are not in
+     * HA mode, the client will round-robin from the beginning of the list and try all servers.
+     * @param configuration An optional configuration used to tweak client behaviour.
+     */
+    @JvmOverloads
+    constructor(haAddressPool: List<NetworkHostAndPort>, configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default()) : this(haAddressPool.first(), configuration, null, null, haAddressPool)
 
     companion object {
         internal fun createWithSsl(
@@ -115,6 +130,14 @@ class CordaRPCClient private constructor(
             return CordaRPCClient(hostAndPort, configuration, sslConfiguration)
         }
 
+        internal fun createWithSsl(
+                haAddressPool: List<NetworkHostAndPort>,
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+                sslConfiguration: SSLConfiguration? = null
+        ): CordaRPCClient {
+            return CordaRPCClient(haAddressPool.first(), configuration, sslConfiguration, null, haAddressPool)
+        }
+
         internal fun createWithSslAndClassLoader(
                 hostAndPort: NetworkHostAndPort,
                 configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
@@ -122,6 +145,15 @@ class CordaRPCClient private constructor(
                 classLoader: ClassLoader? = null
         ): CordaRPCClient {
             return CordaRPCClient(hostAndPort, configuration, sslConfiguration, classLoader)
+        }
+
+        internal fun createWithSslAndClassLoader(
+                haAddressPool: List<NetworkHostAndPort>,
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+                sslConfiguration: SSLConfiguration? = null,
+                classLoader: ClassLoader? = null
+        ): CordaRPCClient {
+            return CordaRPCClient(haAddressPool.first(), configuration, sslConfiguration, classLoader, haAddressPool)
         }
     }
 
@@ -137,11 +169,19 @@ class CordaRPCClient private constructor(
         }
     }
 
-    private val rpcClient = RPCClient<CordaRPCOps>(
-            tcpTransport(ConnectionDirection.Outbound(), hostAndPort, config = sslConfiguration),
-            configuration,
-            if (classLoader != null) KRYO_RPC_CLIENT_CONTEXT.withClassLoader(classLoader) else KRYO_RPC_CLIENT_CONTEXT
-    )
+    private fun getRpcClient() : RPCClient<CordaRPCOps> {
+        return if (haAddressPool.isEmpty()) {
+            RPCClient(
+                    tcpTransport(ConnectionDirection.Outbound(), hostAndPort, config = sslConfiguration),
+                    configuration,
+                    if (classLoader != null) KRYO_RPC_CLIENT_CONTEXT.withClassLoader(classLoader) else KRYO_RPC_CLIENT_CONTEXT)
+        } else {
+            RPCClient(haAddressPool,
+                    sslConfiguration,
+                    configuration,
+                    if (classLoader != null) KRYO_RPC_CLIENT_CONTEXT.withClassLoader(classLoader) else KRYO_RPC_CLIENT_CONTEXT)
+        }
+    }
 
     /**
      * Logs in to the target server and returns an active connection. The returned connection is a [java.io.Closeable]
@@ -169,7 +209,7 @@ class CordaRPCClient private constructor(
      * @throws RPCException if the server version is too low or if the server isn't reachable within a reasonable timeout.
      */
     fun start(username: String, password: String, externalTrace: Trace?, impersonatedActor: Actor?): CordaRPCConnection {
-        return CordaRPCConnection(rpcClient.start(CordaRPCOps::class.java, username, password, externalTrace, impersonatedActor))
+        return CordaRPCConnection(getRpcClient().start(CordaRPCOps::class.java, username, password, externalTrace, impersonatedActor))
     }
 
     /**

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -93,7 +93,8 @@ interface CordaRPCClientConfiguration {
  * [CordaRPCClientConfiguration]. While attempting failover, current and future RPC calls will throw
  * [RPCException] and previously returned observables will call onError().
  *
- * If the client was created using a list of hosts, automatic failover will occur(the servers have to be started in HA mode)
+ * If the client was created using a list of hosts, automatic failover will occur (the servers have to be started in
+ * HA mode).
  *
  * @param hostAndPort The network address to connect to.
  * @param configuration An optional configuration used to tweak client behaviour.
@@ -130,14 +131,6 @@ class CordaRPCClient private constructor(
             return CordaRPCClient(hostAndPort, configuration, sslConfiguration)
         }
 
-        internal fun createWithSsl(
-                haAddressPool: List<NetworkHostAndPort>,
-                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
-                sslConfiguration: SSLConfiguration? = null
-        ): CordaRPCClient {
-            return CordaRPCClient(haAddressPool.first(), configuration, sslConfiguration, null, haAddressPool)
-        }
-
         internal fun createWithSslAndClassLoader(
                 hostAndPort: NetworkHostAndPort,
                 configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
@@ -145,15 +138,6 @@ class CordaRPCClient private constructor(
                 classLoader: ClassLoader? = null
         ): CordaRPCClient {
             return CordaRPCClient(hostAndPort, configuration, sslConfiguration, classLoader)
-        }
-
-        internal fun createWithSslAndClassLoader(
-                haAddressPool: List<NetworkHostAndPort>,
-                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
-                sslConfiguration: SSLConfiguration? = null,
-                classLoader: ClassLoader? = null
-        ): CordaRPCClient {
-            return CordaRPCClient(haAddressPool.first(), configuration, sslConfiguration, classLoader, haAddressPool)
         }
     }
 

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClientProxyHandler.kt
@@ -417,7 +417,7 @@ class RPCClientProxyHandler(
     }
 
     private fun attemptReconnect() {
-        var reconnectAttempts = rpcConfiguration.maxReconnectAttempts * serverLocator.staticTransportConfigurations.size
+        var reconnectAttempts = rpcConfiguration.maxReconnectAttempts.times(serverLocator.staticTransportConfigurations.size)
         var retryInterval = rpcConfiguration.connectionRetryInterval
         val maxRetryInterval = rpcConfiguration.connectionMaxRetryInterval
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/ArtemisTcpTransport.kt
@@ -97,5 +97,19 @@ class ArtemisTcpTransport {
             }
             return TransportConfiguration(factoryName, options)
         }
+
+        /** Create as list of [TransportConfiguration]. **/
+        fun tcpTransportsFromList(
+                direction: ConnectionDirection,
+                hostAndPortList: List<NetworkHostAndPort>,
+                config: SSLConfiguration?,
+                enableSSL: Boolean = true): List<TransportConfiguration>{
+            val tcpTransports = ArrayList<TransportConfiguration>(hostAndPortList.size)
+            hostAndPortList.forEach {
+                tcpTransports.add(tcpTransport(direction, it, config, enableSSL))
+            }
+
+            return tcpTransports
+        }
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -75,6 +75,13 @@ inline fun <reified I : RPCOps> RPCDriverDSL.startRpcClient(
         configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
 ) = startRpcClient(I::class.java, rpcAddress, username, password, configuration)
 
+inline fun<reified I : RPCOps> RPCDriverDSL.startRpcClient(
+        haAddressPool: List<NetworkHostAndPort>,
+        username: String = rpcTestUser.username,
+        password: String = rpcTestUser.password,
+        configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+) = startRpcClient(I::class.java, haAddressPool, username, password, configuration)
+
 data class RpcBrokerHandle(
         val hostAndPort: NetworkHostAndPort?,
         /** null if this is an InVM broker */
@@ -328,6 +335,32 @@ data class RPCDriverDSL(
     ): CordaFuture<I> {
         return driverDSL.executorService.fork {
             val client = RPCClient<I>(ArtemisTcpTransport.tcpTransport(ConnectionDirection.Outbound(), rpcAddress, null), configuration)
+            val connection = client.start(rpcOpsClass, username, password, externalTrace)
+            driverDSL.shutdownManager.registerShutdown {
+                connection.close()
+            }
+            connection.proxy
+        }
+    }
+
+    /**
+     * Starts a Netty RPC client.
+     *
+     * @param rpcOpsClass The [Class] of the RPC interface.
+     * @param haAddressPool The addresses of the RPC servers(configured in HA mode) to connect to.
+     * @param username The username to authenticate with.
+     * @param password The password to authenticate with.
+     * @param configuration The RPC client configuration.
+     */
+    fun <I : RPCOps> startRpcClient(
+            rpcOpsClass: Class<I>,
+            haAddressPool: List<NetworkHostAndPort>,
+            username: String = rpcTestUser.username,
+            password: String = rpcTestUser.password,
+            configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+    ): CordaFuture<I> {
+        return driverDSL.executorService.fork {
+            val client = RPCClient<I>(haAddressPool, null, configuration)
             val connection = client.start(rpcOpsClass, username, password, externalTrace)
             driverDSL.shutdownManager.registerShutdown {
                 connection.close()


### PR DESCRIPTION
Cherry picked. RPC level failover with round-robin through list of available nodes. 
* ENT-1775: reworked client to handle failover in HA mode instead of relying on artemis

* ENT-1775: address PR comments
