### PR TITLE
ENT-1565 Upgrade Artemis version to latest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     ext.capsule_version = '1.0.1'
 
     ext.asm_version = '5.0.4'
-    ext.artemis_version = '2.5.0'
+    ext.artemis_version = '2.6.2'
     ext.jackson_version = '2.9.5'
     ext.jetty_version = '9.4.7.v20170914'
     ext.jersey_version = '2.25'

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ buildscript {
     ext.proguard_version = constants.getProperty('proguardVersion')
     ext.jsch_version = '0.1.54'
     ext.commons_cli_version = '1.4'
-    ext.protonj_version = '0.27.1'
+    ext.protonj_version = '0.27.1' // This is now aligned with the Artemis version, but retaining in case we ever need to diverge again for a bug fix.
     ext.snappy_version = '0.4'
     ext.fast_classpath_scanner_version = '2.12.3'
     ext.jcabi_manifests_version = '1.1'

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -170,6 +170,8 @@ Unreleased
   The log entry starts with `Cross-reference between MappedSchemas.`.
   API: Persistence documentation no longer suggests mapping between different schemas.
 
+* Upgraded Artemis to v2.6.2.
+
 .. _changelog_v3.1:
 
 Version 3.1

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/MessageSizeChecksInterceptor.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/MessageSizeChecksInterceptor.kt
@@ -22,7 +22,7 @@ class ArtemisMessageSizeChecksInterceptor(maxMessageSize: Int) : MessageSizeChec
 }
 
 class AmqpMessageSizeChecksInterceptor(maxMessageSize: Int) : MessageSizeChecksInterceptor<AMQPMessage>(maxMessageSize), AmqpInterceptor {
-    override fun getMessageSize(packet: AMQPMessage?): Int? = packet?.length
+    override fun getMessageSize(packet: AMQPMessage?): Int? = packet?.encodeSize
 }
 
 /**

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -14,6 +14,8 @@ dependencies {
 
     compile "org.ow2.asm:asm:$asm_version"
 
+    compile "com.google.guava:guava:$guava_version"
+
     // For AMQP serialisation.
     compile "org.apache.qpid:proton-j:$protonj_version"
 


### PR DESCRIPTION
Upgrading as soon as possible after CE 3.0 GA to maximise regression finding time.
