### PR TITLE
CORDA-1545 - Arrays of primitive byte arrays don't deserialize

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ArraySerializer.kt
@@ -31,13 +31,13 @@ open class ArraySerializer(override val type: Type, factory: SerializerFactory) 
     // id to generate it properly (it will always return [[[Ljava.lang.type -> type[][][]
     // for example).
     //
-    // We *need* to retain knowledge for AMQP deserialization weather that lowest primitive
+    // We *need* to retain knowledge for AMQP deserialization whether that lowest primitive
     // was boxed or unboxed so just infer it recursively.
     private fun calcTypeName(type: Type, debugOffset : Int = 0): String {
         logger.trace { "${"".padStart(debugOffset, ' ') }  calcTypeName - ${type.typeName}" }
 
         return if (type.componentType().isArray()) {
-            // Special case handler for primitive byte arrays. This is needed because we an silently
+            // Special case handler for primitive byte arrays. This is needed because we can silently
             // coerce a byte[] to our own binary type. Normally, if the component type was itself an
             // array we'd keep walking down the chain but for byte[] stop here and use binary instead
             val typeName =  if (SerializerFactory.isPrimitive(type.componentType())) {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactory.kt
@@ -4,6 +4,7 @@ import com.google.common.primitives.Primitives
 import com.google.common.reflect.TypeResolver
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.ClassWhitelist
+import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
 import net.corda.core.utilities.trace
 import net.corda.serialization.internal.carpenter.*
@@ -245,7 +246,7 @@ open class SerializerFactory(
     private fun processSchema(schemaAndDescriptor: FactorySchemaAndDescriptor, sentinel: Boolean = false) {
         val metaSchema = CarpenterMetaSchema.newInstance()
         for (typeNotation in schemaAndDescriptor.schemas.schema.types) {
-            logger.trace("descriptor=${schemaAndDescriptor.typeDescriptor}, typeNotation=${typeNotation.name}")
+            logger.debug { "descriptor=${schemaAndDescriptor.typeDescriptor}, typeNotation=${typeNotation.name}" }
             try {
                 val serialiser = processSchemaEntry(typeNotation)
                 // if we just successfully built a serializer for the type but the type fingerprint

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
@@ -1,9 +1,6 @@
 package net.corda.serialization.internal.amqp
 
-import net.corda.serialization.internal.amqp.testutils.TestSerializationOutput
-import net.corda.serialization.internal.amqp.testutils.deserialize
-import net.corda.serialization.internal.amqp.testutils.serialize
-import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
+import net.corda.serialization.internal.amqp.testutils.*
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -253,6 +250,14 @@ class DeserializeSimpleTypesTests {
         assertEquals(c.c[0], deserializedC.c[0])
         assertEquals(c.c[1], deserializedC.c[1])
         assertEquals(c.c[2], deserializedC.c[2])
+
+        val di = DeserializationInput(sf2)
+        val deserializedC2 = di.deserialize(serialisedC)
+
+        assertEquals(c.c.size, deserializedC2.c.size)
+        assertEquals(c.c[0], deserializedC2.c[0])
+        assertEquals(c.c[1], deserializedC2.c[1])
+        assertEquals(c.c[2], deserializedC2.c[2])
     }
 
     @Test
@@ -494,7 +499,33 @@ class DeserializeSimpleTypesTests {
         assertEquals(3, da2.a?.a?.b)
         assertEquals(2, da2.a?.a?.a?.b)
         assertEquals(1, da2.a?.a?.a?.a?.b)
-
     }
+
+    // Replicates CORDA-1545
+    @Test
+    fun arrayOfByteArray() {
+        class A(val a : Array<ByteArray>)
+
+        val ba1 = ByteArray(3)
+        ba1[0] = 0b0001; ba1[1] = 0b0101; ba1[2] = 0b1111
+
+        val ba2 = ByteArray(3)
+        ba2[0] = 0b1000; ba2[1] = 0b1100; ba2[2] = 0b1110
+
+        val a = A(arrayOf(ba1, ba2))
+
+        val serializedA = TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(a)
+
+        serializedA.schema.types.forEach {
+            println(it)
+        }
+
+        // This not throwing is the point of the test
+        DeserializationInput(sf1).deserialize(serializedA.obj)
+
+        // This not throwing is the point of the test
+        DeserializationInput(sf2).deserialize(serializedA.obj)
+    }
+
 }
 


### PR DESCRIPTION
At serialization time we incorrectly encode the type as byte[p][] instead
of binary[]

