### PR TITLE
Some code tidy up ahead of post-GA development.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/ConnectionStateMachine.kt
@@ -47,11 +47,15 @@ internal class ConnectionStateMachine(private val serverMode: Boolean,
     }
 
     private fun withMDC(block: () -> Unit) {
-        MDC.put("serverMode", serverMode.toString())
-        MDC.put("localLegalName", localLegalName)
-        MDC.put("remoteLegalName", remoteLegalName)
-        block()
-        MDC.clear()
+        val oldMDC = MDC.getCopyOfContextMap()
+        try {
+            MDC.put("serverMode", serverMode.toString())
+            MDC.put("localLegalName", localLegalName)
+            MDC.put("remoteLegalName", remoteLegalName)
+            block()
+        } finally {
+            MDC.setContextMap(oldMDC)
+        }
     }
 
     private fun logDebugWithMDC(msg: () -> String) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/engine/EventProcessor.kt
@@ -41,11 +41,15 @@ internal class EventProcessor(channel: Channel,
     }
 
     private fun withMDC(block: () -> Unit) {
-        MDC.put("serverMode", serverMode.toString())
-        MDC.put("localLegalName", localLegalName)
-        MDC.put("remoteLegalName", remoteLegalName)
-        block()
-        MDC.clear()
+        val oldMDC = MDC.getCopyOfContextMap()
+        try {
+            MDC.put("serverMode", serverMode.toString())
+            MDC.put("localLegalName", localLegalName)
+            MDC.put("remoteLegalName", remoteLegalName)
+            block()
+        } finally {
+            MDC.setContextMap(oldMDC)
+        }
     }
 
     private fun logDebugWithMDC(msg: () -> String) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPClient.kt
