### PR TITLE
CORDA-1524 Fix NodeSchedulerService

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -71,6 +71,8 @@
       <module name="example-code_integrationTest" target="1.8" />
       <module name="example-code_main" target="1.8" />
       <module name="example-code_test" target="1.8" />
+      <module name="experimental-blobinspector_main" target="1.8" />
+      <module name="experimental-blobinspector_test" target="1.8" />
       <module name="experimental-kryo-hook_main" target="1.8" />
       <module name="experimental-kryo-hook_test" target="1.8" />
       <module name="experimental_main" target="1.8" />

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -71,8 +71,6 @@
       <module name="example-code_integrationTest" target="1.8" />
       <module name="example-code_main" target="1.8" />
       <module name="example-code_test" target="1.8" />
-      <module name="experimental-blobinspector_main" target="1.8" />
-      <module name="experimental-blobinspector_test" target="1.8" />
       <module name="experimental-kryo-hook_main" target="1.8" />
       <module name="experimental-kryo-hook_test" target="1.8" />
       <module name="experimental_main" target="1.8" />

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -110,11 +110,7 @@ import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.node.services.persistence.NodePropertiesPersistentStore
 import net.corda.node.services.schema.HibernateObserver
 import net.corda.node.services.schema.NodeSchemaService
-import net.corda.node.services.statemachine.FlowLogicRefFactoryImpl
-import net.corda.node.services.statemachine.SingleThreadedStateMachineManager
-import net.corda.node.services.statemachine.StateMachineManager
-import net.corda.node.services.statemachine.appName
-import net.corda.node.services.statemachine.flowVersionAndInitiatingClass
+import net.corda.node.services.statemachine.*
 import net.corda.node.services.transactions.BFTNonValidatingNotaryService
 import net.corda.node.services.transactions.BFTSMaRt
 import net.corda.node.services.transactions.RaftNonValidatingNotaryService

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -330,6 +330,7 @@ abstract class AbstractNode(val configuration: NodeConfiguration,
                     drainingModePollPeriod = configuration.drainingModePollPeriod,
                     nodeProperties = nodeProperties)
 
+            runOnStop += { schedulerService.join() }
             (serverThread as? ExecutorService)?.let {
                 runOnStop += {
                     // We wait here, even though any in-flight messages should have been drained away because the

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -158,13 +158,13 @@ class NodeSchedulerService(private val clock: CordaClock,
 
     // We need the [StateMachineManager] to be constructed before this is called in case it schedules a flow.
     fun start() {
-        schedulerTimerExecutor.execute{runLoopFunction()}
+        schedulerTimerExecutor.execute{ runLoopFunction() }
     }
 
     override fun scheduleStateActivity(action: ScheduledStateRef) {
         log.trace { "Schedule $action" }
         // Only increase the number of unfinished schedules if the state didn't already exist on the queue
-        if( !schedulerRepo.merge(action) ){
+        if(!schedulerRepo.merge(action)){
             unfinishedSchedules.countUp()
         }
         contextTransaction.onCommit {
@@ -213,7 +213,7 @@ class NodeSchedulerService(private val clock: CordaClock,
                 }
             }
             else {
-                awaitWithDeadline(clock, Instant.now() + idleWaitSeconds , ourRescheduledFuture )
+                awaitWithDeadline(clock, clock.instant() + idleWaitSeconds , ourRescheduledFuture )
             }
 
         }

--- a/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/events/NodeSchedulerService.kt
@@ -210,7 +210,8 @@ class NodeSchedulerService(private val clock: CordaClock,
             val (scheduledState, ourRescheduledFuture) = mutex.locked {
                 rescheduled = GuavaSettableFuture.create()
                 //get the next scheduled action that isn't currently running
-                nextScheduledAction = schedulerRepo.getLatest(startingStateRefs.size + 1).firstOrNull { !startingStateRefs.contains(it.second) }?.second
+                val deduplicate = HashSet(startingStateRefs) // Take an immutable copy to remove races with afterDatabaseCommit.
+                nextScheduledAction = schedulerRepo.getLatest(deduplicate.size + 1).firstOrNull { !deduplicate.contains(it.second) }?.second
                 Pair(nextScheduledAction, rescheduled!!)
             }
             log.trace(schedulingAsNextFormat, scheduledState)

--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -232,7 +232,6 @@ class NodeSchedulerServiceTest : NodeSchedulerServiceTestBase() {
     fun `test activity due in the future and schedule another for same time`() {
         val eventA = schedule(mark + 1.days)
         val eventB = schedule(mark + 1.days)
-        //assertWaitingFor(eventA)
         testClock.advanceBy(1.days)
         assertStarted(eventA)
         assertStarted(eventB)


### PR DESCRIPTION
The NodeSchedulerService used to have a race condition where it could happen that two flows for the same state get started, leading to an attempted double spend.
This got cleared up by giving the scheduler an event loop on a worker thread, and doing all selection of states etc. on this single thread. The external calls now only trigger this thread to recheck what to execute rather than getting involved in any of the selection logic.
