### PR TITLE
Feature to exclude CorDapps from specific MockNodes in a MockNetwork.

### DIFF
--- a/docs/source/api-testing.rst
+++ b/docs/source/api-testing.rst
@@ -165,6 +165,40 @@ Nodes are created on the ``MockNetwork`` using:
             }
         }
 
+Nodes added using ``createPartyNode`` are provided a default set of node parameters. However, it is also possible to
+provide different parameters to each node using the following methods on ``MockNetwork``:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        /**
+         * Create a started node with the given parameters.
+         *
+         * @param legalName The node's legal name.
+         * @param forcedID A unique identifier for the node.
+         * @param entropyRoot The initial entropy value to use when generating keys. Defaults to an (insecure) random value,
+         * but can be overridden to cause nodes to have stable or colliding identity/service keys.
+         * @param configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
+         * @param extraCordappPackages Extra CorDapp packages to add for this node.
+         */
+        @JvmOverloads
+        fun createNode(legalName: CordaX500Name? = null,
+                       forcedID: Int? = null,
+                       entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
+                       configOverrides: (NodeConfiguration) -> Any? = {},
+                       extraCordappPackages: List<String> = emptyList()
+        ): StartedMockNode
+
+        /** Create a started node with the given parameters. **/
+        fun createNode(parameters: MockNodeParameters = MockNodeParameters()): StartedMockNode
+
+As you can see above, parameters can be added individually or encapsulated within a ``MockNodeParameters`` object. Of
+particular interest are ``configOverrides`` which allow you to override any default config option specified within the
+``NodeConfiguration`` object. Also, the ``extraCordappPackages`` parameter allows you to add extra CorDapps to a
+specific node. This is useful when you wish for all nodes to load a common CorDapp but for a subset of nodes to load
+CorDapps specific to their role in the network.
+
 Running the network
 ^^^^^^^^^^^^^^^^^^^
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -284,7 +284,7 @@ open class MockNetwork(
                             forcedID: Int? = null,
                             entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
                             configOverrides: (NodeConfiguration) -> Any? = {},
-                            cordappPackagesToExclude: List<String>): UnstartedMockNode {
+                            cordappPackagesToExclude: List<String> = emptyList()): UnstartedMockNode {
         val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, cordappPackagesToExclude)
         return UnstartedMockNode.create(internalMockNetwork.createUnstartedNode(InternalMockNodeParameters(parameters)))
     }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -33,17 +33,23 @@ import java.nio.file.Path
  * @property entropyRoot the initial entropy value to use when generating keys. Defaults to an (insecure) random value,
  * but can be overridden to cause nodes to have stable or colliding identity/service keys.
  * @property configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
+ * @property cordappPackagesToExclude Excludes the provided list of CorDapp packages from this node.
  */
 @Suppress("unused")
-data class MockNodeParameters(
+data class MockNodeParameters @JvmOverloads constructor(
         val forcedID: Int? = null,
         val legalName: CordaX500Name? = null,
         val entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
-        val configOverrides: (NodeConfiguration) -> Any? = {}) {
+        val configOverrides: (NodeConfiguration) -> Any? = {},
+        val cordappPackagesToExclude: List<String> = emptyList()) {
     fun withForcedID(forcedID: Int?): MockNodeParameters = copy(forcedID = forcedID)
     fun withLegalName(legalName: CordaX500Name?): MockNodeParameters = copy(legalName = legalName)
     fun withEntropyRoot(entropyRoot: BigInteger): MockNodeParameters = copy(entropyRoot = entropyRoot)
     fun withConfigOverrides(configOverrides: (NodeConfiguration) -> Any?): MockNodeParameters = copy(configOverrides = configOverrides)
+    fun withExcludedCordappPackages(cordappPackagesToExclude: List<String>): MockNodeParameters = copy(cordappPackagesToExclude = cordappPackagesToExclude)
+    fun copy(forcedID: Int?, legalName: CordaX500Name?, entropyRoot: BigInteger, configOverrides: (NodeConfiguration) -> Any?): MockNodeParameters {
+        return MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides)
+    }
 }
 
 /**
@@ -248,14 +254,15 @@ open class MockNetwork(
      * @param entropyRoot The initial entropy value to use when generating keys. Defaults to an (insecure) random value,
      * but can be overridden to cause nodes to have stable or colliding identity/service keys.
      * @param configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
-     * @param version The mock node's platform, release, revision and vendor versions.
+     * @param cordappPackagesToExclude Excludes the provided list of CorDapp packages from this node.
      */
     @JvmOverloads
     fun createNode(legalName: CordaX500Name? = null,
                    forcedID: Int? = null,
                    entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
-                   configOverrides: (NodeConfiguration) -> Any? = {}): StartedMockNode {
-        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides)
+                   configOverrides: (NodeConfiguration) -> Any? = {},
+                   cordappPackagesToExclude: List<String> = emptyList()): StartedMockNode {
+        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, cordappPackagesToExclude)
         return StartedMockNode.create(internalMockNetwork.createNode(InternalMockNodeParameters(parameters)))
     }
 
