### PR TITLE
Remove duplicate Netty classes from Node.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,10 @@ allprojects {
             // We want to use SLF4J's version of these bindings: jcl-over-slf4j
             // Remove any transitive dependency on Apache's version.
             exclude group: 'commons-logging', module: 'commons-logging'
+
+            // Netty-All is an uber-jar which contains every Netty module.
+            // Exclude it to force us to use the individual Netty modules instead.
+            exclude group: 'io.netty', module: 'netty-all'
         }
         runtime {
             // We never want isolated.jar on classPath, since we want to test jar being dynamically loaded as an attachment

--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,13 @@ allprojects {
                 force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
                 force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
                 force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+
+                // Demand that everything uses our given version of Netty.
+                eachDependency { details ->
+                    if (details.requested.group == 'io.netty' && details.requested.name.startsWith('netty-')) {
+                        details.useVersion netty_version
+                    }
+                }
             }
         }
         compile {

--- a/node-api/build.gradle
+++ b/node-api/build.gradle
@@ -18,9 +18,6 @@ dependencies {
     compile "org.apache.activemq:artemis-core-client:${artemis_version}"
     compile "org.apache.activemq:artemis-commons:${artemis_version}"
 
-    // Netty: All of it.
-    compile "io.netty:netty-all:$netty_version"
-
     // For adding serialisation of file upload streams to RPC
     // TODO: Remove this dependency and the code that requires it
     compile "commons-fileupload:commons-fileupload:$fileupload_version"
@@ -54,7 +51,7 @@ dependencies {
 }
 
 configurations {
-        testArtifacts.extendsFrom testRuntime
+    testArtifacts.extendsFrom testRuntime
 }
 
 task testJar(type: Jar) {

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -19,12 +19,6 @@ buildscript {
 
 //noinspection GroovyAssignabilityCheck
 configurations {
-    compile {
-        // We don't need these because we already include netty-all.
-        exclude group: 'io.netty', module: 'netty-transport'
-        exclude group: 'io.netty', module: 'netty-handler'
-    }
-
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
 }


### PR DESCRIPTION
Artemis includes Netty piecemeal, but we prefer to include `netty-all` instead. This means that we end up with _two_ copies of the Netty classes because Gradle is unaware of the overlap.

Fix this by excluding `netty-all` from every module. This will force us to specify precisely which pieces of Netty we wish to use.