### PR TITLE
Reduce log spam on the ConnectionChange events

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionChange.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/ConnectionChange.kt
@@ -3,4 +3,8 @@ package net.corda.nodeapi.internal.protonwrapper.netty
 import java.net.InetSocketAddress
 import java.security.cert.X509Certificate
 
-data class ConnectionChange(val remoteAddress: InetSocketAddress, val remoteCert: X509Certificate?, val connected: Boolean, val badCert: Boolean)
+data class ConnectionChange(val remoteAddress: InetSocketAddress, val remoteCert: X509Certificate?, val connected: Boolean, val badCert: Boolean) {
+    override fun toString(): String {
+        return "ConnectionChange remoteAddress: $remoteAddress connected state: $connected cert subject: ${remoteCert?.subjectDN} cert ok: ${!badCert}"
+    }
+}


### PR DESCRIPTION
The original data class toString printed the full certificates into the logs which caused lots of spam. Now reduce to a few key details, especially as we have improved certificate logging on validation errors elsewhere.
