### PR TITLE
[CORDA-1458]: Prevent passwords from being logged as part of node's configuration.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,8 @@ release, see :doc:`upgrade-notes`.
 Unreleased
 ==========
 
+* ``NodeStartup`` will now only print node's configuration if ``devMode`` is ``true``, avoiding the risk of printing passwords in a production setup.
+
 * SLF4J's MDC will now only be printed to the console if not empty. No more log lines ending with "{}".
 
 * ``WireTransaction.Companion.createComponentGroups`` has been marked as ``@CordaInternal``. It was never intended to be

--- a/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt
@@ -1,11 +1,13 @@
 package net.corda.node
 
+import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import joptsimple.OptionSet
 import joptsimple.util.EnumConverter
 import joptsimple.util.PathConverter
 import net.corda.core.internal.div
 import net.corda.core.internal.exists
+import net.corda.core.utilities.Try
 import net.corda.node.services.config.ConfigHelper
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.parseAsNodeConfiguration
@@ -110,19 +112,22 @@ data class CmdLineOptions(val baseDirectory: Path,
                           val bootstrapRaftCluster: Boolean,
                           val unknownConfigKeysPolicy: UnknownConfigKeysPolicy,
                           val devMode: Boolean) {
-    fun loadConfig(): NodeConfiguration {
-        val config = ConfigHelper.loadConfig(
+    fun loadConfig(): Pair<Config, Try<NodeConfiguration>> {
+        val rawConfig = ConfigHelper.loadConfig(
                 baseDirectory,
                 configFile,
                 configOverrides = ConfigFactory.parseMap(mapOf("noLocalShell" to this.noLocalShell) +
                         if (devMode) mapOf("devMode" to this.devMode) else emptyMap<String, Any>())
-        ).parseAsNodeConfiguration(unknownConfigKeysPolicy::handle)
-        if (nodeRegistrationOption != null) {
-            require(!config.devMode) { "registration cannot occur in devMode" }
-            requireNotNull(config.compatibilityZoneURL) {
-                "compatibilityZoneURL must be present in node configuration file in registration mode."
+        )
+        return rawConfig to Try.on {
+            rawConfig.parseAsNodeConfiguration(unknownConfigKeysPolicy::handle).also {
+                if (nodeRegistrationOption != null) {
+                    require(!it.devMode) { "registration cannot occur in devMode" }
+                    requireNotNull(it.compatibilityZoneURL) {
+                        "compatibilityZoneURL must be present in node configuration file in registration mode."
+                    }
+                }
             }
         }
-        return config
     }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -1,6 +1,8 @@
 package net.corda.node.internal
 
 import com.jcabi.manifests.Manifests
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigRenderOptions
 import io.netty.channel.unix.Errors
 import net.corda.core.crypto.Crypto
 import net.corda.core.internal.Emoji
@@ -8,6 +10,7 @@ import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
 import net.corda.core.internal.randomOrNull
+import net.corda.core.utilities.Try
 import net.corda.core.utilities.loggerFor
 import net.corda.node.CmdLineOptions
 import net.corda.node.NodeArgsParser
@@ -79,7 +82,11 @@ open class NodeStartup(val args: Array<String>) {
         drawBanner(versionInfo)
         Node.printBasicNodeInfo(LOGS_CAN_BE_FOUND_IN_STRING, System.getProperty("log-path"))
         val conf = try {
-            val conf0 = loadConfigFile(cmdlineOptions)
+            val (rawConfig, conf0Result) = loadConfigFile(cmdlineOptions)
+            if (cmdlineOptions.devMode) {
+                println("Config:\n${rawConfig.root().render(ConfigRenderOptions.defaults())}")
+            }
+            val conf0 = conf0Result.getOrThrow()
             if (cmdlineOptions.bootstrapRaftCluster) {
                 if (conf0 is NodeConfigurationImpl) {
                     println("Bootstrapping raft cluster (starting up as seed node).")
@@ -211,7 +218,7 @@ open class NodeStartup(val args: Array<String>) {
         NodeRegistrationHelper(conf, HTTPNetworkRegistrationService(compatibilityZoneURL), nodeRegistrationConfig).buildKeystore()
     }
 
-    protected open fun loadConfigFile(cmdlineOptions: CmdLineOptions): NodeConfiguration = cmdlineOptions.loadConfig()
+    protected open fun loadConfigFile(cmdlineOptions: CmdLineOptions): Pair<Config, Try<NodeConfiguration>> = cmdlineOptions.loadConfig()
 
     protected open fun banJavaSerialisation(conf: NodeConfiguration) {
         SerialFilter.install(if (conf.notary?.bftSMaRt != null) ::bftSMaRtSerialFilter else ::defaultSerialFilter)

--- a/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/ConfigUtilities.kt
@@ -3,7 +3,6 @@ package net.corda.node.services.config
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
-import com.typesafe.config.ConfigRenderOptions
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.createDirectories
 import net.corda.core.internal.div
@@ -49,9 +48,6 @@ object ConfigHelper {
                 .withFallback(devModeConfig) // this needs to be after the appConfig, so it doesn't override the configured devMode
                 .withFallback(defaultConfig)
                 .resolve()
-
-
-        log.info("Config:\n${finalConfig.root().render(ConfigRenderOptions.defaults())}")
 
         val entrySet = finalConfig.entrySet().filter { entry -> entry.key.contains("\"") }
         for ((key) in entrySet) {


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-1458

Approach taken:

- Removed logging side-effect from `ConfigUtilities`
- Returned the raw configuration along with the result of trying to parse it into `NodeConfiguration` in `NodeArgsParser`
- Printed the raw configuration only in case `devMode` is `true` in `NodeStartup`