### PR TITLE
CORDA-1389: Delete the root nodes directory before initialising the nodes

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=3.1.0
+gradlePluginsVersion=3.2.0
 kotlinVersion=1.1.60
 platformVersion=3
 guavaVersion=21.0


### PR DESCRIPTION
This is to enable multiple calls to deployNodes without doing a gradle clean.


