### PR TITLE
ENT-1903: Remove fast-classpath-scanner from serialization-deterministic.

### DIFF
--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     // Configure these by hand. It should be a minimal subset of dependencies,
     // and without any obviously non-deterministic ones such as Hibernate.
     runtimeLibraries project(path: ':core-deterministic', configuration: 'runtimeArtifacts')
-    runtimeLibraries "io.github.lukehutch:fast-classpath-scanner:$fast_classpath_scanner_version"
     runtimeLibraries "org.apache.qpid:proton-j:$protonj_version"
     runtimeLibraries "org.iq80.snappy:snappy:$snappy_version"
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
@@ -44,9 +44,8 @@ abstract class AbstractAMQPSerializationScheme(
     constructor(cordapps: List<Cordapp>) : this(cordapps.customSerializers, ConcurrentHashMap())
 
     // TODO: This method of initialisation for the Whitelist and plugin serializers will have to change
-    // when we have per-cordapp contexts and dynamic app reloading but for now it's the easiest way
+    //       when we have per-cordapp contexts and dynamic app reloading but for now it's the easiest way
     companion object {
-
         const val SCAN_SPEC_PROP_NAME = "amqp.custom.serialization.scanSpec"
 
         private val serializationWhitelists: List<SerializationWhitelist> by lazy {
@@ -54,25 +53,30 @@ abstract class AbstractAMQPSerializationScheme(
         }
 
         private val customSerializers: List<SerializationCustomSerializer<*, *>> by lazy {
-
             val scanSpec: String? = System.getProperty(SCAN_SPEC_PROP_NAME)
 
             if (scanSpec == null) {
                 emptyList()
             } else {
-                FastClasspathScanner(scanSpec).addClassLoader(this::class.java.classLoader).scan()
+                scanClasspathForSerializers(scanSpec)
+            }
+        }
+
+        @StubOutForDJVM
+        private fun scanClasspathForSerializers(scanSpec: String): List<SerializationCustomSerializer<*, *>> =
+            this::class.java.classLoader.let { cl ->
+                FastClasspathScanner(scanSpec).addClassLoader(cl).scan()
                         .getNamesOfClassesImplementing(SerializationCustomSerializer::class.java)
-                        .mapNotNull { this::class.java.classLoader.loadClass(it).asSubclass(SerializationCustomSerializer::class.java) }
+                        .map { cl.loadClass(it).asSubclass(SerializationCustomSerializer::class.java) }
                         .filterNot { Modifier.isAbstract(it.modifiers) }
                         .map { it.kotlin.objectOrNewInstance() }
             }
-        }
 
         @DeleteForDJVM
         val List<Cordapp>.customSerializers get() = flatMap { it.serializationCustomSerializers }.toSet()
     }
 
-    // Parameter "context" is unused directy but passed in by reflection. Removing it will cause failures.
+    // Parameter "context" is unused directly but passed in by reflection. Removing it will cause failures.
     private fun registerCustomSerializers(context: SerializationContext, factory: SerializerFactory) {
         with(factory) {
             register(publicKeySerializer)


### PR DESCRIPTION
Do not scan the classpath for serialisers inside the DJVM.