### PR TITLE
ENT-1574 Progress tracker distinguishes steps which were not processed

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -52,7 +52,6 @@ class FinalityFlow(val transaction: SignedTransaction,
         // Lookup the resolved transactions and use them to map each signed transaction to the list of participants.
         // Then send to the notary if needed, record locally and distribute.
         val parties = getPartiesToSend(verifyTx())
-        progressTracker.currentStep = NOTARISING
         val notarised = notariseAndRecord()
 
         // Each transaction has its own set of recipients, but extra recipients get them all.
@@ -70,6 +69,7 @@ class FinalityFlow(val transaction: SignedTransaction,
     @Suspendable
     private fun notariseAndRecord(): SignedTransaction {
         val notarised = if (needsNotarySignature(transaction)) {
+            progressTracker.currentStep = NOTARISING
             val notarySignatures = subFlow(NotaryFlow.Client(transaction))
             transaction + notarySignatures
         } else {

--- a/core/src/main/kotlin/net/corda/core/internal/Emoji.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/Emoji.kt
@@ -49,6 +49,8 @@ object Emoji {
     val CODE_DEVELOPER: String = codePointsString(0x1F469, 0x200D, 0x1F4BB)
     @JvmStatic
     val CODE_WARNING_SIGN: String = codePointsString(0x26A0, 0xFE0F)
+    @JvmStatic
+    val CROSS_MARK_BUTTON: String = codePointsString(0x274E)
 
     /**
      * When non-null, toString() methods are allowed to use emoji in the output as we're going to render them to a
@@ -76,6 +78,7 @@ object Emoji {
     val rightArrow: String get() = if (emojiMode.get() != null) "$CODE_RIGHT_ARROW  " else "▶︎"
     val skullAndCrossbones: String get() = if (emojiMode.get() != null) "$CODE_SKULL_AND_CROSSBONES  " else "☂"
     val noEntry: String get() = if (emojiMode.get() != null) "$CODE_NO_ENTRY  " else "✘"
+    val notRun: String get() = if (emojiMode.get() != null) "$CROSS_MARK_BUTTON  " else "-"
 
     inline fun <T> renderIfSupported(body: () -> T): T {
         if (hasEmojiTerminal)

--- a/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/ProgressTracker.kt
@@ -148,8 +148,15 @@ class ProgressTracker(vararg steps: Step) {
     val currentStepRecursive: Step
         get() = getChildProgressTracker(currentStep)?.currentStepRecursive ?: currentStep
 
+    /** Returns the current step, descending into children to find the deepest started step we are up to. */
+    private val currentStartedStepRecursive: Step
+        get() {
+            val step = getChildProgressTracker(currentStep)?.currentStartedStepRecursive ?: currentStep
+            return if (step == UNSTARTED) currentStep else step
+        }
+
     private fun currentStepRecursiveWithoutUnstarted(): Step {
-        val stepRecursive = getChildProgressTracker(currentStep)?.currentStepRecursive
+        val stepRecursive = getChildProgressTracker(currentStep)?.currentStartedStepRecursive
         return if (stepRecursive == null || stepRecursive == UNSTARTED) currentStep else stepRecursive
     }
 

--- a/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/ProgressTrackerTest.kt
@@ -132,6 +132,41 @@ class ProgressTrackerTest {
     }
 
     @Test
+    fun `steps tree index counts two levels of children steps`() {
+        pt.setChildProgressTracker(SimpleSteps.FOUR, pt2)
+        pt2.setChildProgressTracker(ChildSteps.SEA, pt3)
+        val allSteps = pt.allSteps
+
+        // Capture notifications.
+        val stepsIndexNotifications = LinkedList<Int>()
+        pt.stepsTreeIndexChanges.subscribe {
+            stepsIndexNotifications += it
+        }
+        val stepsTreeNotification = LinkedList<List<Pair<Int, String>>>()
+        pt.stepsTreeChanges.subscribe {
+            stepsTreeNotification += it
+        }
+
+        fun assertCurrentStepsTree(index: Int, step: ProgressTracker.Step) {
+            assertEquals(index, pt.stepsTreeIndex)
+            assertEquals(step, allSteps[pt.stepsTreeIndex].second)
+        }
+
+        pt.currentStep = SimpleSteps.ONE
+        assertCurrentStepsTree(0, SimpleSteps.ONE)
+
+        pt.currentStep = SimpleSteps.FOUR
+        assertCurrentStepsTree(3, SimpleSteps.FOUR)
+
+        pt2.currentStep = ChildSteps.SEA
+        assertCurrentStepsTree(6, ChildSteps.SEA)
+
+        // Assert no structure changes and proper steps propagation.
+        assertThat(stepsIndexNotifications).containsExactlyElementsOf(listOf(0, 3, 6))
+        assertThat(stepsTreeNotification).isEmpty()
+    }
+    
+    @Test
     fun `structure changes are pushed down when progress trackers are added`() {
         pt.setChildProgressTracker(SimpleSteps.TWO, pt2)
 


### PR DESCRIPTION
* Progress Tracker doesn't set to "green tick" for a step which hasn't been set in the flow 
It marks steps as processed ("green tick") only if they were send to a renderer (set as the current step). Marking with green crossed sign for shell and as minus sign for ssh.  
See attached screenshots.

* Finality Flow sets the current step to NOTARISING only if the actual notarization is performed.


The underlying fix was for ProgressTracker descends to child steps to find stepIndexTree for more than two nested levels.
Added first a unit test which illustrates the problem , and it failed without a fix.
After the fix, the test passes:
https://ci-master.corda.r3cev.com/viewType.html?buildTypeId=Corda_PullRequests&branch_Corda_Build_PullRequests=3173&tab=buildTypeStatusDiv