@@ -270,14 +277,15 @@ open class MockNetwork(
      * @param entropyRoot The initial entropy value to use when generating keys. Defaults to an (insecure) random value,
      * but can be overridden to cause nodes to have stable or colliding identity/service keys.
      * @param configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
-     * @param version The mock node's platform, release, revision and vendor versions.
+     * @param cordappPackagesToExclude Excludes the provided list of CorDapp packages from this node.
      */
     @JvmOverloads
     fun createUnstartedNode(legalName: CordaX500Name? = null,
                             forcedID: Int? = null,
                             entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
-                            configOverrides: (NodeConfiguration) -> Any? = {}): UnstartedMockNode {
-        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides)
+                            configOverrides: (NodeConfiguration) -> Any? = {},
+                            cordappPackagesToExclude: List<String>): UnstartedMockNode {
+        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, cordappPackagesToExclude)
         return UnstartedMockNode.create(internalMockNetwork.createUnstartedNode(InternalMockNodeParameters(parameters)))
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -33,7 +33,7 @@ import java.nio.file.Path
  * @property entropyRoot the initial entropy value to use when generating keys. Defaults to an (insecure) random value,
  * but can be overridden to cause nodes to have stable or colliding identity/service keys.
  * @property configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
- * @property cordappPackagesToExclude Excludes the provided list of CorDapp packages from this node.
+ * @property extraCordappPackages Extra CorDapp packages to include for this node.
  */
 @Suppress("unused")
 data class MockNodeParameters @JvmOverloads constructor(
@@ -41,12 +41,12 @@ data class MockNodeParameters @JvmOverloads constructor(
         val legalName: CordaX500Name? = null,
         val entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
         val configOverrides: (NodeConfiguration) -> Any? = {},
-        val cordappPackagesToExclude: List<String> = emptyList()) {
+        val extraCordappPackages: List<String> = emptyList()) {
     fun withForcedID(forcedID: Int?): MockNodeParameters = copy(forcedID = forcedID)
     fun withLegalName(legalName: CordaX500Name?): MockNodeParameters = copy(legalName = legalName)
     fun withEntropyRoot(entropyRoot: BigInteger): MockNodeParameters = copy(entropyRoot = entropyRoot)
     fun withConfigOverrides(configOverrides: (NodeConfiguration) -> Any?): MockNodeParameters = copy(configOverrides = configOverrides)
-    fun withExcludedCordappPackages(cordappPackagesToExclude: List<String>): MockNodeParameters = copy(cordappPackagesToExclude = cordappPackagesToExclude)
+    fun withExtraCordappPackages(extraCordappPackages: List<String>): MockNodeParameters = copy(extraCordappPackages = extraCordappPackages)
     fun copy(forcedID: Int?, legalName: CordaX500Name?, entropyRoot: BigInteger, configOverrides: (NodeConfiguration) -> Any?): MockNodeParameters {
         return MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides)
     }
@@ -254,15 +254,15 @@ open class MockNetwork(
      * @param entropyRoot The initial entropy value to use when generating keys. Defaults to an (insecure) random value,
      * but can be overridden to cause nodes to have stable or colliding identity/service keys.
      * @param configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
-     * @param cordappPackagesToExclude Excludes the provided list of CorDapp packages from this node.
+     * @param extraCordappPackages Extra CorDapp packages to add for this node.
      */
     @JvmOverloads
     fun createNode(legalName: CordaX500Name? = null,
                    forcedID: Int? = null,
                    entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
                    configOverrides: (NodeConfiguration) -> Any? = {},
-                   cordappPackagesToExclude: List<String> = emptyList()): StartedMockNode {
-        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, cordappPackagesToExclude)
+                   extraCordappPackages: List<String> = emptyList()): StartedMockNode {
+        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, extraCordappPackages)
         return StartedMockNode.create(internalMockNetwork.createNode(InternalMockNodeParameters(parameters)))
     }
 
