### PR TITLE
ENT-1463: Declare default interface methods as Java8 default.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,7 @@ allprojects {
             apiVersion = "1.2"
             jvmTarget = "1.8"
             javaParameters = true   // Useful for reflection.
+            freeCompilerArgs = ['-Xenable-jvm-default']
         }
     }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt
@@ -8,9 +8,9 @@ import java.nio.ByteBuffer
 class OrdinalBits(private val ordinal: Int) {
     interface OrdinalWriter {
         val bits: OrdinalBits
-        val encodedSize get() = 1
-        fun writeTo(stream: OutputStream) = stream.write(bits.ordinal)
-        fun putTo(buffer: ByteBuffer) = buffer.put(bits.ordinal.toByte())!!
+        @JvmDefault val encodedSize get() = 1
+        @JvmDefault fun writeTo(stream: OutputStream) = stream.write(bits.ordinal)
+        @JvmDefault fun putTo(buffer: ByteBuffer) = buffer.put(bits.ordinal.toByte())!!
     }
 
     init {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializer.kt
@@ -31,6 +31,7 @@ interface AMQPSerializer<out T> {
     /**
      * Write the given object, with declared type, to the output.
      */
+    @JvmDefault
     fun writeObject(obj: Any, data: Data, type: Type, output: SerializationOutput,
                     context: SerializationContext, debugIndent: Int = 0)
 


### PR DESCRIPTION
Kotlin will implement default interface methods via a synthetic nested `$DefaultImpls` class unless we apply Kotlin 1.2.40's new `@JvmDefault` annotation. This annotation instructs the compiler to implement them as Java8 `default` methods instead on the interface class itself.

Apply this annotation to interfaces required by the `-deterministic` modules so that no `$DefaultImpls` classes are generated. Otherwise we would need to configure ProGuard explicitly to keep them all.