### PR TITLE
ENT-1463: Upgrade to Kotlin 1.2.50

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -427,14 +427,14 @@ public static final class net.corda.core.contracts.AmountTransfer$Companion exte
 ##
 @CordaSerializable
 public interface net.corda.core.contracts.Attachment extends net.corda.core.contracts.NamedByHash
-  public abstract void extractFile(String, java.io.OutputStream)
+  public void extractFile(String, java.io.OutputStream)
   @NotNull
   public abstract java.util.List<net.corda.core.identity.Party> getSigners()
   public abstract int getSize()
   @NotNull
   public abstract java.io.InputStream open()
   @NotNull
-  public abstract java.util.jar.JarInputStream openAsJAR()
+  public java.util.jar.JarInputStream openAsJAR()
 ##
 @DoNotImplement
 @CordaSerializable
@@ -526,7 +526,6 @@ public final class net.corda.core.contracts.ContractAttachment extends java.lang
   public <init>(net.corda.core.contracts.Attachment, String)
   public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>)
   public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>, String)
-  public void extractFile(String, java.io.OutputStream)
   @NotNull
   public final java.util.Set<String> getAdditionalContracts()
   @NotNull
@@ -544,8 +543,6 @@ public final class net.corda.core.contracts.ContractAttachment extends java.lang
   public final String getUploader()
   @NotNull
   public java.io.InputStream open()
-  @NotNull
-  public java.util.jar.JarInputStream openAsJAR()
   @NotNull
   public String toString()
 ##
@@ -4613,7 +4610,6 @@ public static final class net.corda.core.transactions.ContractUpgradeFilteredTra
 @DoNotImplement
 public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
-  public void checkSignaturesAreValid()
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
   @NotNull
@@ -4642,8 +4638,6 @@ public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction 
   @NotNull
   public final net.corda.core.contracts.Attachment getLegacyContractAttachment()
   @NotNull
-  public java.util.Set<java.security.PublicKey> getMissingSigners()
-  @NotNull
   public net.corda.core.identity.Party getNotary()
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
@@ -4659,9 +4653,6 @@ public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction 
   public final String getUpgradedContractClassName()
   public int hashCode()
   public String toString()
-  public void verifyRequiredSignatures()
-  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
-  public void verifySignaturesExcept(java.security.PublicKey...)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -4879,7 +4870,6 @@ public final class net.corda.core.transactions.MissingContractAttachments extend
 @DoNotImplement
 public final class net.corda.core.transactions.NotaryChangeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
-  public void checkSignaturesAreValid()
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
   @NotNull
@@ -4900,8 +4890,6 @@ public final class net.corda.core.transactions.NotaryChangeLedgerTransaction ext
   @NotNull
   public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
   @NotNull
-  public java.util.Set<java.security.PublicKey> getMissingSigners()
-  @NotNull
   public final net.corda.core.identity.Party getNewNotary()
   @NotNull
   public net.corda.core.identity.Party getNotary()
@@ -4913,9 +4901,6 @@ public final class net.corda.core.transactions.NotaryChangeLedgerTransaction ext
   public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
   public int hashCode()
   public String toString()
-  public void verifyRequiredSignatures()
-  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
-  public void verifySignaturesExcept(java.security.PublicKey...)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -4958,7 +4943,6 @@ public final class net.corda.core.transactions.SignedTransaction extends java.la
   public <init>(net.corda.core.transactions.CoreTransaction, java.util.List<net.corda.core.crypto.TransactionSignature>)
   @NotNull
   public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
-  public void checkSignaturesAreValid()
   @NotNull
   public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> component1()
   @NotNull
@@ -4974,8 +4958,6 @@ public final class net.corda.core.transactions.SignedTransaction extends java.la
   public final java.util.List<net.corda.core.contracts.StateRef> getInputs()
   @NotNull
   public java.util.ArrayList<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
-  @NotNull
-  public java.util.Set<java.security.PublicKey> getMissingSigners()
   @Nullable
   public final net.corda.core.identity.Party getNotary()
   @NotNull
@@ -5012,9 +4994,6 @@ public final class net.corda.core.transactions.SignedTransaction extends java.la
   public String toString()
   public final void verify(net.corda.core.node.ServiceHub)
   public final void verify(net.corda.core.node.ServiceHub, boolean)
-  public void verifyRequiredSignatures()
-  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
-  public void verifySignaturesExcept(java.security.PublicKey...)
   @NotNull
   public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(java.security.KeyPair, net.corda.core.crypto.SignatureMetadata)
   @NotNull
