### PR TITLE
CORDA-1266 When a cash output is identical only the fist output is saved.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -130,9 +130,10 @@ class NodeVaultService(
         fun makeUpdate(tx: WireTransaction): Vault.Update<ContractState>? {
             val ourNewStates = when (statesToRecord) {
                 StatesToRecord.NONE -> throw AssertionError("Should not reach here")
-                StatesToRecord.ONLY_RELEVANT -> tx.outputs.filter { isRelevant(it.data, keyManagementService.filterMyKeys(tx.outputs.flatMap { it.data.participants.map { it.owningKey } }).toSet()) }
-                StatesToRecord.ALL_VISIBLE -> tx.outputs
-            }.map { tx.outRef<ContractState>(it.data) }
+                StatesToRecord.ONLY_RELEVANT -> tx.outputs.withIndex().filter {
+                    isRelevant(it.value.data, keyManagementService.filterMyKeys(tx.outputs.flatMap { it.data.participants.map { it.owningKey } }).toSet()) }
+                StatesToRecord.ALL_VISIBLE -> tx.outputs.withIndex()
+            }.map { tx.outRef<ContractState>(it.index) }
 
             // Retrieve all unconsumed states for this transaction's inputs
             val consumedStates = loadStates(tx.inputs)


### PR DESCRIPTION
Example: issuance of 2 coins of £1 issued by the same notary.

Build #19919 shows the new test (https://github.com/corda/corda/pull/3244/commits/00e484c401d47e2650c7ee5f4eb05a165ea89529) is failing and the next build shows the test passing #19922 after the fix (https://github.com/corda/corda/pull/3244/commits/caabd45b5992d85aac5cc6fe3036055c511bb5ad):
https://ci-master.corda.r3cev.com/viewType.html?buildTypeId=Corda_PullRequests&branch_Corda_Build_PullRequests=3244&tab=buildTypeStatusDiv