### PR TITLE
Configure Gradle's wrapper task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -378,3 +378,8 @@ if(file('corda-docs-only-build').exists() || (System.getenv('CORDA_DOCS_ONLY_BUI
         }
     }
 }
+
+wrapper {
+    gradleVersion = "4.4.1"
+    distributionType = Wrapper.DistributionType.ALL
+}


### PR DESCRIPTION
Configure our build with the correct version of Gradle via the wrapper task. This allows us to upgrade Gradle by editing this version number and then executing:

    $ gradlew wrapper