### PR TITLE
Update to gradle-plugins 4.0.24 for ENT-2059 and ENT-2035

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.23
+gradlePluginsVersion=4.0.24
 kotlinVersion=1.2.41
 platformVersion=4
 guavaVersion=21.0

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -117,9 +117,25 @@ Following the previous example ``PartyB`` node will have additional configuratio
             [...]
             // Grants user1 the ability to start the MyFlow flow.
             rpcUsers = [[ user: "user1", "password": "test", "permissions": ["StartFlow.net.corda.flows.MyFlow"]]]
-            configFile = "samples/trader-demo/src/main/resources/none-b.conf"
+            configFile = "samples/trader-demo/src/main/resources/node-b.conf"
         }
     }
+
+Cordform parameter `drivers` of the `node` entry lists paths of the files to be copied to the `./drivers` subdirectory of the node.
+To copy the same file to all nodes `ext.drivers` can be defined in the top level and reused for each node via `drivers=ext.drivers``.
+
+.. sourcecode:: groovy
+
+    task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
+        ext.drivers = ['lib/my_common_jar.jar']
+        [...]
+        node {
+            name "O=PartyB,L=New York,C=US"
+            [...]
+            drivers = ext.drivers + ['lib/my_specific_jar.jar']
+        }
+    }
+
 
 Specifying a custom webserver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/node-structure.rst
+++ b/docs/source/node-structure.rst
@@ -15,7 +15,7 @@ A Corda node has the following structure:
     ├── corda-webserver.jar     // The built-in node webserver
     ├── corda.jar               // The core Corda libraries
     ├── cordapps                // The CorDapp JARs installed on the node
-    ├── drivers                 // Contains a Jolokia driver used to export JMX metrics
+    ├── drivers                 // Contains a Jolokia driver used to export JMX metrics, the node loads any additional JAR files from this directory at startup.
     ├── logs                    // The node logs
     ├── network-parameters      // The network parameters automatically downloaded from the network map server
     ├── node.conf               // The node's configuration files

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -1,6 +1,13 @@
 Release notes
 =============
 
+Unreleased
+----------
+
+Issues Fixed
+~~~~~~~~~~~~
+* Cordform Gradle task (`deployNodes`) doesn't work when `configFile` element was used.
+
 .. _release_notes_v3_1:
 
 Release 3.1


### PR DESCRIPTION
Update to gradle-plugins to 4.0.24 to bring changes in Cordformation task:
* ENT-2059 Cordform Gradle task ('deployNodes') doesn't work when 'configFile' element was used
* ENT-2035 The 'node' entry has a new optional element 'drivers', which is a list of JAR files to be copied to the './driver' subdirectory relative to node directory.