### PR TITLE
Fix bootstrapper publication problem.

### DIFF
--- a/tools/bootstrapper/build.gradle
+++ b/tools/bootstrapper/build.gradle
@@ -41,6 +41,10 @@ artifacts {
     }
 }
 
+jar {
+    classifier "ignore"
+}
+
 publish {
     disableDefaultJar = true
     name 'corda-tools-network-bootstrapper'


### PR DESCRIPTION
Fixes gradle publish error:

```
Execution failed for task ':tools:bootstrapper:publishTools-network-bootstrapperPublicationToMavenLocal'.
> Failed to publish publication 'tools-network-bootstrapper' to repository 'mavenLocal'
   > Invalid publication 'tools-network-bootstrapper': multiple artifacts with the identical extension and classifier ('jar', 'null').`
```

NOTE: this has already been applied to the `pre-release-V3` branch
https://github.com/corda/enterprise/pull/1002 