### PR TITLE
ENT-1950: handle unknown peers when replying after a flow is processed

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/exceptions/UnknownPeerException.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/exceptions/UnknownPeerException.kt
@@ -1,0 +1,7 @@
+package net.corda.node.internal.exceptions
+
+import net.corda.core.CordaRuntimeException
+
+class UnknownPeerException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause) {
+    constructor(msg: String) : this(msg, null)
+}

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Action.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.statemachine
 
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.StateMachineRunId
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowAsyncOperation
 import net.corda.node.services.messaging.DeduplicationHandler
@@ -31,7 +32,7 @@ sealed class Action {
      * Send a session message to a [peerParty] with which we have an established session.
      */
     data class SendExisting(
-            val peerParty: Party,
+            val peerPartyName: CordaX500Name,
             val message: ExistingSessionMessage,
             val deduplicationId: SenderDeduplicationId
     ) : Action()

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -139,7 +139,7 @@ class ActionExecutorImpl(
                 val sinkSessionId = sessionState.initiatedState.peerSinkSessionId
                 val existingMessage = ExistingSessionMessage(sinkSessionId, errorMessage)
                 val deduplicationId = DeduplicationId.createForError(errorMessage.errorId, sinkSessionId)
-                flowMessaging.sendSessionMessage(sessionState.peerParty, existingMessage, SenderDeduplicationId(deduplicationId, action.senderUUID))
+                flowMessaging.sendSessionMessage(sessionState.peerPartyName, existingMessage, SenderDeduplicationId(deduplicationId, action.senderUUID))
             }
         }
     }
