### PR TITLE
CORDA-1609 - Don't use reserved keyword as method name

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -106,7 +106,7 @@ class RPCStabilityTests {
                 Try.on {
                     startRpcClient<RPCOps>(
                             server.get().broker.hostAndPort!!,
-                            configuration = CordaRPCClientConfigurationImpl.default.copy(minimumServerProtocolVersion = 1)
+                            configuration = CordaRPCClientConfigurationImpl.DEFAULT.copy(minimumServerProtocolVersion = 1)
                     ).get()
                 }
             }
@@ -241,7 +241,7 @@ class RPCStabilityTests {
             val serverPort = startRpcServer<ReconnectOps>(ops = ops).getOrThrow().broker.hostAndPort!!
             serverFollower.unfollow()
             // Set retry interval to 1s to reduce test duration
-            val clientConfiguration = CordaRPCClientConfigurationImpl.default.copy(connectionRetryInterval = 1.seconds)
+            val clientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT.copy(connectionRetryInterval = 1.seconds)
             val clientFollower = shutdownManager.follower()
             val client = startRpcClient<ReconnectOps>(serverPort, configuration = clientConfiguration).getOrThrow()
             clientFollower.unfollow()
@@ -266,7 +266,7 @@ class RPCStabilityTests {
             val serverPort = startRpcServer<ReconnectOps>(ops = ops).getOrThrow().broker.hostAndPort!!
             serverFollower.unfollow()
             // Set retry interval to 1s to reduce test duration
-            val clientConfiguration = CordaRPCClientConfigurationImpl.default.copy(connectionRetryInterval = 1.seconds, maxReconnectAttempts = 5)
+            val clientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT.copy(connectionRetryInterval = 1.seconds, maxReconnectAttempts = 5)
             val clientFollower = shutdownManager.follower()
             val client = startRpcClient<ReconnectOps>(serverPort, configuration = clientConfiguration).getOrThrow()
             clientFollower.unfollow()
@@ -298,7 +298,7 @@ class RPCStabilityTests {
             val serverPort = startRpcServer<NoOps>(ops = ops).getOrThrow().broker.hostAndPort!!
             serverFollower.unfollow()
 
-            val clientConfiguration = CordaRPCClientConfigurationImpl.default.copy(connectionRetryInterval = 500.millis, maxReconnectAttempts = 1)
+            val clientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT.copy(connectionRetryInterval = 500.millis, maxReconnectAttempts = 1)
             val clientFollower = shutdownManager.follower()
             val client = startRpcClient<NoOps>(serverPort, configuration = clientConfiguration).getOrThrow()
             clientFollower.unfollow()

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -27,42 +27,45 @@ class CordaRPCConnection internal constructor(connection: RPCConnection<CordaRPC
 interface CordaRPCClientConfiguration {
 
     /** The minimum protocol version required from the server */
-    val minimumServerProtocolVersion: Int get() = default().minimumServerProtocolVersion
+    val minimumServerProtocolVersion: Int get() = getDefault().minimumServerProtocolVersion
     /**
      * If set to true the client will track RPC call sites. If an error occurs subsequently during the RPC or in a
      * returned Observable stream the stack trace of the originating RPC will be shown as well. Note that
      * constructing call stacks is a moderately expensive operation.
      */
-    val trackRpcCallSites: Boolean get() = default().trackRpcCallSites
+    val trackRpcCallSites: Boolean get() = getDefault().trackRpcCallSites
     /**
      * The interval of unused observable reaping. Leaked Observables (unused ones) are detected using weak references
      * and are cleaned up in batches in this interval. If set too large it will waste server side resources for this
      * duration. If set too low it wastes client side cycles.
      */
-    val reapInterval: Duration get() = default().reapInterval
+    val reapInterval: Duration get() = getDefault().reapInterval
     /** The number of threads to use for observations (for executing [Observable.onNext]) */
-    val observationExecutorPoolSize: Int get() = default().observationExecutorPoolSize
+    val observationExecutorPoolSize: Int get() = getDefault().observationExecutorPoolSize
     /**
      * Determines the concurrency level of the Observable Cache. This is exposed because it implicitly determines
      * the limit on the number of leaked observables reaped because of garbage collection per reaping.
      * See the implementation of [com.google.common.cache.LocalCache] for details.
      */
-    val cacheConcurrencyLevel: Int get() = default().cacheConcurrencyLevel
+    val cacheConcurrencyLevel: Int get() = getDefault().cacheConcurrencyLevel
     /** The retry interval of artemis connections in milliseconds */
-    val connectionRetryInterval: Duration get() = default().connectionRetryInterval
+    val connectionRetryInterval: Duration get() = getDefault().connectionRetryInterval
     /** The retry interval multiplier for exponential backoff */
-    val connectionRetryIntervalMultiplier: Double get() = default().connectionRetryIntervalMultiplier
+    val connectionRetryIntervalMultiplier: Double get() = getDefault().connectionRetryIntervalMultiplier
     /** Maximum retry interval */
-    val connectionMaxRetryInterval: Duration get() = default().connectionMaxRetryInterval
+    val connectionMaxRetryInterval: Duration get() = getDefault().connectionMaxRetryInterval
     /** Maximum reconnect attempts on failover */
-    val maxReconnectAttempts: Int get() = default().maxReconnectAttempts
+    val maxReconnectAttempts: Int get() = getDefault().maxReconnectAttempts
     /** Maximum file size */
-    val maxFileSize: Int get() = default().maxFileSize
+    val maxFileSize: Int get() = getDefault().maxFileSize
     /** The cache expiry of a deduplication watermark per client. */
-    val deduplicationCacheExpiry: Duration get() = default().deduplicationCacheExpiry
+    val deduplicationCacheExpiry: Duration get() = getDefault().deduplicationCacheExpiry
 
     companion object {
-        fun default(): CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.default
+        /**
+         * Get the default configuration used for RPC clients.
+         */
+        fun getDefault(): CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT
     }
 }
 
@@ -105,7 +108,7 @@ interface CordaRPCClientConfiguration {
  */
 class CordaRPCClient private constructor(
         private val hostAndPort: NetworkHostAndPort,
-        private val configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+        private val configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault(),
         private val sslConfiguration: ClientRpcSslOptions? = null,
         private val nodeSslConfiguration: SSLConfiguration? = null,
         private val classLoader: ClassLoader? = null,
@@ -114,7 +117,7 @@ class CordaRPCClient private constructor(
 ) {
     @JvmOverloads
     constructor(hostAndPort: NetworkHostAndPort,
-                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default())
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault())
             : this(hostAndPort, configuration, null)
 
     /**
@@ -124,13 +127,13 @@ class CordaRPCClient private constructor(
      * @param configuration An optional configuration used to tweak client behaviour.
      */
     @JvmOverloads
-    constructor(haAddressPool: List<NetworkHostAndPort>, configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default()) : this(haAddressPool.first(), configuration, null, null, null, haAddressPool)
+    constructor(haAddressPool: List<NetworkHostAndPort>, configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault()) : this(haAddressPool.first(), configuration, null, null, null, haAddressPool)
 
     companion object {
         fun createWithSsl(
                 hostAndPort: NetworkHostAndPort,
                 sslConfiguration: ClientRpcSslOptions,
-                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default()
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault()
         ): CordaRPCClient {
             return CordaRPCClient(hostAndPort, configuration, sslConfiguration)
         }
@@ -138,14 +141,14 @@ class CordaRPCClient private constructor(
         fun createWithSsl(
                 haAddressPool: List<NetworkHostAndPort>,
                 sslConfiguration: ClientRpcSslOptions,
-                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default()
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault()
         ): CordaRPCClient {
             return CordaRPCClient(haAddressPool.first(), configuration, sslConfiguration, haAddressPool = haAddressPool)
         }
 
         internal fun createWithSslAndClassLoader(
                 hostAndPort: NetworkHostAndPort,
-                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault(),
                 sslConfiguration: ClientRpcSslOptions? = null,
                 classLoader: ClassLoader? = null
         ): CordaRPCClient {
@@ -154,7 +157,7 @@ class CordaRPCClient private constructor(
 
         internal fun createWithInternalSslAndClassLoader(
                 hostAndPort: NetworkHostAndPort,
-                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault(),
                 sslConfiguration: SSLConfiguration?,
                 classLoader: ClassLoader? = null
         ): CordaRPCClient {

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/CordaRPCClientUtils.kt
@@ -12,14 +12,14 @@ import rx.Observable
 /** Utility which exposes the internal Corda RPC constructor to other internal Corda components */
 fun createCordaRPCClientWithSslAndClassLoader(
         hostAndPort: NetworkHostAndPort,
-        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault(),
         sslConfiguration: ClientRpcSslOptions? = null,
         classLoader: ClassLoader? = null
 ) = CordaRPCClient.createWithSslAndClassLoader(hostAndPort, configuration, sslConfiguration, classLoader)
 
 fun createCordaRPCClientWithInternalSslAndClassLoader(
         hostAndPort: NetworkHostAndPort,
-        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.default(),
+        configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault(),
         sslConfiguration: SSLConfiguration? = null,
         classLoader: ClassLoader? = null
 ) = CordaRPCClient.createWithInternalSslAndClassLoader(hostAndPort, configuration, sslConfiguration, classLoader)

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -43,7 +43,7 @@ data class CordaRPCClientConfigurationImpl(
     companion object {
         private const val unlimitedReconnectAttempts = -1
         @JvmStatic
-        val default = CordaRPCClientConfigurationImpl(
+        val DEFAULT = CordaRPCClientConfigurationImpl(
                 minimumServerProtocolVersion = 0,
                 trackRpcCallSites = false,
                 reapInterval = 1.seconds,
@@ -64,28 +64,28 @@ data class CordaRPCClientConfigurationImpl(
  */
 class RPCClient<I : RPCOps>(
         val transport: TransportConfiguration,
-        val rpcConfiguration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.default,
+        val rpcConfiguration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT,
         val serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT,
         val haPoolTransportConfigurations: List<TransportConfiguration> = emptyList()
 ) {
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: ClientRpcSslOptions? = null,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.default,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT,
             serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
     ) : this(rpcConnectorTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext)
 
     constructor(
             hostAndPort: NetworkHostAndPort,
             sslConfiguration: SSLConfiguration,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.default,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT,
             serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
     ) : this(rpcInternalClientTcpTransport(hostAndPort, sslConfiguration), configuration, serializationContext)
 
     constructor(
             haAddressPool: List<NetworkHostAndPort>,
             sslConfiguration: ClientRpcSslOptions? = null,
-            configuration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.default,
+            configuration: CordaRPCClientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT,
             serializationContext: SerializationContext = SerializationDefaults.RPC_CLIENT_CONTEXT
     ) : this(rpcConnectorTcpTransport(haAddressPool.first(), sslConfiguration),
             configuration, serializationContext, rpcConnectorTcpTransportsFromList(haAddressPool, sslConfiguration))

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt
@@ -44,7 +44,7 @@ open class AbstractRPCTest {
     inline fun <reified I : RPCOps> RPCDriverDSL.testProxy(
             ops: I,
             rpcUser: User = rpcTestUser,
-            clientConfiguration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default,
+            clientConfiguration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.DEFAULT,
             serverConfiguration: RPCServerConfiguration = RPCServerConfiguration.default
     ): TestProxy<I> {
         return when (mode) {

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
@@ -90,7 +90,7 @@ class RPCConcurrencyTests : AbstractRPCTest() {
     private fun RPCDriverDSL.testProxy(): TestProxy<TestOps> {
         return testProxy<TestOps>(
                 TestOpsImpl(pool),
-                clientConfiguration = CordaRPCClientConfigurationImpl.default.copy(
+                clientConfiguration = CordaRPCClientConfigurationImpl.DEFAULT.copy(
                         reapInterval = 100.millis
                 ),
                 serverConfiguration = RPCServerConfiguration.default.copy(

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt
@@ -55,7 +55,7 @@ class RPCPerformanceTests : AbstractRPCTest() {
     private fun warmup() {
         rpcDriver {
             val proxy = testProxy(
-                    CordaRPCClientConfigurationImpl.default,
+                    CordaRPCClientConfigurationImpl.DEFAULT,
                     RPCServerConfiguration.default
             )
             val executor = Executors.newFixedThreadPool(4)
@@ -85,7 +85,7 @@ class RPCPerformanceTests : AbstractRPCTest() {
         measure(inputOutputSizes, (1..5)) { inputOutputSize, _ ->
             rpcDriver {
                 val proxy = testProxy(
-                        CordaRPCClientConfigurationImpl.default.copy(
+                        CordaRPCClientConfigurationImpl.DEFAULT.copy(
                                 observationExecutorPoolSize = 2
                         ),
                         RPCServerConfiguration.default.copy(
@@ -124,7 +124,7 @@ class RPCPerformanceTests : AbstractRPCTest() {
         rpcDriver {
             val metricRegistry = startReporter(shutdownManager)
             val proxy = testProxy(
-                    CordaRPCClientConfigurationImpl.default.copy(
+                    CordaRPCClientConfigurationImpl.DEFAULT.copy(
                             reapInterval = 1.seconds
                     ),
                     RPCServerConfiguration.default.copy(
@@ -156,7 +156,7 @@ class RPCPerformanceTests : AbstractRPCTest() {
             // TODO this hangs with more parallelism
             rpcDriver {
                 val proxy = testProxy(
-                        CordaRPCClientConfigurationImpl.default,
+                        CordaRPCClientConfigurationImpl.DEFAULT,
                         RPCServerConfiguration.default
                 )
                 val numberOfMessages = 1000

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -57,7 +57,7 @@ import net.corda.nodeapi.internal.config.User as InternalUser
 inline fun <reified I : RPCOps> RPCDriverDSL.startInVmRpcClient(
         username: String = rpcTestUser.username,
         password: String = rpcTestUser.password,
-        configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+        configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.DEFAULT
 ) = startInVmRpcClient(I::class.java, username, password, configuration)
 
 inline fun <reified I : RPCOps> RPCDriverDSL.startRandomRpcClient(
@@ -70,14 +70,14 @@ inline fun <reified I : RPCOps> RPCDriverDSL.startRpcClient(
         rpcAddress: NetworkHostAndPort,
         username: String = rpcTestUser.username,
         password: String = rpcTestUser.password,
-        configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+        configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.DEFAULT
 ) = startRpcClient(I::class.java, rpcAddress, username, password, configuration)
 
 inline fun <reified I : RPCOps> RPCDriverDSL.startRpcClient(
         haAddressPool: List<NetworkHostAndPort>,
         username: String = rpcTestUser.username,
         password: String = rpcTestUser.password,
-        configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+        configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.DEFAULT
 ) = startRpcClient(I::class.java, haAddressPool, username, password, configuration)
 
 data class RpcBrokerHandle(
@@ -259,7 +259,7 @@ data class RPCDriverDSL(
             rpcOpsClass: Class<I>,
             username: String = rpcTestUser.username,
             password: String = rpcTestUser.password,
-            configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+            configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.DEFAULT
     ): CordaFuture<I> {
         return driverDSL.executorService.fork {
             val client = RPCClient<I>(inVmClientTransportConfiguration, configuration)
@@ -330,7 +330,7 @@ data class RPCDriverDSL(
             rpcAddress: NetworkHostAndPort,
             username: String = rpcTestUser.username,
             password: String = rpcTestUser.password,
-            configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+            configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.DEFAULT
     ): CordaFuture<I> {
         return driverDSL.executorService.fork {
             val client = RPCClient<I>(ArtemisTcpTransport.rpcConnectorTcpTransport(rpcAddress, null), configuration)
@@ -356,7 +356,7 @@ data class RPCDriverDSL(
             haAddressPool: List<NetworkHostAndPort>,
             username: String = rpcTestUser.username,
             password: String = rpcTestUser.password,
-            configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.default
+            configuration: CordaRPCClientConfigurationImpl = CordaRPCClientConfigurationImpl.DEFAULT
     ): CordaFuture<I> {
         return driverDSL.executorService.fork {
             val client = RPCClient<I>(haAddressPool, null, configuration)


### PR DESCRIPTION
As reported in [CORDA-1609](https://r3-cev.atlassian.net/browse/CORDA-1609), `CordaRPCClientConfiguration.default` is not accessible from Java since `default` is a reserved keyword.

As part of the refactor made in #2831, `CordaRPCClientConfiguration` went from being a data class to an interface with a backing implementation of type `CordaRPCClientConfigurationImpl`.

This resulted in Java users having to rewrite code that was on the form:

```java
final CordaRPCClient client = new CordaRPCClient(
    nodeAddress, CordaRPCClientConfiguration.DEFAULT
);
```

to something like this:

```java
final CordaRPCClient client = new CordaRPCClient(
    nodeAddress, CordaRPCClientConfiguration.Companion.default()
);
```

However, this does not work. The user would get a compilation error because `default` is a reserved keyword in Java.

Since `CordaRPCClientConfiguration` has been made an interface, there is no easy way of introducing a static final field on the interface from Kotlin.

Consequently, I've changed the name of the function `default()` to `getDefault()`, which is now accessible though the `CordaRPCClientConfiguration.Companion` object. In other words, the user would now have to write:

```java
final CordaRPCClient client = new CordaRPCClient(
    nodeAddress, CordaRPCClientConfiguration.Companion.getDefault()
);
```

It should be noted that `getDefault()` is currently only used internally to pass in default values in `CordaRPCClient.kt` and `CordaRPCClientUtils.kt`. It dereferences `CordaRPCClientConfigurationImpl.DEFAULT`, which is in an internal package.

The latter means that in the above example, the user would actually not have to provide the parameter at all:

```java
final CordaRPCClient client = new CordaRPCClient(nodeAddress);
```

As can be seen from the definition of `CordaRPCClient`:

```kotlin
class CordaRPCClient private constructor(
        // (...)
) {
    @JvmOverloads
    constructor(hostAndPort: NetworkHostAndPort,
                configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.getDefault())
            : this(hostAndPort, configuration, null)
```

The mentioned [refactor](https://github.com/corda/corda/commit/7a077e76f0cdf457cd40033fb0da594805a5951e#diff-0948c125db93a22263eb81eaf3161c17R65) did not make it into the 3.1 release, so from an API-stability perspective, this can be applied without affecting that commitment.