### PR TITLE
CORDA-1499 Fix a typo in node_attchments_contracts table name. -> V3

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -30,6 +30,8 @@ Unreleased
   (even if JPA annotation nullable=false was absent).
   In case your Cordapps use this entity class to persist data in own custom tables as non Primary Key columns refer to :doc:`upgrade-notes` for upgrade instructions.
 
+* Table name with a typo changed from ``NODE_ATTCHMENTS_CONTRACTS`` to ``NODE_ATTACHMENTS_CONTRACTS``.
+
 .. _changelog_v3.1:
 
 Version 3.1

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -67,6 +67,12 @@ UNRELEASED
   No action is needed for default node tables as ``PersistentStateRef`` is used as Primary Key only and the backing columns are automatically not nullable
   or custom Cordapp entities using ``PersistentStateRef`` as Primary Key.
 
+* H2 database upgrade - the table with a typo has been change, for each database instance and schema run the following SQL statement:
+
+    ALTER TABLE [schema].NODE_ATTCHMENTS_CONTRACTS RENAME TO NODE_ATTACHMENTS_CONTRACTS;
+
+  Schema is optional, run SQL when the node is not running.
+
 v3.0 to v3.1
 ------------
 

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -93,7 +93,7 @@ class NodeAttachmentService(
 
             @ElementCollection
             @Column(name = "contract_class_name", nullable = false)
-            @CollectionTable(name = "node_attchments_contracts", joinColumns = arrayOf(
+            @CollectionTable(name = "${NODE_DATABASE_PREFIX}attachments_contracts", joinColumns = arrayOf(
                     JoinColumn(name = "att_id", referencedColumnName = "att_id")),
                     foreignKey = ForeignKey(name = "FK__ctr_class__attachments"))
             var contractClassNames: List<ContractClassName>? = null


### PR DESCRIPTION
Fix a typo in node_attchments_contracts table name.

(cherry picked from commit fc54263)
