### PR TITLE
DOCS - Remove references to webAddress since it's no longer a valid option

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -264,7 +264,6 @@ An example ``web-server.conf`` file is as follow:
         address : "my-corda-node:10003"
         adminAddress : "my-corda-node:10004"
     }
-    webAddress : "localhost:12347",
     rpcUsers : [{ username=user1, password=letmein, permissions=[ StartFlow.net.corda.protocols.CashProtocol ] }]
 
 Configuring a node where the Corda Comatability Zone's registration and Network Map services exist on different URLs
@@ -306,8 +305,6 @@ path to the node's base directory.
                 :sslKeystore: absolute path to the ssl key store, defaulted to ``certificatesDirectory / "sslkeystore.jks"``.
                 :trustStoreFile: absolute path to the trust store, defaulted to ``certificatesDirectory / "truststore.jks"``.
                 :trustStoreFile: absolute path to the trust store, defaulted to ``certificatesDirectory / "truststore.jks"``.
-
-:webAddress: The host and port on which the webserver will listen if it is started. This is not used by the node itself.
 
 :rpcUsers: A list of users who are authorised to access the RPC system. Each user in the list is a config object with the
         following fields:


### PR DESCRIPTION
If you configure a node with it set it won't start, so probably shouldn't have it in the documentation