### PR TITLE
CORDA-1628: Increase max restart count for notary client flows.

### DIFF
--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -22,6 +22,6 @@ rpcSettings = {
 }
 flowTimeout {
     timeout = 30 seconds
-    maxRestartCount = 3
-    backoffBase = 2.0
+    maxRestartCount = 5
+    backoffBase = 1.8
 }


### PR DESCRIPTION
This will ensure that the notary client flow will retry over a sufficient
period of time for the notary to update its network map.

With a backoff base of 1.8 and 5 retries the last retry will fire after
about 20 min 8 sec of the initial flow start:

\#     Timeout, sec
0	30
1	54
2	97.2
3	174.96
4	314.928
5	566.8704

Total 1208 = 20.13 min

@fenryka that should be sufficient to ensure a network update has happened, right?