### PR TITLE
CORDA-1639: Resolve ProviderMismatchException when copying a file into a ZIP.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/PathUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/PathUtils.kt
@@ -43,7 +43,16 @@ fun Path.exists(vararg options: LinkOption): Boolean = Files.exists(this, *optio
 /** Copy the file into the target directory using [Files.copy]. */
 fun Path.copyToDirectory(targetDir: Path, vararg options: CopyOption): Path {
     require(targetDir.isDirectory()) { "$targetDir is not a directory" }
-    val targetFile = targetDir.resolve(fileName)
+    /*
+     * We must use fileName.toString() here because resolve(Path)
+     * will throw ProviderMismatchException if the Path parameter
+     * and targetDir have different Path providers, e.g. a file
+     * on the filesystem vs an entry in a ZIP file.
+     *
+     * Path.toString() is assumed safe because fileName should
+     * not include any path separator characters.
+     */
+    val targetFile = targetDir.resolve(fileName.toString())
     Files.copy(this, targetFile, *options)
     return targetFile
 }

--- a/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt
@@ -4,6 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.URI
+import java.nio.file.FileSystems
+import java.nio.file.Path
 
 class PathUtilsTest {
     @Rule
@@ -58,5 +62,22 @@ class PathUtilsTest {
         (dir2 / "dir3").createDirectories()
         dir.deleteRecursively()
         assertThat(dir).doesNotExist()
+    }
+
+    @Test
+    fun `copy into zip directory`() {
+        val source: Path = tempFolder.newFile("source.txt").let {
+            it.writeText("Example Text")
+            it.toPath()
+        }
+        val target = File(tempFolder.root, "target.zip")
+        FileSystems.newFileSystem(URI.create("jar:${target.toURI()}"), mapOf("create" to "true")).use { fs ->
+            val dir = fs.getPath("dir").createDirectories()
+            val result = source.copyToDirectory(dir)
+            assertThat(result)
+                .isRegularFile()
+                .hasParent(dir)
+                .hasSameContentAs(source)
+        }
     }
 }

--- a/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/PathUtilsTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.File
 import java.net.URI
 import java.nio.file.FileSystems
 import java.nio.file.Path
@@ -65,13 +64,13 @@ class PathUtilsTest {
     }
 
     @Test
-    fun `copy into zip directory`() {
+    fun `copyToDirectory - copy into zip directory`() {
         val source: Path = tempFolder.newFile("source.txt").let {
             it.writeText("Example Text")
             it.toPath()
         }
-        val target = File(tempFolder.root, "target.zip")
-        FileSystems.newFileSystem(URI.create("jar:${target.toURI()}"), mapOf("create" to "true")).use { fs ->
+        val target = tempFolder.root.toPath() / "target.zip"
+        FileSystems.newFileSystem(URI.create("jar:${target.toUri()}"), mapOf("create" to "true")).use { fs ->
             val dir = fs.getPath("dir").createDirectories()
             val result = source.copyToDirectory(dir)
             assertThat(result)


### PR DESCRIPTION
This fixes the creation of DemoBench profiles.