@@ -19,7 +19,6 @@ import net.corda.nodeapi.internal.requireMessageSize
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.lang.Long.min
-import java.security.KeyStore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import javax.net.ssl.KeyManagerFactory
@@ -35,15 +34,8 @@ import kotlin.concurrent.withLock
  */
 class AMQPClient(val targets: List<NetworkHostAndPort>,
                  val allowedRemoteLegalNames: Set<CordaX500Name>,
-                 private val userName: String?,
-                 private val password: String?,
-                 private val keyStore: KeyStore,
-                 private val keyStorePrivateKeyPassword: String,
-                 private val trustStore: KeyStore,
-                 private val crlCheckSoftFail: Boolean,
-                 private val trace: Boolean = false,
-                 private val sharedThreadPool: EventLoopGroup? = null,
-                 private val maxMessageSize: Int) : AutoCloseable {
+                 private val configuration: AMQPConfiguration,
+                 private val sharedThreadPool: EventLoopGroup? = null) : AutoCloseable {
     companion object {
         init {
             InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE)
@@ -121,10 +113,11 @@ class AMQPClient(val targets: List<NetworkHostAndPort>,
     private class ClientChannelInitializer(val parent: AMQPClient) : ChannelInitializer<SocketChannel>() {
         private val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
         private val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        private val conf = parent.configuration
 
         init {
-            keyManagerFactory.init(parent.keyStore, parent.keyStorePrivateKeyPassword.toCharArray())
-            trustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(parent.trustStore, parent.crlCheckSoftFail))
+            keyManagerFactory.init(conf.keyStore, conf.keyStorePrivateKeyPassword)
+            trustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(conf.trustStore, conf.crlCheckSoftFail))
         }
 
         override fun initChannel(ch: SocketChannel) {
@@ -132,12 +125,12 @@ class AMQPClient(val targets: List<NetworkHostAndPort>,
             val target = parent.currentTarget
             val handler = createClientSslHelper(target, keyManagerFactory, trustManagerFactory)
             pipeline.addLast("sslHandler", handler)
-            if (parent.trace) pipeline.addLast("logger", LoggingHandler(LogLevel.INFO))
+            if (conf.trace) pipeline.addLast("logger", LoggingHandler(LogLevel.INFO))
             pipeline.addLast(AMQPChannelHandler(false,
                     parent.allowedRemoteLegalNames,
-                    parent.userName,
-                    parent.password,
-                    parent.trace,
+                    conf.userName,
+                    conf.password,
+                    conf.trace,
                     {
                         parent.retryInterval = MIN_RETRY_INTERVAL // reset to fast reconnect if we connect properly
                         parent._onConnection.onNext(it.second)
@@ -205,7 +198,7 @@ class AMQPClient(val targets: List<NetworkHostAndPort>,
                       topic: String,
                       destinationLegalName: String,
                       properties: Map<String, Any?>): SendableMessage {
-        requireMessageSize(payload.size, maxMessageSize)
+        requireMessageSize(payload.size, configuration.maxMessageSize)
         return SendableMessageImpl(payload, topic, destinationLegalName, currentTarget, properties)
     }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPConfiguration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPConfiguration.kt
@@ -1,0 +1,59 @@
+package net.corda.nodeapi.internal.protonwrapper.netty
+
+import net.corda.nodeapi.internal.ArtemisMessagingComponent
+import java.security.KeyStore
+
+interface AMQPConfiguration {
+    /**
+     * SASL User name presented during protocol handshake. No SASL login if NULL.
+     * For legacy interoperability with Artemis authorisation we typically require this to be "PEER_USER"
+     */
+    @JvmDefault
+    val userName: String?
+        get() = ArtemisMessagingComponent.PEER_USER
+
+    /**
+     * SASL plain text password presented during protocol handshake. No SASL login if NULL.
+     * For legacy interoperability with Artemis authorisation we typically require this to be "PEER_USER"
+     */
+    @JvmDefault
+    val password: String?
+        get() = ArtemisMessagingComponent.PEER_USER
+
+    /**
+     * The keystore used for TLS connections
+     */
+    val keyStore: KeyStore
+
+    /**
+     * Password used to unlock TLS private keys in the KeyStore.
+     */
+    val keyStorePrivateKeyPassword: CharArray
+
+    /**
+     * The trust root KeyStore to validate the peer certificates against
+     */
+    val trustStore: KeyStore
+
+    /**
+     * Setting crlCheckSoftFail to true allows certificate paths where some leaf certificates do not contain cRLDistributionPoints
+     * and also allows validation to continue if the CRL distribution server is not contactable.
+     */
+    @JvmDefault
+    val crlCheckSoftFail: Boolean
+        get() = true
+
+    /**
+     * Enables full debug tracing of all netty and AMQP level packets. This logs aat very high volume and is only for developers.
+     */
+    @JvmDefault
+    val trace: Boolean
+        get() = false
+
+    /**
+     * The maximum allowed size for packets, which will be dropped ahead of send. In future may also be enforced on receive,
+     * but currently that is deferred to Artemis and the bridge code.
+     */
+    val maxMessageSize: Int
+}
+

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/AMQPServer.kt
@@ -23,7 +23,6 @@ import rx.Observable
 import rx.subjects.PublishSubject
 import java.net.BindException
 import java.net.InetSocketAddress
-import java.security.KeyStore
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
 import javax.net.ssl.KeyManagerFactory
@@ -36,14 +35,7 @@ import kotlin.concurrent.withLock
  */
 class AMQPServer(val hostName: String,
                  val port: Int,
-                 private val userName: String?,
-                 private val password: String?,
-                 private val keyStore: KeyStore,
-                 private val keyStorePrivateKeyPassword: CharArray,
-                 private val trustStore: KeyStore,
-                 private val crlCheckSoftFail: Boolean,
-                 private val trace: Boolean = false,
-                 private val maxMessageSize: Int) : AutoCloseable {
+                 private val configuration: AMQPConfiguration) : AutoCloseable {
 
     companion object {
         init {
@@ -62,36 +54,26 @@ class AMQPServer(val hostName: String,
     private var serverChannel: Channel? = null
     private val clientChannels = ConcurrentHashMap<InetSocketAddress, SocketChannel>()
 
-    constructor(hostName: String,
-                port: Int,
-                userName: String?,
-                password: String?,
-                keyStore: KeyStore,
-                keyStorePrivateKeyPassword: String,
-                trustStore: KeyStore,
-                crlCheckSoftFail: Boolean,
-                trace: Boolean = false,
-                maxMessageSize: Int) : this(hostName, port, userName, password, keyStore, keyStorePrivateKeyPassword.toCharArray(), trustStore, crlCheckSoftFail, trace, maxMessageSize)
-
     private class ServerChannelInitializer(val parent: AMQPServer) : ChannelInitializer<SocketChannel>() {
         private val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
         private val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        private val conf = parent.configuration
 
         init {
-            keyManagerFactory.init(parent.keyStore, parent.keyStorePrivateKeyPassword)
-            trustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(parent.trustStore, parent.crlCheckSoftFail))
+            keyManagerFactory.init(conf.keyStore, conf.keyStorePrivateKeyPassword)
+            trustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(conf.trustStore, conf.crlCheckSoftFail))
         }
 
         override fun initChannel(ch: SocketChannel) {
             val pipeline = ch.pipeline()
             val handler = createServerSslHelper(keyManagerFactory, trustManagerFactory)
             pipeline.addLast("sslHandler", handler)
-            if (parent.trace) pipeline.addLast("logger", LoggingHandler(LogLevel.INFO))
+            if (conf.trace) pipeline.addLast("logger", LoggingHandler(LogLevel.INFO))
             pipeline.addLast(AMQPChannelHandler(true,
                     null,
-                    parent.userName,
-                    parent.password,
-                    parent.trace,
+                    conf.userName,
+                    conf.password,
+                    conf.trace,
                     {
                         parent.clientChannels[it.first.remoteAddress()] = it.first
                         parent._onConnection.onNext(it.second)
@@ -159,7 +141,7 @@ class AMQPServer(val hostName: String,
                       destinationLegalName: String,
                       destinationLink: NetworkHostAndPort,
                       properties: Map<String, Any?>): SendableMessage {
-        requireMessageSize(payload.size, maxMessageSize)
+        requireMessageSize(payload.size, configuration.maxMessageSize)
         val dest = InetSocketAddress(destinationLink.host, destinationLink.port)
         require(dest in clientChannels.keys) {
             "Destination not available"


### PR DESCRIPTION
This code rationalises the explosion in constructor parameters to the AMQP protocol wrappers.
Also uses correct nested scopes for the MDC based context logging as recommended by Michele.
Also, handles appropriately the SSL Handshake Timeout, although sadly that does require spotting the message string coming out of Netty.