### PR TITLE
ENT-1463: Replace getStackTraceAsString() with Throwable.initCause().

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -58,7 +58,6 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 
 val Throwable.rootCause: Throwable get() = cause?.rootCause ?: this
-fun Throwable.getStackTraceAsString() = StringWriter().also { printStackTrace(PrintWriter(it)) }.toString()
 
 infix fun Temporal.until(endExclusive: Temporal): Duration = Duration.between(this, endExclusive)
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializationInput.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializationInput.kt
@@ -2,7 +2,6 @@ package net.corda.nodeapi.internal.serialization.amqp
 
 import com.esotericsoftware.kryo.io.ByteBufferInputStream
 import net.corda.core.internal.VisibleForTesting
-import net.corda.core.internal.getStackTraceAsString
 import net.corda.core.serialization.EncodingWhitelist
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializedBytes
@@ -95,7 +94,7 @@ class DeserializationInput @JvmOverloads constructor(private val serializerFacto
 
 
     @Throws(NotSerializableException::class)
-    fun getEnvelope(byteSequence: ByteSequence) = Companion.getEnvelope(byteSequence, encodingWhitelist)
+    fun getEnvelope(byteSequence: ByteSequence) = getEnvelope(byteSequence, encodingWhitelist)
 
     @Throws(NotSerializableException::class)
     inline fun <reified T : Any> deserialize(bytes: SerializedBytes<T>, context: SerializationContext): T =
@@ -109,7 +108,7 @@ class DeserializationInput @JvmOverloads constructor(private val serializerFacto
         } catch (nse: NotSerializableException) {
             throw nse
         } catch (t: Throwable) {
-            throw NotSerializableException("Unexpected throwable: ${t.message} ${t.getStackTraceAsString()}")
+            throw NotSerializableException("Unexpected throwable: ${t.message}").apply { initCause(t) }
         } finally {
             objectHistory.clear()
         }
@@ -163,7 +162,7 @@ class DeserializationInput @JvmOverloads constructor(private val serializerFacto
                 if (!objectRetrieved::class.java.isSubClassOf(type.asClass()!!)) {
                     throw NotSerializableException(
                             "Existing reference type mismatch. Expected: '$type', found: '${objectRetrieved::class.java}' " +
-                                    "@ ${objectIndex}")
+                                    "@ $objectIndex")
                 }
                 objectRetrieved
             } else {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationOutputTests.kt
@@ -487,7 +487,7 @@ class SerializationOutputTests(private val compression: CordaSerializationEncodi
         copy[valueIndex] = 0x00
         assertThatExceptionOfType(NotSerializableException::class.java).isThrownBy {
             des.deserialize(OpaqueBytes(copy), NonZeroByte::class.java, testSerializationContext)
-        }.withMessageContaining("Zero not allowed")
+        }.withStackTraceContaining("Zero not allowed")
     }
 
     @Test


### PR DESCRIPTION
Replace `getStackTraceAsString()` with a more standard approach.