### PR TITLE
CORDA-1693: Ensure that DemoBench's RPC connections terminate on shutdown.

### DIFF
--- a/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/explorer/Explorer.kt
@@ -12,6 +12,7 @@ import net.corda.demobench.readErrorLines
 import tornadofx.*
 import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.util.concurrent.Executors
 
@@ -123,7 +124,7 @@ class Explorer internal constructor(private val explorerController: ExplorerCont
 
 class ExplorerController : Controller() {
     private val jvm by inject<JVMConfig>()
-    private val explorerPath = jvm.applicationDir.resolve("explorer").resolve("node-explorer.jar")
+    private val explorerPath: Path = jvm.applicationDir.resolve("explorer").resolve("node-explorer.jar")
 
     init {
         log.info("Explorer JAR: $explorerPath")

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/pty/R3Pty.kt
@@ -21,7 +21,7 @@ class R3Pty(val name: CordaX500Name, settings: SettingsProvider, dimension: Dime
 
     val terminal = JediTermWidget(dimension, settings)
 
-    val isConnected: Boolean get() = terminal.ttyConnector?.isConnected == true
+    val isConnected: Boolean get() = terminal.ttyConnector?.isConnected ?: false
 
     override fun close() {
         log.info("Closing terminal '{}'", name)
@@ -65,5 +65,5 @@ class R3Pty(val name: CordaX500Name, settings: SettingsProvider, dimension: Dime
 
     @Suppress("unused")
     @Throws(InterruptedException::class)
-    fun waitFor(): Int? = terminal.ttyConnector?.waitFor()
+    fun waitFor(): Int = terminal.ttyConnector?.waitFor() ?: -1
 }

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTerminalView.kt
@@ -42,7 +42,7 @@ class NodeTerminalView : Fragment() {
     override val root by fxml<VBox>()
 
     private companion object {
-        val pageSpecification = PageSpecification(1, 1)
+        private val pageSpecification = PageSpecification(1, 1)
     }
 
     private val nodeController by inject<NodeController>()
@@ -86,7 +86,7 @@ class NodeTerminalView : Fragment() {
         root.children.add(stack)
         root.isVisible = true
 
-        SwingUtilities.invokeLater({
+        SwingUtilities.invokeLater {
             val r3pty = R3Pty(config.nodeConfig.myLegalName, TerminalSettingsProvider(), Dimension(160, 80), onExit)
             pty = r3pty
 
@@ -112,7 +112,7 @@ class NodeTerminalView : Fragment() {
                     rpc?.close()
                 }
             }
-        })
+        }
     }
 
     /*
@@ -181,9 +181,9 @@ class NodeTerminalView : Fragment() {
     }
 
     private fun launchRPC(config: NodeConfigWrapper) = NodeRPC(
-            config = config,
-            start = this::initialise,
-            invoke = this::pollCashBalances
+        config = config,
+        start = ::initialise,
+        invoke = ::pollCashBalances
     )
 
     private fun initialise(config: NodeConfigWrapper, ops: CordaRPCOps) {
@@ -234,8 +234,8 @@ class NodeTerminalView : Fragment() {
     private fun pollCashBalances(ops: CordaRPCOps) {
         try {
             val cashBalances = ops.getCashBalances().entries.joinToString(
-                    separator = ", ",
-                    transform = { e -> e.value.toString() }
+                separator = ", ",
+                transform = { e -> e.value.toString() }
             )
 
             Platform.runLater {
@@ -252,21 +252,18 @@ class NodeTerminalView : Fragment() {
         header.isDisable = true
         subscriptions.forEach {
             // Don't allow any exceptions here to halt tab destruction.
-            try {
-                it.unsubscribe()
-            } catch (e: Exception) {
-            }
+            ignoreExceptions { it.unsubscribe() }
         }
-        webServer.close()
-        explorer.close()
-        viewer.close()
-        rpc?.close()
+        ignoreExceptions { webServer.close() }
+        ignoreExceptions { explorer.close() }
+        ignoreExceptions { viewer.close() }
+        ignoreExceptions { rpc?.close() }
     }
 
     fun destroy() {
         if (!isDestroyed) {
             shutdown()
-            pty?.close()
+            ignoreExceptions { pty?.close() }
             isDestroyed = true
         }
     }
@@ -277,6 +274,10 @@ class NodeTerminalView : Fragment() {
         Platform.runLater {
             swingTerminal.requestFocus()
         }
+    }
+
+    private fun ignoreExceptions(op: () -> Unit) {
+        try { op() } catch (e: Exception) {}
     }
 
     class TerminalSettingsProvider : DefaultSettingsProvider() {


### PR DESCRIPTION
On rare occasions, DemoBench has not shut down in a timely manner because `NodeRPC` timer threads were left running. Therefore:
- Turn these timer threads into daemons.
- Interrupt the timer threads on shutdown, in case they are stuck (e.g.) waiting for network I/O.
- Ensure that all `NodeTerminalView` resources are destroyed on close, despite any exceptions.

Also fix whitespace issues and some compiler warnings.