### PR TITLE
CORDA-1699: Restore binary compatibility for UniqueIdentifier class.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -22,9 +22,6 @@ buildscript {
     }
 }
 
-apply plugin: 'maven'
-apply plugin: 'java'
-
 repositories {
     mavenLocal()
     mavenCentral()
@@ -51,12 +48,13 @@ allprojects {
     }
 }
 
-dependencies {
-    // Add the top-level projects ONLY to the host project.
-    runtime project.childProjects.values().collect {
-        project(it.path)
-    }
+configurations {
+    runtime
 }
 
-// Don't create an empty jar. The plugins are now in child projects.
-jar.enabled = false
+dependencies {
+    // Add the top-level projects ONLY to the host project.
+    runtime project.childProjects.collect { n, p ->
+        project(p.path)
+    }
+}

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
@@ -57,7 +57,7 @@ abstract class KotlinAwareVisitor(
             KOTLIN_CLASS -> processClassMetadata(d1, d2)
             KOTLIN_FILE, KOTLIN_MULTIFILE_PART -> processPackageMetadata(d1, d2)
             KOTLIN_SYNTHETIC -> {
-                logger.info("-- synthetic class ignored")
+                logger.debug("-- synthetic class ignored")
                 emptyList()
             }
             else -> {
@@ -65,7 +65,7 @@ abstract class KotlinAwareVisitor(
                  * For class-kind=4 (i.e. "multi-file"), we currently
                  * expect d1=[list of multi-file-part classes], d2=null.
                  */
-                logger.info("-- unsupported class-kind {}", classKind)
+                logger.debug("-- unsupported class-kind {}", classKind)
                 emptyList()
             }
         }
@@ -134,13 +134,14 @@ abstract class KotlinAfterProcessor(
     }
 
     /**
-     * Do nothing after we have parsed [kotlin.Metadata].
+     * Do nothing immediately after we have parsed [kotlin.Metadata].
      */
     final override fun processKotlinAnnotation() {}
 }
 
 /**
- *
+ * Loads the ProtoBuf data from the [kotlin.Metadata] annotation
+ * and then processes it before visiting the rest of the class.
  */
 abstract class KotlinBeforeProcessor(
     api: Int,

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
@@ -1,5 +1,6 @@
 package net.corda.gradle.jarfilter
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames.*
 import org.objectweb.asm.AnnotationVisitor
@@ -26,6 +27,7 @@ abstract class KotlinAwareVisitor(
     private var classKind: Int = 0
 
     open val hasUnwantedElements: Boolean get() = kotlinMetadata.isNotEmpty()
+    protected open val level: LogLevel = LogLevel.INFO
 
     protected abstract fun processClassMetadata(d1: List<String>, d2: List<String>): List<String>
     protected abstract fun processPackageMetadata(d1: List<String>, d2: List<String>): List<String>
@@ -38,7 +40,7 @@ abstract class KotlinAwareVisitor(
 
     protected fun processMetadata() {
         if (kotlinMetadata.isNotEmpty()) {
-            logger.debug("- Examining Kotlin @Metadata[k={}]", classKind)
+            logger.log(level, "- Examining Kotlin @Metadata[k={}]", classKind)
             val d1 = kotlinMetadata.remove(METADATA_DATA_FIELD_NAME)
             val d2 = kotlinMetadata.remove(METADATA_STRINGS_FIELD_NAME)
             if (d1 != null && d1.isNotEmpty() && d2 != null) {
@@ -57,7 +59,7 @@ abstract class KotlinAwareVisitor(
             KOTLIN_CLASS -> processClassMetadata(d1, d2)
             KOTLIN_FILE, KOTLIN_MULTIFILE_PART -> processPackageMetadata(d1, d2)
             KOTLIN_SYNTHETIC -> {
-                logger.debug("-- synthetic class ignored")
+                logger.log(level,"-- synthetic class ignored")
                 emptyList()
             }
             else -> {
@@ -65,7 +67,7 @@ abstract class KotlinAwareVisitor(
                  * For class-kind=4 (i.e. "multi-file"), we currently
                  * expect d1=[list of multi-file-part classes], d2=null.
                  */
-                logger.debug("-- unsupported class-kind {}", classKind)
+                logger.log(level,"-- unsupported class-kind {}", classKind)
                 emptyList()
             }
         }

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
@@ -17,7 +17,7 @@ class MetaFixerVisitor private constructor(
     private val fields: MutableSet<FieldElement>,
     private val methods: MutableSet<String>,
     private val nestedClasses: MutableSet<String>
-) : KotlinAwareVisitor(ASM6, visitor, logger, kotlinMetadata), Repeatable<MetaFixerVisitor> {
+) : KotlinAfterProcessor(ASM6, visitor, logger, kotlinMetadata), Repeatable<MetaFixerVisitor> {
     constructor(visitor: ClassVisitor, logger: Logger, classNames: Set<String>)
         : this(visitor, logger, mutableMapOf(), classNames, mutableSetOf(), mutableSetOf(), mutableSetOf())
 
@@ -52,7 +52,7 @@ class MetaFixerVisitor private constructor(
         return super.visitInnerClass(clsName, outerName, innerName, access)
     }
 
-    override fun transformClassMetadata(d1: List<String>, d2: List<String>): List<String> {
+    override fun processClassMetadata(d1: List<String>, d2: List<String>): List<String> {
         return ClassMetaFixerTransformer(
                 logger = logger,
                 actualFields = fields,
@@ -64,7 +64,7 @@ class MetaFixerVisitor private constructor(
             .transform()
     }
 
-    override fun transformPackageMetadata(d1: List<String>, d2: List<String>): List<String> {
+    override fun processPackageMetadata(d1: List<String>, d2: List<String>): List<String> {
         return PackageMetaFixerTransformer(
                 logger = logger,
                 actualFields = fields,

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
@@ -1,0 +1,79 @@
+package net.corda.gradle.jarfilter
+
+import org.gradle.api.logging.Logger
+import org.jetbrains.kotlin.metadata.ProtoBuf
+import org.jetbrains.kotlin.metadata.deserialization.Flags.*
+import org.jetbrains.kotlin.metadata.deserialization.TypeTable
+import org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.*
+import org.jetbrains.kotlin.metadata.jvm.deserialization.BitEncoding
+import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmNameResolver
+import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil.EXTENSION_REGISTRY
+import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil.getJvmConstructorSignature
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes.*
+import java.io.ByteArrayInputStream
+
+/**
+ * This is (hopefully?!) a temporary solution for classes with [JvmOverloads] constructors.
+ * We need to be able to annotate ONLY the secondary constructors for such classes, but Kotlin
+ * will apply any annotation to all constructors equally. Nor can we replace the overloaded
+ * constructor with individual constructors because this will break ABI compatibility. (Kotlin
+ * generates a synthetic public constructor to handle default parameter values.)
+ *
+ * This transformer identifies a class's primary constructor and removes all of its unwanted annotations.
+ * It will become superfluous when Kotlin allows us to target only the secondary constructors with our
+ * filtering annotations in the first place.
+ */
+class SanitisingTransformer(visitor: ClassVisitor, logger: Logger, private val unwantedAnnotations: Set<String>)
+    : KotlinBeforeProcessor(ASM6, visitor, logger, mutableMapOf()) {
+
+    var isModified: Boolean = false
+        private set
+
+    private var className: String = "(unknown)"
+    private var primaryConstructor: MethodElement? = null
+
+    override fun processPackageMetadata(d1: List<String>, d2: List<String>): List<String> = emptyList()
+
+    override fun processClassMetadata(d1: List<String>, d2: List<String>): List<String> {
+        val input = ByteArrayInputStream(BitEncoding.decodeBytes(d1.toTypedArray()))
+        val stringTableTypes = StringTableTypes.parseDelimitedFrom(input, EXTENSION_REGISTRY)
+        val nameResolver = JvmNameResolver(stringTableTypes, d2.toTypedArray())
+        val message = ProtoBuf.Class.parseFrom(input, EXTENSION_REGISTRY)
+        val typeTable = TypeTable(message.typeTable)
+
+        for (constructor in message.constructorList) {
+            if (!IS_SECONDARY.get(constructor.flags)) {
+                val signature = getJvmConstructorSignature(constructor, nameResolver, typeTable) ?: break
+                primaryConstructor = MethodElement("<init>", signature.drop("<init>".length))
+                logger.debug("Class {} has primary constructor {}", className, signature)
+                break
+            }
+        }
+        return emptyList()
+    }
+
+    override fun visit(version: Int, access: Int, clsName: String, signature: String?, superName: String?, interfaces: Array<String>?) {
+        className = clsName
+        super.visit(version, access, clsName, signature, superName, interfaces)
+    }
+
+    override fun visitMethod(access: Int, methodName: String, descriptor: String, signature: String?, exceptions: Array<String>?): MethodVisitor? {
+        val method = MethodElement(methodName, descriptor, access)
+        val mv = super.visitMethod(access, methodName, descriptor, signature, exceptions) ?: return null
+        return if (method == primaryConstructor) SanitisingMethodAdapter(mv, method) else mv
+    }
+
+    private inner class SanitisingMethodAdapter(mv: MethodVisitor, private val method: MethodElement) : MethodVisitor(api, mv) {
+        override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor? {
+            if (unwantedAnnotations.contains(descriptor)) {
+                logger.info("Sanitising annotation {} from method {}.{}{}", descriptor, className, method.name, method.descriptor)
+                isModified = true
+                return null
+            }
+            return super.visitAnnotation(descriptor, visible)
+        }
+    }
+}

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
@@ -1,5 +1,6 @@
 package net.corda.gradle.jarfilter
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.jetbrains.kotlin.metadata.ProtoBuf
 import org.jetbrains.kotlin.metadata.deserialization.Flags.*
@@ -31,6 +32,7 @@ class SanitisingTransformer(visitor: ClassVisitor, logger: Logger, private val u
 
     var isModified: Boolean = false
         private set
+    override val level: LogLevel = LogLevel.DEBUG
 
     private var className: String = "(unknown)"
     private var primaryConstructor: MethodElement? = null
@@ -48,7 +50,7 @@ class SanitisingTransformer(visitor: ClassVisitor, logger: Logger, private val u
             if (!IS_SECONDARY.get(constructor.flags)) {
                 val signature = getJvmConstructorSignature(constructor, nameResolver, typeTable) ?: break
                 primaryConstructor = MethodElement("<init>", signature.drop("<init>".length))
-                logger.debug("Class {} has primary constructor {}", className, signature)
+                logger.log(level, "Class {} has primary constructor {}", className, signature)
                 break
             }
         }

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
@@ -36,7 +36,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deleteConstructorWithLongParameter() {
-        val longConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, hasParam(Long::class))
+        val longConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, Long::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasLong>(SECONDARY_CONSTRUCTOR_CLASS).apply {
@@ -58,7 +58,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deleteConstructorWithStringParameter() {
-        val stringConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, hasParam(String::class))
+        val stringConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasString>(SECONDARY_CONSTRUCTOR_CLASS).apply {
@@ -80,7 +80,7 @@ class DeleteConstructorTest {
 
     @Test
     fun showUnannotatedConstructorIsUnaffected() {
-        val intConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, hasParam(Int::class))
+        val intConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, Int::class)
         classLoaderFor(testProject.filteredJar).use { cl ->
             cl.load<HasAll>(SECONDARY_CONSTRUCTOR_CLASS).apply {
                 getDeclaredConstructor(Int::class.java).newInstance(NUMBER).also {
@@ -96,7 +96,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deletePrimaryConstructorWithStringParameter() {
-        val stringConstructor = isConstructor(STRING_PRIMARY_CONSTRUCTOR_CLASS, hasParam(String::class))
+        val stringConstructor = isConstructor(STRING_PRIMARY_CONSTRUCTOR_CLASS, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasString>(STRING_PRIMARY_CONSTRUCTOR_CLASS).apply {
@@ -119,7 +119,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deletePrimaryConstructorWithLongParameter() {
-        val longConstructor = isConstructor(LONG_PRIMARY_CONSTRUCTOR_CLASS, hasParam(Long::class))
+        val longConstructor = isConstructor(LONG_PRIMARY_CONSTRUCTOR_CLASS, Long::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasLong>(LONG_PRIMARY_CONSTRUCTOR_CLASS).apply {
@@ -142,7 +142,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deletePrimaryConstructorWithIntParameter() {
-        val intConstructor = isConstructor(INT_PRIMARY_CONSTRUCTOR_CLASS, hasParam(Int::class))
+        val intConstructor = isConstructor(INT_PRIMARY_CONSTRUCTOR_CLASS, Int::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasInt>(INT_PRIMARY_CONSTRUCTOR_CLASS).apply {

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseConstructorTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseConstructorTest.kt
@@ -43,7 +43,8 @@ class SanitiseConstructorTest {
     )
 
     private fun checkClassWithLongParameter(longClass: String, initialCount: Int) {
-        val longConstructor = isConstructor(longClass, hasParam(Long::class))
+        val longConstructor = isConstructor(longClass, Long::class)
+
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasLong>(longClass).apply {
                 getDeclaredConstructor(Long::class.java).newInstance(BIG_NUMBER).also {
@@ -92,7 +93,8 @@ class SanitiseConstructorTest {
     )
 
     private fun checkClassWithIntParameter(intClass: String, initialCount: Int) {
-        val intConstructor = isConstructor(intClass, hasParam(Int::class))
+        val intConstructor = isConstructor(intClass, Int::class)
+
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasInt>(intClass).apply {
                 getDeclaredConstructor(Int::class.java).newInstance(NUMBER).also {
@@ -105,6 +107,7 @@ class SanitiseConstructorTest {
                 val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
                 assertThat(primary.call(NUMBER).intData()).isEqualTo(NUMBER)
 
+                //assertThat("", constructors, hasItem(isConstructor(""))
                 newInstance().also {
                     assertEquals(0, it.intData())
                 }
@@ -141,7 +144,8 @@ class SanitiseConstructorTest {
     )
 
     private fun checkClassWithStringParameter(stringClass: String, initialCount: Int) {
-        val stringConstructor = isConstructor(stringClass, hasParam(String::class))
+        val stringConstructor = isConstructor(stringClass, String::class)
+
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasString>(stringClass).apply {
                 getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also {

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseConstructorTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseConstructorTest.kt
@@ -1,0 +1,179 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.matcher.*
+import net.corda.gradle.unwanted.HasInt
+import net.corda.gradle.unwanted.HasLong
+import net.corda.gradle.unwanted.HasString
+import org.assertj.core.api.Assertions.*
+import org.hamcrest.core.IsCollectionContaining.hasItem
+import org.junit.Assert.*
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TemporaryFolder
+import org.junit.rules.TestRule
+import kotlin.jvm.kotlin
+import kotlin.reflect.full.primaryConstructor
+import kotlin.test.assertFailsWith
+
+class SanitiseConstructorTest {
+    companion object {
+        private const val COUNT_INITIAL_OVERLOADED = 1
+        private const val COUNT_INITIAL_MULTIPLE = 2
+        private val testProjectDir = TemporaryFolder()
+        private val testProject = JarFilterProject(testProjectDir, "sanitise-constructor")
+
+        @ClassRule
+        @JvmField
+        val rules: TestRule = RuleChain
+            .outerRule(testProjectDir)
+            .around(testProject)
+    }
+
+    @Test
+    fun deleteOverloadedLongConstructor() = checkClassWithLongParameter(
+        "net.corda.gradle.HasOverloadedLongConstructor",
+        COUNT_INITIAL_OVERLOADED
+    )
+
+    @Test
+    fun deleteMultipleLongConstructor() = checkClassWithLongParameter(
+        "net.corda.gradle.HasMultipleLongConstructors",
+        COUNT_INITIAL_MULTIPLE
+    )
+
+    private fun checkClassWithLongParameter(longClass: String, initialCount: Int) {
+        val longConstructor = isConstructor(longClass, hasParam(Long::class))
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasLong>(longClass).apply {
+                getDeclaredConstructor(Long::class.java).newInstance(BIG_NUMBER).also {
+                    assertEquals(BIG_NUMBER, it.longData())
+                }
+                kotlin.constructors.apply {
+                    assertThat("<init>(J) not found", this, hasItem(longConstructor))
+                    assertEquals(initialCount, this.size)
+                }
+                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                assertThat(primary.call(BIG_NUMBER).longData()).isEqualTo(BIG_NUMBER)
+
+                newInstance().also {
+                    assertEquals(0, it.longData())
+                }
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<HasLong>(longClass).apply {
+                getDeclaredConstructor(Long::class.java).newInstance(BIG_NUMBER).also {
+                    assertEquals(BIG_NUMBER, it.longData())
+                }
+                kotlin.constructors.apply {
+                    assertThat("<init>(J) not found", this, hasItem(longConstructor))
+                    assertEquals(1, this.size)
+                }
+                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                assertThat(primary.call(BIG_NUMBER).longData()).isEqualTo(BIG_NUMBER)
+
+                assertFailsWith<NoSuchMethodException> { getDeclaredConstructor() }
+            }
+        }
+    }
+
+    @Test
+    fun deleteOverloadedIntConstructor() = checkClassWithIntParameter(
+        "net.corda.gradle.HasOverloadedIntConstructor",
+        COUNT_INITIAL_OVERLOADED
+    )
+
+    @Test
+    fun deleteMultipleIntConstructor() = checkClassWithIntParameter(
+        "net.corda.gradle.HasMultipleIntConstructors",
+        COUNT_INITIAL_MULTIPLE
+    )
+
+    private fun checkClassWithIntParameter(intClass: String, initialCount: Int) {
+        val intConstructor = isConstructor(intClass, hasParam(Int::class))
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasInt>(intClass).apply {
+                getDeclaredConstructor(Int::class.java).newInstance(NUMBER).also {
+                    assertEquals(NUMBER, it.intData())
+                }
+                kotlin.constructors.apply {
+                    assertThat("<init>(I) not found", this, hasItem(intConstructor))
+                    assertEquals(initialCount, this.size)
+                }
+                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                assertThat(primary.call(NUMBER).intData()).isEqualTo(NUMBER)
+
+                newInstance().also {
+                    assertEquals(0, it.intData())
+                }
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<HasInt>(intClass).apply {
+                getDeclaredConstructor(Int::class.java).newInstance(NUMBER).also {
+                    assertEquals(NUMBER, it.intData())
+                }
+                kotlin.constructors.apply {
+                    assertThat("<init>(I) not found", this, hasItem(intConstructor))
+                    assertEquals(1, this.size)
+                }
+                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                assertThat(primary.call(NUMBER).intData()).isEqualTo(NUMBER)
+
+                assertFailsWith<NoSuchMethodException> { getDeclaredConstructor() }
+            }
+        }
+    }
+
+    @Test
+    fun deleteOverloadedStringConstructor() = checkClassWithStringParameter(
+        "net.corda.gradle.HasOverloadedStringConstructor",
+        COUNT_INITIAL_OVERLOADED
+    )
+
+    @Test
+    fun deleteMultipleStringConstructor() = checkClassWithStringParameter(
+        "net.corda.gradle.HasMultipleStringConstructors",
+        COUNT_INITIAL_MULTIPLE
+    )
+
+    private fun checkClassWithStringParameter(stringClass: String, initialCount: Int) {
+        val stringConstructor = isConstructor(stringClass, hasParam(String::class))
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasString>(stringClass).apply {
+                getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also {
+                    assertEquals(MESSAGE, it.stringData())
+                }
+                kotlin.constructors.apply {
+                    assertThat("<init>(String) not found", this, hasItem(stringConstructor))
+                    assertEquals(initialCount, this.size)
+                }
+                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                assertThat(primary.call(MESSAGE).stringData()).isEqualTo(MESSAGE)
+
+                newInstance().also {
+                    assertEquals(DEFAULT_MESSAGE, it.stringData())
+                }
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<HasString>(stringClass).apply {
+                getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also {
+                    assertEquals(MESSAGE, it.stringData())
+                }
+                kotlin.constructors.apply {
+                    assertThat("<init>(String) not found", this, hasItem(stringConstructor))
+                    assertEquals(1, this.size)
+                }
+                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                assertThat(primary.call(MESSAGE).stringData()).isEqualTo(MESSAGE)
+
+                assertFailsWith<NoSuchMethodException> { getDeclaredConstructor() }
+            }
+        }
+    }
+}

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
@@ -13,10 +13,12 @@ fun isMethod(name: Matcher<in String>, returnType: Matcher<in Class<*>>, vararg 
 }
 
 fun isMethod(name: String, returnType: Class<*>, vararg parameters: Class<*>): Matcher<Method> {
-    return isMethod(equalTo(name), equalTo(returnType), *parameters.map(::equalTo).toTypedArray())
+    return isMethod(equalTo(name), equalTo(returnType), *parameters.toMatchers())
 }
 
-val <T: Any> KClass<T>.javaDeclaredMethods: List<Method> get() = java.declaredMethods.toList()
+private fun Array<out Class<*>>.toMatchers() = map(::equalTo).toTypedArray()
+
+val KClass<*>.javaDeclaredMethods: List<Method> get() = java.declaredMethods.toList()
 
 /**
  * Matcher logic for a Java [Method] object. Also applicable to constructors.

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
@@ -17,7 +17,7 @@ fun isFunction(name: Matcher<in String>, returnType: Matcher<in String>, vararg 
 }
 
 fun isFunction(name: String, returnType: KClass<*>, vararg parameters: KClass<*>): Matcher<KFunction<*>> {
-    return isFunction(equalTo(name), matches(returnType), *parameters.map(::hasParam).toTypedArray())
+    return isFunction(equalTo(name), matches(returnType), *parameters.toMatchers())
 }
 
 fun isConstructor(returnType: Matcher<in String>, vararg parameters: Matcher<in KParameter>): Matcher<KFunction<*>> {
@@ -25,11 +25,11 @@ fun isConstructor(returnType: Matcher<in String>, vararg parameters: Matcher<in 
 }
 
 fun isConstructor(returnType: KClass<*>, vararg parameters: KClass<*>): Matcher<KFunction<*>> {
-    return isConstructor(matches(returnType), *parameters.map(::hasParam).toTypedArray())
+    return isConstructor(matches(returnType), *parameters.toMatchers())
 }
 
-fun isConstructor(returnType: String, vararg parameters: Matcher<in KParameter>): Matcher<KFunction<*>> {
-    return isConstructor(equalTo(returnType), *parameters)
+fun isConstructor(returnType: String, vararg parameters: KClass<*>): Matcher<KFunction<*>> {
+    return isConstructor(equalTo(returnType), *parameters.toMatchers())
 }
 
 fun hasParam(type: Matcher<in String>): Matcher<KParameter> = KParameterMatcher(type)
@@ -43,6 +43,8 @@ fun isProperty(name: Matcher<in String>, type: Matcher<in String>): Matcher<KPro
 fun isClass(name: String): Matcher<KClass<*>> = KClassMatcher(equalTo(name))
 
 fun matches(type: KClass<*>): Matcher<in String> = equalTo(type.qualifiedName)
+
+private fun Array<out KClass<*>>.toMatchers() = map(::hasParam).toTypedArray()
 
 /**
  * Matcher logic for a Kotlin [KFunction] object. Also applicable to constructors.

--- a/buildSrc/jarfilter/src/test/resources/sanitise-constructor/build.gradle
+++ b/buildSrc/jarfilter/src/test/resources/sanitise-constructor/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'net.corda.plugins.jar-filter'
+}
+apply from: 'repositories.gradle'
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir files(
+                '../resources/test/sanitise-constructor/kotlin',
+                '../resources/test/annotations/kotlin'
+            )
+        }
+    }
+}
+
+dependencies {
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
+}
+
+jar {
+    baseName = 'sanitise-constructor'
+}
+
+import net.corda.gradle.jarfilter.JarFilterTask
+task jarFilter(type: JarFilterTask) {
+    jars jar
+    annotations {
+        forDelete = ["net.corda.gradle.jarfilter.DeleteMe"]
+        forSanitise = ["net.corda.gradle.jarfilter.DeleteMe"]
+    }
+}

--- a/buildSrc/jarfilter/src/test/resources/sanitise-constructor/kotlin/net/corda/gradle/HasOverloadedConstructors.kt
+++ b/buildSrc/jarfilter/src/test/resources/sanitise-constructor/kotlin/net/corda/gradle/HasOverloadedConstructors.kt
@@ -1,0 +1,34 @@
+@file:Suppress("UNUSED")
+package net.corda.gradle
+
+import net.corda.gradle.jarfilter.DeleteMe
+import net.corda.gradle.unwanted.*
+
+private const val DEFAULT_MESSAGE = "<default-value>"
+
+class HasOverloadedStringConstructor @JvmOverloads @DeleteMe constructor(private val message: String = DEFAULT_MESSAGE) : HasString {
+    override fun stringData(): String = message
+}
+
+class HasOverloadedLongConstructor @JvmOverloads @DeleteMe constructor(private val data: Long = 0) : HasLong {
+    override fun longData(): Long = data
+}
+
+class HasOverloadedIntConstructor @JvmOverloads @DeleteMe constructor(private val data: Int = 0) : HasInt {
+    override fun intData(): Int = data
+}
+
+class HasMultipleStringConstructors(private val message: String) : HasString {
+    @DeleteMe constructor() : this(DEFAULT_MESSAGE)
+    override fun stringData(): String = message
+}
+
+class HasMultipleLongConstructors(private val data: Long) : HasLong {
+    @DeleteMe constructor() : this(0)
+    override fun longData(): Long = data
+}
+
+class HasMultipleIntConstructors(private val data: Int) : HasInt {
+    @DeleteMe constructor() : this(0)
+    override fun intData(): Int = data
+}

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -103,6 +103,9 @@ task jarFilter(type: JarFilterTask) {
             "co.paralleluniverse.fibers.Suspendable",
             "org.hibernate.annotations.Immutable"
         ]
+        forSanitise = [
+            "net.corda.core.DeleteForDJVM"
+        ]
     }
 }
 

--- a/core-deterministic/testing/build.gradle
+++ b/core-deterministic/testing/build.gradle
@@ -14,3 +14,6 @@ dependencies {
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "junit:junit:$junit_version"
 }
+
+// This module has no artifact and only contains tests.
+jar.enabled = false

--- a/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/contracts/UniqueIdentifierTest.kt
+++ b/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/contracts/UniqueIdentifierTest.kt
@@ -1,0 +1,37 @@
+package net.corda.deterministic.contracts
+
+import net.corda.core.contracts.UniqueIdentifier
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.*
+import kotlin.reflect.full.primaryConstructor
+import kotlin.test.assertFailsWith
+
+class UniqueIdentifierTest {
+    private companion object {
+        private const val NAME = "MyName"
+        private val TEST_UUID: UUID = UUID.fromString("00000000-1111-2222-3333-444444444444")
+    }
+
+    @Test
+    fun testNewInstance() {
+        val id = UniqueIdentifier(NAME, TEST_UUID)
+        assertEquals("${NAME}_$TEST_UUID", id.toString())
+        assertEquals(NAME, id.externalId)
+        assertEquals(TEST_UUID, id.id)
+    }
+
+    @Test
+    fun testPrimaryConstructor() {
+        val primary = UniqueIdentifier::class.primaryConstructor ?: throw AssertionError("primary constructor missing")
+        assertThat(primary.call(NAME, TEST_UUID)).isEqualTo(UniqueIdentifier(NAME, TEST_UUID))
+    }
+
+    @Test
+    fun testConstructors() {
+        assertEquals(1, UniqueIdentifier::class.constructors.size)
+        val ex = assertFailsWith<IllegalArgumentException> { UniqueIdentifier::class.constructors.first().call() }
+        assertThat(ex).hasMessage("Callable expects 2 arguments, but 0 were provided.")
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/contracts/UniqueIdentifier.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/UniqueIdentifier.kt
@@ -20,10 +20,7 @@ import java.util.*
  */
 @CordaSerializable
 @KeepForDJVM
-data class UniqueIdentifier(val externalId: String?, val id: UUID) : Comparable<UniqueIdentifier> {
-    @DeleteForDJVM constructor(externalId: String?) : this(externalId, UUID.randomUUID())
-    @DeleteForDJVM constructor() : this(null)
-
+data class UniqueIdentifier @JvmOverloads @DeleteForDJVM constructor(val externalId: String? = null, val id: UUID = UUID.randomUUID()) : Comparable<UniqueIdentifier> {
     override fun toString(): String = if (externalId != null) "${externalId}_$id" else id.toString()
 
     companion object {

--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -95,6 +95,9 @@ task jarFilter(type: JarFilterTask) {
         forRemove = [
             "co.paralleluniverse.fibers.Suspendable"
         ]
+        forSanitise = [
+            "net.corda.core.DeleteForDJVM"
+        ]
     }
 }
 


### PR DESCRIPTION
Adding default parameter values to a Kotlin constructor instructs the Kotlin compiler to generate a public synthetic secondary constructor as well as the expected primary constructor. This synthetic constructor for `UniqueIdentifier` is now part of Corda's ABI and so needs to be restored after being removed accidentally from `core` proper.

Update `JarFilter` to "sanitise" certain annotations (i.e. `@DeleteForDJVM`) from primary constructors while leaving them on the secondary ones. The net effect is that JarFilter is able to delete all of a class's secondary constructors while leaving the primary constructor intact.