### PR TITLE
ENT-2145: Configure DemoBench nodes to issue selected currencies.

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -34,8 +34,8 @@ repositories {
     flatDir {
         dirs 'libs'
     }
+    jcenter()
     maven {
-        jcenter()
         url 'http://www.sparetimelabs.com/maven2'
     }
 }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeConfig.kt
@@ -1,9 +1,7 @@
 package net.corda.demobench.model
 
-import com.typesafe.config.Config
+import com.typesafe.config.*
 import com.typesafe.config.ConfigFactory.empty
-import com.typesafe.config.ConfigRenderOptions
-import com.typesafe.config.ConfigValueFactory
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.copyToDirectory
 import net.corda.core.internal.createDirectories
@@ -45,13 +43,22 @@ data class NodeConfig(
     }
 
     fun nodeConf(): Config {
-
-        val basic = NodeConfigurationData(myLegalName, p2pAddress, rpcAddress, notary, h2port, rpcUsers, useTestClock, detectPublicIp, devMode).toConfig()
-        val rpcSettings = empty()
-                .withValue("address", ConfigValueFactory.fromAnyRef(rpcAddress.toString()))
-                .withValue("adminAddress", ConfigValueFactory.fromAnyRef(rpcAdminAddress.toString()))
-                .root()
-        return basic.withoutPath("rpcAddress").withoutPath("rpcAdminAddress").withValue("rpcSettings", rpcSettings)
+        val rpcSettings: ConfigObject = empty()
+            .withValue("address", valueFor(rpcAddress.toString()))
+            .withValue("adminAddress", valueFor(rpcAdminAddress.toString()))
+            .root()
+        val customMap: Map<String, Any> = HashMap<String, Any>().also {
+            if (issuableCurrencies.isNotEmpty()) {
+                it["issuableCurrencies"] = issuableCurrencies
+            }
+        }
+        val custom: ConfigObject = ConfigFactory.parseMap(customMap).root()
+        return NodeConfigurationData(myLegalName, p2pAddress, rpcAddress, notary, h2port, rpcUsers, useTestClock, detectPublicIp, devMode)
+            .toConfig()
+            .withoutPath("rpcAddress")
+            .withoutPath("rpcAdminAddress")
+            .withValue("rpcSettings", rpcSettings)
+            .withOptionalValue("custom", custom)
     }
 
     fun webServerConf() = WebServerConfigurationData(myLegalName, rpcAddress, webAddress, rpcUsers).asConfig()
@@ -60,33 +67,29 @@ data class NodeConfig(
 
     fun toWebServerConfText() = webServerConf().render()
 
-    fun serialiseAsString(): String {
-
-        return toConfig().render()
-    }
+    fun serialiseAsString(): String = toConfig().render()
 
     private fun Config.render(): String = root().render(renderOptions)
 }
 
 private data class NodeConfigurationData(
-        val myLegalName: CordaX500Name,
-        val p2pAddress: NetworkHostAndPort,
-        val rpcAddress: NetworkHostAndPort,
-        val notary: NotaryService?,
-        val h2port: Int,
-        val rpcUsers: List<User> = listOf(NodeConfig.defaultUser),
-        val useTestClock: Boolean,
-        val detectPublicIp: Boolean,
-        val devMode: Boolean
+    val myLegalName: CordaX500Name,
+    val p2pAddress: NetworkHostAndPort,
+    val rpcAddress: NetworkHostAndPort,
+    val notary: NotaryService?,
+    val h2port: Int,
+    val rpcUsers: List<User> = listOf(NodeConfig.defaultUser),
+    val useTestClock: Boolean,
+    val detectPublicIp: Boolean,
+    val devMode: Boolean
 )
 
 private data class WebServerConfigurationData(
-        val myLegalName: CordaX500Name,
-        val rpcAddress: NetworkHostAndPort,
-        val webAddress: NetworkHostAndPort,
-        val rpcUsers: List<User>
+    val myLegalName: CordaX500Name,
+    val rpcAddress: NetworkHostAndPort,
+    val webAddress: NetworkHostAndPort,
+    val rpcUsers: List<User>
 ) {
-
    fun asConfig() = toConfig()
 }
 
@@ -117,3 +120,9 @@ data class NodeConfigWrapper(val baseDir: Path, val nodeConfig: NodeConfig) : Ha
 fun user(name: String) = User(name, "letmein", setOf("ALL"))
 
 fun String.toKey() = filter { !it.isWhitespace() }.toLowerCase()
+
+fun <T> valueFor(any: T): ConfigValue = ConfigValueFactory.fromAnyRef(any)
+
+private fun Config.withOptionalValue(path: String, obj: ConfigObject): Config {
+    return if (obj.isEmpty()) this else this.withValue(path, obj)
+}

--- a/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
+++ b/tools/demobench/src/test/kotlin/net/corda/demobench/model/NodeConfigTest.kt
@@ -1,19 +1,16 @@
 package net.corda.demobench.model
 
