### PR TITLE
CORDA-1610: Retain progress tracker during flow retry.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -33,6 +33,7 @@ import net.corda.node.services.statemachine.FlowStateMachineImpl.Companion.creat
 import net.corda.node.services.statemachine.interceptors.*
 import net.corda.node.services.statemachine.transitions.StateMachine
 import net.corda.node.utilities.AffinityExecutor
+import net.corda.node.utilities.injectOldProgressTracker
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.wrapWithDatabaseTransaction
 import net.corda.serialization.internal.SerializeAsTokenContextImpl
@@ -361,7 +362,10 @@ class SingleThreadedStateMachineManager(
             for (sessionId in getFlowSessionIds(currentState.checkpoint)) {
                 sessionToFlow.remove(sessionId)
             }
-            if (flow != null) addAndStartFlow(flowId, flow)
+            if (flow != null) {
+                injectOldProgressTracker(currentState.flowLogic.progressTracker, flow.fiber.logic)
+                addAndStartFlow(flowId, flow)
+            }
             // Deliver all the external events from the old flow instance.
             val unprocessedExternalEvents = mutableListOf<ExternalEvent>()
             do {

--- a/node/src/main/kotlin/net/corda/node/utilities/StateMachineManagerUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/StateMachineManagerUtils.kt
@@ -1,0 +1,22 @@
+package net.corda.node.utilities
+
+import net.corda.core.flows.FlowLogic
+import net.corda.core.utilities.ProgressTracker
+import net.corda.node.services.statemachine.StateMachineManagerInternal
+
+/**
+ * The flow de-serialized from the checkpoint will contain a new instance of the progress tracker, which means that
+ * any existing flow observers would be lost. We need to replace it with the old progress tracker to ensure progress
+ * updates are correctly sent out after the flow is retried.
+ */
+fun StateMachineManagerInternal.injectOldProgressTracker(oldProgressTracker: ProgressTracker?, newFlowLogic: FlowLogic<*>) {
+    if (oldProgressTracker != null) {
+        try {
+            val field = newFlowLogic::class.java.getDeclaredField("progressTracker")
+            field.isAccessible = true
+            field.set(newFlowLogic, oldProgressTracker)
+        } catch (e: NoSuchFieldException) {
+            // The flow does not use a progress tracker.
+        }
+    }
+}


### PR DESCRIPTION
Make sure the same progress tracker object is re-used in the restarted flow so subscribers can keep receiving progress updates.