### PR TITLE
Run filterMyKeys only when required (in NodeVaultService)

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -161,8 +161,7 @@ class NodeVaultService(
                     filter { (_, output) ->
                         if (statesToRecord == StatesToRecord.ONLY_RELEVANT) {
                             isRelevant(output.data, myKeys.toSet())
-                        }
-                        else {
+                        } else {
                             true
                         }
                     }.


### PR DESCRIPTION
`filterMyKeys` might be expensive (due to KMS cache limitations among the others), so we should either compute it lazily and only when specifically required.