### PR TITLE
CORDA-1414: node should continue with parameters from file when network map not available

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -29,7 +29,7 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
         val advertisedParametersHash = try {
             networkMapClient?.getNetworkMap()?.payload?.networkParameterHash
         } catch (e: Exception) {
-            logger.info("Couldn't connect to NetworkMap", e)
+            logger.info("Unable to download network map", e)
             // If NetworkMap is down while restarting the node, we should be still able to continue with parameters from file
             null
         }

--- a/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NetworkParametersReader.kt
@@ -10,7 +10,6 @@ import net.corda.nodeapi.internal.network.NETWORK_PARAMS_FILE_NAME
 import net.corda.nodeapi.internal.network.NETWORK_PARAMS_UPDATE_FILE_NAME
 import net.corda.nodeapi.internal.network.SignedNetworkParameters
 import net.corda.nodeapi.internal.network.verifiedNetworkMapCert
-import java.net.ConnectException
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.security.cert.X509Certificate
@@ -29,7 +28,7 @@ class NetworkParametersReader(private val trustRoot: X509Certificate,
     private fun retrieveNetworkParameters(): NetworkParameters {
         val advertisedParametersHash = try {
             networkMapClient?.getNetworkMap()?.payload?.networkParameterHash
-        } catch (e: ConnectException) {
+        } catch (e: Exception) {
             logger.info("Couldn't connect to NetworkMap", e)
             // If NetworkMap is down while restarting the node, we should be still able to continue with parameters from file
             null

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkParametersReaderTest.kt
@@ -14,6 +14,7 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.internal.DEV_ROOT_CA
 import net.corda.testing.node.internal.network.NetworkMapServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -27,6 +28,7 @@ class NetworkParametersReaderTest {
     @JvmField
     val testSerialization = SerializationEnvironmentRule(true)
 
+    val fs = Jimfs.newFileSystem(Configuration.unix())
     private val cacheTimeout = 100000.seconds
 
     private lateinit var server: NetworkMapServer
@@ -42,11 +44,11 @@ class NetworkParametersReaderTest {
     @After
     fun tearDown() {
         server.close()
+        fs.close()
     }
 
     @Test
     fun `read correct set of parameters from file`() {
-        val fs = Jimfs.newFileSystem(Configuration.unix())
         val baseDirectory = fs.getPath("/node").createDirectories()
         val oldParameters = testNetworkParameters(epoch = 1)
         NetworkParametersCopier(oldParameters).install(baseDirectory)
@@ -59,5 +61,15 @@ class NetworkParametersReaderTest {
                 .readObject<SignedNetworkParameters>()
                 .verifiedNetworkMapCert(DEV_ROOT_CA.certificate)
         assertEquals(server.networkParameters, parametersFromFile)
+    }
+
+    @Test
+    fun `read network parameters from file when network map server is down`() {
+        server.close()
+        val baseDirectory = fs.getPath("/node").createDirectories()
+        val fileParameters = testNetworkParameters(epoch = 1)
+        NetworkParametersCopier(fileParameters).install(baseDirectory)
+        val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, networkMapClient, baseDirectory).networkParameters
+        assertThat(parameters).isEqualTo(fileParameters)
     }
 }


### PR DESCRIPTION
If network map is not available or returns exception on network
parameters reading (either serialization, connection, signature etc.), node should continue with parameters from file.
