### PR TITLE
[CORDA-1539] Minimum RSA key of 2048 bits on validatePublicKey

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1245,6 +1245,7 @@ public final class net.corda.core.crypto.Crypto extends java.lang.Object
   public static final java.security.PublicKey toSupportedPublicKey(java.security.PublicKey)
   @NotNull
   public static final java.security.PublicKey toSupportedPublicKey(org.bouncycastle.asn1.x509.SubjectPublicKeyInfo)
+  public static final boolean validatePublicKey(java.security.PublicKey)
   @NotNull
   public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
   @NotNull

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -897,6 +897,13 @@ object Crypto {
         return signatureScheme.schemeCodeName in signatureSchemeMap
     }
 
+    /**
+     * Check if a public key satisfies algorithm specs.
+     * For instance, an ECC key should lie on the curve and not being point-at-infinity.
+     */
+    @JvmStatic
+    fun validatePublicKey(key: PublicKey): Boolean = validatePublicKey(findSignatureScheme(key), key)
+
     // Validate a key, by checking its algorithmic params.
     private fun validateKey(signatureScheme: SignatureScheme, key: Key): Boolean {
         return when (key) {
@@ -910,7 +917,8 @@ object Crypto {
     private fun validatePublicKey(signatureScheme: SignatureScheme, key: PublicKey): Boolean {
         return when (key) {
             is BCECPublicKey, is EdDSAPublicKey -> publicKeyOnCurve(signatureScheme, key)
-            is BCRSAPublicKey, is BCSphincs256PublicKey -> true // TODO: Check if non-ECC keys satisfy params (i.e. approved/valid RSA modulus size).
+            is BCRSAPublicKey -> key.modulus.bitLength() >= 2048 // Although the recommended RSA key size is 3072, we accept any key >= 2048bits.
+            is BCSphincs256PublicKey -> true
             else -> throw IllegalArgumentException("Unsupported key type: ${key::class}")
         }
     }

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -96,6 +96,9 @@ Unreleased
 
 * Node can be shut down abruptly by ``shutdown`` function in `CordaRPCOps` or gracefully (draining flows first) through ``gracefulShutdown`` command from shell.
 
+* A method to check if public key satisfies algorithm specs has been made public, `Crypto.validatePublicKey(java.security.PublicKey)`.
+  For instance, this method will check if an ECC key lies on a valid curve or if an RSA key is >= 2048bits.
+
 .. _changelog_v3.1:
 
 Version 3.1


### PR DESCRIPTION
Introduce a public function `Crypto.validatePublicKey(java.security.PublicKey)` to be called whenever a key validation is required (i.e, for CSRs to meet the security requirements). In case of an RSA key input, the minimum allowed key size is 2048 bits.