### PR TITLE
Reduce AMQP bridge max retry time back to 1 minute

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt
@@ -51,7 +51,7 @@ class AMQPClient(val targets: List<NetworkHostAndPort>,
 
         val log = contextLogger()
         const val MIN_RETRY_INTERVAL = 1000L
-        const val MAX_RETRY_INTERVAL = 300000L
+        const val MAX_RETRY_INTERVAL = 60000L
         const val BACKOFF_MULTIPLIER = 2L
         const val NUM_CLIENT_THREADS = 2
     }


### PR DESCRIPTION
To reduce log spam I put in exponential backoff for the AMQP bridges. However, I set the max retry time at 5 minutes, which is too long for sensible testing.