@@ -169,7 +169,7 @@ class ActionExecutorImpl(
 
     @Suspendable
     private fun executeSendExisting(action: Action.SendExisting) {
-        flowMessaging.sendSessionMessage(action.peerParty, action.message, action.deduplicationId)
+        flowMessaging.sendSessionMessage(action.peerPartyName, action.message, action.deduplicationId)
     }
 
     @Suspendable

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSessionImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowSessionImpl.kt
@@ -19,14 +19,12 @@ import net.corda.node.internal.exceptions.UnknownPeerException
 class FlowSessionImpl(
         val partyName: CordaX500Name,
         val sourceSessionId: SessionId,
-        var resolvedParty: Party? = null
+        private var resolvedParty: Party? = null
 ) : FlowSession() {
 
     constructor(party: Party, sessionId: SessionId) : this(party.name, sessionId, party)
 
     override val counterparty: Party get() = resolveLazy()
-
-//    private var resolvedParty: Party? = null
 
     private fun resolveLazy(): Party {
         if (resolvedParty == null) {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -144,7 +144,7 @@ class SingleThreadedStateMachineManager(
                 }
             }
 
-            serviceHub.networkMapCache.changed.subscribe({
+            serviceHub.networkMapCache.changed.subscribe {
                 mutex.locked {
                     for ((_, flow) in flows) {
                         if (flowHospital.flowAffected(flow.fiber, UnknownPeerException::class.javaObjectType)) {
@@ -154,7 +154,7 @@ class SingleThreadedStateMachineManager(
                         }
                     }
                 }
-            })
+            }
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -127,8 +127,10 @@ class StaffedFlowHospital {
     fun <T: Throwable> flowAffected(flowFiber: FlowFiber, errorType: Class<T>): Boolean {
         mutex.locked {
             patients[flowFiber.id]?.let {
-                val record = it.records.last() as MedicalRecord.KeptInForObservation
-                return record.errors.last().javaClass == errorType
+                val record = it.records.last()
+                if (record is MedicalRecord.KeptInForObservation) {
+                    return record.errors.last().javaClass == errorType
+                }
             }
         }
         return false

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -4,6 +4,7 @@ import net.corda.core.context.InvocationContext
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowInfo
 import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowIORequest
 import net.corda.core.serialization.SerializedBytes
@@ -121,7 +122,7 @@ sealed class SessionState {
      * @property errors if not empty the session is in an errored state.
      */
     data class Initiated(
-            val peerParty: Party,
+            val peerPartyName: CordaX500Name,
             val peerFlowInfo: FlowInfo,
             val receivedMessages: List<DataSessionMessage>,
             val initiatedState: InitiatedSessionState,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/DeliverSessionMessageTransition.kt
@@ -70,7 +70,7 @@ class DeliverSessionMessageTransition(
             is SessionState.Initiating -> {
                 // Create the new session state that is now Initiated.
                 val initiatedSession = SessionState.Initiated(
-                        peerParty = event.sender,
+                        peerPartyName = event.sender.name,
                         peerFlowInfo = message.initiatedFlowInfo,
                         receivedMessages = emptyList(),
                         initiatedState = InitiatedSessionState.Live(message.initiatedSessionId),
@@ -83,7 +83,7 @@ class DeliverSessionMessageTransition(
                 // Send messages that were buffered pending confirmation of session.
                 val sendActions = sessionState.bufferedMessages.map { (deduplicationId, bufferedMessage) ->
                     val existingMessage = ExistingSessionMessage(message.initiatedSessionId, bufferedMessage)
-                    Action.SendExisting(initiatedSession.peerParty, existingMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID))
+                    Action.SendExisting(initiatedSession.peerPartyName, existingMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID))
                 }
                 actions.addAll(sendActions)
                 currentState = currentState.copy(checkpoint = newCheckpoint)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/StartedFlowTransition.kt
@@ -288,7 +288,7 @@ class StartedFlowTransition(
                             is InitiatedSessionState.Live -> {
                                 val sinkSessionId = existingSessionState.initiatedState.peerSinkSessionId
                                 val existingMessage = ExistingSessionMessage(sinkSessionId, sessionMessage)
-                                actions.add(Action.SendExisting(existingSessionState.peerParty, existingMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID)))
+                                actions.add(Action.SendExisting(existingSessionState.peerPartyName, existingMessage, SenderDeduplicationId(deduplicationId, startingState.senderUUID)))
                                 Unit
                             }
                             InitiatedSessionState.Ended -> {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/TopLevelTransition.kt
@@ -223,7 +223,7 @@ class TopLevelTransition(
             if (state is SessionState.Initiated && state.initiatedState is InitiatedSessionState.Live) {
                 val message = ExistingSessionMessage(state.initiatedState.peerSinkSessionId, EndSessionMessage)
                 val deduplicationId = DeduplicationId.createForNormal(currentState.checkpoint, index, state)
-                Action.SendExisting(state.peerParty, message, SenderDeduplicationId(deduplicationId, currentState.senderUUID))
+                Action.SendExisting(state.peerPartyName, message, SenderDeduplicationId(deduplicationId, currentState.senderUUID))
             } else {
                 null
             }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/UnstartedFlowTransition.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/transitions/UnstartedFlowTransition.kt
@@ -44,7 +44,7 @@ class UnstartedFlowTransition(
     private fun TransitionBuilder.initialiseInitiatedSession(flowStart: FlowStart.Initiated) {
         val initiatingMessage = flowStart.initiatingMessage
         val initiatedState = SessionState.Initiated(
-                peerParty = flowStart.peerSession.counterparty,
+                peerPartyName = flowStart.peerSession.partyName,
                 initiatedState = InitiatedSessionState.Live(initiatingMessage.initiatorSessionId),
                 peerFlowInfo = FlowInfo(
                         flowVersion = flowStart.senderCoreFlowVersion ?: initiatingMessage.flowVersion,
@@ -67,7 +67,7 @@ class UnstartedFlowTransition(
         )
         actions.add(
                 Action.SendExisting(
-                        flowStart.peerSession.counterparty,
+                        flowStart.peerSession.partyName,
                         sessionMessage,
                         SenderDeduplicationId(DeduplicationId.createForNormal(currentState.checkpoint, 0, initiatedState), currentState.senderUUID)
                 )


### PR DESCRIPTION
The flow hospital is used to keep track of flows that failed due to lack of peer info. SMM subscribes to NM cache and retries these flows on next update.