### PR TITLE
CORDA-1280 Update api-current from v3.2 and use most recent version of api-scanner

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6501,22 +6501,27 @@ public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
 ##
 public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
 ##
-public final class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
-  public <init>(java.time.Duration)
+public interface net.corda.client.rpc.CordaRPCClientConfiguration
+  public abstract int getCacheConcurrencyLevel()
   @NotNull
-  public final java.time.Duration component1()
+  public abstract java.time.Duration getConnectionMaxRetryInterval()
   @NotNull
-  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration)
-  public boolean equals(Object)
+  public abstract java.time.Duration getConnectionRetryInterval()
+  public abstract double getConnectionRetryIntervalMultiplier()
   @NotNull
-  public final java.time.Duration getConnectionMaxRetryInterval()
-  public int hashCode()
-  public String toString()
+  public abstract java.time.Duration getDeduplicationCacheExpiry()
+  public abstract int getMaxFileSize()
+  public abstract int getMaxReconnectAttempts()
+  public abstract int getMinimumServerProtocolVersion()
+  public abstract int getObservationExecutorPoolSize()
+  @NotNull
+  public abstract java.time.Duration getReapInterval()
+  public abstract boolean getTrackRpcCallSites()
   public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
-  @NotNull
-  public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
 ##
 public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration default()
 ##
 @DoNotImplement
 public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1804,7 +1804,7 @@ public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING
   public static final net.corda.core.flows.FinalityFlow$Companion$NOTARISING INSTANCE
 ##
 @CordaSerializable
-public class net.corda.core.flows.FlowException extends net.corda.core.CordaException
+public class net.corda.core.flows.FlowException extends net.corda.core.CordaException implements net.corda.core.flows.IdentifiableException
   public <init>()
   public <init>(String)
   public <init>(String, Throwable)
@@ -2408,7 +2408,7 @@ public final class net.corda.core.flows.TransactionParts extends java.lang.Objec
   public String toString()
 ##
 @CordaSerializable
-public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException
+public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
   public <init>(String)
   public <init>(String, Throwable)
 ##

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6170,6 +6170,8 @@ public class net.corda.testing.node.MockNetwork extends java.lang.Object
   @NotNull
   public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
   @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>, java.util.List<String>)
+  @NotNull
   public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
   @NotNull
   public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
@@ -6183,6 +6185,8 @@ public class net.corda.testing.node.MockNetwork extends java.lang.Object
   public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
   @NotNull
   public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>, java.util.List<String>)
   @NotNull
   public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
   @NotNull
@@ -6263,6 +6267,7 @@ public final class net.corda.testing.node.MockNetworkParameters extends java.lan
 public final class net.corda.testing.node.MockNodeParameters extends java.lang.Object
   public <init>()
   public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>, java.util.List<String>)
   @Nullable
   public final Integer component1()
   @Nullable
@@ -6273,6 +6278,8 @@ public final class net.corda.testing.node.MockNodeParameters extends java.lang.O
   public final kotlin.jvm.functions.Function1<net.corda.node.services.config.NodeConfiguration, Object> component4()
   @NotNull
   public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>, java.util.List<String>)
   public boolean equals(Object)
   @NotNull
   public final kotlin.jvm.functions.Function1<net.corda.node.services.config.NodeConfiguration, Object> getConfigOverrides()

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1,44 +1,60 @@
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.CordaException extends java.lang.Exception implements net.corda.core.CordaThrowable
+@CordaSerializable
+public class net.corda.core.CordaException extends java.lang.Exception implements net.corda.core.CordaThrowable
   public <init>()
   public <init>(String)
   public <init>(String, String, Throwable)
   public <init>(String, Throwable)
   public void addSuppressed(Throwable[])
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public Throwable getCause()
-  @org.jetbrains.annotations.Nullable public String getMessage()
-  @org.jetbrains.annotations.Nullable public String getOriginalExceptionClassName()
-  @org.jetbrains.annotations.Nullable public String getOriginalMessage()
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
   public int hashCode()
   public void setCause(Throwable)
   public void setMessage(String)
   public void setOriginalExceptionClassName(String)
 ##
 public final class net.corda.core.CordaOID extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final String CORDA_PLATFORM = "1.3.6.1.4.1.50530.1"
+  @NotNull
+  public static final String CORDA_PLATFORM = "1.3.6.1.4.1.50530.1"
   public static final net.corda.core.CordaOID INSTANCE
-  @org.jetbrains.annotations.NotNull public static final String R3_ROOT = "1.3.6.1.4.1.50530"
-  @org.jetbrains.annotations.NotNull public static final String X509_EXTENSION_CORDA_ROLE = "1.3.6.1.4.1.50530.1.1"
+  @NotNull
+  public static final String R3_ROOT = "1.3.6.1.4.1.50530"
+  @NotNull
+  public static final String X509_EXTENSION_CORDA_ROLE = "1.3.6.1.4.1.50530.1.1"
 ##
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.CordaRuntimeException extends java.lang.RuntimeException implements net.corda.core.CordaThrowable
+@CordaSerializable
+public class net.corda.core.CordaRuntimeException extends java.lang.RuntimeException implements net.corda.core.CordaThrowable
   public <init>(String)
   public <init>(String, String, Throwable)
   public <init>(String, Throwable)
   public void addSuppressed(Throwable[])
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public Throwable getCause()
-  @org.jetbrains.annotations.Nullable public String getMessage()
-  @org.jetbrains.annotations.Nullable public String getOriginalExceptionClassName()
-  @org.jetbrains.annotations.Nullable public String getOriginalMessage()
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
   public int hashCode()
   public void setCause(Throwable)
   public void setMessage(String)
   public void setOriginalExceptionClassName(String)
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.CordaThrowable
+@CordaSerializable
+public interface net.corda.core.CordaThrowable
   public abstract void addSuppressed(Throwable[])
-  @org.jetbrains.annotations.Nullable public abstract String getOriginalExceptionClassName()
-  @org.jetbrains.annotations.Nullable public abstract String getOriginalMessage()
+  @Nullable
+  public abstract String getOriginalExceptionClassName()
+  @Nullable
+  public abstract String getOriginalMessage()
   public abstract void setCause(Throwable)
   public abstract void setMessage(String)
   public abstract void setOriginalExceptionClassName(String)
@@ -46,383 +62,599 @@ public final class net.corda.core.CordaOID extends java.lang.Object
 public @interface net.corda.core.DoNotImplement
 ##
 public final class net.corda.core.Utils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.concurrent.CordaFuture toFuture(rx.Observable)
