### PR TITLE
ENT-1463: Turn ClassCarpenter and SerializerFactoryFactory into interfaces.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializationScheme.kt
@@ -29,14 +29,14 @@ fun SerializerFactory.addToWhitelist(vararg types: Class<*>) {
     }
 }
 
-open class SerializerFactoryFactory {
-    open fun make(context: SerializationContext) =
-            SerializerFactory(context.whitelist, context.deserializationClassLoader)
+// Allow us to create a SerializerFactory with a different ClassCarpenter implementation.
+interface SerializerFactoryFactory {
+    fun make(context: SerializationContext): SerializerFactory
 }
 
 abstract class AbstractAMQPSerializationScheme(
         private val cordappCustomSerializers: Set<SerializationCustomSerializer<*,*>>,
-        val sff: SerializerFactoryFactory = SerializerFactoryFactory()
+        val sff: SerializerFactoryFactory = createSerializerFactoryFactory()
 ) : SerializationScheme {
     constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers)
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializerFactories.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializerFactories.kt
@@ -1,0 +1,11 @@
+@file:JvmName("AMQPSerializerFactories")
+package net.corda.nodeapi.internal.serialization.amqp
+
+import net.corda.core.serialization.SerializationContext
+
+fun createSerializerFactoryFactory(): SerializerFactoryFactory = SerializerFactoryFactoryImpl()
+
+open class SerializerFactoryFactoryImpl : SerializerFactoryFactory {
+    override fun make(context: SerializationContext) =
+            SerializerFactory(context.whitelist, context.deserializationClassLoader)
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenter.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenter.kt
@@ -45,6 +45,13 @@ private val jlClass: String = Type.getInternalName(Class::class.java)
 private val moreObjects: String = Type.getInternalName(MoreObjects::class.java)
 private val toStringHelper: String = Type.getInternalName(MoreObjects.ToStringHelper::class.java)
 
+// Allow us to create alternative ClassCarpenters.
+interface ClassCarpenter {
+    val whitelist: ClassWhitelist
+    val classloader: CarpenterClassLoader
+    fun build(schema: Schema): Class<*>
+}
+
 /**
  * A class carpenter generates JVM bytecodes for a class given a schema and then loads it into a sub-classloader.
  * The generated classes have getters, a toString method and implement a simple property access interface. The
@@ -89,7 +96,7 @@ private val toStringHelper: String = Type.getInternalName(MoreObjects.ToStringHe
  *
  * Equals/hashCode methods are not yet supported.
  */
-class ClassCarpenter(cl: ClassLoader, val whitelist: ClassWhitelist) {
+class ClassCarpenterImpl(cl: ClassLoader, override val whitelist: ClassWhitelist) : ClassCarpenter {
     constructor(whitelist: ClassWhitelist) : this(Thread.currentThread().contextClassLoader, whitelist)
 
     // TODO: Generics.
@@ -98,7 +105,7 @@ class ClassCarpenter(cl: ClassLoader, val whitelist: ClassWhitelist) {
     // TODO: Support annotations.
     // TODO: isFoo getter patterns for booleans (this is what Kotlin generates)
 
-    val classloader = CarpenterClassLoader(cl)
+    override val classloader = CarpenterClassLoader(cl)
 
     private val _loaded = HashMap<String, Class<*>>()
 
@@ -112,7 +119,7 @@ class ClassCarpenter(cl: ClassLoader, val whitelist: ClassWhitelist) {
      * @throws DuplicateNameException if the schema's name is already taken in this namespace (you can create a
      * new ClassCarpenter if you're OK with ambiguous names)
      */
-    fun build(schema: Schema): Class<*> {
+    override fun build(schema: Schema): Class<*> {
         validateSchema(schema)
         // Walk up the inheritance hierarchy and then start walking back down once we either hit the top, or
         // find a class we haven't generated yet.
@@ -239,7 +246,7 @@ class ClassCarpenter(cl: ClassLoader, val whitelist: ClassWhitelist) {
     }
 
     private fun ClassWriter.generateGetMethod() {
-        val ourJvmName = Type.getInternalName(ClassCarpenter::class.java)
+        val ourJvmName = Type.getInternalName(ClassCarpenterImpl::class.java)
         with(visitMethod(ACC_PUBLIC, "get", "(L$jlString;)L$jlObject;", null, null)) {
             visitCode()
             visitVarInsn(ALOAD, 0)  // Load 'this'

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/CorDappSerializerTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/CorDappSerializerTests.kt
@@ -3,14 +3,14 @@ package net.corda.nodeapi.internal.serialization.amqp
 import org.junit.Test
 import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.SerializationCustomSerializer
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactory
 import org.assertj.core.api.Assertions
 import java.io.NotSerializableException
 import kotlin.test.assertEquals
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 
 class CorDappSerializerTests {
@@ -108,7 +108,7 @@ class CorDappSerializerTests {
         data class A (val a: Int, val b: NeedsProxy)
 
         class WL : ClassWhitelist {
-            private val allowedClasses = hashSetOf(
+            private val allowedClasses = setOf<String>(
                     A::class.java.name,
                     NeedsProxy::class.java.name)
 
@@ -135,7 +135,7 @@ class CorDappSerializerTests {
 
         class WL : ClassWhitelist {
             // explicitly don't add NeedsProxy
-            private val allowedClasses = hashSetOf(A::class.java.name)
+            private val allowedClasses = setOf<String>(A::class.java.name)
 
             override fun hasListed(type: Class<*>): Boolean = type.name in allowedClasses
         }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeAndReturnEnvelopeTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeAndReturnEnvelopeTests.kt
@@ -1,6 +1,8 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.core.serialization.CordaSerializable
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryWithWhitelist
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testName
@@ -8,15 +10,11 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class DeserializeAndReturnEnvelopeTests {
     // the 'this' reference means we can't just move this to the common test utils
     @Suppress("NOTHING_TO_INLINE")
-    inline private fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
+    private inline fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
 
     val factory = testDefaultFactoryNoEvolution()
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeMapTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeMapTests.kt
@@ -1,14 +1,12 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import java.util.*
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class DeserializeMapTests {
     companion object {
@@ -74,8 +72,8 @@ class DeserializeMapTests {
         data class C(val c: Dictionary<String, Int>)
 
         val v: Hashtable<String, Int> = Hashtable()
-        v.put("a", 1)
-        v.put("b", 2)
+        v["a"] = 1
+        v["b"] = 2
         val c = C(v)
 
         // expected to throw
@@ -88,8 +86,8 @@ class DeserializeMapTests {
         data class C(val c: Hashtable<String, Int>)
 
         val v: Hashtable<String, Int> = Hashtable()
-        v.put("a", 1)
-        v.put("b", 2)
+        v["a"] = 1
+        v["b"] = 2
         val c = C(v)
 
         // expected to throw

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryOfEnumsTest.kt
@@ -1,16 +1,10 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.nodeapi.internal.serialization.AllWhitelist
-import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
-import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
-import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryWithWhitelist
+import net.corda.nodeapi.internal.serialization.amqp.testutils.*
+import net.corda.nodeapi.internal.serialization.carpenter.*
 import org.junit.Test
 import kotlin.test.*
-import net.corda.nodeapi.internal.serialization.carpenter.*
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class DeserializeNeedingCarpentryOfEnumsTest : AmqpCarpenterBase(AllWhitelist) {
     companion object {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentrySimpleTypesTest.kt
@@ -1,15 +1,13 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.nodeapi.internal.serialization.AllWhitelist
+import net.corda.nodeapi.internal.serialization.carpenter.*
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import org.junit.Test
 import kotlin.test.*
-import net.corda.nodeapi.internal.serialization.carpenter.*
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 // These tests work by having the class carpenter build the classes we serialise and then deserialise. Because
 // those classes don't exist within the system's Class Loader the deserialiser will be forced to carpent
@@ -28,7 +26,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleInt() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "int" to NonNullableField(Integer::class.javaPrimitiveType!!)
         )))
 
@@ -48,7 +46,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleIntNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "int" to NullableField(Integer::class.java)
         )))
 
@@ -64,7 +62,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleIntNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "int" to NullableField(Integer::class.java)
         )))
 
@@ -80,7 +78,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleChar() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "char" to NonNullableField(Character::class.javaPrimitiveType!!)
         )))
 
@@ -93,7 +91,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleCharNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "char" to NullableField(Character::class.javaObjectType)
         )))
 
@@ -106,7 +104,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleCharNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "char" to NullableField(java.lang.Character::class.java)
         )))
 
@@ -119,7 +117,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleLong() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "long" to NonNullableField(Long::class.javaPrimitiveType!!)
         )))
 
@@ -133,7 +131,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleLongNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "long" to NullableField(Long::class.javaObjectType)
         )))
 
