### PR TITLE
CORDA-1288 Node properties can be set as system properties.

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -302,3 +302,13 @@ path to the node's base directory.
             ``foo.bar.FlowClass``, add the string ``StartFlow.foo.bar.FlowClass`` to the list. If the list
             contains the string ``ALL``, the user can start any flow via RPC. This value is intended for administrator
             users and for development.
+
+Fields Override
+---------------
+JVM options or environmental variables prefixed ``corda.`` can override ``node.conf`` fields.
+Provided system properties also can set value for absent fields in ``node.conf``.
+Example adding/overriding keyStore password when starting Corda node:
+
+.. sourcecode:: shell
+
+    java -Dcorda.rpcSettings.ssl.keyStorePassword=mypassword -jar node.jar

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -37,8 +37,6 @@ object ConfigHelper {
         val smartDevMode = CordaSystemUtils.isOsMac() || (CordaSystemUtils.isOsWindows() && !CordaSystemUtils.getOsName().toLowerCase().contains("server"))
         val devModeConfig = ConfigFactory.parseMap(mapOf("devMode" to smartDevMode))
 
-        val finalConfig = configOf(
-
         val systemOverrides = ConfigFactory.systemProperties().cordaEntriesOnly()
         val environmentOverrides = ConfigFactory.systemEnvironment().cordaEntriesOnly()
         val finalConfig = configOf(

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -40,11 +40,13 @@ object ConfigHelper {
         val finalConfig = configOf(
 
         val systemOverrides = ConfigFactory.systemProperties().cordaEntriesOnly()
-        val finalConfig = systemOverrides
-                .withFallback(configOf(
+        val environmentOverrides = ConfigFactory.systemEnvironment().cordaEntriesOnly()
+        val finalConfig = configOf(
                 // Add substitution values here
-                "baseDirectory" to baseDirectory.toString()))
+                "baseDirectory" to baseDirectory.toString())
                 .withFallback(configOverrides)
+                .withFallback(systemOverrides)
+                .withFallback(environmentOverrides)
                 .withFallback(appConfig)
                 .withFallback(devModeConfig) // this needs to be after the appConfig, so it doesn't override the configured devMode
                 .withFallback(defaultConfig)


### PR DESCRIPTION
Allow override node properties by a system property. Especially handy for credentials.