### PR TITLE
Reverted removal of deduplicationSeed parameter

### DIFF
--- a/core/src/test/kotlin/net/corda/core/internal/TopologicalSortTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/TopologicalSortTest.kt
@@ -21,7 +21,7 @@ import rx.Observable
 import java.util.*
 
 class TopologicalSortTest {
-    class DummyTransaction constructor(
+    class DummyTransaction(
             override val id: SecureHash,
             override val inputs: List<StateRef>,
             @Suppress("CanBeParameter") private val numberOfOutputs: Int,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -69,6 +69,7 @@ data class Checkpoint(
                 flowLogicClass: Class<FlowLogic<*>>,
                 frozenFlowLogic: SerializedBytes<FlowLogic<*>>,
                 ourIdentity: Party,
+                @Suppress("UNUSED_PARAMETER") deduplicationSeed: String,
                 subFlowVersion: SubFlowVersion
         ): Try<Checkpoint> {
             return SubFlow.create(flowLogicClass, subFlowVersion).map { topLevelSubFlow ->

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -190,7 +190,7 @@ class DBCheckpointStorageTests {
             override fun call() {}
         }
         val frozenLogic = logic.serialize(context = SerializationDefaults.CHECKPOINT_CONTEXT)
-        val checkpoint = Checkpoint.create(InvocationContext.shell(), FlowStart.Explicit, logic.javaClass, frozenLogic, ALICE, SubFlowVersion.CoreFlow(version)).getOrThrow()
+        val checkpoint = Checkpoint.create(InvocationContext.shell(), FlowStart.Explicit, logic.javaClass, frozenLogic, ALICE, "", SubFlowVersion.CoreFlow(version)).getOrThrow()
         return id to checkpoint.serialize(context = SerializationDefaults.CHECKPOINT_CONTEXT)
     }
 


### PR DESCRIPTION
I accidentally removed the `deduplicationSeed` parameter of `Checkpoint.create`,  which is used by the multi-threaded SMM