### PR TITLE
Define a central gradle variable to capture the proton-j version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ buildscript {
     ext.eaagentloader_version = '1.0.3'
     ext.jsch_version = '0.1.54'
     ext.commons_cli_version = '1.4'
+    ext.protonj_version = '0.27.1'
 
     // Update 121 is required for ObjectInputFilter and at time of writing 131 was latest:
     ext.java8_minUpdateVersion = '131'

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile "de.javakaffee:kryo-serializers:0.41"
 
     // For AMQP serialisation.
-    compile "org.apache.qpid:proton-j:0.27.1"
+    compile "org.apache.qpid:proton-j:${protonj_version}"
 
     // FastClasspathScanner: classpath scanning - needed for the NetworkBootstraper
     compile 'io.github.lukehutch:fast-classpath-scanner:2.12.3'


### PR DESCRIPTION
As this is likely to change moderately often and be re-used in other projects I need a gradle variable