### PR TITLE
Increase guava version to 25.1-jre

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,7 +1,7 @@
 gradlePluginsVersion=4.0.25
 kotlinVersion=1.2.51
 platformVersion=4
-guavaVersion=21.0
+guavaVersion=25.1-jre
 proguardVersion=6.0.3
 bouncycastleVersion=1.57
 typesafeConfigVersion=1.3.1


### PR DESCRIPTION
Allow using the jib gradle plugin to build container images.