### PR TITLE
ENT-2027: The logic in my recent late start bridge PR was wrong. 

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/P2PMessagingClient.kt
@@ -322,6 +322,7 @@ class P2PMessagingClient(val config: NodeConfiguration,
         }
 
         val queues = session.addressQuery(SimpleString("$PEERS_PREFIX#")).queueNames
+        knownQueues.clear()
         for (queue in queues) {
             val queueQuery = session.queueQuery(queue)
             if (!config.lazyBridgeStart || queueQuery.messageCount > 0) {


### PR DESCRIPTION
The lazy init bridge logic was wrong in that if an external bridge is restarted the bridge creation state isn't reset.