### PR TITLE
CORDA-1367: Upgrade DemoBench to TornadoFX 1.7.15

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.tornadofx_version = '1.7.10'
+    ext.tornadofx_version = '1.7.15'
     ext.jna_version = '4.1.0'
     ext.purejavacomm_version = '0.0.18'
     ext.controlsfx_version = '8.40.12'
@@ -36,6 +36,15 @@ repositories {
     maven {
         jcenter()
         url 'http://www.sparetimelabs.com/maven2'
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        // Force TornadoFX to use the same version of Kotlin as Corda.
+        force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+        force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+        force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     }
 }
 


### PR DESCRIPTION
Upgrade DemoBench to TornadoFX 1.7.15, which depends on Kotlin 1.2.
Technically, this version of TornadoFX depends on Kotlin 1.2.21 but I have forced it to use the same version as Corda (1.2.20) rather than forcibly upgrade Corda.