### PR TITLE
CORDA-1711 - Remove dependency on PathUtilsKt in net.corda.core.internal

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashConfigDataFlow.kt
@@ -5,8 +5,6 @@ import com.typesafe.config.ConfigFactory
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.internal.declaredField
-import net.corda.core.internal.div
-import net.corda.core.internal.read
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.CordaSerializable
@@ -17,6 +15,11 @@ import net.corda.finance.GBP
 import net.corda.finance.USD
 import net.corda.finance.flows.ConfigHolder.Companion.supportedCurrencies
 import java.io.IOException
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.OpenOption
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.*
 
 // TODO Until apps have access to their own config, we'll hack things by first getting the baseDirectory, read the node.conf
@@ -25,6 +28,12 @@ import java.util.*
 class ConfigHolder(services: AppServiceHub) : SingletonSerializeAsToken() {
     companion object {
         val supportedCurrencies = listOf(USD, GBP, CHF, EUR)
+
+        // TODO: In future releases, the Finance app should be fully decoupled from internal APIs in Core.
+        private operator fun Path.div(other: String): Path = resolve(other)
+        private operator fun String.div(other: String): Path = Paths.get(this) / other
+        private fun Path.inputStream(vararg options: OpenOption): InputStream = Files.newInputStream(this, *options)
+        private inline fun <R> Path.read(vararg options: OpenOption, block: (InputStream) -> R): R = inputStream(*options).use(block)
     }
 
     val issuableCurrencies: List<Currency>


### PR DESCRIPTION
The Finance CorDapp relied on `net.corda.core.internal.PathUtilsKt` which has undergone refactoring, causing incompatibility across versions OS 3.0, 3.1 and Enterprise 3.0. This PR removes the dependency on the helper class in `net.corda.core.internal`.