### PR TITLE
CORDA-1687: Remove unwanted hibernate-core from DemoBench and Node Explorer.

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
-    ext.tornadofx_version = '1.7.15'
-    ext.jna_version = '4.1.0'
-    ext.purejavacomm_version = '0.0.18'
-    ext.controlsfx_version = '8.40.12'
+    ext {
+        tornadofx_version = '1.7.15'
+        jna_version = '4.1.0'
+        purejavacomm_version = '0.0.18'
+        controlsfx_version = '8.40.12'
 
-    ext.java_home = System.properties.'java.home'
-    ext.pkg_source = "$buildDir/packagesrc"
-    ext.pkg_outDir = "$buildDir/javapackage"
-    ext.dist_source = "$pkg_source/demobench-$version"
-    ext.pkg_version = version.indexOf('-') >= 0 ? version.substring(0, version.indexOf('-')) : version
-    ext.pkg_macosxKeyUserName = 'R3CEV'
+        java_home = System.properties.'java.home'
+        pkg_source = "$buildDir/packagesrc"
+        pkg_outDir = "$buildDir/javapackage"
+        dist_source = "$pkg_source/demobench-$version"
+        pkg_version = version.indexOf('-') >= 0 ? version.substring(0, version.indexOf('-')) : version
+        pkg_macosxKeyUserName = 'R3CEV'
+    }
 
     repositories {
         mavenLocal()
@@ -37,6 +39,13 @@ repositories {
     maven {
         jcenter()
         url 'http://www.sparetimelabs.com/maven2'
+    }
+}
+
+configurations {
+    compile {
+        // We don't need Hibernate just for its @Type annotation.
+        exclude group: 'org.hibernate', module: 'hibernate-core'
     }
 }
 
@@ -74,7 +83,7 @@ dependencies {
 
     testCompile "junit:junit:$junit_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testCompile "org.assertj:assertj-core:${assertj_version}"
+    testCompile "org.assertj:assertj-core:$assertj_version"
 }
 
 jar {

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -15,6 +15,13 @@ processResources {
     from file("$rootDir/config/dev/log4j2.xml")
 }
 
+configurations {
+    compile {
+        // We don't need Hibernate just for its @Type annotation.
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
+}
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
@@ -54,12 +61,12 @@ dependencies {
     compile 'com.yuvimasory:orange-extensions:1.3.0'
 }
 
-task(runDemoNodes, dependsOn: 'classes', type: JavaExec) {
+task runDemoNodes(dependsOn: 'classes', type: JavaExec) {
     main = 'net.corda.explorer.MainKt'
     classpath = sourceSets.main.runtimeClasspath
 }
 
-task(runSimulationNodes, dependsOn: 'classes', type: JavaExec) {
+task runSimulationNodes(dependsOn: 'classes', type: JavaExec) {
     main = 'net.corda.explorer.MainKt'
     classpath = sourceSets.main.runtimeClasspath
     args '-S'


### PR DESCRIPTION
`hibernate-core` is 6.5MB, and neither DemoBench nor Node Explorer needs it. They are both quite fat enough already.

And small warning/consistency fixes in `build.gradle` files too.