### PR TITLE
TimedFlowTests: remove progress tracker completion timeout

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -177,7 +177,7 @@ class TimedFlowTests {
     private fun getDoneFuture(progressTracker: ProgressTracker): Future<ProgressTracker.Change> {
         return progressTracker.changes.takeFirst {
             it.progressTracker.currentStep == ProgressTracker.DONE
-        }.timeout(5, TimeUnit.SECONDS).bufferUntilSubscribed().toBlocking().toFuture()
+        }.timeout(30, TimeUnit.SECONDS).bufferUntilSubscribed().toBlocking().toFuture()
     }
 
     @CordaService

--- a/node/src/integration-test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -177,7 +177,7 @@ class TimedFlowTests {
     private fun getDoneFuture(progressTracker: ProgressTracker): Future<ProgressTracker.Change> {
         return progressTracker.changes.takeFirst {
             it.progressTracker.currentStep == ProgressTracker.DONE
-        }.timeout(30, TimeUnit.SECONDS).bufferUntilSubscribed().toBlocking().toFuture()
+        }.bufferUntilSubscribed().toBlocking().toFuture()
     }
 
     @CordaService


### PR DESCRIPTION
For some reason the timed flow can take 10s or more to retry when running in CI