### PR TITLE
CORDA-1263: Replace deprecated Kotlin artifacts.

### DIFF
--- a/client/jfx/build.gradle
+++ b/client/jfx/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile project(':finance')
     compile project(':client:rpc')
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.google.guava:guava:$guava_version"
 
     // ReactFX: Functional reactive UI programming.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testCompile project(":node")
     testCompile project(":node-driver")
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/experimental/behave/build.gradle
+++ b/experimental/behave/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     // Library
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     compile("com.github.corda.crash:crash.shell:$crash_version") {

--- a/experimental/kryo-hook/build.gradle
+++ b/experimental/kryo-hook/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'idea'
 description 'A javaagent to allow hooking into Kryo'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "javassist:javassist:$javaassist_version"
     compile "com.esotericsoftware:kryo:4.0.0"

--- a/experimental/quasar-hook/build.gradle
+++ b/experimental/quasar-hook/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'idea'
 description 'A javaagent to allow hooking into the instrumentation by Quasar'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "javassist:javassist:$javaassist_version"
 }

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -8,7 +8,7 @@ description 'Corda node API'
 dependencies {
     compile project(":core")
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compile "org.apache.logging.log4j:log4j-web:${log4j_version}"
     compile "org.slf4j:jul-to-slf4j:$slf4j_version"
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -23,7 +23,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -23,7 +23,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // The bank of corda CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')

--- a/samples/notary-demo/build.gradle
+++ b/samples/notary-demo/build.gradle
@@ -15,7 +15,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 
     // Corda integration dependencies

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -27,7 +27,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // The SIMM demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -23,7 +23,7 @@ configurations {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // The trader demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')

--- a/testing/test-utils/build.gradle
+++ b/testing/test-utils/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compile project(':node')
     compile project(':client:mock')
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -16,7 +16,7 @@ processResources {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 


### PR DESCRIPTION
Replace the deprecated `kotlin-stdlib-jre8` artifact with `kotlin-stdlib-jdk8`.