### PR TITLE
Configure NetworkMapUpdater executor so that it doesn't block node shutdown

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -28,6 +28,7 @@ import java.nio.file.StandardCopyOption
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 
@@ -45,7 +46,7 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
     }
 
     private val parametersUpdatesTrack: PublishSubject<ParametersUpdateInfo> = PublishSubject.create<ParametersUpdateInfo>()
-    private val executor = Executors.newSingleThreadScheduledExecutor(NamedThreadFactory("Network Map Updater Thread", Executors.defaultThreadFactory()))
+    private val executor = ScheduledThreadPoolExecutor(1, NamedThreadFactory("Network Map Updater Thread", Executors.defaultThreadFactory()))
     private var newNetworkParameters: Pair<ParametersUpdate, SignedNetworkParameters>? = null
     private var fileWatcherSubscription: Subscription? = null
 
@@ -81,6 +82,7 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
         if (networkMapClient == null) return
 
         // Subscribe to remote network map if configured.
+        executor.executeExistingDelayedTasksAfterShutdownPolicy = false
         executor.submit(object : Runnable {
             override fun run() {
                 val nextScheduleDelay = try {


### PR DESCRIPTION
I noticed that after changing to http-based network map, it takes 10+ seconds for the node to shut down on Ctrl-C. This affects testing of things that need to experiment with starting corda nodes (deployment, ..). Indeed, the shutdown time is related to network map update interval.

I found that by default the executor used here will run the scheduled task on shutdown and that it can be disabled.