### PR TITLE
ENT-1463: Hide more AMQP ConcurrentHashMaps behind interfaces.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/SerializationScheme.kt
@@ -92,7 +92,12 @@ internal class AttachmentsClassLoaderBuilder(private val properties: Map<Any, An
     }
 }
 
-open class SerializationFactoryImpl : SerializationFactory() {
+open class SerializationFactoryImpl(
+    // TODO: This is read-mostly. Probably a faster implementation to be found.
+    private val schemes: MutableMap<Pair<CordaSerializationMagic, SerializationContext.UseCase>, SerializationScheme>
+) : SerializationFactory() {
+    constructor() : this(ConcurrentHashMap())
+
     companion object {
         val magicSize = sequenceOf(kryoMagic, amqpMagic).map { it.size }.distinct().single()
     }
@@ -102,9 +107,6 @@ open class SerializationFactoryImpl : SerializationFactory() {
     private val registeredSchemes: MutableCollection<SerializationScheme> = Collections.synchronizedCollection(mutableListOf())
 
     private val logger = LoggerFactory.getLogger(javaClass)
-
-    // TODO: This is read-mostly. Probably a faster implementation to be found.
-    private val schemes: ConcurrentHashMap<Pair<CordaSerializationMagic, SerializationContext.UseCase>, SerializationScheme> = ConcurrentHashMap()
 
     private fun schemeFor(byteSequence: ByteSequence, target: SerializationContext.UseCase): Pair<SerializationScheme, CordaSerializationMagic> {
         // truncate sequence to at most magicSize, and make sure it's a copy to avoid holding onto large ByteArrays

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializationScheme.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/AMQPSerializationScheme.kt
@@ -35,10 +35,11 @@ interface SerializerFactoryFactory {
 }
 
 abstract class AbstractAMQPSerializationScheme(
-        private val cordappCustomSerializers: Set<SerializationCustomSerializer<*,*>>,
-        val sff: SerializerFactoryFactory = createSerializerFactoryFactory()
+    private val cordappCustomSerializers: Set<SerializationCustomSerializer<*,*>>,
+    private val serializerFactoriesForContexts: MutableMap<Pair<ClassWhitelist, ClassLoader>, SerializerFactory>,
+    val sff: SerializerFactoryFactory = createSerializerFactoryFactory()
 ) : SerializationScheme {
-    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers)
+    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers, ConcurrentHashMap())
 
     // TODO: This method of initialisation for the Whitelist and plugin serializers will have to change
     // when we have per-cordapp contexts and dynamic app reloading but for now it's the easiest way
@@ -128,8 +129,6 @@ abstract class AbstractAMQPSerializationScheme(
         }
     }
 
-    private val serializerFactoriesForContexts = ConcurrentHashMap<Pair<ClassWhitelist, ClassLoader>, SerializerFactory>()
-
     protected abstract fun rpcClientSerializerFactory(context: SerializationContext): SerializerFactory
     protected abstract fun rpcServerSerializerFactory(context: SerializationContext): SerializerFactory
     protected open val publicKeySerializer: CustomSerializer.Implements<PublicKey> = net.corda.nodeapi.internal.serialization.amqp.custom.PublicKeySerializer
@@ -165,9 +164,13 @@ abstract class AbstractAMQPSerializationScheme(
 }
 
 // TODO: This will eventually cover server RPC as well and move to node module, but for now this is not implemented
-class AMQPServerSerializationScheme(cordappCustomSerializers: Set<SerializationCustomSerializer<*, *>> = emptySet())
-    : AbstractAMQPSerializationScheme(cordappCustomSerializers) {
-    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers)
+class AMQPServerSerializationScheme(
+    cordappCustomSerializers: Set<SerializationCustomSerializer<*, *>>,
+    serializerFactoriesForContexts: MutableMap<Pair<ClassWhitelist, ClassLoader>, SerializerFactory>
+) : AbstractAMQPSerializationScheme(cordappCustomSerializers, serializerFactoriesForContexts) {
+    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers, ConcurrentHashMap())
+
+    constructor() : this(emptySet(), ConcurrentHashMap())
 
     override fun rpcClientSerializerFactory(context: SerializationContext): SerializerFactory {
         throw UnsupportedOperationException()
@@ -185,9 +188,13 @@ class AMQPServerSerializationScheme(cordappCustomSerializers: Set<SerializationC
 }
 
 // TODO: This will eventually cover client RPC as well and move to client module, but for now this is not implemented
-class AMQPClientSerializationScheme(cordappCustomSerializers: Set<SerializationCustomSerializer<*,*>> = emptySet())
-    : AbstractAMQPSerializationScheme(cordappCustomSerializers) {
-    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers)
+class AMQPClientSerializationScheme(
+    cordappCustomSerializers: Set<SerializationCustomSerializer<*,*>>,
+    serializerFactoriesForContexts: MutableMap<Pair<ClassWhitelist, ClassLoader>, SerializerFactory>
+) : AbstractAMQPSerializationScheme(cordappCustomSerializers, serializerFactoriesForContexts) {
+    constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers, ConcurrentHashMap())
+
+    constructor() : this(emptySet(), ConcurrentHashMap())
 
     override fun rpcClientSerializerFactory(context: SerializationContext): SerializerFactory {
         throw UnsupportedOperationException()

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationSchemaTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializationSchemaTests.kt
@@ -4,6 +4,7 @@ import net.corda.core.serialization.*
 import net.corda.core.utilities.ByteSequence
 import net.corda.nodeapi.internal.serialization.*
 import org.junit.Test
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.assertEquals
 
 // Make sure all serialization calls in this test don't get stomped on by anything else
@@ -43,7 +44,7 @@ class TestSerializerFactoryFactory : SerializerFactoryFactoryImpl() {
             }
 }
 
-class AMQPTestSerializationScheme : AbstractAMQPSerializationScheme(emptySet(), TestSerializerFactoryFactory()) {
+class AMQPTestSerializationScheme : AbstractAMQPSerializationScheme(emptySet(), ConcurrentHashMap(), TestSerializerFactoryFactory()) {
     override fun rpcClientSerializerFactory(context: SerializationContext): SerializerFactory {
         throw UnsupportedOperationException()
     }


### PR DESCRIPTION
`ConcurrentHashMap` has been deleted from the DJVM, so allow it to be replaced with an ordinary `HashMap`.