### PR TITLE
CORDA-1466: Fix publication of PDF developer documentation

### DIFF
--- a/docs/make-docsite.sh
+++ b/docs/make-docsite.sh
@@ -12,6 +12,11 @@ else
 fi
 
 # TODO: The PDF rendering is pretty ugly and can be improved a lot.
+echo "Generating PDF document ..."
 make pdf
-mv build/pdf/corda-developer-site.pdf build/html/_static/corda-developer-site.pdf
+
+echo "Generating HTML pages ..."
 make html
+
+echo "Moving PDF file into place ..."
+mv $PWD/build/pdf/corda-developer-site.pdf $PWD/build/html/_static/corda-developer-site.pdf


### PR DESCRIPTION
Published PDF file is missing because of a missing target directory in the script move command:
https://docs.corda.net/head/_static/corda-developer-site.pdf