### PR TITLE
Replaced all uses of assert with require

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/utils/FlattenedList.kt
@@ -106,7 +106,7 @@ class FlattenedList<A>(val sourceList: ObservableList<out ObservableValue<out A>
             }
         }
         endChange()
-        assert(sourceList.size == indexMap.size)
+        require(sourceList.size == indexMap.size)
     }
 
     override fun get(index: Int): A = sourceList[index].value

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -91,7 +91,7 @@ class RPCStabilityTests {
             // This is a less than check because threads from other tests may be shutting down while this test is running.
             // This is therefore a "best effort" check. When this test is run on its own this should be a strict equality.
             // In case of failure we output the threads along with their stacktraces to get an idea what was running at a time.
-            assert(threadsBefore.keys.size >= threadsAfter.keys.size, { "threadsBefore: $threadsBefore\nthreadsAfter: $threadsAfter" })
+            require(threadsBefore.keys.size >= threadsAfter.keys.size, { "threadsBefore: $threadsBefore\nthreadsAfter: $threadsAfter" })
         } finally {
             executor.shutdownNow()
         }

--- a/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/FlowCookbookJava.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static net.corda.core.contracts.ContractsDSL.requireThat;
 import static net.corda.core.crypto.Crypto.generateKeyPair;
 
@@ -662,7 +663,7 @@ public class FlowCookbookJava {
                     requireThat(require -> {
                         // Any additional checking we see fit...
                         DummyState outputState = (DummyState) stx.getTx().getOutputs().get(0).getData();
-                        assert (outputState.getMagicNumber() == 777);
+                        checkArgument(outputState.getMagicNumber() == 777);
                         return null;
                     });
                 }

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/FlowCookbook.kt
@@ -642,7 +642,7 @@ class ResponderFlow(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
             override fun checkTransaction(stx: SignedTransaction) = requireThat {
                 // Any additional checking we see fit...
                 val outputState = stx.tx.outputsOfType<DummyState>().single()
-                assert(outputState.magicNumber == 777)
+                require(outputState.magicNumber == 777)
             }
         }
 

