### PR TITLE
CORDA-1704: Suppress ProGuard's "note" output

### DIFF
--- a/buildSrc/jarfilter/kotlin-metadata/build.gradle
+++ b/buildSrc/jarfilter/kotlin-metadata/build.gradle
@@ -39,7 +39,6 @@ task metadata(type: ProGuardTask) {
 
     keepattributes '*'
     dontoptimize
-    printseeds
     verbose
 
     dontwarn 'com.sun.jna.**'
@@ -47,6 +46,7 @@ task metadata(type: ProGuardTask) {
     dontwarn 'org.jetbrains.kotlin.com.intellij.**'
     dontwarn 'org.jetbrains.kotlin.com.google.j2objc.annotations.**'
     dontwarn 'org.jetbrains.kotlin.com.google.errorprone.annotations.**'
+    dontnote
 
     keep 'class org.jetbrains.kotlin.load.java.JvmAnnotationNames { *; }'
     keep 'class org.jetbrains.kotlin.metadata.** { *; }', includedescriptorclasses: true
@@ -68,6 +68,7 @@ task validate(type: ProGuardTask) {
     verbose
 
     dontwarn 'org.jetbrains.kotlin.com.google.errorprone.annotations.**'
+    dontnote
 
     keep 'class *'
 }
@@ -77,5 +78,4 @@ artifacts {
 }
 
 defaultTasks "metadata"
-assemble.dependsOn metadata
 metadata.finalizedBy validate

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -78,6 +78,7 @@ task predeterminise(type: ProGuardTask) {
     dontpreverify
     dontobfuscate
     dontoptimize
+    dontnote
     printseeds
     verbose
 
@@ -121,6 +122,7 @@ task determinise(type: ProGuardTask) {
     keepattributes '*'
     keepdirectories
     dontobfuscate
+    dontnote
     printseeds
     verbose
 
@@ -166,7 +168,6 @@ task checkDeterminism(type: ProGuardTask, dependsOn: jdkTask) {
 defaultTasks "determinise"
 determinise.finalizedBy metafix
 metafix.finalizedBy checkDeterminism
-assemble.dependsOn checkDeterminism
 
 def deterministicJar = metafix.outputs.files.singleFile
 artifacts {

--- a/core/src/main/kotlin/net/corda/core/flows/StateMachineRunId.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/StateMachineRunId.kt
@@ -8,10 +8,10 @@ import java.util.*
  * A unique identifier for a single state machine run, valid across node restarts. Note that a single run always
  * has at least one flow, but that flow may also invoke sub-flows: they all share the same run id.
  */
+@DeleteForDJVM
 @CordaSerializable
 data class StateMachineRunId(val uuid: UUID) {
     companion object {
-        @DeleteForDJVM
         fun createRandom(): StateMachineRunId = StateMachineRunId(UUID.randomUUID())
     }
 

--- a/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FlowStateMachine.kt
@@ -1,6 +1,7 @@
 package net.corda.core.internal
 
 import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.DeleteForDJVM
 import net.corda.core.DoNotImplement
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.context.InvocationContext
@@ -10,6 +11,7 @@ import net.corda.core.node.ServiceHub
 import org.slf4j.Logger
 
 /** This is an internal interface that is implemented by code in the node module. You should look at [FlowLogic]. */
+@DeleteForDJVM
 @DoNotImplement
 interface FlowStateMachine<FLOWRETURN> {
     @Suspendable

--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -74,6 +74,7 @@ task predeterminise(type: ProGuardTask, dependsOn: project(':core-deterministic'
     dontpreverify
     dontobfuscate
     dontoptimize
+    dontnote
     printseeds
     verbose
 
@@ -114,6 +115,7 @@ task determinise(type: ProGuardTask) {
     keepattributes '*'
     keepdirectories
     dontobfuscate
+    dontnote
     printseeds
     verbose
 
@@ -152,7 +154,6 @@ task checkDeterminism(type: ProGuardTask, dependsOn: jdkTask) {
 defaultTasks "determinise"
 determinise.finalizedBy metafix
 metafix.finalizedBy checkDeterminism
-assemble.dependsOn checkDeterminism
 
 def deterministicJar = metafix.outputs.files.singleFile
 artifacts {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer
 
 @KeepForDJVM
 class OrdinalBits(private val ordinal: Int) {
+    @KeepForDJVM
     interface OrdinalWriter {
         val bits: OrdinalBits
         @JvmDefault val encodedSize get() = 1

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
@@ -1,5 +1,6 @@
 package net.corda.serialization.internal.amqp
 
+import net.corda.core.KeepForDJVM
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.SerializationContext
 import net.corda.serialization.internal.amqp.SerializerFactory.Companion.nameForType
@@ -58,6 +59,7 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
      * subclass in the schema, so that we can distinguish between subclasses.
      */
     // TODO: should this be a custom serializer at all, or should it just be a plain AMQPSerializer?
+    @KeepForDJVM
     class SubClass<T : Any>(private val clazz: Class<*>, private val superClassSerializer: CustomSerializer<T>) : CustomSerializer<T>() {
         // TODO: should this be empty or contain the schema of the super?
         override val schemaForDocumentation = Schema(emptyList())

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt
@@ -70,6 +70,7 @@ enum class TransformTypes(val build: (Annotation) -> Transform) : DescribedType 
          * @param constants The list of enum constants on the type the transforms are being applied to
          */
         override fun validate(list: List<Transform>, constants: Map<String, Int>) {
+            @KeepForDJVM
             data class Node(val transform: RenameSchemaTransform, var next: Node?, var prev: Node?, var visitedBy: Node? = null) {
                 fun visit(visitedBy: Node) {
                     this.visitedBy = visitedBy

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt
@@ -154,6 +154,7 @@ class EnumDefaultSchemaTransform(val old: String, val new: String) : Transform()
  * @property from the name of the property or constant prior to being changed, i.e. what it was
  * @property to the new name of the property or constant after the change has been made, i.e. what it is now
  */
+@KeepForDJVM
 class RenameSchemaTransform(val from: String, val to: String) : Transform() {
     companion object : DescribedTypeConstructor<RenameSchemaTransform> {
         /**


### PR DESCRIPTION
Some of ProGuard's output is useful, although a lot of it isn't. And it can only be configured on a "class by class" basis. So disable it completely except for the `checkDeterminism` tasks.

Also resolve some of the issues that ProGuard is noticing.