### PR TITLE
CORDA-1476 Adding TLS certificate CRL extension point configs

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -205,6 +205,10 @@ absolute path to the node's base directory.
 
             .. note:: This is temporary feature for onboarding network participants that limits their visibility for privacy reasons.
 
+:tlsCertCrlDistPoint: CRL distribution point (i.e. URL) for the TLS certificate. Default value is NULL.
+
+:tlsCertCrlIssuer: CRL issuer (given in the X500 name format) for the TLS certificate. Default value is NULL.
+
 Examples
 --------
 

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -52,6 +52,8 @@ interface NodeConfiguration : NodeSSLConfiguration {
     // do not change this value without syncing it with ScheduledFlowsDrainingModeTest
     val drainingModePollPeriod: Duration get() = Duration.ofSeconds(5)
     val extraNetworkMapKeys: List<UUID>
+    val tlsCertCrlDistPoint: URL?
+    val tlsCertCrlIssuer: String?
 
     fun validate(): List<String>
 
@@ -132,6 +134,8 @@ data class NodeConfigurationImpl(
         override val crlCheckSoftFail: Boolean,
         override val dataSourceProperties: Properties,
         override val compatibilityZoneURL: URL? = null,
+        override val tlsCertCrlDistPoint: URL? = null,
+        override val tlsCertCrlIssuer: String? = null,
         override val rpcUsers: List<User>,
         override val security: SecurityConfiguration? = null,
         override val verifierType: VerifierType,

--- a/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/config/NodeConfigurationImplTest.kt
@@ -147,7 +147,8 @@ class NodeConfigurationImplTest {
                 devMode = true,
                 noLocalShell = false,
                 rpcSettings = rpcSettings,
-                crlCheckSoftFail = true
+                crlCheckSoftFail = true,
+                tlsCertCrlDistPoint = null
         )
     }
 }

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -58,6 +58,8 @@ class NetworkRegistrationHelperTest {
             doReturn("cordacadevpass").whenever(it).keyStorePassword
             doReturn(nodeLegalName).whenever(it).myLegalName
             doReturn("").whenever(it).emailAddress
+            doReturn(null).whenever(it).tlsCertCrlDistPoint
+            doReturn(null).whenever(it).tlsCertCrlIssuer
         }
     }
 


### PR DESCRIPTION
This PR extends node configuration file with 2 additional parameters related to the TLS-level certificate CRL configuration.
