### PR TITLE
Remove default value for `myLegalName`

### DIFF
--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -1,4 +1,3 @@
-myLegalName = "Vast Global MegaCorp, Ltd"
 emailAddress = "admin@company.com"
 keyStorePassword = "cordacadevpass"
 trustStorePassword = "trustpass"


### PR DESCRIPTION
When the config files doesn't contain `myLegalName` the exception says:

> improperly specified input name: Vast Global MegaCorp, Ltd