### PR TITLE
Ent 1962 - better exception handling

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -175,7 +175,12 @@ internal class CordaRPCOpsImpl(
         if (isFlowsDrainingModeEnabled()) {
             throw RejectedCommandException("Node is draining before shutdown. Cannot start new flows through RPC.")
         }
-        return flowStarter.invokeFlowAsync(logicType, context(), *args).getOrThrow()
+        // It is possible that a flow is started during node shutdown process (after SMM but before RPC)
+        try {
+            return flowStarter.invokeFlowAsync(logicType, context(), *args).getOrThrow()
+        } catch (e: IllegalArgumentException) {
+            throw RejectedCommandException("Node is shutting down. Cannot start new flows throw RPC.")
+        }
     }
 
     override fun attachmentExists(id: SecureHash): Boolean {

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -179,7 +179,7 @@ internal class CordaRPCOpsImpl(
         try {
             return flowStarter.invokeFlowAsync(logicType, context(), *args).getOrThrow()
         } catch (e: IllegalArgumentException) {
-            throw RejectedCommandException("Node is shutting down. Cannot start new flows throw RPC.")
+            throw RejectedCommandException("Node is shutting down. Cannot start new flows through RPC.")
         }
     }
 


### PR DESCRIPTION
It is possible for a flow to be initiated by an RPC client while the node is shutting down, specifically after SMM but before messaging service. In this case, the SMM will refuse via an IllegalArgumentException which is poor user experience. Solution is to catch and rethrow as RejectedCommandException. 