### PR TITLE
CORDA-1407 Node Explorer - fix total column

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
@@ -1,15 +1,15 @@
 package net.corda.client.jfx.model
 
 import javafx.beans.value.ObservableValue
-import javafx.collections.FXCollections
-import javafx.collections.ObservableMap
-import net.corda.client.jfx.utils.*
+import net.corda.client.jfx.utils.distinctBy
+import net.corda.client.jfx.utils.lift
+import net.corda.client.jfx.utils.map
+import net.corda.client.jfx.utils.recordInSequence
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
-import org.fxmisc.easybind.EasyBind
 
 /**
  * [PartiallyResolvedTransaction] holds a [SignedTransaction] that has zero or more inputs resolved. The intent is
@@ -43,38 +43,36 @@ data class PartiallyResolvedTransaction(
     companion object {
         fun fromSignedTransaction(
                 transaction: SignedTransaction,
-                stateMap: ObservableMap<StateRef, StateAndRef<ContractState>>
-        ) = PartiallyResolvedTransaction(
-                transaction = transaction,
-                inputs = transaction.inputs.map { stateRef ->
-                    EasyBind.map(stateMap.getObservableValue(stateRef)) {
-                        if (it == null) {
+                inputTransactions: Map<StateRef, SignedTransaction?>
+        ): PartiallyResolvedTransaction {
+            return PartiallyResolvedTransaction(
+                    transaction = transaction,
+                    inputs = transaction.inputs.map { stateRef ->
+                        val tx = inputTransactions.get(stateRef)
+                        if (tx == null) {
                             InputResolution.Unresolved(stateRef)
                         } else {
-                            InputResolution.Resolved(it)
+                            InputResolution.Resolved(tx.coreTransaction.outRef(stateRef.index))
+                        }.lift()
+                    },
+                    outputs = if (transaction.coreTransaction is WireTransaction) {
+                        transaction.tx.outRefsOfType<ContractState>().map {
+                            OutputResolution.Resolved(it).lift()
                         }
-                    }
-                },
-                outputs = if (transaction.coreTransaction is WireTransaction) {
-                    transaction.tx.outRefsOfType<ContractState>().map {
-                        OutputResolution.Resolved(it).lift()
-                    }
-                } else {
-                    // Transaction will have the same number of outputs as inputs
-                    val outputCount = transaction.coreTransaction.inputs.size
-                    val stateRefs = (0 until outputCount).map { StateRef(transaction.id, it) }
-                    stateRefs.map { stateRef ->
-                        EasyBind.map(stateMap.getObservableValue(stateRef)) {
-                            if (it == null) {
+                    } else {
+                        // Transaction will have the same number of outputs as inputs
+                        val outputCount = transaction.coreTransaction.inputs.size
+                        val stateRefs = (0 until outputCount).map { StateRef(transaction.id, it) }
+                        stateRefs.map { stateRef ->
+                            val tx = inputTransactions.get(stateRef)
+                            if (tx == null) {
                                 OutputResolution.Unresolved(stateRef)
                             } else {
-                                OutputResolution.Resolved(it)
-                            }
+                                OutputResolution.Resolved(tx.coreTransaction.outRef(stateRef.index))
+                            }.lift()
                         }
-                    }
-                }
-
-        )
+                    })
+        }
     }
 }
 
@@ -84,13 +82,12 @@ data class PartiallyResolvedTransaction(
 class TransactionDataModel {
     private val transactions by observable(NodeMonitorModel::transactions)
     private val collectedTransactions = transactions.recordInSequence().distinctBy { it.id }
-    private val vaultUpdates by observable(NodeMonitorModel::vaultUpdates)
-    private val stateMap = vaultUpdates.fold(FXCollections.observableHashMap<StateRef, StateAndRef<ContractState>>()) { map, (consumed, produced) ->
-        val states = consumed + produced
-        states.forEach { map[it.ref] = it }
-    }
+    private val rpcProxy by observableValue(NodeMonitorModel::proxyObservable)
 
     val partiallyResolvedTransactions = collectedTransactions.map {
-        PartiallyResolvedTransaction.fromSignedTransaction(it, stateMap)
+        PartiallyResolvedTransaction.fromSignedTransaction(it,
+                it.inputs.map { stateRef ->
+                    stateRef to rpcProxy.value!!.cordaRPCOps.internalFindVerifiedTransaction(stateRef.txhash)
+                }.toMap())
     }
 }

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -195,6 +195,14 @@ interface CordaRPCOps : RPCOps {
     fun internalVerifiedTransactionsSnapshot(): List<SignedTransaction>
 
     /**
+     * @suppress Returns the full transaction for the provided ID
+     *
+     * TODO This method should be removed once SGX work is finalised and the design of the corresponding API using [FilteredTransaction] can be started
+     */
+    @Deprecated("This method is intended only for internal use and will be removed from the public API soon.")
+    fun internalFindVerifiedTransaction(txnId: SecureHash): SignedTransaction?
+
+    /**
      * @suppress Returns a data feed of all recorded transactions and an observable of future recorded ones.
      *
      * TODO This method should be removed once SGX work is finalised and the design of the corresponding API using [FilteredTransaction] can be started

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -107,6 +107,8 @@ internal class CordaRPCOpsImpl(
         return snapshot
     }
 
+    override fun internalFindVerifiedTransaction(txnId: SecureHash): SignedTransaction? = services.validatedTransactions.getTransaction(txnId)
+
     @Suppress("OverridingDeprecatedMember")
     override fun internalVerifiedTransactionsFeed(): DataFeed<List<SignedTransaction>, SignedTransaction> {
         return services.validatedTransactions.track()


### PR DESCRIPTION
The issue is that by default, not all states are saved to the vault. Only the "relevant" ones.
This causes issues with the Explorer, which displays all transactions, and calculates the balance updates based on the input and output states of the tx.
The fix is to just load the transaction that created the inputStates from the database 