### PR TITLE
VaultTrack returns undesired states #3276

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,9 @@ release, see :doc:`upgrade-notes`.
 Unreleased
 ==========
 
+* Fixed an issue where ``trackBy`` was returning ``ContractStates`` from a transaction that were not being tracked. The
+  unrelated ``ContractStates`` will now be filtered out from the returned ``Vault.Update``.
+
 * Introducing the flow hospital - a component of the node that manages flows that have errored and whether they should
   be retried from their previous checkpoints or have their errors propagate. Currently it will respond to any error that
   occurs during the resolution of a received transaction as part of ``FinalityFlow``. In such a scenerio the receiving

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -497,13 +497,12 @@ class NodeVaultService(
         }
     }
 
-    private fun <T : ContractState> filterContractStates(update: Vault.Update<T>, contractStateType: Class<out T>): Vault.Update<T> {
-        return update.copy(consumed = filterByContractState(contractStateType, update.consumed),
-                produced = filterByContractState(contractStateType, update.produced))
-    }
+    private fun <T : ContractState> filterContractStates(update: Vault.Update<T>, contractStateType: Class<out T>) =
+            update.copy(consumed = filterByContractState(contractStateType, update.consumed),
+                    produced = filterByContractState(contractStateType, update.produced))
 
-    private fun <T : ContractState> filterByContractState(contractStateType: Class<out T>, stateAndRefs: Set<StateAndRef<T>>)
-            = stateAndRefs.filter { contractStateType.isAssignableFrom(it.state.data.javaClass) }.toSet()
+    private fun <T : ContractState> filterByContractState(contractStateType: Class<out T>, stateAndRefs: Set<StateAndRef<T>>) =
+            stateAndRefs.filter { contractStateType.isAssignableFrom(it.state.data.javaClass) }.toSet()
 
     private fun getSession() = database.currentOrNew().session
     /**

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -2296,12 +2296,54 @@ class VaultQueryTests : VaultQueryTestsBase(), VaultQueryParties by delegate {
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
                         require(consumed.isEmpty()) {}
-                        require(produced.size == 3) {}
-                    },
+                        require(produced.size == 10) {}
+                        require(produced.filter { DummyDealContract.State::class.java.isAssignableFrom(it.state.data::class.java) }.size == 10) {}
+                    }
+            )
+        }
+    }
+
+    @Test
+    fun `track by of super class only returns updates of sub classes of tracked type`() {
+        val updates = database.transaction {
+            val (snapshot, updates) = vaultService.trackBy<DealState>()
+            assertThat(snapshot.states).hasSize(0)
+            val states = vaultFiller.fillWithSomeTestLinearAndDealStates(10).states
+            this.session.flush()
+            vaultFiller.consumeLinearStates(states.toList())
+            updates
+        }
+
+        updates.expectEvents {
+            sequence(
                     expect { (consumed, produced, flowId) ->
                         require(flowId == null) {}
                         require(consumed.isEmpty()) {}
-                        require(produced.size == 1) {}
+                        require(produced.size == 10) {}
+                        require(produced.filter { DealState::class.java.isAssignableFrom(it.state.data::class.java) }.size == 10) {}
+                    }
+            )
+        }
+    }
+
+    @Test
+    fun `track by of contract state interface returns updates of all states`() {
+        val updates = database.transaction {
+            val (snapshot, updates) = vaultService.trackBy<ContractState>()
+            assertThat(snapshot.states).hasSize(0)
+            val states = vaultFiller.fillWithSomeTestLinearAndDealStates(10).states
+            this.session.flush()
+            vaultFiller.consumeLinearStates(states.toList())
+            updates
+        }
+
+        updates.expectEvents {
+            sequence(
+                    expect { (consumed, produced, flowId) ->
+                        require(flowId == null) {}
+                        require(consumed.isEmpty()) {}
+                        require(produced.size == 20) {}
+                        require(produced.filter { ContractState::class.java.isAssignableFrom(it.state.data::class.java) }.size == 20) {}
                     }
             )
         }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
@@ -203,42 +203,6 @@ class VaultFiller @JvmOverloads constructor(
         return Vault(states)
     }
 
-    @JvmOverloads
-    fun fillWithSomeTestLinearStatesAndCash(numberToCreate: Int,
-                                     externalId: String? = null,
-                                     participants: List<AbstractParty> = emptyList(),
-                                     linearString: String = "",
-                                     linearNumber: Long = 0L,
-                                     linearBoolean: Boolean = false,
-                                     linearTimestamp: Instant = now()): Vault<LinearState> {
-        val myKey: PublicKey = services.myInfo.chooseIdentity().owningKey
-        val me = AnonymousParty(myKey)
-        val issuerKey = defaultNotary.keyPair
-        val signatureMetadata = SignatureMetadata(services.myInfo.platformVersion, Crypto.findSignatureScheme(issuerKey.public).schemeNumberID)
-        val transactions: List<SignedTransaction> = (1..numberToCreate).map {
-            // Issue a Linear state
-            val dummyIssue = TransactionBuilder(notary = defaultNotary.party).apply {
-                addOutputState(DummyLinearContract.State(
-                        linearId = UniqueIdentifier(externalId),
-                        participants = participants.plus(me),
-                        linearString = linearString,
-                        linearNumber = linearNumber,
-                        linearBoolean = linearBoolean,
-                        linearTimestamp = linearTimestamp), DUMMY_LINEAR_CONTRACT_PROGRAM_ID)
-                addCommand(dummyCommand())
-            }
-            return@map services.signInitialTransaction(dummyIssue).withAdditionalSignature(issuerKey, signatureMetadata)
-        }
-        services.recordTransactions(transactions)
-        // Get all the StateAndRefs of all the generated transactions.
-        val states = transactions.flatMap { stx ->
-            stx.tx.outputs.indices.map { i -> stx.tx.outRef<LinearState>(i) }
-        }
-
-        return Vault(states)
-    }
-
-
     /**
      * Puts together an issuance transaction for the specified amount that starts out being owned by the given pubkey.
      */

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
@@ -128,6 +128,42 @@ class VaultFiller @JvmOverloads constructor(
     }
 
     @JvmOverloads
