### PR TITLE
ENT-1796 RPC SSL

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -120,7 +120,8 @@ absolute path to the node's base directory.
             The Node operator must provide RPC clients with a truststore containing the certificate they can trust.
             We advise Node operators to not use the P2P keystore for RPC.
             The node ships with a command line argument "--just-generate-rpc-ssl-settings", which generates a secure keystore
-            and truststore that can be used to secure the RPC connection.
+            and truststore that can be used to secure the RPC connection. You can use this if you have no special requirements.
+
 
 :security: Contains various nested fields controlling user authentication/authorization, in particular for RPC accesses. See
     :doc:`clientrpc` for details.

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -108,10 +108,10 @@ absolute path to the node's base directory.
 :rpcSettings: Options for the RPC server exposed by the Node.
 
         :address: host and port for the RPC server binding.
-        :adminAddress: host and port for the RPC admin binding (This is the endpoint where the actual Node process will connect to).
+        :adminAddress: host and port for the RPC admin binding (this is the endpoint that the node process will connect to).
         :standAloneBroker: (optional) boolean, indicates whether the node will connect to a standalone broker for RPC, defaulted to ``false``.
-        :useSsl: (optional) boolean, indicates whether the node should require clients to use SSL for RPC connections, defaulted to ``false``.
-        :ssl: (mandatory if useSsl=true) SSL settings for the RPC server.
+        :useSsl: (optional) boolean, indicates whether or not the node should require clients to use SSL for RPC connections, defaulted to ``false``.
+        :ssl: (mandatory if ``useSsl=true``) SSL settings for the RPC server.
 
                 :keyStorePath: Absolute path to the key store containing the RPC SSL certificate.
                 :keyStorePassword: Password for the key store.
@@ -267,76 +267,16 @@ Simple notary configuration file:
     devMode : false
     compatibilityZoneURL : "https://cz.corda.net"
 
-An example ``web-server.conf`` file is as follow:
-
-.. parsed-literal::
-
-    myLegalName : "O=Notary Service,OU=corda,L=London,C=GB"
-    keyStorePassword : "cordacadevpass"
-    trustStorePassword : "trustpass"
-    rpcSettings = {
-        useSsl = false
-        standAloneBroker = false
-        address : "my-corda-node:10003"
-        adminAddress : "my-corda-node:10004"
-    }
-    rpcUsers : [{ username=user1, password=letmein, permissions=[ StartFlow.net.corda.protocols.CashProtocol ] }]
-
-Configuring a node where the Corda Comatability Zone's registration and Network Map services exist on different URLs
+Configuring a node where the Corda Compatibility Zone's registration and Network Map services exist on different URLs
 
 .. literalinclude:: example-code/src/main/resources/example-node-with-networkservices.conf
 
-Fields
-------
-
-The available config fields are listed below. ``baseDirectory`` is available as a substitution value, containing the absolute
-path to the node's base directory.
-
-:myLegalName: The legal identity of the node acts as a human readable alias to the node's public key and several demos use
-        this to lookup the NodeInfo.
-
-:keyStorePassword: The password to unlock the KeyStore file (``<workspace>/certificates/sslkeystore.jks``) containing the
-    node certificate and private key.
-
-    .. note:: This is the non-secret value for the development certificates automatically generated during the first node run.
-       Longer term these keys will be managed in secure hardware devices.
-
-:trustStorePassword: The password to unlock the Trust store file (``<workspace>/certificates/truststore.jks``) containing
-    the Corda network root certificate. This is the non-secret value for the development certificates automatically
-    generated during the first node run.
-
-    .. note:: Longer term these keys will be managed in secure hardware devices.
-
-:rpcSettings: Options for the RPC server.
-
-        :useSsl: (optional) boolean, indicates whether the node should require clients to use SSL for RPC connections, defaulted to ``false``.
-        :standAloneBroker: (optional) boolean, indicates whether the node will connect to a standalone broker for RPC, defaulted to ``false``.
-        :address: (optional) host and port for the RPC server binding, if any.
-        :adminAddress: (optional) host and port for the RPC admin binding (only required when ``useSsl`` is ``false``, because the node connects to Artemis using SSL to ensure admin privileges are not accessible outside the node).
-        :ssl: (optional) SSL settings for the RPC client.
-
-                :keyStorePassword: password for the key store.
-                :trustStorePassword: password for the trust store.
-                :certificatesDirectory: directory in which the stores will be searched, unless absolute paths are provided.
-                :sslKeystore: absolute path to the ssl key store, defaulted to ``certificatesDirectory / "sslkeystore.jks"``.
-                :trustStoreFile: absolute path to the trust store, defaulted to ``certificatesDirectory / "truststore.jks"``.
-                :trustStoreFile: absolute path to the trust store, defaulted to ``certificatesDirectory / "truststore.jks"``.
-
-:rpcUsers: A list of users who are authorised to access the RPC system. Each user in the list is a config object with the
-        following fields:
-
-        :username: Username consisting only of word characters (a-z, A-Z, 0-9 and _)
-        :password: The password
-        :permissions: A list of permissions for starting flows via RPC. To give the user the permission to start the flow
-            ``foo.bar.FlowClass``, add the string ``StartFlow.foo.bar.FlowClass`` to the list. If the list
-            contains the string ``ALL``, the user can start any flow via RPC. This value is intended for administrator
-            users and for development.
-
 Fields Override
 ---------------
