### PR TITLE
CORDA-1441: Upgrade to Kotlin 1.2.41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,6 +209,14 @@ allprojects {
     }
 
     configurations {
+        all {
+            resolutionStrategy {
+                // Force dependencies to use the same version of Kotlin as Corda.
+                force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+                force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+                force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+            }
+        }
         compile {
             // We want to use SLF4J's version of these bindings: jcl-over-slf4j
             // Remove any transitive dependency on Apache's version.

--- a/constants.properties
+++ b/constants.properties
@@ -1,5 +1,5 @@
 gradlePluginsVersion=4.0.15
-kotlinVersion=1.2.20
+kotlinVersion=1.2.41
 platformVersion=4
 guavaVersion=21.0
 bouncycastleVersion=1.57

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt
@@ -17,7 +17,6 @@ import net.corda.finance.GBP
 import net.corda.finance.USD
 import net.corda.finance.flows.ConfigHolder.Companion.supportedCurrencies
 import java.io.IOException
-import java.nio.file.Path
 import java.util.*
 
 // TODO Until apps have access to their own config, we'll hack things by first getting the baseDirectory, read the node.conf

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
@@ -15,6 +15,9 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.contracts.asset.cash.selection.AbstractCashSelection
+import net.corda.finance.flows.AbstractCashFlow.Companion.FINALISING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.SIGNING_TX
 import net.corda.finance.issuedBy
 import java.util.*
 

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
@@ -9,6 +9,9 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.flows.AbstractCashFlow.Companion.FINALISING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.SIGNING_TX
 import net.corda.finance.issuedBy
 import java.util.*
 

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -11,6 +11,10 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.flows.AbstractCashFlow.Companion.FINALISING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_ID
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.SIGNING_TX
 import java.util.*
 
 /**

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -99,17 +99,17 @@ class VaultQueryTests {
             // register additional identities
             val databaseAndServices = makeTestDatabaseAndMockServices(
                     cordappPackages,
-                    makeTestIdentityService(Companion.MEGA_CORP_IDENTITY, Companion.MINI_CORP_IDENTITY, Companion.dummyCashIssuer.identity, Companion.dummyNotary.identity),
+                    makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity),
                     Companion.megaCorp,
-                    moreKeys = Companion.DUMMY_NOTARY_KEY)
+                    moreKeys = DUMMY_NOTARY_KEY)
             database = databaseAndServices.first
             services = databaseAndServices.second
-            vaultFiller = VaultFiller(services, Companion.dummyNotary)
-            vaultFillerCashNotary = VaultFiller(services, Companion.dummyNotary, Companion.CASH_NOTARY)
-            notaryServices = MockServices(cordappPackages, Companion.dummyNotary, rigorousMock(), Companion.dummyCashIssuer.keyPair, Companion.BOC_KEY, Companion.MEGA_CORP_KEY)
+            vaultFiller = VaultFiller(services, dummyNotary)
+            vaultFillerCashNotary = VaultFiller(services, dummyNotary, CASH_NOTARY)
+            notaryServices = MockServices(cordappPackages, dummyNotary, rigorousMock(), dummyCashIssuer.keyPair, BOC_KEY, MEGA_CORP_KEY)
             identitySvc = services.identityService
             // Register all of the identities we're going to use
-            (notaryServices.myInfo.legalIdentitiesAndCerts + Companion.BOC_IDENTITY + Companion.CASH_NOTARY_IDENTITY + Companion.MINI_CORP_IDENTITY + Companion.MEGA_CORP_IDENTITY).forEach { identity ->
+            (notaryServices.myInfo.legalIdentitiesAndCerts + BOC_IDENTITY + CASH_NOTARY_IDENTITY + MINI_CORP_IDENTITY + MEGA_CORP_IDENTITY).forEach { identity ->
                 services.identityService.verifyAndRegisterIdentity(identity)
             }
         }

--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -39,15 +39,6 @@ repositories {
     }
 }
 
-configurations.all {
-    resolutionStrategy {
-        // Force TornadoFX to use the same version of Kotlin as Corda.
-        force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-        force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    }
-}
-
 dependencies {
     // TornadoFX: A lightweight Kotlin framework for working with JavaFX UI's.
     compile "no.tornado:tornadofx:$tornadofx_version"


### PR DESCRIPTION
Upgrade Corda from Kotlin 1.2.20 to 1.2.41, and fix some of the new compiler warnings.