### PR TITLE
ENT-1463: Refactor serialisation slightly for determinisation.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ByteBufferStreams.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ByteBufferStreams.kt
@@ -10,9 +10,9 @@ import java.nio.ByteBuffer
 import kotlin.math.min
 
 internal val serializeOutputStreamPool = LazyPool(
-        clear = ByteBufferOutputStream::reset,
-        shouldReturnToPool = { it.size() < 256 * 1024 }, // Discard if it grew too large
-        newInstance = { ByteBufferOutputStream(64 * 1024) })
+    clear = ByteBufferOutputStream::reset,
+    shouldReturnToPool = { it.size() < 256 * 1024 }, // Discard if it grew too large
+    newInstance = { ByteBufferOutputStream(64 * 1024) })
 
 internal fun <T> byteArrayOutput(task: (ByteBufferOutputStream) -> T): ByteArray {
     return serializeOutputStreamPool.run { underlying ->

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/ServerContexts.kt
@@ -2,15 +2,10 @@
 
 package net.corda.nodeapi.internal.serialization
 
-import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.nodeapi.internal.serialization.amqp.amqpMagic
 import net.corda.nodeapi.internal.serialization.kryo.kryoMagic
-
-object QuasarWhitelist : ClassWhitelist {
-    override fun hasListed(type: Class<*>): Boolean = true
-}
 
 /*
  * Serialisation contexts for the server.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SharedContexts.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SharedContexts.kt
@@ -2,10 +2,7 @@
 
 package net.corda.nodeapi.internal.serialization
 
-import net.corda.core.serialization.EncodingWhitelist
-import net.corda.core.serialization.SerializationContext
-import net.corda.core.serialization.SerializationDefaults
-import net.corda.core.serialization.SerializationEncoding
+import net.corda.core.serialization.*
 import net.corda.nodeapi.internal.serialization.amqp.amqpMagic
 import net.corda.nodeapi.internal.serialization.kryo.kryoMagic
 
@@ -35,4 +32,8 @@ val AMQP_P2P_CONTEXT = SerializationContextImpl(amqpMagic,
 
 internal object AlwaysAcceptEncodingWhitelist : EncodingWhitelist {
     override fun acceptEncoding(encoding: SerializationEncoding) = true
+}
+
+object QuasarWhitelist : ClassWhitelist {
+    override fun hasListed(type: Class<*>): Boolean = true
 }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializationScheme.kt
@@ -95,11 +95,11 @@ abstract class AbstractAMQPSerializationScheme(
             register(net.corda.nodeapi.internal.serialization.amqp.custom.X509CRLSerializer)
             register(net.corda.nodeapi.internal.serialization.amqp.custom.CertPathSerializer(this))
             register(net.corda.nodeapi.internal.serialization.amqp.custom.StringBufferSerializer)
-            register(net.corda.nodeapi.internal.serialization.amqp.custom.SimpleStringSerializer)
             register(net.corda.nodeapi.internal.serialization.amqp.custom.InputStreamSerializer)
             register(net.corda.nodeapi.internal.serialization.amqp.custom.BitSetSerializer(this))
             register(net.corda.nodeapi.internal.serialization.amqp.custom.EnumSetSerializer(this))
             register(net.corda.nodeapi.internal.serialization.amqp.custom.ContractAttachmentSerializer(this))
+            registerNonDeterministicSerializers(factory)
         }
         for (whitelistProvider in serializationWhitelists) {
             factory.addToWhitelist(*whitelistProvider.whitelist.toTypedArray())
@@ -116,7 +116,15 @@ abstract class AbstractAMQPSerializationScheme(
                 factory.registerExternal(CorDappCustomSerializer(customSerializer, factory))
             }
         }
+    }
 
+    /*
+     * Register the serializers which will be excluded from the DJVM.
+     */
+    private fun registerNonDeterministicSerializers(factory: SerializerFactory) {
+        with(factory) {
+            register(net.corda.nodeapi.internal.serialization.amqp.custom.SimpleStringSerializer)
+        }
     }
 
     private val serializerFactoriesForContexts = ConcurrentHashMap<Pair<ClassWhitelist, ClassLoader>, SerializerFactory>()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenter.kt
@@ -89,8 +89,9 @@ private val toStringHelper: String = Type.getInternalName(MoreObjects.ToStringHe
  *
  * Equals/hashCode methods are not yet supported.
  */
-class ClassCarpenter(cl: ClassLoader = Thread.currentThread().contextClassLoader,
-                     val whitelist: ClassWhitelist) {
+class ClassCarpenter(cl: ClassLoader, val whitelist: ClassWhitelist) {
+    constructor(whitelist: ClassWhitelist) : this(Thread.currentThread().contextClassLoader, whitelist)
+
     // TODO: Generics.
     // TODO: Sandbox the generated code when a security manager is in use.
     // TODO: Generate equals/hashCode.


### PR DESCRIPTION
- Remove `Thread` reference from `ClassCarpenter` primary constructor.
- Put `QuasarWhitelist` in the same file as the thing that uses it.
- Allow Artemis `SimpleString` serialiser to be dropped from DJVM.
- Whitespace fixes.