### PR TITLE
Resolve compiler warnings for Kotlin >= 1.2.40.

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashExitFlow.kt
@@ -15,6 +15,9 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.contracts.asset.cash.selection.AbstractCashSelection
+import net.corda.finance.flows.AbstractCashFlow.Companion.FINALISING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.SIGNING_TX
 import net.corda.finance.issuedBy
 import java.util.*
 

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt
@@ -9,6 +9,9 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.flows.AbstractCashFlow.Companion.FINALISING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.SIGNING_TX
 import net.corda.finance.issuedBy
 import java.util.*
 

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -11,6 +11,10 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.ProgressTracker
 import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.flows.AbstractCashFlow.Companion.FINALISING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_ID
+import net.corda.finance.flows.AbstractCashFlow.Companion.GENERATING_TX
+import net.corda.finance.flows.AbstractCashFlow.Companion.SIGNING_TX
 import java.util.*
 
 /**


### PR DESCRIPTION
Add `import` statements to resolve compiler warnings like:
```
w: /work/corda/finance/src/main/kotlin/net/corda/finance/flows/CashIssueFlow.kt: (49, 39): Access to this type by short name is deprecated, and soon is going to be removed. Please, add explicit qualifier or import
```
