### PR TITLE
Late start bridges (unless configured otherwise) if the queue is empty.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -9,9 +9,9 @@ import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.seconds
 import net.corda.node.internal.artemis.CertificateChainCheckPolicy
 import net.corda.node.services.config.rpc.NodeRpcOptions
-import net.corda.nodeapi.internal.config.*
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.nodeapi.internal.config.NodeSSLConfiguration
+import net.corda.nodeapi.internal.config.UnknownConfigKeysPolicy
 import net.corda.nodeapi.internal.config.User
 import net.corda.nodeapi.internal.config.parseAs
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
@@ -46,6 +46,7 @@ interface NodeConfiguration : NodeSSLConfiguration {
     val messagingServerExternal: Boolean
     // TODO Move into DevModeOptions
     val useTestClock: Boolean get() = false
+    val lazyBridgeStart: Boolean
     val detectPublicIp: Boolean get() = true
     val sshd: SSHDConfiguration?
     val database: DatabaseConfig
@@ -157,6 +158,7 @@ data class NodeConfigurationImpl(
         override val noLocalShell: Boolean = false,
         override val devModeOptions: DevModeOptions? = null,
         override val useTestClock: Boolean = false,
+        override val lazyBridgeStart: Boolean = true,
         override val detectPublicIp: Boolean = true,
         // TODO See TODO above. Rename this to nodeInfoPollingFrequency and make it of type Duration
         override val additionalNodeInfoPollingFrequencyMsec: Long = 5.seconds.toMillis(),

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -3,6 +3,7 @@ emailAddress = "admin@company.com"
 keyStorePassword = "cordacadevpass"
 trustStorePassword = "trustpass"
 crlCheckSoftFail = true
+lazyBridgeStart = true
 dataSourceProperties = {
     dataSourceClassName = org.h2.jdbcx.JdbcDataSource
     dataSource.url = "jdbc:h2:file:"${baseDirectory}"/persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=100;AUTO_SERVER_PORT="${h2port}


### PR DESCRIPTION
The logic change here to the bridges means that we won't initiate an outgoing bridge until our first message, unless the queue is non-empty from a previous session, or we configure to initiate always.

I believe this logic is safe, even when we move towards a clustered node, though it does require the queue count to be trustworthy. If not we can disable it via config, so this shouldn't strand anyone.