-JVM options or environmental variables prefixed ``corda.`` can override ``node.conf`` fields.
-Provided system properties also can set value for absent fields in ``node.conf``.
-Example adding/overriding keyStore password when starting Corda node:
+JVM options or environmental variables prefixed with ``corda.`` can override ``node.conf`` fields.
+Provided system properties can also set values for absent fields in ``node.conf``.
+
+This is an example of adding/overriding the keyStore password :
 
 .. sourcecode:: shell
 

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -103,21 +103,24 @@ absolute path to the node's base directory.
         :maxRestartCount: Maximum number of times the flow will restart before resulting in an error.
         :backoffBase: The base of the exponential backoff, `t_{wait} = timeout * backoffBase^{retryCount}`.
 
-:rpcAddress: The address of the RPC system on which RPC requests can be made to the node. If not provided then the node will run without RPC. This is now deprecated in favour of the ``rpcSettings`` block.
+:rpcAddress: (Deprecated) The address of the RPC system on which RPC requests can be made to the node. If not provided then the node will run without RPC. This is now deprecated in favour of the ``rpcSettings`` block.
 
-:rpcSettings: Options for the RPC server.
+:rpcSettings: Options for the RPC server exposed by the Node.
 
-        :useSsl: (optional) boolean, indicates whether the node should require clients to use SSL for RPC connections, defaulted to ``false``.
+        :address: host and port for the RPC server binding.
+        :adminAddress: host and port for the RPC admin binding (This is the endpoint where the actual Node process will connect to).
         :standAloneBroker: (optional) boolean, indicates whether the node will connect to a standalone broker for RPC, defaulted to ``false``.
-        :address: (optional) host and port for the RPC server binding, if any.
-        :adminAddress: (optional) host and port for the RPC admin binding (only required when ``useSsl`` is ``false``, because the node connects to Artemis using SSL to ensure admin privileges are not accessible outside the node).
-        :ssl: (optional) SSL settings for the RPC server.
+        :useSsl: (optional) boolean, indicates whether the node should require clients to use SSL for RPC connections, defaulted to ``false``.
+        :ssl: (mandatory if useSsl=true) SSL settings for the RPC server.
 
