### PR TITLE
ENT-1463, ENT-1903: Raise minimum JDK to 8u171 to fix ZIP compression bugs,

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,9 @@ buildscript {
 
     ext.deterministic_rt_version = '1.0-SNAPSHOT'
 
-    // Update 121 is required for ObjectInputFilter and at time of writing 131 was latest:
-    ext.java8_minUpdateVersion = '131'
+    // Update 121 is required for ObjectInputFilter.
+    // Updates [131, 161] also have zip compression bugs on MacOS (High Sierra).
+    ext.java8_minUpdateVersion = '171'
 
     repositories {
         mavenLocal()

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/DummyJar.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/DummyJar.kt
@@ -88,8 +88,7 @@ class DummyJar(
                     jar.write(arrayOfJunk(DATA_SIZE))
 
                     // One uncompressed text file
-                    val text = """
-Jar: ${_path.toAbsolutePath()}
+                    val text = """Jar: ${_path.toAbsolutePath()}
 Class: ${testClass.name}
 """.toByteArray()
                     jar.putNextEntry(uncompressed("comment.txt", text))

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
@@ -262,7 +262,7 @@ task jarFilter(type: JarFilterTask) {
         testProjectDir.newFile("build.gradle").writeText(script)
         return GradleRunner.create()
             .withProjectDir(testProjectDir.root)
-            .withArguments(getBasicArgsForTasks("jarFilter", "--stacktrace"))
+            .withArguments(getBasicArgsForTasks("jarFilter"))
             .withPluginClasspath()
     }
 

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
@@ -69,7 +69,7 @@ task metafix(type: MetaFixerTask) {
         testProjectDir.newFile("build.gradle").writeText(script)
         return GradleRunner.create()
             .withProjectDir(testProjectDir.root)
-            .withArguments(getBasicArgsForTasks("metafix", "--stacktrace"))
+            .withArguments(getBasicArgsForTasks("metafix"))
             .withPluginClasspath()
     }
 

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
@@ -29,7 +29,7 @@ private val testGradleUserHome: String get() = testGradleUserHomeValue
     ?: throw AssumptionViolatedException("System property 'test.gradle.user.home' not set.")
 
 fun getGradleArgsForTasks(vararg taskNames: String): MutableList<String> = getBasicArgsForTasks(*taskNames).apply { add("--info") }
-fun getBasicArgsForTasks(vararg taskNames: String): MutableList<String> = mutableListOf(*taskNames, "-g", testGradleUserHome)
+fun getBasicArgsForTasks(vararg taskNames: String): MutableList<String> = mutableListOf(*taskNames, "--stacktrace", "-g", testGradleUserHome)
 
 @Throws(IOException::class)
 fun copyResourceTo(resourceName: String, target: Path) {


### PR DESCRIPTION
JDKs 8u <= 161 have zip compresion bugs on MacOS (High Sierra), so raise minimum JDK to 8u171.
Also ensure that Gradle unit tests show stacktraces to make bugs like these easier to diagnose in future.