### PR TITLE
CORDA-1494: Remove isTimed check from flow hospital when handling tim…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -204,23 +204,13 @@ class StaffedFlowHospital {
     object DoctorTimeout : Staff {
         override fun consult(flowFiber: FlowFiber, currentState: StateMachineState, newError: Throwable, history: MedicalHistory): Diagnosis {
             if (newError is FlowTimeoutException) {
-                if (isTimedFlow(flowFiber)) {
-                    if (history.notDischargedForTheSameThingMoreThan(newError.maxRetries, this)) {
-                        return Diagnosis.DISCHARGE
-                    } else {
-                        log.warn("\"Maximum number of retries reached for timed flow ${flowFiber.javaClass}")
-                    }
+                if (history.notDischargedForTheSameThingMoreThan(newError.maxRetries, this)) {
+                    return Diagnosis.DISCHARGE
                 } else {
-                    log.warn("\"Unable to restart flow: ${flowFiber.javaClass}, it is not timed and does not contain any timed sub-flows.")
+                    log.warn("\"Maximum number of retries reached for timed flow ${flowFiber.javaClass}")
                 }
             }
             return Diagnosis.NOT_MY_SPECIALTY
-        }
-
-        private fun isTimedFlow(flowFiber: FlowFiber): Boolean {
-            return flowFiber.snapshot().checkpoint.subFlowStack.any {
-                TimedFlow::class.java.isAssignableFrom(it.flowClass)
-            }
         }
     }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -2,7 +2,6 @@ package net.corda.node.services.statemachine
 
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.ThreadBox
-import net.corda.core.internal.TimedFlow
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.messaging.DataFeed
 import net.corda.core.utilities.contextLogger

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -27,6 +27,7 @@ import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.SerializationWhitelist
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.hours
 import net.corda.core.utilities.seconds
 import net.corda.node.VersionInfo
 import net.corda.node.internal.AbstractNode
@@ -481,7 +482,8 @@ private fun mockNodeConfiguration(): NodeConfiguration {
         doReturn(null).whenever(it).compatibilityZoneURL
         doReturn(null).whenever(it).networkServices
         doReturn(VerifierType.InMemory).whenever(it).verifierType
-        doReturn(P2PMessagingRetryConfiguration(5.seconds, 3, backoffBase = 1.0)).whenever(it).p2pMessagingRetry
+        // Set to be long enough so retries don't trigger unless we override it
+        doReturn(P2PMessagingRetryConfiguration(1.hours, 3, backoffBase = 2.0)).whenever(it).p2pMessagingRetry
         doReturn(5.seconds.toMillis()).whenever(it).additionalNodeInfoPollingFrequencyMsec
         doReturn(null).whenever(it).devModeOptions
     }


### PR DESCRIPTION
…eout exceptions - the timeout might expire just after the TimeFlow has finished and the staff member would throw an exception.

Increase the default flow timeout value in mock network so retries don't happen – this has cause test flakiness.
