### PR TITLE
CORDA-1499 - Fix a typo in node_attchments_contracts table name.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -110,6 +110,8 @@ Unreleased
   For instance, this method will check if an ECC key lies on a valid curve or if an RSA key is >= 2048bits. This might
   be required for extra key validation checks, e.g., for Doorman to check that a CSR key meets the minimum security requirements.
 
+* Table name with a typo changed from ``NODE_ATTCHMENTS_CONTRACTS`` to ``NODE_ATTACHMENTS_CONTRACTS``.
+
 .. _changelog_v3.1:
 
 Version 3.1

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -67,6 +67,12 @@ UNRELEASED
   No action is needed for default node tables as ``PersistentStateRef`` is used as Primary Key only and the backing columns are automatically not nullable
   or custom Cordapp entities using ``PersistentStateRef`` as Primary Key.
 
+* H2 database upgrade - the table with a typo has been change, for each database instance and schema run the following SQL statement:
+
+    ALTER TABLE [schema].NODE_ATTCHMENTS_CONTRACTS RENAME TO NODE_ATTACHMENTS_CONTRACTS;
+
+  Schema is optional, run SQL when the node is not running.
+
 v3.0 to v3.1
 ------------
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -112,7 +112,7 @@ class NodeAttachmentService(
 
             @ElementCollection
             @Column(name = "contract_class_name", nullable = false)
-            @CollectionTable(name = "node_attchments_contracts", joinColumns = [(JoinColumn(name = "att_id", referencedColumnName = "att_id"))],
+            @CollectionTable(name = "${NODE_DATABASE_PREFIX}attachments_contracts", joinColumns = [(JoinColumn(name = "att_id", referencedColumnName = "att_id"))],
                     foreignKey = ForeignKey(name = "FK__ctr_class__attachments"))
             var contractClassNames: List<ContractClassName>? = null
     ) : Serializable


### PR DESCRIPTION
Database table is missing an "a" in the word attachments: `node_attchments_contracts`.