### PR TITLE
CORDA-1685: Remove `bank-of-corda.jar` from DemoBench.

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -127,11 +127,6 @@ distributions {
                 into 'cordapps'
                 fileMode = 0444
             }
-            from(project(':samples:bank-of-corda-demo').jar) {
-                rename 'bank-of-corda-demo-(.*)', 'bank-of-corda.jar'
-                into 'cordapps'
-                fileMode = 0444
-            }
         }
     }
 }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/plugin/CordappController.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/plugin/CordappController.kt
@@ -15,7 +15,6 @@ class CordappController : Controller() {
 
     private val jvm by inject<JVMConfig>()
     private val cordappDir: Path = jvm.applicationDir.resolve(NodeConfig.cordappDirName)
-    private val bankOfCorda: Path = cordappDir.resolve("bank-of-corda.jar")
     private val finance: Path = cordappDir.resolve("corda-finance.jar")
 
     /**
@@ -30,11 +29,6 @@ class CordappController : Controller() {
             finance.copyToDirectory(config.cordappsDir, StandardCopyOption.REPLACE_EXISTING)
             log.info("Installed 'Finance' cordapp")
         }
-        // Nodes cannot issue cash unless they contain the "Bank of Corda" cordapp.
-        if (config.nodeConfig.issuableCurrencies.isNotEmpty() && bankOfCorda.exists()) {
-            bankOfCorda.copyToDirectory(config.cordappsDir, StandardCopyOption.REPLACE_EXISTING)
-            log.info("Installed 'Bank of Corda' cordapp")
-        }
     }
 
     /**
@@ -44,14 +38,12 @@ class CordappController : Controller() {
     fun useCordappsFor(config: HasCordapps): List<Path> {
         if (!config.cordappsDir.isDirectory()) return emptyList()
         return config.cordappsDir.walk(1) { paths ->
-            paths
-                    .filter(Path::isCordapp)
-                    .filter { !bankOfCorda.endsWith(it.fileName) }
-                    .filter { !finance.endsWith(it.fileName) }
-                    .toList()
+            paths.filter(Path::isCordapp)
+                 .filter { !finance.endsWith(it.fileName) }
+                 .toList()
         }
     }
 }
 
-fun Path.isCordapp(): Boolean = this.isReadable && this.fileName.toString().endsWith(".jar")
-fun Path.inCordappsDir(): Boolean = (this.parent != null) && this.parent.endsWith("cordapps/")
+val Path.isCordapp: Boolean get() = this.isReadable && this.fileName.toString().endsWith(".jar")
+val Path.inCordappsDir: Boolean get() = (this.parent != null) && this.parent.endsWith("cordapps/")

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/profile/ProfileController.kt
@@ -115,7 +115,7 @@ class ProfileController : Controller() {
             // Now extract all of the plugins from the ZIP file,
             // and copy them to a temporary location.
             StreamSupport.stream(fs.rootDirectories.spliterator(), false)
-                    .flatMap { Files.find(it, 3, BiPredicate { p, attr -> p.inCordappsDir() && p.isCordapp() && attr.isRegularFile }) }
+                    .flatMap { Files.find(it, 3, BiPredicate { p, attr -> p.inCordappsDir && p.isCordapp && attr.isRegularFile }) }
                     .forEach { cordapp ->
                         val config = nodeIndex[cordapp.getName(0).toString()] ?: return@forEach
 

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -52,7 +52,7 @@ task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').co
     }
 }
 
-build.dependsOn buildExplorerJAR
+assemble.dependsOn buildExplorerJAR
 
 artifacts {
     runtimeArtifacts buildExplorerJAR


### PR DESCRIPTION
The `bank-of-corda` JAR used to enable the `CashIssueFlow`. However, this functionality has since been superseded and so this JAR can now be deleted.