@@ -147,7 +145,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleLongNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "long" to NullableField(Long::class.javaObjectType)
         )))
 
@@ -160,7 +158,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleBoolean() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "boolean" to NonNullableField(Boolean::class.javaPrimitiveType!!)
         )))
 
@@ -173,7 +171,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleBooleanNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "boolean" to NullableField(Boolean::class.javaObjectType)
         )))
 
@@ -186,7 +184,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleBooleanNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "boolean" to NullableField(Boolean::class.javaObjectType)
         )))
 
@@ -199,7 +197,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleDouble() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "double" to NonNullableField(Double::class.javaPrimitiveType!!)
         )))
 
@@ -212,7 +210,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleDoubleNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "double" to NullableField(Double::class.javaObjectType)
         )))
 
@@ -225,7 +223,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleDoubleNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "double" to NullableField(Double::class.javaObjectType)
         )))
 
@@ -238,7 +236,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleShort() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "short" to NonNullableField(Short::class.javaPrimitiveType!!)
         )))
 
@@ -251,7 +249,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleShortNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "short" to NullableField(Short::class.javaObjectType)
         )))
 
@@ -264,7 +262,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleShortNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "short" to NullableField(Short::class.javaObjectType)
         )))
 
@@ -277,7 +275,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleFloat() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "float" to NonNullableField(Float::class.javaPrimitiveType!!)
         )))
 
