### PR TITLE
Register crypto providers after we init logging

### DIFF
--- a/node/src/main/kotlin/net/corda/node/Corda.kt
+++ b/node/src/main/kotlin/net/corda/node/Corda.kt
@@ -3,15 +3,10 @@
 
 package net.corda.node
 
-import net.corda.core.crypto.CordaSecurityProvider
-import net.corda.core.crypto.Crypto
 import net.corda.node.internal.NodeStartup
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
-    // Register all cryptography [Provider]s first thing on boot.
-    // Required to install our [SecureRandom] before e.g., UUID asks for one.
-    Crypto.registerProviders()
     // Pass the arguments to the Node factory. In the Enterprise edition, this line is modified to point to a subclass.
     // It will exit the process in case of startup failure and is not intended to be used by embedders. If you want
     // to embed Node in your own container, instantiate it directly and set up the configuration objects yourself.

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -56,8 +56,9 @@ open class NodeStartup(val args: Array<String>) {
 
         initLogging(cmdlineOptions)
 
-        // Register all cryptography [Provider]s first thing on boot.
+        // Register all cryptography [Provider]s.
         // Required to install our [SecureRandom] before e.g., UUID asks for one.
+        // This needs to go after initLogging(netty clashes with our logging).
         Crypto.registerProviders()
 
         val versionInfo = getVersionInfo()

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -1,6 +1,7 @@
 package net.corda.node.internal
 
 import com.jcabi.manifests.Manifests
+import net.corda.core.crypto.Crypto
 import net.corda.core.internal.Emoji
 import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.internal.createDirectories
@@ -54,6 +55,10 @@ open class NodeStartup(val args: Array<String>) {
         enforceSingleNodeIsRunning(cmdlineOptions.baseDirectory)
 
         initLogging(cmdlineOptions)
+
+        // Register all cryptography [Provider]s first thing on boot.
+        // Required to install our [SecureRandom] before e.g., UUID asks for one.
+        Crypto.registerProviders()
 
         val versionInfo = getVersionInfo()
 


### PR DESCRIPTION
New version of netty(4.1.15) clashes with our logging. We use FastThreadLocal which ends up initialising slf4j before we can set defaultLogLevel property.