### PR TITLE
ENT-2124 Flush before detach in Hibernate

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/AppendOnlyPersistentMap.kt
@@ -123,8 +123,12 @@ abstract class AppendOnlyPersistentMapBase<K, V, E, out EK>(
     }
 
     protected fun loadValue(key: K): V? {
-        val result = currentDBSession().find(persistentEntityClass, toPersistentEntityKey(key))
-        return result?.apply { currentDBSession().detach(result) }?.let(fromPersistentEntity)?.second
+        val session = currentDBSession()
+        // IMPORTANT: The flush is needed because detach() makes the queue of unflushed entries invalid w.r.t. Hibernate internal state if the found entity is unflushed.
+        // We want the detach() so that we rely on our cache memory management and don't retain strong references in the Hibernate session.
+        session.flush()
+        val result = session.find(persistentEntityClass, toPersistentEntityKey(key))
+        return result?.apply { session.detach(result) }?.let(fromPersistentEntity)?.second
     }
 
     operator fun contains(key: K) = get(key) != null


### PR DESCRIPTION
If we don't `flush`, the `detach` partially unhooks some of the pending write, if there is one.  This can happen if there is a cache (our persistent map) eviction in the same database transaction we store the cache entry.  i.e. Hibernate makes itself internally inconsistent and self-confesses a potential Hibernate bug in the exception message generated.

We saw this with the transaction cache.
