### PR TITLE
ENT-1902: Explorer GUI from Enterprise cannot be started against remote Node

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt
@@ -70,7 +70,8 @@ class NodeMonitorModel {
 
             // Only execute using "runLater()" if JavaFX been initialized.
             // It may not be initialized in the unit test.
-            if(initialized.value.get()) {
+            // Also if we are already in the JavaFX thread - perform direct invocation without postponing it.
+            if(initialized.value.get() && !Platform.isFxApplicationThread()) {
                 Platform.runLater(op)
             } else {
                 op()


### PR DESCRIPTION
If we are already in the JavaFX thread - perform direct invocation without postponing it.
Or else if we are operating in JavaFX thread the sequence of invocations will change.