+    fun fillWithSomeTestLinearAndDealStates(numberToCreate: Int,
+                                     externalId: String? = null,
+                                     participants: List<AbstractParty> = emptyList(),
+                                     linearString: String = "",
+                                     linearNumber: Long = 0L,
+                                     linearBoolean: Boolean = false,
+                                     linearTimestamp: Instant = now()): Vault<LinearState> {
+        val myKey: PublicKey = services.myInfo.chooseIdentity().owningKey
+        val me = AnonymousParty(myKey)
+        val issuerKey = defaultNotary.keyPair
+        val signatureMetadata = SignatureMetadata(services.myInfo.platformVersion, Crypto.findSignatureScheme(issuerKey.public).schemeNumberID)
+        val transactions: List<SignedTransaction> = (1..numberToCreate).map {
+            val dummyIssue = TransactionBuilder(notary = defaultNotary.party).apply {
+                // Issue a Linear state
+                addOutputState(DummyLinearContract.State(
+                        linearId = UniqueIdentifier(externalId),
+                        participants = participants.plus(me),
+                        linearString = linearString,
+                        linearNumber = linearNumber,
+                        linearBoolean = linearBoolean,
+                        linearTimestamp = linearTimestamp), DUMMY_LINEAR_CONTRACT_PROGRAM_ID)
+                // Issue a Deal state
+                addOutputState(DummyDealContract.State(ref = "test ref", participants = participants.plus(me)), DUMMY_DEAL_PROGRAM_ID)
+                addCommand(dummyCommand())
+            }
+            return@map services.signInitialTransaction(dummyIssue).withAdditionalSignature(issuerKey, signatureMetadata)
+        }
+        services.recordTransactions(transactions)
+        // Get all the StateAndRefs of all the generated transactions.
+        val states = transactions.flatMap { stx ->
+            stx.tx.outputs.indices.map { i -> stx.tx.outRef<LinearState>(i) }
+        }
+        return Vault(states)
+    }
+
+    @JvmOverloads
     fun fillWithSomeTestCash(howMuch: Amount<Currency>,
                              issuerServices: ServiceHub,
                              thisManyStates: Int,
@@ -162,6 +198,41 @@ class VaultFiller @JvmOverloads constructor(
         // Get all the StateRefs of all the generated transactions.
         val states = transactions.flatMap { stx ->
             stx.tx.outputs.indices.map { i -> stx.tx.outRef<Cash.State>(i) }
+        }
+
+        return Vault(states)
+    }
+
+    @JvmOverloads
+    fun fillWithSomeTestLinearStatesAndCash(numberToCreate: Int,
+                                     externalId: String? = null,
+                                     participants: List<AbstractParty> = emptyList(),
+                                     linearString: String = "",
+                                     linearNumber: Long = 0L,
+                                     linearBoolean: Boolean = false,
+                                     linearTimestamp: Instant = now()): Vault<LinearState> {
+        val myKey: PublicKey = services.myInfo.chooseIdentity().owningKey
+        val me = AnonymousParty(myKey)
+        val issuerKey = defaultNotary.keyPair
+        val signatureMetadata = SignatureMetadata(services.myInfo.platformVersion, Crypto.findSignatureScheme(issuerKey.public).schemeNumberID)
+        val transactions: List<SignedTransaction> = (1..numberToCreate).map {
+            // Issue a Linear state
+            val dummyIssue = TransactionBuilder(notary = defaultNotary.party).apply {
+                addOutputState(DummyLinearContract.State(
+                        linearId = UniqueIdentifier(externalId),
+                        participants = participants.plus(me),
+                        linearString = linearString,
+                        linearNumber = linearNumber,
+                        linearBoolean = linearBoolean,
+                        linearTimestamp = linearTimestamp), DUMMY_LINEAR_CONTRACT_PROGRAM_ID)
+                addCommand(dummyCommand())
+            }
+            return@map services.signInitialTransaction(dummyIssue).withAdditionalSignature(issuerKey, signatureMetadata)
+        }
+        services.recordTransactions(transactions)
+        // Get all the StateAndRefs of all the generated transactions.
+        val states = transactions.flatMap { stx ->
+            stx.tx.outputs.indices.map { i -> stx.tx.outRef<LinearState>(i) }
         }
 
         return Vault(states)


### PR DESCRIPTION
Filter contract states returned from `NodeVaultService._trackBy` to only include the tracked state type in the `produced` and `consumed` sets.
