### PR TITLE
Increase the number of log files retained per day

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -21,7 +21,7 @@
             <PatternLayout pattern="%msg%n" />
         </Console>
 
-        <!-- Will generate up to 10 log files for a given day. During every rollover it will delete
+        <!-- Will generate up to 100 log files for a given day. During every rollover it will delete
              those that are older than 60 days, but keep the most recent 10 GB -->
         <RollingFile name="RollingFile-Appender"
                      fileName="${sys:log-path}/${log-name}.log"
@@ -34,7 +34,7 @@
                 <SizeBasedTriggeringPolicy size="10MB"/>
             </Policies>
 
-            <DefaultRolloverStrategy min="1" max="10">
+            <DefaultRolloverStrategy min="1" max="100">
                 <Delete basePath="${archive}" maxDepth="1">
                     <IfFileName glob="${log-name}*.log.gz"/>
                     <IfLastModified age="60d">


### PR DESCRIPTION
Currently the node will keep up to 10 compressed log files during rollover, and discard old ones. This limit seems too low for production use and might lead to valuable log data loss.