### PR TITLE
CORDA-1723: Upgrade to Kotlin 1.2.51.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,10 +141,6 @@ allprojects {
     apply plugin: 'org.owasp.dependencycheck'
     apply plugin: 'kotlin-allopen'
 
-    // This line works around a serious performance regression in the Kotlin 1.2.50 gradle plugin, it's fixed in 1.2.51
-    // TODO: Remove when we upgrade past Kotlin 1.2.51
-    inspectClassesForKotlinIC.enabled = false
-
     allOpen {
         annotations(
                 "javax.persistence.Entity",

--- a/constants.properties
+++ b/constants.properties
@@ -1,5 +1,5 @@
 gradlePluginsVersion=4.0.25
-kotlinVersion=1.2.50
+kotlinVersion=1.2.51
 platformVersion=4
 guavaVersion=21.0
 proguardVersion=6.0.3


### PR DESCRIPTION
This fixes the compiler performance regression introduced by Kotlin 1.2.50.