-                :keyStorePassword: password for the key store.
-                :trustStorePassword: password for the trust store.
-                :certificatesDirectory: directory in which the stores will be searched, unless absolute paths are provided.
-                :sslKeystore: absolute path to the ssl key store, defaulted to ``certificatesDirectory / "sslkeystore.jks"``.
-                :trustStoreFile: absolute path to the trust store, defaulted to ``certificatesDirectory / "truststore.jks"``.
+                :keyStorePath: Absolute path to the key store containing the RPC SSL certificate.
+                :keyStorePassword: Password for the key store.
+
+        .. note:: The RPC SSL certificate is used by RPC clients to authenticate the connection.
+            The Node operator must provide RPC clients with a truststore containing the certificate they can trust.
+            We advise Node operators to not use the P2P keystore for RPC.
+            The node ships with a command line argument "--just-generate-rpc-ssl-settings", which generates a secure keystore
+            and truststore that can be used to secure the RPC connection.
 
 :security: Contains various nested fields controlling user authentication/authorization, in particular for RPC accesses. See
     :doc:`clientrpc` for details.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -48,7 +48,7 @@ object X509Utilities {
     const val CORDA_CLIENT_TLS = "cordaclienttls"
     const val CORDA_CLIENT_CA = "cordaclientca"
 
-    private val DEFAULT_VALIDITY_WINDOW = Pair(0.millis, 3650.days)
+    val DEFAULT_VALIDITY_WINDOW = Pair(0.millis, 3650.days)
 
     /**
      * Helper function to return the latest out of an instant and an optional date.

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
@@ -7,7 +7,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.core.messaging.ClientRpcSslOptions
-import net.corda.node.utilities.createKeyPairAndSelfSignedCertificate
+import net.corda.node.utilities.createKeyPairAndSelfSignedTLSCertificate
 import net.corda.node.utilities.saveToKeyStore
 import net.corda.node.utilities.saveToTrustStore
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NODE_RPC_USER
@@ -23,6 +23,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import javax.security.auth.x500.X500Principal
 
 class RpcSslTest {
 
@@ -30,13 +31,15 @@ class RpcSslTest {
     @JvmField
     val tempFolder = TemporaryFolder()
 
+    val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
+
     @Test
     fun `RPC client using ssl is able to run a command`() {
         val user = User("mark", "dadada", setOf(all()))
         var successfulLogin = false
         var failedLogin = false
 
-        val (keyPair, cert) = createKeyPairAndSelfSignedCertificate()
+        val (keyPair, cert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFolder.root.toPath() / "keystore.jks", keyPair, cert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
 
@@ -73,11 +76,11 @@ class RpcSslTest {
         val user = User("mark", "dadada", setOf(all()))
         var successful = false
 
-        val (keyPair, cert) = createKeyPairAndSelfSignedCertificate()
+        val (keyPair, cert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFolder.root.toPath() / "keystore.jks", keyPair, cert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
 
-        val (_, cert1) = createKeyPairAndSelfSignedCertificate()
+        val (_, cert1) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val trustStorePath = saveToTrustStore(tempFolder.root.toPath() / "truststore.jks", cert1)
         val clientSslOptions = ClientRpcSslOptions(trustStorePath, "password")
 
@@ -115,7 +118,7 @@ class RpcSslTest {
 
     @Test
     fun `The system RPC user can not connect to the rpc broker without the node's key`() {
-        val (keyPair, cert) = createKeyPairAndSelfSignedCertificate()
+        val (keyPair, cert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFolder.root.toPath() / "keystore.jks", keyPair, cert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
         val trustStorePath = saveToTrustStore(tempFolder.root.toPath() / "truststore.jks", cert)

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/RpcSslTest.kt
@@ -7,13 +7,13 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.core.messaging.ClientRpcSslOptions
+import net.corda.node.utilities.createKeyPairAndSelfSignedCertificate
+import net.corda.node.utilities.saveToKeyStore
+import net.corda.node.utilities.saveToTrustStore
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.NODE_RPC_USER
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.internal.RandomFree
-import net.corda.testing.internal.createKeyPairAndSelfSignedCertificate
-import net.corda.testing.internal.saveToKeyStore
-import net.corda.testing.internal.saveToTrustStore
 import net.corda.testing.internal.useSslRpcOverrides
 import net.corda.testing.node.User
 import org.apache.activemq.artemis.api.core.ActiveMQException

--- a/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt
@@ -54,6 +54,8 @@ class NodeArgsParser : AbstractArgsParser<CmdLineOptions>() {
     private val isVersionArg = optionParser.accepts("version", "Print the version and exit")
     private val justGenerateNodeInfoArg = optionParser.accepts("just-generate-node-info",
             "Perform the node start-up task necessary to generate its nodeInfo, save it to disk, then quit")
+    private val justGenerateRpcSslCertsArg = optionParser.accepts("just-generate-rpc-ssl-settings",
+            "Helper to generate the ssl keystore and truststore for a secure RPC connection.")
     private val bootstrapRaftClusterArg = optionParser.accepts("bootstrap-raft-cluster", "Bootstraps Raft cluster. The node forms a single node cluster (ignoring otherwise configured peer addresses), acting as a seed for other nodes to join the cluster.")
     private val clearNetworkMapCache = optionParser.accepts("clear-network-map-cache", "Clears local copy of network map, on node startup it will be restored from server or file system.")
 
@@ -70,6 +72,7 @@ class NodeArgsParser : AbstractArgsParser<CmdLineOptions>() {
         val noLocalShell = optionSet.has(noLocalShellArg)
         val sshdServer = optionSet.has(sshdServerArg)
         val justGenerateNodeInfo = optionSet.has(justGenerateNodeInfoArg)
+        val justGenerateRpcSslCerts = optionSet.has(justGenerateRpcSslCertsArg)
         val bootstrapRaftCluster = optionSet.has(bootstrapRaftClusterArg)
         val networkRootTrustStorePath = optionSet.valueOf(networkRootTrustStorePathArg)
         val networkRootTrustStorePassword = optionSet.valueOf(networkRootTrustStorePasswordArg)
@@ -94,6 +97,7 @@ class NodeArgsParser : AbstractArgsParser<CmdLineOptions>() {
                 noLocalShell,
                 sshdServer,
                 justGenerateNodeInfo,
+                justGenerateRpcSslCerts,
                 bootstrapRaftCluster,
                 unknownConfigKeysPolicy,
                 devMode,
@@ -112,6 +116,7 @@ data class CmdLineOptions(val baseDirectory: Path,
                           val noLocalShell: Boolean,
                           val sshdServer: Boolean,
                           val justGenerateNodeInfo: Boolean,
+                          val justGenerateRpcSslCerts: Boolean,
                           val bootstrapRaftCluster: Boolean,
                           val unknownConfigKeysPolicy: UnknownConfigKeysPolicy,
                           val devMode: Boolean,

--- a/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeArgsParser.kt
@@ -55,7 +55,7 @@ class NodeArgsParser : AbstractArgsParser<CmdLineOptions>() {
     private val justGenerateNodeInfoArg = optionParser.accepts("just-generate-node-info",
             "Perform the node start-up task necessary to generate its nodeInfo, save it to disk, then quit")
     private val justGenerateRpcSslCertsArg = optionParser.accepts("just-generate-rpc-ssl-settings",
-            "Helper to generate the ssl keystore and truststore for a secure RPC connection.")
+            "Generate the ssl keystore and truststore for a secure RPC connection.")
     private val bootstrapRaftClusterArg = optionParser.accepts("bootstrap-raft-cluster", "Bootstraps Raft cluster. The node forms a single node cluster (ignoring otherwise configured peer addresses), acting as a seed for other nodes to join the cluster.")
     private val clearNetworkMapCache = optionParser.accepts("clear-network-map-cache", "Clears local copy of network map, on node startup it will be restored from server or file system.")
 

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -239,7 +239,7 @@ open class Node(configuration: NodeConfiguration,
                 val rpcBrokerDirectory: Path = baseDirectory / "brokers" / "rpc"
                 with(rpcOptions) {
                     rpcBroker = if (useSsl) {
-                        ArtemisRpcBroker.withSsl(configuration, this.address, adminAddress, sslConfig, securityManager, MAX_RPC_MESSAGE_SIZE, jmxMonitoringHttpPort != null, rpcBrokerDirectory, shouldStartLocalShell())
+                        ArtemisRpcBroker.withSsl(configuration, this.address, adminAddress, sslConfig!!, securityManager, MAX_RPC_MESSAGE_SIZE, jmxMonitoringHttpPort != null, rpcBrokerDirectory, shouldStartLocalShell())
                     } else {
                         ArtemisRpcBroker.withoutSsl(configuration, this.address, adminAddress, securityManager, MAX_RPC_MESSAGE_SIZE, jmxMonitoringHttpPort != null, rpcBrokerDirectory, shouldStartLocalShell())
                     }

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -192,7 +192,7 @@ open class NodeStartup(val args: Array<String>) {
                             println("The keystore passwords don't match.")
                             continue
                         }
-                        val keyStorePath = saveToKeyStore(conf.baseDirectory / "certificates" / "rpcsslkeystore.jks", keyPair, cert, String(keystorePassword1))
+                        val keyStorePath = saveToKeyStore(conf.baseDirectory / "certificates" / "rpcsslkeystore.jks", keyPair, cert, String(keystorePassword1), "rpcssl")
                         println("The keystore was saved to: $keyStorePath")
                         break
                     }
@@ -205,7 +205,7 @@ open class NodeStartup(val args: Array<String>) {
                             continue
                         }
 
-                        val trustStorePath = saveToTrustStore(conf.baseDirectory / "certificates" / "export" / "rpcssltruststore.jks", cert, String(trustStorePassword1))
+                        val trustStorePath = saveToTrustStore(conf.baseDirectory / "certificates" / "export" / "rpcssltruststore.jks", cert, String(trustStorePassword1), "rpcssl")
                         println("The trustore was saved to: $trustStorePath")
                         println("You need to distribute this file along with the password in a secure way to all Rpc clients.")
                         break

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -227,7 +227,7 @@ data class NodeConfigurationImpl(
 
     override val rpcOptions: NodeRpcOptions
         get() {
-            return actualRpcSettings.asOptions(BrokerRpcSslOptions(baseDirectory / "certificates" / "nodekeystore.jks", keyStorePassword))
+            return actualRpcSettings.asOptions()
         }
 
     private fun validateTlsCertCrlConfig(): List<String> {
@@ -273,10 +273,11 @@ data class NodeConfigurationImpl(
 
     private fun validateRpcSettings(options: NodeRpcSettings): List<String> {
         val errors = mutableListOf<String>()
-        if (options.address != null) {
-            if (!options.useSsl && options.adminAddress == null) {
-                errors += "'rpcSettings.adminAddress': missing. Property is mandatory when 'rpcSettings.useSsl' is false (default)."
-            }
+        if (options.adminAddress == null) {
+            errors += "'rpcSettings.adminAddress': missing"
+        }
+        if (options.useSsl && options.ssl == null) {
+            errors += "'rpcSettings.ssl': missing (rpcSettings.useSsl=true was set to true)."
         }
         return errors
     }
@@ -350,13 +351,13 @@ data class NodeRpcSettings(
         val useSsl: Boolean = false,
         val ssl: BrokerRpcSslOptions?
 ) {
-    fun asOptions(fallbackSslOptions: BrokerRpcSslOptions): NodeRpcOptions {
+    fun asOptions(): NodeRpcOptions {
         return object : NodeRpcOptions {
             override val address = this@NodeRpcSettings.address!!
             override val adminAddress = this@NodeRpcSettings.adminAddress!!
             override val standAloneBroker = this@NodeRpcSettings.standAloneBroker
             override val useSsl = this@NodeRpcSettings.useSsl
-            override val sslConfig = this@NodeRpcSettings.ssl ?: fallbackSslOptions
+            override val sslConfig = this@NodeRpcSettings.ssl
 
             override fun toString(): String {
                 return "address: $address, adminAddress: $adminAddress, standAloneBroker: $standAloneBroker, useSsl: $useSsl, sslConfig: $sslConfig"

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -277,7 +277,7 @@ data class NodeConfigurationImpl(
             errors += "'rpcSettings.adminAddress': missing"
         }
         if (options.useSsl && options.ssl == null) {
-            errors += "'rpcSettings.ssl': missing (rpcSettings.useSsl=true was set to true)."
+            errors += "'rpcSettings.ssl': missing (rpcSettings.useSsl was set to true)."
         }
         return errors
     }

--- a/node/src/main/kotlin/net/corda/node/services/config/rpc/NodeRpcOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/rpc/NodeRpcOptions.kt
@@ -8,5 +8,5 @@ interface NodeRpcOptions {
     val adminAddress: NetworkHostAndPort
     val standAloneBroker: Boolean
     val useSsl: Boolean
-    val sslConfig: BrokerRpcSslOptions
+    val sslConfig: BrokerRpcSslOptions?
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/CertificatesUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/CertificatesUtils.kt
@@ -5,14 +5,20 @@ import net.corda.nodeapi.internal.crypto.*
 import java.nio.file.Path
 import java.security.KeyPair
 import java.security.cert.X509Certificate
+import java.time.Duration
 import javax.security.auth.x500.X500Principal
 
-val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
-
-fun createKeyPairAndSelfSignedCertificate(x500Principal: X500Principal = testName): Pair<KeyPair, X509Certificate> {
+fun createKeyPairAndSelfSignedTLSCertificate(x500Principal: X500Principal): Pair<KeyPair, X509Certificate> {
     val rpcKeyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
-    val selfSignCert = X509Utilities.createSelfSignedCACertificate(x500Principal, rpcKeyPair)
+    val selfSignCert = createSelfSignedTLSCertificate(x500Principal, rpcKeyPair)
     return Pair(rpcKeyPair, selfSignCert)
+}
+
+fun createSelfSignedTLSCertificate(subject: X500Principal,
+                                  keyPair: KeyPair,
+                                  validityWindow: Pair<Duration, Duration> = X509Utilities.DEFAULT_VALIDITY_WINDOW): X509Certificate {
+    val window = X509Utilities.getCertificateValidityWindow(validityWindow.first, validityWindow.second)
+    return X509Utilities.createCertificate(CertificateType.TLS, subject, keyPair, subject, keyPair.public, window)
 }
 
 fun saveToKeyStore(keyStorePath: Path, rpcKeyPair: KeyPair, selfSignCert: X509Certificate, password: String = "password", alias: String = "Key"): Path {

--- a/node/src/main/kotlin/net/corda/node/utilities/CertificatesUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/CertificatesUtils.kt
@@ -9,22 +9,22 @@ import javax.security.auth.x500.X500Principal
 
 val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
 
-fun createKeyPairAndSelfSignedCertificate(x500Principal: X500Principal= testName): Pair<KeyPair, X509Certificate> {
+fun createKeyPairAndSelfSignedCertificate(x500Principal: X500Principal = testName): Pair<KeyPair, X509Certificate> {
     val rpcKeyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
     val selfSignCert = X509Utilities.createSelfSignedCACertificate(x500Principal, rpcKeyPair)
     return Pair(rpcKeyPair, selfSignCert)
 }
 
-fun saveToKeyStore(keyStorePath: Path, rpcKeyPair: KeyPair, selfSignCert: X509Certificate, password: String = "password"): Path {
+fun saveToKeyStore(keyStorePath: Path, rpcKeyPair: KeyPair, selfSignCert: X509Certificate, password: String = "password", alias: String = "Key"): Path {
     val keyStore = loadOrCreateKeyStore(keyStorePath, password)
-    keyStore.addOrReplaceKey("Key", rpcKeyPair.private, password.toCharArray(), arrayOf(selfSignCert))
+    keyStore.addOrReplaceKey(alias, rpcKeyPair.private, password.toCharArray(), arrayOf(selfSignCert))
     keyStore.save(keyStorePath, password)
     return keyStorePath
 }
 
-fun saveToTrustStore(trustStorePath: Path, selfSignCert: X509Certificate, password: String = "password"): Path {
+fun saveToTrustStore(trustStorePath: Path, selfSignCert: X509Certificate, password: String = "password", alias: String = "Key"): Path {
     val trustStore = loadOrCreateKeyStore(trustStorePath, password)
-    trustStore.addOrReplaceCertificate("Key", selfSignCert)
+    trustStore.addOrReplaceCertificate(alias, selfSignCert)
     trustStore.save(trustStorePath, password)
     return trustStorePath
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/CertificatesUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/CertificatesUtils.kt
@@ -1,0 +1,30 @@
+package net.corda.node.utilities
+
+import net.corda.core.crypto.Crypto
+import net.corda.nodeapi.internal.crypto.*
+import java.nio.file.Path
+import java.security.KeyPair
+import java.security.cert.X509Certificate
+import javax.security.auth.x500.X500Principal
+
+val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
+
+fun createKeyPairAndSelfSignedCertificate(x500Principal: X500Principal= testName): Pair<KeyPair, X509Certificate> {
+    val rpcKeyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
+    val selfSignCert = X509Utilities.createSelfSignedCACertificate(x500Principal, rpcKeyPair)
+    return Pair(rpcKeyPair, selfSignCert)
+}
+
+fun saveToKeyStore(keyStorePath: Path, rpcKeyPair: KeyPair, selfSignCert: X509Certificate, password: String = "password"): Path {
+    val keyStore = loadOrCreateKeyStore(keyStorePath, password)
+    keyStore.addOrReplaceKey("Key", rpcKeyPair.private, password.toCharArray(), arrayOf(selfSignCert))
+    keyStore.save(keyStorePath, password)
+    return keyStorePath
+}
+
+fun saveToTrustStore(trustStorePath: Path, selfSignCert: X509Certificate, password: String = "password"): Path {
+    val trustStore = loadOrCreateKeyStore(trustStorePath, password)
+    trustStore.addOrReplaceCertificate("Key", selfSignCert)
+    trustStore.save(trustStorePath, password)
+    return trustStorePath
+}

--- a/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt
+++ b/node/src/test/kotlin/net/corda/node/NodeArgsParserTest.kt
@@ -42,6 +42,7 @@ class NodeArgsParserTest {
                 noLocalShell = false,
                 sshdServer = false,
                 justGenerateNodeInfo = false,
+                justGenerateRpcSslCerts = false,
                 bootstrapRaftCluster = false,
                 unknownConfigKeysPolicy = UnknownConfigKeysPolicy.FAIL,
                 devMode = false,

--- a/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
@@ -14,7 +14,7 @@ import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.services.messaging.InternalRPCMessagingClient
 import net.corda.node.services.messaging.RPCServerConfiguration
-import net.corda.node.utilities.createKeyPairAndSelfSignedCertificate
+import net.corda.node.utilities.createKeyPairAndSelfSignedTLSCertificate
 import net.corda.node.utilities.saveToKeyStore
 import net.corda.node.utilities.saveToTrustStore
 import net.corda.nodeapi.ArtemisTcpTransport.Companion.rpcConnectorTcpTransport
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Path
+import javax.security.auth.x500.X500Principal
 
 class ArtemisRpcTests {
     private val ports: PortAllocation = RandomFree
@@ -49,9 +50,11 @@ class ArtemisRpcTests {
     @JvmField
     val tempFolder = TemporaryFolder()
 
+    val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
+
     @Test
     fun rpc_with_ssl_enabled() {
-        val (rpcKeyPair, selfSignCert) = createKeyPairAndSelfSignedCertificate()
+        val (rpcKeyPair, selfSignCert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFile("rpcKeystore.jks"), rpcKeyPair, selfSignCert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
         val trustStorePath = saveToTrustStore(tempFile("rpcTruststore.jks"), selfSignCert)
@@ -66,7 +69,7 @@ class ArtemisRpcTests {
 
     @Test
     fun rpc_with_no_ssl_on_client_side_and_ssl_on_server_side() {
-        val (rpcKeyPair, selfSignCert) = createKeyPairAndSelfSignedCertificate()
+        val (rpcKeyPair, selfSignCert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFile("rpcKeystore.jks"), rpcKeyPair, selfSignCert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
         // here client sslOptions are passed null (as in, do not use SSL)
@@ -77,12 +80,12 @@ class ArtemisRpcTests {
 
     @Test
     fun rpc_client_certificate_untrusted_to_server() {
-        val (rpcKeyPair, selfSignCert) = createKeyPairAndSelfSignedCertificate()
+        val (rpcKeyPair, selfSignCert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFile("rpcKeystore.jks"), rpcKeyPair, selfSignCert)
 
         // create another keypair and certificate and add that to the client truststore
         // the ssl connection should not
-        val (_, selfSignCert1) = createKeyPairAndSelfSignedCertificate()
+        val (_, selfSignCert1) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val trustStorePath = saveToTrustStore(tempFile("rpcTruststore.jks"), selfSignCert1)
 
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")

--- a/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
@@ -14,6 +14,9 @@ import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.services.messaging.InternalRPCMessagingClient
 import net.corda.node.services.messaging.RPCServerConfiguration
+import net.corda.node.utilities.createKeyPairAndSelfSignedCertificate
+import net.corda.node.utilities.saveToKeyStore
+import net.corda.node.utilities.saveToTrustStore
 import net.corda.nodeapi.ArtemisTcpTransport.Companion.rpcConnectorTcpTransport
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.nodeapi.internal.config.SSLConfiguration
@@ -21,10 +24,7 @@ import net.corda.nodeapi.internal.config.User
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.internal.RandomFree
-import net.corda.testing.internal.createKeyPairAndSelfSignedCertificate
 import net.corda.testing.internal.createNodeSslConfig
-import net.corda.testing.internal.saveToKeyStore
-import net.corda.testing.internal.saveToTrustStore
 import org.apache.activemq.artemis.api.core.ActiveMQConnectionTimedOutException
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
 import org.assertj.core.api.Assertions.assertThat

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt
@@ -2,11 +2,13 @@ package net.corda.traderdemo
 
 import joptsimple.OptionParser
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.messaging.ClientRpcSslOptions
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.finance.DOLLARS
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
+import java.nio.file.Paths
 import kotlin.system.exitProcess
 
 /**
@@ -31,31 +33,38 @@ private class TraderDemo {
     }
 
     fun main(args: Array<String>) {
-        val parser = OptionParser()
-
-        val roleArg = parser.accepts("role").withRequiredArg().ofType(Role::class.java).required()
-        val options = try {
-            parser.parse(*args)
-        } catch (e: Exception) {
-            logger.error(e.message)
-            printHelp(parser)
-            exitProcess(1)
+        CordaRPCClient.createWithSsl(
+                NetworkHostAndPort("localhost", 10006),
+                ClientRpcSslOptions(Paths.get("/Users/tudormalene/Workspace/corda/samples/trader-demo/build/nodes/Bank A/certificates/export/rpcssltruststore.jks"), "pass")
+        ).use("demo", "demo") {
+            println(it.proxy.nodeInfo())
         }
 
-        // What happens next depends on the role. The buyer sits around waiting for a trade to start. The seller role
-        // will contact the buyer and actually make something happen.  We intentionally use large amounts here.
-        val role = options.valueOf(roleArg)!!
-        if (role == Role.BANK) {
-            val bankHost = NetworkHostAndPort("localhost", bankRpcPort)
-            CordaRPCClient(bankHost).use("demo", "demo") {
-                TraderDemoClientApi(it.proxy).runIssuer(1_100_000_000_000.DOLLARS, buyerName, sellerName)
-            }
-        } else {
-            val sellerHost = NetworkHostAndPort("localhost", sellerRpcPort)
-            CordaRPCClient(sellerHost).use("demo", "demo") {
-                TraderDemoClientApi(it.proxy).runSeller(1_000_000_000_000.DOLLARS, buyerName)
-            }
-        }
+//        val parser = OptionParser()
+//
+//        val roleArg = parser.accepts("role").withRequiredArg().ofType(Role::class.java).required()
+//        val options = try {
+//            parser.parse(*args)
+//        } catch (e: Exception) {
+//            logger.error(e.message)
+//            printHelp(parser)
+//            exitProcess(1)
+//        }
+//
+//        // What happens next depends on the role. The buyer sits around waiting for a trade to start. The seller role
+//        // will contact the buyer and actually make something happen.  We intentionally use large amounts here.
+//        val role = options.valueOf(roleArg)!!
+//        if (role == Role.BANK) {
+//            val bankHost = NetworkHostAndPort("localhost", bankRpcPort)
+//            CordaRPCClient(bankHost).use("demo", "demo") {
+//                TraderDemoClientApi(it.proxy).runIssuer(1_100_000_000_000.DOLLARS, buyerName, sellerName)
+//            }
+//        } else {
+//            val sellerHost = NetworkHostAndPort("localhost", sellerRpcPort)
+//            CordaRPCClient(sellerHost).use("demo", "demo") {
+//                TraderDemoClientApi(it.proxy).runSeller(1_000_000_000_000.DOLLARS, buyerName)
+//            }
+//        }
     }
 
     fun printHelp(parser: OptionParser) {

--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/TraderDemo.kt
@@ -2,13 +2,11 @@ package net.corda.traderdemo
 
 import joptsimple.OptionParser
 import net.corda.client.rpc.CordaRPCClient
-import net.corda.core.messaging.ClientRpcSslOptions
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.finance.DOLLARS
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_BANK_B_NAME
-import java.nio.file.Paths
 import kotlin.system.exitProcess
 
 /**
@@ -33,38 +31,31 @@ private class TraderDemo {
     }
 
     fun main(args: Array<String>) {
-        CordaRPCClient.createWithSsl(
-                NetworkHostAndPort("localhost", 10006),
-                ClientRpcSslOptions(Paths.get("/Users/tudormalene/Workspace/corda/samples/trader-demo/build/nodes/Bank A/certificates/export/rpcssltruststore.jks"), "pass")
-        ).use("demo", "demo") {
-            println(it.proxy.nodeInfo())
+        val parser = OptionParser()
+
+        val roleArg = parser.accepts("role").withRequiredArg().ofType(Role::class.java).required()
+        val options = try {
+            parser.parse(*args)
+        } catch (e: Exception) {
+            logger.error(e.message)
+            printHelp(parser)
+            exitProcess(1)
         }
 
-//        val parser = OptionParser()
-//
-//        val roleArg = parser.accepts("role").withRequiredArg().ofType(Role::class.java).required()
-//        val options = try {
-//            parser.parse(*args)
-//        } catch (e: Exception) {
-//            logger.error(e.message)
-//            printHelp(parser)
-//            exitProcess(1)
-//        }
-//
-//        // What happens next depends on the role. The buyer sits around waiting for a trade to start. The seller role
-//        // will contact the buyer and actually make something happen.  We intentionally use large amounts here.
-//        val role = options.valueOf(roleArg)!!
-//        if (role == Role.BANK) {
-//            val bankHost = NetworkHostAndPort("localhost", bankRpcPort)
-//            CordaRPCClient(bankHost).use("demo", "demo") {
-//                TraderDemoClientApi(it.proxy).runIssuer(1_100_000_000_000.DOLLARS, buyerName, sellerName)
-//            }
-//        } else {
-//            val sellerHost = NetworkHostAndPort("localhost", sellerRpcPort)
-//            CordaRPCClient(sellerHost).use("demo", "demo") {
-//                TraderDemoClientApi(it.proxy).runSeller(1_000_000_000_000.DOLLARS, buyerName)
-//            }
-//        }
+        // What happens next depends on the role. The buyer sits around waiting for a trade to start. The seller role
+        // will contact the buyer and actually make something happen.  We intentionally use large amounts here.
+        val role = options.valueOf(roleArg)!!
+        if (role == Role.BANK) {
+            val bankHost = NetworkHostAndPort("localhost", bankRpcPort)
+            CordaRPCClient(bankHost).use("demo", "demo") {
+                TraderDemoClientApi(it.proxy).runIssuer(1_100_000_000_000.DOLLARS, buyerName, sellerName)
+            }
+        } else {
+            val sellerHost = NetworkHostAndPort("localhost", sellerRpcPort)
+            CordaRPCClient(sellerHost).use("demo", "demo") {
+                TraderDemoClientApi(it.proxy).runSeller(1_000_000_000_000.DOLLARS, buyerName)
+            }
+        }
     }
 
     fun printHelp(parser: OptionParser) {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -1,6 +1,5 @@
 package net.corda.testing.internal
 
-import com.nhaarman.mockito_kotlin.doAnswer
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.Crypto.generateKeyPair
 import net.corda.core.identity.CordaX500Name
@@ -19,7 +18,6 @@ import net.corda.serialization.internal.amqp.AMQP_ENABLED
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyPair
-import java.security.cert.X509Certificate
 import javax.security.auth.x500.X500Principal
 
 @Suppress("unused")
@@ -140,25 +138,4 @@ fun createNodeSslConfig(path: Path, name: CordaX500Name = CordaX500Name("MegaCor
     trustStore.save(sslConfig.trustStoreFile, sslConfig.trustStorePassword)
 
     return sslConfig
-}
-
-fun createKeyPairAndSelfSignedCertificate(): Pair<KeyPair, X509Certificate> {
-    val rpcKeyPair = Crypto.generateKeyPair(X509Utilities.DEFAULT_TLS_SIGNATURE_SCHEME)
-    val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
-    val selfSignCert = X509Utilities.createSelfSignedCACertificate(testName, rpcKeyPair)
-    return Pair(rpcKeyPair, selfSignCert)
-}
-
-fun saveToKeyStore(keyStorePath: Path, rpcKeyPair: KeyPair, selfSignCert: X509Certificate, password: String = "password"): Path {
-    val keyStore = loadOrCreateKeyStore(keyStorePath, password)
-    keyStore.addOrReplaceKey("Key", rpcKeyPair.private, password.toCharArray(), arrayOf(selfSignCert))
-    keyStore.save(keyStorePath, password)
-    return keyStorePath
-}
-
-fun saveToTrustStore(trustStorePath: Path, selfSignCert: X509Certificate, password: String = "password"): Path {
-    val trustStore = loadOrCreateKeyStore(trustStorePath, password)
-    trustStore.addOrReplaceCertificate("Key", selfSignCert)
-    trustStore.save(trustStorePath, password)
-    return trustStorePath
 }

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -12,7 +12,7 @@ import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.services.config.shell.toShellConfig
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.core.messaging.ClientRpcSslOptions
-import net.corda.node.utilities.createKeyPairAndSelfSignedCertificate
+import net.corda.node.utilities.createKeyPairAndSelfSignedTLSCertificate
 import net.corda.node.utilities.saveToKeyStore
 import net.corda.node.utilities.saveToTrustStore
 import net.corda.testing.core.ALICE_NAME
@@ -30,6 +30,7 @@ import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import javax.security.auth.x500.X500Principal
 import kotlin.test.assertTrue
 
 class InteractiveShellIntegrationTest {
@@ -37,6 +38,8 @@ class InteractiveShellIntegrationTest {
     @Rule
     @JvmField
     val tempFolder = TemporaryFolder()
+
+    val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
 
     @Test
     fun `shell should not log in with invalid credentials`() {
@@ -75,7 +78,7 @@ class InteractiveShellIntegrationTest {
         val user = User("mark", "dadada", setOf(all()))
         var successful = false
 
-        val (keyPair, cert) = createKeyPairAndSelfSignedCertificate()
+        val (keyPair, cert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFolder.root.toPath() / "keystore.jks", keyPair, cert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
 
@@ -102,11 +105,11 @@ class InteractiveShellIntegrationTest {
     @Test
     fun `shell shoud not log in with invalid truststore`() {
         val user = User("mark", "dadada", setOf("ALL"))
-        val (keyPair, cert) = createKeyPairAndSelfSignedCertificate()
+        val (keyPair, cert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFolder.root.toPath() / "keystore.jks", keyPair, cert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
 
-        val (_, cert1) = createKeyPairAndSelfSignedCertificate()
+        val (_, cert1) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val trustStorePath = saveToTrustStore(tempFolder.root.toPath() / "truststore.jks", cert1)
         val clientSslOptions = ClientRpcSslOptions(trustStorePath, "password")
 
@@ -186,7 +189,7 @@ class InteractiveShellIntegrationTest {
                 Permissions.invokeRpc(CordaRPCOps::registeredFlows),
                 Permissions.invokeRpc(CordaRPCOps::nodeInfo)/*all()*/))
 
