### PR TITLE
Database transaction optional ability to retry on nested SQL Exception. 

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -157,7 +157,7 @@ class CordaPersistence(
                 val answer = transaction.statement()
                 transaction.commit()
                 return answer
-           } catch (e: Throwable) {
+            } catch (e: Throwable) {
                 quietly(transaction::rollback)
                 if (e is SQLException || (recoverAnyNestedSQLException && e.hasSQLExceptionCause)) {
                     if (++recoverableFailureCount > recoverableFailureTolerance) throw e


### PR DESCRIPTION
Database transaction can be set to retry failure due to any exception with the cause or the nested cause of SQLException type.

It may happen that underlying SQL Exception is wrapped by Hibernate, allow in such case to retry but only if this was requested e.g.
`val recoverAnyNestedSQLException = true`\
`val maxTransactionRecoveryAttempts = 3`\
`database.transaction(TransactionIsolationLevel.SERIALIZABLE, maxTransactionRecoveryAttempts, recoverAnyNestedSQLException) { .... }`

The change doesn't alter the existing behaviour.

The change is required for ENT-1447 and it's part of https://github.com/corda/enterprise/pull/777.