### PR TITLE
CORDA-1748: Delete unwanted default parameter values from Kotlin metadata.

### DIFF
--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/Elements.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/Elements.kt
@@ -81,6 +81,13 @@ internal class FieldElement(name: String, descriptor: String = "?", val extensio
 val String.extensionType: String get() = substring(0, 1 + indexOf(')'))
 
 /**
+ * Returns a fully-qualified class name as it would exist
+ * in the byte-code, e.g. as "a/b/c/ClassName$Nested".
+ */
+fun NameResolver.getClassInternalName(idx: Int): String
+    = getQualifiedClassName(idx).replace('.', '$')
+
+/**
  * Construct the signatures of the synthetic methods that
  * Kotlin would create to handle default parameter values.
  */

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/Elements.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/Elements.kt
@@ -13,6 +13,7 @@ import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 import java.util.*
 
 private const val DEFAULT_CONSTRUCTOR_MARKER = "ILkotlin/jvm/internal/DefaultConstructorMarker;"
+private const val DEFAULT_FUNCTION_MARKER = "ILjava/lang/Object;"
 private const val DUMMY_PASSES = 1
 
 private val DECLARES_DEFAULT_VALUE_MASK: Int = DECLARES_DEFAULT_VALUE.toFlags(true).inv()
@@ -80,6 +81,23 @@ internal class FieldElement(name: String, descriptor: String = "?", val extensio
 val String.extensionType: String get() = substring(0, 1 + indexOf(')'))
 
 /**
+ * Construct the signatures of the synthetic methods that
+ * Kotlin would create to handle default parameter values.
+ */
+fun String.toKotlinDefaultConstructor(): String {
+    val closer = lastIndexOf(')')
+    return substring(0, closer) + DEFAULT_CONSTRUCTOR_MARKER + substring(closer)
+}
+
+fun String.toKotlinDefaultFunction(classDescriptor: String): String {
+    val opener = indexOf('(')
+    val closer = lastIndexOf(')')
+    return (substring(0, opener) + "\$default("
+               + classDescriptor + substring(opener + 1, closer) + DEFAULT_FUNCTION_MARKER
+               + substring(closer))
+}
+
+/**
  * Convert Kotlin getter/setter method data to [MethodElement] objects.
  */
 internal fun JvmProtoBuf.JvmPropertySignature.toGetter(nameResolver: NameResolver): MethodElement? {
@@ -124,11 +142,20 @@ internal fun JvmProtoBuf.JvmPropertySignature.toFieldElement(property: ProtoBuf.
 }
 
 /**
- * Rewrites metadata for constructor parameters.
+ * Rewrites metadata for function and constructor parameters.
  */
 internal fun ProtoBuf.Constructor.Builder.updateValueParameters(
     updater: (ProtoBuf.ValueParameter) -> ProtoBuf.ValueParameter
 ): ProtoBuf.Constructor.Builder {
+    for (idx in 0 until valueParameterList.size) {
+        setValueParameter(idx, updater(valueParameterList[idx]))
+    }
+    return this
+}
+
+internal fun ProtoBuf.Function.Builder.updateValueParameters(
+    updater: (ProtoBuf.ValueParameter) -> ProtoBuf.ValueParameter
+): ProtoBuf.Function.Builder {
     for (idx in 0 until valueParameterList.size) {
         setValueParameter(idx, updater(valueParameterList[idx]))
     }
@@ -142,3 +169,6 @@ internal fun ProtoBuf.ValueParameter.clearDeclaresDefaultValue(): ProtoBuf.Value
         this
     }
 }
+
+internal val List<ProtoBuf.ValueParameter>.hasAnyDefaultValues
+    get() = any { DECLARES_DEFAULT_VALUE.get(it.flags) }

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
@@ -79,7 +79,7 @@ internal abstract class MetaFixerTransformer<out T : MessageLite>(
         var count = 0
         var idx = 0
         while (idx < sealedSubclassNames.size) {
-            val sealedSubclassName = nameResolver.getString(sealedSubclassNames[idx]).replace('.', '$')
+            val sealedSubclassName = nameResolver.getClassInternalName(sealedSubclassNames[idx])
             if (actualClasses.contains(sealedSubclassName)) {
                 ++idx
             } else {
@@ -219,7 +219,7 @@ internal class ClassMetaFixerTransformer(
     ProtoBuf.Class::parseFrom
 ) {
     override val typeTable = TypeTable(message.typeTable)
-    override val classDescriptor = "L${nameResolver.getString(message.fqName)};"
+    override val classDescriptor = "L${nameResolver.getClassInternalName(message.fqName)};"
     override val classKind: ProtoBuf.Class.Kind = CLASS_KIND.get(message.flags)
     override val properties = mutableList(message.propertyList)
     override val functions = mutableList(message.functionList)

--- a/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/buildSrc/jarfilter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -200,7 +200,7 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
         var count = 0
         var idx = 0
         while (idx < sealedSubclassNames.size) {
-            val subclassName = nameResolver.getString(sealedSubclassNames[idx]).replace('.', '$')
+            val subclassName = nameResolver.getClassInternalName(sealedSubclassNames[idx])
             if (deletedClasses.contains(subclassName)) {
                 logger.info("-- removing sealed subclass: {}", subclassName)
                 sealedSubclassNames.removeAt(idx)
@@ -248,7 +248,7 @@ internal class ClassMetadataTransformer(
     ProtoBuf.Class::parseFrom
 ) {
     override val typeTable = TypeTable(message.typeTable)
-    override val className = nameResolver.getString(message.fqName)
+    override val className = nameResolver.getClassInternalName(message.fqName)
     override val nestedClassNames = mutableList(message.nestedClassNameList)
     override val sealedSubclassNames = mutableList(message.sealedSubclassFqNameList)
     override val properties = mutableList(message.propertyList)

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
@@ -1,0 +1,110 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.asm.recodeMetadataFor
+import net.corda.gradle.jarfilter.asm.toClass
+import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.unwanted.HasAll
+import org.assertj.core.api.Assertions.*
+import org.gradle.api.logging.Logger
+import org.hamcrest.core.IsCollectionContaining.*
+import org.junit.Assert.*
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.reflect.full.primaryConstructor
+
+class MetaFixConstructorDefaultParameterTest {
+    companion object {
+        private val logger: Logger = StdOutLogging(MetaFixConstructorDefaultParameterTest::class)
+        private val primaryCon
+                = isConstructor(WithConstructorParameters::class, Long::class, Int::class, String::class)
+        private val secondaryCon
+                = isConstructor(WithConstructorParameters::class, Char::class, String::class)
+
+        lateinit var sourceClass: Class<out HasAll>
+        lateinit var fixedClass: Class<out HasAll>
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            val bytecode = recodeMetadataFor<WithConstructorParameters, MetadataTemplate>()
+            sourceClass = bytecode.toClass<WithConstructorParameters, HasAll>()
+            fixedClass = bytecode.fixMetadata(logger, pathsOf(WithConstructorParameters::class))
+                    .toClass<WithConstructorParameters, HasAll>()
+        }
+    }
+
+    @Test
+    fun `test source constructor has optional parameters`() {
+        with(sourceClass.kotlin.constructors) {
+            assertThat(size).isEqualTo(2)
+            assertThat("source primary constructor missing", this, hasItem(primaryCon))
+            assertThat("source secondary constructor missing", this, hasItem(secondaryCon))
+        }
+
+        val sourcePrimary = sourceClass.kotlin.primaryConstructor
+                ?: throw AssertionError("source primary constructor missing")
+        sourcePrimary.call(BIG_NUMBER, NUMBER, MESSAGE).apply {
+            assertThat(longData()).isEqualTo(BIG_NUMBER)
+            assertThat(intData()).isEqualTo(NUMBER)
+            assertThat(stringData()).isEqualTo(MESSAGE)
+        }
+
+        val sourceSecondary = sourceClass.kotlin.constructors.firstOrNull { it != sourcePrimary }
+                ?: throw AssertionError("source secondary constructor missing")
+        sourceSecondary.call('X', MESSAGE).apply {
+            assertThat(stringData()).isEqualTo("X$MESSAGE")
+        }
+
+        assertTrue("All source parameters should have defaults", sourcePrimary.hasAllOptionalParameters)
+    }
+
+    @Test
+    fun `test fixed constructors exist`() {
+        with(fixedClass.kotlin.constructors) {
+            assertThat(size).isEqualTo(2)
+            assertThat("fixed primary constructor missing", this, hasItem(primaryCon))
+            assertThat("fixed secondary constructor missing", this, hasItem(secondaryCon))
+        }
+    }
+
+    @Test
+    fun `test fixed primary constructor has mandatory parameters`() {
+        val fixedPrimary = fixedClass.kotlin.primaryConstructor
+                ?: throw AssertionError("fixed primary constructor missing")
+        assertTrue("All fixed parameters should be mandatory", fixedPrimary.hasAllMandatoryParameters)
+    }
+
+    @Test
+    fun `test fixed secondary constructor still has optional parameters`() {
+        val fixedSecondary = (fixedClass.kotlin.constructors - fixedClass.kotlin.primaryConstructor).firstOrNull()
+                ?: throw AssertionError("fixed secondary constructor missing")
+        assertTrue("Some fixed parameters should be optional", fixedSecondary.hasAnyOptionalParameters)
+    }
+
+    class MetadataTemplate(
+        private val longData: Long = 0,
+        private val intData: Int = 0,
+        private val message: String = DEFAULT_MESSAGE
+    ) : HasAll {
+        @Suppress("UNUSED")
+        constructor(prefix: Char, message: String = DEFAULT_MESSAGE) : this(message = prefix + message)
+
+        override fun longData(): Long = longData
+        override fun intData(): Int = intData
+        override fun stringData(): String = message
+    }
+}
+
+class WithConstructorParameters(
+    private val longData: Long,
+    private val intData: Int,
+    private val message: String
+) : HasAll {
+    @Suppress("UNUSED")
+    constructor(prefix: Char, message: String = DEFAULT_MESSAGE) : this(0, 0, prefix + message)
+
+    override fun longData(): Long = longData
+    override fun intData(): Int = intData
+    override fun stringData(): String = message
+}
+

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
@@ -1,0 +1,96 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.asm.recodeMetadataFor
+import net.corda.gradle.jarfilter.asm.toClass
+import net.corda.gradle.jarfilter.matcher.isFunction
+import org.assertj.core.api.Assertions.*
+import org.gradle.api.logging.Logger
+import org.hamcrest.core.IsCollectionContaining.*
+import org.junit.Assert.*
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.declaredFunctions
+
+class MetaFixFunctionDefaultParameterTest {
+    companion object {
+        private val logger: Logger = StdOutLogging(MetaFixFunctionDefaultParameterTest::class)
+        private val hasMandatoryParams
+                = isFunction("hasMandatoryParams", String::class, Long::class, Int::class, String::class)
+        private val hasOptionalParams
+                = isFunction("hasOptionalParams", String::class, String::class)
+
+        lateinit var sourceClass: Class<out Any>
+        lateinit var fixedClass: Class<out Any>
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            val bytecode = recodeMetadataFor<WithFunctionParameters, MetadataTemplate>()
+            sourceClass = bytecode.toClass<WithFunctionParameters, Any>()
+            fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFunctionParameters::class))
+                    .toClass<WithFunctionParameters, Any>()
+        }
+    }
+
+    @Test
+    fun `test source functions have default parameters`() {
+        with(sourceClass.kotlin.declaredFunctions) {
+            assertThat(size).isEqualTo(2)
+            assertThat("source mandatory parameters missing", this, hasItem(hasMandatoryParams))
+            assertThat("source optional parameters missing", this, hasItem(hasOptionalParams))
+        }
+
+        val sourceUnwanted = sourceClass.kotlin.declaredFunctions.findOrFail("hasMandatoryParams")
+        assertThat(sourceUnwanted.call(sourceClass.newInstance(), BIG_NUMBER, NUMBER, MESSAGE))
+            .isEqualTo("Long: $BIG_NUMBER, Int: $NUMBER, String: $MESSAGE")
+
+        assertTrue("All source parameters should be optional", sourceUnwanted.hasAllOptionalParameters)
+
+        val sourceWanted = sourceClass.kotlin.declaredFunctions.findOrFail("hasOptionalParams")
+        assertThat(sourceWanted.call(sourceClass.newInstance(), MESSAGE))
+            .isEqualTo(MESSAGE)
+
+        assertTrue("All source parameters should be optional", sourceWanted.hasAllOptionalParameters)
+    }
+
+    @Test
+    fun `test fixed functions exist`() {
+        with(fixedClass.kotlin.declaredFunctions) {
+            assertThat(size).isEqualTo(2)
+            assertThat("fixed mandatory parameters missing", this, hasItem(hasMandatoryParams))
+            assertThat("fixed optional parameters missing", this, hasItem(hasOptionalParams))
+        }
+    }
+
+    @Test
+    fun `test unwanted default parameters are removed`() {
+        val fixedMandatory = fixedClass.kotlin.declaredFunctions.findOrFail("hasMandatoryParams")
+        assertTrue("All fixed parameters should be mandatory", fixedMandatory.hasAllMandatoryParameters)
+    }
+
+    @Test
+    fun `test wanted default parameters are kept`() {
+        val fixedOptional = fixedClass.kotlin.declaredFunctions.findOrFail("hasOptionalParams")
+        assertTrue("All fixed parameters should be optional", fixedOptional.hasAllOptionalParameters)
+    }
+
+    @Suppress("UNUSED")
+    abstract class MetadataTemplate {
+        abstract fun hasMandatoryParams(longData: Long = 0, intData: Int = 0, message: String = DEFAULT_MESSAGE): String
+        abstract fun hasOptionalParams(message: String = DEFAULT_MESSAGE): String
+    }
+
+    private fun <T> Iterable<KFunction<T>>.findOrFail(name: String): KFunction<T> {
+        return find { it.name == name } ?: throw AssertionError("$name missing")
+    }
+}
+
+@Suppress("UNUSED")
+class WithFunctionParameters {
+    fun hasMandatoryParams(longData: Long, intData: Int, message: String): String {
+        return "Long: $longData, Int: $intData, String: $message"
+    }
+
+    fun hasOptionalParams(message: String = DEFAULT_MESSAGE): String = message
+}

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageDefaultParameterTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageDefaultParameterTest.kt
@@ -1,0 +1,39 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.asm.metadataAs
+import net.corda.gradle.jarfilter.asm.toClass
+import org.gradle.api.logging.Logger
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.reflect.full.declaredFunctions
+import kotlin.test.assertFailsWith
+
+/**
+ * These tests cannot actually "test" anything until Kotlin reflection
+ * supports package metadata. Until then, we can only execute the code
+ * paths to ensure they don't throw any exceptions.
+ */
+class MetaFixPackageDefaultParameterTest {
+    companion object {
+        private const val TEMPLATE_CLASS = "net.corda.gradle.jarfilter.template.PackageWithDefaultParameters"
+        private const val DEFAULT_PARAMETERS_CLASS = "net.corda.gradle.jarfilter.PackageWithDefaultParameters"
+        private val logger: Logger = StdOutLogging(MetaFixPackageDefaultParameterTest::class)
+
+        lateinit var sourceClass: Class<out Any>
+        lateinit var fixedClass: Class<out Any>
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            val defaultParametersClass = Class.forName(DEFAULT_PARAMETERS_CLASS)
+            val bytecode = defaultParametersClass.metadataAs(Class.forName(TEMPLATE_CLASS))
+            sourceClass = bytecode.toClass(defaultParametersClass, Any::class.java)
+            fixedClass = bytecode.fixMetadata(logger, setOf(DEFAULT_PARAMETERS_CLASS)).toClass(sourceClass, Any::class.java)
+        }
+    }
+
+    @Test
+    fun `test package functions`() {
+        assertFailsWith<UnsupportedOperationException> { fixedClass.kotlin.declaredFunctions }
+    }
+}

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageTest.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageTest.kt
@@ -41,21 +41,21 @@ class MetaFixPackageTest {
 
     @Test
     fun testPackageFunction() {
-        assertFailsWith<UnsupportedOperationException> { sourceClass.kotlin.declaredFunctions }
+        assertFailsWith<UnsupportedOperationException> { fixedClass.kotlin.declaredFunctions }
         //assertThat("templateFun() not found", sourceClass.kotlin.declaredFunctions, hasItem(staticFun))
         //assertThat("templateFun() still exists", fixedClass.kotlin.declaredFunctions, not(hasItem(staticFun)))
     }
 
     @Test
     fun testPackageVal() {
-        assertFailsWith<UnsupportedOperationException> { sourceClass.kotlin.declaredMembers }
+        assertFailsWith<UnsupportedOperationException> { fixedClass.kotlin.declaredMembers }
         //assertThat("templateVal not found", sourceClass.kotlin.declaredMembers, hasItem(staticVal))
         //assertThat("templateVal still exists", fixedClass.kotlin.declaredMembers, not(hasItem(staticVal)))
     }
 
     @Test
     fun testPackageVar() {
-        assertFailsWith<UnsupportedOperationException> { sourceClass.kotlin.declaredMembers }
+        assertFailsWith<UnsupportedOperationException> { fixedClass.kotlin.declaredMembers }
         //assertThat("templateVar not found", sourceClass.kotlin.declaredMembers, hasItem(staticVar))
         //assertThat("templateVar still exists", fixedClass.kotlin.declaredMembers, not(hasItem(staticVar)))
     }

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/PackageWithDefaultParameters.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/PackageWithDefaultParameters.kt
@@ -1,0 +1,12 @@
+@file:JvmName("PackageWithDefaultParameters")
+@file:Suppress("UNUSED")
+package net.corda.gradle.jarfilter
+
+/**
+ * Example package functions, one with default parameter values and one without.
+ * We will rewrite this class's metadata so that it expects both functions to
+ * have default parameter values, and then ask the [MetaFixerTask] to fix it.
+ */
+fun hasDefaultParameters(intData: Int=0, message: String=DEFAULT_MESSAGE): String = "$message: intData=$intData"
+
+fun hasMandatoryParameters(longData: Long, message: String): String = "$message: longData=$longData"

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
@@ -16,6 +16,7 @@ import java.util.zip.ZipFile
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
+import kotlin.reflect.full.valueParameters
 
 const val DEFAULT_MESSAGE = "<default-value>"
 const val MESSAGE = "Goodbye, Cruel World!"
@@ -67,8 +68,17 @@ fun arrayOfJunk(size: Int) = ByteArray(size).apply {
     }
 }
 
+val KFunction<*>.hasAnyOptionalParameters: Boolean
+    get() = valueParameters.any(KParameter::isOptional)
+
+val KFunction<*>.hasAllOptionalParameters: Boolean
+    get() = valueParameters.all(KParameter::isOptional)
+
+val KFunction<*>.hasAllMandatoryParameters: Boolean
+    get() = valueParameters.none(KParameter::isOptional)
+
 val <T : Any> KClass<T>.noArgConstructor: KFunction<T>?
-    get() = constructors.firstOrNull { it.parameters.all(KParameter::isOptional) }
+    get() = constructors.firstOrNull(KFunction<*>::hasAllOptionalParameters)
 
 @Throws(MalformedURLException::class)
 fun classLoaderFor(jar: Path) = URLClassLoader(arrayOf(jar.toUri().toURL()), classLoader)

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/asm/ClassMetadata.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/asm/ClassMetadata.kt
@@ -1,6 +1,7 @@
 package net.corda.gradle.jarfilter.asm
 
 import net.corda.gradle.jarfilter.MetadataTransformer
+import net.corda.gradle.jarfilter.getClassInternalName
 import net.corda.gradle.jarfilter.toPackageFormat
 import net.corda.gradle.jarfilter.mutableList
 import org.gradle.api.logging.Logger
@@ -24,7 +25,7 @@ internal class ClassMetadata(
     ProtoBuf.Class::parseFrom
 ) {
     override val typeTable = TypeTable(message.typeTable)
-    override val className = nameResolver.getString(message.fqName)
+    override val className = nameResolver.getClassInternalName(message.fqName)
     override val nestedClassNames = mutableList(message.nestedClassNameList)
     override val properties = mutableList(message.propertyList)
     override val functions = mutableList(message.functionList)
@@ -35,13 +36,13 @@ internal class ClassMetadata(
     override fun rebuild(): ProtoBuf.Class = message
 
     val sealedSubclasses: List<String> = sealedSubclassNames.map {
-        // Transform "a/b/c/BaseName.SubclassName" -> "a.b.c.BaseName$SubclassName"
-        nameResolver.getString(it).replace('.', '$').toPackageFormat }.toList()
+        // Transform "a/b/c/BaseName$SubclassName" -> "a.b.c.BaseName$SubclassName"
+        nameResolver.getClassInternalName(it).toPackageFormat }.toList()
 
     val nestedClasses: List<String>
 
     init {
         val internalClassName = className.toPackageFormat
-        nestedClasses = nestedClassNames.map { "$internalClassName\$${nameResolver.getString(it)}" }.toList()
+        nestedClasses = nestedClassNames.map { "$internalClassName\$${nameResolver.getClassInternalName(it)}" }.toList()
     }
 }

--- a/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/template/PackageWithDefaultParameters.kt
+++ b/buildSrc/jarfilter/src/test/kotlin/net/corda/gradle/jarfilter/template/PackageWithDefaultParameters.kt
@@ -1,0 +1,9 @@
+@file:JvmName("PackageWithDefaultParameters")
+@file:Suppress("UNUSED")
+package net.corda.gradle.jarfilter.template
+
+import net.corda.gradle.jarfilter.DEFAULT_MESSAGE
+
+fun hasDefaultParameters(intData: Int=0, message: String=DEFAULT_MESSAGE): String = "$message: intData=$intData"
+
+fun hasMandatoryParameters(longData: Long=0, message: String=DEFAULT_MESSAGE): String = "$message: longData=$longData"


### PR DESCRIPTION
Kotlin generates special synthetic constructors and functions to support any default parameter values. So ensure that we also update the Kotlin metadata accordingly, should these synthetic methods happen to disappear (e.g. ProGuard).