### PR TITLE
CORDA-1644: Add a more descriptive error message when the notary type…

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/NotaryWireFormat.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryWireFormat.kt
@@ -61,12 +61,18 @@ data class NotarisationPayload(val transaction: Any, val requestSignature: Notar
      * A helper for automatically casting the underlying [transaction] payload to a [SignedTransaction].
      * Should only be used by validating notaries.
      */
-    val signedTransaction get() = transaction as SignedTransaction
+    val signedTransaction get() = transaction as? SignedTransaction ?: throw exception()
+
     /**
      * A helper for automatically casting the underlying [transaction] payload to a [CoreTransaction].
      * Should only be used by non-validating notaries.
      */
-    val coreTransaction get() = transaction as CoreTransaction
+    val coreTransaction get() = transaction as? CoreTransaction ?: throw exception()
+
+    private fun exception() = IllegalArgumentException("Unexpected transaction type in the notarisation payload: " +
+            "${transaction::class.java}, it may be that there is a discrepancy between the configured notary type " +
+            "(validating/non-validating) and the one advertised on the network parameters."
+    )
 }
 
 /** Payload returned by the notary service flow to the client. */


### PR DESCRIPTION
… is mis-configured.
