### PR TITLE
CORDA-1543 create test for flow checkpoint simple

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
@@ -1,0 +1,70 @@
+package net.corda.node.flows
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.internal.div
+import net.corda.core.internal.list
+import net.corda.core.internal.packageName
+import net.corda.core.internal.readLines
+import net.corda.core.messaging.startTrackedFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.internal.CheckpointIncompatibleException
+import net.corda.node.internal.NodeStartup
+import net.corda.node.services.Permissions
+import net.corda.testMessage.Message
+import net.corda.testMessage.MessageState
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.RandomFree
+import net.corda.testing.node.User
+import net.test.cordapp.v1.SendMessageFlow
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FlowCheckpointVersionNodeStartupCheck {
+    companion object {
+        val message = Message("Hello world!")
+    }
+
+    @Test
+    fun `restart nodes with incompatible version of sunspended flow - different jar name`() {
+
+        val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlow>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = false,
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName, "net.test.cordapp.v1"))) {
+            val logFolder = {
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME).getOrThrow()
+                alice.stop()
+                CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
+                    val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlow, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
+                    //wait until Bob progresses as far as possible because alice node is offline
+                    flowTracker.takeFirst { it == SendMessageFlow.Companion.FINALISING_TRANSACTION.label }.toBlocking().single()
+                }
+
+                val logFolder = bob.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
+
+                bob.stop()
+                logFolder
+            }()
+
+            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false)).getOrThrow()
+            //assertFailsWith(CheckpointIncompatibleException.FlowNotInstalledException::class) {
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false)).getOrThrow()
+            //}
+
+            val logFile = logFolder.list { it.filter { it.fileName.toString().endsWith(".log") }.findAny().get() }
+            // We count the number of nodes that wrote into the logfile by counting "Logs can be found in"
+            //val numberOfNodesThatLogged = logFile.readLines { it.filter { "that is incompatible with the current installed version of" in it }.count() }
+
+            //val expectedLogMessage = CheckpointIncompatibleException.FlowNotInstalledException(SendMessageFlow::class)
+            val numberOfNodesThatLogged = logFile.readLines { it.filter {"Found checkpoint"/*"that is no longer installed"*/ in it }
+                    .map{ a-> a}
+                    .count() }
+            assertEquals(1, numberOfNodesThatLogged)
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
@@ -33,7 +33,9 @@ class FlowCheckpointVersionNodeStartupCheck {
     fun `restart nodes with incompatible version of sunspended flow - different jar name`() {
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlow>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = false,
+        return driver(DriverParameters(isDebug = true,
+                startNodesInProcess = false, // start nodes in separate processes to ensure CordappLoader is not shared between restarts
+                inMemoryDB = false, // ensure database is persisted between node restarts so we can keep suspended flow in Bob's node
                 portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName, "net.test.cordapp.v1"))) {
             val logFolder = {
                 val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME).getOrThrow()
@@ -41,29 +43,26 @@ class FlowCheckpointVersionNodeStartupCheck {
                 alice.stop()
                 CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
                     val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlow, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
-                    //wait until Bob progresses as far as possible because alice node is offline
+                    // wait until Bob progresses as far as possible because Alice node is offline
                     flowTracker.takeFirst { it == SendMessageFlow.Companion.FINALISING_TRANSACTION.label }.toBlocking().single()
                 }
-
                 val logFolder = bob.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
-
+                // SendMessageFlow suspends in Bob node
                 bob.stop()
                 logFolder
             }()
 
+            //after nodes restart the package with the flow is loaded bvia a JAR filw with different name (a random UUID is added)
             startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false)).getOrThrow()
-            //assertFailsWith(CheckpointIncompatibleException.FlowNotInstalledException::class) {
+            assertFailsWith(net.corda.testing.node.internal.ListenProcessDeathException::class) {
+                //ALic node is up so Bob's suspended flow should restart, however this time is loaded from different JAR file
                 startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false)).getOrThrow()
-            //}
+            }
 
             val logFile = logFolder.list { it.filter { it.fileName.toString().endsWith(".log") }.findAny().get() }
-            // We count the number of nodes that wrote into the logfile by counting "Logs can be found in"
-            //val numberOfNodesThatLogged = logFile.readLines { it.filter { "that is incompatible with the current installed version of" in it }.count() }
+            val expectedLogMessage = CheckpointIncompatibleException.FlowNotInstalledException(SendMessageFlow::class.java)
 