--- a/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/StatusTransitions.kt
+++ b/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/StatusTransitions.kt
@@ -67,7 +67,7 @@ class StatusTransitions<out S, in R, T : StatusTrackingContractState<S, R>>(priv
             // for each combination of in x out which should normally be at most 1...
             inputStates.forEach { inp ->
                 outputStates.forEach { outp ->
-                    assert((inp != null) || (outp != null))
+                    require(inp != null || outp != null)
                     val options = matchingTransitions(inp?.status, outp?.status, cmd.value)
 
                     val signerGroup = options.groupBy { it.signer }.entries.singleOrNull()

--- a/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt
+++ b/experimental/src/main/kotlin/net/corda/finance/contracts/universal/UniversalContract.kt
@@ -204,7 +204,7 @@ class UniversalContract : Contract {
                 val rest = extractRemainder(arr, action)
 
                 // for now - let's assume not
-                assert(rest is Zero)
+                require(rest is Zero)
 
                 requireThat {
                     "action must have a time-window" using (tx.timeWindow != null)

--- a/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt
+++ b/experimental/src/main/kotlin/net/corda/finance/contracts/universal/Util.kt
@@ -125,7 +125,7 @@ fun actions(arrangement: Arrangement): Map<String, Action> = when (arrangement) 
 }
 
 fun debugCompare(left: String, right: String) {
-    assert(left == right)
+    require(left == right)
 }
 
 fun <T> debugCompare(perLeft: Perceivable<T>, perRight: Perceivable<T>) {
@@ -142,7 +142,7 @@ fun <T> debugCompare(perLeft: Perceivable<T>, perRight: Perceivable<T>) {
             if (perRight is PerceivableOperation) {
                 debugCompare(perLeft.left, perRight.left)
                 debugCompare(perLeft.right, perRight.right)
-                assert(perLeft.op == perRight.op)
+                require(perLeft.op == perRight.op)
                 return
             }
         }
@@ -152,7 +152,7 @@ fun <T> debugCompare(perLeft: Perceivable<T>, perRight: Perceivable<T>) {
                 debugCompare(perLeft.interest, perRight.interest)
                 debugCompare(perLeft.start, perRight.start)
                 debugCompare(perLeft.end, perRight.end)
-                assert(perLeft.dayCountConvention == perRight.dayCountConvention)
+                require(perLeft.dayCountConvention == perRight.dayCountConvention)
                 return
             }
         }
@@ -166,25 +166,25 @@ fun <T> debugCompare(perLeft: Perceivable<T>, perRight: Perceivable<T>) {
         }
     }
 
-    assert(false)
+    require(false)
 }
 
 fun debugCompare(parLeft: Party, parRight: Party) {
-    assert(parLeft == parRight)
+    require(parLeft == parRight)
 }
 
 fun debugCompare(left: Frequency, right: Frequency) {
-    assert(left == right)
+    require(left == right)
 }
 
 fun debugCompare(left: LocalDate, right: LocalDate) {
-    assert(left == right)
+    require(left == right)
 }
 
 fun debugCompare(parLeft: Set<Party>, parRight: Set<Party>) {
     if (parLeft == parRight) return
 
-    assert(parLeft == parRight)
+    require(parLeft == parRight)
 }
 
 fun debugCompare(arrLeft: Arrangement, arrRight: Arrangement) {
@@ -229,5 +229,5 @@ fun debugCompare(arrLeft: Arrangement, arrRight: Arrangement) {
         }
     }
 
-    assert(false)
+    require(false)
 }

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
@@ -74,7 +74,7 @@ class ImmutableClassSerializer<T : Any>(val klass: KClass<T>) : Serializer<T>() 
 
     init {
         // Verify that this class is immutable (all properties are final)
-        assert(props.none { it is KMutableProperty<*> })
+        require(props.none { it is KMutableProperty<*> })
     }
 
     // Just a utility to help us catch cases where nodes are running out of sync versions.
@@ -109,7 +109,7 @@ class ImmutableClassSerializer<T : Any>(val klass: KClass<T>) : Serializer<T>() 
     }
 
     override fun read(kryo: Kryo, input: Input, type: Class<T>): T {
-        assert(type.kotlin == klass)
+        require(type.kotlin == klass)
         val numFields = input.readVarInt(true)
         val fieldTypeHash = input.readInt()
 

--- a/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/RPCSecurityManagerTest.kt
@@ -121,7 +121,7 @@ class RPCSecurityManagerTest {
                 id = AuthServiceId("TEST"))
         val subject = userRealm.buildSubject("foo")
         for (action in allActions) {
-            assert(!subject.isPermitted(action)) {
+            require(!subject.isPermitted(action)) {
                 "Invalid subject should not be allowed to call $action"
             }
         }
@@ -143,24 +143,24 @@ class RPCSecurityManagerTest {
             for (request in permitted) {
                 val call = request.first()
                 val args = request.drop(1).toTypedArray()
-                assert(subject.isPermitted(request.first(), *args)) {
+                require(subject.isPermitted(request.first(), *args)) {
                     "User ${subject.principal} should be permitted $call with target '${request.toList()}'"
                 }
                 if (args.isEmpty()) {
-                    assert(subject.isPermitted(request.first(), "XXX")) {
+                    require(subject.isPermitted(request.first(), "XXX")) {
                         "User ${subject.principal} should be permitted $call with any target"
                     }
                 }
             }
 
             disabled.forEach {
-                assert(!subject.isPermitted(it)) {
+                require(!subject.isPermitted(it)) {
                     "Permissions $permissions should not allow to call $it"
                 }
             }
 
             disabled.filter { !permitted.contains(listOf(it, "foo")) }.forEach {
-                assert(!subject.isPermitted(it, "foo")) {
+                require(!subject.isPermitted(it, "foo")) {
                     "Permissions $permissions should not allow to call $it with argument 'foo'"
                 }
             }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt
@@ -139,7 +139,7 @@ class ClassCarpenterImpl(cl: ClassLoader, override val whitelist: ClassWhitelist
             }
         }
 
-        assert(schema.name in _loaded)
+        require(schema.name in _loaded)
 
         return _loaded[schema.name]!!
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/MetaCarpenter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/MetaCarpenter.kt
@@ -72,7 +72,7 @@ abstract class MetaCarpenterBase(val schemas: CarpenterMetaSchema, val cc: Class
         // carpented class existing and remove it from their dependency list, If that
         // list is now empty we have no impediment to carpenting that class up
         schemas.dependsOn.remove(newObject.name)?.forEach { dependent ->
-            assert(newObject.name in schemas.dependencies[dependent]!!.second)
+            require(newObject.name in schemas.dependencies[dependent]!!.second)
 
             schemas.dependencies[dependent]?.second?.remove(newObject.name)
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/SchemaFields.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/SchemaFields.kt
@@ -67,7 +67,7 @@ open class NonNullableField(field: Class<out Any?>) : ClassField(field) {
     }
 
     override fun nullTest(mv: MethodVisitor, slot: Int) {
-        assert(name != unsetName)
+        require(name != unsetName)
 
         if (!field.isPrimitive) {
             with(mv) {
@@ -103,7 +103,7 @@ class NullableField(field: Class<out Any?>) : ClassField(field) {
     }
 
     override fun nullTest(mv: MethodVisitor, slot: Int) {
-        assert(name != unsetName)
+        require(name != unsetName)
     }
 }
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt
@@ -170,8 +170,8 @@ class ClassCarpenterTest {
 
         val iface = cc.build(schema1)
 
-        assert(iface.isInterface)
-        assert(iface.constructors.isEmpty())
+        require(iface.isInterface)
+        require(iface.constructors.isEmpty())
         assertEquals(iface.declaredMethods.size, 1)
         assertEquals(iface.declaredMethods[0].name, "getA")
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/CompositeMemberCompositeSchemaToClassCarpenterTests.kt
@@ -30,15 +30,15 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val b = B(A(testA), testB)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(b))
 
-        assert(obj.obj is B)
+        require(obj.obj is B)
 
         val amqpObj = obj.obj as B
 
         assertEquals(testB, amqpObj.b)
         assertEquals(testA, amqpObj.a.a)
         assertEquals(2, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
-        assert(obj.envelope.schema.types[1] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[1] is CompositeType)
 
         var amqpSchemaA: CompositeType? = null
         var amqpSchemaB: CompositeType? = null
@@ -50,8 +50,8 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
             }
         }
 
-        assert(amqpSchemaA != null)
-        assert(amqpSchemaB != null)
+        require(amqpSchemaA != null)
+        require(amqpSchemaB != null)
 
         // Just ensure the amqp schema matches what we want before we go messing
         // around with the internals
@@ -68,9 +68,9 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val metaSchema = obj.envelope.schema.carpenterSchema(ClassLoader.getSystemClassLoader())
 
         // if we know all the classes there is nothing to really achieve here
-        assert(metaSchema.carpenterSchemas.isEmpty())
-        assert(metaSchema.dependsOn.isEmpty())
-        assert(metaSchema.dependencies.isEmpty())
+        require(metaSchema.carpenterSchemas.isEmpty())
+        require(metaSchema.dependsOn.isEmpty())
+        require(metaSchema.dependencies.isEmpty())
     }
 
     // you cannot have an element of a composite class we know about
@@ -92,7 +92,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(b))
         val amqpSchema = obj.envelope.schema.mangleNames(listOf(classTestName("A")))
 
-        assert(obj.obj is B)
+        require(obj.obj is B)
 
         amqpSchema.carpenterSchema(ClassLoader.getSystemClassLoader())
     }
@@ -111,7 +111,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val b = B(A(testA), testB)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(b))
 
-        assert(obj.obj is B)
+        require(obj.obj is B)
 
         val amqpSchema = obj.envelope.schema.mangleNames(listOf(classTestName("B")))
         val carpenterSchema = amqpSchema.carpenterSchema(ClassLoader.getSystemClassLoader())
@@ -122,7 +122,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
 
         metaCarpenter.build()
 
-        assert(mangleName(classTestName("B")) in metaCarpenter.objects)
+        require(mangleName(classTestName("B")) in metaCarpenter.objects)
     }
 
     @Test
@@ -139,7 +139,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val b = B(A(testA), testB)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(b))
 
-        assert(obj.obj is B)
+        require(obj.obj is B)
 
         val amqpSchema = obj.envelope.schema.mangleNames(listOf(classTestName("A"), classTestName("B")))
         val carpenterSchema = amqpSchema.carpenterSchema(ClassLoader.getSystemClassLoader())
@@ -149,9 +149,9 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         assertEquals(1, carpenterSchema.size)
         assertEquals(mangleName(classTestName("A")), carpenterSchema.carpenterSchemas.first().name)
         assertEquals(1, carpenterSchema.dependencies.size)
-        assert(mangleName(classTestName("B")) in carpenterSchema.dependencies)
+        require(mangleName(classTestName("B")) in carpenterSchema.dependencies)
         assertEquals(1, carpenterSchema.dependsOn.size)
-        assert(mangleName(classTestName("A")) in carpenterSchema.dependsOn)
+        require(mangleName(classTestName("A")) in carpenterSchema.dependsOn)
 
         val metaCarpenter = TestMetaCarpenter(carpenterSchema, ClassCarpenterImpl(whitelist = AllWhitelist))
 
@@ -172,8 +172,8 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
 
         // second manual iteration, will carpent B
         metaCarpenter.build()
-        assert(mangleName(classTestName("A")) in metaCarpenter.objects)
-        assert(mangleName(classTestName("B")) in metaCarpenter.objects)
+        require(mangleName(classTestName("A")) in metaCarpenter.objects)
+        require(mangleName(classTestName("B")) in metaCarpenter.objects)
 
         // and we must be finished
         assertTrue(carpenterSchema.carpenterSchemas.isEmpty())
@@ -198,7 +198,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val c = C(B(testA, testB), testC)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(c))
 
-        assert(obj.obj is C)
+        require(obj.obj is C)
 
         val amqpSchema = obj.envelope.schema.mangleNames(listOf(classTestName("A"), classTestName("B")))
 
@@ -224,7 +224,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val c = C(B(testA, testB), testC)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(c))
 
-        assert(obj.obj is C)
+        require(obj.obj is C)
 
         val amqpSchema = obj.envelope.schema.mangleNames(listOf(classTestName("A"), classTestName("B")))
 
@@ -250,7 +250,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val c = C(B(testA, testB), testC)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(c))
 
