### PR TITLE
CORDA-1466: Fix problem with PDF document rendering

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -99,7 +99,7 @@ absolute path to the node's base directory.
 
         :messageRedeliveryDelay: The initial retry delay, e.g. `30 seconds`.
         :maxRetryCount: How many retries to attempt.
-        :backoffBase: The base of the exponential backoff, :math:`t_{wait} = messageRedeliveryDelay * backoffBase^{retryCount}`.
+        :backoffBase: The base of the exponential backoff, `t_{wait} = messageRedeliveryDelay * backoffBase^{retryCount}`.
 
 :rpcAddress: The address of the RPC system on which RPC requests can be made to the node. If not provided then the node will run without RPC. This is now deprecated in favour of the ``rpcSettings`` block.
 


### PR DESCRIPTION
Fix problem with Python PDF builder failing to render the Sphinx **:math:** tag directive correctly, causing generation of a 0 byte pdf file.

Python PDF rendering fails using latest version of `Matplotlib` (version 2.2.2).
```
[11:44:10][:docs:makeDocs] [ERROR] pdfbuilder.py:130 invalid literal for float(): 0.000000/
[11:44:10][:docs:makeDocs] paragraph text u'<para>The base of the exponential backoff, <img src="/data/BuildAgent/temp/buildTmp/tmpzY63cH.png" width=10.000000 height=10.000000 valign=0.000000/>.</para>' caused exception
[11:44:10][:docs:makeDocs] Traceback (most recent call last):
```

