### PR TITLE
artemis upgrade to 2.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
      * The issue has been reported to upstream:
      * https://issues.apache.org/jira/browse/ARTEMIS-1559
      */
-    ext.artemis_version = '2.2.0'
+    ext.artemis_version = '2.5.0'
     ext.jackson_version = '2.9.3'
     ext.jetty_version = '9.4.7.v20170914'
     ext.jersey_version = '2.25'
@@ -49,7 +49,7 @@ buildscript {
     ext.caffeine_version = constants.getProperty("caffeineVersion")
     ext.metrics_version = constants.getProperty("metricsVersion")
     ext.okhttp_version = '3.5.0'
-    ext.netty_version = '4.1.9.Final'
+    ext.netty_version = '4.1.22.Final'
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.3.3'
     ext.junit_version = '4.12'

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -18,6 +18,9 @@ dependencies {
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
     compile "org.apache.activemq:artemis-commons:${artemis_version}"
 
+    // Netty: All of it.
+    compile "io.netty:netty-all:$netty_version"
+
     // For adding serialisation of file upload streams to RPC
     // TODO: Remove this dependency and the code that requires it
     compile "commons-fileupload:commons-fileupload:$fileupload_version"

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -147,9 +147,6 @@ dependencies {
     compile 'io.atomix.copycat:copycat-server:1.2.8'
     compile 'io.atomix.catalyst:catalyst-netty:1.2.1'
 
-    // Netty: All of it.
-    compile "io.netty:netty-all:$netty_version"
-
     // OkHTTP: Simple HTTP library.
     compile "com.squareup.okhttp3:okhttp:$okhttp_version"
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -48,7 +48,7 @@ import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings
-import org.apache.activemq.artemis.spi.core.remoting.Connection
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3
 import java.lang.reflect.Method
 import java.nio.file.Path
@@ -145,11 +145,11 @@ fun <A> rpcDriver(
 private class SingleUserSecurityManager(val rpcUser: User) : ActiveMQSecurityManager3 {
     override fun validateUser(user: String?, password: String?) = isValid(user, password)
     override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?) = isValid(user, password)
-    override fun validateUser(user: String?, password: String?, connection: Connection?): String? {
+    override fun validateUser(user: String?, password: String?, connection: RemotingConnection?): String? {
         return validate(user, password)
     }
 
-    override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?, address: String?, connection: Connection?): String? {
+    override fun validateUserAndRole(user: String?, password: String?, roles: MutableSet<Role>?, checkType: CheckType?, address: String?, connection: RemotingConnection?): String? {
         return validate(user, password)
     }
 


### PR DESCRIPTION
Upgrading o artemis 2.5.0 which caused a few issues with netty dependencies. Basically, in node-api, artemis-core-client and artemis-commons are used which, in 2.2.0, used to pull in netty-all. 2.5.0 doesn't pull in the netty dependencies used by the AMQP code. Therefore, moved the netty-all dependency from node to node-api.