@@ -5115,18 +5094,18 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
 ##
 @DoNotImplement
 public interface net.corda.core.transactions.TransactionWithSignatures extends net.corda.core.contracts.NamedByHash
-  public abstract void checkSignaturesAreValid()
+  public void checkSignaturesAreValid()
   @NotNull
   public abstract java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
   @NotNull
-  public abstract java.util.Set<java.security.PublicKey> getMissingSigners()
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
   @NotNull
   public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
   @NotNull
   public abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
-  public abstract void verifyRequiredSignatures()
-  public abstract void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
-  public abstract void verifySignaturesExcept(java.security.PublicKey...)
+  public void verifyRequiredSignatures()
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
+  public void verifySignaturesExcept(java.security.PublicKey...)
 ##
 @DoNotImplement
 @CordaSerializable

--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ allprojects {
             apiVersion = "1.2"
             jvmTarget = "1.8"
             javaParameters = true   // Useful for reflection.
-            freeCompilerArgs = ['-Xenable-jvm-default']
+            freeCompilerArgs = ['-Xjvm-default=compatibility']
         }
     }
 

--- a/constants.properties
+++ b/constants.properties
@@ -1,5 +1,5 @@
 gradlePluginsVersion=4.0.23
-kotlinVersion=1.2.41
+kotlinVersion=1.2.50
 platformVersion=4
 guavaVersion=21.0
 proguardVersion=6.0.3

--- a/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt
@@ -32,6 +32,8 @@ import java.util.jar.JarInputStream
 @CordaSerializable
 interface Attachment : NamedByHash {
     fun open(): InputStream
+
+    @JvmDefault
     fun openAsJAR(): JarInputStream {
         val stream = open()
         try {
@@ -45,6 +47,7 @@ interface Attachment : NamedByHash {
      * Finds the named file case insensitively and copies it to the output stream.
      * @throws FileNotFoundException if the given path doesn't exist in the attachment.
      */
+    @JvmDefault
     fun extractFile(path: String, outputTo: OutputStream) = openAsJAR().use { it.extractFile(path, outputTo) }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -33,6 +33,7 @@ interface TransactionWithSignatures : NamedByHash {
      * @throws SignatureException if any signatures are invalid or unrecognised.
      * @throws SignaturesMissingException if any signatures should have been present but were not.
      */
+    @JvmDefault
     @Throws(SignatureException::class)
     fun verifyRequiredSignatures() = verifySignaturesExcept(emptySet())
 
@@ -48,6 +49,7 @@ interface TransactionWithSignatures : NamedByHash {
      * @throws SignatureException if any signatures are invalid or unrecognised.
      * @throws SignaturesMissingException if any signatures should have been present but were not.
      */
+    @JvmDefault
     @Throws(SignatureException::class)
     fun verifySignaturesExcept(vararg allowedToBeMissing: PublicKey) {
         verifySignaturesExcept(Arrays.asList(*allowedToBeMissing))
@@ -65,6 +67,7 @@ interface TransactionWithSignatures : NamedByHash {
      * @throws SignatureException if any signatures are invalid or unrecognised.
      * @throws SignaturesMissingException if any signatures should have been present but were not.
      */
+    @JvmDefault
     @Throws(SignatureException::class)
     fun verifySignaturesExcept(allowedToBeMissing: Collection<PublicKey>) {
         val needed = getMissingSigners() - allowedToBeMissing
@@ -82,6 +85,7 @@ interface TransactionWithSignatures : NamedByHash {
      * @throws InvalidKeyException if the key on a signature is invalid.
      * @throws SignatureException if a signature fails to verify.
      */
+    @JvmDefault
     @Throws(InvalidKeyException::class, SignatureException::class)
     fun checkSignaturesAreValid() {
         for (sig in sigs) {
@@ -100,6 +104,7 @@ interface TransactionWithSignatures : NamedByHash {
     /**
      * Return the [PublicKey]s for which we still need signatures.
      */
+    @JvmDefault
     fun getMissingSigners(): Set<PublicKey> {
         val sigKeys = sigs.map { it.by }.toSet()
         // TODO Problem is that we can get single PublicKey wrapped as CompositeKey in allowedToBeMissing/mustSign


### PR DESCRIPTION
Kotlin 1.2.50 allows `@JvmDefault` also to generate the previous `$DefaultImpls` classes, and therefore preserve binary compatibility with earlier Corda releases.

The updated compiler option also requires everyone to update the IntelliJ Kotlin plugin to 1.2.50.