@@ -290,7 +288,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleFloatNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "float" to NullableField(Float::class.javaObjectType)
         )))
 
@@ -303,7 +301,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleFloatNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "float" to NullableField(Float::class.javaObjectType)
         )))
 
@@ -316,7 +314,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleByte() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "byte" to NonNullableField(Byte::class.javaPrimitiveType!!)
         )))
 
@@ -331,7 +329,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleByteNullable() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "byte" to NullableField(Byte::class.javaObjectType)
         )))
 
@@ -346,7 +344,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun singleByteNullableNull() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "byte" to NullableField(Byte::class.javaObjectType)
         )))
 
@@ -359,7 +357,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun simpleTypeKnownInterface() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(
                 testName(), mapOf("name" to NonNullableField(String::class.java)),
                 interfaces = listOf(I::class.java)))
         val testVal = "Some Person"
@@ -374,7 +372,7 @@ class DeserializeNeedingCarpentrySimpleTypesTest : AmqpCarpenterBase(AllWhitelis
 
     @Test
     fun manyTypes() {
-        val manyClass = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val manyClass = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "intA" to NonNullableField(Int::class.java),
                 "intB" to NullableField(Integer::class.java),
                 "intC" to NullableField(Integer::class.java),

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryTests.kt
@@ -1,8 +1,6 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.core.serialization.CordaSerializable
-import org.junit.Test
-import kotlin.test.*
 import net.corda.nodeapi.internal.serialization.carpenter.*
 import net.corda.nodeapi.internal.serialization.AllWhitelist
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
@@ -10,6 +8,8 @@ import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactor
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryWithWhitelist
 import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import org.junit.Test
+import kotlin.test.*
 
 @CordaSerializable
 interface I {
@@ -40,7 +40,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
     @Test
     fun verySimpleType() {
         val testVal = 10
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(),
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(),
                 mapOf("a" to NonNullableField(Int::class.java))))
         val classInstance = clazz.constructors[0].newInstance(testVal)
         val serialisedBytes = TestSerializationOutput(VERBOSE, sf1).serialize(classInstance)
@@ -74,7 +74,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
         val testValA = 10
         val testValB = 20
         val testValC = 20
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema("${testName()}_clazz",
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema("${testName()}_clazz",
                 mapOf("a" to NonNullableField(Int::class.java))))
 
         val concreteA = clazz.constructors[0].newInstance(testValA)
@@ -107,7 +107,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
 
     @Test
     fun simpleTypeKnownInterface() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(
                 testName(), mapOf("name" to NonNullableField(String::class.java)),
                 interfaces = listOf(I::class.java)))
         val testVal = "Some Person"
@@ -122,7 +122,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
 
     @Test
     fun arrayOfTypes() {
-        val clazz = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(),
+        val clazz = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(),
                 mapOf("a" to NonNullableField(Int::class.java))))
 
         @CordaSerializable