-        assert(obj.obj is C)
+        require(obj.obj is C)
 
         val carpenterSchema = obj.envelope.schema.mangleNames(listOf(classTestName("A"), classTestName("B")))
         TestMetaCarpenter(carpenterSchema.carpenterSchema(
@@ -273,7 +273,7 @@ class CompositeMembers : AmqpCarpenterBase(AllWhitelist) {
         val b = B(testA, testB)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(b))
 
-        assert(obj.obj is B)
+        require(obj.obj is B)
 
         val carpenterSchema = obj.envelope.schema.mangleNames(listOf(classTestName("A"), classTestName("B")))
         val metaCarpenter = TestMetaCarpenter(carpenterSchema.carpenterSchema())

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
@@ -21,13 +21,13 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
         val a = A(testA, testB)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(testA, amqpObj.a)
         assertEquals(testB, amqpObj.b)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
 
@@ -65,13 +65,13 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
         val a = A(testA, testB)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(testA, amqpObj.a)
         assertEquals(testB, amqpObj.b)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/SingleMemberCompositeSchemaToClassCarpenterTests.kt
@@ -18,12 +18,12 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
         val a = A(test)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(test, amqpObj.a)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
 
@@ -54,12 +54,12 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
 
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(test, amqpObj.a)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
         val carpenterSchema = CarpenterMetaSchema.newInstance()
@@ -84,12 +84,12 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
         val a = A(test)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(test, amqpObj.a)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
 
@@ -119,12 +119,12 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
         val a = A(test)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(test, amqpObj.a)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
 
@@ -154,12 +154,12 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
         val a = A(test)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(test, amqpObj.a)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
 
@@ -189,12 +189,12 @@ class SingleMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWh
         val a = A(test)
         val obj = DeserializationInput(factory).deserializeAndReturnEnvelope(serialise(a))
 
-        assert(obj.obj is A)
+        require(obj.obj is A)
         val amqpObj = obj.obj as A
 
         assertEquals(test, amqpObj.a)
         assertEquals(1, obj.envelope.schema.types.size)
-        assert(obj.envelope.schema.types[0] is CompositeType)
+        require(obj.envelope.schema.types[0] is CompositeType)
 
         val amqpSchema = obj.envelope.schema.types[0] as CompositeType
 


### PR DESCRIPTION
JVM assertions have to be enabled with the -ea flag so it's possible for these checks to be ignored.