@@ -277,15 +277,15 @@ open class MockNetwork(
      * @param entropyRoot The initial entropy value to use when generating keys. Defaults to an (insecure) random value,
      * but can be overridden to cause nodes to have stable or colliding identity/service keys.
      * @param configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
-     * @param cordappPackagesToExclude Excludes the provided list of CorDapp packages from this node.
+     * @param extraCordappPackages Extra CorDapp packages to add for this node.
      */
     @JvmOverloads
     fun createUnstartedNode(legalName: CordaX500Name? = null,
                             forcedID: Int? = null,
                             entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
                             configOverrides: (NodeConfiguration) -> Any? = {},
-                            cordappPackagesToExclude: List<String> = emptyList()): UnstartedMockNode {
-        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, cordappPackagesToExclude)
+                            extraCordappPackages: List<String> = emptyList()): UnstartedMockNode {
+        val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, extraCordappPackages)
         return UnstartedMockNode.create(internalMockNetwork.createUnstartedNode(InternalMockNodeParameters(parameters)))
     }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -223,7 +223,7 @@ open class InternalMockNetwork(private val cordappPackages: List<String>,
             args.config,
             TestClock(Clock.systemUTC()),
             args.version,
-            // Exclude the specified CorDapps.
+            // Add the specified additional CorDapps.
             CordappLoader.createDefaultWithTestPackages(args.config, args.network.cordappPackages + args.extraCordappPackages),
             args.network.busyLatch
     ) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -75,7 +75,7 @@ data class MockNodeArgs(
         val id: Int,
         val entropyRoot: BigInteger,
         val version: VersionInfo = MOCK_VERSION_INFO,
-        val cordappPackagesToExclude: List<String> = emptyList()
+        val extraCordappPackages: List<String> = emptyList()
 )
 
 data class InternalMockNodeParameters(
@@ -84,14 +84,14 @@ data class InternalMockNodeParameters(
         val entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
         val configOverrides: (NodeConfiguration) -> Any? = {},
         val version: VersionInfo = MOCK_VERSION_INFO,
-        val cordappPackagesToExclude: List<String> = emptyList()) {
+        val extraCordappPackages: List<String> = emptyList()) {
     constructor(mockNodeParameters: MockNodeParameters) : this(
             mockNodeParameters.forcedID,
             mockNodeParameters.legalName,
             mockNodeParameters.entropyRoot,
             mockNodeParameters.configOverrides,
             MOCK_VERSION_INFO,
-            mockNodeParameters.cordappPackagesToExclude
+            mockNodeParameters.extraCordappPackages
     )
 }
 
@@ -224,7 +224,7 @@ open class InternalMockNetwork(private val cordappPackages: List<String>,
             TestClock(Clock.systemUTC()),
             args.version,
             // Exclude the specified CorDapps.
-            CordappLoader.createDefaultWithTestPackages(args.config, args.network.cordappPackages - args.cordappPackagesToExclude),
+            CordappLoader.createDefaultWithTestPackages(args.config, args.network.cordappPackages + args.extraCordappPackages),
             args.network.busyLatch
     ) {
         companion object {
@@ -375,7 +375,7 @@ open class InternalMockNetwork(private val cordappPackages: List<String>,
             doReturn(emptyList<SecureHash>()).whenever(it).extraNetworkMapKeys
             parameters.configOverrides(it)
         }
-        val node = nodeFactory(MockNodeArgs(config, this, id, parameters.entropyRoot, parameters.version, parameters.cordappPackagesToExclude))
+        val node = nodeFactory(MockNodeArgs(config, this, id, parameters.entropyRoot, parameters.version, parameters.extraCordappPackages))
         _nodes += node
         if (start) {
             node.start()


### PR DESCRIPTION
Little feature that allows you to exclude a list of CorDapps from specified MockNodes. I've done this because, currently, all nodes get the same CorDapps and this doesn't work under certain scenarios... In my case, I subscribe to an observable inside a CordaService. This should only be done by one node but all do it as they all get the CorDapp, this results in unusual behaviour. This PR prevents that from happening.