### PR TITLE
ENT-1540: Make sure transactions with "expired" time windows get re-notarised correctly

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2112,7 +2112,7 @@ public final class net.corda.core.node.services.TimeWindowChecker extends java.l
 ##
 @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.node.services.TrustedAuthorityNotaryService extends net.corda.core.node.services.NotaryService
   public <init>()
-  public final void commitInputStates(List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.flows.NotarisationRequestSignature)
+  public final void commitInputStates(List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.flows.NotarisationRequestSignature, net.corda.core.contracts.TimeWindow)
   @org.jetbrains.annotations.NotNull protected org.slf4j.Logger getLog()
   @org.jetbrains.annotations.NotNull protected net.corda.core.node.services.TimeWindowChecker getTimeWindowChecker()
   @org.jetbrains.annotations.NotNull protected abstract net.corda.core.node.services.UniquenessProvider getUniquenessProvider()
@@ -2128,7 +2128,7 @@ public static final class net.corda.core.node.services.TrustedAuthorityNotarySer
   @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.UniquenessProvider$Conflict getError()
 ##
 public interface net.corda.core.node.services.UniquenessProvider
-  public abstract void commit(List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.flows.NotarisationRequestSignature)
+  public abstract void commit(List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.flows.NotarisationRequestSignature, net.corda.core.contracts.TimeWindow)
 ##
 @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.UniquenessProvider$Conflict extends java.lang.Object
   public <init>(Map)

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -146,8 +146,8 @@ class NotaryFlow {
             try {
                 val parts = validateRequest(requestPayload)
                 txId = parts.id
-                service.validateTimeWindow(parts.timestamp)
-                service.commitInputStates(parts.inputs, txId, otherSideSession.counterparty, requestPayload.requestSignature)
+                checkNotary(parts.notary)
+                service.commitInputStates(parts.inputs, txId, otherSideSession.counterparty, requestPayload.requestSignature, parts.timestamp)
                 signTransactionAndSendResponse(txId)
             } catch (e: NotaryInternalException) {
                 throw NotaryException(e.error, txId)

--- a/core/src/main/kotlin/net/corda/core/internal/NotaryUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/NotaryUtils.kt
@@ -1,9 +1,14 @@
 package net.corda.core.internal
 
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.flows.NotarisationResponse
+import net.corda.core.flows.NotaryError
+import net.corda.core.flows.StateConsumptionDetails
 import net.corda.core.identity.Party
+import java.time.Instant
 
 /**
  * Checks that there are sufficient signatures to satisfy the notary signing requirement and validates the signatures
@@ -13,4 +18,19 @@ fun NotarisationResponse.validateSignatures(txId: SecureHash, notary: Party) {
     val signingKeys = signatures.map { it.by }
     require(notary.owningKey.isFulfilledBy(signingKeys)) { "Insufficient signatures to fulfill the notary signing requirement for $notary" }
     signatures.forEach { it.verify(txId) }
+}
+
+/** Checks if the provided states were used as inputs in the specified transaction. */
+fun isConsumedByTheSameTx(txIdHash: SecureHash, consumedStates: Map<StateRef, StateConsumptionDetails>): Boolean {
+    val conflicts = consumedStates.filter { (_, cause) ->
+        cause.hashOfTransactionId != txIdHash
+    }
+    return conflicts.isEmpty()
+}
+
+/** Returns [NotaryError.TimeWindowInvalid] if [currentTime] is outside the [timeWindow], and *null* otherwise. */
+fun validateTimeWindow(currentTime: Instant, timeWindow: TimeWindow?): NotaryError.TimeWindowInvalid? {
+    return if (timeWindow != null && currentTime !in timeWindow) {
+        NotaryError.TimeWindowInvalid(currentTime, timeWindow)
+    } else null
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NotaryService.kt
@@ -17,6 +17,7 @@ abstract class NotaryService : SingletonSerializeAsToken() {
     companion object {
         @Deprecated("No longer used")
         const val ID_PREFIX = "corda.notary."
+
         @Deprecated("No longer used")
         fun constructId(validating: Boolean, raft: Boolean = false, bft: Boolean = false, custom: Boolean = false): String {
             require(Booleans.countTrue(raft, bft, custom) <= 1) { "At most one of raft, bft or custom may be true" }
@@ -79,9 +80,9 @@ abstract class TrustedAuthorityNotaryService : NotaryService() {
      * A NotaryException is thrown if any of the states have been consumed by a different transaction. Note that
      * this method does not throw an exception when input states are present multiple times within the transaction.
      */
-    fun commitInputStates(inputs: List<StateRef>, txId: SecureHash, caller: Party, requestSignature: NotarisationRequestSignature) {
+    fun commitInputStates(inputs: List<StateRef>, txId: SecureHash, caller: Party, requestSignature: NotarisationRequestSignature, timeWindow: TimeWindow?) {
         try {
-            uniquenessProvider.commit(inputs, txId, caller, requestSignature)
+            uniquenessProvider.commit(inputs, txId, caller, requestSignature, timeWindow)
         } catch (e: NotaryInternalException) {
             if (e.error is NotaryError.Conflict) {
                 val conflicts = inputs.filterIndexed { _, stateRef ->

--- a/core/src/main/kotlin/net/corda/core/node/services/UniquenessProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/UniquenessProvider.kt
@@ -2,6 +2,7 @@ package net.corda.core.node.services
 
 import net.corda.core.CordaException
 import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.NotarisationRequestSignature
 import net.corda.core.identity.Party
@@ -15,7 +16,13 @@ import net.corda.core.serialization.CordaSerializable
  */
 interface UniquenessProvider {
     /** Commits all input states of the given transaction. */
-    fun commit(states: List<StateRef>, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature)
+    fun commit(
+            states: List<StateRef>,
+            txId: SecureHash,
+            callerIdentity: Party,
+            requestSignature: NotarisationRequestSignature,
+            timeWindow: TimeWindow? = null
+    )
 
     /** Specifies the consuming transaction for every conflicting state. */
     @CordaSerializable

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -143,9 +143,9 @@ dependencies {
     compileOnly "co.paralleluniverse:capsule:$capsule_version"
 
     // Java Atomix: RAFT library
-    compile 'io.atomix.copycat:copycat-client:1.2.3'
-    compile 'io.atomix.copycat:copycat-server:1.2.3'
-    compile 'io.atomix.catalyst:catalyst-netty:1.1.2'
+    compile 'io.atomix.copycat:copycat-client:1.2.8'
+    compile 'io.atomix.copycat:copycat-server:1.2.8'
+    compile 'io.atomix.catalyst:catalyst-netty:1.2.1'
 
     // Netty: All of it.
     compile "io.netty:netty-all:$netty_version"

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTNotaryServiceTests.kt
@@ -5,8 +5,8 @@ import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.CompositeKey
-import net.corda.core.crypto.sha256
+import net.corda.core.contracts.TimeWindow
+import net.corda.core.crypto.*
 import net.corda.core.flows.NotaryError
 import net.corda.core.flows.NotaryException
 import net.corda.core.flows.NotaryFlow
@@ -31,87 +31,78 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.dummyCommand
 import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.PortAllocation
+import net.corda.testing.node.TestClock
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNetwork.MockNode
 import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.startFlow
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.hamcrest.Matchers.instanceOf
+import org.junit.*
+import org.junit.Assert.assertThat
 import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.ExecutionException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class BFTNotaryServiceTests {
-    private lateinit var mockNet: InternalMockNetwork
-    private lateinit var notary: Party
-    private lateinit var node: StartedNode<MockNode>
+    companion object {
+        private lateinit var mockNet: InternalMockNetwork
+        private lateinit var notary: Party
+        private lateinit var node: StartedNode<MockNode>
 
-    @Before
-    fun before() {
-        mockNet = InternalMockNetwork(listOf("net.corda.testing.contracts"))
-    }
-
-    @After
-    fun stopNodes() {
-        mockNet.stopNodes()
-    }
-
-    private fun startBftClusterAndNode(clusterSize: Int, exposeRaces: Boolean = false) {
-        (Paths.get("config") / "currentView").deleteIfExists() // XXX: Make config object warn if this exists?
-        val replicaIds = (0 until clusterSize)
-
-        notary = DevIdentityGenerator.generateDistributedNotaryCompositeIdentity(
-                replicaIds.map { mockNet.baseDirectory(mockNet.nextNodeId + it) },
-                CordaX500Name("BFT", "Zurich", "CH"))
-
-        val networkParameters = NetworkParametersCopier(testNetworkParameters(listOf(NotaryInfo(notary, false))))
-
-        val clusterAddresses = replicaIds.map { NetworkHostAndPort("localhost", 11000 + it * 10) }
-
-        val nodes = replicaIds.map { replicaId ->
-            mockNet.createUnstartedNode(InternalMockNodeParameters(configOverrides = {
-                val notary = NotaryConfig(validating = false, bftSMaRt = BFTSMaRtConfiguration(replicaId, clusterAddresses, exposeRaces = exposeRaces))
-                doReturn(notary).whenever(it).notary
-            }))
-        } + mockNet.createUnstartedNode()
-
-        // MockNetwork doesn't support BFT clusters, so we create all the nodes we need unstarted, and then install the
-        // network-parameters in their directories before they're started.
-        node = nodes.map { node ->
-            networkParameters.install(mockNet.baseDirectory(node.id))
-            node.start()
-        }.last()
-    }
-
-    /** Failure mode is the redundant replica gets stuck in startup, so we can't dispose it cleanly at the end. */
-    @Test
-    fun `all replicas start even if there is a new consensus during startup`() {
-        startBftClusterAndNode(minClusterSize(1), exposeRaces = true) // This true adds a sleep to expose the race.
-        val f = node.run {
-            val trivialTx = signInitialTransaction(notary) {
-                addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
-            }
-            // Create a new consensus while the redundant replica is sleeping:
-            services.startFlow(NotaryFlow.Client(trivialTx)).resultFuture
+        @BeforeClass
+        @JvmStatic
+        fun before() {
+            mockNet = InternalMockNetwork(listOf("net.corda.testing.contracts"))
+            val clusterSize = minClusterSize(1)
+            val started = startBftClusterAndNode(clusterSize, mockNet)
+            notary = started.first
+            node = started.second
         }
-        mockNet.runNetwork()
-        f.getOrThrow()
+
+        @AfterClass
+        @JvmStatic
+        fun stopNodes() {
+            mockNet.stopNodes()
+        }
+
+        fun startBftClusterAndNode(clusterSize: Int, mockNet: InternalMockNetwork, exposeRaces: Boolean = false): Pair<Party, StartedNode<MockNode>> {
+            (Paths.get("config") / "currentView").deleteIfExists() // XXX: Make config object warn if this exists?
+            val replicaIds = (0 until clusterSize)
+
+            val notaryIdentity = DevIdentityGenerator.generateDistributedNotaryCompositeIdentity(
+                    replicaIds.map { mockNet.baseDirectory(mockNet.nextNodeId + it) },
+                    CordaX500Name("BFT", "Zurich", "CH"))
+
+            val networkParameters = NetworkParametersCopier(testNetworkParameters(listOf(NotaryInfo(notaryIdentity, false))))
+
+            val clusterAddresses = replicaIds.map { NetworkHostAndPort("localhost", 11000 + it * 10) }
+
+            val nodes = replicaIds.map { replicaId ->
+                mockNet.createUnstartedNode(InternalMockNodeParameters(configOverrides = {
+                    val notary = NotaryConfig(validating = false, bftSMaRt = BFTSMaRtConfiguration(replicaId, clusterAddresses, exposeRaces = exposeRaces))
+                    doReturn(notary).whenever(it).notary
+                }))
+            } + mockNet.createUnstartedNode()
+
+            // MockNetwork doesn't support BFT clusters, so we create all the nodes we need unstarted, and then install the
+            // network-parameters in their directories before they're started.
+            val node = nodes.map { node ->
+                networkParameters.install(mockNet.baseDirectory(node.id))
+                node.start()
+            }.last()
+
+            return Pair(notaryIdentity, node)
+        }
     }
 
     @Test
-    fun `detect double spend 1 faulty`() {
-        detectDoubleSpend(1)
-    }
-
-    @Test
-    fun `detect double spend 2 faulty`() {
-        detectDoubleSpend(2)
-    }
-
-    private fun detectDoubleSpend(faultyReplicas: Int) {
-        val clusterSize = minClusterSize(faultyReplicas)
-        startBftClusterAndNode(clusterSize)
+    fun `detect double spend`() {
         node.run {
             val issueTx = signInitialTransaction(notary) {
                 addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
@@ -132,7 +123,7 @@ class BFTNotaryServiceTests {
             val successfulIndex = results.mapIndexedNotNull { index, result ->
                 if (result is Try.Success) {
                     val signers = result.value.map { it.by }
-                    assertEquals(minCorrectReplicas(clusterSize), signers.size)
+                    assertEquals(minCorrectReplicas(3), signers.size)
                     signers.forEach {
                         assertTrue(it in (notary.owningKey as CompositeKey).leafKeys)
                     }
@@ -152,6 +143,63 @@ class BFTNotaryServiceTests {
                 }
             }
         }
+    }
+
+    @Test
+    fun `transactions outside their time window are rejected`() {
+        node.run {
+            val issueTx = signInitialTransaction(notary) {
+                addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
+            }
+            database.transaction {
+                services.recordTransactions(issueTx)
+            }
+            val spendTx = signInitialTransaction(notary) {
+                addInputState(issueTx.tx.outRef<ContractState>(0))
+                setTimeWindow(TimeWindow.fromOnly(Instant.MAX))
+            }
+            val flow = NotaryFlow.Client(spendTx)
+            val resultFuture = services.startFlow(flow).resultFuture
+            mockNet.runNetwork()
+            val exception = assertFailsWith<ExecutionException> { resultFuture.get() }
+            assertThat(exception.cause, instanceOf(NotaryException::class.java))
+            val error = (exception.cause as NotaryException).error
+            assertThat(error, instanceOf(NotaryError.TimeWindowInvalid::class.java))
+        }
+    }
+
+    @Test
+    fun `transactions can be re-notarised outside their time window`() {
+        node.run {
+            val issueTx = signInitialTransaction(notary) {
+                addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
+            }
+            database.transaction {
+                services.recordTransactions(issueTx)
+            }
+            val spendTx = signInitialTransaction(notary) {
+                addInputState(issueTx.tx.outRef<ContractState>(0))
+                setTimeWindow(TimeWindow.untilOnly(Instant.now() + Duration.ofHours(1)))
+            }
+            val resultFuture = services.startFlow(NotaryFlow.Client(spendTx)).resultFuture
+            mockNet.runNetwork()
+            val signatures = resultFuture.get()
+            verifySignatures(signatures, spendTx.id)
+
+            for (node in mockNet.nodes) {
+                (node.started!!.services.clock as TestClock).advanceBy(Duration.ofDays(1))
+            }
+
+            val resultFuture2 = services.startFlow(NotaryFlow.Client(spendTx)).resultFuture
+            mockNet.runNetwork()
+            val signatures2 = resultFuture2.get()
+            verifySignatures(signatures2, spendTx.id)
+        }
+    }
+
+    private fun verifySignatures(signatures: List<TransactionSignature>, txId: SecureHash) {
+        notary.owningKey.isFulfilledBy(signatures.map { it.by })
+        signatures.forEach { it.verify(txId) }
     }
 
     private fun StartedNode<MockNode>.signInitialTransaction(notary: Party, block: TransactionBuilder.() -> Any?): SignedTransaction {

--- a/node/src/integration-test/kotlin/net/corda/node/services/BFTSMaRtTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/BFTSMaRtTests.kt
@@ -1,0 +1,59 @@
+package net.corda.node.services
+
+import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint
+import net.corda.core.flows.NotaryFlow
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.internal.StartedNode
+import net.corda.node.services.BFTNotaryServiceTests.Companion.startBftClusterAndNode
+import net.corda.node.services.transactions.minClusterSize
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.dummyCommand
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.node.internal.InternalMockNetwork
+import net.corda.testing.node.internal.InternalMockNetwork.MockNode
+import net.corda.testing.node.internal.startFlow
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class BFTSMaRtTests {
+    private lateinit var mockNet: InternalMockNetwork
+
+    @Before
+    fun before() {
+        mockNet = InternalMockNetwork(listOf("net.corda.testing.contracts"))
+    }
+
+    @After
+    fun stopNodes() {
+        mockNet.stopNodes()
+    }
+
+    /** Failure mode is the redundant replica gets stuck in startup, so we can't dispose it cleanly at the end. */
+    @Test
+    fun `all replicas start even if there is a new consensus during startup`() {
+        val clusterSize = minClusterSize(1)
+        val (notary, node) = startBftClusterAndNode(clusterSize, mockNet, exposeRaces = true) // This true adds a sleep to expose the race.
+        val f = node.run {
+            val trivialTx = signInitialTransaction(notary) {
+                addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
+            }
+            // Create a new consensus while the redundant replica is sleeping:
+            services.startFlow(NotaryFlow.Client(trivialTx)).resultFuture
+        }
+        mockNet.runNetwork()
+        f.getOrThrow()
+    }
+
+    private fun StartedNode<MockNode>.signInitialTransaction(notary: Party, block: TransactionBuilder.() -> Any?): SignedTransaction {
+        return services.signInitialTransaction(
+                TransactionBuilder(notary).apply {
+                    addCommand(dummyCommand(services.myInfo.singleIdentity().owningKey))
+                    block()
+                }
+        )
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/BFTNonValidatingNotaryService.kt
@@ -139,9 +139,9 @@ class BFTNonValidatingNotaryService(
                 val id = transaction.id
                 val inputs = transaction.inputs
                 val notary = transaction.notary
-                if (transaction is FilteredTransaction) NotaryService.validateTimeWindow(services.clock, transaction.timeWindow)
+                val timeWindow = (transaction as? FilteredTransaction)?.timeWindow
                 if (notary !in services.myInfo.legalIdentities) throw NotaryInternalException(NotaryError.WrongNotary)
-                commitInputStates(inputs, id, callerIdentity.name, requestSignature)
+                commitInputStates(inputs, id, callerIdentity.name, requestSignature, timeWindow)
                 log.debug { "Inputs committed successfully, signing $id" }
                 BFTSMaRt.ReplicaResponse.Signature(sign(id))
             } catch (e: NotaryInternalException) {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -1,6 +1,7 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
 import net.corda.core.flows.NotarisationRequestSignature
@@ -9,12 +10,15 @@ import net.corda.core.flows.NotaryInternalException
 import net.corda.core.flows.StateConsumptionDetails
 import net.corda.core.identity.Party
 import net.corda.core.internal.ThreadBox
+import net.corda.core.internal.isConsumedByTheSameTx
+import net.corda.core.internal.validateTimeWindow
 import net.corda.core.node.services.UniquenessProvider
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.debug
 import net.corda.node.utilities.AppendOnlyPersistentMap
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
 import net.corda.nodeapi.internal.persistence.currentDBSession
@@ -64,7 +68,7 @@ class PersistentUniquenessProvider(val clock: Clock) : UniquenessProvider, Singl
     class CommittedState(id: PersistentStateRef, consumingTxHash: String) : BaseComittedState(id, consumingTxHash)
 
     private class InnerState {
-        val committedStates = createMap()
+        val commitLog = createMap()
     }
 
     private val mutex = ThreadBox(InnerState())
@@ -95,10 +99,21 @@ class PersistentUniquenessProvider(val clock: Clock) : UniquenessProvider, Singl
                 )
     }
 
-    override fun commit(states: List<StateRef>, txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature) {
-        logRequest(txId, callerIdentity, requestSignature)
-        val conflict = commitStates(states, txId)
-        if (conflict != null) throw NotaryInternalException(NotaryError.Conflict(txId, conflict))
+    override fun commit(
+            states: List<StateRef>,
+            txId: SecureHash,
+            callerIdentity: Party,
+            requestSignature: NotarisationRequestSignature,
+            timeWindow: TimeWindow?) {
+        mutex.locked {
+            logRequest(txId, callerIdentity, requestSignature)
+            val conflictingStates = findAlreadyCommitted(states, commitLog)
+            if (conflictingStates.isNotEmpty()) {
+                handleConflicts(txId, conflictingStates)
+            } else {
+                handleNoConflicts(timeWindow, states, txId, commitLog)
+            }
+        }
     }
 
     private fun logRequest(txId: SecureHash, callerIdentity: Party, requestSignature: NotarisationRequestSignature) {
@@ -112,25 +127,35 @@ class PersistentUniquenessProvider(val clock: Clock) : UniquenessProvider, Singl
         session.persist(request)
     }
 
-    private fun commitStates(states: List<StateRef>, txId: SecureHash): Map<StateRef, StateConsumptionDetails>? {
-        val conflict = mutex.locked {
-            val conflictingStates = LinkedHashMap<StateRef, SecureHash>()
-            for (inputState in states) {
-                val consumingTx = committedStates[inputState]
-                if (consumingTx != null) conflictingStates[inputState] = consumingTx
-            }
-            if (conflictingStates.isNotEmpty()) {
-                log.debug("Failure, input states already committed: ${conflictingStates.keys}")
-                val conflict = conflictingStates.mapValues { (_, txId) -> StateConsumptionDetails(txId.sha256()) }
-                conflict
-            } else {
-                states.forEach { stateRef ->
-                    committedStates[stateRef] = txId
-                }
-                log.debug("Successfully committed all input states: $states")
-                null
-            }
+    private fun findAlreadyCommitted(states: List<StateRef>, commitLog: AppendOnlyPersistentMap<StateRef, SecureHash, CommittedState, PersistentStateRef>): LinkedHashMap<StateRef, StateConsumptionDetails> {
+        val conflictingStates = LinkedHashMap<StateRef, StateConsumptionDetails>()
+        for (inputState in states) {
+            val consumingTx = commitLog[inputState]
+            if (consumingTx != null) conflictingStates[inputState] = StateConsumptionDetails(consumingTx.sha256())
         }
-        return conflict
+        return conflictingStates
+    }
+
+    private fun handleConflicts(txId: SecureHash, conflictingStates: LinkedHashMap<StateRef, StateConsumptionDetails>) {
+        if (isConsumedByTheSameTx(txId.sha256(), conflictingStates)) {
+            log.debug { "Transaction $txId already notarised" }
+            return
+        } else {
+            log.debug { "Failure, input states already committed: ${conflictingStates.keys}" }
+            val conflictError = NotaryError.Conflict(txId, conflictingStates)
+            throw NotaryInternalException(conflictError)
+        }
+    }
+
+    private fun handleNoConflicts(timeWindow: TimeWindow?, states: List<StateRef>, txId: SecureHash, commitLog: AppendOnlyPersistentMap<StateRef, SecureHash, CommittedState, PersistentStateRef>) {
+        val outsideTimeWindowError = validateTimeWindow(clock.instant(), timeWindow)
+        if (outsideTimeWindowError == null) {
+            states.forEach { stateRef ->
+                commitLog[stateRef] = txId
+            }
+            log.debug { "Successfully committed all input states: $states" }
+        } else {
+            throw NotaryInternalException(outsideTimeWindowError)
+        }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt
@@ -65,15 +65,17 @@ class PersistentUniquenessProviderTests {
             val inputState = generateStateRef()
 
             val inputs = listOf(inputState)
-            provider.commit(inputs, txID, identity, requestSignature)
+            val firstTxId = txID
+            provider.commit(inputs, firstTxId, identity, requestSignature)
 
+            val secondTxId = SecureHash.randomSHA256()
             val ex = assertFailsWith<NotaryInternalException> {
-                provider.commit(inputs, txID, identity, requestSignature)
+                provider.commit(inputs, secondTxId, identity, requestSignature)
             }
             val error = ex.error as NotaryError.Conflict
 
             val conflictCause = error.consumedStates[inputState]!!
-            assertEquals(conflictCause.hashOfTransactionId, txID.sha256())
+            assertEquals(conflictCause.hashOfTransactionId, firstTxId.sha256())
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLogTests.kt
@@ -7,7 +7,9 @@ import io.atomix.copycat.server.CopycatServer
 import io.atomix.copycat.server.storage.Storage
 import io.atomix.copycat.server.storage.StorageLevel
 import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.NotaryError
 import net.corda.core.internal.concurrent.asCordaFuture
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.NetworkHostAndPort
@@ -22,14 +24,14 @@ import net.corda.testing.core.freeLocalHostAndPort
 import net.corda.testing.internal.LogHelper
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
-import org.junit.After
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.hamcrest.Matchers.instanceOf
+import org.junit.*
+import org.junit.Assert.assertThat
 import java.time.Clock
+import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertNull
 
 class RaftTransactionCommitLogTests {
     data class Member(val client: CopycatClient, val server: CopycatServer)
@@ -66,8 +68,8 @@ class RaftTransactionCommitLogTests {
         val requestSignature = ByteArray(1024)
 
         val commitCommand = RaftTransactionCommitLog.Commands.CommitTransaction(states, txId, requestingPartyName.toString(), requestSignature)
-        val conflict = client.submit(commitCommand).getOrThrow()
-        assertTrue { conflict.isEmpty() }
+        val commitError = client.submit(commitCommand).getOrThrow()
+        assertNull(commitError)
 
         val value1 = client.submit(RaftTransactionCommitLog.Commands.Get(states[0]))
         val value2 = client.submit(RaftTransactionCommitLog.Commands.Get(states[1]))
@@ -81,17 +83,60 @@ class RaftTransactionCommitLogTests {
         val client = cluster.last().client
 
         val states = listOf(StateRef(SecureHash.randomSHA256(), 0), StateRef(SecureHash.randomSHA256(), 0))
-        val txId: SecureHash = SecureHash.randomSHA256()
+        val txIdFirst = SecureHash.randomSHA256()
+        val txIdSecond = SecureHash.randomSHA256()
         val requestingPartyName = ALICE_NAME
         val requestSignature = ByteArray(1024)
 
-        val commitCommand = RaftTransactionCommitLog.Commands.CommitTransaction(states, txId, requestingPartyName.toString(), requestSignature)
-        var conflict = client.submit(commitCommand).getOrThrow()
-        assertTrue { conflict.isEmpty() }
+        val commitCommandFirst = RaftTransactionCommitLog.Commands.CommitTransaction(states, txIdFirst, requestingPartyName.toString(), requestSignature)
+        var commitError = client.submit(commitCommandFirst).getOrThrow()
+        assertNull(commitError)
 
-        conflict = client.submit(commitCommand).getOrThrow()
-        assertEquals(conflict.keys, states.toSet())
-        conflict.forEach { assertEquals(it.value, txId) }
+        val commitCommandSecond = RaftTransactionCommitLog.Commands.CommitTransaction(states, txIdSecond, requestingPartyName.toString(), requestSignature)
+        commitError = client.submit(commitCommandSecond).getOrThrow()
+        val conflict = commitError as NotaryError.Conflict
+        assertEquals(states.toSet(), conflict.consumedStates.keys)
+    }
+
+    @Test
+    fun `transactions outside their time window are rejected`() {
+        val client = cluster.last().client
+
+        val states = listOf(StateRef(SecureHash.randomSHA256(), 0), StateRef(SecureHash.randomSHA256(), 0))
+        val txId: SecureHash = SecureHash.randomSHA256()
+        val requestingPartyName = ALICE_NAME
+        val requestSignature = ByteArray(1024)
+        val timeWindow = TimeWindow.fromOnly(Instant.MAX)
+
+        val commitCommand = RaftTransactionCommitLog.Commands.CommitTransaction(
+                states, txId, requestingPartyName.toString(), requestSignature, timeWindow
+        )
+        val commitError = client.submit(commitCommand).getOrThrow()
+        assertThat(commitError, instanceOf(NotaryError.TimeWindowInvalid::class.java))
+    }
+
+    @Test
+    fun `transactions can be re-notarised outside their time window`() {
+        val client = cluster.last().client
+
+        val states = listOf(StateRef(SecureHash.randomSHA256(), 0), StateRef(SecureHash.randomSHA256(), 0))
+        val txId: SecureHash = SecureHash.randomSHA256()
+        val requestingPartyName = ALICE_NAME
+        val requestSignature = ByteArray(1024)
+        val timeWindow = TimeWindow.fromOnly(Instant.MIN)
+
+        val commitCommand = RaftTransactionCommitLog.Commands.CommitTransaction(
+                states, txId, requestingPartyName.toString(), requestSignature, timeWindow
+        )
+        val commitError = client.submit(commitCommand).getOrThrow()
+        assertNull(commitError)
+
+        val expiredTimeWindow = TimeWindow.untilOnly(Instant.MIN)
+        val commitCommand2 = RaftTransactionCommitLog.Commands.CommitTransaction(
+                states, txId, requestingPartyName.toString(), requestSignature, expiredTimeWindow
+        )
+        val commitError2 = client.submit(commitCommand2).getOrThrow()
+        assertNull(commitError2)
     }
 
     private fun setUpCluster(nodeCount: Int = 3): List<Member> {


### PR DESCRIPTION
Currently the time window is checked before states are being passed to a uniqueness provider. If the time window is invalid, the transaction will be rejected even if it has already been notarised, which violates idempotency.

For this reason the time window verification was moved alongside state conflict checks – this required some interface changes.

- Added expired timewindow re-notarisation tests for all types of notaries.
- As a result, BFTNotaryService tests were taking around 3min to run, so I split the test up into `BFTSMaRtTests` and `BFTNotaryServiceTests`. The latter re-uses the same cluster for all tests, shaving down the total run-time to under a minute.