### PR TITLE
CORDA-1506: Cash selection logic fails when selection with a change from more that 2 different issuer groups

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/OnLedgerAsset.kt
@@ -152,7 +152,7 @@ abstract class OnLedgerAsset<T : Any, out C : CommandData, S : FungibleAsset<T>>
                         delta > 0 -> {
                             // The states from the current issuer more than covers this payment.
                             outputStates += deriveState(templateState, Amount(remainingToPay, token), party)
-                            remainingFromEachIssuer[0] = Pair(token, Amount(delta, token))
+                            remainingFromEachIssuer[remainingFromEachIssuer.lastIndex] = Pair(token, Amount(delta, token))
                             remainingToPay = 0
                         }
                         delta == 0L -> {

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
@@ -56,7 +56,7 @@ class CashSelectionH2ImplTest {
     }
 
     @Test
-    fun `select coins from more that two different issue references`() {
+    fun `select coins with a change from more that two different issuer references`() {
         val node = mockNet.createNode()
         val notary = mockNet.defaultNotaryIdentity
 

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
@@ -56,7 +56,7 @@ class CashSelectionH2ImplTest {
     }
 
     @Test
-    fun `select coins with a change from more that two different issuer references`() {
+    fun `select pennies amount from cash states with more than two different issuers and expect change`() {
         val node = mockNet.createNode()
         val notary = mockNet.defaultNotaryIdentity
 

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
@@ -56,21 +56,17 @@ class CashSelectionH2ImplTest {
     }
 
     @Test
-    fun `special Coin Selection`() {
-        val bankA = mockNet.createNode()
-        val bankB = mockNet.createNode()
+    fun `select coins from more that two different issue references`() {
+        val node = mockNet.createNode()
         val notary = mockNet.defaultNotaryIdentity
 
-        // Issue some cash to Bank A
-        bankA.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(1), notary)).getOrThrow()
-        bankA.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(2), notary)).getOrThrow()
-        bankA.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(3), notary)).getOrThrow()
-        bankA.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(4), notary)).getOrThrow()
-        bankA.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(5), notary)).getOrThrow()
-        bankA.startFlow(CashIssueFlow(1000.POUNDS, OpaqueBytes.of(6), notary)).getOrThrow()
+        // Issue some cash
+        node.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(1), notary)).getOrThrow()
+        node.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(2), notary)).getOrThrow()
+        node.startFlow(CashIssueFlow(1000.POUNDS, OpaqueBytes.of(3), notary)).getOrThrow()
 
-        // Make a payment to Bank B
-        val paymentResult = bankA.startFlow(CashPaymentFlow(999.POUNDS, anonymous = false, recipient = bankB.info.legalIdentities.single())).getOrThrow()
+        // Make a payment
+        val paymentResult = node.startFlow(CashPaymentFlow(999.POUNDS, node.info.legalIdentities[0], false)).getOrThrow()
         assertNotNull(paymentResult.recipient)
     }
 }


### PR DESCRIPTION
Description will change in the future and Jira item to follow.