### PR TITLE
CORDA-1710 Swap order of Java and Kotlin examples in HTML docs

### DIFF
--- a/docs/source/_static/codesets.js
+++ b/docs/source/_static/codesets.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
             $(el).children(".highlight-kotlin")[0].style.display = "block";
         }
         else{
-            // Don't display kotlin by default
+            // By default show Java, not Kotlin
             $(el).children(".highlight-kotlin")[0].style.display = "none";
         }
         c.insertBefore(el);

--- a/docs/source/_static/codesets.js
+++ b/docs/source/_static/codesets.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
     $(".codeset").each(function(index, el) {
-        var c = $("<div class='codesnippet-widgets'><span class='current'>Kotlin</span><span>Java</span></div>");
-        var kotlinButton = c.children()[0];
-        var javaButton = c.children()[1];
+        var c = $("<div class='codesnippet-widgets'><span class='current'>Java</span><span>Kotlin</span></div>");
+        var javaButton = c.children()[0];
+        var kotlinButton = c.children()[1];
         kotlinButton.onclick = function() {
             $(el).children(".highlight-java")[0].style.display = "none";
             $(el).children(".highlight-kotlin")[0].style.display = "block";
@@ -19,6 +19,12 @@ $(document).ready(function() {
         if ($(el).children(".highlight-java").length == 0) {
             // No Java for this example.
             javaButton.style.display = "none";
+            // In this case, display Kotlin by default
+            $(el).children(".highlight-kotlin")[0].style.display = "block";
+        }
+        else{
+            // Don't display kotlin by default
+            $(el).children(".highlight-kotlin")[0].style.display = "none";
         }
         c.insertBefore(el);
     });

--- a/docs/source/_static/codesets.js
+++ b/docs/source/_static/codesets.js
@@ -22,10 +22,6 @@ $(document).ready(function() {
             // In this case, display Kotlin by default
             $(el).children(".highlight-kotlin")[0].style.display = "block";
         }
-        else{
-            // By default show Java, not Kotlin
-            $(el).children(".highlight-kotlin")[0].style.display = "none";
-        }
         c.insertBefore(el);
     });
 });

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -122,6 +122,11 @@ a:visited {
     background: #263673;
 }
 
+.codeset > .highlight-kotlin {
+    display: none;
+}
+
+
 /* Notification boxes */
 
 .wy-alert.wy-alert-warning .wy-alert-title,

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -122,11 +122,6 @@ a:visited {
     background: #263673;
 }
 
-.codeset > .highlight-java {
-    display: none;
-}
-
-
 /* Notification boxes */
 
 .wy-alert.wy-alert-warning .wy-alert-title,


### PR DESCRIPTION
Make java examples the default in the doc site html version to make life easier for Java devs writing CordApps.
Doing this for HTML is easy as it just requires a small change in the JavaScript we use for displaying code blocks.