-  @org.jetbrains.annotations.NotNull public static final rx.Observable toObservable(net.corda.core.concurrent.CordaFuture)
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<T> toFuture(rx.Observable<T>)
+  @NotNull
+  public static final rx.Observable<A> toObservable(net.corda.core.concurrent.CordaFuture<? extends A>)
 ##
 public final class net.corda.core.concurrent.ConcurrencyUtils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.concurrent.CordaFuture firstOf(net.corda.core.concurrent.CordaFuture[], kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.concurrent.CordaFuture firstOf(net.corda.core.concurrent.CordaFuture[], org.slf4j.Logger, kotlin.jvm.functions.Function1)
-  public static final Object match(concurrent.Future, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final String shortCircuitedTaskFailedMessage = "Short-circuited task failed:"
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<W> firstOf(net.corda.core.concurrent.CordaFuture<? extends V>[], kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<? extends V>, ? extends W>)
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<W> firstOf(net.corda.core.concurrent.CordaFuture<? extends V>[], org.slf4j.Logger, kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<? extends V>, ? extends W>)
+  public static final W match(java.util.concurrent.Future<V>, kotlin.jvm.functions.Function1<? super V, ? extends W>, kotlin.jvm.functions.Function1<? super Throwable, ? extends W>)
+  @NotNull
+  public static final String shortCircuitedTaskFailedMessage = "Short-circuited task failed:"
 ##
 public interface net.corda.core.concurrent.CordaFuture extends java.util.concurrent.Future
-  public abstract void then(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public abstract concurrent.CompletableFuture toCompletableFuture()
+  public abstract void then(kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<V>, ? extends W>)
+  @NotNull
+  public abstract java.util.concurrent.CompletableFuture<V> toCompletableFuture()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.context.Actor extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.context.Actor extends java.lang.Object
   public <init>(net.corda.core.context.Actor$Id, net.corda.core.context.AuthServiceId, net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Actor$Id component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.AuthServiceId component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Actor copy(net.corda.core.context.Actor$Id, net.corda.core.context.AuthServiceId, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.context.Actor$Id component1()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId component2()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component3()
+  @NotNull
+  public final net.corda.core.context.Actor copy(net.corda.core.context.Actor$Id, net.corda.core.context.AuthServiceId, net.corda.core.identity.CordaX500Name)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Actor$Id getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.AuthServiceId getServiceId()
+  @NotNull
+  public final net.corda.core.context.Actor$Id getId()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId getServiceId()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
   public String toString()
   public static final net.corda.core.context.Actor$Companion Companion
 ##
 public static final class net.corda.core.context.Actor$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.Actor$Id extends java.lang.Object
+@CordaSerializable
+public static final class net.corda.core.context.Actor$Id extends java.lang.Object
   public <init>(String)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Actor$Id copy(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.context.Actor$Id copy(String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getValue()
+  @NotNull
+  public final String getValue()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.context.AuthServiceId extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.context.AuthServiceId extends java.lang.Object
   public <init>(String)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.AuthServiceId copy(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId copy(String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getValue()
+  @NotNull
+  public final String getValue()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.context.InvocationContext extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.context.InvocationContext extends java.lang.Object
   public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationOrigin component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace component2()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.context.Actor component3()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.context.Trace component4()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.context.Actor component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext copy(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin component1()
+  @NotNull
+  public final net.corda.core.context.Trace component2()
+  @Nullable
+  public final net.corda.core.context.Actor component3()
+  @Nullable
+  public final net.corda.core.context.Trace component4()
+  @Nullable
+  public final net.corda.core.context.Actor component5()
+  @NotNull
+  public final net.corda.core.context.InvocationContext copy(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.context.Actor getActor()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.context.Trace getExternalTrace()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.context.Actor getImpersonatedActor()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationOrigin getOrigin()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace getTrace()
+  @Nullable
+  public final net.corda.core.context.Actor getActor()
+  @Nullable
+  public final net.corda.core.context.Trace getExternalTrace()
+  @Nullable
+  public final net.corda.core.context.Actor getImpersonatedActor()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin getOrigin()
+  @NotNull
+  public final net.corda.core.context.Trace getTrace()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public final java.security.Principal principal()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final java.security.Principal principal()
+  @NotNull
+  public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
   public String toString()
   public static final net.corda.core.context.InvocationContext$Companion Companion
 ##
 public static final class net.corda.core.context.InvocationContext$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.context.InvocationOrigin extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public abstract java.security.Principal principal()
+@CordaSerializable
+public abstract class net.corda.core.context.InvocationOrigin extends java.lang.Object
+  @NotNull
+  public abstract java.security.Principal principal()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.InvocationOrigin$Peer extends net.corda.core.context.InvocationOrigin
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Peer extends net.corda.core.context.InvocationOrigin
   public <init>(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationOrigin$Peer copy(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Peer copy(net.corda.core.identity.CordaX500Name)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getParty()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getParty()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public java.security.Principal principal()
+  @NotNull
+  public java.security.Principal principal()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.InvocationOrigin$RPC extends net.corda.core.context.InvocationOrigin
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$RPC extends net.corda.core.context.InvocationOrigin
   public <init>(net.corda.core.context.Actor)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationOrigin$RPC copy(net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$RPC copy(net.corda.core.context.Actor)
   public boolean equals(Object)
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public java.security.Principal principal()
+  @NotNull
+  public java.security.Principal principal()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.InvocationOrigin$Scheduled extends net.corda.core.context.InvocationOrigin
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Scheduled extends net.corda.core.context.InvocationOrigin
   public <init>(net.corda.core.contracts.ScheduledStateRef)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ScheduledStateRef component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationOrigin$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public java.security.Principal principal()
+  @NotNull
+  public java.security.Principal principal()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.InvocationOrigin$Service extends net.corda.core.context.InvocationOrigin
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Service extends net.corda.core.context.InvocationOrigin
   public <init>(String, net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationOrigin$Service copy(String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Service copy(String, net.corda.core.identity.CordaX500Name)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
-  @org.jetbrains.annotations.NotNull public final String getServiceClassName()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
+  @NotNull
+  public final String getServiceClassName()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public java.security.Principal principal()
+  @NotNull
+  public java.security.Principal principal()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.InvocationOrigin$Shell extends net.corda.core.context.InvocationOrigin
-  @org.jetbrains.annotations.NotNull public java.security.Principal principal()
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Shell extends net.corda.core.context.InvocationOrigin
+  @NotNull
+  public java.security.Principal principal()
   public static final net.corda.core.context.InvocationOrigin$Shell INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.context.Trace extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.context.Trace extends java.lang.Object
   public <init>(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace$InvocationId component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace$SessionId component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace copy(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId component1()
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId component2()
+  @NotNull
+  public final net.corda.core.context.Trace copy(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace$InvocationId getInvocationId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace$SessionId getSessionId()
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId getInvocationId()
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId getSessionId()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  @NotNull
+  public static final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
   public String toString()
   public static final net.corda.core.context.Trace$Companion Companion
 ##
 public static final class net.corda.core.context.Trace$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  @NotNull
+  public final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.Trace$InvocationId extends net.corda.core.utilities.Id
+@CordaSerializable
+public static final class net.corda.core.context.Trace$InvocationId extends net.corda.core.utilities.Id
   public <init>(String, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
+  @NotNull
+  public static final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
   public static final net.corda.core.context.Trace$InvocationId$Companion Companion
 ##
 public static final class net.corda.core.context.Trace$InvocationId$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.context.Trace$SessionId extends net.corda.core.utilities.Id
+@CordaSerializable
+public static final class net.corda.core.context.Trace$SessionId extends net.corda.core.utilities.Id
   public <init>(String, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
+  @NotNull
+  public static final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
   public static final net.corda.core.context.Trace$SessionId$Companion Companion
 ##
 public static final class net.corda.core.context.Trace$SessionId$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.AlwaysAcceptAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AlwaysAcceptAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public static final net.corda.core.contracts.AlwaysAcceptAttachmentConstraint INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.Amount extends java.lang.Object implements java.lang.Comparable
-  public <init>(long, Object)
-  public <init>(long, java.math.BigDecimal, Object)
-  public int compareTo(net.corda.core.contracts.Amount)
+@CordaSerializable
+public final class net.corda.core.contracts.Amount extends java.lang.Object implements java.lang.Comparable
+  public <init>(long, T)
+  public <init>(long, java.math.BigDecimal, T)
+  public int compareTo(net.corda.core.contracts.Amount<T>)
   public final long component1()
-  @org.jetbrains.annotations.NotNull public final java.math.BigDecimal component2()
-  @org.jetbrains.annotations.NotNull public final Object component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount copy(long, java.math.BigDecimal, Object)
+  @NotNull
+  public final java.math.BigDecimal component2()
+  @NotNull
+  public final T component3()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> copy(long, java.math.BigDecimal, T)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Amount fromDecimal(java.math.BigDecimal, Object)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Amount fromDecimal(java.math.BigDecimal, Object, java.math.RoundingMode)
-  @org.jetbrains.annotations.NotNull public final java.math.BigDecimal getDisplayTokenSize()
-  @org.jetbrains.annotations.NotNull public static final java.math.BigDecimal getDisplayTokenSize(Object)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T, java.math.RoundingMode)
+  @NotNull
+  public final java.math.BigDecimal getDisplayTokenSize()
+  @NotNull
+  public static final java.math.BigDecimal getDisplayTokenSize(Object)
   public final long getQuantity()
-  @org.jetbrains.annotations.NotNull public final Object getToken()
+  @NotNull
+  public final T getToken()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount minus(net.corda.core.contracts.Amount)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Amount parseCurrency(String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount plus(net.corda.core.contracts.Amount)
-  @org.jetbrains.annotations.NotNull public final List splitEvenly(int)
-  @org.jetbrains.annotations.Nullable public static final net.corda.core.contracts.Amount sumOrNull(Iterable)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Amount sumOrThrow(Iterable)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Amount sumOrZero(Iterable, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount times(int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount times(long)
-  @org.jetbrains.annotations.NotNull public final java.math.BigDecimal toDecimal()
-  @org.jetbrains.annotations.NotNull public String toString()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Amount zero(Object)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> minus(net.corda.core.contracts.Amount<T>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<java.util.Currency> parseCurrency(String)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> plus(net.corda.core.contracts.Amount<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Amount<T>> splitEvenly(int)
+  @Nullable
+  public static final net.corda.core.contracts.Amount<T> sumOrNull(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> sumOrThrow(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> sumOrZero(Iterable<net.corda.core.contracts.Amount<T>>, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> times(int)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> times(long)
+  @NotNull
+  public final java.math.BigDecimal toDecimal()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> zero(T)
   public static final net.corda.core.contracts.Amount$Companion Companion
 ##
 public static final class net.corda.core.contracts.Amount$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount fromDecimal(java.math.BigDecimal, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount fromDecimal(java.math.BigDecimal, Object, java.math.RoundingMode)
-  @org.jetbrains.annotations.NotNull public final java.math.BigDecimal getDisplayTokenSize(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount parseCurrency(String)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.contracts.Amount sumOrNull(Iterable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount sumOrThrow(Iterable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount sumOrZero(Iterable, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount zero(Object)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T, java.math.RoundingMode)
+  @NotNull
+  public final java.math.BigDecimal getDisplayTokenSize(Object)
+  @NotNull
+  public final net.corda.core.contracts.Amount<java.util.Currency> parseCurrency(String)
+  @Nullable
+  public final net.corda.core.contracts.Amount<T> sumOrNull(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> sumOrThrow(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> sumOrZero(Iterable<net.corda.core.contracts.Amount<T>>, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> zero(T)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.AmountTransfer extends java.lang.Object
-  public <init>(long, Object, Object, Object)
-  @org.jetbrains.annotations.NotNull public final List apply(List, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.AmountTransfer copy(long, Object, Object, Object)
+@CordaSerializable
+public final class net.corda.core.contracts.AmountTransfer extends java.lang.Object
+  public <init>(long, T, P, P)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.SourceAndAmount<T, P>> apply(java.util.List<? extends net.corda.core.contracts.SourceAndAmount<T, ? extends P>>, Object)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> copy(long, T, P, P)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.AmountTransfer fromDecimal(java.math.BigDecimal, Object, Object, Object)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.AmountTransfer fromDecimal(java.math.BigDecimal, Object, Object, Object, java.math.RoundingMode)
-  @org.jetbrains.annotations.NotNull public final Object getDestination()
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P)
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P, java.math.RoundingMode)
+  @NotNull
+  public final P getDestination()
   public final long getQuantityDelta()
-  @org.jetbrains.annotations.NotNull public final Object getSource()
-  @org.jetbrains.annotations.NotNull public final Object getToken()
+  @NotNull
+  public final P getSource()
+  @NotNull
+  public final T getToken()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public final List novate(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.AmountTransfer plus(net.corda.core.contracts.AmountTransfer)
-  @org.jetbrains.annotations.NotNull public final java.math.BigDecimal toDecimal()
-  @org.jetbrains.annotations.NotNull public String toString()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.AmountTransfer zero(Object, Object, Object)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.AmountTransfer<T, P>> novate(P)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> plus(net.corda.core.contracts.AmountTransfer<T, P>)
+  @NotNull
+  public final java.math.BigDecimal toDecimal()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> zero(T, P, P)
   public static final net.corda.core.contracts.AmountTransfer$Companion Companion
 ##
 public static final class net.corda.core.contracts.AmountTransfer$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.AmountTransfer fromDecimal(java.math.BigDecimal, Object, Object, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.AmountTransfer fromDecimal(java.math.BigDecimal, Object, Object, Object, java.math.RoundingMode)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.AmountTransfer zero(Object, Object, Object)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P, java.math.RoundingMode)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> zero(T, P, P)
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.Attachment extends net.corda.core.contracts.NamedByHash
+@CordaSerializable
+public interface net.corda.core.contracts.Attachment extends net.corda.core.contracts.NamedByHash
   public abstract void extractFile(String, java.io.OutputStream)
-  @org.jetbrains.annotations.NotNull public abstract List getSigners()
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> getSigners()
   public abstract int getSize()
-  @org.jetbrains.annotations.NotNull public abstract java.io.InputStream open()
-  @org.jetbrains.annotations.NotNull public abstract jar.JarInputStream openAsJAR()
+  @NotNull
+  public abstract java.io.InputStream open()
+  @NotNull
+  public abstract java.util.jar.JarInputStream openAsJAR()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.AttachmentConstraint
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.contracts.AttachmentConstraint
   public abstract boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
+@CordaSerializable
+public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.AutomaticHashConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AutomaticHashConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public static final net.corda.core.contracts.AutomaticHashConstraint INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.Command extends java.lang.Object
-  public <init>(net.corda.core.contracts.CommandData, java.security.PublicKey)
-  public <init>(net.corda.core.contracts.CommandData, List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandData component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Command copy(net.corda.core.contracts.CommandData, List)
+@CordaSerializable
+public final class net.corda.core.contracts.Command extends java.lang.Object
+  public <init>(T, java.security.PublicKey)
+  public <init>(T, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> component2()
+  @NotNull
+  public final net.corda.core.contracts.Command<T> copy(T, java.util.List<? extends java.security.PublicKey>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getSigners()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandData getValue()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigners()
+  @NotNull
+  public final T getValue()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
 public final class net.corda.core.contracts.CommandAndState extends java.lang.Object
   public <init>(net.corda.core.contracts.CommandData, net.corda.core.contracts.OwnableState)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandData component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.OwnableState component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandAndState copy(net.corda.core.contracts.CommandData, net.corda.core.contracts.OwnableState)
+  @NotNull
+  public final net.corda.core.contracts.CommandData component1()
+  @NotNull
+  public final net.corda.core.contracts.OwnableState component2()
+  @NotNull
+  public final net.corda.core.contracts.CommandAndState copy(net.corda.core.contracts.CommandData, net.corda.core.contracts.OwnableState)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandData getCommand()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.OwnableState getOwnableState()
+  @NotNull
+  public final net.corda.core.contracts.CommandData getCommand()
+  @NotNull
+  public final net.corda.core.contracts.OwnableState getOwnableState()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.CommandData
+@CordaSerializable
+public interface net.corda.core.contracts.CommandData
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.CommandWithParties extends java.lang.Object
-  public <init>(List, List, net.corda.core.contracts.CommandData)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandData component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandWithParties copy(List, List, net.corda.core.contracts.CommandData)
+@CordaSerializable
+public final class net.corda.core.contracts.CommandWithParties extends java.lang.Object
+  public <init>(java.util.List<? extends java.security.PublicKey>, java.util.List<net.corda.core.identity.Party>, T)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> component2()
+  @NotNull
+  public final T component3()
+  @NotNull
+  public final net.corda.core.contracts.CommandWithParties<T> copy(java.util.List<? extends java.security.PublicKey>, java.util.List<net.corda.core.identity.Party>, T)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getSigners()
-  @org.jetbrains.annotations.NotNull public final List getSigningParties()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.CommandData getValue()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigners()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> getSigningParties()
+  @NotNull
+  public final T getValue()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.core.contracts.ComponentGroupEnum extends java.lang.Enum
-  protected <init>(String, int)
+  protected <init>()
   public static net.corda.core.contracts.ComponentGroupEnum valueOf(String)
   public static net.corda.core.contracts.ComponentGroupEnum[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.Contract
+@CordaSerializable
+public interface net.corda.core.contracts.Contract
   public abstract void verify(net.corda.core.transactions.LedgerTransaction)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.ContractAttachment extends java.lang.Object implements net.corda.core.contracts.Attachment
+@CordaSerializable
+public final class net.corda.core.contracts.ContractAttachment extends java.lang.Object implements net.corda.core.contracts.Attachment
   public <init>(net.corda.core.contracts.Attachment, String)
-  public <init>(net.corda.core.contracts.Attachment, String, Set)
-  public <init>(net.corda.core.contracts.Attachment, String, Set, String)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>, String)
   public void extractFile(String, java.io.OutputStream)
-  @org.jetbrains.annotations.NotNull public final Set getAdditionalContracts()
-  @org.jetbrains.annotations.NotNull public final Set getAllContracts()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Attachment getAttachment()
-  @org.jetbrains.annotations.NotNull public final String getContract()
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public List getSigners()
+  @NotNull
+  public final java.util.Set<String> getAdditionalContracts()
+  @NotNull
+  public final java.util.Set<String> getAllContracts()
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment()
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.identity.Party> getSigners()
   public int getSize()
-  @org.jetbrains.annotations.Nullable public final String getUploader()
-  @org.jetbrains.annotations.NotNull public java.io.InputStream open()
-  @org.jetbrains.annotations.NotNull public jar.JarInputStream openAsJAR()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @Nullable
+  public final String getUploader()
+  @NotNull
+  public java.io.InputStream open()
+  @NotNull
+  public java.util.jar.JarInputStream openAsJAR()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.ContractState
-  @org.jetbrains.annotations.NotNull public abstract List getParticipants()
+@CordaSerializable
+public interface net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
 ##
 public final class net.corda.core.contracts.ContractsDSL extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.CommandWithParties requireSingleCommand(Collection, Class)
-  public static final Object requireThat(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final List select(Collection, Class, java.security.PublicKey, net.corda.core.identity.AbstractParty)
-  @org.jetbrains.annotations.NotNull public static final List select(Collection, Class, Collection, Collection)
+  @NotNull
+  public static final net.corda.core.contracts.CommandWithParties<C> requireSingleCommand(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>)
+  public static final R requireThat(kotlin.jvm.functions.Function1<? super net.corda.core.contracts.Requirements, ? extends R>)
+  @NotNull
+  public static final java.util.List<net.corda.core.contracts.CommandWithParties<C>> select(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>, java.security.PublicKey, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final java.util.List<net.corda.core.contracts.CommandWithParties<C>> select(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>, java.util.Collection<? extends java.security.PublicKey>, java.util.Collection<net.corda.core.identity.Party>)
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.FungibleAsset extends net.corda.core.contracts.OwnableState
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.Amount getAmount()
-  @org.jetbrains.annotations.NotNull public abstract Collection getExitKeys()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.FungibleAsset withNewOwnerAndAmount(net.corda.core.contracts.Amount, net.corda.core.identity.AbstractParty)
+@CordaSerializable
+public interface net.corda.core.contracts.FungibleAsset extends net.corda.core.contracts.OwnableState
+  @NotNull
+  public abstract net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>> getAmount()
+  @NotNull
+  public abstract java.util.Collection<java.security.PublicKey> getExitKeys()
+  @NotNull
+  public abstract net.corda.core.contracts.FungibleAsset<T> withNewOwnerAndAmount(net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>>, net.corda.core.identity.AbstractParty)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.HashAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.HashAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public <init>(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.HashAttachmentConstraint copy(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.contracts.HashAttachmentConstraint copy(net.corda.core.crypto.SecureHash)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getAttachmentId()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
   public int hashCode()
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.InsufficientBalanceException extends net.corda.core.flows.FlowException
-  public <init>(net.corda.core.contracts.Amount)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount getAmountMissing()
+@CordaSerializable
+public final class net.corda.core.contracts.InsufficientBalanceException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.contracts.Amount<?>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<?> getAmountMissing()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.Issued extends java.lang.Object
-  public <init>(net.corda.core.contracts.PartyAndReference, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PartyAndReference component1()
-  @org.jetbrains.annotations.NotNull public final Object component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Issued copy(net.corda.core.contracts.PartyAndReference, Object)
+@CordaSerializable
+public final class net.corda.core.contracts.Issued extends java.lang.Object
+  public <init>(net.corda.core.contracts.PartyAndReference, P)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference component1()
+  @NotNull
+  public final P component2()
+  @NotNull
+  public final net.corda.core.contracts.Issued<P> copy(net.corda.core.contracts.PartyAndReference, P)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PartyAndReference getIssuer()
-  @org.jetbrains.annotations.NotNull public final Object getProduct()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference getIssuer()
+  @NotNull
+  public final P getProduct()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
 public @interface net.corda.core.contracts.LegalProseReference
   public abstract String uri()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.LinearState extends net.corda.core.contracts.ContractState
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.UniqueIdentifier getLinearId()
+@CordaSerializable
+public interface net.corda.core.contracts.LinearState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.contracts.UniqueIdentifier getLinearId()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.MoveCommand extends net.corda.core.contracts.CommandData
-  @org.jetbrains.annotations.Nullable public abstract Class getContract()
+@CordaSerializable
+public interface net.corda.core.contracts.MoveCommand extends net.corda.core.contracts.CommandData
+  @Nullable
+  public abstract Class<? extends net.corda.core.contracts.Contract> getContract()
 ##
 public interface net.corda.core.contracts.NamedByHash
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getId()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.OwnableState extends net.corda.core.contracts.ContractState
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.identity.AbstractParty getOwner()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
+@CordaSerializable
+public interface net.corda.core.contracts.OwnableState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.identity.AbstractParty getOwner()
+  @NotNull
+  public abstract net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.PartyAndReference extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.contracts.PartyAndReference extends java.lang.Object
   public <init>(net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.AbstractParty component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.OpaqueBytes component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PartyAndReference copy(net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public final net.corda.core.identity.AbstractParty component1()
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes component2()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference copy(net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.AbstractParty getParty()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.OpaqueBytes getReference()
+  @NotNull
+  public final net.corda.core.identity.AbstractParty getParty()
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes getReference()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.PrivacySalt extends net.corda.core.utilities.OpaqueBytes
+@CordaSerializable
+public final class net.corda.core.contracts.PrivacySalt extends net.corda.core.utilities.OpaqueBytes
   public <init>()
   public <init>(byte[])
 ##
@@ -430,258 +662,371 @@ public final class net.corda.core.contracts.Requirements extends java.lang.Objec
   public final void using(String, boolean)
   public static final net.corda.core.contracts.Requirements INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.SchedulableState extends net.corda.core.contracts.ContractState
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.contracts.ScheduledActivity nextScheduledActivity(net.corda.core.contracts.StateRef, net.corda.core.flows.FlowLogicRefFactory)
+@CordaSerializable
+public interface net.corda.core.contracts.SchedulableState extends net.corda.core.contracts.ContractState
+  @Nullable
+  public abstract net.corda.core.contracts.ScheduledActivity nextScheduledActivity(net.corda.core.contracts.StateRef, net.corda.core.flows.FlowLogicRefFactory)
 ##
 public interface net.corda.core.contracts.Scheduled
-  @org.jetbrains.annotations.NotNull public abstract java.time.Instant getScheduledAt()
+  @NotNull
+  public abstract java.time.Instant getScheduledAt()
 ##
 public final class net.corda.core.contracts.ScheduledActivity extends java.lang.Object implements net.corda.core.contracts.Scheduled
   public <init>(net.corda.core.flows.FlowLogicRef, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowLogicRef component1()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ScheduledActivity copy(net.corda.core.flows.FlowLogicRef, java.time.Instant)
+  @NotNull
+  public final net.corda.core.flows.FlowLogicRef component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledActivity copy(net.corda.core.flows.FlowLogicRef, java.time.Instant)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowLogicRef getLogicRef()
-  @org.jetbrains.annotations.NotNull public java.time.Instant getScheduledAt()
+  @NotNull
+  public final net.corda.core.flows.FlowLogicRef getLogicRef()
+  @NotNull
+  public java.time.Instant getScheduledAt()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.ScheduledStateRef extends java.lang.Object implements net.corda.core.contracts.Scheduled
+@CordaSerializable
+public final class net.corda.core.contracts.ScheduledStateRef extends java.lang.Object implements net.corda.core.contracts.Scheduled
   public <init>(net.corda.core.contracts.StateRef, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef component1()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ScheduledStateRef copy(net.corda.core.contracts.StateRef, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef copy(net.corda.core.contracts.StateRef, java.time.Instant)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef getRef()
-  @org.jetbrains.annotations.NotNull public java.time.Instant getScheduledAt()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public java.time.Instant getScheduledAt()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.core.contracts.SourceAndAmount extends java.lang.Object
-  public <init>(Object, net.corda.core.contracts.Amount, Object)
-  @org.jetbrains.annotations.NotNull public final Object component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount component2()
-  @org.jetbrains.annotations.Nullable public final Object component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.SourceAndAmount copy(Object, net.corda.core.contracts.Amount, Object)
+  public <init>(P, net.corda.core.contracts.Amount<T>, Object)
+  @NotNull
+  public final P component1()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> component2()
+  @Nullable
+  public final Object component3()
+  @NotNull
+  public final net.corda.core.contracts.SourceAndAmount<T, P> copy(P, net.corda.core.contracts.Amount<T>, Object)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Amount getAmount()
-  @org.jetbrains.annotations.Nullable public final Object getRef()
-  @org.jetbrains.annotations.NotNull public final Object getSource()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> getAmount()
+  @Nullable
+  public final Object getRef()
+  @NotNull
+  public final P getSource()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.core.contracts.StateAndContract extends java.lang.Object
   public <init>(net.corda.core.contracts.ContractState, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndContract copy(net.corda.core.contracts.ContractState, String)
+  @NotNull
+  public final net.corda.core.contracts.ContractState component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.contracts.StateAndContract copy(net.corda.core.contracts.ContractState, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getContract()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState getState()
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getState()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.StateAndRef extends java.lang.Object
-  public <init>(net.corda.core.contracts.TransactionState, net.corda.core.contracts.StateRef)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TransactionState component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef copy(net.corda.core.contracts.TransactionState, net.corda.core.contracts.StateRef)
+@CordaSerializable
+public final class net.corda.core.contracts.StateAndRef extends java.lang.Object
+  public <init>(net.corda.core.contracts.TransactionState<? extends T>, net.corda.core.contracts.StateRef)
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> component1()
+  @NotNull
+  public final net.corda.core.contracts.StateRef component2()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> copy(net.corda.core.contracts.TransactionState<? extends T>, net.corda.core.contracts.StateRef)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef getRef()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TransactionState getState()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> getState()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.StateRef extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.contracts.StateRef extends java.lang.Object
   public <init>(net.corda.core.crypto.SecureHash, int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
   public final int component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef copy(net.corda.core.crypto.SecureHash, int)
+  @NotNull
+  public final net.corda.core.contracts.StateRef copy(net.corda.core.crypto.SecureHash, int)
   public boolean equals(Object)
   public final int getIndex()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getTxhash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxhash()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
 public final class net.corda.core.contracts.Structures extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash hash(net.corda.core.contracts.ContractState)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Amount withoutIssuer(net.corda.core.contracts.Amount)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash hash(net.corda.core.contracts.ContractState)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> withoutIssuer(net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>>)
   public static final int MAX_ISSUER_REF_SIZE = 512
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.contracts.TimeWindow extends java.lang.Object
+@CordaSerializable
+public abstract class net.corda.core.contracts.TimeWindow extends java.lang.Object
   public <init>()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
   public abstract boolean contains(java.time.Instant)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
-  @org.jetbrains.annotations.Nullable public abstract java.time.Instant getFromTime()
-  @org.jetbrains.annotations.Nullable public final java.time.Duration getLength()
-  @org.jetbrains.annotations.Nullable public abstract java.time.Instant getMidpoint()
-  @org.jetbrains.annotations.Nullable public abstract java.time.Instant getUntilTime()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
+  @Nullable
+  public abstract java.time.Instant getFromTime()
+  @Nullable
+  public final java.time.Duration getLength()
+  @Nullable
+  public abstract java.time.Instant getMidpoint()
+  @Nullable
+  public abstract java.time.Instant getUntilTime()
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
   public static final net.corda.core.contracts.TimeWindow$Companion Companion
 ##
 public static final class net.corda.core.contracts.TimeWindow$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
 ##
 public interface net.corda.core.contracts.TokenizableAssetInfo
-  @org.jetbrains.annotations.NotNull public abstract java.math.BigDecimal getDisplayTokenSize()
+  @NotNull
+  public abstract java.math.BigDecimal getDisplayTokenSize()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.TransactionResolutionException extends net.corda.core.flows.FlowException
+@CordaSerializable
+public final class net.corda.core.contracts.TransactionResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.TransactionState extends java.lang.Object
-  public <init>(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party)
-  public <init>(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer)
-  public <init>(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component3()
-  @org.jetbrains.annotations.Nullable public final Integer component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.AttachmentConstraint component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TransactionState copy(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+@CordaSerializable
+public final class net.corda.core.contracts.TransactionState extends java.lang.Object
+  public <init>(T, String, net.corda.core.identity.Party)
+  public <init>(T, String, net.corda.core.identity.Party, Integer)
+  public <init>(T, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @Nullable
+  public final Integer component4()
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint component5()
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> copy(T, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.AttachmentConstraint getConstraint()
-  @org.jetbrains.annotations.NotNull public final String getContract()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState getData()
-  @org.jetbrains.annotations.Nullable public final Integer getEncumbrance()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getNotary()
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint getConstraint()
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public final T getData()
+  @Nullable
+  public final Integer getEncumbrance()
+  @NotNull
+  public final net.corda.core.identity.Party getNotary()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.core.contracts.TransactionStateKt extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.contracts.TransactionVerificationException extends net.corda.core.flows.FlowException
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getTxId()
+@CordaSerializable
+public abstract class net.corda.core.contracts.TransactionVerificationException extends net.corda.core.flows.FlowException
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$ConflictingAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ConflictingAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String)
-  @org.jetbrains.annotations.NotNull public final String getContractClass()
+  @NotNull
+  public final String getContractClass()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$ContractConstraintRejection extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractConstraintRejection extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String)
-  @org.jetbrains.annotations.NotNull public final String getContractClass()
+  @NotNull
+  public final String getContractClass()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$ContractCreationError extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractCreationError extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
-  @org.jetbrains.annotations.NotNull public final String getContractClass()
+  @NotNull
+  public final String getContractClass()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$ContractRejection extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractRejection extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.Contract, Throwable)
-  @org.jetbrains.annotations.NotNull public final String getContractClass()
+  @NotNull
+  public final String getContractClass()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$Direction extends java.lang.Enum
-  protected <init>(String, int)
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$Direction extends java.lang.Enum
+  protected <init>()
   public static net.corda.core.contracts.TransactionVerificationException$Direction valueOf(String)
   public static net.corda.core.contracts.TransactionVerificationException$Direction[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateInputStates extends net.corda.core.contracts.TransactionVerificationException
-  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.utilities.NonEmptySet)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NonEmptySet getDuplicates()
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateInputStates extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef> getDuplicates()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$InvalidNotaryChange extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$InvalidNotaryChange extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$MissingAttachmentRejection extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MissingAttachmentRejection extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String)
-  @org.jetbrains.annotations.NotNull public final String getContractClass()
+  @NotNull
+  public final String getContractClass()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$MoreThanOneNotary extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MoreThanOneNotary extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$NotaryChangeInWrongTransactionType extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$NotaryChangeInWrongTransactionType extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getOutputNotary()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getTxNotary()
+  @NotNull
+  public final net.corda.core.identity.Party getOutputNotary()
+  @NotNull
+  public final net.corda.core.identity.Party getTxNotary()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$SignersMissing extends net.corda.core.contracts.TransactionVerificationException
-  public <init>(net.corda.core.crypto.SecureHash, List)
-  @org.jetbrains.annotations.NotNull public final List getMissing()
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$SignersMissing extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getMissing()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.contracts.TransactionVerificationException$TransactionMissingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionMissingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, int, net.corda.core.contracts.TransactionVerificationException$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TransactionVerificationException$Direction getInOut()
+  @NotNull
+  public final net.corda.core.contracts.TransactionVerificationException$Direction getInOut()
   public final int getMissing()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.lang.Object implements net.corda.core.contracts.CommandData
+@CordaSerializable
+public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.lang.Object implements net.corda.core.contracts.CommandData
   public <init>()
   public boolean equals(Object)
   public int hashCode()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.UniqueIdentifier extends java.lang.Object implements java.lang.Comparable
+@CordaSerializable
+public final class net.corda.core.contracts.UniqueIdentifier extends java.lang.Object implements java.lang.Comparable
   public <init>()
-  public <init>(String, UUID)
+  public <init>(String, java.util.UUID)
   public int compareTo(net.corda.core.contracts.UniqueIdentifier)
-  @org.jetbrains.annotations.Nullable public final String component1()
-  @org.jetbrains.annotations.NotNull public final UUID component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.UniqueIdentifier copy(String, UUID)
+  @Nullable
+  public final String component1()
+  @NotNull
+  public final java.util.UUID component2()
+  @NotNull
+  public final net.corda.core.contracts.UniqueIdentifier copy(String, java.util.UUID)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final String getExternalId()
-  @org.jetbrains.annotations.NotNull public final UUID getId()
+  @Nullable
+  public final String getExternalId()
+  @NotNull
+  public final java.util.UUID getId()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
   public static final net.corda.core.contracts.UniqueIdentifier$Companion Companion
 ##
 public static final class net.corda.core.contracts.UniqueIdentifier$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.UniqueIdentifier fromString(String)
+  @NotNull
+  public final net.corda.core.contracts.UniqueIdentifier fromString(String)
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.UpgradedContract extends net.corda.core.contracts.Contract
-  @org.jetbrains.annotations.NotNull public abstract String getLegacyContract()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.ContractState upgrade(net.corda.core.contracts.ContractState)
+@CordaSerializable
+public interface net.corda.core.contracts.UpgradedContract extends net.corda.core.contracts.Contract
+  @NotNull
+  public abstract String getLegacyContract()
+  @NotNull
+  public abstract NewState upgrade(OldState)
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.contracts.UpgradedContractWithLegacyConstraint extends net.corda.core.contracts.UpgradedContract
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+@CordaSerializable
+public interface net.corda.core.contracts.UpgradedContractWithLegacyConstraint extends net.corda.core.contracts.UpgradedContract
+  @NotNull
+  public abstract net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public static final net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint INSTANCE
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.cordapp.Cordapp
-  @org.jetbrains.annotations.NotNull public abstract List getContractClassNames()
-  @org.jetbrains.annotations.NotNull public abstract List getCordappClasses()
-  @org.jetbrains.annotations.NotNull public abstract Set getCustomSchemas()
-  @org.jetbrains.annotations.NotNull public abstract List getInitiatedFlows()
-  @org.jetbrains.annotations.NotNull public abstract java.net.URL getJarPath()
-  @org.jetbrains.annotations.NotNull public abstract String getName()
-  @org.jetbrains.annotations.NotNull public abstract List getRpcFlows()
-  @org.jetbrains.annotations.NotNull public abstract List getSchedulableFlows()
-  @org.jetbrains.annotations.NotNull public abstract List getSerializationCustomSerializers()
-  @org.jetbrains.annotations.NotNull public abstract List getSerializationWhitelists()
-  @org.jetbrains.annotations.NotNull public abstract List getServiceFlows()
-  @org.jetbrains.annotations.NotNull public abstract List getServices()
-##
-@net.corda.core.DoNotImplement public interface net.corda.core.cordapp.CordappConfig
-  public abstract boolean exists(String)
-  @org.jetbrains.annotations.NotNull public abstract Object get(String)
-  public abstract boolean getBoolean(String)
-  public abstract double getDouble(String)
-  public abstract float getFloat(String)
-  public abstract int getInt(String)
-  public abstract long getLong(String)
-  @org.jetbrains.annotations.NotNull public abstract Number getNumber(String)
-  @org.jetbrains.annotations.NotNull public abstract String getString(String)
-##
-public final class net.corda.core.cordapp.CordappConfigException extends java.lang.Exception
-  public <init>(String, Throwable)
+@DoNotImplement
+public interface net.corda.core.cordapp.Cordapp
+  @NotNull
+  public abstract java.util.List<String> getContractClassNames()
+  @NotNull
+  public abstract java.util.List<String> getCordappClasses()
+  @NotNull
+  public abstract java.util.Set<net.corda.core.schemas.MappedSchema> getCustomSchemas()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getInitiatedFlows()
+  @NotNull
+  public abstract java.net.URL getJarPath()
+  @NotNull
+  public abstract String getName()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getRpcFlows()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getSchedulableFlows()
+  @NotNull
+  public abstract java.util.List<net.corda.core.serialization.SerializationCustomSerializer<?, ?>> getSerializationCustomSerializers()
+  @NotNull
+  public abstract java.util.List<net.corda.core.serialization.SerializationWhitelist> getSerializationWhitelists()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getServiceFlows()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.serialization.SerializeAsToken>> getServices()
 ##
 public final class net.corda.core.cordapp.CordappContext extends java.lang.Object
-  public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader, net.corda.core.cordapp.CordappConfig)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.crypto.SecureHash getAttachmentId()
-  @org.jetbrains.annotations.NotNull public final ClassLoader getClassLoader()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.cordapp.CordappConfig getConfig()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.cordapp.Cordapp getCordapp()
+  public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader)
+  @Nullable
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
+  @NotNull
+  public final ClassLoader getClassLoader()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp getCordapp()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.cordapp.CordappProvider
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.cordapp.CordappContext getAppContext()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.crypto.SecureHash getContractAttachmentID(String)
+@DoNotImplement
+public interface net.corda.core.cordapp.CordappProvider
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappContext getAppContext()
+  @Nullable
+  public abstract net.corda.core.crypto.SecureHash getContractAttachmentID(String)
 ##
 public class net.corda.core.crypto.AddressFormatException extends java.lang.IllegalArgumentException
   public <init>()
@@ -694,325 +1039,488 @@ public class net.corda.core.crypto.Base58 extends java.lang.Object
   public static java.math.BigInteger decodeToBigInteger(String)
   public static String encode(byte[])
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.crypto.CompositeKey extends java.lang.Object implements java.security.PublicKey
+@CordaSerializable
+public final class net.corda.core.crypto.CompositeKey extends java.lang.Object implements java.security.PublicKey
   public final void checkValidity()
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public String getAlgorithm()
-  @org.jetbrains.annotations.NotNull public final List getChildren()
-  @org.jetbrains.annotations.NotNull public byte[] getEncoded()
-  @org.jetbrains.annotations.NotNull public String getFormat()
-  @org.jetbrains.annotations.NotNull public final Set getLeafKeys()
+  @NotNull
+  public String getAlgorithm()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.CompositeKey$NodeAndWeight> getChildren()
+  @NotNull
+  public byte[] getEncoded()
+  @NotNull
+  public String getFormat()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getLeafKeys()
   public final int getThreshold()
   public int hashCode()
-  public final boolean isFulfilledBy(Iterable)
+  public final boolean isFulfilledBy(Iterable<? extends java.security.PublicKey>)
   public final boolean isFulfilledBy(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
   public static final net.corda.core.crypto.CompositeKey$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final String KEY_ALGORITHM = "COMPOSITE"
+  @NotNull
+  public static final String KEY_ALGORITHM = "COMPOSITE"
 ##
 public static final class net.corda.core.crypto.CompositeKey$Builder extends java.lang.Object
   public <init>()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey$Builder addKey(java.security.PublicKey, int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey$Builder addKeys(List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.security.PublicKey...)
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey build(Integer)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKey(java.security.PublicKey, int)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.security.PublicKey...)
+  @NotNull
+  public final java.security.PublicKey build(Integer)
 ##
 public static final class net.corda.core.crypto.CompositeKey$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getInstance(org.bouncycastle.asn1.ASN1Primitive)
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getInstance(byte[])
+  @NotNull
+  public final java.security.PublicKey getInstance(org.bouncycastle.asn1.ASN1Primitive)
+  @NotNull
+  public final java.security.PublicKey getInstance(byte[])
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.crypto.CompositeKey$NodeAndWeight extends org.bouncycastle.asn1.ASN1Object implements java.lang.Comparable
+@CordaSerializable
+public static final class net.corda.core.crypto.CompositeKey$NodeAndWeight extends org.bouncycastle.asn1.ASN1Object implements java.lang.Comparable
   public <init>(java.security.PublicKey, int)
   public int compareTo(net.corda.core.crypto.CompositeKey$NodeAndWeight)
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey component1()
+  @NotNull
+  public final java.security.PublicKey component1()
   public final int component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey$NodeAndWeight copy(java.security.PublicKey, int)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$NodeAndWeight copy(java.security.PublicKey, int)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getNode()
+  @NotNull
+  public final java.security.PublicKey getNode()
   public final int getWeight()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public org.bouncycastle.asn1.ASN1Primitive toASN1Primitive()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public org.bouncycastle.asn1.ASN1Primitive toASN1Primitive()
+  @NotNull
+  public String toString()
 ##
 public final class net.corda.core.crypto.CompositeKeyFactory extends java.security.KeyFactorySpi
   public <init>()
-  @org.jetbrains.annotations.NotNull protected java.security.PrivateKey engineGeneratePrivate(java.security.spec.KeySpec)
-  @org.jetbrains.annotations.Nullable protected java.security.PublicKey engineGeneratePublic(java.security.spec.KeySpec)
-  @org.jetbrains.annotations.NotNull protected java.security.spec.KeySpec engineGetKeySpec(java.security.Key, Class)
-  @org.jetbrains.annotations.NotNull protected java.security.Key engineTranslateKey(java.security.Key)
+  @NotNull
+  protected java.security.PrivateKey engineGeneratePrivate(java.security.spec.KeySpec)
+  @Nullable
+  protected java.security.PublicKey engineGeneratePublic(java.security.spec.KeySpec)
+  @NotNull
+  protected T engineGetKeySpec(java.security.Key, Class<T>)
+  @NotNull
+  protected java.security.Key engineTranslateKey(java.security.Key)
 ##
 public final class net.corda.core.crypto.CompositeSignature extends java.security.Signature
   public <init>()
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull protected Object engineGetParameter(String)
+  @NotNull
+  protected Object engineGetParameter(String)
   protected void engineInitSign(java.security.PrivateKey)
   protected void engineInitVerify(java.security.PublicKey)
-  @kotlin.Deprecated protected void engineSetParameter(String, Object)
+  protected void engineSetParameter(String, Object)
   protected void engineSetParameter(java.security.spec.AlgorithmParameterSpec)
-  @org.jetbrains.annotations.NotNull protected byte[] engineSign()
+  @NotNull
+  protected byte[] engineSign()
   protected void engineUpdate(byte)
   protected void engineUpdate(byte[], int, int)
   protected boolean engineVerify(byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.Provider$Service getService(java.security.Provider)
+  @NotNull
+  public static final java.security.Provider$Service getService(java.security.Provider)
   public static final net.corda.core.crypto.CompositeSignature$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final String SIGNATURE_ALGORITHM = "COMPOSITESIG"
+  @NotNull
+  public static final String SIGNATURE_ALGORITHM = "COMPOSITESIG"
 ##
 public static final class net.corda.core.crypto.CompositeSignature$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final java.security.Provider$Service getService(java.security.Provider)
+  @NotNull
+  public final java.security.Provider$Service getService(java.security.Provider)
 ##
 public static final class net.corda.core.crypto.CompositeSignature$State extends java.lang.Object
   public <init>(java.io.ByteArrayOutputStream, net.corda.core.crypto.CompositeKey)
-  @org.jetbrains.annotations.NotNull public final java.io.ByteArrayOutputStream component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeSignature$State copy(java.io.ByteArrayOutputStream, net.corda.core.crypto.CompositeKey)
+  @NotNull
+  public final java.io.ByteArrayOutputStream component1()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey component2()
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignature$State copy(java.io.ByteArrayOutputStream, net.corda.core.crypto.CompositeKey)
   public final boolean engineVerify(byte[])
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final java.io.ByteArrayOutputStream getBuffer()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeKey getVerifyKey()
+  @NotNull
+  public final java.io.ByteArrayOutputStream getBuffer()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey getVerifyKey()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.crypto.CompositeSignaturesWithKeys extends java.lang.Object
-  public <init>(List)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeSignaturesWithKeys copy(List)
+@CordaSerializable
+public final class net.corda.core.crypto.CompositeSignaturesWithKeys extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component1()
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignaturesWithKeys copy(java.util.List<net.corda.core.crypto.TransactionSignature>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getSigs()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
   public int hashCode()
   public String toString()
   public static final net.corda.core.crypto.CompositeSignaturesWithKeys$Companion Companion
 ##
 public static final class net.corda.core.crypto.CompositeSignaturesWithKeys$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.CompositeSignaturesWithKeys getEMPTY()
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignaturesWithKeys getEMPTY()
 ##
 public final class net.corda.core.crypto.CordaObjectIdentifier extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_KEY
-  @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_SIGNATURE
+  @NotNull
+  public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_KEY
+  @NotNull
+  public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_SIGNATURE
   public static final net.corda.core.crypto.CordaObjectIdentifier INSTANCE
 ##
 public final class net.corda.core.crypto.CordaSecurityProvider extends java.security.Provider
   public <init>()
   public static final net.corda.core.crypto.CordaSecurityProvider$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final String PROVIDER_NAME = "Corda"
+  @NotNull
+  public static final String PROVIDER_NAME = "Corda"
 ##
 public static final class net.corda.core.crypto.CordaSecurityProvider$Companion extends java.lang.Object
 ##
 public final class net.corda.core.crypto.Crypto extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final java.security.PrivateKey decodePrivateKey(String, byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.PrivateKey decodePrivateKey(net.corda.core.crypto.SignatureScheme, byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.PrivateKey decodePrivateKey(byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.PublicKey decodePublicKey(String, byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.PublicKey decodePublicKey(net.corda.core.crypto.SignatureScheme, byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.PublicKey decodePublicKey(byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair deriveKeyPair(java.security.PrivateKey, byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair deriveKeyPair(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair deriveKeyPairFromEntropy(java.math.BigInteger)
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair deriveKeyPairFromEntropy(net.corda.core.crypto.SignatureScheme, java.math.BigInteger)
-  @org.jetbrains.annotations.NotNull public static final byte[] doSign(String, java.security.PrivateKey, byte[])
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.TransactionSignature doSign(java.security.KeyPair, net.corda.core.crypto.SignableData)
-  @org.jetbrains.annotations.NotNull public static final byte[] doSign(java.security.PrivateKey, byte[])
-  @org.jetbrains.annotations.NotNull public static final byte[] doSign(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(String, byte[])
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(net.corda.core.crypto.SignatureScheme, byte[])
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(String, byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(net.corda.core.crypto.SignatureScheme, byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPair(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPair(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPairFromEntropy(java.math.BigInteger)
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPairFromEntropy(net.corda.core.crypto.SignatureScheme, java.math.BigInteger)
+  @NotNull
+  public static final byte[] doSign(String, java.security.PrivateKey, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.TransactionSignature doSign(java.security.KeyPair, net.corda.core.crypto.SignableData)
+  @NotNull
+  public static final byte[] doSign(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final byte[] doSign(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
   public static final boolean doVerify(String, java.security.PublicKey, byte[], byte[])
   public static final boolean doVerify(java.security.PublicKey, byte[], byte[])
   public static final boolean doVerify(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
   public static final boolean doVerify(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
-  @org.jetbrains.annotations.NotNull public static final java.security.Provider findProvider(String)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(String)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PrivateKey)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(org.bouncycastle.asn1.x509.AlgorithmIdentifier)
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair generateKeyPair()
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair generateKeyPair(String)
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair generateKeyPair(net.corda.core.crypto.SignatureScheme)
+  @NotNull
+  public static final java.security.Provider findProvider(String)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(String)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PrivateKey)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(org.bouncycastle.asn1.x509.AlgorithmIdentifier)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair()
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair(String)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair(net.corda.core.crypto.SignatureScheme)
   public static final boolean isSupportedSignatureScheme(net.corda.core.crypto.SignatureScheme)
   public static final boolean isValid(java.security.PublicKey, byte[], byte[])
   public static final boolean isValid(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
   public static final boolean isValid(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
   public static final boolean publicKeyOnCurve(net.corda.core.crypto.SignatureScheme, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public static final List supportedSignatureSchemes()
-  @org.jetbrains.annotations.NotNull public static final java.security.PrivateKey toSupportedPrivateKey(java.security.PrivateKey)
-  @org.jetbrains.annotations.NotNull public static final java.security.PublicKey toSupportedPublicKey(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public static final java.security.PublicKey toSupportedPublicKey(org.bouncycastle.asn1.x509.SubjectPublicKeyInfo)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme DEFAULT_SIGNATURE_SCHEME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256K1_SHA256
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256R1_SHA256
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme EDDSA_ED25519_SHA512
+  @NotNull
+  public static final java.util.List<net.corda.core.crypto.SignatureScheme> supportedSignatureSchemes()
+  @NotNull
+  public static final java.security.PrivateKey toSupportedPrivateKey(java.security.PrivateKey)
+  @NotNull
+  public static final java.security.PublicKey toSupportedPublicKey(java.security.PublicKey)
+  @NotNull
+  public static final java.security.PublicKey toSupportedPublicKey(org.bouncycastle.asn1.x509.SubjectPublicKeyInfo)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme DEFAULT_SIGNATURE_SCHEME
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256K1_SHA256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256R1_SHA256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme EDDSA_ED25519_SHA512
   public static final net.corda.core.crypto.Crypto INSTANCE
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme RSA_SHA256
-  @org.jetbrains.annotations.NotNull public static final org.bouncycastle.asn1.DLSequence SHA512_256
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SignatureScheme SPHINCS256_SHA256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme RSA_SHA256
+  @NotNull
+  public static final org.bouncycastle.asn1.DLSequence SHA512_256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme SPHINCS256_SHA256
 ##
 public final class net.corda.core.crypto.CryptoUtils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final Set byKeys(Iterable)
-  @org.jetbrains.annotations.NotNull public static final java.security.PrivateKey component1(java.security.KeyPair)
-  @org.jetbrains.annotations.NotNull public static final java.security.PublicKey component2(java.security.KeyPair)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.crypto.SecureHash, net.corda.core.utilities.OpaqueBytes)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.utilities.OpaqueBytes, net.corda.core.contracts.PrivacySalt, int, int)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 computeNonce(net.corda.core.contracts.PrivacySalt, int, int)
-  public static final boolean containsAny(java.security.PublicKey, Iterable)
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair entropyToKeyPair(java.math.BigInteger)
-  @org.jetbrains.annotations.NotNull public static final java.security.KeyPair generateKeyPair()
-  @org.jetbrains.annotations.NotNull public static final Set getKeys(java.security.PublicKey)
-  public static final boolean isFulfilledBy(java.security.PublicKey, Iterable)
+  @NotNull
+  public static final java.util.Set<java.security.PublicKey> byKeys(Iterable<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public static final java.security.PrivateKey component1(java.security.KeyPair)
+  @NotNull
+  public static final java.security.PublicKey component2(java.security.KeyPair)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.crypto.SecureHash, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.utilities.OpaqueBytes, net.corda.core.contracts.PrivacySalt, int, int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 computeNonce(net.corda.core.contracts.PrivacySalt, int, int)
+  public static final boolean containsAny(java.security.PublicKey, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public static final java.security.KeyPair entropyToKeyPair(java.math.BigInteger)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair()
+  @NotNull
+  public static final java.util.Set<java.security.PublicKey> getKeys(java.security.PublicKey)
+  public static final boolean isFulfilledBy(java.security.PublicKey, Iterable<? extends java.security.PublicKey>)
   public static final boolean isFulfilledBy(java.security.PublicKey, java.security.PublicKey)
   public static final boolean isValid(java.security.PublicKey, byte[], net.corda.core.crypto.DigitalSignature)
-  @org.jetbrains.annotations.NotNull public static final java.security.SecureRandom newSecureRandom()
+  @NotNull
+  public static final java.security.SecureRandom newSecureRandom()
   public static final long random63BitValue()
-  @org.jetbrains.annotations.NotNull public static final byte[] secureRandomBytes(int)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash serializedHash(Object)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.TransactionSignature sign(java.security.KeyPair, net.corda.core.crypto.SignableData)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, net.corda.core.utilities.OpaqueBytes)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, byte[])
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.DigitalSignature sign(java.security.PrivateKey, byte[])
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.PrivateKey, byte[], java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public static final String toStringShort(java.security.PublicKey)
+  @NotNull
+  public static final byte[] secureRandomBytes(int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash serializedHash(T)
+  @NotNull
+  public static final net.corda.core.crypto.TransactionSignature sign(java.security.KeyPair, net.corda.core.crypto.SignableData)
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature sign(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.PrivateKey, byte[], java.security.PublicKey)
+  @NotNull
+  public static final String toStringShort(java.security.PublicKey)
   public static final boolean verify(java.security.KeyPair, byte[], byte[])
   public static final boolean verify(java.security.PublicKey, byte[], net.corda.core.crypto.DigitalSignature)
   public static final boolean verify(java.security.PublicKey, byte[], byte[])
 ##
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.crypto.DigitalSignature extends net.corda.core.utilities.OpaqueBytes
+@CordaSerializable
+public class net.corda.core.crypto.DigitalSignature extends net.corda.core.utilities.OpaqueBytes
   public <init>(byte[])
 ##
-@net.corda.core.serialization.CordaSerializable public static class net.corda.core.crypto.DigitalSignature$WithKey extends net.corda.core.crypto.DigitalSignature
+@CordaSerializable
+public static class net.corda.core.crypto.DigitalSignature$WithKey extends net.corda.core.crypto.DigitalSignature
   public <init>(java.security.PublicKey, byte[])
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getBy()
+  @NotNull
+  public final java.security.PublicKey getBy()
   public final boolean isValid(byte[])
   public final boolean verify(net.corda.core.utilities.OpaqueBytes)
   public final boolean verify(byte[])
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.DigitalSignature withoutKey()
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature withoutKey()
 ##
 public abstract class net.corda.core.crypto.MerkleTree extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getHash()
   public static final net.corda.core.crypto.MerkleTree$Companion Companion
 ##
 public static final class net.corda.core.crypto.MerkleTree$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree getMerkleTree(List)
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getMerkleTree(java.util.List<? extends net.corda.core.crypto.SecureHash>)
 ##
 public static final class net.corda.core.crypto.MerkleTree$Leaf extends net.corda.core.crypto.MerkleTree
   public <init>(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree$Leaf copy(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree$Leaf copy(net.corda.core.crypto.SecureHash)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getHash()
   public int hashCode()
   public String toString()
 ##
 public static final class net.corda.core.crypto.MerkleTree$Node extends net.corda.core.crypto.MerkleTree
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.MerkleTree, net.corda.core.crypto.MerkleTree)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree$Node copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.MerkleTree, net.corda.core.crypto.MerkleTree)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree component2()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree component3()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree$Node copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.MerkleTree, net.corda.core.crypto.MerkleTree)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getHash()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree getLeft()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree getRight()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getLeft()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getRight()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.crypto.MerkleTreeException extends net.corda.core.CordaException
+@CordaSerializable
+public final class net.corda.core.crypto.MerkleTreeException extends net.corda.core.CordaException
   public <init>(String)
-  @org.jetbrains.annotations.NotNull public final String getReason()
+  @NotNull
+  public final String getReason()
 ##
 public final class net.corda.core.crypto.NullKeys extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.AnonymousParty getNULL_PARTY()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.TransactionSignature getNULL_SIGNATURE()
+  @NotNull
+  public final net.corda.core.identity.AnonymousParty getNULL_PARTY()
+  @NotNull
+  public final net.corda.core.crypto.TransactionSignature getNULL_SIGNATURE()
   public static final net.corda.core.crypto.NullKeys INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.crypto.NullKeys$NullPublicKey extends java.lang.Object implements java.security.PublicKey, java.lang.Comparable
+@CordaSerializable
+public static final class net.corda.core.crypto.NullKeys$NullPublicKey extends java.lang.Object implements java.security.PublicKey, java.lang.Comparable
   public int compareTo(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public String getAlgorithm()
-  @org.jetbrains.annotations.NotNull public byte[] getEncoded()
-  @org.jetbrains.annotations.NotNull public String getFormat()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String getAlgorithm()
+  @NotNull
+  public byte[] getEncoded()
+  @NotNull
+  public String getFormat()
+  @NotNull
+  public String toString()
   public static final net.corda.core.crypto.NullKeys$NullPublicKey INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.crypto.PartialMerkleTree extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.crypto.PartialMerkleTree extends java.lang.Object
   public <init>(net.corda.core.crypto.PartialMerkleTree$PartialTree)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRoot()
-  public final boolean verify(net.corda.core.crypto.SecureHash, List)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRoot()
+  public final boolean verify(net.corda.core.crypto.SecureHash, java.util.List<? extends net.corda.core.crypto.SecureHash>)
   public static final net.corda.core.crypto.PartialMerkleTree$Companion Companion
 ##
 public static final class net.corda.core.crypto.PartialMerkleTree$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree build(net.corda.core.crypto.MerkleTree, List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash rootAndUsedHashes(net.corda.core.crypto.PartialMerkleTree$PartialTree, List)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree build(net.corda.core.crypto.MerkleTree, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash rootAndUsedHashes(net.corda.core.crypto.PartialMerkleTree$PartialTree, java.util.List<net.corda.core.crypto.SecureHash>)
 ##
-@net.corda.core.serialization.CordaSerializable public abstract static class net.corda.core.crypto.PartialMerkleTree$PartialTree extends java.lang.Object
+@CordaSerializable
+public abstract static class net.corda.core.crypto.PartialMerkleTree$PartialTree extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
   public <init>(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf copy(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf copy(net.corda.core.crypto.SecureHash)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
   public <init>(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf copy(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf copy(net.corda.core.crypto.SecureHash)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Node extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Node extends net.corda.core.crypto.PartialMerkleTree$PartialTree
   public <init>(net.corda.core.crypto.PartialMerkleTree$PartialTree, net.corda.core.crypto.PartialMerkleTree$PartialTree)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Node copy(net.corda.core.crypto.PartialMerkleTree$PartialTree, net.corda.core.crypto.PartialMerkleTree$PartialTree)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree component2()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Node copy(net.corda.core.crypto.PartialMerkleTree$PartialTree, net.corda.core.crypto.PartialMerkleTree$PartialTree)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree getLeft()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRight()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getLeft()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRight()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.crypto.SecureHash extends net.corda.core.utilities.OpaqueBytes
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 hashConcat(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 parse(String)
-  @org.jetbrains.annotations.NotNull public final String prefixChars(int)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
-  @org.jetbrains.annotations.NotNull public String toString()
+@CordaSerializable
+public abstract class net.corda.core.crypto.SecureHash extends net.corda.core.utilities.OpaqueBytes
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 hashConcat(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 parse(String)
+  @NotNull
+  public final String prefixChars(int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
+  @NotNull
+  public String toString()
   public static final net.corda.core.crypto.SecureHash$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 allOnesHash
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 zeroHash
 ##
 public static final class net.corda.core.crypto.SecureHash$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 getAllOnesHash()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 getZeroHash()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 parse(String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getAllOnesHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getZeroHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 parse(String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.crypto.SecureHash$SHA256 extends net.corda.core.crypto.SecureHash
+@CordaSerializable
+public static final class net.corda.core.crypto.SecureHash$SHA256 extends net.corda.core.crypto.SecureHash
   public <init>(byte[])
 ##
 public final class net.corda.core.crypto.SecureHashKt extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 sha256(net.corda.core.utilities.OpaqueBytes)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.crypto.SignableData extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.crypto.SignableData extends java.lang.Object
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignatureMetadata)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignatureMetadata component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignableData copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignatureMetadata)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata component2()
+  @NotNull
+  public final net.corda.core.crypto.SignableData copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignatureMetadata)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getTxId()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.crypto.SignatureMetadata extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.crypto.SignatureMetadata extends java.lang.Object
   public <init>(int, int)
   public final int component1()
   public final int component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignatureMetadata copy(int, int)
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata copy(int, int)
   public boolean equals(Object)
   public final int getPlatformVersion()
   public final int getSchemeNumberID()
@@ -1020,46 +1528,73 @@ public final class net.corda.core.crypto.SecureHashKt extends java.lang.Object
   public String toString()
 ##
 public final class net.corda.core.crypto.SignatureScheme extends java.lang.Object
-  public <init>(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, List, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
+  public <init>(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, java.util.List<? extends org.bouncycastle.asn1.x509.AlgorithmIdentifier>, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final String component10()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final org.bouncycastle.asn1.x509.AlgorithmIdentifier component3()
-  @org.jetbrains.annotations.NotNull public final List component4()
-  @org.jetbrains.annotations.NotNull public final String component5()
-  @org.jetbrains.annotations.NotNull public final String component6()
-  @org.jetbrains.annotations.NotNull public final String component7()
-  @org.jetbrains.annotations.Nullable public final java.security.spec.AlgorithmParameterSpec component8()
-  @org.jetbrains.annotations.Nullable public final Integer component9()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignatureScheme copy(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, List, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
+  @NotNull
+  public final String component10()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final org.bouncycastle.asn1.x509.AlgorithmIdentifier component3()
+  @NotNull
+  public final java.util.List<org.bouncycastle.asn1.x509.AlgorithmIdentifier> component4()
+  @NotNull
+  public final String component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final String component7()
+  @Nullable
+  public final java.security.spec.AlgorithmParameterSpec component8()
+  @Nullable
+  public final Integer component9()
+  @NotNull
+  public final net.corda.core.crypto.SignatureScheme copy(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, java.util.List<? extends org.bouncycastle.asn1.x509.AlgorithmIdentifier>, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final java.security.spec.AlgorithmParameterSpec getAlgSpec()
-  @org.jetbrains.annotations.NotNull public final String getAlgorithmName()
-  @org.jetbrains.annotations.NotNull public final List getAlternativeOIDs()
-  @org.jetbrains.annotations.NotNull public final String getDesc()
-  @org.jetbrains.annotations.Nullable public final Integer getKeySize()
-  @org.jetbrains.annotations.NotNull public final String getProviderName()
-  @org.jetbrains.annotations.NotNull public final String getSchemeCodeName()
+  @Nullable
+  public final java.security.spec.AlgorithmParameterSpec getAlgSpec()
+  @NotNull
+  public final String getAlgorithmName()
+  @NotNull
+  public final java.util.List<org.bouncycastle.asn1.x509.AlgorithmIdentifier> getAlternativeOIDs()
+  @NotNull
+  public final String getDesc()
+  @Nullable
+  public final Integer getKeySize()
+  @NotNull
+  public final String getProviderName()
+  @NotNull
+  public final String getSchemeCodeName()
   public final int getSchemeNumberID()
-  @org.jetbrains.annotations.NotNull public final String getSignatureName()
-  @org.jetbrains.annotations.NotNull public final org.bouncycastle.asn1.x509.AlgorithmIdentifier getSignatureOID()
+  @NotNull
+  public final String getSignatureName()
+  @NotNull
+  public final org.bouncycastle.asn1.x509.AlgorithmIdentifier getSignatureOID()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.crypto.SignedData extends java.lang.Object
-  public <init>(net.corda.core.serialization.SerializedBytes, net.corda.core.crypto.DigitalSignature$WithKey)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializedBytes getRaw()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.DigitalSignature$WithKey getSig()
-  @org.jetbrains.annotations.NotNull public final Object verified()
-  protected void verifyData(Object)
+@CordaSerializable
+public class net.corda.core.crypto.SignedData extends java.lang.Object
+  public <init>(net.corda.core.serialization.SerializedBytes<T>, net.corda.core.crypto.DigitalSignature$WithKey)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> getRaw()
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey getSig()
+  @NotNull
+  public final T verified()
+  protected void verifyData(T)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.crypto.TransactionSignature extends net.corda.core.crypto.DigitalSignature
+@CordaSerializable
+public final class net.corda.core.crypto.TransactionSignature extends net.corda.core.crypto.DigitalSignature
   public <init>(byte[], java.security.PublicKey, net.corda.core.crypto.SignatureMetadata)
   public <init>(byte[], java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.crypto.PartialMerkleTree)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getBy()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
+  @NotNull
+  public final java.security.PublicKey getBy()
+  @Nullable
+  public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
   public int hashCode()
   public final boolean isValid(net.corda.core.crypto.SecureHash)
   public final boolean verify(net.corda.core.crypto.SecureHash)
@@ -1070,463 +1605,739 @@ public abstract class net.corda.core.flows.AbstractStateReplacementFlow extends 
 public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.Nullable public Void call()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowSession getInitiatingSession()
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.ProgressTracker getProgressTracker()
-  protected abstract void verifyProposal(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.AbstractStateReplacementFlow$Proposal)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getInitiatingSession()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  protected abstract void verifyProposal(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.AbstractStateReplacementFlow$Proposal<? extends T>)
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion Companion
 ##
 public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker tracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$APPROVING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$APPROVING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$APPROVING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$VERIFYING INSTANCE
 ##
 public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Instigator extends net.corda.core.flows.FlowLogic
-  public <init>(net.corda.core.contracts.StateAndRef, Object, net.corda.core.utilities.ProgressTracker)
-  @org.jetbrains.annotations.NotNull protected abstract net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public net.corda.core.contracts.StateAndRef call()
-  public final Object getModification()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef getOriginalState()
-  @org.jetbrains.annotations.NotNull public List getParticipantSessions()
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  public <init>(net.corda.core.contracts.StateAndRef<? extends S>, M, net.corda.core.utilities.ProgressTracker)
+  @NotNull
+  protected abstract net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+  @Suspendable
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> call()
+  public final M getModification()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<S> getOriginalState()
+  @NotNull
+  public java.util.List<kotlin.Pair<net.corda.core.flows.FlowSession, java.util.List<net.corda.core.identity.AbstractParty>>> getParticipantSessions()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion Companion
 ##
 public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker tracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$NOTARY extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$NOTARY extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$NOTARY INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$SIGNING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.AbstractStateReplacementFlow$Proposal extends java.lang.Object
-  public <init>(net.corda.core.contracts.StateRef, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef component1()
-  public final Object component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.AbstractStateReplacementFlow$Proposal copy(net.corda.core.contracts.StateRef, Object)
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Proposal extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateRef, M)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  public final M component2()
+  @NotNull
+  public final net.corda.core.flows.AbstractStateReplacementFlow$Proposal<M> copy(net.corda.core.contracts.StateRef, M)
   public boolean equals(Object)
-  public final Object getModification()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef getStateRef()
+  public final M getModification()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
   public int hashCode()
   public String toString()
 ##
 public static final class net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx extends java.lang.Object
   public <init>(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx copy(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction component1()
+  @NotNull
+  public final net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx copy(net.corda.core.transactions.SignedTransaction)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction getStx()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getStx()
   public int hashCode()
   public String toString()
 ##
-@co.paralleluniverse.fibers.Suspendable public final class net.corda.core.flows.CollectSignatureFlow extends net.corda.core.flows.FlowLogic
-  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, List)
+@Suspendable
+public final class net.corda.core.flows.CollectSignatureFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, java.util.List<? extends java.security.PublicKey>)
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, java.security.PublicKey...)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public List call()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowSession getSession()
-  @org.jetbrains.annotations.NotNull public final List getSigningKeys()
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> call()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getSession()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigningKeys()
 ##
 public final class net.corda.core.flows.CollectSignaturesFlow extends net.corda.core.flows.FlowLogic
-  public <init>(net.corda.core.transactions.SignedTransaction, Collection)
-  public <init>(net.corda.core.transactions.SignedTransaction, Collection, Iterable)
-  public <init>(net.corda.core.transactions.SignedTransaction, Collection, Iterable, net.corda.core.utilities.ProgressTracker)
-  public <init>(net.corda.core.transactions.SignedTransaction, Collection, net.corda.core.utilities.ProgressTracker)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction call()
-  @org.jetbrains.annotations.Nullable public final Iterable getMyOptionalKeys()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.ProgressTracker getProgressTracker()
-  @org.jetbrains.annotations.NotNull public final Collection getSessionsToCollectFrom()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.ProgressTracker tracker()
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @Nullable
+  public final Iterable<java.security.PublicKey> getMyOptionalKeys()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final java.util.Collection<net.corda.core.flows.FlowSession> getSessionsToCollectFrom()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
   public static final net.corda.core.flows.CollectSignaturesFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.CollectSignaturesFlow$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker tracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$COLLECTING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$COLLECTING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.CollectSignaturesFlow$Companion$COLLECTING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.CollectSignaturesFlow$Companion$VERIFYING INSTANCE
 ##
 public final class net.corda.core.flows.ContractUpgradeFlow extends java.lang.Object
   public static final net.corda.core.flows.ContractUpgradeFlow INSTANCE
 ##
-@net.corda.core.flows.StartableByRPC public static final class net.corda.core.flows.ContractUpgradeFlow$Authorise extends net.corda.core.flows.FlowLogic
-  public <init>(net.corda.core.contracts.StateAndRef, Class)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.Nullable public Void call()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef getStateAndRef()
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Authorise extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.contracts.StateAndRef<?>, Class<? extends net.corda.core.contracts.UpgradedContract<?, ?>>)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<?> getStateAndRef()
 ##
-@net.corda.core.flows.StartableByRPC public static final class net.corda.core.flows.ContractUpgradeFlow$Deauthorise extends net.corda.core.flows.FlowLogic
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Deauthorise extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.contracts.StateRef)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.Nullable public Void call()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef getStateRef()
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
 ##
-@net.corda.core.flows.InitiatingFlow @net.corda.core.flows.StartableByRPC public static final class net.corda.core.flows.ContractUpgradeFlow$Initiate extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
-  public <init>(net.corda.core.contracts.StateAndRef, Class)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+@InitiatingFlow
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Initiate extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
+  public <init>(net.corda.core.contracts.StateAndRef<? extends OldState>, Class<? extends net.corda.core.contracts.UpgradedContract<? super OldState, ? extends NewState>>)
+  @Suspendable
+  @NotNull
+  protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
 ##
 public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession, Object)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.Nullable public Void call()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowSession getOtherSideSession()
-  @org.jetbrains.annotations.NotNull public final Object getPayload()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull protected net.corda.core.utilities.UntrustworthyData sendPayloadAndReceiveDataRequest(net.corda.core.flows.FlowSession, Object)
-  @co.paralleluniverse.fibers.Suspendable protected void verifyDataRequest(net.corda.core.internal.FetchDataFlow$Request$Data)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public final Object getPayload()
+  @Suspendable
+  @NotNull
+  protected net.corda.core.utilities.UntrustworthyData<net.corda.core.internal.FetchDataFlow$Request> sendPayloadAndReceiveDataRequest(net.corda.core.flows.FlowSession, Object)
+  @Suspendable
+  protected void verifyDataRequest(net.corda.core.internal.FetchDataFlow$Request$Data)
 ##
-@net.corda.core.flows.InitiatingFlow public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
+@InitiatingFlow
+public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
-  public <init>(net.corda.core.transactions.SignedTransaction, Set)
-  public <init>(net.corda.core.transactions.SignedTransaction, Set, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction call()
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.ProgressTracker getProgressTracker()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction getTransaction()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.ProgressTracker tracker()
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getTransaction()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
   public static final net.corda.core.flows.FinalityFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.FinalityFlow$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker tracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING extends net.corda.core.utilities.ProgressTracker$Step
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.ProgressTracker childProgressTracker()
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING extends net.corda.core.utilities.ProgressTracker$Step
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker childProgressTracker()
   public static final net.corda.core.flows.FinalityFlow$Companion$NOTARISING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.flows.FlowException extends net.corda.core.CordaException implements net.corda.core.flows.IdentifiableException
+@CordaSerializable
+public class net.corda.core.flows.FlowException extends net.corda.core.CordaException
   public <init>()
   public <init>(String)
   public <init>(String, Throwable)
   public <init>(Throwable)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.FlowInfo extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.flows.FlowInfo extends java.lang.Object
   public <init>(int, String)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInfo copy(int, String)
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.FlowInfo copy(int, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getAppName()
+  @NotNull
+  public final String getAppName()
   public final int getFlowVersion()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.flows.FlowInitiator extends java.lang.Object implements java.security.Principal
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext getInvocationContext()
+@CordaSerializable
+public abstract class net.corda.core.flows.FlowInitiator extends java.lang.Object implements java.security.Principal
+  @NotNull
+  public final net.corda.core.context.InvocationContext getInvocationContext()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.FlowInitiator$Peer extends net.corda.core.flows.FlowInitiator
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Peer extends net.corda.core.flows.FlowInitiator
   public <init>(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInitiator$Peer copy(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Peer copy(net.corda.core.identity.Party)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public String getName()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getParty()
+  @NotNull
+  public String getName()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.FlowInitiator$RPC extends net.corda.core.flows.FlowInitiator
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$RPC extends net.corda.core.flows.FlowInitiator
   public <init>(String)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInitiator$RPC copy(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$RPC copy(String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public String getName()
-  @org.jetbrains.annotations.NotNull public final String getUsername()
+  @NotNull
+  public String getName()
+  @NotNull
+  public final String getUsername()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.FlowInitiator$Scheduled extends net.corda.core.flows.FlowInitiator
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Scheduled extends net.corda.core.flows.FlowInitiator
   public <init>(net.corda.core.contracts.ScheduledStateRef)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ScheduledStateRef component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInitiator$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public String getName()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
+  @NotNull
+  public String getName()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.FlowInitiator$Service extends net.corda.core.flows.FlowInitiator
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Service extends net.corda.core.flows.FlowInitiator
   public <init>(String)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInitiator$Service copy(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Service copy(String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public String getName()
-  @org.jetbrains.annotations.NotNull public final String getServiceClassName()
+  @NotNull
+  public String getName()
+  @NotNull
+  public final String getServiceClassName()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.FlowInitiator$Shell extends net.corda.core.flows.FlowInitiator
-  @org.jetbrains.annotations.NotNull public String getName()
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Shell extends net.corda.core.flows.FlowInitiator
+  @NotNull
+  public String getName()
   public static final net.corda.core.flows.FlowInitiator$Shell INSTANCE
 ##
 public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public <init>()
-  @co.paralleluniverse.fibers.Suspendable public abstract Object call()
-  public final void checkFlowPermission(String, Map)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.Nullable public final net.corda.core.flows.FlowStackSnapshot flowStackSnapshot()
-  @org.jetbrains.annotations.Nullable public static final net.corda.core.flows.FlowLogic getCurrentTopLevel()
-  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInfo getFlowInfo(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final org.slf4j.Logger getLogger()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getOurIdentity()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.PartyAndCertificate getOurIdentityAndCert()
-  @org.jetbrains.annotations.Nullable public net.corda.core.utilities.ProgressTracker getProgressTracker()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId getRunId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.ServiceHub getServiceHub()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.identity.Party)
-  @co.paralleluniverse.fibers.Suspendable public final void persistFlowStackSnapshot()
-  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated @org.jetbrains.annotations.NotNull public net.corda.core.utilities.UntrustworthyData receive(Class, net.corda.core.identity.Party)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public List receiveAll(Class, List)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public Map receiveAllMap(Map)
-  public final void recordAuditEvent(String, String, Map)
-  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated public void send(net.corda.core.identity.Party, Object)
-  @co.paralleluniverse.fibers.Suspendable @kotlin.Deprecated @org.jetbrains.annotations.NotNull public net.corda.core.utilities.UntrustworthyData sendAndReceive(Class, net.corda.core.identity.Party, Object)
-  @co.paralleluniverse.fibers.Suspendable public static final void sleep(java.time.Duration)
-  @co.paralleluniverse.fibers.Suspendable public Object subFlow(net.corda.core.flows.FlowLogic)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed track()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed trackStepsTree()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed trackStepsTreeIndex()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash, boolean)
+  @Suspendable
+  public abstract T call()
+  public final void checkFlowPermission(String, java.util.Map<String, String>)
+  @Suspendable
+  @Nullable
+  public final net.corda.core.flows.FlowStackSnapshot flowStackSnapshot()
+  @Nullable
+  public static final net.corda.core.flows.FlowLogic<?> getCurrentTopLevel()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.flows.FlowInfo getFlowInfo(net.corda.core.identity.Party)
+  @NotNull
+  public final org.slf4j.Logger getLogger()
+  @NotNull
+  public final net.corda.core.identity.Party getOurIdentity()
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate getOurIdentityAndCert()
+  @Nullable
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getRunId()
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServiceHub()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.identity.Party)
+  @Suspendable
+  public final void persistFlowStackSnapshot()
+  @Suspendable
+  @NotNull
+  public net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>, net.corda.core.identity.Party)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(Class<R>, java.util.List<? extends net.corda.core.flows.FlowSession>)
+  @Suspendable
+  @NotNull
+  public java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAllMap(java.util.Map<net.corda.core.flows.FlowSession, ? extends Class<?>>)
+  public final void recordAuditEvent(String, String, java.util.Map<String, String>)
+  @Suspendable
+  public void send(net.corda.core.identity.Party, Object)
+  @Suspendable
+  @NotNull
+  public net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, net.corda.core.identity.Party, Object)
+  @Suspendable
+  public static final void sleep(java.time.Duration)
+  @Suspendable
+  public R subFlow(net.corda.core.flows.FlowLogic<? extends R>)
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> track()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> trackStepsTree()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<Integer, Integer> trackStepsTreeIndex()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash)
+  @Suspendable
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash, boolean)
   public static final net.corda.core.flows.FlowLogic$Companion Companion
 ##
 public static final class net.corda.core.flows.FlowLogic$Companion extends java.lang.Object
-  @org.jetbrains.annotations.Nullable public final net.corda.core.flows.FlowLogic getCurrentTopLevel()
-  @co.paralleluniverse.fibers.Suspendable public final void sleep(java.time.Duration)
+  @Nullable
+  public final net.corda.core.flows.FlowLogic<?> getCurrentTopLevel()
+  @Suspendable
+  public final void sleep(java.time.Duration)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public interface net.corda.core.flows.FlowLogicRef
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.flows.FlowLogicRef
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.flows.FlowLogicRefFactory
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowLogicRef create(Class, Object...)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowLogicRef create(String, Object...)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowLogic toFlowLogic(net.corda.core.flows.FlowLogicRef)
+@DoNotImplement
+public interface net.corda.core.flows.FlowLogicRefFactory
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogicRef create(Class<? extends net.corda.core.flows.FlowLogic<?>>, Object...)
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogicRef create(String, Object...)
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogic<?> toFlowLogic(net.corda.core.flows.FlowLogicRef)
 ##
-@net.corda.core.DoNotImplement public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
+@DoNotImplement
+public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
   public <init>()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.identity.Party getCounterparty()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo(boolean)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.utilities.UntrustworthyData receive(Class)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.utilities.UntrustworthyData receive(Class, boolean)
-  @co.paralleluniverse.fibers.Suspendable public abstract void send(Object)
-  @co.paralleluniverse.fibers.Suspendable public abstract void send(Object, boolean)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.utilities.UntrustworthyData sendAndReceive(Class, Object)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.utilities.UntrustworthyData sendAndReceive(Class, Object, boolean)
+  @NotNull
+  public abstract net.corda.core.identity.Party getCounterparty()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo(boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>, boolean)
+  @Suspendable
+  public abstract void send(Object)
+  @Suspendable
+  public abstract void send(Object, boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, Object)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, Object, boolean)
 ##
 public final class net.corda.core.flows.FlowStackSnapshot extends java.lang.Object
-  public <init>(java.time.Instant, String, List)
-  @org.jetbrains.annotations.NotNull public final java.time.Instant component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final List component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowStackSnapshot copy(java.time.Instant, String, List)
+  public <init>(java.time.Instant, String, java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame>)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame> component3()
+  @NotNull
+  public final net.corda.core.flows.FlowStackSnapshot copy(java.time.Instant, String, java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getFlowClass()
-  @org.jetbrains.annotations.NotNull public final List getStackFrames()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant getTime()
+  @NotNull
+  public final String getFlowClass()
+  @NotNull
+  public final java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame> getStackFrames()
+  @NotNull
+  public final java.time.Instant getTime()
   public int hashCode()
   public String toString()
 ##
 public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends java.lang.Object
-  public <init>(StackTraceElement, List)
-  @org.jetbrains.annotations.NotNull public final StackTraceElement component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowStackSnapshot$Frame copy(StackTraceElement, List)
+  public <init>(StackTraceElement, java.util.List<?>)
+  @NotNull
+  public final StackTraceElement component1()
+  @NotNull
+  public final java.util.List<Object> component2()
+  @NotNull
+  public final net.corda.core.flows.FlowStackSnapshot$Frame copy(StackTraceElement, java.util.List<?>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getStackObjects()
-  @org.jetbrains.annotations.NotNull public final StackTraceElement getStackTraceElement()
+  @NotNull
+  public final java.util.List<Object> getStackObjects()
+  @NotNull
+  public final StackTraceElement getStackTraceElement()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.IllegalFlowLogicException extends java.lang.IllegalArgumentException
-  public <init>(Class, String)
+@CordaSerializable
+public final class net.corda.core.flows.IllegalFlowLogicException extends java.lang.IllegalArgumentException
+  public <init>(Class<?>, String)
   public <init>(String, String)
-  @org.jetbrains.annotations.NotNull public final String getType()
+  @NotNull
+  public final String getType()
 ##
 public @interface net.corda.core.flows.InitiatedBy
-  public abstract Class value()
+  public abstract Class<? extends net.corda.core.flows.FlowLogic<?>> value()
 ##
 public @interface net.corda.core.flows.InitiatingFlow
   public abstract int version()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.NotarisationPayload extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationPayload extends java.lang.Object
   public <init>(Object, net.corda.core.flows.NotarisationRequestSignature)
-  @org.jetbrains.annotations.NotNull public final Object component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotarisationRequestSignature component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotarisationPayload copy(Object, net.corda.core.flows.NotarisationRequestSignature)
+  @NotNull
+  public final Object component1()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature component2()
+  @NotNull
+  public final net.corda.core.flows.NotarisationPayload copy(Object, net.corda.core.flows.NotarisationRequestSignature)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotarisationRequestSignature getRequestSignature()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction getSignedTransaction()
-  @org.jetbrains.annotations.NotNull public final Object getTransaction()
+  @NotNull
+  public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature getRequestSignature()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getSignedTransaction()
+  @NotNull
+  public final Object getTransaction()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.NotarisationRequest extends java.lang.Object
-  public <init>(List, net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final List getStatesToConsume()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getTransactionId()
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationRequest extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getStatesToConsume()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTransactionId()
+  public final void verifySignature(net.corda.core.flows.NotarisationRequestSignature, net.corda.core.identity.Party)
   public static final net.corda.core.flows.NotarisationRequest$Companion Companion
 ##
 public static final class net.corda.core.flows.NotarisationRequest$Companion extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.NotarisationRequestSignature extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationRequestSignature extends java.lang.Object
   public <init>(net.corda.core.crypto.DigitalSignature$WithKey, int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.DigitalSignature$WithKey component1()
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey component1()
   public final int component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotarisationRequestSignature copy(net.corda.core.crypto.DigitalSignature$WithKey, int)
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature copy(net.corda.core.crypto.DigitalSignature$WithKey, int)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.DigitalSignature$WithKey getDigitalSignature()
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey getDigitalSignature()
   public final int getPlatformVersion()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.NotarisationResponse extends java.lang.Object
-  public <init>(List)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotarisationResponse copy(List)
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationResponse extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component1()
+  @NotNull
+  public final net.corda.core.flows.NotarisationResponse copy(java.util.List<net.corda.core.crypto.TransactionSignature>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getSignatures()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> getSignatures()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.flows.InitiatingFlow public final class net.corda.core.flows.NotaryChangeFlow extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
-  public <init>(net.corda.core.contracts.StateAndRef, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker)
-  @org.jetbrains.annotations.NotNull protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+@InitiatingFlow
+public final class net.corda.core.flows.NotaryChangeFlow extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
+  public <init>(net.corda.core.contracts.StateAndRef<? extends T>, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker)
+  @NotNull
+  protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
+@CordaSerializable
+public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryError$Conflict extends net.corda.core.flows.NotaryError
-  public <init>(net.corda.core.crypto.SecureHash, Map)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final Map component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError$Conflict copy(net.corda.core.crypto.SecureHash, Map)
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$Conflict extends net.corda.core.flows.NotaryError
+  public <init>(net.corda.core.crypto.SecureHash, java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails>)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails> component2()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$Conflict copy(net.corda.core.crypto.SecureHash, java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Map getConsumedStates()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getTxId()
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails> getConsumedStates()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryError$General extends net.corda.core.flows.NotaryError
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$General extends net.corda.core.flows.NotaryError
   public <init>(Throwable)
-  @org.jetbrains.annotations.NotNull public final Throwable component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError$General copy(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$General copy(Throwable)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Throwable getCause()
+  @NotNull
+  public final Throwable getCause()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryError$RequestSignatureInvalid extends net.corda.core.flows.NotaryError
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$RequestSignatureInvalid extends net.corda.core.flows.NotaryError
   public <init>(Throwable)
-  @org.jetbrains.annotations.NotNull public final Throwable component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError$RequestSignatureInvalid copy(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$RequestSignatureInvalid copy(Throwable)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Throwable getCause()
+  @NotNull
+  public final Throwable getCause()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid extends net.corda.core.flows.NotaryError
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid extends net.corda.core.flows.NotaryError
   public <init>(java.time.Instant, net.corda.core.contracts.TimeWindow)
-  @org.jetbrains.annotations.NotNull public final java.time.Instant component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TimeWindow component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError$TimeWindowInvalid copy(java.time.Instant, net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow component2()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$TimeWindowInvalid copy(java.time.Instant, net.corda.core.contracts.TimeWindow)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final java.time.Instant getCurrentTime()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.TimeWindow getTxTimeWindow()
+  @NotNull
+  public final java.time.Instant getCurrentTime()
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow getTxTimeWindow()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
   public static final net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.flows.NotaryError$TimeWindowInvalid INSTANCE
+  @NotNull
+  public static final net.corda.core.flows.NotaryError$TimeWindowInvalid INSTANCE
 ##
 public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryError$TransactionInvalid extends net.corda.core.flows.NotaryError
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$TransactionInvalid extends net.corda.core.flows.NotaryError
   public <init>(Throwable)
-  @org.jetbrains.annotations.NotNull public final Throwable component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError$TransactionInvalid copy(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$TransactionInvalid copy(Throwable)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Throwable getCause()
+  @NotNull
+  public final Throwable getCause()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryError$WrongNotary extends net.corda.core.flows.NotaryError
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$WrongNotary extends net.corda.core.flows.NotaryError
   public static final net.corda.core.flows.NotaryError$WrongNotary INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.NotaryException extends net.corda.core.flows.FlowException
+@CordaSerializable
+public final class net.corda.core.flows.NotaryException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.NotaryError getError()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.crypto.SecureHash getTxId()
+  @NotNull
+  public final net.corda.core.flows.NotaryError getError()
+  @Nullable
+  public final net.corda.core.crypto.SecureHash getTxId()
 ##
 public final class net.corda.core.flows.NotaryFlow extends java.lang.Object
   public <init>()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.flows.InitiatingFlow public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.flows.FlowLogic
+@DoNotImplement
+@InitiatingFlow
+public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public List call()
-  @org.jetbrains.annotations.NotNull protected final net.corda.core.identity.Party checkTransaction()
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.ProgressTracker getProgressTracker()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull protected final net.corda.core.utilities.UntrustworthyData notarise(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull protected final List validateResponse(net.corda.core.utilities.UntrustworthyData, net.corda.core.identity.Party)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> call()
+  @NotNull
+  protected final net.corda.core.identity.Party checkTransaction()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @Suspendable
+  @NotNull
+  protected final net.corda.core.utilities.UntrustworthyData<net.corda.core.flows.NotarisationResponse> notarise(net.corda.core.identity.Party)
+  @NotNull
+  protected final java.util.List<net.corda.core.crypto.TransactionSignature> validateResponse(net.corda.core.utilities.UntrustworthyData<net.corda.core.flows.NotarisationResponse>, net.corda.core.identity.Party)
   public static final net.corda.core.flows.NotaryFlow$Client$Companion Companion
 ##
 public static final class net.corda.core.flows.NotaryFlow$Client$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker tracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUESTING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUESTING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.NotaryFlow$Client$Companion$REQUESTING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
+##
+public abstract static class net.corda.core.flows.NotaryFlow$Service extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.node.services.TrustedAuthorityNotaryService)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @Suspendable
+  protected final void checkNotary(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public final net.corda.core.node.services.TrustedAuthorityNotaryService getService()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.TransactionParts receiveAndVerifyTx()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotaryInternalException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.flows.NotaryError)
+  @NotNull
+  public final net.corda.core.flows.NotaryError getError()
 ##
 public final class net.corda.core.flows.ReceiveStateAndRefFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public List call()
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<T>> call()
 ##
 public final class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, boolean)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction call()
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
 ##
 public @interface net.corda.core.flows.SchedulableFlow
 ##
 public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flows.DataVendingFlow
-  public <init>(net.corda.core.flows.FlowSession, List)
+  public <init>(net.corda.core.flows.FlowSession, java.util.List<? extends net.corda.core.contracts.StateAndRef<?>>)
 ##
 public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
 ##
 public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction call()
-  @co.paralleluniverse.fibers.Suspendable protected abstract void checkTransaction(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowSession getOtherSideSession()
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.ProgressTracker getProgressTracker()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.ProgressTracker tracker()
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @Suspendable
+  protected abstract void checkTransaction(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
   public static final net.corda.core.flows.SignTransactionFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.SignTransactionFlow$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker tracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.SignTransactionFlow$Companion$RECEIVING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$RECEIVING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.SignTransactionFlow$Companion$RECEIVING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.SignTransactionFlow$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.SignTransactionFlow$Companion$SIGNING INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING INSTANCE
 ##
 public final class net.corda.core.flows.StackFrameDataToken extends java.lang.Object
   public <init>(String)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StackFrameDataToken copy(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.StackFrameDataToken copy(String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getClassName()
+  @NotNull
+  public final String getClassName()
   public int hashCode()
   public String toString()
 ##
@@ -1534,76 +2345,140 @@ public @interface net.corda.core.flows.StartableByRPC
 ##
 public @interface net.corda.core.flows.StartableByService
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.StateConsumptionDetails extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.flows.StateConsumptionDetails extends java.lang.Object
   public <init>(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateConsumptionDetails copy(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails copy(net.corda.core.crypto.SecureHash)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHashOfTransactionId()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHashOfTransactionId()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.StateMachineRunId extends java.lang.Object
-  public <init>(UUID)
-  @org.jetbrains.annotations.NotNull public final UUID component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId copy(UUID)
+@CordaSerializable
+public final class net.corda.core.flows.StateMachineRunId extends java.lang.Object
+  public <init>(java.util.UUID)
+  @NotNull
+  public final java.util.UUID component1()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId copy(java.util.UUID)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final UUID getUuid()
+  @NotNull
+  public final java.util.UUID getUuid()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
   public static final net.corda.core.flows.StateMachineRunId$Companion Companion
 ##
 public static final class net.corda.core.flows.StateMachineRunId$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId createRandom()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId createRandom()
 ##
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.flows.StateReplacementException extends net.corda.core.flows.FlowException
+@CordaSerializable
+public class net.corda.core.flows.StateReplacementException extends net.corda.core.flows.FlowException
   public <init>()
   public <init>(String)
   public <init>(String, Throwable)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
+public final class net.corda.core.flows.TransactionParts extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.contracts.TimeWindow, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> component2()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow component3()
+  @Nullable
+  public final net.corda.core.identity.Party component4()
+  @NotNull
+  public final net.corda.core.flows.TransactionParts copy(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.contracts.TimeWindow, net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimestamp()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException
   public <init>(String)
   public <init>(String, Throwable)
-  public <init>(String, Throwable, Long)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.identity.AbstractParty extends java.lang.Object
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.identity.AbstractParty extends java.lang.Object
   public <init>(java.security.PublicKey)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getOwningKey()
+  @NotNull
+  public final java.security.PublicKey getOwningKey()
   public int hashCode()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.CordaX500Name nameOrNull()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PartyAndReference ref(byte...)
+  @Nullable
+  public abstract net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public abstract net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference ref(byte...)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.identity.AnonymousParty extends net.corda.core.identity.AbstractParty
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.identity.AnonymousParty extends net.corda.core.identity.AbstractParty
   public <init>(java.security.PublicKey)
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.CordaX500Name nameOrNull()
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @Nullable
+  public net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.identity.CordaX500Name extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.identity.CordaX500Name extends java.lang.Object
   public <init>(String, String, String)
   public <init>(String, String, String, String)
   public <init>(String, String, String, String, String, String)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
-  @org.jetbrains.annotations.Nullable public final String component1()
-  @org.jetbrains.annotations.Nullable public final String component2()
-  @org.jetbrains.annotations.NotNull public final String component3()
-  @org.jetbrains.annotations.NotNull public final String component4()
-  @org.jetbrains.annotations.Nullable public final String component5()
-  @org.jetbrains.annotations.NotNull public final String component6()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name copy(String, String, String, String, String, String)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
+  @Nullable
+  public final String component1()
+  @Nullable
+  public final String component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final String component4()
+  @Nullable
+  public final String component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name copy(String, String, String, String, String, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final String getCommonName()
-  @org.jetbrains.annotations.NotNull public final String getCountry()
-  @org.jetbrains.annotations.NotNull public final String getLocality()
-  @org.jetbrains.annotations.NotNull public final String getOrganisation()
-  @org.jetbrains.annotations.Nullable public final String getOrganisationUnit()
-  @org.jetbrains.annotations.Nullable public final String getState()
-  @org.jetbrains.annotations.NotNull public final javax.security.auth.x500.X500Principal getX500Principal()
+  @Nullable
+  public final String getCommonName()
+  @NotNull
+  public final String getCountry()
+  @NotNull
+  public final String getLocality()
+  @NotNull
+  public final String getOrganisation()
+  @Nullable
+  public final String getOrganisationUnit()
+  @Nullable
+  public final String getState()
+  @NotNull
+  public final javax.security.auth.x500.X500Principal getX500Principal()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name parse(String)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name parse(String)
+  @NotNull
+  public String toString()
   public static final net.corda.core.identity.CordaX500Name$Companion Companion
   public static final int LENGTH_COUNTRY = 2
   public static final int MAX_LENGTH_COMMON_NAME = 64
@@ -1613,903 +2488,1538 @@ public static final class net.corda.core.flows.StateMachineRunId$Companion exten
   public static final int MAX_LENGTH_STATE = 64
 ##
 public static final class net.corda.core.identity.CordaX500Name$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name parse(String)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name parse(String)
 ##
 public final class net.corda.core.identity.IdentityUtils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final Map excludeHostNode(net.corda.core.node.ServiceHub, Map)
-  @org.jetbrains.annotations.NotNull public static final Map excludeNotary(Map, net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public static final Map groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, Collection)
-  @org.jetbrains.annotations.NotNull public static final Map groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, Collection, boolean)
-  @org.jetbrains.annotations.NotNull public static final Map groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, Collection)
-  @org.jetbrains.annotations.NotNull public static final Map groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, Collection, boolean)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, T> excludeHostNode(net.corda.core.node.ServiceHub, java.util.Map<net.corda.core.identity.Party, ? extends T>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, T> excludeNotary(java.util.Map<net.corda.core.identity.Party, ? extends T>, net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<net.corda.core.identity.AbstractParty>> groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<net.corda.core.identity.AbstractParty>> groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends net.corda.core.identity.AbstractParty>, boolean)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>, boolean)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.identity.Party extends net.corda.core.identity.AbstractParty
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.identity.Party extends net.corda.core.identity.AbstractParty
   public <init>(java.security.cert.X509Certificate)
   public <init>(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.AnonymousParty anonymise()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getName()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.CordaX500Name nameOrNull()
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public final net.corda.core.identity.AnonymousParty anonymise()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.identity.PartyAndCertificate extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.identity.PartyAndCertificate extends java.lang.Object
   public <init>(java.security.cert.CertPath)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component1()
-  @org.jetbrains.annotations.NotNull public final java.security.cert.X509Certificate component2()
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final java.security.cert.X509Certificate component2()
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final java.security.cert.CertPath getCertPath()
-  @org.jetbrains.annotations.NotNull public final java.security.cert.X509Certificate getCertificate()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getName()
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getOwningKey()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getParty()
+  @NotNull
+  public final java.security.cert.CertPath getCertPath()
+  @NotNull
+  public final java.security.cert.X509Certificate getCertificate()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final java.security.PublicKey getOwningKey()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
-  @org.jetbrains.annotations.NotNull public final java.security.cert.PKIXCertPathValidatorResult verify(java.security.cert.TrustAnchor)
+  @NotNull
+  public String toString()
+  @NotNull
+  public final java.security.cert.PKIXCertPathValidatorResult verify(java.security.cert.TrustAnchor)
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.messaging.AllPossibleRecipients extends net.corda.core.messaging.MessageRecipients
+@CordaSerializable
+public interface net.corda.core.messaging.AllPossibleRecipients extends net.corda.core.messaging.MessageRecipients
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.messaging.RPCOps
+@DoNotImplement
+public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.messaging.RPCOps
   public abstract void acceptNewNetworkParameters(net.corda.core.crypto.SecureHash)
   public abstract void addVaultTransactionNote(net.corda.core.crypto.SecureHash, String)
   public abstract boolean attachmentExists(net.corda.core.crypto.SecureHash)
   public abstract void clearNetworkMapCache()
-  @org.jetbrains.annotations.NotNull public abstract java.time.Instant currentNodeTime()
+  @NotNull
+  public abstract java.time.Instant currentNodeTime()
   public abstract int getProtocolVersion()
-  @org.jetbrains.annotations.NotNull public abstract Iterable getVaultTransactionNotes(net.corda.core.crypto.SecureHash)
-  @kotlin.Deprecated @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed internalVerifiedTransactionsFeed()
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public abstract List internalVerifiedTransactionsSnapshot()
+  @NotNull
+  public abstract Iterable<String> getVaultTransactionNotes(net.corda.core.crypto.SecureHash)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction> internalVerifiedTransactionsFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.transactions.SignedTransaction> internalVerifiedTransactionsSnapshot()
   public abstract boolean isFlowsDrainingModeEnabled()
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed networkMapFeed()
-  @org.jetbrains.annotations.NotNull public abstract List networkMapSnapshot()
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed networkParametersFeed()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.NodeInfo nodeInfo()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
-  @org.jetbrains.annotations.NotNull public abstract List notaryIdentities()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party notaryPartyFromX500Name(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public abstract java.io.InputStream openAttachment(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public abstract Set partiesFromName(String, boolean)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract List queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
-  @org.jetbrains.annotations.NotNull public abstract List registeredFlows()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> networkMapFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> networkMapSnapshot()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.messaging.ParametersUpdateInfo, net.corda.core.messaging.ParametersUpdateInfo> networkParametersFeed()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo nodeInfo()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> notaryIdentities()
+  @Nullable
+  public abstract net.corda.core.identity.Party notaryPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract java.io.InputStream openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String, boolean)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+  @NotNull
+  public abstract java.util.List<String> registeredFlows()
   public abstract void setFlowsDrainingModeEnabled(boolean)
-  public abstract void shutdown()
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowHandle startFlowDynamic(Class, Object...)
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowProgressHandle startTrackedFlowDynamic(Class, Object...)
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed stateMachineRecordedTransactionMappingFeed()
-  @org.jetbrains.annotations.NotNull public abstract List stateMachineRecordedTransactionMappingSnapshot()
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed stateMachinesFeed()
-  @org.jetbrains.annotations.NotNull public abstract List stateMachinesSnapshot()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash uploadAttachment(java.io.InputStream)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash uploadAttachmentWithMetadata(java.io.InputStream, String, String)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page vaultQuery(Class)
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page vaultQueryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page vaultQueryByCriteria(net.corda.core.node.services.vault.QueryCriteria, Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page vaultQueryByWithPagingSpec(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page vaultQueryByWithSorting(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed vaultTrack(Class)
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed vaultTrackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed vaultTrackByCriteria(Class, net.corda.core.node.services.vault.QueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed vaultTrackByWithPagingSpec(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed vaultTrackByWithSorting(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
-  @net.corda.core.messaging.RPCReturnsObservables @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture waitUntilNetworkReady()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.FlowHandle<T> startFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.messaging.StateMachineTransactionMapping>, net.corda.core.messaging.StateMachineTransactionMapping> stateMachineRecordedTransactionMappingFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.messaging.StateMachineTransactionMapping> stateMachineRecordedTransactionMappingSnapshot()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.messaging.StateMachineInfo>, net.corda.core.messaging.StateMachineUpdate> stateMachinesFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.messaging.StateMachineInfo> stateMachinesSnapshot()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash uploadAttachment(java.io.InputStream)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash uploadAttachmentWithMetadata(java.io.InputStream, String, String)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQuery(Class<? extends T>)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByCriteria(net.corda.core.node.services.vault.QueryCriteria, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByWithPagingSpec(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByWithSorting(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrack(Class<? extends T>)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByCriteria(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByWithPagingSpec(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByWithSorting(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<Void> waitUntilNetworkReady()
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
 public final class net.corda.core.messaging.CordaRPCOpsKt extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.messaging.DataFeed pendingFlowsCount(net.corda.core.messaging.CordaRPCOps)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.DataFeed extends java.lang.Object
-  public <init>(Object, rx.Observable)
-  public final Object component1()
-  @org.jetbrains.annotations.NotNull public final rx.Observable component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.DataFeed copy(Object, rx.Observable)
+@CordaSerializable
+public final class net.corda.core.messaging.DataFeed extends java.lang.Object
+  public <init>(A, rx.Observable<B>)
+  public final A component1()
+  @NotNull
+  public final rx.Observable<B> component2()
+  @NotNull
+  public final net.corda.core.messaging.DataFeed<A, B> copy(A, rx.Observable<B>)
   public boolean equals(Object)
-  public final Object getSnapshot()
-  @org.jetbrains.annotations.NotNull public final rx.Observable getUpdates()
+  public final A getSnapshot()
+  @NotNull
+  public final rx.Observable<B> getUpdates()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.messaging.FlowHandle extends java.lang.AutoCloseable
+@DoNotImplement
+public interface net.corda.core.messaging.FlowHandle extends java.lang.AutoCloseable
   public abstract void close()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.StateMachineRunId getId()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture getReturnValue()
+  @NotNull
+  public abstract net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<A> getReturnValue()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowHandle
-  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowHandle
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>)
   public void close()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.concurrent.CordaFuture component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.FlowHandleImpl copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<A> component2()
+  @NotNull
+  public final net.corda.core.messaging.FlowHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.flows.StateMachineRunId getId()
-  @org.jetbrains.annotations.NotNull public net.corda.core.concurrent.CordaFuture getReturnValue()
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.messaging.FlowProgressHandle extends net.corda.core.messaging.FlowHandle
+@DoNotImplement
+public interface net.corda.core.messaging.FlowProgressHandle extends net.corda.core.messaging.FlowHandle
   public abstract void close()
-  @org.jetbrains.annotations.NotNull public abstract rx.Observable getProgress()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.messaging.DataFeed getStepsTreeFeed()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.messaging.DataFeed getStepsTreeIndexFeed()
+  @NotNull
+  public abstract rx.Observable<String> getProgress()
+  @Nullable
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeFeed()
+  @Nullable
+  public abstract net.corda.core.messaging.DataFeed<Integer, Integer> getStepsTreeIndexFeed()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowProgressHandle
-  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable)
-  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed)
-  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed, net.corda.core.messaging.DataFeed)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowProgressHandle
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>, net.corda.core.messaging.DataFeed<? extends java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>>)
   public void close()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.concurrent.CordaFuture component2()
-  @org.jetbrains.annotations.NotNull public final rx.Observable component3()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed component4()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.FlowProgressHandleImpl copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.FlowProgressHandleImpl copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed, net.corda.core.messaging.DataFeed)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<A> component2()
+  @NotNull
+  public final rx.Observable<String> component3()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<Integer, Integer> component4()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> component5()
+  @NotNull
+  public final net.corda.core.messaging.FlowProgressHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>)
+  @NotNull
+  public final net.corda.core.messaging.FlowProgressHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>, net.corda.core.messaging.DataFeed<? extends java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.flows.StateMachineRunId getId()
-  @org.jetbrains.annotations.NotNull public rx.Observable getProgress()
-  @org.jetbrains.annotations.NotNull public net.corda.core.concurrent.CordaFuture getReturnValue()
-  @org.jetbrains.annotations.Nullable public net.corda.core.messaging.DataFeed getStepsTreeFeed()
-  @org.jetbrains.annotations.Nullable public net.corda.core.messaging.DataFeed getStepsTreeIndexFeed()
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public rx.Observable<String> getProgress()
+  @NotNull
+  public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+  @Nullable
+  public net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeFeed()
+  @Nullable
+  public net.corda.core.messaging.DataFeed<Integer, Integer> getStepsTreeIndexFeed()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.messaging.MessageRecipientGroup extends net.corda.core.messaging.MessageRecipients
+@CordaSerializable
+public interface net.corda.core.messaging.MessageRecipientGroup extends net.corda.core.messaging.MessageRecipients
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.messaging.MessageRecipients
+@CordaSerializable
+public interface net.corda.core.messaging.MessageRecipients
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.ParametersUpdateInfo extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.messaging.ParametersUpdateInfo extends java.lang.Object
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.node.NetworkParameters, String, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters component2()
-  @org.jetbrains.annotations.NotNull public final String component3()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.ParametersUpdateInfo copy(net.corda.core.crypto.SecureHash, net.corda.core.node.NetworkParameters, String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final java.time.Instant component4()
+  @NotNull
+  public final net.corda.core.messaging.ParametersUpdateInfo copy(net.corda.core.crypto.SecureHash, net.corda.core.node.NetworkParameters, String, java.time.Instant)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getDescription()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHash()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters getParameters()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant getUpdateDeadline()
+  @NotNull
+  public final String getDescription()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getParameters()
+  @NotNull
+  public final java.time.Instant getUpdateDeadline()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.messaging.RPCOps
+@DoNotImplement
+public interface net.corda.core.messaging.RPCOps
   public abstract int getProtocolVersion()
 ##
 public @interface net.corda.core.messaging.RPCReturnsObservables
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.messaging.SingleMessageRecipient extends net.corda.core.messaging.MessageRecipients
+@CordaSerializable
+public interface net.corda.core.messaging.SingleMessageRecipient extends net.corda.core.messaging.MessageRecipients
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.StateMachineInfo extends java.lang.Object
-  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed)
-  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed, net.corda.core.context.InvocationContext)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInitiator component3()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed, net.corda.core.context.InvocationContext)
+@CordaSerializable
+public final class net.corda.core.messaging.StateMachineInfo extends java.lang.Object
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>)
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>, net.corda.core.context.InvocationContext)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator component3()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> component4()
+  @NotNull
+  public final net.corda.core.context.InvocationContext component5()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>)
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>, net.corda.core.context.InvocationContext)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getFlowLogicClassName()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.FlowInitiator getInitiator()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.context.InvocationContext getInvocationContext()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.messaging.DataFeed getProgressTrackerStepAndUpdates()
+  @NotNull
+  public final String getFlowLogicClassName()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator getInitiator()
+  @NotNull
+  public final net.corda.core.context.InvocationContext getInvocationContext()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> getProgressTrackerStepAndUpdates()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.messaging.StateMachineTransactionMapping extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.messaging.StateMachineTransactionMapping extends java.lang.Object
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.StateMachineTransactionMapping copy(net.corda.core.flows.StateMachineRunId, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component2()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineTransactionMapping copy(net.corda.core.flows.StateMachineRunId, net.corda.core.crypto.SecureHash)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId getStateMachineRunId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getTransactionId()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getStateMachineRunId()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTransactionId()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.messaging.StateMachineUpdate extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.flows.StateMachineRunId getId()
+@CordaSerializable
+public abstract class net.corda.core.messaging.StateMachineUpdate extends java.lang.Object
+  @NotNull
+  public abstract net.corda.core.flows.StateMachineRunId getId()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.messaging.StateMachineUpdate$Added extends net.corda.core.messaging.StateMachineUpdate
+@CordaSerializable
+public static final class net.corda.core.messaging.StateMachineUpdate$Added extends net.corda.core.messaging.StateMachineUpdate
   public <init>(net.corda.core.messaging.StateMachineInfo)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.StateMachineInfo component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.StateMachineUpdate$Added copy(net.corda.core.messaging.StateMachineInfo)
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo component1()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineUpdate$Added copy(net.corda.core.messaging.StateMachineInfo)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.flows.StateMachineRunId getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.StateMachineInfo getStateMachineInfo()
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo getStateMachineInfo()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.messaging.StateMachineUpdate$Removed extends net.corda.core.messaging.StateMachineUpdate
-  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.flows.StateMachineRunId component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.StateMachineUpdate$Removed copy(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try)
+@CordaSerializable
+public static final class net.corda.core.messaging.StateMachineUpdate$Removed extends net.corda.core.messaging.StateMachineUpdate
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try<?>)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.utilities.Try<?> component2()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineUpdate$Removed copy(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try<?>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.flows.StateMachineRunId getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try getResult()
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.utilities.Try<?> getResult()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.ServiceHub
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowHandle startFlow(net.corda.core.flows.FlowLogic)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.FlowProgressHandle startTrackedFlow(net.corda.core.flows.FlowLogic)
+@DoNotImplement
+public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.ServiceHub
+  @NotNull
+  public abstract net.corda.core.messaging.FlowHandle<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlow(net.corda.core.flows.FlowLogic<? extends T>)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.NetworkParameters extends java.lang.Object
-  public <init>(int, List, int, int, java.time.Instant, int, Map)
+@CordaSerializable
+public final class net.corda.core.node.NetworkParameters extends java.lang.Object
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
+  @NotNull
+  public final java.util.List<net.corda.core.node.NotaryInfo> component2()
   public final int component3()
   public final int component4()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant component5()
+  @NotNull
+  public final java.time.Instant component5()
   public final int component6()
-  @org.jetbrains.annotations.NotNull public final Map component7()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters copy(int, List, int, int, java.time.Instant, int, Map)
+  @NotNull
+  public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> component7()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
   public boolean equals(Object)
   public final int getEpoch()
   public final int getMaxMessageSize()
   public final int getMaxTransactionSize()
   public final int getMinimumPlatformVersion()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant getModifiedTime()
-  @org.jetbrains.annotations.NotNull public final List getNotaries()
-  @org.jetbrains.annotations.NotNull public final Map getWhitelistedContractImplementations()
+  @NotNull
+  public final java.time.Instant getModifiedTime()
+  @NotNull
+  public final java.util.List<net.corda.core.node.NotaryInfo> getNotaries()
+  @NotNull
+  public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> getWhitelistedContractImplementations()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.NodeInfo extends java.lang.Object
-  public <init>(List, List, int, long)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
+@CordaSerializable
+public final class net.corda.core.node.NodeInfo extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.PartyAndCertificate> component2()
   public final int component3()
   public final long component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo copy(List, List, int, long)
+  @NotNull
+  public final net.corda.core.node.NodeInfo copy(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getAddresses()
-  @org.jetbrains.annotations.NotNull public final List getLegalIdentities()
-  @org.jetbrains.annotations.NotNull public final List getLegalIdentitiesAndCerts()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getAddresses()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> getLegalIdentities()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.PartyAndCertificate> getLegalIdentitiesAndCerts()
   public final int getPlatformVersion()
   public final long getSerial()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.PartyAndCertificate identityAndCertFromX500Name(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party identityFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate identityAndCertFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.Party identityFromX500Name(net.corda.core.identity.CordaX500Name)
   public final boolean isLegalIdentity(net.corda.core.identity.Party)
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.NotaryInfo extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.node.NotaryInfo extends java.lang.Object
   public <init>(net.corda.core.identity.Party, boolean)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.core.identity.Party component1()
   public final boolean component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NotaryInfo copy(net.corda.core.identity.Party, boolean)
+  @NotNull
+  public final net.corda.core.node.NotaryInfo copy(net.corda.core.identity.Party, boolean)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getIdentity()
+  @NotNull
+  public final net.corda.core.identity.Party getIdentity()
   public final boolean getValidating()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.ServiceHub extends net.corda.core.node.ServicesForResolution
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializeAsToken cordaService(Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.cordapp.CordappContext getAppContext()
-  @org.jetbrains.annotations.NotNull public abstract java.time.Clock getClock()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.KeyManagementService getKeyManagementService()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.NodeInfo getMyInfo()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.TransactionStorage getValidatedTransactions()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.VaultService getVaultService()
-  @org.jetbrains.annotations.NotNull public abstract java.sql.Connection jdbcSession()
-  public abstract void recordTransactions(Iterable)
-  public abstract void recordTransactions(net.corda.core.node.StatesToRecord, Iterable)
+@DoNotImplement
+public interface net.corda.core.node.ServiceHub extends net.corda.core.node.ServicesForResolution
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract T cordaService(Class<T>)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract java.time.Clock getClock()
+  @NotNull
+  public abstract net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public abstract net.corda.core.node.services.KeyManagementService getKeyManagementService()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getMyInfo()
+  @NotNull
+  public abstract net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
+  @NotNull
+  public abstract net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
+  @NotNull
+  public abstract net.corda.core.node.services.TransactionStorage getValidatedTransactions()
+  @NotNull
+  public abstract net.corda.core.node.services.VaultService getVaultService()
+  @NotNull
+  public abstract java.sql.Connection jdbcSession()
+  public abstract void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public abstract void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
   public abstract void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  public abstract void recordTransactions(boolean, Iterable)
+  public abstract void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
   public abstract void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  public abstract void registerUnloadHandler(kotlin.jvm.functions.Function0)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.StateAndRef toStateAndRef(net.corda.core.contracts.StateRef)
+  public abstract void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.ServicesForResolution
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.AttachmentStorage getAttachments()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.cordapp.CordappProvider getCordappProvider()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.IdentityService getIdentityService()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.TransactionState loadState(net.corda.core.contracts.StateRef)
-  @org.jetbrains.annotations.NotNull public abstract Set loadStates(Set)
+@DoNotImplement
+public interface net.corda.core.node.ServicesForResolution
+  @NotNull
+  public abstract net.corda.core.node.services.AttachmentStorage getAttachments()
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public abstract net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public abstract net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
 ##
 public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
-  protected <init>(String, int)
+  protected <init>()
   public static net.corda.core.node.StatesToRecord valueOf(String)
   public static net.corda.core.node.StatesToRecord[] values()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.AttachmentStorage
+@DoNotImplement
+public interface net.corda.core.node.services.AttachmentStorage
   public abstract boolean hasAttachment(net.corda.core.crypto.SecureHash)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public abstract List queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
+  @Nullable
+  public abstract net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
 ##
 public final class net.corda.core.node.services.AttachmentStorageKt extends java.lang.Object
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.ContractUpgradeService
-  @org.jetbrains.annotations.Nullable public abstract String getAuthorisedContractUpgrade(net.corda.core.contracts.StateRef)
+@DoNotImplement
+public interface net.corda.core.node.services.ContractUpgradeService
+  @Nullable
+  public abstract String getAuthorisedContractUpgrade(net.corda.core.contracts.StateRef)
   public abstract void removeAuthorisedContractUpgrade(net.corda.core.contracts.StateRef)
-  public abstract void storeAuthorisedContractUpgrade(net.corda.core.contracts.StateRef, Class)
+  public abstract void storeAuthorisedContractUpgrade(net.corda.core.contracts.StateRef, Class<? extends net.corda.core.contracts.UpgradedContract<?, ?>>)
 ##
 public @interface net.corda.core.node.services.CordaService
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.IdentityService
+@DoNotImplement
+public interface net.corda.core.node.services.IdentityService
   public abstract void assertOwnership(net.corda.core.identity.Party, net.corda.core.identity.AnonymousParty)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract Iterable getAllIdentities()
-  @org.jetbrains.annotations.NotNull public abstract java.security.cert.CertStore getCaCertStore()
-  @org.jetbrains.annotations.NotNull public abstract java.security.cert.TrustAnchor getTrustAnchor()
-  @org.jetbrains.annotations.NotNull public abstract java.security.cert.X509Certificate getTrustRoot()
-  @org.jetbrains.annotations.NotNull public abstract Set partiesFromName(String, boolean)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.identity.Party requireWellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.PartyAndCertificate verifyAndRegisterIdentity(net.corda.core.identity.PartyAndCertificate)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.contracts.PartyAndReference)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract Iterable<net.corda.core.identity.PartyAndCertificate> getAllIdentities()
+  @NotNull
+  public abstract java.security.cert.CertStore getCaCertStore()
+  @NotNull
+  public abstract java.security.cert.TrustAnchor getTrustAnchor()
+  @NotNull
+  public abstract java.security.cert.X509Certificate getTrustRoot()
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String, boolean)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.identity.Party requireWellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate verifyAndRegisterIdentity(net.corda.core.identity.PartyAndCertificate)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.contracts.PartyAndReference)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.KeyManagementService
-  @org.jetbrains.annotations.NotNull public abstract Iterable filterMyKeys(Iterable)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract java.security.PublicKey freshKey()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean)
-  @org.jetbrains.annotations.NotNull public abstract Set getKeys()
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.TransactionSignature sign(net.corda.core.crypto.SignableData, java.security.PublicKey)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.DigitalSignature$WithKey sign(byte[], java.security.PublicKey)
+@DoNotImplement
+public interface net.corda.core.node.services.KeyManagementService
+  @NotNull
+  public abstract Iterable<java.security.PublicKey> filterMyKeys(Iterable<? extends java.security.PublicKey>)
+  @Suspendable
+  @NotNull
+  public abstract java.security.PublicKey freshKey()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean)
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getKeys()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature sign(net.corda.core.crypto.SignableData, java.security.PublicKey)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.crypto.DigitalSignature$WithKey sign(byte[], java.security.PublicKey)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.NetworkMapCache extends net.corda.core.node.services.NetworkMapCacheBase
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.NodeInfo getNodeByLegalIdentity(net.corda.core.identity.AbstractParty)
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkMapCache extends net.corda.core.node.services.NetworkMapCacheBase
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByLegalIdentity(net.corda.core.identity.AbstractParty)
 ##
-@net.corda.core.serialization.CordaSerializable public abstract static class net.corda.core.node.services.NetworkMapCache$MapChange extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.NodeInfo getNode()
+@CordaSerializable
+public abstract static class net.corda.core.node.services.NetworkMapCache$MapChange extends java.lang.Object
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getNode()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Added extends net.corda.core.node.services.NetworkMapCache$MapChange
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Added extends net.corda.core.node.services.NetworkMapCache$MapChange
   public <init>(net.corda.core.node.NodeInfo)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.NetworkMapCache$MapChange$Added copy(net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Added copy(net.corda.core.node.NodeInfo)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NodeInfo getNode()
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Modified extends net.corda.core.node.services.NetworkMapCache$MapChange
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Modified extends net.corda.core.node.services.NetworkMapCache$MapChange
   public <init>(net.corda.core.node.NodeInfo, net.corda.core.node.NodeInfo)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.NetworkMapCache$MapChange$Modified copy(net.corda.core.node.NodeInfo, net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.NodeInfo component2()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Modified copy(net.corda.core.node.NodeInfo, net.corda.core.node.NodeInfo)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NodeInfo getNode()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo getPreviousNode()
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
+  @NotNull
+  public final net.corda.core.node.NodeInfo getPreviousNode()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Removed extends net.corda.core.node.services.NetworkMapCache$MapChange
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Removed extends net.corda.core.node.services.NetworkMapCache$MapChange
   public <init>(net.corda.core.node.NodeInfo)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.NetworkMapCache$MapChange$Removed copy(net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Removed copy(net.corda.core.node.NodeInfo)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NodeInfo getNode()
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.NetworkMapCacheBase
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkMapCacheBase
   public abstract void clearNetworkMapCache()
-  @org.jetbrains.annotations.NotNull public abstract List getAllNodes()
-  @org.jetbrains.annotations.NotNull public abstract rx.Observable getChanged()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.NodeInfo getNodeByAddress(net.corda.core.utilities.NetworkHostAndPort)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.NodeInfo getNodeByLegalName(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture getNodeReady()
-  @org.jetbrains.annotations.NotNull public abstract List getNodesByLegalIdentityKey(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public abstract List getNodesByLegalName(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party getNotary(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public abstract List getNotaryIdentities()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.node.services.PartyInfo getPartyInfo(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party getPeerByLegalName(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.PartyAndCertificate getPeerCertificateByLegalName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getAllNodes()
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.NetworkMapCache$MapChange> getChanged()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByAddress(net.corda.core.utilities.NetworkHostAndPort)
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByLegalName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<Void> getNodeReady()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getNodesByLegalIdentityKey(java.security.PublicKey)
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getNodesByLegalName(net.corda.core.identity.CordaX500Name)
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> getNotaryIdentities()
+  @Nullable
+  public abstract net.corda.core.node.services.PartyInfo getPartyInfo(net.corda.core.identity.Party)
+  @Nullable
+  public abstract net.corda.core.identity.Party getPeerByLegalName(net.corda.core.identity.CordaX500Name)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate getPeerCertificateByLegalName(net.corda.core.identity.CordaX500Name)
   public abstract boolean isNotary(net.corda.core.identity.Party)
   public abstract boolean isValidatingNotary(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed track()
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> track()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.NotaryService extends net.corda.core.serialization.SingletonSerializeAsToken
+  public <init>()
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogic<Void> createServiceFlow(net.corda.core.flows.FlowSession)
+  @NotNull
+  public abstract java.security.PublicKey getNotaryIdentityKey()
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServices()
+  public abstract void start()
+  public abstract void stop()
+  public static final void validateTimeWindow(java.time.Clock, net.corda.core.contracts.TimeWindow)
+  public static final net.corda.core.node.services.NotaryService$Companion Companion
+  @NotNull
+  public static final String ID_PREFIX = "corda.notary."
+##
+public static final class net.corda.core.node.services.NotaryService$Companion extends java.lang.Object
+  @NotNull
+  public final String constructId(boolean, boolean, boolean, boolean)
+  public final void validateTimeWindow(java.time.Clock, net.corda.core.contracts.TimeWindow)
 ##
 public abstract class net.corda.core.node.services.PartyInfo extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.identity.Party getParty()
+  @NotNull
+  public abstract net.corda.core.identity.Party getParty()
 ##
 public static final class net.corda.core.node.services.PartyInfo$DistributedNode extends net.corda.core.node.services.PartyInfo
   public <init>(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.PartyInfo$DistributedNode copy(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.core.node.services.PartyInfo$DistributedNode copy(net.corda.core.identity.Party)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party getParty()
+  @NotNull
+  public net.corda.core.identity.Party getParty()
   public int hashCode()
   public String toString()
 ##
 public static final class net.corda.core.node.services.PartyInfo$SingleNode extends net.corda.core.node.services.PartyInfo
-  public <init>(net.corda.core.identity.Party, List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.PartyInfo$SingleNode copy(net.corda.core.identity.Party, List)
+  public <init>(net.corda.core.identity.Party, java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> component2()
+  @NotNull
+  public final net.corda.core.node.services.PartyInfo$SingleNode copy(net.corda.core.identity.Party, java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getAddresses()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party getParty()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getAddresses()
+  @NotNull
+  public net.corda.core.identity.Party getParty()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.StatesNotAvailableException extends net.corda.core.flows.FlowException
+@CordaSerializable
+public final class net.corda.core.node.services.StatesNotAvailableException extends net.corda.core.flows.FlowException
   public <init>(String, Throwable)
-  @org.jetbrains.annotations.Nullable public Throwable getCause()
-  @org.jetbrains.annotations.Nullable public String getMessage()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @NotNull
+  public String toString()
 ##
 public final class net.corda.core.node.services.TimeWindowChecker extends java.lang.Object
   public <init>()
   public <init>(java.time.Clock)
-  @org.jetbrains.annotations.NotNull public final java.time.Clock getClock()
+  @NotNull
+  public final java.time.Clock getClock()
   public final boolean isValid(net.corda.core.contracts.TimeWindow)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.TransactionStorage
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.transactions.SignedTransaction getTransaction(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public abstract rx.Observable getUpdates()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed track()
+@DoNotImplement
+public interface net.corda.core.node.services.TransactionStorage
+  @Nullable
+  public abstract net.corda.core.transactions.SignedTransaction getTransaction(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.transactions.SignedTransaction> getUpdates()
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction> track()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.TransactionVerifierService
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture verify(net.corda.core.transactions.LedgerTransaction)
+@DoNotImplement
+public interface net.corda.core.node.services.TransactionVerifierService
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<?> verify(net.corda.core.transactions.LedgerTransaction)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.UnknownAnonymousPartyException extends net.corda.core.CordaException
+@CordaSerializable
+public abstract class net.corda.core.node.services.TrustedAuthorityNotaryService extends net.corda.core.node.services.NotaryService
+  public <init>()
+  public final void commitInputStates(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party)
+  @NotNull
+  protected org.slf4j.Logger getLog()
+  @NotNull
+  protected net.corda.core.node.services.TimeWindowChecker getTimeWindowChecker()
+  @NotNull
+  protected abstract net.corda.core.node.services.UniquenessProvider getUniquenessProvider()
+  @NotNull
+  public final net.corda.core.crypto.TransactionSignature sign(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey sign(byte[])
+  public final void validateTimeWindow(net.corda.core.contracts.TimeWindow)
+  public static final net.corda.core.node.services.TrustedAuthorityNotaryService$Companion Companion
+##
+public static final class net.corda.core.node.services.TrustedAuthorityNotaryService$Companion extends java.lang.Object
+##
+@CordaSerializable
+public final class net.corda.core.node.services.UniquenessException extends net.corda.core.CordaException
+  public <init>(net.corda.core.node.services.UniquenessProvider$Conflict)
+  @NotNull
+  public final net.corda.core.node.services.UniquenessProvider$Conflict getError()
+##
+public interface net.corda.core.node.services.UniquenessProvider
+  public abstract void commit(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.UniquenessProvider$Conflict extends java.lang.Object
+  public <init>(java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx>)
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx> component1()
+  @NotNull
+  public final net.corda.core.node.services.UniquenessProvider$Conflict copy(java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx> getStateHistory()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.UniquenessProvider$ConsumingTx extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, int, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @NotNull
+  public final net.corda.core.node.services.UniquenessProvider$ConsumingTx copy(net.corda.core.crypto.SecureHash, int, net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  public final int getInputIndex()
+  @NotNull
+  public final net.corda.core.identity.Party getRequestingParty()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.UnknownAnonymousPartyException extends net.corda.core.CordaException
   public <init>(String)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.Vault extends java.lang.Object
-  public <init>(Iterable)
-  @org.jetbrains.annotations.NotNull public final Iterable getStates()
+@CordaSerializable
+public final class net.corda.core.node.services.Vault extends java.lang.Object
+  public <init>(Iterable<? extends net.corda.core.contracts.StateAndRef<? extends T>>)
+  @NotNull
+  public final Iterable<net.corda.core.contracts.StateAndRef<T>> getStates()
   public static final net.corda.core.node.services.Vault$Companion Companion
 ##
 public static final class net.corda.core.node.services.Vault$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$Update getNoNotaryUpdate()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$Update getNoUpdate()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoNotaryUpdate()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoUpdate()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
-  public <init>(List, List, long, net.corda.core.node.services.Vault$StateStatus, List)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.node.services.Vault$StateMetadata> component2()
   public final long component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus component4()
-  @org.jetbrains.annotations.NotNull public final List component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$Page copy(List, List, long, net.corda.core.node.services.Vault$StateStatus, List)
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component4()
+  @NotNull
+  public final java.util.List<Object> component5()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getOtherResults()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus getStateTypes()
-  @org.jetbrains.annotations.NotNull public final List getStates()
-  @org.jetbrains.annotations.NotNull public final List getStatesMetadata()
+  @NotNull
+  public final java.util.List<Object> getOtherResults()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus getStateTypes()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> getStates()
+  @NotNull
+  public final java.util.List<net.corda.core.node.services.Vault$StateMetadata> getStatesMetadata()
   public final long getTotalStatesAvailable()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.Vault$StateMetadata extends java.lang.Object
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$StateMetadata extends java.lang.Object
   public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant component3()
-  @org.jetbrains.annotations.Nullable public final java.time.Instant component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus component5()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.AbstractParty component6()
-  @org.jetbrains.annotations.Nullable public final String component7()
-  @org.jetbrains.annotations.Nullable public final java.time.Instant component8()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateMetadata copy(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.time.Instant component3()
+  @Nullable
+  public final java.time.Instant component4()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component5()
+  @Nullable
+  public final net.corda.core.identity.AbstractParty component6()
+  @Nullable
+  public final String component7()
+  @Nullable
+  public final java.time.Instant component8()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateMetadata copy(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final java.time.Instant getConsumedTime()
-  @org.jetbrains.annotations.NotNull public final String getContractStateClassName()
-  @org.jetbrains.annotations.Nullable public final String getLockId()
-  @org.jetbrains.annotations.Nullable public final java.time.Instant getLockUpdateTime()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.AbstractParty getNotary()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant getRecordedTime()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateRef getRef()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public final java.time.Instant getConsumedTime()
+  @NotNull
+  public final String getContractStateClassName()
+  @Nullable
+  public final String getLockId()
+  @Nullable
+  public final java.time.Instant getLockUpdateTime()
+  @Nullable
+  public final net.corda.core.identity.AbstractParty getNotary()
+  @NotNull
+  public final java.time.Instant getRecordedTime()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus getStatus()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.Vault$StateStatus extends java.lang.Enum
-  protected <init>(String, int)
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$StateStatus extends java.lang.Enum
+  protected <init>()
   public static net.corda.core.node.services.Vault$StateStatus valueOf(String)
   public static net.corda.core.node.services.Vault$StateStatus[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.Vault$Update extends java.lang.Object
-  public <init>(Set, Set, UUID, net.corda.core.node.services.Vault$UpdateType)
-  @org.jetbrains.annotations.NotNull public final Set component1()
-  @org.jetbrains.annotations.NotNull public final Set component2()
-  @org.jetbrains.annotations.Nullable public final UUID component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$UpdateType component4()
-  public final boolean containsType(Class, net.corda.core.node.services.Vault$StateStatus)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$Update copy(Set, Set, UUID, net.corda.core.node.services.Vault$UpdateType)
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$Update extends java.lang.Object
+  public <init>(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component1()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component2()
+  @Nullable
+  public final java.util.UUID component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$UpdateType component4()
+  public final boolean containsType(Class<T>, net.corda.core.node.services.Vault$StateStatus)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<U> copy(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Set getConsumed()
-  @org.jetbrains.annotations.Nullable public final UUID getFlowId()
-  @org.jetbrains.annotations.NotNull public final Set getProduced()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$UpdateType getType()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getConsumed()
+  @Nullable
+  public final java.util.UUID getFlowId()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getProduced()
+  @NotNull
+  public final net.corda.core.node.services.Vault$UpdateType getType()
   public int hashCode()
   public final boolean isEmpty()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$Update plus(net.corda.core.node.services.Vault$Update)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<U> plus(net.corda.core.node.services.Vault$Update<U>)
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.Vault$UpdateType extends java.lang.Enum
-  protected <init>(String, int)
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$UpdateType extends java.lang.Enum
+  protected <init>()
   public static net.corda.core.node.services.Vault$UpdateType valueOf(String)
   public static net.corda.core.node.services.Vault$UpdateType[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.VaultQueryException extends net.corda.core.flows.FlowException
+@CordaSerializable
+public final class net.corda.core.node.services.VaultQueryException extends net.corda.core.flows.FlowException
   public <init>(String)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.VaultService
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page _queryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed _trackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class)
+@DoNotImplement
+public interface net.corda.core.node.services.VaultService
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> _queryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> _trackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
   public abstract void addNoteToTransaction(net.corda.core.crypto.SecureHash, String)
-  @org.jetbrains.annotations.NotNull public abstract rx.Observable getRawUpdates()
-  @org.jetbrains.annotations.NotNull public abstract Iterable getTransactionNotes(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public abstract rx.Observable getUpdates()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page queryBy(Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page queryBy(Class, net.corda.core.node.services.vault.QueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page queryBy(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page queryBy(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$Page queryBy(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
-  public abstract void softLockRelease(UUID, net.corda.core.utilities.NonEmptySet)
-  public abstract void softLockReserve(UUID, net.corda.core.utilities.NonEmptySet)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed trackBy(Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed trackBy(Class, net.corda.core.node.services.vault.QueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed trackBy(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed trackBy(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.DataFeed trackBy(Class, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
-  @co.paralleluniverse.fibers.Suspendable @org.jetbrains.annotations.NotNull public abstract List tryLockFungibleStatesForSpending(UUID, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.contracts.Amount, Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture whenConsumed(net.corda.core.contracts.StateRef)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> getRawUpdates()
+  @NotNull
+  public abstract Iterable<String> getTransactionNotes(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> getUpdates()
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  public abstract void softLockRelease(java.util.UUID, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  public abstract void softLockReserve(java.util.UUID, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @Suspendable
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<T>> tryLockFungibleStatesForSpending(java.util.UUID, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.contracts.Amount<U>, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> whenConsumed(net.corda.core.contracts.StateRef)
 ##
 public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum
-  protected <init>(String, int)
+@CordaSerializable
+public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum
+  protected <init>()
   public static net.corda.core.node.services.vault.AggregateFunctionType valueOf(String)
   public static net.corda.core.node.services.vault.AggregateFunctionType[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.node.services.vault.AttachmentQueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.AttachmentQueryCriteria and(net.corda.core.node.services.vault.AttachmentQueryCriteria)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.AttachmentQueryCriteria or(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.AttachmentQueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria and(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria or(net.corda.core.node.services.vault.AttachmentQueryCriteria)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AndComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AndComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
   public <init>(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentQueryCriteria)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria extends net.corda.core.node.services.vault.AttachmentQueryCriteria
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria extends net.corda.core.node.services.vault.AttachmentQueryCriteria
   public <init>()
-  public <init>(net.corda.core.node.services.vault.ColumnPredicate)
-  public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate)
-  public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate component1()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate component2()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria copy(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> component1()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> component2()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria copy(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate getFilenameCondition()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate getUploadDateCondition()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate getUploaderCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> getFilenameCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> getUploadDateCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> getUploaderCondition()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$OrComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$OrComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
   public <init>(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentQueryCriteria)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.AttachmentSort extends net.corda.core.node.services.vault.BaseSort
-  public <init>(Collection)
-  @org.jetbrains.annotations.NotNull public final Collection component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.AttachmentSort copy(Collection)
+@CordaSerializable
+public final class net.corda.core.node.services.vault.AttachmentSort extends net.corda.core.node.services.vault.BaseSort
+  public <init>(java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn>)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort copy(java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Collection getColumns()
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn> getColumns()
   public int hashCode()
   public String toString()
 ##
 public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute extends java.lang.Enum
-  protected <init>(String, int, String)
-  @org.jetbrains.annotations.NotNull public final String getColumnName()
+  protected <init>(String)
+  @NotNull
+  public final String getColumnName()
   public static net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute valueOf(String)
   public static net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn extends java.lang.Object
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn extends java.lang.Object
   public <init>(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort$Direction component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn copy(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn copy(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort$Direction getDirection()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute getSortAttribute()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction getDirection()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute getSortAttribute()
   public int hashCode()
   public String toString()
 ##
 public interface net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
-  @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria)
 ##
 public interface net.corda.core.node.services.vault.BaseQueryCriteriaParser
-  @org.jetbrains.annotations.NotNull public abstract Collection parse(net.corda.core.node.services.vault.GenericQueryCriteria, net.corda.core.node.services.vault.BaseSort)
-  @org.jetbrains.annotations.NotNull public abstract Collection parseAnd(net.corda.core.node.services.vault.GenericQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract Collection parseOr(net.corda.core.node.services.vault.GenericQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parse(Q, S)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseAnd(Q, Q)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseOr(Q, Q)
 ##
 public abstract class net.corda.core.node.services.vault.BaseSort extends java.lang.Object
   public <init>()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.BinaryComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
-  protected <init>(String, int)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.BinaryComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
   public static net.corda.core.node.services.vault.BinaryComparisonOperator valueOf(String)
   public static net.corda.core.node.services.vault.BinaryComparisonOperator[] values()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.BinaryLogicalOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
-  protected <init>(String, int)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.BinaryLogicalOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
   public static net.corda.core.node.services.vault.BinaryLogicalOperator valueOf(String)
   public static net.corda.core.node.services.vault.BinaryLogicalOperator[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.Builder extends java.lang.Object
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression avg(reflect.Field)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression avg(reflect.Field, List)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression avg(reflect.Field, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression avg(kotlin.reflect.KProperty1, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$Between between(Comparable, Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression between(reflect.Field, Comparable, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression between(kotlin.reflect.KProperty1, Comparable, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison compare(net.corda.core.node.services.vault.BinaryComparisonOperator, Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression comparePredicate(reflect.Field, net.corda.core.node.services.vault.BinaryComparisonOperator, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression comparePredicate(kotlin.reflect.KProperty1, net.corda.core.node.services.vault.BinaryComparisonOperator, Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression count(reflect.Field)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression count(kotlin.reflect.KProperty1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison equal(Object)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression equal(reflect.Field, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression equal(kotlin.reflect.KProperty1, Object)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression functionPredicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression functionPredicate(kotlin.reflect.KProperty1, net.corda.core.node.services.vault.ColumnPredicate, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison greaterThan(Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression greaterThan(reflect.Field, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression greaterThan(kotlin.reflect.KProperty1, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison greaterThanOrEqual(Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression greaterThanOrEqual(reflect.Field, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression greaterThanOrEqual(kotlin.reflect.KProperty1, Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression in(reflect.Field, Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression in(Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression in(kotlin.reflect.KProperty1, Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression isNotNull()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression isNull()
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression isNull(reflect.Field)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression isNull(kotlin.reflect.KProperty1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison lessThan(Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression lessThan(reflect.Field, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression lessThan(kotlin.reflect.KProperty1, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison lessThanOrEqual(Comparable)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression lessThanOrEqual(reflect.Field, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression lessThanOrEqual(kotlin.reflect.KProperty1, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$Likeness like(String)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression like(reflect.Field, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression like(kotlin.reflect.KProperty1, String)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression max(reflect.Field)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression max(reflect.Field, List)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression max(reflect.Field, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression max(kotlin.reflect.KProperty1, List, net.corda.core.node.services.vault.Sort$Direction)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression min(reflect.Field)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression min(reflect.Field, List)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression min(reflect.Field, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression min(kotlin.reflect.KProperty1, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison notEqual(Object)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notEqual(reflect.Field, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notEqual(kotlin.reflect.KProperty1, Object)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notIn(reflect.Field, Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression notIn(Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notIn(kotlin.reflect.KProperty1, Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$Likeness notLike(String)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notLike(reflect.Field, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notLike(kotlin.reflect.KProperty1, String)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notNull(reflect.Field)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression notNull(kotlin.reflect.KProperty1)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression predicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression predicate(kotlin.reflect.KProperty1, net.corda.core.node.services.vault.ColumnPredicate)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression sum(reflect.Field)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression sum(reflect.Field, List)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression sum(reflect.Field, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression sum(kotlin.reflect.KProperty1, List, net.corda.core.node.services.vault.Sort$Direction)
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Builder extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> avg(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Between<R> between(R, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> between(reflect.Field, R, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> between(kotlin.reflect.KProperty1<O, ? extends R>, R, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> compare(net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> comparePredicate(reflect.Field, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> comparePredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, Object> count(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> count(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> equal(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> equal(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> functionPredicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<Object, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> functionPredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThan(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThan(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThanOrEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThanOrEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(reflect.Field, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> in(java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> in(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<R> isNotNull()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<R> isNull()
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> isNull(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> isNull(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThan(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThan(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThanOrEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThanOrEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness like(String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(reflect.Field, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> like(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> max(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> min(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> notEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(reflect.Field, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> notIn(java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notIn(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness notLike(String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(reflect.Field, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> notLike(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> notNull(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notNull(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> predicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> predicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> sum(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
   public static final net.corda.core.node.services.vault.Builder INSTANCE
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.CollectionOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
-  protected <init>(String, int)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.CollectionOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
   public static net.corda.core.node.services.vault.CollectionOperator valueOf(String)
   public static net.corda.core.node.services.vault.CollectionOperator[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.Column extends java.lang.Object
-  public <init>(String, Class)
-  @kotlin.Deprecated public <init>(reflect.Field)
-  public <init>(kotlin.reflect.KProperty1)
-  @org.jetbrains.annotations.NotNull public final Class getDeclaringClass()
-  @org.jetbrains.annotations.NotNull public final String getName()
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Column extends java.lang.Object
+  public <init>(String, Class<?>)
+  public <init>(reflect.Field)
+  public <init>(kotlin.reflect.KProperty1<O, ? extends C>)
+  @NotNull
+  public final Class<?> getDeclaringClass()
+  @NotNull
+  public final String getName()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.node.services.vault.ColumnPredicate extends java.lang.Object
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.ColumnPredicate extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction extends net.corda.core.node.services.vault.ColumnPredicate
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction extends net.corda.core.node.services.vault.ColumnPredicate
   public <init>(net.corda.core.node.services.vault.AggregateFunctionType)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.AggregateFunctionType component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction copy(net.corda.core.node.services.vault.AggregateFunctionType)
+  @NotNull
+  public final net.corda.core.node.services.vault.AggregateFunctionType component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction<C> copy(net.corda.core.node.services.vault.AggregateFunctionType)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.AggregateFunctionType getType()
+  @NotNull
+  public final net.corda.core.node.services.vault.AggregateFunctionType getType()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.ColumnPredicate$Between extends net.corda.core.node.services.vault.ColumnPredicate
-  public <init>(Comparable, Comparable)
-  @org.jetbrains.annotations.NotNull public final Comparable component1()
-  @org.jetbrains.annotations.NotNull public final Comparable component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$Between copy(Comparable, Comparable)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$Between extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(C, C)
+  @NotNull
+  public final C component1()
+  @NotNull
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Between<C> copy(C, C)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Comparable getRightFromLiteral()
-  @org.jetbrains.annotations.NotNull public final Comparable getRightToLiteral()
+  @NotNull
+  public final C getRightFromLiteral()
+  @NotNull
+  public final C getRightToLiteral()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison extends net.corda.core.node.services.vault.ColumnPredicate
-  public <init>(net.corda.core.node.services.vault.BinaryComparisonOperator, Comparable)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.BinaryComparisonOperator component1()
-  @org.jetbrains.annotations.NotNull public final Comparable component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison copy(net.corda.core.node.services.vault.BinaryComparisonOperator, Comparable)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.BinaryComparisonOperator, C)
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryComparisonOperator component1()
+  @NotNull
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<C> copy(net.corda.core.node.services.vault.BinaryComparisonOperator, C)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.BinaryComparisonOperator getOperator()
-  @org.jetbrains.annotations.NotNull public final Comparable getRightLiteral()
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryComparisonOperator getOperator()
+  @NotNull
+  public final C getRightLiteral()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression extends net.corda.core.node.services.vault.ColumnPredicate
-  public <init>(net.corda.core.node.services.vault.CollectionOperator, Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CollectionOperator component1()
-  @org.jetbrains.annotations.NotNull public final Collection component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression copy(net.corda.core.node.services.vault.CollectionOperator, Collection)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.CollectionOperator, java.util.Collection<? extends C>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CollectionOperator component1()
+  @NotNull
+  public final java.util.Collection<C> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<C> copy(net.corda.core.node.services.vault.CollectionOperator, java.util.Collection<? extends C>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CollectionOperator getOperator()
-  @org.jetbrains.annotations.NotNull public final Collection getRightLiteral()
+  @NotNull
+  public final net.corda.core.node.services.vault.CollectionOperator getOperator()
+  @NotNull
+  public final java.util.Collection<C> getRightLiteral()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison extends net.corda.core.node.services.vault.ColumnPredicate
-  public <init>(net.corda.core.node.services.vault.EqualityComparisonOperator, Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.EqualityComparisonOperator component1()
-  public final Object component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison copy(net.corda.core.node.services.vault.EqualityComparisonOperator, Object)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.EqualityComparisonOperator, C)
+  @NotNull
+  public final net.corda.core.node.services.vault.EqualityComparisonOperator component1()
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<C> copy(net.corda.core.node.services.vault.EqualityComparisonOperator, C)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.EqualityComparisonOperator getOperator()
-  public final Object getRightLiteral()
+  @NotNull
+  public final net.corda.core.node.services.vault.EqualityComparisonOperator getOperator()
+  public final C getRightLiteral()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.ColumnPredicate$Likeness extends net.corda.core.node.services.vault.ColumnPredicate
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$Likeness extends net.corda.core.node.services.vault.ColumnPredicate
   public <init>(net.corda.core.node.services.vault.LikenessOperator, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.LikenessOperator component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$Likeness copy(net.corda.core.node.services.vault.LikenessOperator, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.LikenessOperator component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness copy(net.corda.core.node.services.vault.LikenessOperator, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.LikenessOperator getOperator()
-  @org.jetbrains.annotations.NotNull public final String getRightLiteral()
+  @NotNull
+  public final net.corda.core.node.services.vault.LikenessOperator getOperator()
+  @NotNull
+  public final String getRightLiteral()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.ColumnPredicate$NullExpression extends net.corda.core.node.services.vault.ColumnPredicate
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$NullExpression extends net.corda.core.node.services.vault.ColumnPredicate
   public <init>(net.corda.core.node.services.vault.NullOperator)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.NullOperator component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression copy(net.corda.core.node.services.vault.NullOperator)
+  @NotNull
+  public final net.corda.core.node.services.vault.NullOperator component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<C> copy(net.corda.core.node.services.vault.NullOperator)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.NullOperator getOperator()
+  @NotNull
+  public final net.corda.core.node.services.vault.NullOperator getOperator()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.node.services.vault.CriteriaExpression extends java.lang.Object
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.CriteriaExpression extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression extends net.corda.core.node.services.vault.CriteriaExpression
-  public <init>(net.corda.core.node.services.vault.Column, net.corda.core.node.services.vault.ColumnPredicate, List, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Column component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate component2()
-  @org.jetbrains.annotations.Nullable public final List component3()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.Sort$Direction component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression copy(net.corda.core.node.services.vault.Column, net.corda.core.node.services.vault.ColumnPredicate, List, net.corda.core.node.services.vault.Sort$Direction)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends C>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> component2()
+  @Nullable
+  public final java.util.List<net.corda.core.node.services.vault.Column<O, C>> component3()
+  @Nullable
+  public final net.corda.core.node.services.vault.Sort$Direction component4()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, C> copy(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends C>>, net.corda.core.node.services.vault.Sort$Direction)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Column getColumn()
-  @org.jetbrains.annotations.Nullable public final List getGroupByColumns()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.Sort$Direction getOrderBy()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate getPredicate()
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> getColumn()
+  @Nullable
+  public final java.util.List<net.corda.core.node.services.vault.Column<O, C>> getGroupByColumns()
+  @Nullable
+  public final net.corda.core.node.services.vault.Sort$Direction getOrderBy()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical extends net.corda.core.node.services.vault.CriteriaExpression
-  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.vault.BinaryLogicalOperator)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.BinaryLogicalOperator component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical copy(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.vault.BinaryLogicalOperator)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.BinaryLogicalOperator)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryLogicalOperator component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical<O> copy(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.BinaryLogicalOperator)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression getLeft()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.BinaryLogicalOperator getOperator()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression getRight()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getLeft()
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryLogicalOperator getOperator()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getRight()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression extends net.corda.core.node.services.vault.CriteriaExpression
-  public <init>(net.corda.core.node.services.vault.Column, net.corda.core.node.services.vault.ColumnPredicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Column component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression copy(net.corda.core.node.services.vault.Column, net.corda.core.node.services.vault.ColumnPredicate)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, C> copy(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Column getColumn()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate getPredicate()
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> getColumn()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.CriteriaExpression$Not extends net.corda.core.node.services.vault.CriteriaExpression
-  public <init>(net.corda.core.node.services.vault.CriteriaExpression)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression$Not copy(net.corda.core.node.services.vault.CriteriaExpression)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$Not extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$Not<O> copy(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression getExpression()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getExpression()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.EqualityComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
-  protected <init>(String, int)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.EqualityComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
   public static net.corda.core.node.services.vault.EqualityComparisonOperator valueOf(String)
   public static net.corda.core.node.services.vault.EqualityComparisonOperator[] values()
 ##
 public interface net.corda.core.node.services.vault.GenericQueryCriteria
-  @org.jetbrains.annotations.NotNull public abstract Collection visit(net.corda.core.node.services.vault.BaseQueryCriteriaParser)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
 ##
 public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.vault.GenericQueryCriteria and(net.corda.core.node.services.vault.GenericQueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.vault.GenericQueryCriteria or(net.corda.core.node.services.vault.GenericQueryCriteria)
+  @NotNull
+  public abstract Q and(Q)
+  @NotNull
+  public abstract Q or(Q)
 ##
 public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor extends net.corda.core.node.services.vault.GenericQueryCriteria
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.vault.GenericQueryCriteria getA()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.vault.GenericQueryCriteria getB()
-  @org.jetbrains.annotations.NotNull public abstract Collection visit(net.corda.core.node.services.vault.BaseQueryCriteriaParser)
+  @NotNull
+  public abstract Q getA()
+  @NotNull
+  public abstract Q getB()
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
 ##
 public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor extends net.corda.core.node.services.vault.GenericQueryCriteria
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.vault.GenericQueryCriteria getA()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.vault.GenericQueryCriteria getB()
-  @org.jetbrains.annotations.NotNull public abstract Collection visit(net.corda.core.node.services.vault.BaseQueryCriteriaParser)
+  @NotNull
+  public abstract Q getA()
+  @NotNull
+  public abstract Q getB()
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.node.services.vault.IQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
-  @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria)
-  @org.jetbrains.annotations.NotNull public abstract Collection parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria)
+@DoNotImplement
+public interface net.corda.core.node.services.vault.IQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L>)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.LikenessOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
-  protected <init>(String, int)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.LikenessOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
   public static net.corda.core.node.services.vault.LikenessOperator valueOf(String)
   public static net.corda.core.node.services.vault.LikenessOperator[] values()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.NullOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
-  protected <init>(String, int)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.NullOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
   public static net.corda.core.node.services.vault.NullOperator valueOf(String)
   public static net.corda.core.node.services.vault.NullOperator[] values()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public interface net.corda.core.node.services.vault.Operator
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.node.services.vault.Operator
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.PageSpecification extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.node.services.vault.PageSpecification extends java.lang.Object
   public <init>()
   public <init>(int, int)
   public final int component1()
   public final int component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.PageSpecification copy(int, int)
+  @NotNull
+  public final net.corda.core.node.services.vault.PageSpecification copy(int, int)
   public boolean equals(Object)
   public final int getPageNumber()
   public final int getPageSize()
@@ -2517,235 +4027,358 @@ public static interface net.corda.core.node.services.vault.GenericQueryCriteria$
   public final boolean isDefault()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.node.services.vault.QueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.QueryCriteria and(net.corda.core.node.services.vault.QueryCriteria)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.QueryCriteria or(net.corda.core.node.services.vault.QueryCriteria)
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.QueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria and(net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria or(net.corda.core.node.services.vault.QueryCriteria)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$AndComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$AndComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
   public <init>(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.QueryCriteria)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.QueryCriteria getA()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.QueryCriteria getB()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public abstract static class net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria
+@CordaSerializable
+public abstract static class net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria
   public <init>()
-  @org.jetbrains.annotations.Nullable public abstract Set getContractStateTypes()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.services.Vault$StateStatus getStatus()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @Nullable
+  public abstract java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$StateStatus getStatus()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
   public <init>()
-  public <init>(List)
-  public <init>(List, List)
-  public <init>(List, List, net.corda.core.node.services.vault.ColumnPredicate)
-  public <init>(List, List, net.corda.core.node.services.vault.ColumnPredicate, List)
-  public <init>(List, List, net.corda.core.node.services.vault.ColumnPredicate, List, List)
-  public <init>(List, List, net.corda.core.node.services.vault.ColumnPredicate, List, List, net.corda.core.node.services.Vault$StateStatus)
-  public <init>(List, List, net.corda.core.node.services.vault.ColumnPredicate, List, List, net.corda.core.node.services.Vault$StateStatus, Set)
-  @org.jetbrains.annotations.Nullable public final List component1()
-  @org.jetbrains.annotations.Nullable public final List component2()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate component3()
-  @org.jetbrains.annotations.Nullable public final List component4()
-  @org.jetbrains.annotations.Nullable public final List component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus component6()
-  @org.jetbrains.annotations.Nullable public final Set component7()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(List, List, net.corda.core.node.services.vault.ColumnPredicate, List, List, net.corda.core.node.services.Vault$StateStatus, Set)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> component3()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component4()
+  @Nullable
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component5()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component6()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component7()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public Set getContractStateTypes()
-  @org.jetbrains.annotations.Nullable public final List getIssuer()
-  @org.jetbrains.annotations.Nullable public final List getIssuerRef()
-  @org.jetbrains.annotations.Nullable public final List getOwner()
-  @org.jetbrains.annotations.Nullable public final List getParticipants()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.ColumnPredicate getQuantity()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getIssuer()
+  @Nullable
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getIssuerRef()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwner()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> getQuantity()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
   public <init>()
-  public <init>(List)
-  public <init>(List, List)
-  public <init>(List, List, List)
-  public <init>(List, List, List, net.corda.core.node.services.Vault$StateStatus)
-  public <init>(List, List, List, net.corda.core.node.services.Vault$StateStatus, Set)
-  public <init>(List, List, net.corda.core.node.services.Vault$StateStatus, Set)
-  @org.jetbrains.annotations.Nullable public final List component1()
-  @org.jetbrains.annotations.Nullable public final List component2()
-  @org.jetbrains.annotations.Nullable public final List component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus component4()
-  @org.jetbrains.annotations.Nullable public final Set component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(List, List, List, net.corda.core.node.services.Vault$StateStatus, Set)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final java.util.List<java.util.UUID> component2()
+  @Nullable
+  public final java.util.List<String> component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component4()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component5()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public Set getContractStateTypes()
-  @org.jetbrains.annotations.Nullable public final List getExternalId()
-  @org.jetbrains.annotations.Nullable public final List getParticipants()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.Vault$StateStatus getStatus()
-  @org.jetbrains.annotations.Nullable public final List getUuid()
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<String> getExternalId()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public final java.util.List<java.util.UUID> getUuid()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$OrComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$OrComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
   public <init>(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.QueryCriteria)
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.QueryCriteria getA()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.vault.QueryCriteria getB()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition extends java.lang.Object
-  public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition copy(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, List)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List<java.util.UUID>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType component1()
+  @NotNull
+  public final java.util.List<java.util.UUID> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition copy(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List<java.util.UUID>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List getLockIds()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType getType()
+  @NotNull
+  public final java.util.List<java.util.UUID> getLockIds()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType getType()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingType extends java.lang.Enum
-  protected <init>(String, int)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingType extends java.lang.Enum
+  protected <init>()
   public static net.corda.core.node.services.vault.QueryCriteria$SoftLockingType valueOf(String)
   public static net.corda.core.node.services.vault.QueryCriteria$SoftLockingType[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$TimeCondition extends java.lang.Object
-  public <init>(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition copy(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$TimeCondition extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition copy(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.ColumnPredicate getPredicate()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType getType()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> getPredicate()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType getType()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$TimeInstantType extends java.lang.Enum
-  protected <init>(String, int)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$TimeInstantType extends java.lang.Enum
+  protected <init>()
   public static net.corda.core.node.services.vault.QueryCriteria$TimeInstantType valueOf(String)
   public static net.corda.core.node.services.vault.QueryCriteria$TimeInstantType[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
-  public <init>(net.corda.core.node.services.vault.CriteriaExpression)
-  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus)
-  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, Set)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus component2()
-  @org.jetbrains.annotations.Nullable public final Set component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria copy(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, Set)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component2()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> copy(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public Set getContractStateTypes()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.CriteriaExpression getExpression()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> getExpression()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
   public <init>()
   public <init>(net.corda.core.node.services.Vault$StateStatus)
-  public <init>(net.corda.core.node.services.Vault$StateStatus, Set)
-  public <init>(net.corda.core.node.services.Vault$StateStatus, Set, List)
-  public <init>(net.corda.core.node.services.Vault$StateStatus, Set, List, List)
-  public <init>(net.corda.core.node.services.Vault$StateStatus, Set, List, List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
-  public <init>(net.corda.core.node.services.Vault$StateStatus, Set, List, List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.Vault$StateStatus component1()
-  @org.jetbrains.annotations.Nullable public final Set component2()
-  @org.jetbrains.annotations.Nullable public final List component3()
-  @org.jetbrains.annotations.Nullable public final List component4()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition component5()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition component6()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, Set, List, List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component1()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component2()
+  @Nullable
+  public final java.util.List<net.corda.core.contracts.StateRef> component3()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component4()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition component5()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition component6()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public Set getContractStateTypes()
-  @org.jetbrains.annotations.Nullable public final List getNotary()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition getSoftLockingCondition()
-  @org.jetbrains.annotations.Nullable public final List getStateRefs()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.Vault$StateStatus getStatus()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition getTimeCondition()
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getNotary()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition getSoftLockingCondition()
+  @Nullable
+  public final java.util.List<net.corda.core.contracts.StateRef> getStateRefs()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition getTimeCondition()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public Collection visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
 ##
 public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends java.lang.Object
-  public static final Object builder(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final String getColumnName(net.corda.core.node.services.vault.Column)
-  @org.jetbrains.annotations.NotNull public static final Class resolveEnclosingObjectFromColumn(net.corda.core.node.services.vault.Column)
-  @org.jetbrains.annotations.NotNull public static final Class resolveEnclosingObjectFromExpression(net.corda.core.node.services.vault.CriteriaExpression)
+  public static final A builder(kotlin.jvm.functions.Function1<? super net.corda.core.node.services.vault.Builder, ? extends A>)
+  @NotNull
+  public static final String getColumnName(net.corda.core.node.services.vault.Column<O, ? extends C>)
+  @NotNull
+  public static final Class<O> resolveEnclosingObjectFromColumn(net.corda.core.node.services.vault.Column<O, ? extends C>)
+  @NotNull
+  public static final Class<O> resolveEnclosingObjectFromExpression(net.corda.core.node.services.vault.CriteriaExpression<O, ? extends R>)
   public static final int DEFAULT_PAGE_NUM = 1
   public static final int DEFAULT_PAGE_SIZE = 200
   public static final int MAX_PAGE_SIZE = 2147483647
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.node.services.vault.Sort extends net.corda.core.node.services.vault.BaseSort
-  public <init>(Collection)
-  @org.jetbrains.annotations.NotNull public final Collection component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort copy(Collection)
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Sort extends net.corda.core.node.services.vault.BaseSort
+  public <init>(java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn>)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort copy(java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Collection getColumns()
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn> getColumns()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static interface net.corda.core.node.services.vault.Sort$Attribute
+@DoNotImplement
+@CordaSerializable
+public static interface net.corda.core.node.services.vault.Sort$Attribute
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$CommonStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
-  protected <init>(String, int, String, String)
-  @org.jetbrains.annotations.Nullable public final String getAttributeChild()
-  @org.jetbrains.annotations.NotNull public final String getAttributeParent()
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$CommonStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String, String)
+  @Nullable
+  public final String getAttributeChild()
+  @NotNull
+  public final String getAttributeParent()
   public static net.corda.core.node.services.vault.Sort$CommonStateAttribute valueOf(String)
   public static net.corda.core.node.services.vault.Sort$CommonStateAttribute[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$Direction extends java.lang.Enum
-  protected <init>(String, int)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$Direction extends java.lang.Enum
+  protected <init>()
   public static net.corda.core.node.services.vault.Sort$Direction valueOf(String)
   public static net.corda.core.node.services.vault.Sort$Direction[] values()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$FungibleStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
-  protected <init>(String, int, String)
-  @org.jetbrains.annotations.NotNull public final String getAttributeName()
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$FungibleStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
   public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute valueOf(String)
   public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute[] values()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$LinearStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
-  protected <init>(String, int, String)
-  @org.jetbrains.annotations.NotNull public final String getAttributeName()
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$LinearStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
   public static net.corda.core.node.services.vault.Sort$LinearStateAttribute valueOf(String)
   public static net.corda.core.node.services.vault.Sort$LinearStateAttribute[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$SortColumn extends java.lang.Object
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$SortColumn extends java.lang.Object
   public <init>(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.SortAttribute component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort$Direction component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort$SortColumn copy(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$SortColumn copy(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort$Direction getDirection()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.SortAttribute getSortAttribute()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction getDirection()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute getSortAttribute()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.Sort$VaultStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
-  protected <init>(String, int, String)
-  @org.jetbrains.annotations.NotNull public final String getAttributeName()
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$VaultStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
   public static net.corda.core.node.services.vault.Sort$VaultStateAttribute valueOf(String)
   public static net.corda.core.node.services.vault.Sort$VaultStateAttribute[] values()
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.node.services.vault.SortAttribute extends java.lang.Object
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.SortAttribute extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.SortAttribute$Custom extends net.corda.core.node.services.vault.SortAttribute
-  public <init>(Class, String)
-  @org.jetbrains.annotations.NotNull public final Class component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.SortAttribute$Custom copy(Class, String)
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.SortAttribute$Custom extends net.corda.core.node.services.vault.SortAttribute
+  public <init>(Class<? extends net.corda.core.schemas.PersistentState>, String)
+  @NotNull
+  public final Class<? extends net.corda.core.schemas.PersistentState> component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute$Custom copy(Class<? extends net.corda.core.schemas.PersistentState>, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Class getEntityStateClass()
-  @org.jetbrains.annotations.NotNull public final String getEntityStateColumnName()
+  @NotNull
+  public final Class<? extends net.corda.core.schemas.PersistentState> getEntityStateClass()
+  @NotNull
+  public final String getEntityStateColumnName()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.node.services.vault.SortAttribute$Standard extends net.corda.core.node.services.vault.SortAttribute
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.SortAttribute$Standard extends net.corda.core.node.services.vault.SortAttribute
   public <init>(net.corda.core.node.services.vault.Sort$Attribute)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort$Attribute component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.SortAttribute$Standard copy(net.corda.core.node.services.vault.Sort$Attribute)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Attribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute$Standard copy(net.corda.core.node.services.vault.Sort$Attribute)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.vault.Sort$Attribute getAttribute()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Attribute getAttribute()
   public int hashCode()
   public String toString()
 ##
@@ -2755,67 +4388,93 @@ public final class net.corda.core.schemas.CommonSchema extends java.lang.Object
 public final class net.corda.core.schemas.CommonSchemaV1 extends net.corda.core.schemas.MappedSchema
   public static final net.corda.core.schemas.CommonSchemaV1 INSTANCE
 ##
-@javax.persistence.MappedSuperclass @net.corda.core.serialization.CordaSerializable public static class net.corda.core.schemas.CommonSchemaV1$FungibleState extends net.corda.core.schemas.PersistentState
+@MappedSuperclass
+@CordaSerializable
+public static class net.corda.core.schemas.CommonSchemaV1$FungibleState extends net.corda.core.schemas.PersistentState
   public <init>()
-  public <init>(Set, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[])
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.AbstractParty getIssuer()
-  @org.jetbrains.annotations.NotNull public byte[] getIssuerRef()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.AbstractParty getOwner()
-  @org.jetbrains.annotations.Nullable public Set getParticipants()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[])
+  @NotNull
+  public net.corda.core.identity.AbstractParty getIssuer()
+  @NotNull
+  public byte[] getIssuerRef()
+  @NotNull
+  public net.corda.core.identity.AbstractParty getOwner()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
   public long getQuantity()
   public void setIssuer(net.corda.core.identity.AbstractParty)
   public void setIssuerRef(byte[])
   public void setOwner(net.corda.core.identity.AbstractParty)
-  public void setParticipants(Set)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
   public void setQuantity(long)
 ##
-@javax.persistence.MappedSuperclass @net.corda.core.serialization.CordaSerializable public static class net.corda.core.schemas.CommonSchemaV1$LinearState extends net.corda.core.schemas.PersistentState
+@MappedSuperclass
+@CordaSerializable
+public static class net.corda.core.schemas.CommonSchemaV1$LinearState extends net.corda.core.schemas.PersistentState
   public <init>()
-  public <init>(Set, String, UUID)
-  public <init>(net.corda.core.contracts.UniqueIdentifier, Set)
-  @org.jetbrains.annotations.Nullable public String getExternalId()
-  @org.jetbrains.annotations.Nullable public Set getParticipants()
-  @org.jetbrains.annotations.NotNull public UUID getUuid()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, String, java.util.UUID)
+  public <init>(net.corda.core.contracts.UniqueIdentifier, java.util.Set<? extends net.corda.core.identity.AbstractParty>)
+  @Nullable
+  public String getExternalId()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public java.util.UUID getUuid()
   public void setExternalId(String)
-  public void setParticipants(Set)
-  public void setUuid(UUID)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setUuid(java.util.UUID)
 ##
 public class net.corda.core.schemas.MappedSchema extends java.lang.Object
-  public <init>(Class, int, Iterable)
-  @org.jetbrains.annotations.NotNull public final Iterable getMappedTypes()
-  @org.jetbrains.annotations.NotNull public final String getName()
+  public <init>(Class<?>, int, Iterable<? extends Class<?>>)
+  @NotNull
+  public final Iterable<Class<?>> getMappedTypes()
+  @NotNull
+  public final String getName()
   public final int getVersion()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@javax.persistence.MappedSuperclass @net.corda.core.serialization.CordaSerializable public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.StatePersistable
+@MappedSuperclass
+@CordaSerializable
+public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.StatePersistable
   public <init>()
   public <init>(net.corda.core.schemas.PersistentStateRef)
-  @org.jetbrains.annotations.Nullable public net.corda.core.schemas.PersistentStateRef getStateRef()
+  @Nullable
+  public net.corda.core.schemas.PersistentStateRef getStateRef()
   public void setStateRef(net.corda.core.schemas.PersistentStateRef)
 ##
-@javax.persistence.Embeddable public class net.corda.core.schemas.PersistentStateRef extends java.lang.Object implements java.io.Serializable
+@Embeddable
+public class net.corda.core.schemas.PersistentStateRef extends java.lang.Object implements java.io.Serializable
   public <init>()
   public <init>(String, Integer)
   public <init>(net.corda.core.contracts.StateRef)
-  @org.jetbrains.annotations.Nullable public final String component1()
-  @org.jetbrains.annotations.Nullable public final Integer component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.schemas.PersistentStateRef copy(String, Integer)
+  @Nullable
+  public final String component1()
+  @Nullable
+  public final Integer component2()
+  @NotNull
+  public final net.corda.core.schemas.PersistentStateRef copy(String, Integer)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public Integer getIndex()
-  @org.jetbrains.annotations.Nullable public String getTxId()
+  @Nullable
+  public Integer getIndex()
+  @Nullable
+  public String getTxId()
   public int hashCode()
   public void setIndex(Integer)
   public void setTxId(String)
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.schemas.QueryableState extends net.corda.core.contracts.ContractState
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.schemas.PersistentState generateMappedObject(net.corda.core.schemas.MappedSchema)
-  @org.jetbrains.annotations.NotNull public abstract Iterable supportedSchemas()
+@CordaSerializable
+public interface net.corda.core.schemas.QueryableState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.schemas.PersistentState generateMappedObject(net.corda.core.schemas.MappedSchema)
+  @NotNull
+  public abstract Iterable<net.corda.core.schemas.MappedSchema> supportedSchemas()
 ##
 public interface net.corda.core.schemas.StatePersistable extends java.io.Serializable
 ##
 public interface net.corda.core.serialization.ClassWhitelist
-  public abstract boolean hasListed(Class)
+  public abstract boolean hasListed(Class<?>)
 ##
 public @interface net.corda.core.serialization.ConstructorForDeserialization
 ##
@@ -2838,414 +4497,655 @@ public @interface net.corda.core.serialization.CordaSerializationTransformRename
 public @interface net.corda.core.serialization.DeprecatedConstructorForDeserialization
   public abstract int version()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.serialization.EncodingWhitelist
-  public abstract boolean acceptEncoding(net.corda.core.serialization.SerializationEncoding)
-##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.serialization.MissingAttachmentsException extends net.corda.core.CordaException
-  public <init>(List)
-  @org.jetbrains.annotations.NotNull public final List getIds()
+@CordaSerializable
+public final class net.corda.core.serialization.MissingAttachmentsException extends net.corda.core.CordaException
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
 ##
 public final class net.corda.core.serialization.ObjectWithCompatibleContext extends java.lang.Object
-  public <init>(Object, net.corda.core.serialization.SerializationContext)
-  @org.jetbrains.annotations.NotNull public final Object component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.ObjectWithCompatibleContext copy(Object, net.corda.core.serialization.SerializationContext)
+  public <init>(T, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext component2()
+  @NotNull
+  public final net.corda.core.serialization.ObjectWithCompatibleContext<T> copy(T, net.corda.core.serialization.SerializationContext)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getContext()
-  @org.jetbrains.annotations.NotNull public final Object getObj()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getContext()
+  @NotNull
+  public final T getObj()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.core.serialization.SerializationAPIKt extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.serialization.SerializedBytes serialize(Object, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> serialize(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.serialization.SerializationContext
-  @org.jetbrains.annotations.NotNull public abstract ClassLoader getDeserializationClassLoader()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.serialization.SerializationEncoding getEncoding()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.EncodingWhitelist getEncodingWhitelist()
+public interface net.corda.core.serialization.SerializationContext
+  @NotNull
+  public abstract ClassLoader getDeserializationClassLoader()
   public abstract boolean getObjectReferencesEnabled()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.utilities.ByteSequence getPreferredSerializationVersion()
-  @org.jetbrains.annotations.NotNull public abstract Map getProperties()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext$UseCase getUseCase()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.ClassWhitelist getWhitelist()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext withAttachmentsClassLoader(List)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext withClassLoader(ClassLoader)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext withEncoding(net.corda.core.serialization.SerializationEncoding)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext withPreferredSerializationVersion(net.corda.core.utilities.ByteSequence)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext withProperty(Object, Object)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext withWhitelisted(Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationContext withoutReferences()
+  @NotNull
+  public abstract net.corda.core.utilities.ByteSequence getPreferredSerializationVersion()
+  @NotNull
+  public abstract java.util.Map<Object, Object> getProperties()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext$UseCase getUseCase()
+  @NotNull
+  public abstract net.corda.core.serialization.ClassWhitelist getWhitelist()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withAttachmentsClassLoader(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withClassLoader(ClassLoader)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withPreferredSerializationVersion(net.corda.core.utilities.ByteSequence)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withProperty(Object, Object)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withWhitelisted(Class<?>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withoutReferences()
 ##
 public static final class net.corda.core.serialization.SerializationContext$UseCase extends java.lang.Enum
-  protected <init>(String, int)
+  protected <init>()
   public static net.corda.core.serialization.SerializationContext$UseCase valueOf(String)
   public static net.corda.core.serialization.SerializationContext$UseCase[] values()
 ##
 public interface net.corda.core.serialization.SerializationCustomSerializer
-  public abstract Object fromProxy(Object)
-  public abstract Object toProxy(Object)
+  public abstract OBJ fromProxy(PROXY)
+  public abstract PROXY toProxy(OBJ)
 ##
 public final class net.corda.core.serialization.SerializationDefaults extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getCHECKPOINT_CONTEXT()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getP2P_CONTEXT()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getRPC_CLIENT_CONTEXT()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getRPC_SERVER_CONTEXT()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationFactory getSERIALIZATION_FACTORY()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getSTORAGE_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getCHECKPOINT_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getP2P_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getRPC_CLIENT_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getRPC_SERVER_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getSERIALIZATION_FACTORY()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getSTORAGE_CONTEXT()
   public static final net.corda.core.serialization.SerializationDefaults INSTANCE
-##
-@net.corda.core.DoNotImplement public interface net.corda.core.serialization.SerializationEncoding
 ##
 public abstract class net.corda.core.serialization.SerializationFactory extends java.lang.Object
   public <init>()
-  public final Object asCurrent(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public abstract Object deserialize(net.corda.core.utilities.ByteSequence, Class, net.corda.core.serialization.SerializationContext)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.ObjectWithCompatibleContext deserializeWithCompatibleContext(net.corda.core.utilities.ByteSequence, Class, net.corda.core.serialization.SerializationContext)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.serialization.SerializationContext getCurrentContext()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getDefaultContext()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializedBytes serialize(Object, net.corda.core.serialization.SerializationContext)
-  public final Object withCurrentContext(net.corda.core.serialization.SerializationContext, kotlin.jvm.functions.Function0)
+  public final T asCurrent(kotlin.jvm.functions.Function1<? super net.corda.core.serialization.SerializationFactory, ? extends T>)
+  @NotNull
+  public abstract T deserialize(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public abstract net.corda.core.serialization.ObjectWithCompatibleContext<T> deserializeWithCompatibleContext(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.SerializationContext)
+  @Nullable
+  public final net.corda.core.serialization.SerializationContext getCurrentContext()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getDefaultContext()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializedBytes<T> serialize(T, net.corda.core.serialization.SerializationContext)
+  public final T withCurrentContext(net.corda.core.serialization.SerializationContext, kotlin.jvm.functions.Function0<? extends T>)
   public static final net.corda.core.serialization.SerializationFactory$Companion Companion
 ##
 public static final class net.corda.core.serialization.SerializationFactory$Companion extends java.lang.Object
-  @org.jetbrains.annotations.Nullable public final net.corda.core.serialization.SerializationFactory getCurrentFactory()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationFactory getDefaultFactory()
+  @Nullable
+  public final net.corda.core.serialization.SerializationFactory getCurrentFactory()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getDefaultFactory()
 ##
 public interface net.corda.core.serialization.SerializationToken
-  @org.jetbrains.annotations.NotNull public abstract Object fromToken(net.corda.core.serialization.SerializeAsTokenContext)
+  @NotNull
+  public abstract Object fromToken(net.corda.core.serialization.SerializeAsTokenContext)
 ##
 public interface net.corda.core.serialization.SerializationWhitelist
-  @org.jetbrains.annotations.NotNull public abstract List getWhitelist()
+  @NotNull
+  public abstract java.util.List<Class<?>> getWhitelist()
 ##
-@net.corda.core.serialization.CordaSerializable public interface net.corda.core.serialization.SerializeAsToken
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
+@CordaSerializable
+public interface net.corda.core.serialization.SerializeAsToken
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
 ##
 public interface net.corda.core.serialization.SerializeAsTokenContext
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.ServiceHub getServiceHub()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializeAsToken getSingleton(String)
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServiceHub()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializeAsToken getSingleton(String)
   public abstract void putSingleton(net.corda.core.serialization.SerializeAsToken)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.serialization.SerializedBytes extends net.corda.core.utilities.OpaqueBytes
+@CordaSerializable
+public final class net.corda.core.serialization.SerializedBytes extends net.corda.core.utilities.OpaqueBytes
   public <init>(byte[])
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
 ##
 public final class net.corda.core.serialization.SingletonSerializationToken extends java.lang.Object implements net.corda.core.serialization.SerializationToken
-  @org.jetbrains.annotations.NotNull public net.corda.core.serialization.SerializeAsToken fromToken(net.corda.core.serialization.SerializeAsTokenContext)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SingletonSerializationToken registerWithContext(net.corda.core.serialization.SerializeAsTokenContext, net.corda.core.serialization.SerializeAsToken)
+  @NotNull
+  public net.corda.core.serialization.SerializeAsToken fromToken(net.corda.core.serialization.SerializeAsTokenContext)
+  @NotNull
+  public final net.corda.core.serialization.SingletonSerializationToken registerWithContext(net.corda.core.serialization.SerializeAsTokenContext, net.corda.core.serialization.SerializeAsToken)
   public static final net.corda.core.serialization.SingletonSerializationToken$Companion Companion
 ##
 public static final class net.corda.core.serialization.SingletonSerializationToken$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SingletonSerializationToken singletonSerializationToken(Class)
+  @NotNull
+  public final net.corda.core.serialization.SingletonSerializationToken singletonSerializationToken(Class<T>)
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.serialization.SingletonSerializeAsToken extends java.lang.Object implements net.corda.core.serialization.SerializeAsToken
+@CordaSerializable
+public abstract class net.corda.core.serialization.SingletonSerializeAsToken extends java.lang.Object implements net.corda.core.serialization.SerializeAsToken
   public <init>()
-  @org.jetbrains.annotations.NotNull public net.corda.core.serialization.SingletonSerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
+  @NotNull
+  public net.corda.core.serialization.SingletonSerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
 ##
-@net.corda.core.DoNotImplement public abstract class net.corda.core.transactions.BaseTransaction extends java.lang.Object implements net.corda.core.contracts.NamedByHash
+@DoNotImplement
+public abstract class net.corda.core.transactions.BaseTransaction extends java.lang.Object implements net.corda.core.contracts.NamedByHash
   public <init>()
   protected void checkBaseInvariants()
-  @org.jetbrains.annotations.NotNull public final List filterOutRefs(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final List filterOutputs(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef findOutRef(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState findOutput(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public abstract List getInputs()
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState getOutput(int)
-  @org.jetbrains.annotations.NotNull public final List getOutputStates()
-  @org.jetbrains.annotations.NotNull public abstract List getOutputs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef outRef(int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef outRef(net.corda.core.contracts.ContractState)
-  @org.jetbrains.annotations.NotNull public final List outRefsOfType(Class)
-  @org.jetbrains.annotations.NotNull public final List outputsOfType(Class)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterOutRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterOutputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findOutRef(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findOutput(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public abstract java.util.List<?> getInputs()
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getOutput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> outRef(int)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> outRef(net.corda.core.contracts.ContractState)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> outRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> outputsOfType(Class<T>)
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.transactions.ComponentGroup extends java.lang.Object
-  public <init>(int, List)
-  @org.jetbrains.annotations.NotNull public List getComponents()
+@CordaSerializable
+public class net.corda.core.transactions.ComponentGroup extends java.lang.Object
+  public <init>(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  @NotNull
+  public java.util.List<net.corda.core.utilities.OpaqueBytes> getComponents()
   public int getGroupIndex()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.ComponentVisibilityException extends net.corda.core.CordaException
+@CordaSerializable
+public final class net.corda.core.transactions.ComponentVisibilityException extends net.corda.core.CordaException
   public <init>(net.corda.core.crypto.SecureHash, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public final String getReason()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final String getReason()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.ContractUpgradeFilteredTransaction extends net.corda.core.transactions.CoreTransaction
-  public <init>(Map, Map)
-  @org.jetbrains.annotations.NotNull public final Map component1()
-  @org.jetbrains.annotations.NotNull public final Map component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeFilteredTransaction copy(Map, Map)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.ContractUpgradeFilteredTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent>, java.util.Map<Integer, ? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent> component1()
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.crypto.SecureHash> component2()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeFilteredTransaction copy(java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent>, java.util.Map<Integer, ? extends net.corda.core.crypto.SecureHash>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Map getHiddenComponents()
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public List getInputs()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public List getOutputs()
-  @org.jetbrains.annotations.NotNull public final Map getVisibleComponents()
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.crypto.SecureHash> getHiddenComponents()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent> getVisibleComponents()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent extends java.lang.Object
+@CordaSerializable
+public static final class net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent extends java.lang.Object
   public <init>(net.corda.core.utilities.OpaqueBytes, net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.OpaqueBytes getComponent()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getNonce()
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes getComponent()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getNonce()
 ##
-@net.corda.core.DoNotImplement public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
-  public <init>(List, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, List, net.corda.core.node.NetworkParameters)
+@DoNotImplement
+public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
   public void checkSignaturesAreValid()
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Attachment component3()
-  @org.jetbrains.annotations.NotNull public final String component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Attachment component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component6()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PrivacySalt component7()
-  @org.jetbrains.annotations.NotNull public final List component8()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeLedgerTransaction copy(List, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, List, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final net.corda.core.identity.Party component2()
+  @NotNull
+  public final net.corda.core.contracts.Attachment component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.contracts.Attachment component5()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component6()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component7()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component8()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public List getInputs()
-  @org.jetbrains.annotations.NotNull public List getKeyDescriptions(Set)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Attachment getLegacyContractAttachment()
-  @org.jetbrains.annotations.NotNull public Set getMissingSigners()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public List getOutputs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
-  @org.jetbrains.annotations.NotNull public Set getRequiredSigningKeys()
-  @org.jetbrains.annotations.NotNull public List getSigs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Attachment getUpgradedContractAttachment()
-  @org.jetbrains.annotations.NotNull public final String getUpgradedContractClassName()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @NotNull
+  public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getLegacyContractAttachment()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @NotNull
+  public final net.corda.core.contracts.Attachment getUpgradedContractAttachment()
+  @NotNull
+  public final String getUpgradedContractClassName()
   public int hashCode()
   public String toString()
   public void verifyRequiredSignatures()
-  public void verifySignaturesExcept(Collection)
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
   public void verifySignaturesExcept(java.security.PublicKey...)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.ContractUpgradeWireTransaction extends net.corda.core.transactions.CoreTransaction
-  public <init>(List, net.corda.core.contracts.PrivacySalt)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeFilteredTransaction buildFilteredTransaction()
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PrivacySalt component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeWireTransaction copy(List, net.corda.core.contracts.PrivacySalt)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.ContractUpgradeWireTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeFilteredTransaction buildFilteredTransaction()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component1()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component2()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeWireTransaction copy(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.contracts.PrivacySalt)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public List getInputs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getLegacyContractAttachmentId()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public List getOutputs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
-  @org.jetbrains.annotations.NotNull public final List getSerializedComponents()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getUpgradedContractAttachmentId()
-  @org.jetbrains.annotations.NotNull public final String getUpgradedContractClassName()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getLegacyContractAttachmentId()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getUpgradedContractAttachmentId()
+  @NotNull
+  public final String getUpgradedContractClassName()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, List)
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
   public String toString()
 ##
 public static final class net.corda.core.transactions.ContractUpgradeWireTransaction$Component extends java.lang.Enum
-  protected <init>(String, int)
+  protected <init>()
   public static net.corda.core.transactions.ContractUpgradeWireTransaction$Component valueOf(String)
   public static net.corda.core.transactions.ContractUpgradeWireTransaction$Component[] values()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.transactions.CoreTransaction extends net.corda.core.transactions.BaseTransaction
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.transactions.CoreTransaction extends net.corda.core.transactions.BaseTransaction
   public <init>()
-  @org.jetbrains.annotations.NotNull public abstract List getInputs()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.FilteredComponentGroup extends net.corda.core.transactions.ComponentGroup
-  public <init>(int, List, List, net.corda.core.crypto.PartialMerkleTree)
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredComponentGroup extends net.corda.core.transactions.ComponentGroup
+  public <init>(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.crypto.PartialMerkleTree)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final List component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.FilteredComponentGroup copy(int, List, List, net.corda.core.crypto.PartialMerkleTree)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component2()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> component3()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree component4()
+  @NotNull
+  public final net.corda.core.transactions.FilteredComponentGroup copy(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.crypto.PartialMerkleTree)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public List getComponents()
+  @NotNull
+  public java.util.List<net.corda.core.utilities.OpaqueBytes> getComponents()
   public int getGroupIndex()
-  @org.jetbrains.annotations.NotNull public final List getNonces()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getNonces()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.FilteredTransaction extends net.corda.core.transactions.TraversableTransaction
-  public <init>(net.corda.core.crypto.SecureHash, List, List)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, function.Predicate)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredTransaction extends net.corda.core.transactions.TraversableTransaction
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.transactions.FilteredComponentGroup>, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public static final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, java.util.function.Predicate<Object>)
   public final void checkAllComponentsVisible(net.corda.core.contracts.ComponentGroupEnum)
   public final void checkCommandVisibility(java.security.PublicKey)
-  public final boolean checkWithFun(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final List getFilteredComponentGroups()
-  @org.jetbrains.annotations.NotNull public final List getGroupHashes()
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
+  public final boolean checkWithFun(kotlin.jvm.functions.Function1<Object, Boolean>)
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.FilteredComponentGroup> getFilteredComponentGroups()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getGroupHashes()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
   public final void verify()
   public static final net.corda.core.transactions.FilteredTransaction$Companion Companion
 ##
 public static final class net.corda.core.transactions.FilteredTransaction$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, function.Predicate)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, java.util.function.Predicate<Object>)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.FilteredTransactionVerificationException extends net.corda.core.CordaException
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredTransactionVerificationException extends net.corda.core.CordaException
   public <init>(net.corda.core.crypto.SecureHash, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public final String getReason()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final String getReason()
 ##
-@net.corda.core.DoNotImplement public abstract class net.corda.core.transactions.FullTransaction extends net.corda.core.transactions.BaseTransaction
+@DoNotImplement
+public abstract class net.corda.core.transactions.FullTransaction extends net.corda.core.transactions.BaseTransaction
   public <init>()
   protected void checkBaseInvariants()
-  @org.jetbrains.annotations.NotNull public abstract List getInputs()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
-  public <init>(List, List, List, List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
-  public <init>(List, List, List, List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
-  @org.jetbrains.annotations.NotNull public final List commandsOfType(Class)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final List component3()
-  @org.jetbrains.annotations.NotNull public final List component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component5()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.Party component6()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.contracts.TimeWindow component7()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PrivacySalt component8()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction copy(List, List, List, List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction copy(List, List, List, List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<T>> commandsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> component2()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.CommandWithParties<net.corda.core.contracts.CommandData>> component3()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Attachment> component4()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component5()
+  @Nullable
+  public final net.corda.core.identity.Party component6()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow component7()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component8()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final List filterCommands(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final List filterInRefs(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final List filterInputs(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Command findCommand(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef findInRef(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState findInput(Class, function.Predicate)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Attachment getAttachment(int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Attachment getAttachment(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final List getAttachments()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.Command getCommand(int)
-  @org.jetbrains.annotations.NotNull public final List getCommands()
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState getInput(int)
-  @org.jetbrains.annotations.NotNull public final List getInputStates()
-  @org.jetbrains.annotations.NotNull public List getInputs()
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public List getOutputs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.contracts.TimeWindow getTimeWindow()
-  @org.jetbrains.annotations.NotNull public final List groupStates(Class, kotlin.jvm.functions.Function1)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<T>> filterCommands(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterInRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterInputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.Command<T> findCommand(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findInRef(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findInput(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment(int)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Attachment> getAttachments()
+  @NotNull
+  public final net.corda.core.contracts.Command<T> getCommand(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.CommandWithParties<net.corda.core.contracts.CommandData>> getCommands()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getInput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getInputStates()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @Nullable
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimeWindow()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.LedgerTransaction$InOutGroup<T, K>> groupStates(Class<T>, kotlin.jvm.functions.Function1<? super T, ? extends K>)
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.StateAndRef inRef(int)
-  @org.jetbrains.annotations.NotNull public final List inRefsOfType(Class)
-  @org.jetbrains.annotations.NotNull public final List inputsOfType(Class)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> inRef(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> inRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> inputsOfType(Class<T>)
   public String toString()
   public final void verify()
-  @java.lang.Deprecated public static final net.corda.core.transactions.LedgerTransaction$Companion Companion
+  public static final net.corda.core.transactions.LedgerTransaction$Companion Companion
 ##
 public static final class net.corda.core.transactions.LedgerTransaction$InOutGroup extends java.lang.Object
-  public <init>(List, List, Object)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final Object component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction$InOutGroup copy(List, List, Object)
+  public <init>(java.util.List<? extends T>, java.util.List<? extends T>, K)
+  @NotNull
+  public final java.util.List<T> component1()
+  @NotNull
+  public final java.util.List<T> component2()
+  @NotNull
+  public final K component3()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction$InOutGroup<T, K> copy(java.util.List<? extends T>, java.util.List<? extends T>, K)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Object getGroupingKey()
-  @org.jetbrains.annotations.NotNull public final List getInputs()
-  @org.jetbrains.annotations.NotNull public final List getOutputs()
+  @NotNull
+  public final K getGroupingKey()
+  @NotNull
+  public final java.util.List<T> getInputs()
+  @NotNull
+  public final java.util.List<T> getOutputs()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.MissingContractAttachments extends net.corda.core.flows.FlowException
-  public <init>(List)
-  @org.jetbrains.annotations.NotNull public final List getStates()
+@CordaSerializable
+public final class net.corda.core.transactions.MissingContractAttachments extends net.corda.core.flows.FlowException
+  public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getStates()
 ##
-@net.corda.core.DoNotImplement public final class net.corda.core.transactions.NotaryChangeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
-  public <init>(List, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, List)
+@DoNotImplement
+public final class net.corda.core.transactions.NotaryChangeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
   public void checkSignaturesAreValid()
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash component4()
-  @org.jetbrains.annotations.NotNull public final List component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeLedgerTransaction copy(List, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, List)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final net.corda.core.identity.Party component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component4()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component5()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public List getInputs()
-  @org.jetbrains.annotations.NotNull public List getKeyDescriptions(Set)
-  @org.jetbrains.annotations.NotNull public Set getMissingSigners()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getNewNotary()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public List getOutputs()
-  @org.jetbrains.annotations.NotNull public Set getRequiredSigningKeys()
-  @org.jetbrains.annotations.NotNull public List getSigs()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @NotNull
+  public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
+  @NotNull
+  public final net.corda.core.identity.Party getNewNotary()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
   public int hashCode()
   public String toString()
   public void verifyRequiredSignatures()
-  public void verifySignaturesExcept(Collection)
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
   public void verifySignaturesExcept(java.security.PublicKey...)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.NotaryChangeWireTransaction extends net.corda.core.transactions.CoreTransaction
-  public <init>(List)
-  @kotlin.Deprecated public <init>(List, net.corda.core.identity.Party, net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final List component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeWireTransaction copy(List)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.NotaryChangeWireTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.identity.Party, net.corda.core.identity.Party)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component1()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeWireTransaction copy(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public List getInputs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getNewNotary()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public List getOutputs()
-  @org.jetbrains.annotations.NotNull public final List getSerializedComponents()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final net.corda.core.identity.Party getNewNotary()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServiceHub, List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, List)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServiceHub, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
   public String toString()
 ##
 public static final class net.corda.core.transactions.NotaryChangeWireTransaction$Component extends java.lang.Enum
-  protected <init>(String, int)
+  protected <init>()
   public static net.corda.core.transactions.NotaryChangeWireTransaction$Component valueOf(String)
   public static net.corda.core.transactions.NotaryChangeWireTransaction$Component[] values()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.SignedTransaction extends java.lang.Object implements net.corda.core.transactions.TransactionWithSignatures
-  public <init>(net.corda.core.serialization.SerializedBytes, List)
-  public <init>(net.corda.core.transactions.CoreTransaction, List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(function.Predicate)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.SignedTransaction extends java.lang.Object implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction>, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public <init>(net.corda.core.transactions.CoreTransaction, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
   public void checkSignaturesAreValid()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializedBytes component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction copy(net.corda.core.serialization.SerializedBytes, List)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component2()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction copy(net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction>, java.util.List<net.corda.core.crypto.TransactionSignature>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public final List getInputs()
-  @org.jetbrains.annotations.NotNull public ArrayList getKeyDescriptions(Set)
-  @org.jetbrains.annotations.NotNull public Set getMissingSigners()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
-  @org.jetbrains.annotations.NotNull public Set getRequiredSigningKeys()
-  @org.jetbrains.annotations.NotNull public List getSigs()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction getTx()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializedBytes getTxBits()
+  @NotNull
+  public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public java.util.ArrayList<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction getTx()
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
   public int hashCode()
-  @kotlin.Deprecated public final boolean isNotaryChangeTransaction()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction plus(Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction plus(net.corda.core.crypto.TransactionSignature)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.BaseTransaction resolveBaseTransaction(net.corda.core.node.ServicesForResolution)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolveContractUpgradeTransaction(net.corda.core.node.ServicesForResolution)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServiceHub)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServicesForResolution)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionWithSignatures resolveTransactionWithSignatures(net.corda.core.node.ServicesForResolution)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub, boolean)
-  @org.jetbrains.annotations.NotNull public String toString()
+  public final boolean isNotaryChangeTransaction()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction plus(java.util.Collection<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction plus(net.corda.core.crypto.TransactionSignature)
+  @NotNull
+  public final net.corda.core.transactions.BaseTransaction resolveBaseTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolveContractUpgradeTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.TransactionWithSignatures resolveTransactionWithSignatures(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub, boolean)
+  @NotNull
+  public String toString()
   public final void verify(net.corda.core.node.ServiceHub)
   public final void verify(net.corda.core.node.ServiceHub, boolean)
   public void verifyRequiredSignatures()
-  public void verifySignaturesExcept(Collection)
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
   public void verifySignaturesExcept(java.security.PublicKey...)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(java.security.KeyPair, net.corda.core.crypto.SignatureMetadata)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(net.corda.core.crypto.TransactionSignature)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable)
-  @java.lang.Deprecated public static final net.corda.core.transactions.SignedTransaction$Companion Companion
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(java.security.KeyPair, net.corda.core.crypto.SignatureMetadata)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(net.corda.core.crypto.TransactionSignature)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable<net.corda.core.crypto.TransactionSignature>)
+  public static final net.corda.core.transactions.SignedTransaction$Companion Companion
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.transactions.SignedTransaction$SignaturesMissingException extends java.security.SignatureException implements net.corda.core.CordaThrowable, net.corda.core.contracts.NamedByHash
-  public <init>(Set, List, net.corda.core.crypto.SecureHash)
+@CordaSerializable
+public static final class net.corda.core.transactions.SignedTransaction$SignaturesMissingException extends java.security.SignatureException implements net.corda.core.CordaThrowable, net.corda.core.contracts.NamedByHash
+  public <init>(java.util.Set<? extends java.security.PublicKey>, java.util.List<String>, net.corda.core.crypto.SecureHash)
   public void addSuppressed(Throwable[])
-  @org.jetbrains.annotations.NotNull public final List getDescriptions()
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public final Set getMissing()
-  @org.jetbrains.annotations.Nullable public String getOriginalExceptionClassName()
-  @org.jetbrains.annotations.Nullable public String getOriginalMessage()
+  @NotNull
+  public final java.util.List<String> getDescriptions()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getMissing()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
   public void setCause(Throwable)
   public void setMessage(String)
   public void setOriginalExceptionClassName(String)
@@ -3253,389 +5153,587 @@ public static final class net.corda.core.transactions.NotaryChangeWireTransactio
 public class net.corda.core.transactions.TransactionBuilder extends java.lang.Object
   public <init>()
   public <init>(net.corda.core.identity.Party)
-  public <init>(net.corda.core.identity.Party, UUID, List, List, List, List, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addAttachment(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.Command)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, List)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.security.PublicKey...)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.TransactionBuilder addInputState(net.corda.core.contracts.StateAndRef)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.contracts.AttachmentConstraint)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.TransactionState)
-  @org.jetbrains.annotations.NotNull public final List attachments()
-  @org.jetbrains.annotations.NotNull public final List commands()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder copy()
-  @org.jetbrains.annotations.NotNull protected final List getAttachments()
-  @org.jetbrains.annotations.NotNull protected final List getCommands()
-  @org.jetbrains.annotations.NotNull protected final List getInputs()
-  @org.jetbrains.annotations.NotNull public final UUID getLockId()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull protected final List getOutputs()
-  @org.jetbrains.annotations.NotNull protected final net.corda.core.contracts.PrivacySalt getPrivacySalt()
-  @org.jetbrains.annotations.Nullable protected final net.corda.core.contracts.TimeWindow getWindow()
-  @org.jetbrains.annotations.NotNull public final List inputStates()
-  @org.jetbrains.annotations.NotNull public final List outputStates()
-  public final void setLockId(UUID)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.Command<?>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.security.PublicKey...)
+  @NotNull
+  public net.corda.core.transactions.TransactionBuilder addInputState(net.corda.core.contracts.StateAndRef<?>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.TransactionState<?>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> attachments()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<?>> commands()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder copy()
+  @NotNull
+  protected final java.util.List<net.corda.core.crypto.SecureHash> getAttachments()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.Command<?>> getCommands()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final java.util.UUID getLockId()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  protected final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @Nullable
+  protected final net.corda.core.contracts.TimeWindow getWindow()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> inputStates()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<?>> outputStates()
+  public final void setLockId(java.util.UUID)
   public final void setNotary(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder setPrivacySalt(net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setPrivacySalt(net.corda.core.contracts.PrivacySalt)
   protected final void setPrivacySalt(net.corda.core.contracts.PrivacySalt)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder setTimeWindow(java.time.Instant, java.time.Duration)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder setTimeWindow(net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setTimeWindow(java.time.Instant, java.time.Duration)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setTimeWindow(net.corda.core.contracts.TimeWindow)
   protected final void setWindow(net.corda.core.contracts.TimeWindow)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.SignedTransaction toSignedTransaction(net.corda.core.node.services.KeyManagementService, java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.node.ServicesForResolution)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction toWireTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction toSignedTransaction(net.corda.core.node.services.KeyManagementService, java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction toWireTransaction(net.corda.core.node.ServicesForResolution)
   public final void verify(net.corda.core.node.ServiceHub)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder withItems(Object...)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder withItems(Object...)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.core.transactions.TransactionWithSignatures extends net.corda.core.contracts.NamedByHash
+@DoNotImplement
+public interface net.corda.core.transactions.TransactionWithSignatures extends net.corda.core.contracts.NamedByHash
   public abstract void checkSignaturesAreValid()
-  @org.jetbrains.annotations.NotNull public abstract List getKeyDescriptions(Set)
-  @org.jetbrains.annotations.NotNull public abstract Set getMissingSigners()
-  @org.jetbrains.annotations.NotNull public abstract Set getRequiredSigningKeys()
-  @org.jetbrains.annotations.NotNull public abstract List getSigs()
+  @NotNull
+  public abstract java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getMissingSigners()
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
   public abstract void verifyRequiredSignatures()
-  public abstract void verifySignaturesExcept(Collection)
+  public abstract void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
   public abstract void verifySignaturesExcept(java.security.PublicKey...)
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.transactions.TraversableTransaction extends net.corda.core.transactions.CoreTransaction
-  public <init>(List)
-  @org.jetbrains.annotations.NotNull public final List getAttachments()
-  @org.jetbrains.annotations.NotNull public final List getAvailableComponentGroups()
-  @org.jetbrains.annotations.NotNull public final List getCommands()
-  @org.jetbrains.annotations.NotNull public List getComponentGroups()
-  @org.jetbrains.annotations.NotNull public List getInputs()
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party getNotary()
-  @org.jetbrains.annotations.NotNull public List getOutputs()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.contracts.TimeWindow getTimeWindow()
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.transactions.TraversableTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getAttachments()
+  @NotNull
+  public final java.util.List<java.util.List<Object>> getAvailableComponentGroups()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<?>> getCommands()
+  @NotNull
+  public java.util.List<net.corda.core.transactions.ComponentGroup> getComponentGroups()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimeWindow()
 ##
-@net.corda.core.DoNotImplement @net.corda.core.serialization.CordaSerializable public final class net.corda.core.transactions.WireTransaction extends net.corda.core.transactions.TraversableTransaction
-  @kotlin.Deprecated public <init>(List, List, List, List, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
-  public <init>(List, net.corda.core.contracts.PrivacySalt)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(function.Predicate)
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.WireTransaction extends net.corda.core.transactions.TraversableTransaction
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.crypto.SecureHash>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>, net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
   public final void checkSignature(net.corda.core.crypto.TransactionSignature)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.MerkleTree getMerkleTree()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
-  @org.jetbrains.annotations.NotNull public final Set getRequiredSigningKeys()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getMerkleTree()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
   public int hashCode()
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServicesForResolution)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(kotlin.jvm.functions.Function1<? super java.security.PublicKey, net.corda.core.identity.Party>, kotlin.jvm.functions.Function1<? super net.corda.core.crypto.SecureHash, ? extends net.corda.core.contracts.Attachment>, kotlin.jvm.functions.Function1<? super net.corda.core.contracts.StateRef, ? extends net.corda.core.contracts.TransactionState<?>>, kotlin.jvm.functions.Function1<? super net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>, ? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public String toString()
   public static final net.corda.core.transactions.WireTransaction$Companion Companion
 ##
 public static final class net.corda.core.transactions.WireTransaction$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final List createComponentGroups(List, List, List, List, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.ComponentGroup> createComponentGroups(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow)
 ##
 public final class net.corda.core.utilities.ByteArrays extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final byte[] parseAsHex(String)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.ByteSequence sequence(byte[], int, int)
-  @org.jetbrains.annotations.NotNull public static final String toHexString(byte[])
+  @NotNull
+  public static final byte[] parseAsHex(String)
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence sequence(byte[], int, int)
+  @NotNull
+  public static final String toHexString(byte[])
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.utilities.ByteSequence extends java.lang.Object implements java.lang.Comparable
+@CordaSerializable
+public abstract class net.corda.core.utilities.ByteSequence extends java.lang.Object implements java.lang.Comparable
   public int compareTo(net.corda.core.utilities.ByteSequence)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ByteSequence copy()
-  @org.jetbrains.annotations.NotNull public final byte[] copyBytes()
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence copy()
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public abstract byte[] getBytes()
-  public final int getOffset()
-  public final int getSize()
+  @NotNull
+  public abstract byte[] getBytes()
+  public abstract int getOffset()
+  public abstract int getSize()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.ByteSequence of(byte[])
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.ByteSequence of(byte[], int)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.ByteSequence of(byte[], int, int)
-  @org.jetbrains.annotations.NotNull public final java.io.ByteArrayInputStream open()
-  @org.jetbrains.annotations.NotNull public final java.nio.ByteBuffer putTo(java.nio.ByteBuffer)
-  @org.jetbrains.annotations.NotNull public final java.nio.ByteBuffer slice(int, int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ByteSequence subSequence(int, int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ByteSequence take(int)
-  @org.jetbrains.annotations.NotNull public String toString()
-  public final void writeTo(java.io.OutputStream)
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[])
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[], int)
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[], int, int)
+  @NotNull
+  public final java.io.ByteArrayInputStream open()
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence subSequence(int, int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence take(int)
+  @NotNull
+  public String toString()
   public static final net.corda.core.utilities.ByteSequence$Companion Companion
 ##
 public static final class net.corda.core.utilities.ByteSequence$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ByteSequence of(byte[])
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ByteSequence of(byte[], int)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ByteSequence of(byte[], int, int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[])
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[], int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[], int, int)
 ##
 public final class net.corda.core.utilities.EncodingUtils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final byte[] base58ToByteArray(String)
-  @org.jetbrains.annotations.NotNull public static final String base58ToRealString(String)
-  @org.jetbrains.annotations.NotNull public static final String base58toBase64(String)
-  @org.jetbrains.annotations.NotNull public static final String base58toHex(String)
-  @org.jetbrains.annotations.NotNull public static final byte[] base64ToByteArray(String)
-  @org.jetbrains.annotations.NotNull public static final String base64ToRealString(String)
-  @org.jetbrains.annotations.NotNull public static final String base64toBase58(String)
-  @org.jetbrains.annotations.NotNull public static final String base64toHex(String)
-  @org.jetbrains.annotations.NotNull public static final String hexToBase58(String)
-  @org.jetbrains.annotations.NotNull public static final String hexToBase64(String)
-  @org.jetbrains.annotations.NotNull public static final byte[] hexToByteArray(String)
-  @org.jetbrains.annotations.NotNull public static final String hexToRealString(String)
-  @org.jetbrains.annotations.NotNull public static final java.security.PublicKey parsePublicKeyBase58(String)
-  @org.jetbrains.annotations.NotNull public static final String toBase58(byte[])
-  @org.jetbrains.annotations.NotNull public static final String toBase58String(java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public static final String toBase64(byte[])
-  @org.jetbrains.annotations.NotNull public static final String toHex(byte[])
-  @org.jetbrains.annotations.NotNull public static final byte[] toSHA256Bytes(java.security.PublicKey)
+  @NotNull
+  public static final byte[] base58ToByteArray(String)
+  @NotNull
+  public static final String base58ToRealString(String)
+  @NotNull
+  public static final String base58toBase64(String)
+  @NotNull
+  public static final String base58toHex(String)
+  @NotNull
+  public static final byte[] base64ToByteArray(String)
+  @NotNull
+  public static final String base64ToRealString(String)
+  @NotNull
+  public static final String base64toBase58(String)
+  @NotNull
+  public static final String base64toHex(String)
+  @NotNull
+  public static final String hexToBase58(String)
+  @NotNull
+  public static final String hexToBase64(String)
+  @NotNull
+  public static final byte[] hexToByteArray(String)
+  @NotNull
+  public static final String hexToRealString(String)
+  @NotNull
+  public static final java.security.PublicKey parsePublicKeyBase58(String)
+  @NotNull
+  public static final String toBase58(byte[])
+  @NotNull
+  public static final String toBase58String(java.security.PublicKey)
+  @NotNull
+  public static final String toBase64(byte[])
+  @NotNull
+  public static final String toHex(byte[])
+  @NotNull
+  public static final byte[] toSHA256Bytes(java.security.PublicKey)
   public static final int MAX_HASH_HEX_SIZE = 130
 ##
 public class net.corda.core.utilities.Id extends java.lang.Object
-  public <init>(Object, String, java.time.Instant)
+  public <init>(VALUE, String, java.time.Instant)
   public final boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final String getEntityType()
-  @org.jetbrains.annotations.NotNull public final java.time.Instant getTimestamp()
-  @org.jetbrains.annotations.NotNull public final Object getValue()
+  @Nullable
+  public final String getEntityType()
+  @NotNull
+  public final java.time.Instant getTimestamp()
+  @NotNull
+  public final VALUE getValue()
   public final int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.Id newInstance(Object, String, java.time.Instant)
-  @org.jetbrains.annotations.NotNull public final String toString()
+  @NotNull
+  public static final net.corda.core.utilities.Id<V> newInstance(V, String, java.time.Instant)
+  @NotNull
+  public final String toString()
   public static final net.corda.core.utilities.Id$Companion Companion
 ##
 public static final class net.corda.core.utilities.Id$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Id newInstance(Object, String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.utilities.Id<V> newInstance(V, String, java.time.Instant)
 ##
 public final class net.corda.core.utilities.KotlinUtilsKt extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final org.slf4j.Logger contextLogger(Object)
-  public static final void debug(org.slf4j.Logger, kotlin.jvm.functions.Function0)
+  @NotNull
+  public static final org.slf4j.Logger contextLogger(Object)
+  public static final void debug(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
   public static final int exactAdd(int, int)
   public static final long exactAdd(long, long)
-  @org.jetbrains.annotations.NotNull public static final java.time.Duration getDays(int)
-  @org.jetbrains.annotations.NotNull public static final java.time.Duration getHours(int)
-  @org.jetbrains.annotations.NotNull public static final java.time.Duration getMillis(int)
-  @org.jetbrains.annotations.NotNull public static final java.time.Duration getMinutes(int)
-  public static final Object getOrThrow(concurrent.Future, java.time.Duration)
-  @org.jetbrains.annotations.NotNull public static final java.time.Duration getSeconds(int)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NonEmptySet toNonEmptySet(Collection)
-  public static final void trace(org.slf4j.Logger, kotlin.jvm.functions.Function0)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.PropertyDelegate transient(kotlin.jvm.functions.Function0)
+  @NotNull
+  public static final java.time.Duration getDays(int)
+  @NotNull
+  public static final java.time.Duration getHours(int)
+  @NotNull
+  public static final java.time.Duration getMillis(int)
+  @NotNull
+  public static final java.time.Duration getMinutes(int)
+  public static final V getOrThrow(java.util.concurrent.Future<V>, java.time.Duration)
+  @NotNull
+  public static final java.time.Duration getSeconds(int)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> toNonEmptySet(java.util.Collection<? extends T>)
+  public static final void trace(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
+  @NotNull
+  public static final net.corda.core.utilities.PropertyDelegate<T> transient(kotlin.jvm.functions.Function0<? extends T>)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.utilities.NetworkHostAndPort extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.utilities.NetworkHostAndPort extends java.lang.Object
   public <init>(String, int)
-  @org.jetbrains.annotations.NotNull public final String component1()
+  @NotNull
+  public final String component1()
   public final int component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NetworkHostAndPort copy(String, int)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort copy(String, int)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getHost()
+  @NotNull
+  public final String getHost()
   public final int getPort()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NetworkHostAndPort parse(String)
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public static final net.corda.core.utilities.NetworkHostAndPort parse(String)
+  @NotNull
+  public String toString()
   public static final net.corda.core.utilities.NetworkHostAndPort$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final String INVALID_PORT_FORMAT = "Invalid port: %s"
-  @org.jetbrains.annotations.NotNull public static final String MISSING_PORT_FORMAT = "Missing port: %s"
-  @org.jetbrains.annotations.NotNull public static final String UNPARSEABLE_ADDRESS_FORMAT = "Unparseable address: %s"
+  @NotNull
+  public static final String INVALID_PORT_FORMAT = "Invalid port: %s"
+  @NotNull
+  public static final String MISSING_PORT_FORMAT = "Missing port: %s"
+  @NotNull
+  public static final String UNPARSEABLE_ADDRESS_FORMAT = "Unparseable address: %s"
 ##
 public static final class net.corda.core.utilities.NetworkHostAndPort$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NetworkHostAndPort parse(String)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort parse(String)
 ##
 public final class net.corda.core.utilities.NonEmptySet extends java.lang.Object implements kotlin.jvm.internal.markers.KMappedMarker, java.util.Set
-  public boolean add(Object)
-  public boolean addAll(Collection)
+  public boolean add(T)
+  public boolean addAll(java.util.Collection<? extends T>)
   public void clear()
   public boolean contains(Object)
-  public boolean containsAll(Collection)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NonEmptySet copyOf(Collection)
+  public boolean containsAll(java.util.Collection<?>)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> copyOf(java.util.Collection<? extends T>)
   public boolean equals(Object)
-  public void forEach(function.Consumer)
+  public void forEach(java.util.function.Consumer<? super T>)
   public int getSize()
   public int hashCode()
-  public final Object head()
+  public final T head()
   public boolean isEmpty()
-  @org.jetbrains.annotations.NotNull public Iterator iterator()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NonEmptySet of(Object)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NonEmptySet of(Object, Object, Object...)
-  @org.jetbrains.annotations.NotNull public stream.Stream parallelStream()
+  @NotNull
+  public java.util.Iterator<T> iterator()
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> of(T)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> of(T, T, T...)
+  @NotNull
+  public java.util.stream.Stream<T> parallelStream()
   public boolean remove(Object)
-  public boolean removeAll(Collection)
-  public boolean retainAll(Collection)
-  @org.jetbrains.annotations.NotNull public Spliterator spliterator()
-  @org.jetbrains.annotations.NotNull public stream.Stream stream()
+  public boolean removeAll(java.util.Collection<?>)
+  public boolean retainAll(java.util.Collection<?>)
+  @NotNull
+  public java.util.Spliterator<T> spliterator()
+  @NotNull
+  public java.util.stream.Stream<T> stream()
   public Object[] toArray()
-  public Object[] toArray(Object[])
-  @org.jetbrains.annotations.NotNull public String toString()
+  public T[] toArray(T[])
+  @NotNull
+  public String toString()
   public static final net.corda.core.utilities.NonEmptySet$Companion Companion
 ##
 public static final class net.corda.core.utilities.NonEmptySet$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NonEmptySet copyOf(Collection)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NonEmptySet of(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NonEmptySet of(Object, Object, Object...)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> copyOf(java.util.Collection<? extends T>)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> of(T)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> of(T, T, T...)
 ##
-public static final class net.corda.core.utilities.NonEmptySet$iterator$1 extends java.lang.Object implements java.util.Iterator, kotlin.jvm.internal.markers.KMappedMarker
-  public boolean hasNext()
-  public Object next()
-  public void remove()
-##
-@net.corda.core.serialization.CordaSerializable public class net.corda.core.utilities.OpaqueBytes extends net.corda.core.utilities.ByteSequence
+@CordaSerializable
+public class net.corda.core.utilities.OpaqueBytes extends net.corda.core.utilities.ByteSequence
   public <init>(byte[])
-  @org.jetbrains.annotations.NotNull public final byte[] getBytes()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.OpaqueBytes of(byte...)
+  @NotNull
+  public final byte[] getBytes()
+  public int getOffset()
+  public int getSize()
+  @NotNull
+  public static final net.corda.core.utilities.OpaqueBytes of(byte...)
   public static final net.corda.core.utilities.OpaqueBytes$Companion Companion
 ##
 public static final class net.corda.core.utilities.OpaqueBytes$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.OpaqueBytes of(byte...)
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes of(byte...)
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.utilities.OpaqueBytesSubSequence extends net.corda.core.utilities.ByteSequence
+@CordaSerializable
+public final class net.corda.core.utilities.OpaqueBytesSubSequence extends net.corda.core.utilities.ByteSequence
   public <init>(byte[], int, int)
-  @org.jetbrains.annotations.NotNull public byte[] getBytes()
+  @NotNull
+  public byte[] getBytes()
+  public int getOffset()
+  public int getSize()
 ##
-@net.corda.core.serialization.CordaSerializable public final class net.corda.core.utilities.ProgressTracker extends java.lang.Object
+@CordaSerializable
+public final class net.corda.core.utilities.ProgressTracker extends java.lang.Object
   public <init>(net.corda.core.utilities.ProgressTracker$Step...)
   public final void endWithError(Throwable)
-  @org.jetbrains.annotations.NotNull public final List getAllSteps()
-  @org.jetbrains.annotations.NotNull public final List getAllStepsLabels()
-  @org.jetbrains.annotations.NotNull public final rx.Observable getChanges()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.utilities.ProgressTracker getChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step getCurrentStep()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step getCurrentStepRecursive()
+  @NotNull
+  public final java.util.List<kotlin.Pair<Integer, net.corda.core.utilities.ProgressTracker$Step>> getAllSteps()
+  @NotNull
+  public final java.util.List<kotlin.Pair<Integer, String>> getAllStepsLabels()
+  @NotNull
+  public final rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
+  @Nullable
+  public final net.corda.core.utilities.ProgressTracker getChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getCurrentStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getCurrentStepRecursive()
   public final boolean getHasEnded()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.utilities.ProgressTracker getParent()
+  @Nullable
+  public final net.corda.core.utilities.ProgressTracker getParent()
   public final int getStepIndex()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step[] getSteps()
-  @org.jetbrains.annotations.NotNull public final rx.Observable getStepsTreeChanges()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step[] getSteps()
+  @NotNull
+  public final rx.Observable<java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeChanges()
   public final int getStepsTreeIndex()
-  @org.jetbrains.annotations.NotNull public final rx.Observable getStepsTreeIndexChanges()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker getTopLevelTracker()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step nextStep()
+  @NotNull
+  public final rx.Observable<Integer> getStepsTreeIndexChanges()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTopLevelTracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step nextStep()
   public final void setChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step, net.corda.core.utilities.ProgressTracker)
   public final void setCurrentStep(net.corda.core.utilities.ProgressTracker$Step)
 ##
-@net.corda.core.serialization.CordaSerializable public abstract static class net.corda.core.utilities.ProgressTracker$Change extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker getProgressTracker()
+@CordaSerializable
+public abstract static class net.corda.core.utilities.ProgressTracker$Change extends java.lang.Object
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getProgressTracker()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.utilities.ProgressTracker$Change$Position extends net.corda.core.utilities.ProgressTracker$Change
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Position extends net.corda.core.utilities.ProgressTracker$Change
   public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Change$Position copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Position copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step getNewStep()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker getTracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getNewStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.utilities.ProgressTracker$Change$Rendering extends net.corda.core.utilities.ProgressTracker$Change
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Rendering extends net.corda.core.utilities.ProgressTracker$Change
   public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Change$Rendering copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Rendering copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step getOfStep()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker getTracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getOfStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.utilities.ProgressTracker$Change$Structural extends net.corda.core.utilities.ProgressTracker$Change
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Structural extends net.corda.core.utilities.ProgressTracker$Change
   public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Change$Structural copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Structural copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker$Step getParent()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ProgressTracker getTracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getParent()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.utilities.ProgressTracker$DONE extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$DONE extends net.corda.core.utilities.ProgressTracker$Step
   public boolean equals(Object)
   public static final net.corda.core.utilities.ProgressTracker$DONE INSTANCE
 ##
-@net.corda.core.serialization.CordaSerializable public static class net.corda.core.utilities.ProgressTracker$Step extends java.lang.Object
+@CordaSerializable
+public static class net.corda.core.utilities.ProgressTracker$Step extends java.lang.Object
   public <init>(String)
-  @org.jetbrains.annotations.Nullable public net.corda.core.utilities.ProgressTracker childProgressTracker()
-  @org.jetbrains.annotations.NotNull public rx.Observable getChanges()
-  @org.jetbrains.annotations.NotNull public Map getExtraAuditData()
-  @org.jetbrains.annotations.NotNull public String getLabel()
+  @Nullable
+  public net.corda.core.utilities.ProgressTracker childProgressTracker()
+  @NotNull
+  public rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
+  @NotNull
+  public java.util.Map<String, String> getExtraAuditData()
+  @NotNull
+  public String getLabel()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED extends net.corda.core.utilities.ProgressTracker$Step
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED extends net.corda.core.utilities.ProgressTracker$Step
   public boolean equals(Object)
   public static final net.corda.core.utilities.ProgressTracker$UNSTARTED INSTANCE
 ##
 public interface net.corda.core.utilities.PropertyDelegate
-  public abstract Object getValue(Object, kotlin.reflect.KProperty)
+  public abstract T getValue(Object, kotlin.reflect.KProperty<?>)
 ##
-@net.corda.core.serialization.CordaSerializable public abstract class net.corda.core.utilities.Try extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try combine(net.corda.core.utilities.Try, kotlin.jvm.functions.Function2)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try flatMap(kotlin.jvm.functions.Function1)
-  public abstract Object getOrThrow()
+@CordaSerializable
+public abstract class net.corda.core.utilities.Try extends java.lang.Object
+  @NotNull
+  public final net.corda.core.utilities.Try<C> combine(net.corda.core.utilities.Try<? extends B>, kotlin.jvm.functions.Function2<? super A, ? super B, ? extends C>)
+  @NotNull
+  public final net.corda.core.utilities.Try<B> flatMap(kotlin.jvm.functions.Function1<? super A, ? extends net.corda.core.utilities.Try<? extends B>>)
+  public abstract A getOrThrow()
   public abstract boolean isFailure()
   public abstract boolean isSuccess()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try map(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.Try on(kotlin.jvm.functions.Function0)
+  @NotNull
+  public final net.corda.core.utilities.Try<B> map(kotlin.jvm.functions.Function1<? super A, ? extends B>)
+  @NotNull
+  public static final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
   public static final net.corda.core.utilities.Try$Companion Companion
 ##
 public static final class net.corda.core.utilities.Try$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try on(kotlin.jvm.functions.Function0)
+  @NotNull
+  public final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.utilities.Try$Failure extends net.corda.core.utilities.Try
+@CordaSerializable
+public static final class net.corda.core.utilities.Try$Failure extends net.corda.core.utilities.Try
   public <init>(Throwable)
-  @org.jetbrains.annotations.NotNull public final Throwable component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try$Failure copy(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.utilities.Try$Failure<A> copy(Throwable)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Throwable getException()
-  public Object getOrThrow()
+  @NotNull
+  public final Throwable getException()
+  public A getOrThrow()
   public int hashCode()
   public boolean isFailure()
   public boolean isSuccess()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.core.utilities.Try$Success extends net.corda.core.utilities.Try
-  public <init>(Object)
-  public final Object component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.Try$Success copy(Object)
+@CordaSerializable
+public static final class net.corda.core.utilities.Try$Success extends net.corda.core.utilities.Try
+  public <init>(A)
+  public final A component1()
+  @NotNull
+  public final net.corda.core.utilities.Try$Success<A> copy(A)
   public boolean equals(Object)
-  public Object getOrThrow()
-  public final Object getValue()
+  public A getOrThrow()
+  public final A getValue()
   public int hashCode()
   public boolean isFailure()
   public boolean isSuccess()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
 public final class net.corda.core.utilities.UntrustworthyData extends java.lang.Object
-  public <init>(Object)
-  public final Object getFromUntrustedWorld()
-  @co.paralleluniverse.fibers.Suspendable public final Object unwrap(net.corda.core.utilities.UntrustworthyData$Validator)
+  public <init>(T)
+  public final T getFromUntrustedWorld()
+  @Suspendable
+  public final R unwrap(net.corda.core.utilities.UntrustworthyData$Validator<? super T, ? extends R>)
 ##
 public static interface net.corda.core.utilities.UntrustworthyData$Validator extends java.io.Serializable
-  @co.paralleluniverse.fibers.Suspendable public abstract Object validate(Object)
+  @Suspendable
+  public abstract R validate(T)
 ##
 public final class net.corda.core.utilities.UntrustworthyDataKt extends java.lang.Object
-  public static final Object unwrap(net.corda.core.utilities.UntrustworthyData, kotlin.jvm.functions.Function1)
+  public static final R unwrap(net.corda.core.utilities.UntrustworthyData<? extends T>, kotlin.jvm.functions.Function1<? super T, ? extends R>)
 ##
 public final class net.corda.core.utilities.UuidGenerator extends java.lang.Object
   public <init>()
   public static final net.corda.core.utilities.UuidGenerator$Companion Companion
 ##
 public static final class net.corda.core.utilities.UuidGenerator$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final UUID next()
+  @NotNull
+  public final java.util.UUID next()
 ##
 public interface net.corda.core.utilities.VariablePropertyDelegate extends net.corda.core.utilities.PropertyDelegate
-  public abstract void setValue(Object, kotlin.reflect.KProperty, Object)
+  public abstract void setValue(Object, kotlin.reflect.KProperty<?>, T)
 ##
 public final class net.corda.client.jackson.JacksonSupport extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps)
-  @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory)
-  @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory)
-  @kotlin.Deprecated @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
-  @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper()
-  @org.jetbrains.annotations.NotNull public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory)
-  @org.jetbrains.annotations.NotNull public final com.fasterxml.jackson.databind.Module getCordaModule()
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper()
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public final com.fasterxml.jackson.databind.Module getCordaModule()
   public static final net.corda.client.jackson.JacksonSupport INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$AmountDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.Amount deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public net.corda.core.contracts.Amount<?> deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$AmountDeserializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$AmountSerializer extends com.fasterxml.jackson.databind.JsonSerializer
-  public void serialize(net.corda.core.contracts.Amount, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public void serialize(net.corda.core.contracts.Amount<?>, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
   public static final net.corda.client.jackson.JacksonSupport$AmountSerializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.AnonymousParty deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public net.corda.core.identity.AnonymousParty deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
@@ -3643,29 +5741,38 @@ public static final class net.corda.client.jackson.JacksonSupport$AnonymousParty
   public static final net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.CordaX500Name deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public net.corda.core.identity.CordaX500Name deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer extends com.fasterxml.jackson.databind.JsonSerializer
   public void serialize(net.corda.core.identity.CordaX500Name, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
   public static final net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer INSTANCE
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.client.jackson.JacksonSupport$IdentityObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+public static final class net.corda.client.jackson.JacksonSupport$IdentityObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
   public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
   public final boolean getFuzzyIdentityMatch()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.services.IdentityService getIdentityService()
-  @org.jetbrains.annotations.NotNull public Set partiesFromName(String)
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
   public <init>(com.fasterxml.jackson.core.JsonFactory)
-  @org.jetbrains.annotations.NotNull public Set partiesFromName(String)
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public Void partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
 public static final class net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NodeInfo deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public net.corda.core.node.NodeInfo deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$NodeInfoSerializer extends com.fasterxml.jackson.databind.JsonSerializer
@@ -3673,7 +5780,8 @@ public static final class net.corda.client.jackson.JacksonSupport$NodeInfoSerial
   public static final net.corda.client.jackson.JacksonSupport$NodeInfoSerializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @org.jetbrains.annotations.NotNull public net.corda.core.utilities.OpaqueBytes deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public net.corda.core.utilities.OpaqueBytes deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer extends com.fasterxml.jackson.databind.JsonSerializer
@@ -3681,37 +5789,47 @@ public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesSer
   public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$PartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.Party deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public net.corda.core.identity.Party deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$PartyDeserializer INSTANCE
 ##
-@net.corda.core.DoNotImplement public static interface net.corda.client.jackson.JacksonSupport$PartyObjectMapper
-  @org.jetbrains.annotations.NotNull public abstract Set partiesFromName(String)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+public static interface net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
 public static final class net.corda.client.jackson.JacksonSupport$PartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
   public void serialize(net.corda.core.identity.Party, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
   public static final net.corda.client.jackson.JacksonSupport$PartySerializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
-  @org.jetbrains.annotations.NotNull public java.security.PublicKey deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public java.security.PublicKey deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer INSTANCE
 ##
 public static final class net.corda.client.jackson.JacksonSupport$PublicKeySerializer extends com.fasterxml.jackson.databind.JsonSerializer
   public void serialize(java.security.PublicKey, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
   public static final net.corda.client.jackson.JacksonSupport$PublicKeySerializer INSTANCE
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.client.jackson.JacksonSupport$RpcObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+public static final class net.corda.client.jackson.JacksonSupport$RpcObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
   public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
   public final boolean getFuzzyIdentityMatch()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.CordaRPCOps getRpc()
-  @org.jetbrains.annotations.NotNull public Set partiesFromName(String)
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
-  @org.jetbrains.annotations.Nullable public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.messaging.CordaRPCOps getRpc()
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
 public static final class net.corda.client.jackson.JacksonSupport$SecureHashDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
   public <init>()
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  @NotNull
+  public T deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
 ##
 public static final class net.corda.client.jackson.JacksonSupport$SecureHashSerializer extends com.fasterxml.jackson.databind.JsonSerializer
   public void serialize(net.corda.core.crypto.SecureHash, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
@@ -3719,15 +5837,33 @@ public static final class net.corda.client.jackson.JacksonSupport$SecureHashSeri
 ##
 public abstract static class net.corda.client.jackson.JacksonSupport$SignedTransactionMixin extends java.lang.Object
   public <init>()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash getId()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract List getInputs()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.Nullable public abstract net.corda.core.identity.Party getNotary()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract Set getRequiredSigningKeys()
-  @com.fasterxml.jackson.annotation.JsonProperty @org.jetbrains.annotations.NotNull protected abstract List getSigs()
-  @com.fasterxml.jackson.annotation.JsonProperty @org.jetbrains.annotations.NotNull protected abstract net.corda.core.transactions.CoreTransaction getTransaction()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.WireTransaction getTx()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract net.corda.core.serialization.SerializedBytes getTxBits()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getId()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @JsonIgnore
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @JsonProperty
+  @NotNull
+  protected abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @JsonProperty
+  @NotNull
+  protected abstract net.corda.core.transactions.CoreTransaction getTransaction()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction getTx()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
 ##
 public static final class net.corda.client.jackson.JacksonSupport$ToStringSerializer extends com.fasterxml.jackson.databind.JsonSerializer
   public void serialize(Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
@@ -3735,32 +5871,52 @@ public static final class net.corda.client.jackson.JacksonSupport$ToStringSerial
 ##
 public abstract static class net.corda.client.jackson.JacksonSupport$WireTransactionMixin extends java.lang.Object
   public <init>()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract List getAvailableComponentHashes()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract List getAvailableComponents()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.MerkleTree getMerkleTree()
-  @com.fasterxml.jackson.annotation.JsonIgnore @org.jetbrains.annotations.NotNull public abstract List getOutputStates()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> getAvailableComponentHashes()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<Object> getAvailableComponents()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.MerkleTree getMerkleTree()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
 ##
-@javax.annotation.concurrent.ThreadSafe public class net.corda.client.jackson.StringToMethodCallParser extends java.lang.Object
-  public <init>(Class)
-  public <init>(Class, com.fasterxml.jackson.databind.ObjectMapper)
-  public <init>(kotlin.reflect.KClass)
-  @org.jetbrains.annotations.NotNull public final Map getAvailableCommands()
-  @org.jetbrains.annotations.NotNull protected final com.google.common.collect.Multimap getMethodMap()
-  @org.jetbrains.annotations.NotNull public final Map getMethodParamNames()
-  @org.jetbrains.annotations.NotNull public List paramNamesFromConstructor(reflect.Constructor)
-  @org.jetbrains.annotations.NotNull public List paramNamesFromMethod(reflect.Method)
-  @org.jetbrains.annotations.NotNull public final net.corda.client.jackson.StringToMethodCallParser$ParsedMethodCall parse(Object, String)
-  @org.jetbrains.annotations.NotNull public final Object[] parseArguments(String, List, String)
+@ThreadSafe
+public class net.corda.client.jackson.StringToMethodCallParser extends java.lang.Object
+  public <init>(Class<? extends T>)
+  public <init>(Class<? extends T>, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(kotlin.reflect.KClass<? extends T>)
+  @NotNull
+  public final java.util.Map<String, String> getAvailableCommands()
+  @NotNull
+  protected final com.google.common.collect.Multimap<String, reflect.Method> getMethodMap()
+  @NotNull
+  public final java.util.Map<String, java.util.List<String>> getMethodParamNames()
+  @NotNull
+  public java.util.List<String> paramNamesFromConstructor(reflect.Constructor<?>)
+  @NotNull
+  public java.util.List<String> paramNamesFromMethod(reflect.Method)
+  @NotNull
+  public final net.corda.client.jackson.StringToMethodCallParser<T>$ParsedMethodCall parse(T, String)
+  @NotNull
+  public final Object[] parseArguments(String, java.util.List<? extends kotlin.Pair<String, ? extends Class<?>>>, String)
   public static final net.corda.client.jackson.StringToMethodCallParser$Companion Companion
 ##
 public static final class net.corda.client.jackson.StringToMethodCallParser$Companion extends java.lang.Object
 ##
 public final class net.corda.client.jackson.StringToMethodCallParser$ParsedMethodCall extends java.lang.Object implements java.util.concurrent.Callable
-  public <init>(net.corda.client.jackson.StringToMethodCallParser, Object, reflect.Method, Object[])
-  @org.jetbrains.annotations.Nullable public Object call()
-  @org.jetbrains.annotations.NotNull public final Object[] getArgs()
-  @org.jetbrains.annotations.NotNull public final reflect.Method getMethod()
-  @org.jetbrains.annotations.Nullable public final Object invoke()
+  public <init>(T, reflect.Method, Object[])
+  @Nullable
+  public Object call()
+  @NotNull
+  public final Object[] getArgs()
+  @NotNull
+  public final reflect.Method getMethod()
+  @Nullable
+  public final Object invoke()
 ##
 public static class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException extends net.corda.core.CordaException
   public <init>(String, Throwable)
@@ -3770,7 +5926,8 @@ public static final class net.corda.client.jackson.StringToMethodCallParser$Unpa
 ##
 public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$MissingParameter extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
   public <init>(String, String, String)
-  @org.jetbrains.annotations.NotNull public final String getParamName()
+  @NotNull
+  public final String getParamName()
 ##
 public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$ReflectionDataMissing extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
   public <init>(String, int)
@@ -3780,262 +5937,402 @@ public static final class net.corda.client.jackson.StringToMethodCallParser$Unpa
 ##
 public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$UnknownMethod extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
   public <init>(String)
-  @org.jetbrains.annotations.NotNull public final String getMethodName()
+  @NotNull
+  public final String getMethodName()
 ##
 public final class net.corda.testing.driver.Driver extends java.lang.Object
-  public static final Object driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1)
+  public static final A driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1<? super net.corda.testing.driver.DriverDSL, ? extends A>)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.driver.DriverDSL
-  @org.jetbrains.annotations.NotNull public abstract java.nio.file.Path baseDirectory(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.testing.driver.NotaryHandle getDefaultNotaryHandle()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.identity.Party getDefaultNotaryIdentity()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture getDefaultNotaryNode()
-  @org.jetbrains.annotations.NotNull public abstract List getNotaryHandles()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture startNode(net.corda.testing.driver.NodeParameters)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, List, net.corda.testing.driver.VerifierType, Map, Boolean, String)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture startWebserver(net.corda.testing.driver.NodeHandle)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture startWebserver(net.corda.testing.driver.NodeHandle, String)
+@DoNotImplement
+public interface net.corda.testing.driver.DriverDSL
+  @NotNull
+  public abstract java.nio.file.Path baseDirectory(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract net.corda.testing.driver.NotaryHandle getDefaultNotaryHandle()
+  @NotNull
+  public abstract net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> getDefaultNotaryNode()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.driver.NotaryHandle> getNotaryHandles()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle, String)
 ##
 public final class net.corda.testing.driver.DriverParameters extends java.lang.Object
   public <init>()
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, Map, boolean, boolean, boolean, List, List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
   public final boolean component1()
-  @org.jetbrains.annotations.NotNull public final List component10()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.JmxPolicy component11()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters component12()
-  @org.jetbrains.annotations.NotNull public final java.nio.file.Path component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.PortAllocation component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.PortAllocation component4()
-  @org.jetbrains.annotations.NotNull public final Map component5()
+  @NotNull
+  public final java.util.List<String> component10()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy component11()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component12()
+  @NotNull
+  public final java.nio.file.Path component2()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component3()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component4()
+  @NotNull
+  public final java.util.Map<String, String> component5()
   public final boolean component6()
   public final boolean component7()
   public final boolean component8()
-  @org.jetbrains.annotations.NotNull public final List component9()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, Map, boolean, boolean, boolean, List, List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> component9()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
-  @org.jetbrains.annotations.NotNull public final java.nio.file.Path getDriverDirectory()
-  @org.jetbrains.annotations.NotNull public final List getExtraCordappPackagesToScan()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.JmxPolicy getJmxPolicy()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters getNetworkParameters()
-  @org.jetbrains.annotations.NotNull public final List getNotarySpecs()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.PortAllocation getPortAllocation()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
+  @NotNull
+  public final java.nio.file.Path getDriverDirectory()
+  @NotNull
+  public final java.util.List<String> getExtraCordappPackagesToScan()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy getJmxPolicy()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getPortAllocation()
   public final boolean getStartNodesInProcess()
-  @org.jetbrains.annotations.NotNull public final Map getSystemProperties()
+  @NotNull
+  public final java.util.Map<String, String> getSystemProperties()
   public final boolean getUseTestClock()
   public final boolean getWaitForAllNodesToFinish()
   public int hashCode()
   public final boolean isDebug()
   public String toString()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(List)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withIsDebug(boolean)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withJmxPolicy(net.corda.testing.driver.JmxPolicy)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withNotarySpecs(List)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withPortAllocation(net.corda.testing.driver.PortAllocation)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withStartNodesInProcess(boolean)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withSystemProperties(Map)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withUseTestClock(boolean)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.DriverParameters withWaitForAllNodesToFinish(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(java.util.List<String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withIsDebug(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withJmxPolicy(net.corda.testing.driver.JmxPolicy)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withStartNodesInProcess(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withSystemProperties(java.util.Map<String, String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withUseTestClock(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withWaitForAllNodesToFinish(boolean)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.driver.InProcess extends net.corda.testing.driver.NodeHandle
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.ServiceHub getServices()
-  @org.jetbrains.annotations.NotNull public abstract rx.Observable registerInitiatedFlow(Class)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.concurrent.CordaFuture startFlow(net.corda.core.flows.FlowLogic)
+@DoNotImplement
+public interface net.corda.testing.driver.InProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServices()
+  @NotNull
+  public abstract rx.Observable<T> registerInitiatedFlow(Class<T>)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
 ##
 public final class net.corda.testing.driver.JmxPolicy extends java.lang.Object
   public <init>()
   public <init>(boolean, net.corda.testing.driver.PortAllocation)
   public final boolean component1()
-  @org.jetbrains.annotations.Nullable public final net.corda.testing.driver.PortAllocation component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.JmxPolicy copy(boolean, net.corda.testing.driver.PortAllocation)
+  @Nullable
+  public final net.corda.testing.driver.PortAllocation component2()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy copy(boolean, net.corda.testing.driver.PortAllocation)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final net.corda.testing.driver.PortAllocation getJmxHttpServerPortAllocation()
+  @Nullable
+  public final net.corda.testing.driver.PortAllocation getJmxHttpServerPortAllocation()
   public final boolean getStartJmxHttpServer()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoCloseable
-  @org.jetbrains.annotations.NotNull public abstract java.nio.file.Path getBaseDirectory()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.node.NodeInfo getNodeInfo()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.utilities.NetworkHostAndPort getP2pAddress()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.CordaRPCOps getRpc()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAddress()
-  @org.jetbrains.annotations.NotNull public abstract List getRpcUsers()
+@DoNotImplement
+public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoCloseable
+  @NotNull
+  public abstract java.nio.file.Path getBaseDirectory()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getNodeInfo()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getP2pAddress()
+  @NotNull
+  public abstract net.corda.core.messaging.CordaRPCOps getRpc()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAddress()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.node.User> getRpcUsers()
   public abstract void stop()
 ##
 public final class net.corda.testing.driver.NodeParameters extends java.lang.Object
   public <init>()
-  public <init>(net.corda.core.identity.CordaX500Name, List, net.corda.testing.driver.VerifierType, Map, Boolean, String)
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.CordaX500Name component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.VerifierType component3()
-  @org.jetbrains.annotations.NotNull public final Map component4()
-  @org.jetbrains.annotations.Nullable public final Boolean component5()
-  @org.jetbrains.annotations.NotNull public final String component6()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, List, net.corda.testing.driver.VerifierType, Map, Boolean, String)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component2()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component3()
+  @NotNull
+  public final java.util.Map<String, Object> component4()
+  @Nullable
+  public final Boolean component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Map getCustomOverrides()
-  @org.jetbrains.annotations.NotNull public final String getMaximumHeapSize()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.CordaX500Name getProvidedName()
-  @org.jetbrains.annotations.NotNull public final List getRpcUsers()
-  @org.jetbrains.annotations.Nullable public final Boolean getStartInSameProcess()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.VerifierType getVerifierType()
+  @NotNull
+  public final java.util.Map<String, Object> getCustomOverrides()
+  @NotNull
+  public final String getMaximumHeapSize()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getProvidedName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  @Nullable
+  public final Boolean getStartInSameProcess()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NodeParameters withCustomOverrides(Map)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NodeParameters withProvidedName(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NodeParameters withRpcUsers(List)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NodeParameters withStartInSameProcess(Boolean)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NodeParameters withVerifierType(net.corda.testing.driver.VerifierType)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withProvidedName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withRpcUsers(java.util.List<net.corda.testing.node.User>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withStartInSameProcess(Boolean)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withVerifierType(net.corda.testing.driver.VerifierType)
 ##
 public final class net.corda.testing.driver.NotaryHandle extends java.lang.Object
-  public <init>(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component1()
+  public <init>(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
   public final boolean component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.concurrent.CordaFuture component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.NotaryHandle copy(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture)
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> component3()
+  @NotNull
+  public final net.corda.testing.driver.NotaryHandle copy(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getIdentity()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.concurrent.CordaFuture getNodeHandles()
+  @NotNull
+  public final net.corda.core.identity.Party getIdentity()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> getNodeHandles()
   public final boolean getValidating()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.driver.OutOfProcess extends net.corda.testing.driver.NodeHandle
-  @org.jetbrains.annotations.NotNull public abstract Process getProcess()
+@DoNotImplement
+public interface net.corda.testing.driver.OutOfProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract Process getProcess()
 ##
-@net.corda.core.DoNotImplement public abstract class net.corda.testing.driver.PortAllocation extends java.lang.Object
+@DoNotImplement
+public abstract class net.corda.testing.driver.PortAllocation extends java.lang.Object
   public <init>()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NetworkHostAndPort nextHostAndPort()
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort nextHostAndPort()
   public abstract int nextPort()
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.driver.PortAllocation$Incremental extends net.corda.testing.driver.PortAllocation
+@DoNotImplement
+public static final class net.corda.testing.driver.PortAllocation$Incremental extends net.corda.testing.driver.PortAllocation
   public <init>(int)
-  @org.jetbrains.annotations.NotNull public final concurrent.atomic.AtomicInteger getPortCounter()
+  @NotNull
+  public final java.util.concurrent.atomic.AtomicInteger getPortCounter()
   public int nextPort()
 ##
 public final class net.corda.testing.driver.VerifierType extends java.lang.Enum
-  protected <init>(String, int)
+  protected <init>()
   public static net.corda.testing.driver.VerifierType valueOf(String)
   public static net.corda.testing.driver.VerifierType[] values()
 ##
 public final class net.corda.testing.driver.WebserverHandle extends java.lang.Object
   public <init>(net.corda.core.utilities.NetworkHostAndPort, Process)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NetworkHostAndPort component1()
-  @org.jetbrains.annotations.NotNull public final Process component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.WebserverHandle copy(net.corda.core.utilities.NetworkHostAndPort, Process)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort component1()
+  @NotNull
+  public final Process component2()
+  @NotNull
+  public final net.corda.testing.driver.WebserverHandle copy(net.corda.core.utilities.NetworkHostAndPort, Process)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.NetworkHostAndPort getListenAddress()
-  @org.jetbrains.annotations.NotNull public final Process getProcess()
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort getListenAddress()
+  @NotNull
+  public final Process getProcess()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
+@DoNotImplement
+public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
   public <init>()
   public abstract int getClusterSize()
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.node.ClusterSpec$Raft extends net.corda.testing.node.ClusterSpec
+@DoNotImplement
+public static final class net.corda.testing.node.ClusterSpec$Raft extends net.corda.testing.node.ClusterSpec
   public <init>(int)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.ClusterSpec$Raft copy(int)
+  @NotNull
+  public final net.corda.testing.node.ClusterSpec$Raft copy(int)
   public boolean equals(Object)
   public int getClusterSize()
   public int hashCode()
   public String toString()
 ##
-@javax.annotation.concurrent.ThreadSafe public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.corda.core.serialization.SingletonSerializeAsToken
-  @org.jetbrains.annotations.NotNull public synchronized final List getEndpointsExternal()
-  @org.jetbrains.annotations.NotNull public final rx.Observable getReceivedMessages()
-  @org.jetbrains.annotations.NotNull public final rx.Observable getSentMessages()
-  @org.jetbrains.annotations.Nullable public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpSend(boolean)
+@ThreadSafe
+public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.corda.core.serialization.SingletonSerializeAsToken
+  @NotNull
+  public final synchronized java.util.List<net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService> getEndpointsExternal()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getReceivedMessages()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getSentMessages()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpSend(boolean)
   public final void stop()
   public static final net.corda.testing.node.InMemoryMessagingNetwork$Companion Companion
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$Companion extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle extends java.lang.Object implements net.corda.core.messaging.MessageRecipientGroup
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle extends java.lang.Object implements net.corda.core.messaging.MessageRecipientGroup
   public <init>(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle copy(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle copy(net.corda.core.identity.Party)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getParty()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
 public static interface net.corda.testing.node.InMemoryMessagingNetwork$LatencyCalculator
-  @org.jetbrains.annotations.NotNull public abstract java.time.Duration between(net.corda.core.messaging.SingleMessageRecipient, net.corda.core.messaging.SingleMessageRecipient)
+  @NotNull
+  public abstract java.time.Duration between(net.corda.core.messaging.SingleMessageRecipient, net.corda.core.messaging.SingleMessageRecipient)
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.utilities.ByteSequence getMessageData()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.messaging.MessageRecipients getRecipients()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle getSender()
-  @org.jetbrains.annotations.NotNull public String toString()
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer extends java.lang.Object
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence getMessageData()
+  @NotNull
+  public final net.corda.core.messaging.MessageRecipients getRecipients()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle getSender()
+  @NotNull
+  public String toString()
   public static final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion Companion
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion extends java.lang.Object
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService extends java.lang.Object
-  @org.jetbrains.annotations.Nullable public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
   public static final net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion Companion
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion extends java.lang.Object
 ##
-@net.corda.core.serialization.CordaSerializable public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle extends java.lang.Object implements net.corda.core.messaging.SingleMessageRecipient
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle extends java.lang.Object implements net.corda.core.messaging.SingleMessageRecipient
   public <init>(int, net.corda.core.identity.CordaX500Name)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle copy(int, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle copy(int, net.corda.core.identity.CordaX500Name)
   public boolean equals(Object)
   public final int getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public String toString()
+  @NotNull
+  public String toString()
 ##
-@net.corda.core.DoNotImplement public abstract static class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy extends java.lang.Object
-  public abstract Object pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, List)
+@DoNotImplement
+public abstract static class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy extends java.lang.Object
+  public abstract A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$Random extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$Random extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
   public <init>()
-  public <init>(SplittableRandom)
-  @org.jetbrains.annotations.NotNull public final SplittableRandom getRandom()
-  public Object pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, List)
+  public <init>(java.util.SplittableRandom)
+  @NotNull
+  public final java.util.SplittableRandom getRandom()
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
   public <init>()
-  public Object pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, List)
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
 ##
 public class net.corda.testing.node.MockNetwork extends java.lang.Object
-  public <init>(List)
-  public <init>(List, net.corda.testing.node.MockNetworkParameters)
-  public <init>(List, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, List, net.corda.core.node.NetworkParameters)
-  @org.jetbrains.annotations.NotNull public final java.nio.file.Path baseDirectory(int)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
-  @org.jetbrains.annotations.NotNull public final List getCordappPackages()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getDefaultNotaryIdentity()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode getDefaultNotaryNode()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkParameters getDefaultParameters()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public <init>(java.util.List<String>)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final java.nio.file.Path baseDirectory(int)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode()
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final java.util.List<String> getCordappPackages()
+  @NotNull
+  public final net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode getDefaultNotaryNode()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters getDefaultParameters()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
   public final boolean getNetworkSendManuallyPumped()
   public final int getNextNodeId()
-  @org.jetbrains.annotations.NotNull public final List getNotaryNodes()
-  @org.jetbrains.annotations.NotNull public final List getNotarySpecs()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.StartedMockNode> getNotaryNodes()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
   public final boolean getThreadPerNode()
   public final void runNetwork()
   public final void runNetwork(int)
@@ -4046,272 +6343,326 @@ public class net.corda.testing.node.MockNetwork extends java.lang.Object
 public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lang.Object
   public <init>(net.corda.core.identity.CordaX500Name)
   public <init>(net.corda.core.identity.CordaX500Name, boolean)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
   public final boolean component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkNotarySpec copy(net.corda.core.identity.CordaX500Name, boolean)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkNotarySpec copy(net.corda.core.identity.CordaX500Name, boolean)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
   public final boolean getValidating()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.testing.node.MockNetworkParameters extends java.lang.Object
   public <init>()
-  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, List, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
   public final boolean component1()
   public final boolean component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy component3()
-  @org.jetbrains.annotations.NotNull public final List component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, List, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy component3()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> component4()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component5()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
   public final boolean getNetworkSendManuallyPumped()
-  @org.jetbrains.annotations.NotNull public final List getNotarySpecs()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
   public final boolean getThreadPerNode()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkParameters withNetworkSendManuallyPumped(boolean)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkParameters withNotarySpecs(List)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkParameters withServicePeerAllocationStrategy(net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNetworkParameters withThreadPerNode(boolean)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkSendManuallyPumped(boolean)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNotarySpecs(java.util.List<net.corda.testing.node.MockNetworkNotarySpec>)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withServicePeerAllocationStrategy(net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withThreadPerNode(boolean)
 ##
 public final class net.corda.testing.node.MockNodeParameters extends java.lang.Object
   public <init>()
-  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.Nullable public final Integer component1()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.CordaX500Name component2()
-  @org.jetbrains.annotations.NotNull public final java.math.BigInteger component3()
-  @org.jetbrains.annotations.NotNull public final kotlin.jvm.functions.Function1 component4()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @Nullable
+  public final Integer component1()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final java.math.BigInteger component3()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<net.corda.node.services.config.NodeConfiguration, Object> component4()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final kotlin.jvm.functions.Function1 getConfigOverrides()
-  @org.jetbrains.annotations.NotNull public final java.math.BigInteger getEntropyRoot()
-  @org.jetbrains.annotations.Nullable public final Integer getForcedID()
-  @org.jetbrains.annotations.Nullable public final net.corda.core.identity.CordaX500Name getLegalName()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<net.corda.node.services.config.NodeConfiguration, Object> getConfigOverrides()
+  @NotNull
+  public final java.math.BigInteger getEntropyRoot()
+  @Nullable
+  public final Integer getForcedID()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getLegalName()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNodeParameters withConfigOverrides(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNodeParameters withEntropyRoot(java.math.BigInteger)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNodeParameters withForcedID(Integer)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockNodeParameters withLegalName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withConfigOverrides(kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withEntropyRoot(java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withForcedID(Integer)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withLegalName(net.corda.core.identity.CordaX500Name)
 ##
 public class net.corda.testing.node.MockServices extends java.lang.Object implements net.corda.core.node.ServiceHub
   public <init>()
-  public <init>(List)
-  public <init>(List, net.corda.core.identity.CordaX500Name)
-  public <init>(List, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
-  public <init>(List, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
-  public <init>(List, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
-  public <init>(List, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
-  public <init>(List, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
-  public <init>(List, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public <init>(java.util.List<String>)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
   public <init>(net.corda.core.identity.CordaX500Name)
   public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
   public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
   public final void addMockCordapp(String)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.serialization.SerializeAsToken cordaService(Class)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.cordapp.CordappContext getAppContext()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.services.MockAttachmentStorage getAttachments()
-  @org.jetbrains.annotations.NotNull public java.time.Clock getClock()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.cordapp.CordappProvider getCordappProvider()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.IdentityService getIdentityService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.KeyManagementService getKeyManagementService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NodeInfo getMyInfo()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NetworkParameters getNetworkParameters()
-  @org.jetbrains.annotations.NotNull protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.TransactionStorage getValidatedTransactions()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.VaultService getVaultService()
-  @org.jetbrains.annotations.NotNull public java.sql.Connection jdbcSession()
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.TransactionState loadState(net.corda.core.contracts.StateRef)
-  @org.jetbrains.annotations.NotNull public Set loadStates(Set)
-  @org.jetbrains.annotations.NotNull public static final Properties makeTestDataSourceProperties(String)
-  @org.jetbrains.annotations.NotNull public static final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
-  @org.jetbrains.annotations.NotNull public static final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
-  public void recordTransactions(Iterable)
-  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public T cordaService(Class<T>)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public final net.corda.testing.services.MockAttachmentStorage getAttachments()
+  @NotNull
+  public java.time.Clock getClock()
+  @NotNull
+  public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public net.corda.core.node.services.KeyManagementService getKeyManagementService()
+  @NotNull
+  public net.corda.core.node.NodeInfo getMyInfo()
+  @NotNull
+  public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
+  @NotNull
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
+  @NotNull
+  public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
+  @NotNull
+  public net.corda.core.node.services.TransactionStorage getValidatedTransactions()
+  @NotNull
+  public net.corda.core.node.services.VaultService getVaultService()
+  @NotNull
+  public java.sql.Connection jdbcSession()
+  @NotNull
+  public net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
+  @NotNull
+  public java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public static final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
   public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  public void recordTransactions(boolean, Iterable)
+  public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
   public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  @org.jetbrains.annotations.NotNull public Void registerUnloadHandler(kotlin.jvm.functions.Function0)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.StateAndRef toStateAndRef(net.corda.core.contracts.StateRef)
+  @NotNull
+  public Void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
   public static final net.corda.testing.node.MockServices$Companion Companion
 ##
 public static final class net.corda.testing.node.MockServices$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final Properties makeTestDataSourceProperties(String)
-  @org.jetbrains.annotations.NotNull public final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
-  @org.jetbrains.annotations.NotNull public final kotlin.Pair makeTestDatabaseAndMockServices(List, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
-##
-public static final class net.corda.testing.node.MockServices$Companion$makeTestDatabaseAndMockServices$mockService$1$1 extends net.corda.testing.node.MockServices
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.VaultService getVaultService()
-  @org.jetbrains.annotations.NotNull public java.sql.Connection jdbcSession()
-  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable)
+  @NotNull
+  public final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
 ##
 public final class net.corda.testing.node.MockServicesKt extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.serialization.SerializeAsToken createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final net.corda.node.services.identity.InMemoryIdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
-##
-public static final class net.corda.testing.node.MockServicesKt$createMockCordaService$MockAppServiceHubImpl extends java.lang.Object implements net.corda.core.node.AppServiceHub, net.corda.core.node.ServiceHub
-  public <init>(net.corda.testing.node.MockServices, net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.serialization.SerializeAsToken cordaService(Class)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.cordapp.CordappContext getAppContext()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.AttachmentStorage getAttachments()
-  @org.jetbrains.annotations.NotNull public java.time.Clock getClock()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.cordapp.CordappProvider getCordappProvider()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.IdentityService getIdentityService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.KeyManagementService getKeyManagementService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NodeInfo getMyInfo()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NetworkParameters getNetworkParameters()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.MockServices getServiceHub()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializeAsToken getServiceInstance()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.TransactionStorage getValidatedTransactions()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.VaultService getVaultService()
-  @org.jetbrains.annotations.NotNull public java.sql.Connection jdbcSession()
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.TransactionState loadState(net.corda.core.contracts.StateRef)
-  @org.jetbrains.annotations.NotNull public Set loadStates(Set)
-  public void recordTransactions(Iterable)
-  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable)
-  public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  public void recordTransactions(boolean, Iterable)
-  public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
-  public void registerUnloadHandler(kotlin.jvm.functions.Function0)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public net.corda.core.messaging.FlowHandle startFlow(net.corda.core.flows.FlowLogic)
-  @org.jetbrains.annotations.NotNull public net.corda.core.messaging.FlowProgressHandle startTrackedFlow(net.corda.core.flows.FlowLogic)
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.StateAndRef toStateAndRef(net.corda.core.contracts.StateRef)
+  @NotNull
+  public static final T createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1<? super net.corda.core.node.AppServiceHub, ? extends T>)
+  @NotNull
+  public static final net.corda.node.services.identity.InMemoryIdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
 ##
 public final class net.corda.testing.node.NodeTestUtils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.dsl.LedgerDSL ledger(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.dsl.LedgerDSL ledger(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.Actor testActor(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.context.InvocationContext testContext(net.corda.core.identity.CordaX500Name)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.dsl.LedgerDSL transaction(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.dsl.LedgerDSL transaction(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.core.context.Actor testActor(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext testContext(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
 ##
 public final class net.corda.testing.node.NotarySpec extends java.lang.Object
-  public <init>(net.corda.core.identity.CordaX500Name, boolean, List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name component1()
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
   public final boolean component2()
-  @org.jetbrains.annotations.NotNull public final List component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.VerifierType component4()
-  @org.jetbrains.annotations.Nullable public final net.corda.testing.node.ClusterSpec component5()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component3()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component4()
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec component5()
+  @NotNull
+  public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final net.corda.testing.node.ClusterSpec getCluster()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getName()
-  @org.jetbrains.annotations.NotNull public final List getRpcUsers()
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec getCluster()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
   public final boolean getValidating()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.driver.VerifierType getVerifierType()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.testing.node.StartedMockNode extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final List findStateMachines(Class)
+  @NotNull
+  public final java.util.List<kotlin.Pair<F, net.corda.core.concurrent.CordaFuture<?>>> findStateMachines(Class<F>)
   public final int getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.NodeInfo getInfo()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.ServiceHub getServices()
-  @org.jetbrains.annotations.Nullable public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
-  @org.jetbrains.annotations.NotNull public final rx.Observable registerInitiatedFlow(Class)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.concurrent.CordaFuture startFlow(net.corda.core.flows.FlowLogic)
+  @NotNull
+  public final net.corda.core.node.NodeInfo getInfo()
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServices()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  @NotNull
+  public final rx.Observable<F> registerInitiatedFlow(Class<F>)
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
   public final void stop()
-  public final Object transaction(kotlin.jvm.functions.Function0)
+  public final T transaction(kotlin.jvm.functions.Function0<? extends T>)
   public static final net.corda.testing.node.StartedMockNode$Companion Companion
 ##
 public static final class net.corda.testing.node.StartedMockNode$Companion extends java.lang.Object
 ##
-@javax.annotation.concurrent.ThreadSafe public final class net.corda.testing.node.TestClock extends net.corda.node.MutableClock
+@ThreadSafe
+public final class net.corda.testing.node.TestClock extends net.corda.node.MutableClock
   public <init>(java.time.Clock)
-  public synchronized final void advanceBy(java.time.Duration)
-  public synchronized final void setTo(java.time.Instant)
+  public final synchronized void advanceBy(java.time.Duration)
+  public final synchronized void setTo(java.time.Instant)
 ##
 public final class net.corda.testing.node.UnstartedMockNode extends java.lang.Object
   public final int getId()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.StartedMockNode start()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode start()
   public static final net.corda.testing.node.UnstartedMockNode$Companion Companion
 ##
 public static final class net.corda.testing.node.UnstartedMockNode$Companion extends java.lang.Object
 ##
 public final class net.corda.testing.node.User extends java.lang.Object
-  public <init>(String, String, Set)
-  @org.jetbrains.annotations.NotNull public final String component1()
-  @org.jetbrains.annotations.NotNull public final String component2()
-  @org.jetbrains.annotations.NotNull public final Set component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.node.User copy(String, String, Set)
+  public <init>(String, String, java.util.Set<String>)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.util.Set<String> component3()
+  @NotNull
+  public final net.corda.testing.node.User copy(String, String, java.util.Set<String>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final String getPassword()
-  @org.jetbrains.annotations.NotNull public final Set getPermissions()
-  @org.jetbrains.annotations.NotNull public final String getUsername()
+  @NotNull
+  public final String getPassword()
+  @NotNull
+  public final java.util.Set<String> getPermissions()
+  @NotNull
+  public final String getUsername()
   public int hashCode()
   public String toString()
 ##
 public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
   public <init>(net.corda.core.utilities.NetworkHostAndPort)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
-  @org.jetbrains.annotations.NotNull public final net.corda.client.rpc.CordaRPCConnection start(String, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
-  public final Object use(String, String, kotlin.jvm.functions.Function1)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public final A use(String, String, kotlin.jvm.functions.Function1<? super net.corda.client.rpc.CordaRPCConnection, ? extends A>)
   public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
 ##
 public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
 ##
-public interface net.corda.client.rpc.CordaRPCClientConfiguration
-  public abstract int getCacheConcurrencyLevel()
-  @org.jetbrains.annotations.NotNull public abstract java.time.Duration getConnectionMaxRetryInterval()
-  @org.jetbrains.annotations.NotNull public abstract java.time.Duration getConnectionRetryInterval()
-  public abstract double getConnectionRetryIntervalMultiplier()
-  @org.jetbrains.annotations.NotNull public abstract java.time.Duration getDeduplicationCacheExpiry()
-  public abstract int getMaxFileSize()
-  public abstract int getMaxReconnectAttempts()
-  public abstract int getMinimumServerProtocolVersion()
-  public abstract int getObservationExecutorPoolSize()
-  @org.jetbrains.annotations.NotNull public abstract java.time.Duration getReapInterval()
-  public abstract boolean getTrackRpcCallSites()
+public final class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
+  public <init>(java.time.Duration)
+  @NotNull
+  public final java.time.Duration component1()
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration)
+  public boolean equals(Object)
+  @NotNull
+  public final java.time.Duration getConnectionMaxRetryInterval()
+  public int hashCode()
+  public String toString()
   public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
+  @NotNull
+  public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
 ##
 public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.client.rpc.CordaRPCClientConfiguration default()
 ##
-@net.corda.core.DoNotImplement public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
-  public <init>(net.corda.client.rpc.RPCConnection)
+@DoNotImplement
+public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
+  public <init>(net.corda.client.rpc.RPCConnection<? extends net.corda.core.messaging.CordaRPCOps>)
   public void close()
   public void forceClose()
-  @org.jetbrains.annotations.NotNull public net.corda.core.messaging.CordaRPCOps getProxy()
+  @NotNull
+  public net.corda.core.messaging.CordaRPCOps getProxy()
   public int getServerProtocolVersion()
   public void notifyServerAndClose()
 ##
-public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException implements net.corda.nodeapi.exceptions.RpcSerializableError
+public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException
   public <init>(String)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
+@DoNotImplement
+public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
   public abstract void forceClose()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.messaging.RPCOps getProxy()
+  @NotNull
+  public abstract I getProxy()
   public abstract int getServerProtocolVersion()
   public abstract void notifyServerAndClose()
 ##
@@ -4323,24 +6674,32 @@ public @interface net.corda.client.rpc.RPCSinceVersion
   public abstract int version()
 ##
 public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
-  public static final void notUsed(rx.Observable)
+  public static final void notUsed(rx.Observable<T>)
 ##
 public final class net.corda.testing.contracts.DummyContract extends java.lang.Object implements net.corda.core.contracts.Contract
   public <init>()
   public <init>(Object)
-  @org.jetbrains.annotations.Nullable public final Object component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.contracts.DummyContract copy(Object)
+  @Nullable
+  public final Object component1()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract copy(Object)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
-  @org.jetbrains.annotations.Nullable public final Object getBlank()
-  @org.jetbrains.annotations.NotNull public final String getPROGRAM_ID()
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @Nullable
+  public final Object getBlank()
+  @NotNull
+  public final String getPROGRAM_ID()
   public int hashCode()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.transactions.TransactionBuilder move(List, net.corda.core.identity.AbstractParty)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
   public String toString()
   public void verify(net.corda.core.transactions.LedgerTransaction)
   public static final net.corda.testing.contracts.DummyContract$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContract"
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContract"
 ##
 public static interface net.corda.testing.contracts.DummyContract$Commands extends net.corda.core.contracts.CommandData
 ##
@@ -4351,46 +6710,65 @@ public static final class net.corda.testing.contracts.DummyContract$Commands$Mov
   public <init>()
 ##
 public static final class net.corda.testing.contracts.DummyContract$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder move(List, net.corda.core.identity.AbstractParty)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.contracts.DummyContract$MultiOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State
-  public <init>(int, List)
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$MultiOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.contracts.DummyContract$MultiOwnerState copy(int, List)
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$MultiOwnerState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   public int getMagicNumber()
-  @org.jetbrains.annotations.NotNull public final List getOwners()
-  @org.jetbrains.annotations.NotNull public List getParticipants()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.contracts.DummyContract$SingleOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State, net.corda.core.contracts.OwnableState
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$SingleOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State, net.corda.core.contracts.OwnableState
   public <init>(int, net.corda.core.identity.AbstractParty)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.AbstractParty component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.contracts.DummyContract$SingleOwnerState copy(int, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.identity.AbstractParty component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$SingleOwnerState copy(int, net.corda.core.identity.AbstractParty)
   public boolean equals(Object)
   public int getMagicNumber()
-  @org.jetbrains.annotations.NotNull public net.corda.core.identity.AbstractParty getOwner()
-  @org.jetbrains.annotations.NotNull public List getParticipants()
+  @NotNull
+  public net.corda.core.identity.AbstractParty getOwner()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
   public String toString()
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
 ##
-@net.corda.core.DoNotImplement public static interface net.corda.testing.contracts.DummyContract$State extends net.corda.core.contracts.ContractState
+@DoNotImplement
+public static interface net.corda.testing.contracts.DummyContract$State extends net.corda.core.contracts.ContractState
   public abstract int getMagicNumber()
 ##
 public final class net.corda.testing.contracts.DummyContractV2 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
   public <init>()
-  @org.jetbrains.annotations.NotNull public String getLegacyContract()
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
-  @org.jetbrains.annotations.NotNull public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
+  @NotNull
+  public String getLegacyContract()
+  @NotNull
+  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+  @NotNull
+  public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
   public void verify(net.corda.core.transactions.LedgerTransaction)
   public static final net.corda.testing.contracts.DummyContractV2$Companion Companion
-  @org.jetbrains.annotations.NotNull public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV2"
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV2"
 ##
 public static interface net.corda.testing.contracts.DummyContractV2$Commands extends net.corda.core.contracts.CommandData
 ##
@@ -4403,14 +6781,18 @@ public static final class net.corda.testing.contracts.DummyContractV2$Commands$M
 public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
 ##
 public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
-  public <init>(int, List)
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final List component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.contracts.DummyContractV2$State copy(int, List)
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContractV2$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   public final int getMagicNumber()
-  @org.jetbrains.annotations.NotNull public final List getOwners()
-  @org.jetbrains.annotations.NotNull public List getParticipants()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
   public String toString()
 ##
@@ -4418,10 +6800,12 @@ public final class net.corda.testing.contracts.DummyState extends java.lang.Obje
   public <init>()
   public <init>(int)
   public final int component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.contracts.DummyState copy(int)
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int)
   public boolean equals(Object)
   public final int getMagicNumber()
-  @org.jetbrains.annotations.NotNull public List getParticipants()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
   public String toString()
 ##
@@ -4429,259 +6813,374 @@ public final class net.corda.testing.core.DummyCommandData extends net.corda.cor
   public static final net.corda.testing.core.DummyCommandData INSTANCE
 ##
 public final class net.corda.testing.core.Expect extends java.lang.Object
-  public <init>(Class, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final Class component1()
-  @org.jetbrains.annotations.NotNull public final kotlin.jvm.functions.Function1 component2()
-  @org.jetbrains.annotations.NotNull public final kotlin.jvm.functions.Function1 component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.Expect copy(Class, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function1)
+  public <init>(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  @NotNull
+  public final Class<T> component1()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> component2()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> component3()
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> copy(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public final Class getClazz()
-  @org.jetbrains.annotations.NotNull public final kotlin.jvm.functions.Function1 getExpectClosure()
-  @org.jetbrains.annotations.NotNull public final kotlin.jvm.functions.Function1 getMatch()
+  @NotNull
+  public final Class<T> getClazz()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> getExpectClosure()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> getMatch()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public abstract class net.corda.testing.core.ExpectCompose extends java.lang.Object
+@DoNotImplement
+public abstract class net.corda.testing.core.ExpectCompose extends java.lang.Object
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.core.ExpectCompose$Parallel extends net.corda.testing.core.ExpectCompose
-  public <init>(List)
-  @org.jetbrains.annotations.NotNull public final List getParallel()
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Parallel extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getParallel()
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.core.ExpectCompose$Sequential extends net.corda.testing.core.ExpectCompose
-  public <init>(List)
-  @org.jetbrains.annotations.NotNull public final List getSequence()
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Sequential extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getSequence()
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.core.ExpectCompose$Single extends net.corda.testing.core.ExpectCompose
-  public <init>(net.corda.testing.core.Expect)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.Expect getExpect()
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Single extends net.corda.testing.core.ExpectCompose
+  public <init>(net.corda.testing.core.Expect<? extends E, T>)
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> getExpect()
 ##
 public static final class net.corda.testing.core.ExpectComposeState$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.ExpectComposeState fromExpectCompose(net.corda.testing.core.ExpectCompose)
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> fromExpectCompose(net.corda.testing.core.ExpectCompose<? extends E>)
 ##
 public static final class net.corda.testing.core.ExpectComposeState$Finished extends net.corda.testing.core.ExpectComposeState
   public <init>()
-  @org.jetbrains.annotations.NotNull public List getExpectedEvents()
-  @org.jetbrains.annotations.Nullable public Void nextState(Object)
+  @NotNull
+  public java.util.List<Class<E>> getExpectedEvents()
+  @Nullable
+  public Void nextState(E)
 ##
 public static final class net.corda.testing.core.ExpectComposeState$Parallel extends net.corda.testing.core.ExpectComposeState
-  public <init>(net.corda.testing.core.ExpectCompose$Parallel, List)
-  @org.jetbrains.annotations.NotNull public List getExpectedEvents()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.ExpectCompose$Parallel getParallel()
-  @org.jetbrains.annotations.NotNull public final List getStates()
-  @org.jetbrains.annotations.Nullable public kotlin.Pair nextState(Object)
+  public <init>(net.corda.testing.core.ExpectCompose$Parallel<? extends E>, java.util.List<? extends net.corda.testing.core.ExpectComposeState<E>>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Parallel<E> getParallel()
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectComposeState<E>> getStates()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
 ##
 public static final class net.corda.testing.core.ExpectComposeState$Sequential extends net.corda.testing.core.ExpectComposeState
-  public <init>(net.corda.testing.core.ExpectCompose$Sequential, int, net.corda.testing.core.ExpectComposeState)
-  @org.jetbrains.annotations.NotNull public List getExpectedEvents()
+  public <init>(net.corda.testing.core.ExpectCompose$Sequential<? extends E>, int, net.corda.testing.core.ExpectComposeState<E>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
   public final int getIndex()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.ExpectCompose$Sequential getSequential()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.ExpectComposeState getState()
-  @org.jetbrains.annotations.Nullable public kotlin.Pair nextState(Object)
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Sequential<E> getSequential()
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> getState()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
 ##
 public static final class net.corda.testing.core.ExpectComposeState$Single extends net.corda.testing.core.ExpectComposeState
-  public <init>(net.corda.testing.core.ExpectCompose$Single)
-  @org.jetbrains.annotations.NotNull public List getExpectedEvents()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.ExpectCompose$Single getSingle()
-  @org.jetbrains.annotations.Nullable public kotlin.Pair nextState(Object)
+  public <init>(net.corda.testing.core.ExpectCompose$Single<? extends E, T>)
+  @NotNull
+  public java.util.List<Class<T>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Single<E, T> getSingle()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
 ##
 public final class net.corda.testing.core.ExpectKt extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose expect(Class, kotlin.jvm.functions.Function1, kotlin.jvm.functions.Function1)
-  public static final void expectEvents(Iterable, boolean, kotlin.jvm.functions.Function0)
-  public static final void expectEvents(rx.Observable, boolean, kotlin.jvm.functions.Function0)
-  public static final void genericExpectEvents(Object, boolean, kotlin.jvm.functions.Function2, kotlin.jvm.functions.Function0)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose parallel(List)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose parallel(net.corda.testing.core.ExpectCompose...)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose replicate(int, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose sequence(List)
-  @org.jetbrains.annotations.NotNull public static final net.corda.testing.core.ExpectCompose sequence(net.corda.testing.core.ExpectCompose...)
-##
-public static final class net.corda.testing.core.ExpectKt$expectEvents$1$lock$1 extends java.lang.Object
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> expect(Class<E>, kotlin.jvm.functions.Function1<? super E, Boolean>, kotlin.jvm.functions.Function1<? super E, kotlin.Unit>)
+  public static final void expectEvents(Iterable<? extends E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void expectEvents(rx.Observable<E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void genericExpectEvents(S, boolean, kotlin.jvm.functions.Function2<? super S, ? super kotlin.jvm.functions.Function1<? super E, kotlin.Unit>, kotlin.Unit>, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(net.corda.testing.core.ExpectCompose<? extends E>...)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> replicate(int, kotlin.jvm.functions.Function1<? super Integer, ? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(net.corda.testing.core.ExpectCompose<? extends E>...)
 ##
 public final class net.corda.testing.core.SerializationEnvironmentRule extends java.lang.Object implements org.junit.rules.TestRule
   public <init>()
   public <init>(boolean)
-  @org.jetbrains.annotations.NotNull public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement, org.junit.runner.Description)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationContext getCheckpointContext()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.serialization.SerializationFactory getSerializationFactory()
+  @NotNull
+  public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement, org.junit.runner.Description)
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getCheckpointContext()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getSerializationFactory()
   public static final net.corda.testing.core.SerializationEnvironmentRule$Companion Companion
 ##
 public static final class net.corda.testing.core.SerializationEnvironmentRule$Companion extends java.lang.Object
-  public final Object run(String, kotlin.jvm.functions.Function1)
-##
-public static final class net.corda.testing.core.SerializationEnvironmentRule$apply$1 extends org.junit.runners.model.Statement
-  public void evaluate()
+  public final T run(String, kotlin.jvm.functions.Function1<? super net.corda.core.serialization.internal.SerializationEnvironment, ? extends T>)
 ##
 public final class net.corda.testing.core.TestConstants extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.Command dummyCommand(java.security.PublicKey...)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name ALICE_NAME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name BOB_NAME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name BOC_NAME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
+  @NotNull
+  public static final net.corda.core.contracts.Command<net.corda.core.contracts.TypeOnlyCommandData> dummyCommand(java.security.PublicKey...)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name ALICE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOB_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOC_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
   public static final int MAX_MESSAGE_SIZE = 10485760
 ##
 public final class net.corda.testing.core.TestIdentity extends java.lang.Object
   public <init>(net.corda.core.identity.CordaX500Name)
   public <init>(net.corda.core.identity.CordaX500Name, long)
   public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.PartyAndCertificate getIdentity()
-  @org.jetbrains.annotations.NotNull public final java.security.KeyPair getKeyPair()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.CordaX500Name getName()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.identity.Party getParty()
-  @org.jetbrains.annotations.NotNull public final java.security.PublicKey getPublicKey()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.PartyAndReference ref(byte...)
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate getIdentity()
+  @NotNull
+  public final java.security.KeyPair getKeyPair()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  @NotNull
+  public final java.security.PublicKey getPublicKey()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference ref(byte...)
   public static final net.corda.testing.core.TestIdentity$Companion Companion
 ##
 public static final class net.corda.testing.core.TestIdentity$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.core.TestIdentity fresh(String)
+  @NotNull
+  public final net.corda.testing.core.TestIdentity fresh(String)
 ##
 public final class net.corda.testing.core.TestUtils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.utilities.NetworkHostAndPort freeLocalHostAndPort()
+  @NotNull
+  public static final net.corda.core.utilities.NetworkHostAndPort freeLocalHostAndPort()
   public static final int freePort()
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.contracts.StateRef generateStateRef()
-  @org.jetbrains.annotations.NotNull public static final List getFreeLocalPorts(String, int)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
-  @org.jetbrains.annotations.NotNull public static final net.corda.core.identity.PartyAndCertificate singleIdentityAndCert(net.corda.core.node.NodeInfo)
+  @NotNull
+  public static final net.corda.core.contracts.StateRef generateStateRef()
+  @NotNull
+  public static final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getFreeLocalPorts(String, int)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.Party)
+  @NotNull
+  public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate singleIdentityAndCert(net.corda.core.node.NodeInfo)
 ##
 public final class net.corda.testing.dsl.AttachmentResolutionException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.crypto.SecureHash)
 ##
 public final class net.corda.testing.dsl.DoubleSpentInputs extends net.corda.core.flows.FlowException
-  public <init>(List)
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
 ##
 public final class net.corda.testing.dsl.DuplicateOutputLabel extends net.corda.core.flows.FlowException
   public <init>(String)
 ##
-@net.corda.core.DoNotImplement public abstract class net.corda.testing.dsl.EnforceVerifyOrFail extends java.lang.Object
+@DoNotImplement
+public abstract class net.corda.testing.dsl.EnforceVerifyOrFail extends java.lang.Object
 ##
-@net.corda.core.DoNotImplement public static final class net.corda.testing.dsl.EnforceVerifyOrFail$Token extends net.corda.testing.dsl.EnforceVerifyOrFail
+@DoNotImplement
+public static final class net.corda.testing.dsl.EnforceVerifyOrFail$Token extends net.corda.testing.dsl.EnforceVerifyOrFail
   public static final net.corda.testing.dsl.EnforceVerifyOrFail$Token INSTANCE
 ##
-@net.corda.core.DoNotImplement public final class net.corda.testing.dsl.LedgerDSL extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
-  public <init>(net.corda.testing.dsl.LedgerDSLInterpreter, net.corda.core.identity.Party)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  public void _tweak(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails()
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.dsl.LedgerDSLInterpreter getInterpreter()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.contracts.ContractState retrieveOutput(Class, String)
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.StateAndRef retrieveOutputStateAndRef(Class, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction transaction(String, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction transaction(kotlin.jvm.functions.Function1)
-  public final void tweak(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction unverifiedTransaction(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+@DoNotImplement
+public final class net.corda.testing.dsl.LedgerDSL extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
+  public <init>(L, net.corda.core.identity.Party)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public final L getInterpreter()
+  @NotNull
+  public final S retrieveOutput(Class<S>, String)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(String, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public final void tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<? extends T, ? extends L>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.dsl.LedgerDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  public abstract void _tweak(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+@DoNotImplement
+public interface net.corda.testing.dsl.LedgerDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super T, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public abstract void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<? extends T>, kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.dsl.OutputStateLookup
-  @org.jetbrains.annotations.NotNull public abstract net.corda.core.contracts.StateAndRef retrieveOutputStateAndRef(Class, String)
+@DoNotImplement
+public interface net.corda.testing.dsl.OutputStateLookup
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
 ##
-@net.corda.core.DoNotImplement public final class net.corda.testing.dsl.TestLedgerDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
+@DoNotImplement
+public final class net.corda.testing.dsl.TestLedgerDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
   public <init>(net.corda.core.node.ServiceHub)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  public void _tweak(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.ServiceHub component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.dsl.TestLedgerDSLInterpreter copy(net.corda.core.node.ServiceHub, HashMap, HashMap, HashMap)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TestTransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TestTransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TestTransactionDSLInterpreter, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+  @NotNull
+  public final net.corda.core.node.ServiceHub component1()
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter copy(net.corda.core.node.ServiceHub, java.util.HashMap<String, net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>>, java.util.HashMap<net.corda.core.crypto.SecureHash, net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation>, java.util.HashMap<net.corda.core.crypto.SecureHash, net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails()
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.ServiceHub getServices()
-  @org.jetbrains.annotations.NotNull public final List getTransactionsToVerify()
-  @org.jetbrains.annotations.NotNull public final List getTransactionsUnverified()
-  @org.jetbrains.annotations.NotNull public final List getWireTransactions()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServices()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getTransactionsToVerify()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getTransactionsUnverified()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getWireTransactions()
   public int hashCode()
-  @org.jetbrains.annotations.Nullable public final String outputToLabel(net.corda.core.contracts.ContractState)
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.StateAndRef retrieveOutputStateAndRef(Class, String)
+  @Nullable
+  public final String outputToLabel(net.corda.core.contracts.ContractState)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
   public String toString()
-  @org.jetbrains.annotations.Nullable public final String transactionName(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+  @Nullable
+  public final String transactionName(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
   public static final net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion Companion
 ##
 public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion extends java.lang.Object
 ##
 public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$TypeMismatch extends java.lang.Exception
-  public <init>(Class, Class)
+  public <init>(Class<?>, Class<?>)
 ##
 public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$VerifiesFailed extends java.lang.Exception
   public <init>(String, Throwable)
 ##
 public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation extends java.lang.Object
   public <init>(String, net.corda.core.transactions.WireTransaction, String)
-  @org.jetbrains.annotations.Nullable public final String component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction component2()
-  @org.jetbrains.annotations.Nullable public final String component3()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation copy(String, net.corda.core.transactions.WireTransaction, String)
+  @Nullable
+  public final String component1()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction component2()
+  @Nullable
+  public final String component3()
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation copy(String, net.corda.core.transactions.WireTransaction, String)
   public boolean equals(Object)
-  @org.jetbrains.annotations.Nullable public final String getLabel()
-  @org.jetbrains.annotations.Nullable public final String getLocation()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.WireTransaction getTransaction()
+  @Nullable
+  public final String getLabel()
+  @Nullable
+  public final String getLocation()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction getTransaction()
   public int hashCode()
   public String toString()
 ##
-@net.corda.core.DoNotImplement public final class net.corda.testing.dsl.TestTransactionDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter, net.corda.testing.dsl.OutputStateLookup
+@DoNotImplement
+public final class net.corda.testing.dsl.TestTransactionDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter, net.corda.testing.dsl.OutputStateLookup
   public <init>(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder)
   public void _attachment(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
   public void attachment(net.corda.core.crypto.SecureHash)
-  public void command(List, net.corda.core.contracts.CommandData)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.dsl.TestLedgerDSLInterpreter component1()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder component2()
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.dsl.TestTransactionDSLInterpreter copy(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder, HashMap)
+  public void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter component1()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder component2()
+  @NotNull
+  public final net.corda.testing.dsl.TestTransactionDSLInterpreter copy(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder, java.util.HashMap<String, Integer>)
   public boolean equals(Object)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails()
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.TestLedgerDSLInterpreter getLedgerInterpreter()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.node.ServicesForResolution getServices()
-  @org.jetbrains.annotations.NotNull public final net.corda.core.transactions.TransactionBuilder getTransactionBuilder()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public net.corda.testing.dsl.TestLedgerDSLInterpreter getLedgerInterpreter()
+  @NotNull
+  public final net.corda.core.node.ServicesForResolution getServices()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder getTransactionBuilder()
   public int hashCode()
   public void input(net.corda.core.contracts.StateRef)
   public void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.StateAndRef retrieveOutputStateAndRef(Class, String)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
   public void timeWindow(net.corda.core.contracts.TimeWindow)
   public String toString()
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
 ##
-public static final class net.corda.testing.dsl.TestTransactionDSLInterpreter$services$1 extends java.lang.Object implements net.corda.core.node.ServicesForResolution
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.AttachmentStorage getAttachments()
-  @org.jetbrains.annotations.NotNull public net.corda.core.cordapp.CordappProvider getCordappProvider()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.services.IdentityService getIdentityService()
-  @org.jetbrains.annotations.NotNull public net.corda.core.node.NetworkParameters getNetworkParameters()
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.TransactionState loadState(net.corda.core.contracts.StateRef)
-  @org.jetbrains.annotations.NotNull public Set loadStates(Set)
-##
-@net.corda.core.DoNotImplement public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter
-  public <init>(net.corda.testing.dsl.TransactionDSLInterpreter, net.corda.core.identity.Party)
+@DoNotImplement
+public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter
+  public <init>(T, net.corda.core.identity.Party)
   public void _attachment(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
   public final void attachment(String)
   public void attachment(net.corda.core.crypto.SecureHash)
   public final void attachments(String...)
   public final void command(java.security.PublicKey, net.corda.core.contracts.CommandData)
-  public void command(List, net.corda.core.contracts.CommandData)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails()
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.LedgerDSLInterpreter getLedgerInterpreter()
+  public void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
   public final void input(String)
   public final void input(String, net.corda.core.contracts.ContractState)
   public void input(net.corda.core.contracts.StateRef)
@@ -4692,43 +7191,58 @@ public static final class net.corda.testing.dsl.TestTransactionDSLInterpreter$se
   public final void output(String, String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
   public final void output(String, net.corda.core.contracts.ContractState)
   public final void output(String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
-  @org.jetbrains.annotations.NotNull public net.corda.core.contracts.StateAndRef retrieveOutputStateAndRef(Class, String)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
   public final void timeWindow(java.time.Instant)
   public final void timeWindow(java.time.Instant, java.time.Duration)
   public void timeWindow(net.corda.core.contracts.TimeWindow)
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.dsl.EnforceVerifyOrFail tweak(kotlin.jvm.functions.Function1)
-  @org.jetbrains.annotations.NotNull public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+  @NotNull
+  public final net.corda.testing.dsl.EnforceVerifyOrFail tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.dsl.TransactionDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
+@DoNotImplement
+public interface net.corda.testing.dsl.TransactionDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
   public abstract void _attachment(String)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
   public abstract void attachment(net.corda.core.crypto.SecureHash)
-  public abstract void command(List, net.corda.core.contracts.CommandData)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.testing.dsl.LedgerDSLInterpreter getLedgerInterpreter()
+  public abstract void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public abstract net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
   public abstract void input(net.corda.core.contracts.StateRef)
   public abstract void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
   public abstract void timeWindow(net.corda.core.contracts.TimeWindow)
 ##
-@net.corda.core.DoNotImplement public interface net.corda.testing.dsl.Verifies
-  @org.jetbrains.annotations.NotNull public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails()
-  @org.jetbrains.annotations.NotNull public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
-  @org.jetbrains.annotations.NotNull public abstract net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+@DoNotImplement
+public interface net.corda.testing.dsl.Verifies
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail verifies()
 ##
 public final class net.corda.testing.http.HttpApi extends java.lang.Object
   public <init>(java.net.URL, com.fasterxml.jackson.databind.ObjectMapper)
-  @org.jetbrains.annotations.NotNull public final com.fasterxml.jackson.databind.ObjectMapper getMapper()
-  @org.jetbrains.annotations.NotNull public final java.net.URL getRoot()
+  @NotNull
+  public final com.fasterxml.jackson.databind.ObjectMapper getMapper()
+  @NotNull
+  public final java.net.URL getRoot()
   public final void postJson(String, Object)
   public final void postPlain(String, String)
   public final void putJson(String, Object)
   public static final net.corda.testing.http.HttpApi$Companion Companion
 ##
 public static final class net.corda.testing.http.HttpApi$Companion extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final net.corda.testing.http.HttpApi fromHostAndPort(net.corda.core.utilities.NetworkHostAndPort, String, String, com.fasterxml.jackson.databind.ObjectMapper)
+  @NotNull
+  public final net.corda.testing.http.HttpApi fromHostAndPort(net.corda.core.utilities.NetworkHostAndPort, String, String, com.fasterxml.jackson.databind.ObjectMapper)
 ##
 public final class net.corda.testing.http.HttpUtils extends java.lang.Object
-  @org.jetbrains.annotations.NotNull public final com.fasterxml.jackson.databind.ObjectMapper getDefaultMapper()
+  @NotNull
+  public final com.fasterxml.jackson.databind.ObjectMapper getDefaultMapper()
   public final void postJson(java.net.URL, String)
   public final void postPlain(java.net.URL, String)
   public final void putJson(java.net.URL, String)
@@ -4736,13 +7250,21 @@ public final class net.corda.testing.http.HttpUtils extends java.lang.Object
 ##
 public final class net.corda.testing.services.MockAttachmentStorage extends net.corda.core.serialization.SingletonSerializeAsToken implements net.corda.core.node.services.AttachmentStorage
   public <init>()
-  @org.jetbrains.annotations.NotNull public final kotlin.Pair getAttachmentIdAndBytes(java.io.InputStream)
-  @org.jetbrains.annotations.NotNull public final Map getFiles()
+  @NotNull
+  public final kotlin.Pair<net.corda.core.crypto.SecureHash, byte[]> getAttachmentIdAndBytes(java.io.InputStream)
+  @NotNull
+  public final java.util.Map<net.corda.core.crypto.SecureHash, kotlin.Pair<net.corda.core.contracts.Attachment, byte[]>> getFiles()
   public boolean hasAttachment(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
-  @org.jetbrains.annotations.NotNull public final net.corda.core.crypto.SecureHash importContractAttachment(List, String, java.io.InputStream)
-  @org.jetbrains.annotations.NotNull public net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
-  @org.jetbrains.annotations.Nullable public net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
-  @org.jetbrains.annotations.NotNull public List queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
+  @Nullable
+  public net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
 ##

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6339,7 +6339,7 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @NotNull
   public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
   @NotNull
-  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
   protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
   @NotNull

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -5630,10 +5630,11 @@ public static final class net.corda.client.jackson.JacksonSupport$IdentityObject
   @Nullable
   public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
+@DoNotImplement
 public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
   public <init>(com.fasterxml.jackson.core.JsonFactory)
   @NotNull
-  public Void partiesFromName(String)
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
   @Nullable
   public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
   @Nullable

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6533,7 +6533,7 @@ public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Obj
   public int getServerProtocolVersion()
   public void notifyServerAndClose()
 ##
-public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException
+public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException implements net.corda.nodeapi.exceptions.RpcSerializableError
   public <init>(String)
 ##
 @DoNotImplement

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -5177,8 +5177,8 @@ public abstract class net.corda.core.utilities.ByteSequence extends java.lang.Ob
   public boolean equals(Object)
   @NotNull
   public abstract byte[] getBytes()
-  public abstract int getOffset()
-  public abstract int getSize()
+  public final int getOffset()
+  public final int getSize()
   public int hashCode()
   @NotNull
   public static final net.corda.core.utilities.ByteSequence of(byte[])
@@ -5363,8 +5363,6 @@ public class net.corda.core.utilities.OpaqueBytes extends net.corda.core.utiliti
   public <init>(byte[])
   @NotNull
   public final byte[] getBytes()
-  public int getOffset()
-  public int getSize()
   @NotNull
   public static final net.corda.core.utilities.OpaqueBytes of(byte...)
   public static final net.corda.core.utilities.OpaqueBytes$Companion Companion
@@ -5378,8 +5376,6 @@ public final class net.corda.core.utilities.OpaqueBytesSubSequence extends net.c
   public <init>(byte[], int, int)
   @NotNull
   public byte[] getBytes()
-  public int getOffset()
-  public int getSize()
 ##
 @CordaSerializable
 public final class net.corda.core.utilities.ProgressTracker extends java.lang.Object

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2084,7 +2084,6 @@ public final class net.corda.core.flows.NotarisationRequest extends java.lang.Ob
   public final java.util.List<net.corda.core.contracts.StateRef> getStatesToConsume()
   @NotNull
   public final net.corda.core.crypto.SecureHash getTransactionId()
-  public final void verifySignature(net.corda.core.flows.NotarisationRequestSignature, net.corda.core.identity.Party)
   public static final net.corda.core.flows.NotarisationRequest$Companion Companion
 ##
 public static final class net.corda.core.flows.NotarisationRequest$Companion extends java.lang.Object
@@ -2255,27 +2254,6 @@ public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUE
 public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
 ##
-public abstract static class net.corda.core.flows.NotaryFlow$Service extends net.corda.core.flows.FlowLogic
-  public <init>(net.corda.core.flows.FlowSession, net.corda.core.node.services.TrustedAuthorityNotaryService)
-  @Suspendable
-  @Nullable
-  public Void call()
-  @Suspendable
-  protected final void checkNotary(net.corda.core.identity.Party)
-  @NotNull
-  public final net.corda.core.flows.FlowSession getOtherSideSession()
-  @NotNull
-  public final net.corda.core.node.services.TrustedAuthorityNotaryService getService()
-  @Suspendable
-  @NotNull
-  public abstract net.corda.core.flows.TransactionParts receiveAndVerifyTx()
-##
-@CordaSerializable
-public final class net.corda.core.flows.NotaryInternalException extends net.corda.core.flows.FlowException
-  public <init>(net.corda.core.flows.NotaryError)
-  @NotNull
-  public final net.corda.core.flows.NotaryError getError()
-##
 public final class net.corda.core.flows.ReceiveStateAndRefFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   @Suspendable
@@ -2382,30 +2360,6 @@ public class net.corda.core.flows.StateReplacementException extends net.corda.co
   public <init>()
   public <init>(String)
   public <init>(String, Throwable)
-##
-public final class net.corda.core.flows.TransactionParts extends java.lang.Object
-  public <init>(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.contracts.TimeWindow, net.corda.core.identity.Party)
-  @NotNull
-  public final net.corda.core.crypto.SecureHash component1()
-  @NotNull
-  public final java.util.List<net.corda.core.contracts.StateRef> component2()
-  @Nullable
-  public final net.corda.core.contracts.TimeWindow component3()
-  @Nullable
-  public final net.corda.core.identity.Party component4()
-  @NotNull
-  public final net.corda.core.flows.TransactionParts copy(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.contracts.TimeWindow, net.corda.core.identity.Party)
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.core.crypto.SecureHash getId()
-  @NotNull
-  public final java.util.List<net.corda.core.contracts.StateRef> getInputs()
-  @Nullable
-  public final net.corda.core.identity.Party getNotary()
-  @Nullable
-  public final net.corda.core.contracts.TimeWindow getTimestamp()
-  public int hashCode()
-  public String toString()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
@@ -3165,27 +3119,6 @@ public interface net.corda.core.node.services.NetworkMapCacheBase
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> track()
 ##
-@CordaSerializable
-public abstract class net.corda.core.node.services.NotaryService extends net.corda.core.serialization.SingletonSerializeAsToken
-  public <init>()
-  @NotNull
-  public abstract net.corda.core.flows.FlowLogic<Void> createServiceFlow(net.corda.core.flows.FlowSession)
-  @NotNull
-  public abstract java.security.PublicKey getNotaryIdentityKey()
-  @NotNull
-  public abstract net.corda.core.node.ServiceHub getServices()
-  public abstract void start()
-  public abstract void stop()
-  public static final void validateTimeWindow(java.time.Clock, net.corda.core.contracts.TimeWindow)
-  public static final net.corda.core.node.services.NotaryService$Companion Companion
-  @NotNull
-  public static final String ID_PREFIX = "corda.notary."
-##
-public static final class net.corda.core.node.services.NotaryService$Companion extends java.lang.Object
-  @NotNull
-  public final String constructId(boolean, boolean, boolean, boolean)
-  public final void validateTimeWindow(java.time.Clock, net.corda.core.contracts.TimeWindow)
-##
 public abstract class net.corda.core.node.services.PartyInfo extends java.lang.Object
   @NotNull
   public abstract net.corda.core.identity.Party getParty()
@@ -3248,66 +3181,6 @@ public interface net.corda.core.node.services.TransactionStorage
 public interface net.corda.core.node.services.TransactionVerifierService
   @NotNull
   public abstract net.corda.core.concurrent.CordaFuture<?> verify(net.corda.core.transactions.LedgerTransaction)
-##
-@CordaSerializable
-public abstract class net.corda.core.node.services.TrustedAuthorityNotaryService extends net.corda.core.node.services.NotaryService
-  public <init>()
-  public final void commitInputStates(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party)
-  @NotNull
-  protected org.slf4j.Logger getLog()
-  @NotNull
-  protected net.corda.core.node.services.TimeWindowChecker getTimeWindowChecker()
-  @NotNull
-  protected abstract net.corda.core.node.services.UniquenessProvider getUniquenessProvider()
-  @NotNull
-  public final net.corda.core.crypto.TransactionSignature sign(net.corda.core.crypto.SecureHash)
-  @NotNull
-  public final net.corda.core.crypto.DigitalSignature$WithKey sign(byte[])
-  public final void validateTimeWindow(net.corda.core.contracts.TimeWindow)
-  public static final net.corda.core.node.services.TrustedAuthorityNotaryService$Companion Companion
-##
-public static final class net.corda.core.node.services.TrustedAuthorityNotaryService$Companion extends java.lang.Object
-##
-@CordaSerializable
-public final class net.corda.core.node.services.UniquenessException extends net.corda.core.CordaException
-  public <init>(net.corda.core.node.services.UniquenessProvider$Conflict)
-  @NotNull
-  public final net.corda.core.node.services.UniquenessProvider$Conflict getError()
-##
-public interface net.corda.core.node.services.UniquenessProvider
-  public abstract void commit(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party)
-##
-@CordaSerializable
-public static final class net.corda.core.node.services.UniquenessProvider$Conflict extends java.lang.Object
-  public <init>(java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx>)
-  @NotNull
-  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx> component1()
-  @NotNull
-  public final net.corda.core.node.services.UniquenessProvider$Conflict copy(java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx>)
-  public boolean equals(Object)
-  @NotNull
-  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx> getStateHistory()
-  public int hashCode()
-  public String toString()
-##
-@CordaSerializable
-public static final class net.corda.core.node.services.UniquenessProvider$ConsumingTx extends java.lang.Object
-  public <init>(net.corda.core.crypto.SecureHash, int, net.corda.core.identity.Party)
-  @NotNull
-  public final net.corda.core.crypto.SecureHash component1()
-  public final int component2()
-  @NotNull
-  public final net.corda.core.identity.Party component3()
-  @NotNull
-  public final net.corda.core.node.services.UniquenessProvider$ConsumingTx copy(net.corda.core.crypto.SecureHash, int, net.corda.core.identity.Party)
-  public boolean equals(Object)
-  @NotNull
-  public final net.corda.core.crypto.SecureHash getId()
-  public final int getInputIndex()
-  @NotNull
-  public final net.corda.core.identity.Party getRequestingParty()
-  public int hashCode()
-  public String toString()
 ##
 @CordaSerializable
 public final class net.corda.core.node.services.UnknownAnonymousPartyException extends net.corda.core.CordaException

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1013,7 +1013,7 @@ public interface net.corda.core.cordapp.Cordapp
   public abstract java.util.List<Class<? extends net.corda.core.serialization.SerializeAsToken>> getServices()
 ##
 public final class net.corda.core.cordapp.CordappContext extends java.lang.Object
-  public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader)
+  public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader, net.corda.core.cordapp.CordappConfig)
   @Nullable
   public final net.corda.core.crypto.SecureHash getAttachmentId()
   @NotNull

--- a/build.gradle
+++ b/build.gradle
@@ -103,9 +103,7 @@ buildscript {
         classpath "net.corda.plugins:quasar-utils:$gradle_plugins_version"
         classpath "net.corda.plugins:cordformation:$gradle_plugins_version"
         classpath "net.corda.plugins:cordapp:$gradle_plugins_version"
-        //TODO Anthony- this should be changed back to $gradle_plugins_version when the api-scaner is fixed
         classpath "net.corda.plugins:api-scanner:$gradle_plugins_version"
-//        classpath "net.corda.plugins:api-scanner:4.0.19"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
         classpath "org.jetbrains.kotlin:kotlin-noarg:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -104,8 +104,8 @@ buildscript {
         classpath "net.corda.plugins:cordformation:$gradle_plugins_version"
         classpath "net.corda.plugins:cordapp:$gradle_plugins_version"
         //TODO Anthony- this should be changed back to $gradle_plugins_version when the api-scaner is fixed
-//        classpath "net.corda.plugins:api-scanner:$gradle_plugins_version"
-        classpath "net.corda.plugins:api-scanner:4.0.15"
+        classpath "net.corda.plugins:api-scanner:$gradle_plugins_version"
+//        classpath "net.corda.plugins:api-scanner:4.0.19"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
         classpath "org.jetbrains.kotlin:kotlin-noarg:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"


### PR DESCRIPTION
- Updated api scanner to use current version
- Ported accross the generated `api-current.txt` from the release-v3 branch (from this PR here: https://github.com/corda/corda/pull/3154)
- Applied any changes to `api-current.txt` which have already been approved (original jira tickets/PR numbers are in individual commits to make it easier to follow)
- There was one further internal exposure which was highlighted due to the fact that the new version of api scanner shows detail of generic parameters and lambda inputs. The exposure has already been 'committed' to so I'm not sure what the best course of action is, but I've raised a seperate story here: https://r3-cev.atlassian.net/browse/CORDA-1489 to remove it.