@@ -156,7 +156,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
 
     @Test
     fun reusedClasses() {
-        val cc = ClassCarpenter(whitelist = AllWhitelist)
+        val cc = ClassCarpenterImpl(whitelist = AllWhitelist)
 
         val innerType = cc.build(ClassSchema("${testName()}.inner", mapOf("a" to NonNullableField(Int::class.java))))
         val outerType = cc.build(ClassSchema("${testName()}.outer", mapOf("a" to NonNullableField(innerType))))
@@ -175,7 +175,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
 
     @Test
     fun nestedTypes() {
-        val cc = ClassCarpenter(whitelist = AllWhitelist)
+        val cc = ClassCarpenterImpl(whitelist = AllWhitelist)
         val nestedClass = cc.build(ClassSchema("nestedType",
                 mapOf("name" to NonNullableField(String::class.java))))
 
@@ -192,7 +192,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
 
     @Test
     fun repeatedNestedTypes() {
-        val cc = ClassCarpenter(whitelist = AllWhitelist)
+        val cc = ClassCarpenterImpl(whitelist = AllWhitelist)
         val nestedClass = cc.build(ClassSchema("nestedType",
                 mapOf("name" to NonNullableField(String::class.java))))
 
@@ -212,7 +212,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
 
     @Test
     fun listOfType() {
-        val unknownClass = ClassCarpenter(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
+        val unknownClass = ClassCarpenterImpl(whitelist = AllWhitelist).build(ClassSchema(testName(), mapOf(
                 "v1" to NonNullableField(Int::class.java),
                 "v2" to NonNullableField(Int::class.java))))
 
@@ -236,7 +236,7 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
 
     @Test
     fun unknownInterface() {
-        val cc = ClassCarpenter(whitelist = AllWhitelist)
+        val cc = ClassCarpenterImpl(whitelist = AllWhitelist)
 
         val interfaceClass = cc.build(InterfaceSchema(
                 "gen.Interface",

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -1,11 +1,11 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import org.junit.Test
 import kotlin.test.assertEquals
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 // Prior to certain fixes being made within the [PropertySerializaer] classes these simple
 // deserialization operations would've blown up with type mismatch errors where the deserlized

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumEvolvabilityTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumEvolvabilityTests.kt
@@ -2,6 +2,9 @@ package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.core.serialization.*
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import org.assertj.core.api.Assertions
@@ -12,9 +15,6 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
 
 class EnumEvolvabilityTests {
     @Suppress("UNUSED")

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumEvolveTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumEvolveTests.kt
@@ -4,6 +4,8 @@ import net.corda.core.internal.toPath
 import net.corda.core.serialization.CordaSerializationTransformEnumDefault
 import net.corda.core.serialization.CordaSerializationTransformEnumDefaults
 import net.corda.core.serialization.SerializedBytes
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testName
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
@@ -14,8 +16,6 @@ import java.io.NotSerializableException
 import java.net.URI
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 // NOTE: To recreate the test files used by these tests uncomment the original test classes and comment
 //       the new ones out, then change each test to write out the serialized bytes rather than read

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EnumTests.kt
@@ -4,6 +4,10 @@ import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testName
 import org.assertj.core.api.Assertions
@@ -12,10 +16,6 @@ import java.io.NotSerializableException
 import java.time.DayOfWeek
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class EnumTests {
     enum class Bras {
@@ -69,7 +69,7 @@ class EnumTests {
     }
 
     @Suppress("NOTHING_TO_INLINE")
-    inline private fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
+    private inline fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
 
     private val sf1 = testDefaultFactoryNoEvolution()
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/ErrorMessagesTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/ErrorMessagesTests.kt
@@ -1,16 +1,14 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testName
 import org.assertj.core.api.Assertions
 import org.junit.Ignore
 import org.junit.Test
 import java.io.NotSerializableException
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class ErrorMessagesTests {
     companion object {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EvolvabilityTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/EvolvabilityTests.kt
@@ -9,6 +9,8 @@ import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.serialization.SerializedBytes
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.testing.common.internal.ProjectStructure.projectRootDir
 import net.corda.testing.core.DUMMY_NOTARY_NAME
@@ -20,8 +22,6 @@ import java.io.NotSerializableException
 import java.net.URI
 import java.time.Instant
 import kotlin.test.assertEquals
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 // To regenerate any of the binary test files do the following
 //

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/FingerPrinterTesting.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/FingerPrinterTesting.kt
@@ -27,7 +27,7 @@ class FingerPrinterTesting  : FingerPrinter {
 
 class FingerPrinterTestingTests {
     companion object {
-        val VERBOSE = true
+        const val VERBOSE = true
     }
     @Test
     fun testingTest() {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/GenericsTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/GenericsTests.kt
@@ -23,7 +23,7 @@ class TestAttachmentConstraint : AttachmentConstraint {
 
 class GenericsTests {
     companion object {
-        val VERBOSE = true
+        const val VERBOSE = true
 
         @Suppress("UNUSED")
         var localPath = projectRootDir.toUri().resolve(

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/PrivatePropertyTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/PrivatePropertyTests.kt
@@ -3,15 +3,16 @@ package net.corda.nodeapi.internal.serialization.amqp
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.assertEquals
 import net.corda.core.serialization.ConstructorForDeserialization
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import org.junit.Test
 import org.apache.qpid.proton.amqp.Symbol
 import org.assertj.core.api.Assertions
 import java.io.NotSerializableException
 import java.util.concurrent.ConcurrentHashMap
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import java.util.*
 
 class PrivatePropertyTests {
     private val factory = testDefaultFactoryNoEvolution()
@@ -78,6 +79,7 @@ class PrivatePropertyTests {
                 is D -> other.a == a && other.b == b
                 else -> false
             }
+            override fun hashCode(): Int = Objects.hash(a, b)
         }
 
         val d1 = D("clump", "lump")

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/RoundTripTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/RoundTripTests.kt
@@ -1,11 +1,11 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.core.serialization.ConstructorForDeserialization
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import org.assertj.core.api.Assertions
 import org.junit.Test
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class RoundTripTests {
     @Test

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationOutputTests.kt
@@ -24,6 +24,7 @@ import net.corda.nodeapi.internal.crypto.ContentSignerBuilder
 import net.corda.nodeapi.internal.serialization.*
 import net.corda.nodeapi.internal.serialization.amqp.SerializerFactory.Companion.isPrimitive
 import net.corda.nodeapi.internal.serialization.amqp.testutils.*
+import net.corda.nodeapi.internal.serialization.carpenter.ClassCarpenterImpl
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.SerializationEnvironmentRule

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationPropertyOrdering.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationPropertyOrdering.kt
@@ -2,6 +2,8 @@ package net.corda.nodeapi.internal.serialization.amqp
 
 import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import org.junit.Test
 import java.util.concurrent.ConcurrentHashMap
@@ -10,10 +12,6 @@ import org.apache.qpid.proton.amqp.Symbol
 import java.lang.reflect.Method
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class SerializationPropertyOrdering {
     companion object {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationSchemaTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationSchemaTests.kt
@@ -35,7 +35,7 @@ val testFactory = TestSerializerFactory(TESTING_CONTEXT.whitelist, TESTING_CONTE
 // Serializer factory factory, plugs into the SerializationScheme and controls which factory type
 // we make for each use case. For our tests we need to make sure if its the Testing use case we return
 // the global factory object created above that counts registrations.
-class TestSerializerFactoryFactory : SerializerFactoryFactory() {
+class TestSerializerFactoryFactory : SerializerFactoryFactoryImpl() {
     override fun make(context: SerializationContext) =
             when (context.useCase) {
                 SerializationContext.UseCase.Testing -> testFactory

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializeAndReturnSchemaTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializeAndReturnSchemaTest.kt
@@ -1,17 +1,17 @@
 package net.corda.nodeapi.internal.serialization.amqp
 
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testName
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
 
 class SerializeAndReturnSchemaTest {
     // the 'this' reference means we can't just move this to the common test utils
     @Suppress("NOTHING_TO_INLINE")
-    inline private fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
+    private inline fun classTestName(clazz: String) = "${this.javaClass.name}\$${testName()}\$$clazz"
 
     val factory = testDefaultFactoryNoEvolution()
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/StaticInitialisationOfSerializedObjectTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/StaticInitialisationOfSerializedObjectTest.kt
@@ -3,17 +3,14 @@ package net.corda.nodeapi.internal.serialization.amqp
 import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.SerializedBytes
 import net.corda.nodeapi.internal.serialization.AllWhitelist
-import net.corda.nodeapi.internal.serialization.carpenter.ClassCarpenter
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.carpenter.ClassCarpenterImpl
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.assertEquals
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serializeAndReturnSchema
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
 
 class InStatic : Exception("Help!, help!, I'm being repressed")
 
@@ -102,8 +99,7 @@ class StaticInitialisationOfSerializedObjectTest {
     // Version of a serializer factory that will allow the class carpenter living on the
     // factory to have a different whitelist applied to it than the factory
     class TestSerializerFactory(wl1: ClassWhitelist, wl2: ClassWhitelist) :
-            SerializerFactory(wl1, ClassLoader.getSystemClassLoader()) {
-        override val classCarpenter = ClassCarpenter(ClassLoader.getSystemClassLoader(), wl2)
+            SerializerFactory(wl1, ClassCarpenterImpl(ClassLoader.getSystemClassLoader(), wl2)) {
     }
 
     // This time have the serialization factory and the carpenter use different whitelists

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/CarpenterExceptionTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/CarpenterExceptionTests.kt
@@ -1,30 +1,28 @@
 package net.corda.nodeapi.internal.serialization.carpenter
 
 import com.google.common.reflect.TypeToken
-import junit.framework.Assert.assertTrue
 import net.corda.nodeapi.internal.serialization.AllWhitelist
 import net.corda.nodeapi.internal.serialization.amqp.*
 import net.corda.nodeapi.internal.serialization.amqp.testutils.TestSerializationOutput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
 import net.corda.nodeapi.internal.serialization.amqp.testutils.testDefaultFactory
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import java.io.NotSerializableException
 import java.lang.reflect.Type
-import java.net.URL
 import kotlin.reflect.jvm.jvmName
-import kotlin.test.assertEquals
-import net.corda.nodeapi.internal.serialization.amqp.testutils.serialize
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserialize
+import kotlin.test.*
 
 // Simple way to ensure we end up trying to carpent a class, "remove" it from the class loader (if only
 // actually doing that was simple)
-class TestClassLoader (private var exclude: List<String>) : ClassLoader() {
-    override fun loadClass(p0: String?, p1: Boolean): Class<*> {
-        if (p0 in exclude) {
-            throw ClassNotFoundException("Pretending we can't find class $p0")
+class TestClassLoader(private var exclude: List<String>) : ClassLoader() {
+    override fun loadClass(name: String, resolve: Boolean): Class<*> {
+        if (name in exclude) {
+            throw ClassNotFoundException("Pretending we can't find class $name")
         }
 
-        return super.loadClass(p0, p1)
+        return super.loadClass(name, resolve)
     }
 }
 
@@ -35,8 +33,8 @@ interface TestInterface {
 // Create a custom serialization factory where we need to be able to both specify a carpenter
 // but also have the class loader used by the carpenter be substantially different from the
 // one used by the factory so as to ensure we can control their behaviour independently.
-class TestFactory(override val classCarpenter: ClassCarpenter, cl: ClassLoader)
-    : SerializerFactory (classCarpenter.whitelist, cl)
+class TestFactory(classCarpenter: ClassCarpenter)
+    : SerializerFactory(classCarpenter.whitelist, classCarpenter)
 
 class CarpenterExceptionTests {
     companion object {
@@ -45,14 +43,16 @@ class CarpenterExceptionTests {
 
     @Test
     fun checkClassComparison() {
-        class clA : ClassLoader() {
-            override fun loadClass(name: String?, resolve: Boolean): Class<*> {
+        class CLA : ClassLoader() {
+            override fun loadClass(name: String, resolve: Boolean): Class<*> {
+                println("CLA::loadClass $name")
                 return super.loadClass(name, resolve)
             }
         }
 
-        class clB : ClassLoader() {
-            override fun loadClass(name: String?, resolve: Boolean): Class<*> {
+        class CLB : ClassLoader() {
+            override fun loadClass(name: String, resolve: Boolean): Class<*> {
+                println("CLB::loadClass $name")
                 return super.loadClass(name, resolve)
             }
         }
@@ -60,8 +60,8 @@ class CarpenterExceptionTests {
         data class A(val a: Int, val b: Int)
 
         val a3 = ClassLoader.getSystemClassLoader().loadClass(A::class.java.name)
-        val a1 = clA().loadClass(A::class.java.name)
-        val a2 = clB().loadClass(A::class.java.name)
+        val a1 = CLA().loadClass(A::class.java.name)
+        val a2 = CLB().loadClass(A::class.java.name)
 
         assertTrue (TypeToken.of(a1).isSubtypeOf(a2))
         assertTrue (a1 is Type)
@@ -89,8 +89,8 @@ class CarpenterExceptionTests {
         // carpent that class up. However, when looking at the fields specified as properties of that class
         // we set the class loader of the ClassCarpenter to reject one of them, resulting in a CarpentryError
         // which we then  want the code to wrap in a NotSerializeableException
-        val cc = ClassCarpenter(TestClassLoader(listOf(C2::class.jvmName)), AllWhitelist)
-        val factory = TestFactory(cc, TestClassLoader(listOf(C1::class.jvmName)))
+        val cc = ClassCarpenterImpl(TestClassLoader(listOf(C2::class.jvmName)), AllWhitelist)
+        val factory = TestFactory(cc)
 
         Assertions.assertThatThrownBy {
             DeserializationInput(factory).deserialize(ser)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenterTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenterTest.kt
@@ -17,7 +17,7 @@ class ClassCarpenterTest {
         val b: Int
     }
 
-    private val cc = ClassCarpenter(whitelist = AllWhitelist)
+    private val cc = ClassCarpenterImpl(whitelist = AllWhitelist)
 
     // We have to ignore synthetic fields even though ClassCarpenter doesn't create any because the JaCoCo
     // coverage framework auto-magically injects one method and one field into every class loaded into the JVM.

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenterTestUtils.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenterTestUtils.kt
@@ -39,11 +39,11 @@ fun Schema.mangleNames(names: List<String>): Schema {
  * Custom implementation of a [SerializerFactory] where we need to give it a class carpenter
  * rather than have it create its own
  */
-class SerializerFactoryExternalCarpenter(override val classCarpenter: ClassCarpenter)
-    : SerializerFactory (classCarpenter.whitelist, classCarpenter.classloader)
+class SerializerFactoryExternalCarpenter(classCarpenter: ClassCarpenter)
+    : SerializerFactory (classCarpenter.whitelist, classCarpenter)
 
 open class AmqpCarpenterBase(whitelist: ClassWhitelist) {
-    var cc = ClassCarpenter(whitelist = whitelist)
+    var cc = ClassCarpenterImpl(whitelist = whitelist)
     var factory = SerializerFactoryExternalCarpenter(cc)
 
     fun serialise(clazz: Any) = SerializationOutput(factory).serialize(clazz)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenterWhitelistTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/ClassCarpenterWhitelistTest.kt
@@ -16,14 +16,14 @@ class ClassCarpenterWhitelistTest {
         data class A(val a: Int)
 
         class WL : ClassWhitelist {
-            private val allowedClasses = hashSetOf<String>(
+            private val allowedClasses = setOf<String>(
                     A::class.java.name
             )
 
             override fun hasListed(type: Class<*>): Boolean = type.name in allowedClasses
         }
 
-        val cc = ClassCarpenter(whitelist = WL())
+        val cc = ClassCarpenterImpl(whitelist = WL())
 
         // if this works, the test works, if it throws then we're in a world of pain, we could
         // go further but there are a lot of other tests that test weather we can build
@@ -41,7 +41,7 @@ class ClassCarpenterWhitelistTest {
             override fun hasListed(type: Class<*>) = false
         }
 
-        val cc = ClassCarpenter(whitelist = WL())
+        val cc = ClassCarpenterImpl(whitelist = WL())
 
         // Class A isn't on the whitelist, so we should fail to carpent it
         Assertions.assertThatThrownBy {
@@ -59,7 +59,7 @@ class ClassCarpenterWhitelistTest {
             override fun hasListed(type: Class<*>) = false
         }
 
-        val cc = ClassCarpenter(whitelist = WL())
+        val cc = ClassCarpenterImpl(whitelist = WL())
 
         // again, simply not throwing here is enough to show the test worked and the carpenter
         // didn't reject the type even though it wasn't on the whitelist because it was
@@ -76,7 +76,7 @@ class ClassCarpenterWhitelistTest {
             override fun hasListed(type: Class<*>) = type.name == "int"
         }
 
-        val cc = ClassCarpenter(whitelist = WL())
+        val cc = ClassCarpenterImpl(whitelist = WL())
 
         val schema1a = ClassSchema("thing1a", mapOf("a" to NonNullableField(Int::class.java)))
 

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt
@@ -4,11 +4,11 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.nodeapi.internal.serialization.AllWhitelist
 import net.corda.nodeapi.internal.serialization.amqp.CompositeType
 import net.corda.nodeapi.internal.serialization.amqp.DeserializationInput
+import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import net.corda.nodeapi.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
 
 @CordaSerializable
 interface I_ {
@@ -118,7 +118,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
 
         assertEquals(1, carpenterSchema.size)
 
-        val metaCarpenter = MetaCarpenter(carpenterSchema, ClassCarpenter(whitelist = AllWhitelist))
+        val metaCarpenter = MetaCarpenter(carpenterSchema, ClassCarpenterImpl(whitelist = AllWhitelist))
 
         metaCarpenter.build()
 
@@ -153,7 +153,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         assertEquals(1, carpenterSchema.dependsOn.size)
         assert(mangleName(classTestName("A")) in carpenterSchema.dependsOn)
 
-        val metaCarpenter = TestMetaCarpenter(carpenterSchema, ClassCarpenter(whitelist = AllWhitelist))
+        val metaCarpenter = TestMetaCarpenter(carpenterSchema, ClassCarpenterImpl(whitelist = AllWhitelist))
 
         assertEquals(0, metaCarpenter.objects.size)
 
@@ -254,7 +254,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
 
         val carpenterSchema = obj.envelope.schema.mangleNames(listOf(classTestName("A"), classTestName("B")))
         TestMetaCarpenter(carpenterSchema.carpenterSchema(
-                ClassLoader.getSystemClassLoader()), ClassCarpenter(whitelist = AllWhitelist))
+                ClassLoader.getSystemClassLoader()), ClassCarpenterImpl(whitelist = AllWhitelist))
     }
 
     /*

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/EnumClassTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/EnumClassTests.kt
@@ -85,7 +85,7 @@ class EnumClassTests : AmqpCarpenterBase(AllWhitelist) {
     // exception, hence the lack of asserts
     @Test
     fun assignAndTest() {
-        val cc2 = ClassCarpenter(whitelist = AllWhitelist)
+        val cc2 = ClassCarpenterImpl(whitelist = AllWhitelist)
 
         val schema1 = EnumSchema("gen.enum",
                 listOf("AAA", "BBB", "CCC", "DDD", "EEE", "FFF").associateBy({ it }, { EnumField() }))

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/InheritanceSchemaToClassCarpenterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/InheritanceSchemaToClassCarpenterTests.kt
@@ -63,7 +63,7 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertEquals(1, aSchema.interfaces.size)
         assertEquals(J::class.java, aSchema.interfaces[0])
 
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val objJ = aBuilder.constructors[0].newInstance(testJ)
         val j = objJ as J
 
@@ -108,7 +108,7 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertEquals(1, aSchema.interfaces.size)
         assertEquals(J::class.java, aSchema.interfaces[0])
 
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val objJ = aBuilder.constructors[0].newInstance(testJ, testJJ)
         val j = objJ as J
 
@@ -156,7 +156,7 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertTrue(I::class.java in aSchema.interfaces)
         assertTrue(II::class.java in aSchema.interfaces)
 
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val objA = aBuilder.constructors[0].newInstance(testI, testII)
         val i = objA as I
         val ii = objA as II
@@ -202,7 +202,7 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertTrue(I::class.java in aSchema.interfaces)
         assertTrue(III::class.java in aSchema.interfaces)
 
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val objA = aBuilder.constructors[0].newInstance(testI, testIII)
         val i = objA as I
         val iii = objA as III
@@ -249,8 +249,8 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertNotEquals(null, aCarpenterSchema)
         assertNotEquals(null, bCarpenterSchema)
 
-        val cc = ClassCarpenter(whitelist = AllWhitelist)
-        val cc2 = ClassCarpenter(whitelist = AllWhitelist)
+        val cc = ClassCarpenterImpl(whitelist = AllWhitelist)
+        val cc2 = ClassCarpenterImpl(whitelist = AllWhitelist)
         val bBuilder = cc.build(bCarpenterSchema!!)
         bBuilder.constructors[0].newInstance(a, testIIII)
 
@@ -334,7 +334,7 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertEquals(1, carpenterSchema.dependsOn[iName]!!.size)
         assertEquals(aName, carpenterSchema.dependsOn[iName]!![0])
 
-        val mc = MetaCarpenter(carpenterSchema, ClassCarpenter(whitelist = AllWhitelist))
+        val mc = MetaCarpenter(carpenterSchema, ClassCarpenterImpl(whitelist = AllWhitelist))
         mc.build()
 
         assertEquals(0, mc.schemas.carpenterSchemas.size)
@@ -387,7 +387,7 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertNotNull(carpenterSchema.dependencies[aName]!!.second.find { it == iName })
         assertNotNull(carpenterSchema.dependencies[aName]!!.second.find { it == iiName })
 
-        val mc = MetaCarpenter(carpenterSchema, ClassCarpenter(whitelist = AllWhitelist))
+        val mc = MetaCarpenter(carpenterSchema, ClassCarpenterImpl(whitelist = AllWhitelist))
         mc.build()
 
         assertEquals(0, mc.schemas.carpenterSchemas.size)
@@ -447,7 +447,7 @@ class InheritanceSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhitelist) {
         assertNotNull(carpenterSchema.dependencies[aName]!!.second.find { it == iiiName })
         assertNotNull(carpenterSchema.dependencies[aName]!!.second.find { it == iName })
 
-        val mc = MetaCarpenter(carpenterSchema, ClassCarpenter(whitelist = AllWhitelist))
+        val mc = MetaCarpenter(carpenterSchema, ClassCarpenterImpl(whitelist = AllWhitelist))
         mc.build()
 
         assertEquals(0, mc.schemas.carpenterSchemas.size)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
@@ -48,7 +48,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
 
         assertNotEquals(null, aSchema)
 
-        val pinochio = ClassCarpenter(whitelist = AllWhitelist).build(aSchema!!)
+        val pinochio = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema!!)
         val p = pinochio.constructors[0].newInstance(testA, testB)
 
         assertEquals(pinochio.getMethod("getA").invoke(p), amqpObj.a)
@@ -92,7 +92,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
 
         assertNotEquals(null, aSchema)
 
-        val pinochio = ClassCarpenter(whitelist = AllWhitelist).build(aSchema!!)
+        val pinochio = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema!!)
         val p = pinochio.constructors[0].newInstance(testA, testB)
 
         assertEquals(pinochio.getMethod("getA").invoke(p), amqpObj.a)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt
@@ -38,7 +38,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
                 force = true)
 
         val aSchema = carpenterSchema.carpenterSchemas.find { it.name == classTestName("A") }!!
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val p = aBuilder.constructors[0].newInstance(test)
 
         assertEquals(aBuilder.getMethod("getA").invoke(p), amqpObj.a)
@@ -69,7 +69,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
                 force = true)
 
         val aSchema = carpenterSchema.carpenterSchemas.find { it.name == classTestName("A") }!!
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val p = aBuilder.constructors[0].newInstance(test)
 
         assertEquals(aBuilder.getMethod("getA").invoke(p), amqpObj.a)
@@ -104,7 +104,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
                 force = true)
 
         val aSchema = carpenterSchema.carpenterSchemas.find { it.name == classTestName("A") }!!
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val p = aBuilder.constructors[0].newInstance(test)
 
         assertEquals(aBuilder.getMethod("getA").invoke(p), amqpObj.a)
@@ -139,7 +139,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
                 force = true)
 
         val aSchema = carpenterSchema.carpenterSchemas.find { it.name == classTestName("A") }!!
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val p = aBuilder.constructors[0].newInstance(test)
 
         assertEquals(aBuilder.getMethod("getA").invoke(p), amqpObj.a)
@@ -174,7 +174,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
                 force = true)
 
         val aSchema = carpenterSchema.carpenterSchemas.find { it.name == classTestName("A") }!!
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val p = aBuilder.constructors[0].newInstance(test)
 
         assertEquals(aBuilder.getMethod("getA").invoke(p), amqpObj.a)
@@ -209,7 +209,7 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
                 force = true)
 
         val aSchema = carpenterSchema.carpenterSchemas.find { it.name == classTestName("A") }!!
-        val aBuilder = ClassCarpenter(whitelist = AllWhitelist).build(aSchema)
+        val aBuilder = ClassCarpenterImpl(whitelist = AllWhitelist).build(aSchema)
         val p = aBuilder.constructors[0].newInstance(test)
 
         assertEquals(aBuilder.getMethod("getA").invoke(p), amqpObj.a)


### PR DESCRIPTION
The DJVM will want to drop the Class Carpenter, so abstract it behind some interfaces. More precisely:
- `ClassCarpenter` -> `ClassCarpenterImpl`
- `SerializerFactoryFactory` -> `SerializerFactoryFactoryImpl`

with new interfaces `ClassCarpenter` and `SerializerFactoryFactory`.

Also fix up some warnings in the unit tests.