### PR TITLE
[CORDA-894] Metadata key-type cross checking.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -1004,10 +1004,10 @@ object Crypto {
         //      if key and metadata schemes match.
         val keyScheme = Crypto.findSignatureScheme(transactionSignature.by)
         val metadataScheme = signatureSchemeNumberIDMap[transactionSignature.signatureMetadata.schemeNumberID]
-        require(metadataScheme != null) { "Signature scheme with numberID: $metadataScheme is not supported" }
+        require(metadataScheme != null) { "Signature scheme with numberID: ${transactionSignature.signatureMetadata.schemeNumberID} is not supported" }
         // Bypassing the following requirement when metadataScheme == Crypto.COMPOSITE_KEY due to backwards compatibility purposes.
         // TODO: consider removing the COMPOSITE_KEY check when minimum platform is enforced.
-        require(keyScheme == metadataScheme || metadataScheme == Crypto.COMPOSITE_KEY) { "Signature scheme of metadata with numberID: $metadataScheme does not correspond to the public key scheme numberID: $keyScheme" }
+        require(keyScheme == metadataScheme || metadataScheme == Crypto.COMPOSITE_KEY) { "Signature scheme of metadata with numberID: ${metadataScheme!!.schemeNumberID} does not correspond to the public key scheme numberID: ${keyScheme.schemeNumberID}" }
         val signableData = SignableData(originalSignedHash(txId, transactionSignature.partialMerkleTree), transactionSignature.signatureMetadata)
         return Pair(keyScheme, signableData)
     }

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -604,6 +604,8 @@ object Crypto {
         require(isSupportedSignatureScheme(signatureScheme)) {
             "Unsupported key/algorithm for schemeCodeName: ${signatureScheme.schemeCodeName}"
         }
+        require(signatureData.isNotEmpty()) { "Signature data is empty!" }
+        require(clearData.isNotEmpty()) { "Clear data is empty, nothing to verify!" }
         val signature = Signature.getInstance(signatureScheme.signatureName, providerMap[signatureScheme.providerName])
         signature.initVerify(publicKey)
         signature.update(clearData)


### PR DESCRIPTION
- Previously `findSignatureScheme(key: PublicKey)` was used to identify the scheme type when verifying signatures. However, we could use attached Metadata's `schemeNumberID` to bypass `findSignatureScheme`. Security-wised this PR is more correct, as we inherently check if the metadata contains the expected scheme.

- At the moment we validate public keys and param matching with the advertised metadata scheme during signing and verification. **For better performance we could bypass this crosscheck and use Metadata's scheme directly**

- Extra handling is required when the `COMPOSITE_KEY` is advertised in metadata (this is unfortunately happening in Notary services). When signing, but metadata advertises a composite key, we should rewrite `SignableData` to include the actual signing key type.

- On the other hand, For backward compatibility purposes in verification, we bypass metadata key-type crosschecking when `COMPOSITE_KEY` is mentioned in metadata.

- A descriptive log output has been added to `doVerify`, required for debugging purposes.

- a few minor fixes and related unit test.