### PR TITLE
Use an expiry time of a century instead of a decade for dev certs.

### DIFF
--- a/docs/source/permissioning.rst
+++ b/docs/source/permissioning.rst
@@ -76,6 +76,11 @@ required public/private keypairs and certificates using Bouncy Castle. You can f
 repository <https://github.com/corda/corda>`__, under
 ``/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt``.
 
+.. note:: Corda allows any expiry time to be set in identity certificates. However, we recommend that the expiry time
+   is set so far in the future that the certificate will effectively never expire. Certificate expiration has been
+   responsible for causing many outages in the past, and is not an effective way to phase out old algorithms either.
+   It's better and safer not to use it.
+
 Certificate role extension
 --------------------------
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -5,7 +5,6 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SignatureScheme
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.internal.*
-import net.corda.core.utilities.days
 import net.corda.core.utilities.millis
 import org.bouncycastle.asn1.*
 import org.bouncycastle.asn1.x500.X500Name
@@ -48,7 +47,7 @@ object X509Utilities {
     const val CORDA_CLIENT_TLS = "cordaclienttls"
     const val CORDA_CLIENT_CA = "cordaclientca"
 
-    val DEFAULT_VALIDITY_WINDOW = Pair(0.millis, 3650.days)
+    val DEFAULT_VALIDITY_WINDOW = Pair(0.millis, Duration.ofDays(100 * 365))  // 1 century
 
     /**
      * Helper function to return the latest out of an instant and an optional date.


### PR DESCRIPTION
This is effectively the same as not expiring (I plan to have died of an over-generous lunch habit, by the time I'm 134).
