### PR TITLE
CORDA-1443: cleanup tests, eliminate connection loss timeout

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
@@ -35,14 +35,15 @@ class RpcSslTest {
             withKeyStores(server, client) { nodeSslOptions, clientSslOptions ->
                 var successful = false
                 driver(DriverParameters(isDebug = true, startNodesInProcess = true, portAllocation = RandomFree)) {
-                    startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow().use { node ->
-                        createCordaRPCClientWithSsl(node.rpcAddress, sslConfiguration = clientSslOptions).start(user.username, user.password).use { connection ->
-                            connection.proxy.apply {
-                                nodeInfo()
-                                successful = true
-                            }
-                        }
+                    val node = startNode(rpcUsers = listOf(user), customOverrides = nodeSslOptions.useSslRpcOverrides()).getOrThrow()
+                    val client = createCordaRPCClientWithSsl(node.rpcAddress, sslConfiguration = clientSslOptions)
+                    val connection = client.start(user.username, user.password)
+                    connection.proxy.apply {
+                        nodeInfo()
+                        successful = true
                     }
+
+                    connection.close()
                 }
                 assertThat(successful).isTrue()
             }
@@ -54,14 +55,15 @@ class RpcSslTest {
         val user = User("mark", "dadada", setOf(all()))
         var successful = false
         driver(DriverParameters(isDebug = true, startNodesInProcess = true, portAllocation = RandomFree)) {
-            startNode(rpcUsers = listOf(user)).getOrThrow().use { node ->
-                CordaRPCClient(node.rpcAddress).start(user.username, user.password).use { connection ->
-                    connection.proxy.apply {
-                        nodeInfo()
-                        successful = true
-                    }
-                }
+            val node = startNode(rpcUsers = listOf(user)).getOrThrow()
+            val client = CordaRPCClient(node.rpcAddress)
+            val connection = client.start(user.username, user.password)
+            connection.proxy.apply {
+                nodeInfo()
+                successful = true
             }
+
+            connection.close()
         }
         assertThat(successful).isTrue()
     }


### PR DESCRIPTION
Re-wrote the tests to do proper connection close and get rid of connection loss timeout that caused the tests to hang needlessly.