### PR TITLE
CORDA-1564 Clean up old sessions when retrying flows.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -354,6 +354,10 @@ class SingleThreadedStateMachineManager(
             null
         }
         externalEventMutex.withLock {
+            // Remove any sessions the old flow has.
+            for (sessionId in getFlowSessionIds(currentState.checkpoint)) {
+                sessionToFlow.remove(sessionId)
+            }
             if (flow != null) addAndStartFlow(flowId, flow)
             // Deliver all the external events from the old flow instance.
             val unprocessedExternalEvents = mutableListOf<ExternalEvent>()


### PR DESCRIPTION
Just so we don't accidentally error the newly re-created flow with a message on a session that doesn't exist in the the newly restored flow.  The line after the change puts the sessions that existed at the last checkpoint back into that map, so cleaning them all up is fine.