### PR TITLE
Rename JarFilter's ClassTransformer to FilterTransformer.

### DIFF
--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
@@ -15,7 +15,7 @@ import org.objectweb.asm.Opcodes.*
  * This Visitor is applied to the byte-code repeatedly until it has removed
  * everything that is no longer wanted.
  */
-class ClassTransformer private constructor (
+class FilterTransformer private constructor (
     visitor: ClassVisitor,
     logger: Logger,
     kotlinMetadata: MutableMap<String, List<String>>,
@@ -26,7 +26,7 @@ class ClassTransformer private constructor (
     private val unwantedFields: MutableSet<FieldElement>,
     private val deletedMethods: MutableSet<MethodElement>,
     private val stubbedMethods: MutableSet<MethodElement>
-) : KotlinAwareVisitor(ASM6, visitor, logger, kotlinMetadata), Repeatable<ClassTransformer> {
+) : KotlinAwareVisitor(ASM6, visitor, logger, kotlinMetadata), Repeatable<FilterTransformer> {
     constructor(
         visitor: ClassVisitor,
         logger: Logger,
@@ -62,7 +62,7 @@ class ClassTransformer private constructor (
         name.startsWith("$className\$${method.visibleName}\$")
     }
 
-    override fun recreate(visitor: ClassVisitor) = ClassTransformer(
+    override fun recreate(visitor: ClassVisitor) = FilterTransformer(
         visitor = visitor,
         logger = logger,
         kotlinMetadata = kotlinMetadata,

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -211,7 +211,7 @@ open class JarFilterTask : DefaultTask() {
             private fun transform(inBytes: ByteArray): ByteArray {
                 var reader = ClassReader(inBytes)
                 var writer = ClassWriter(COMPUTE_MAXS)
-                var transformer = ClassTransformer(
+                var transformer = FilterTransformer(
                     visitor = writer,
                     logger = logger,
                     removeAnnotations = toDescriptors(forRemove),

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -19,7 +19,7 @@ import java.io.InputStream
 
 /**
  * Base class for removing unwanted elements from [kotlin.Metadata] annotations.
- * This is used by [ClassTransformer] for [JarFilterTask].
+ * This is used by [FilterTransformer] for [JarFilterTask].
  */
 internal abstract class MetadataTransformer<out T : MessageLite>(
     private val logger: Logger,

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/FieldRemovalTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/FieldRemovalTest.kt
@@ -46,7 +46,7 @@ class FieldRemovalTest {
 
     private fun <T: R, R: Any> transform(type: Class<in T>, asType: Class<out R>): Class<out R> {
         val bytecode = type.bytecode.execute({ writer ->
-            ClassTransformer(
+            FilterTransformer(
                 visitor = writer,
                 logger = logger,
                 removeAnnotations = emptySet(),

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/StaticFieldRemovalTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/StaticFieldRemovalTest.kt
@@ -28,7 +28,7 @@ class StaticFieldRemovalTest {
 
         private fun <T : R, R : Any> transform(type: Class<in T>, asType: Class<out R>): Class<out R> {
             val bytecode = type.bytecode.execute({ writer ->
-                ClassTransformer(
+                FilterTransformer(
                     visitor = writer,
                     logger = logger,
                     removeAnnotations = emptySet(),


### PR DESCRIPTION
Give `ClassTransformer` a more descriptive name now that the JarFilter plugin has evolved to implement more than one task.