+import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigValueFactory
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.services.config.parseAsNodeConfiguration
 import net.corda.nodeapi.internal.config.User
 import net.corda.webserver.WebServerConfig
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class NodeConfigTest {
     companion object {
@@ -24,22 +21,25 @@ class NodeConfigTest {
     @Test
     fun `reading node configuration`() {
         val config = createConfig(
-                legalName = myLegalName,
-                p2pPort = 10001,
-                rpcPort = 40002,
-                rpcAdminPort = 40005,
-                webPort = 20001,
-                h2port = 30001,
-                notary = NotaryService(validating = false),
-                users = listOf(user("jenny"))
+            legalName = myLegalName,
+            p2pPort = 10001,
+            rpcPort = 40002,
+            rpcAdminPort = 40005,
+            webPort = 20001,
+            h2port = 30001,
+            notary = NotaryService(validating = false),
+            users = listOf(user("jenny"))
         )
 
         val nodeConfig = config.nodeConf()
-                .withValue("baseDirectory", ConfigValueFactory.fromAnyRef(baseDir.toString()))
-                .withFallback(ConfigFactory.parseResources("reference.conf"))
-                .withFallback(ConfigFactory.parseMap(mapOf("devMode" to true)))
-                .resolve()
+            .withValue("baseDirectory", valueFor(baseDir.toString()))
+            .withFallback(ConfigFactory.parseResources("reference.conf"))
+            .withFallback(ConfigFactory.parseMap(mapOf("devMode" to true)))
+            .resolve()
         val fullConfig = nodeConfig.parseAsNodeConfiguration()
+
+        // No custom configuration is created by default.
+        assertFailsWith<ConfigException.Missing> { nodeConfig.getConfig("custom") }
 
         assertEquals(myLegalName, fullConfig.myLegalName)
         assertEquals(localPort(40002), fullConfig.rpcOptions.address)
@@ -50,23 +50,47 @@ class NodeConfigTest {
     }
 
     @Test
+    fun `reading node configuration with currencies`() {
+        val config = createConfig(
+            legalName = myLegalName,
+            p2pPort = 10001,
+            rpcPort = 10002,
+            rpcAdminPort = 10003,
+            webPort = 10004,
+            h2port = 10005,
+            notary = NotaryService(validating = false),
+            issuableCurrencies = listOf("GBP")
+        )
+
+        val nodeConfig = config.nodeConf()
+            .withValue("baseDirectory", valueFor(baseDir.toString()))
+            .withFallback(ConfigFactory.parseResources("reference.conf"))
+            .resolve()
+        val custom = nodeConfig.getConfig("custom")
+        assertEquals(listOf("GBP"), custom.getAnyRefList("issuableCurrencies"))
+    }
+
+    @Test
     fun `reading webserver configuration`() {
         val config = createConfig(
-                legalName = myLegalName,
-                p2pPort = 10001,
-                rpcPort = 40002,
-                rpcAdminPort = 40003,
-                webPort = 20001,
-                h2port = 30001,
-                notary = NotaryService(validating = false),
-                users = listOf(user("jenny"))
+            legalName = myLegalName,
+            p2pPort = 10001,
+            rpcPort = 40002,
+            rpcAdminPort = 40003,
+            webPort = 20001,
+            h2port = 30001,
+            notary = NotaryService(validating = false),
+            users = listOf(user("jenny"))
         )
 
         val nodeConfig = config.webServerConf()
-                .withValue("baseDirectory", ConfigValueFactory.fromAnyRef(baseDir.toString()))
-                .withFallback(ConfigFactory.parseResources("web-reference.conf"))
-                .resolve()
+            .withValue("baseDirectory", valueFor(baseDir.toString()))
+            .withFallback(ConfigFactory.parseResources("web-reference.conf"))
+            .resolve()
         val webConfig = WebServerConfig(baseDir, nodeConfig)
+
+        // No custom configuration is created by default.
+        assertFailsWith<ConfigException.Missing> { nodeConfig.getConfig("custom") }
 
         assertEquals(localPort(20001), webConfig.webAddress)
         assertEquals(localPort(40002), webConfig.rpcAddress)
@@ -75,24 +99,26 @@ class NodeConfigTest {
     }
 
     private fun createConfig(
-            legalName: CordaX500Name = CordaX500Name(organisation = "Unknown", locality = "Nowhere", country = "GB"),
-            p2pPort: Int = -1,
-            rpcPort: Int = -1,
-            rpcAdminPort: Int = -1,
-            webPort: Int = -1,
-            h2port: Int = -1,
-            notary: NotaryService?,
-            users: List<User> = listOf(user("guest"))
+        legalName: CordaX500Name = CordaX500Name(organisation = "Unknown", locality = "Nowhere", country = "GB"),
+        p2pPort: Int = -1,
+        rpcPort: Int = -1,
+        rpcAdminPort: Int = -1,
+        webPort: Int = -1,
+        h2port: Int = -1,
+        notary: NotaryService?,
+        users: List<User> = listOf(user("guest")),
+        issuableCurrencies: List<String> = emptyList()
     ): NodeConfig {
         return NodeConfig(
-                myLegalName = legalName,
-                p2pAddress = localPort(p2pPort),
-                rpcAddress = localPort(rpcPort),
-                rpcAdminAddress = localPort(rpcAdminPort),
-                webAddress = localPort(webPort),
-                h2port = h2port,
-                notary = notary,
-                rpcUsers = users
+            myLegalName = legalName,
+            p2pAddress = localPort(p2pPort),
+            rpcAddress = localPort(rpcPort),
+            rpcAdminAddress = localPort(rpcAdminPort),
+            webAddress = localPort(webPort),
+            h2port = h2port,
+            notary = notary,
+            rpcUsers = users,
+            issuableCurrencies = issuableCurrencies
         )
     }
 


### PR DESCRIPTION
Write issuable currencies into `node.conf` so that DemoBench's Node Explorer can execute `Cash Issue` transactions.