### PR TITLE
Removed the negative reference to ethereum/bitcoin

### DIFF
--- a/docs/source/flow-state-machines.rst
+++ b/docs/source/flow-state-machines.rst
@@ -24,9 +24,7 @@ partially signed invalid transactions outside of the main network, and by doing 
 traded asset are performed atomically by the same transaction. To perform such a trade involves a multi-step flow
 in which messages are passed back and forth privately between parties, checked, signed and so on.
 
-Despite how useful these flows are, platforms such as Bitcoin and Ethereum do not assist the developer with the rather
-tricky task of actually building them. That is unfortunate. There are many awkward problems in their implementation
-that a good platform would take care of for you, problems like:
+There are many benefits of this flow based design and some development complexities as well.  Some of the development challenges include:
 
 * Avoiding "callback hell" in which code that should ideally be sequential is turned into an unreadable mess due to the
   desire to avoid using up a thread for every flow instantiation.


### PR DESCRIPTION
in reading this document from docs.corda.net, trying to understand the flow state machines (support /development perspective), I found that the negative outlook of limitations in ethereum and bitcoin may be a bit out-dated and interrupted learning thought/understanding - on this specific page.  adjusted the verbage to keep the point that there are development challenges that we've addressed, but removed the excess language around ethereum and bitcoin

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described here? https://docs.corda.net/head/testing.html
- [ ] If you added/changed public APIs, did you write/update the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially release notes?
- [ ] If you are contributing for the first time, please read the agreement in CONTRIBUTING.md now and add to this Pull Request that you agree to it.

Thanks for your code, it's appreciated! :)