-        val (keyPair, cert) = createKeyPairAndSelfSignedCertificate()
+        val (keyPair, cert) = createKeyPairAndSelfSignedTLSCertificate(testName)
         val keyStorePath = saveToKeyStore(tempFolder.root.toPath() / "keystore.jks", keyPair, cert)
         val brokerSslOptions = BrokerRpcSslOptions(keyStorePath, "password")
         val trustStorePath = saveToTrustStore(tempFolder.root.toPath() / "truststore.jks", cert)

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -12,14 +12,14 @@ import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.services.config.shell.toShellConfig
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.core.messaging.ClientRpcSslOptions
+import net.corda.node.utilities.createKeyPairAndSelfSignedCertificate
+import net.corda.node.utilities.saveToKeyStore
+import net.corda.node.utilities.saveToTrustStore
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.internal.NodeHandleInternal
 import net.corda.testing.driver.internal.RandomFree
-import net.corda.testing.internal.createKeyPairAndSelfSignedCertificate
-import net.corda.testing.internal.saveToKeyStore
-import net.corda.testing.internal.saveToTrustStore
 import net.corda.testing.internal.useSslRpcOverrides
 import net.corda.testing.node.User
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException


### PR DESCRIPTION
see https://r3-cev.atlassian.net/browse/ENT-1796

Problems addressed by this PR:
- add "--just-generate-rpc-ssl-settings" command line argument that generates all the plumbing and also instructions around the rpc ssl configuration
- fix config documentation and add note around how to generate the settings
- make config checks better 