-            //val expectedLogMessage = CheckpointIncompatibleException.FlowNotInstalledException(SendMessageFlow::class)
-            val numberOfNodesThatLogged = logFile.readLines { it.filter {"Found checkpoint"/*"that is no longer installed"*/ in it }
-                    .map{ a-> a}
-                    .count() }
+            val numberOfNodesThatLogged = logFile.readLines { it.filter { expectedLogMessage.message in it }.count() }
             assertEquals(1, numberOfNodesThatLogged)
         }
     }

--- a/node/src/integration-test/kotlin/net/test/cordapp/v1/FlowCheckpointCordapp.kt
+++ b/node/src/integration-test/kotlin/net/test/cordapp/v1/FlowCheckpointCordapp.kt
@@ -1,0 +1,68 @@
+package net.test.cordapp.v1
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.StateAndContract
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+import net.corda.testMessage.MESSAGE_CONTRACT_PROGRAM_ID
+import net.corda.testMessage.Message
+import net.corda.testMessage.MessageContract
+import net.corda.testMessage.MessageState
+
+@StartableByRPC
+@InitiatingFlow
+class SendMessageFlow(private val message: Message, private val notary: Party, private val reciepent: Party? = null) : FlowLogic<SignedTransaction>() {
+    companion object {
+        object GENERATING_TRANSACTION : ProgressTracker.Step("Generating transaction based on the message.")
+        object VERIFYING_TRANSACTION : ProgressTracker.Step("Verifying contract constraints.")
+        object SIGNING_TRANSACTION : ProgressTracker.Step("Signing transaction with our private key.")
+        object FINALISING_TRANSACTION : ProgressTracker.Step("Obtaining notary signature and recording transaction.") {
+            override fun childProgressTracker() = FinalityFlow.tracker()
+        }
+
+        fun tracker() = ProgressTracker(GENERATING_TRANSACTION, VERIFYING_TRANSACTION, SIGNING_TRANSACTION, FINALISING_TRANSACTION)
+    }
+
+    override val progressTracker = tracker()
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        progressTracker.currentStep = GENERATING_TRANSACTION
+
+        val messageState = MessageState(message = message, by = /*reciepent ?:*/ ourIdentity)
+        val txCommand = Command(MessageContract.Commands.Send(), messageState.participants.map { it.owningKey })
+        val txBuilder = TransactionBuilder(notary).withItems(StateAndContract(messageState, MESSAGE_CONTRACT_PROGRAM_ID), txCommand)
+
+        progressTracker.currentStep = VERIFYING_TRANSACTION
+        txBuilder.toWireTransaction(serviceHub).toLedgerTransaction(serviceHub).verify()
+
+        progressTracker.currentStep = SIGNING_TRANSACTION
+        val signedTx = serviceHub.signInitialTransaction(txBuilder)
+
+        progressTracker.currentStep = FINALISING_TRANSACTION
+
+        if (reciepent != null) {
+            val session = initiateFlow(reciepent)
+            subFlow(SendTransactionFlow(session, signedTx))
+            return  subFlow(FinalityFlow(signedTx, setOf(reciepent), FINALISING_TRANSACTION.childProgressTracker()))
+        } else {
+            return subFlow(FinalityFlow(signedTx, FINALISING_TRANSACTION.childProgressTracker()))
+        }
+    }
+}
+
+
+@InitiatedBy(SendMessageFlow::class)
+class Record(private val session: FlowSession) : FlowLogic<Unit>() {
+
+    @Suspendable
+    override fun call() {
+        val tx = subFlow(ReceiveTransactionFlow(session, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        serviceHub.addSignature(tx)
+    }
+}


### PR DESCRIPTION
Integration test for https://r3-cev.atlassian.net/browse/CORDA-1477.
This is minimal test for change JAR file name contains a cordapp, without any alterations to driverDSL.
The check for hash of the file content needs some DriverDSL addition (the next PR).
The node starts a flow which is suspended after initial progress.
The node is restarted, due to driverDSL and CodappLoader for test packages the flow class is loaded from different JAR file (random UUID is added to the file name).
Because the node can't match the restarted flow with the old JAR name, the  node throws the error.
The actual check expects a log entry with `Found checkpoint for flow: <flowClass> that is no longer installed.....`
