### PR TITLE
CORDA- 1543 modification to DriverDsl to allow more advanced CordappVerifier tests

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
@@ -43,7 +43,7 @@ class FlowCheckpointVersionNodeStartupCheck {
         val cordappsVersionAtRestart = mapOf("net.test.cordapp.v1" to "fancy")
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = true, portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true, inMemoryDB = false, portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
             {
                 val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
                 val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
@@ -83,7 +83,7 @@ class FlowCheckpointVersionNodeStartupCheck {
         val cordappsVersionAtRestart = mapOf("net.test.cordapp" to "fancy")  // including now addtional Dummy class to change hash of JAr file, despite reusing the same file name
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true, inMemoryDB = false,
                 portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
             {
                 val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
@@ -116,7 +116,7 @@ class FlowCheckpointVersionNodeStartupCheck {
         val cordappsVersionAtRestart = mapOf("net.test.cordapp.v1" to null)
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true, inMemoryDB = false,
                 portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
             {
                 val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
@@ -1,0 +1,122 @@
+package net.corda.node.flows
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.internal.div
+import net.corda.core.internal.list
+import net.corda.core.internal.packageName
+import net.corda.core.internal.readLines
+import net.corda.core.messaging.startTrackedFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.internal.NodeStartup
+import net.corda.node.services.Permissions
+import net.corda.testMessage.Message
+import net.corda.testMessage.MessageState
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.RandomFree
+import net.corda.testing.node.User
+import net.test.cordapp.v1.SendMessageFlowY
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class FlowCheckpointVersionNodeStartupCheck {
+    companion object {
+        val message = Message("Hello world!")
+    }
+
+    fun nodes_interaction(message: Message, cordappsVersionAtStartup: List<String>, cordappsVersionAtRestart: List<String>): StateAndRef<MessageState>? {
+
+        val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = false,//isQuasarAgentSpecified(),
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
+            {
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup).getOrThrow()
+                alice.stop()
+                CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
+                    val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
+                    //wait until Bob progresses as far as possible because alice node is off
+                    flowTracker.takeFirst { it == SendMessageFlowY.Companion.FINALISING_TRANSACTION.label }.toBlocking().single()
+                }
+                bob.stop()
+            }()
+            //CordappLoader.invalidateAll()
+            val result =  {
+                //Bob will resume the flow
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtRestart, customOverrides = mapOf( "devMode" to false)).getOrThrow()
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false)).getOrThrow()
+                CordaRPCClient(alice.rpcAddress).start(user.username, user.password).use {
+                    val page = it.proxy.vaultTrack(MessageState::class.java)
+                    if (page.snapshot.states.isNotEmpty()) {
+                        page.snapshot.states.first()
+                    } else {
+                        val r = page.updates.timeout(10, TimeUnit.SECONDS).take(1).toBlocking().single()
+                        if (r.consumed.isNotEmpty()) r.consumed.first() else r.produced.first()
+                    }
+                }
+            }()
+            result
+        }
+    }
+
+    @Test
+    fun `restart nodes with sunspended flow`() {
+
+        val stateAndRef = nodes_interaction(message, listOf("net.test.cordapp.v1"), listOf("net.test.cordapp.v1"))
+        assertNotNull(stateAndRef)
+        assertEquals(message, stateAndRef!!.state.data.message)
+    }
+
+    @Test
+    fun `restart nodes with incompatible version of sunspended flow`() {
+//        assertFailsWith(RuntimeException::class) {
+//            val stateAndRef =  nodes_interaction(message, listOf("net.test.cordapp.v2"), listOf("net.test.cordapp"))
+//            //assertNotNull(stateAndRef)
+//        //println(stateAndRef!!.state.data)
+//        }
+
+        val cordappsVersionAtStartup = listOf("net.test.cordapp.v1")
+        val cordappsVersionAtRestart = listOf("net.test.cordapp")
+
+        val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = false,//isQuasarAgentSpecified(),
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
+            val logFolder = {
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup).getOrThrow()
+                alice.stop()
+                CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
+                    val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
+                    //wait until Bob progresses as far as possible because alice node is off
+                    flowTracker.takeFirst { it == SendMessageFlowY.Companion.FINALISING_TRANSACTION.label }.toBlocking().single()
+                }
+
+
+                val logFolder = bob.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
+
+
+                bob.stop()
+                 logFolder
+            }()
+            //CordappLoader.invalidateAll()
+
+            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false)).getOrThrow()
+            assertFailsWith(net.corda.testing.node.internal.ListenProcessDeathException::class) {
+                    startNode(providedName = BOB_NAME, rpcUsers = listOf(user), packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false)).getOrThrow()
+            }
+
+            val logFile = logFolder.list { it.filter { it.fileName.toString().endsWith(".log") }.findAny().get() }
+            // We count the number of nodes that wrote into the logfile by counting "Logs can be found in"
+            val numberOfNodesThatLogged = logFile.readLines { it.filter { "that is incompatible with the current installed version of" in it }.count() }
+            assertEquals(1, numberOfNodesThatLogged)
+
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
@@ -8,6 +8,7 @@ import net.corda.core.internal.readLines
 import net.corda.core.messaging.startTrackedFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.NodeStartup
+import net.corda.node.internal.cordapp.CordappLoader
 import net.corda.node.services.Permissions
 import net.corda.testMessage.Message
 import net.corda.testMessage.MessageState
@@ -36,12 +37,15 @@ class FlowCheckpointVersionNodeStartupCheck {
         val cordappsVersionAtStartup = listOf("net.test.cordapp.v1")
         val cordappsVersionAtRestart = listOf("net.test.cordapp.v1")
 
+        val jarNamesVersionAtStartup = mapOf("net.test.cordapp.v1" to "fancy")
+        val jarNamesVersionAtRestart = mapOf("net.test.cordapp.v1" to "fancy")
+
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = false,//isQuasarAgentSpecified(),
-                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName, "net.test.cordapp.v1"))) {
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,//isQuasarAgentSpecified(),
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
             {
-                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup).getOrThrow()
-                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup).getOrThrow()
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
                 alice.stop()
                 CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
                     val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
@@ -51,11 +55,11 @@ class FlowCheckpointVersionNodeStartupCheck {
                 bob.stop()
             }()
             //for in-process nodes the cahce of CordappLoader should be invalidated
-
+            CordappLoader.invalidateCache()
             val result =  {
                 //Bob will resume the flow
-                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtRestart, customOverrides = mapOf( "devMode" to false)).getOrThrow()
-                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false)).getOrThrow()
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtRestart, customOverrides = mapOf( "devMode" to false), packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false), packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
                 CordaRPCClient(alice.rpcAddress).start(user.username, user.password).use {
                     val page = it.proxy.vaultTrack(MessageState::class.java)
                     if (page.snapshot.states.isNotEmpty()) {
@@ -75,14 +79,18 @@ class FlowCheckpointVersionNodeStartupCheck {
     fun `restart nodes with incompatible version of sunspended flow`() {
 
         val cordappsVersionAtStartup = listOf("net.test.cordapp.v1")
-        val cordappsVersionAtRestart = listOf("net.test.cordapp")
+        val cordappsVersionAtRestart = listOf("net.test.cordapp")  // we collect additional dummy class so the hash will be different ......
+
+        val jarNamesVersionAtStartup = mapOf("net.test.cordapp.v1" to "fancy")
+        val jarNamesVersionAtRestart = mapOf("net.test.cordapp" to "fancy")  // ...despite the same JAR file name
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = false,//isQuasarAgentSpecified(),
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,//isQuasarAgentSpecified(),
                 portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName/*, "net.test.cordapp.v1"*/))) {
-            val logFolder = {
-                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup).getOrThrow()
-                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup).getOrThrow()
+            //val logFolder =
+                    {
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
                 alice.stop()
                 CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
                     val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
@@ -96,17 +104,70 @@ class FlowCheckpointVersionNodeStartupCheck {
                  logFolder
             }()
             //for in-process nodes the cahce of CordappLoader should be invalidated
+            CordappLoader.invalidateCache()
 
-            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false)).getOrThrow()
-            assertFailsWith(net.corda.testing.node.internal.ListenProcessDeathException::class) {
-                    startNode(providedName = BOB_NAME, rpcUsers = listOf(user), packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false)).getOrThrow()
+            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false),
+                    packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+            assertFailsWith(net.corda.node.internal.CheckpointIncompatibleException.FlowVersionIncompatibleException::class) {
+                    startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false),
+                            packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
             }
 
-            val logFile = logFolder.list { it.filter { it.fileName.toString().endsWith(".log") }.findAny().get() }
+            //for out of process node
+            //val logFile = logFolder.list { it.filter { it.fileName.toString().endsWith(".log") }.findAny().get() }
             // We count the number of nodes that wrote into the logfile by counting "Logs can be found in"
-            val numberOfNodesThatLogged = logFile.readLines { it.filter { "that is incompatible with the current installed version of" in it }.count() }
+            //val numberOfNodesThatLogged = logFile.readLines { it.filter { "that is incompatible with the current installed version of" in it }.count() }
             //val numberOfNodesThatLogged = logFile.readLines { it.filter {"that is no longer installed" in it }.count() }
-            assertEquals(1, numberOfNodesThatLogged)
+            //assertEquals(1, numberOfNodesThatLogged)
+
+        }
+    }
+
+
+    @Test
+    fun `restart nodes with incompatible version of sunspended flow - different jar name`() {
+
+        val cordappsVersionAtStartup = listOf("net.test.cordapp.v1")
+        val cordappsVersionAtRestart = listOf("net.test.cordapp.v1")
+
+        val jarNamesVersionAtStartup = mapOf<String, String>("net.test.cordapp.v1" to "zzzz")  //the same content by the JAR will have different random name (we don't provide a package to JAr name mapping)
+        val jarNamesVersionAtRestart = mapOf<String, String>("net.test.cordapp.v1" to "yyyy")
+
+        val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,//isQuasarAgentSpecified(),
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName/*, "net.test.cordapp.v1"*/))) {
+            //val logFolder =
+            {
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
+                alice.stop()
+                CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
+                    val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
+                    //wait until Bob progresses as far as possible because alice node is off
+                    flowTracker.takeFirst { it == SendMessageFlowY.Companion.FINALISING_TRANSACTION.label }.toBlocking().single()
+                }
+
+                val logFolder = bob.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
+
+                bob.stop()
+                logFolder
+            }()
+            //for in-process nodes the cahce of CordappLoader should be invalidated
+            CordappLoader.invalidateCache()
+
+            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false),
+                    packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+            assertFailsWith(net.corda.node.internal.CheckpointIncompatibleException.FlowNotInstalledException::class) {
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false),
+                        packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+            }
+
+            //for out of process node
+            //val logFile = logFolder.list { it.filter { it.fileName.toString().endsWith(".log") }.findAny().get() }
+            // We count the number of nodes that wrote into the logfile by counting "Logs can be found in"
+            //val numberOfNodesThatLogged = logFile.readLines { it.filter { "that is incompatible with the current installed version of" in it }.count() }
+            //val numberOfNodesThatLogged = logFile.readLines { it.filter {"that is no longer installed" in it }.count() }
+            //assertEquals(1, numberOfNodesThatLogged)
 
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheck.kt
@@ -2,9 +2,7 @@ package net.corda.node.flows
 
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.internal.div
-import net.corda.core.internal.list
 import net.corda.core.internal.packageName
-import net.corda.core.internal.readLines
 import net.corda.core.messaging.startTrackedFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.internal.NodeStartup
@@ -41,17 +39,14 @@ class FlowCheckpointVersionNodeStartupCheck {
     @Test
     fun `restart nodes with sunspended flow`() {
 
-        val cordappsVersionAtStartup = listOf("net.test.cordapp.v1")
-        val cordappsVersionAtRestart = listOf("net.test.cordapp.v1")
-
-        val jarNamesVersionAtStartup = mapOf("net.test.cordapp.v1" to "fancy")
-        val jarNamesVersionAtRestart = mapOf("net.test.cordapp.v1" to "fancy")
+        val cordappsVersionAtStartup = mapOf("net.test.cordapp.v1" to "fancy")
+        val cordappsVersionAtRestart = mapOf("net.test.cordapp.v1" to "fancy")
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
         return driver(DriverParameters(isDebug = true, startNodesInProcess = true, portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
             {
-                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
-                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
                 alice.stop()
                 CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
                     val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
@@ -62,12 +57,10 @@ class FlowCheckpointVersionNodeStartupCheck {
             }()
             //for in-process nodes the cache of CordappLoader should be invalidated
             CordappLoader.invalidateCache()
-            val result =  {
+            val result = {
                 //Bob will resume the flow
-                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtRestart, customOverrides = mapOf( "devMode" to false),
-                        packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
-                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), packages = cordappsVersionAtRestart, customOverrides = mapOf("devMode" to false),
-                        packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false), packageToGeneratedJarName = cordappsVersionAtRestart).getOrThrow()
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false), packageToGeneratedJarName = cordappsVersionAtRestart).getOrThrow()
                 CordaRPCClient(alice.rpcAddress).start(user.username, user.password).use {
                     val page = it.proxy.vaultTrack(MessageState::class.java)
                     if (page.snapshot.states.isNotEmpty()) {
@@ -86,39 +79,31 @@ class FlowCheckpointVersionNodeStartupCheck {
     @Test
     fun `restart nodes with incompatible version of sunspended flow`() {
 
-        val cordappsVersionAtStartup = listOf("net.test.cordapp.v1")
-        val cordappsVersionAtRestart = listOf("net.test.cordapp")  // we collect additional dummy class so the hash will be different ......
-
-        val jarNamesVersionAtStartup = mapOf("net.test.cordapp.v1" to "fancy")
-        val jarNamesVersionAtRestart = mapOf("net.test.cordapp" to "fancy")  // ...despite the same JAR file name
+        val cordappsVersionAtStartup = mapOf("net.test.cordapp.v1" to "fancy")
+        val cordappsVersionAtRestart = mapOf("net.test.cordapp" to "fancy")  // including now addtional Dummy class to change hash of JAr file, despite reusing the same file name
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,//isQuasarAgentSpecified(),
-                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName/*, "net.test.cordapp.v1"*/))) {
-            //val logFolder =
-                    {
-                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
-                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
+            {
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
                 alice.stop()
                 CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
                     val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
                     //wait until Bob progresses as far as possible because alice node is off
                     flowTracker.takeFirst { it == SendMessageFlowY.Companion.FINALISING_TRANSACTION.label }.toBlocking().single()
                 }
-
                 val logFolder = bob.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
-
                 bob.stop()
-                 logFolder
+                logFolder
             }()
             //for in-process nodes the cache of CordappLoader should be invalidated
             CordappLoader.invalidateCache()
 
-            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false),
-                    packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false), packageToGeneratedJarName = cordappsVersionAtRestart).getOrThrow()
             assertFailsWith(net.corda.node.internal.CheckpointIncompatibleException.FlowVersionIncompatibleException::class) {
-                    startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false),
-                            packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false), packageToGeneratedJarName = cordappsVersionAtRestart).getOrThrow()
             }
         }
     }
@@ -127,39 +112,31 @@ class FlowCheckpointVersionNodeStartupCheck {
     @Test
     fun `restart nodes with incompatible version of sunspended flow - different jar name`() {
 
-        val cordappsVersionAtStartup = listOf("net.test.cordapp.v1")
-        val cordappsVersionAtRestart = listOf("net.test.cordapp.v1")
-
-        val jarNamesVersionAtStartup = emptyMap<String, String>() //mapOf<String, String>("net.test.cordapp.v1" to "zzzz")  //the same content by the JAR will have different random name (we don't provide a package to JAr name mapping)
-        val jarNamesVersionAtRestart = emptyMap<String, String>() //mapOf<String, String>("net.test.cordapp.v1" to "yyyy")
+        val cordappsVersionAtStartup = mapOf("net.test.cordapp.v1" to null)  // no JAR file name, CordappLoader will generate a name with random UUID so between restarts, jAR file name will change
+        val cordappsVersionAtRestart = mapOf("net.test.cordapp.v1" to null)
 
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlowY>(), Permissions.invokeRpc("vaultQuery"), Permissions.invokeRpc("vaultTrack")))
-        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,//isQuasarAgentSpecified(),
-                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName/*, "net.test.cordapp.v1"*/))) {
-            //val logFolder =
+        return driver(DriverParameters(isDebug = true, startNodesInProcess = true,
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
             {
-                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
-                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packages = cordappsVersionAtStartup, packageToGeneratedJarNames = jarNamesVersionAtStartup).getOrThrow()
+                val alice = startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
+                val bob = startNode(rpcUsers = listOf(user), providedName = BOB_NAME, packageToGeneratedJarName = cordappsVersionAtStartup).getOrThrow()
                 alice.stop()
                 CordaRPCClient(bob.rpcAddress).start(user.username, user.password).use {
                     val flowTracker = it.proxy.startTrackedFlow(::SendMessageFlowY, message, defaultNotaryIdentity, alice.nodeInfo.singleIdentity()).progress
                     //wait until Bob progresses as far as possible because alice node is off
                     flowTracker.takeFirst { it == SendMessageFlowY.Companion.FINALISING_TRANSACTION.label }.toBlocking().single()
                 }
-
                 val logFolder = bob.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME
-
                 bob.stop()
                 logFolder
             }()
             //for in-process nodes the cache of CordappLoader should be invalidated
             CordappLoader.invalidateCache()
 
-            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false),
-                    packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+            startNode(rpcUsers = listOf(user), providedName = ALICE_NAME, customOverrides = mapOf("devMode" to false), packageToGeneratedJarName = cordappsVersionAtRestart).getOrThrow()
             assertFailsWith(net.corda.node.internal.CheckpointIncompatibleException.FlowNotInstalledException::class) {
-                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false),
-                        packages = cordappsVersionAtRestart, packageToGeneratedJarNames = jarNamesVersionAtRestart).getOrThrow()
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), customOverrides = mapOf("devMode" to false), packageToGeneratedJarName = cordappsVersionAtRestart).getOrThrow()
             }
         }
     }

--- a/node/src/integration-test/kotlin/net/test/cordapp/DummyClass.kt
+++ b/node/src/integration-test/kotlin/net/test/cordapp/DummyClass.kt
@@ -1,0 +1,4 @@
+package net.test.cordapp
+
+
+class DummyClass

--- a/node/src/integration-test/kotlin/net/test/cordapp/v1/FlowCheckpointCordapp.kt
+++ b/node/src/integration-test/kotlin/net/test/cordapp/v1/FlowCheckpointCordapp.kt
@@ -1,0 +1,69 @@
+
+package net.test.cordapp.v1
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.StateAndContract
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+import net.corda.testMessage.MESSAGE_CONTRACT_PROGRAM_ID
+import net.corda.testMessage.Message
+import net.corda.testMessage.MessageContract
+import net.corda.testMessage.MessageState
+
+@StartableByRPC
+@InitiatingFlow
+class SendMessageFlowY(private val message: Message, private val notary: Party, private val reciepent: Party? = null) : FlowLogic<SignedTransaction>() {
+    companion object {
+        object GENERATING_TRANSACTION : ProgressTracker.Step("Generating transaction based on the message.")
+        object VERIFYING_TRANSACTION : ProgressTracker.Step("Verifying contract constraints.")
+        object SIGNING_TRANSACTION : ProgressTracker.Step("Signing transaction with our private key.")
+        object FINALISING_TRANSACTION : ProgressTracker.Step("Obtaining notary signature and recording transaction.") {
+            override fun childProgressTracker() = FinalityFlow.tracker()
+        }
+
+        fun tracker() = ProgressTracker(GENERATING_TRANSACTION, VERIFYING_TRANSACTION, SIGNING_TRANSACTION, FINALISING_TRANSACTION)
+    }
+
+    override val progressTracker = tracker()
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        progressTracker.currentStep = GENERATING_TRANSACTION
+
+        val messageState = MessageState(message = message, by = /*reciepent ?:*/ ourIdentity)
+        val txCommand = Command(MessageContract.Commands.Send(), messageState.participants.map { it.owningKey })
+        val txBuilder = TransactionBuilder(notary).withItems(StateAndContract(messageState, MESSAGE_CONTRACT_PROGRAM_ID), txCommand)
+
+        progressTracker.currentStep = VERIFYING_TRANSACTION
+        txBuilder.toWireTransaction(serviceHub).toLedgerTransaction(serviceHub).verify()
+
+        progressTracker.currentStep = SIGNING_TRANSACTION
+        val signedTx = serviceHub.signInitialTransaction(txBuilder)
+
+        progressTracker.currentStep = FINALISING_TRANSACTION
+
+        if (reciepent != null) {
+            val session = initiateFlow(reciepent)
+            subFlow(SendTransactionFlow(session, signedTx))
+            return  subFlow(FinalityFlow(signedTx, setOf(reciepent), FINALISING_TRANSACTION.childProgressTracker()))
+        } else {
+            return subFlow(FinalityFlow(signedTx, FINALISING_TRANSACTION.childProgressTracker()))
+        }
+    }
+}
+
+
+@InitiatedBy(SendMessageFlowY::class)
+class RecordY(private val session: FlowSession) : FlowLogic<Unit>() {
+
+    @Suspendable
+    override fun call() {
+        val tx = subFlow(ReceiveTransactionFlow(session, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        serviceHub.addSignature(tx)
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -106,7 +106,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
          * @param testPackages See [createWithTestPackages]
          */
         @VisibleForTesting
-        fun createDefaultWithTestPackages(configuration: NodeConfiguration, testPackages: List<String>, testPackageToGeneratedJarName: Map<String, String> = emptyMap()): CordappLoader {
+        fun createDefaultWithTestPackages(configuration: NodeConfiguration, testPackages: List<String>, testPackageToGeneratedJarName: Map<String, String?> = emptyMap()): CordappLoader {
             if (!configuration.devMode) {
                 logger.warn("Package scanning should only occur in dev mode!")
             }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -155,7 +155,11 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
             return generatedCordapps.computeIfAbsent(url) {
                 // TODO Using the driver in out-of-process mode causes each node to have their own copy of the same dev CorDapps
                 val cordappDir = (Paths.get("build") / "tmp" / "generated-test-cordapps").createDirectories()
-                val cordappJar = cordappDir / "$scanPackage-${UUID.randomUUID()}.jar"
+                val cordappJar = if (scanPackage == "net.test.cordapp" || scanPackage == "net.test.cordapp.v1" ) {
+                    cordappDir /  "myjar.jar"
+                } else {
+                    cordappDir / "$scanPackage-${UUID.randomUUID()}.jar"
+                }
                 logger.info("Generating a test-only CorDapp of classes discovered for package $scanPackage in $url: $cordappJar")
                 JarOutputStream(cordappJar.outputStream()).use { jos ->
                     val scanDir = url.toPath()

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -94,6 +94,11 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
             }
         }
 
+        @VisibleForTesting
+        fun invalidateCache() {
+            cordappLoadersCache.invalidateAll()
+            generatedCordapps.clear()
+        }
         /**
          * Create a dev mode CordappLoader for test environments that creates and loads cordapps from the classpath
          * and cordapps directory. This is intended mostly for use by the driver.
@@ -101,11 +106,11 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
          * @param testPackages See [createWithTestPackages]
          */
         @VisibleForTesting
-        fun createDefaultWithTestPackages(configuration: NodeConfiguration, testPackages: List<String>): CordappLoader {
+        fun createDefaultWithTestPackages(configuration: NodeConfiguration, testPackages: List<String>, packageToGeneratedJarNames: Map<String,String> = emptyMap()): CordappLoader {
             if (!configuration.devMode) {
                 logger.warn("Package scanning should only occur in dev mode!")
             }
-            val urls = getNodeCordappURLs(configuration.baseDirectory) + simplifyScanPackages(testPackages).flatMap(this::getPackageURLs)
+            val urls = getNodeCordappURLs(configuration.baseDirectory) + simplifyScanPackages(testPackages).map { name -> name to packageToGeneratedJarNames[name]}.flatMap { p -> getPackageURLs(p.first, p.second) }
             return cordappLoadersCache.asMap().computeIfAbsent(urls, ::CordappLoader)
         }
 
@@ -118,7 +123,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
          */
         @VisibleForTesting
         fun createWithTestPackages(testPackages: List<String>): CordappLoader {
-            val urls = simplifyScanPackages(testPackages).flatMap(this::getPackageURLs)
+            val urls = simplifyScanPackages(testPackages).flatMap{ name -> getPackageURLs(name) }
             return cordappLoadersCache.asMap().computeIfAbsent(urls, ::CordappLoader)
         }
 
@@ -130,7 +135,7 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
         @VisibleForTesting
         fun createDevMode(scanJars: List<URL>) = CordappLoader(scanJars.map { RestrictedURL(it, null) })
 
-        private fun getPackageURLs(scanPackage: String): List<RestrictedURL> {
+        private fun getPackageURLs(scanPackage: String, generatedJarName: String? = null): List<RestrictedURL> {
             val resource = scanPackage.replace('.', '/')
             return this::class.java.classLoader.getResources(resource)
                     .asSequence()
@@ -144,19 +149,19 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
                             RestrictedURL((url.openConnection() as JarURLConnection).jarFileURL, scanPackage)
                         } else {
                             // No need to restrict as createDevCordappJar has already done that:
-                            RestrictedURL(createDevCordappJar(scanPackage, url, resource).toUri().toURL(), null)
+                            RestrictedURL(createDevCordappJar(scanPackage, url, resource, generatedJarName).toUri().toURL(), null)
                         }
                     }
                     .toList()
         }
 
         /** Takes a package of classes and creates a JAR from them - only use in tests. */
-        private fun createDevCordappJar(scanPackage: String, url: URL, resource: String): Path {
+        private fun createDevCordappJar(scanPackage: String, url: URL, resource: String, generatedJarName: String? = null): Path {
             return generatedCordapps.computeIfAbsent(url) {
                 // TODO Using the driver in out-of-process mode causes each node to have their own copy of the same dev CorDapps
                 val cordappDir = (Paths.get("build") / "tmp" / "generated-test-cordapps").createDirectories()
-                val cordappJar = if (scanPackage == "net.test.cordapp" || scanPackage == "net.test.cordapp.v1" ) { //TODO hack to test the test
-                    cordappDir / "myjar.jar"
+                val cordappJar = if (generatedJarName!=null) { //scanPackage == "net.test.cordapp" || scanPackage == "net.test.cordapp.v1" ) {
+                    cordappDir /  "$generatedJarName.jar" //"myjar.jar"
                 } else {
                     cordappDir / "$scanPackage-${UUID.randomUUID()}.jar"
                 }

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappLoader.kt
@@ -155,8 +155,8 @@ class CordappLoader private constructor(private val cordappJarPaths: List<Restri
             return generatedCordapps.computeIfAbsent(url) {
                 // TODO Using the driver in out-of-process mode causes each node to have their own copy of the same dev CorDapps
                 val cordappDir = (Paths.get("build") / "tmp" / "generated-test-cordapps").createDirectories()
-                val cordappJar = if (scanPackage == "net.test.cordapp" || scanPackage == "net.test.cordapp.v1" ) {
-                    cordappDir /  "myjar.jar"
+                val cordappJar = if (scanPackage == "net.test.cordapp" || scanPackage == "net.test.cordapp.v1" ) { //TODO hack to test the test
+                    cordappDir / "myjar.jar"
                 } else {
                     cordappDir / "$scanPackage-${UUID.randomUUID()}.jar"
                 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -78,8 +78,7 @@ interface DriverDSL {
             customOverrides: Map<String, Any?> = defaultParameters.customOverrides,
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
-            packages: List<String> = emptyList(),
-            packageToGeneratedJarName: Map<String,String> = emptyMap()
+            packageToGeneratedJarName: Map<String,String?> = emptyMap()
     ): CordaFuture<NodeHandle>
 
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -77,7 +77,8 @@ interface DriverDSL {
             verifierType: VerifierType = defaultParameters.verifierType,
             customOverrides: Map<String, Any?> = defaultParameters.customOverrides,
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
-            maximumHeapSize: String = defaultParameters.maximumHeapSize
+            maximumHeapSize: String = defaultParameters.maximumHeapSize,
+            packages: List<String> = emptyList()
     ): CordaFuture<NodeHandle>
 
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -79,7 +79,7 @@ interface DriverDSL {
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
             packages: List<String> = emptyList(),
-            packageToGeneratedJarNames: Map<String,String> = emptyMap()
+            packageToGeneratedJarName: Map<String,String> = emptyMap()
     ): CordaFuture<NodeHandle>
 
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -78,7 +78,8 @@ interface DriverDSL {
             customOverrides: Map<String, Any?> = defaultParameters.customOverrides,
             startInSameProcess: Boolean? = defaultParameters.startInSameProcess,
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
-            packages: List<String> = emptyList()
+            packages: List<String> = emptyList(),
+            packageToGeneratedJarNames: Map<String,String> = emptyMap()
     ): CordaFuture<NodeHandle>
 
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -195,7 +195,7 @@ class DriverDSLImpl(
             startInSameProcess: Boolean?,
             maximumHeapSize: String,
             packages: List<String>,
-            packageToGeneratedJarNames: Map<String,String>
+            packageToGeneratedJarName: Map<String,String>
     ): CordaFuture<NodeHandle> {
         val p2pAddress = portAllocation.nextHostAndPort()
         // TODO: Derive name from the full picked name, don't just wrap the common name
@@ -211,7 +211,7 @@ class DriverDSLImpl(
         return registrationFuture.flatMap {
             networkMapAvailability.flatMap {
                 // But starting the node proper does require the network map
-                startRegisteredNode(name, it, rpcUsers, verifierType, customOverrides, startInSameProcess, maximumHeapSize, p2pAddress, packages, packageToGeneratedJarNames)
+                startRegisteredNode(name, it, rpcUsers, verifierType, customOverrides, startInSameProcess, maximumHeapSize, p2pAddress, packages, packageToGeneratedJarName)
             }
         }
     }
@@ -225,7 +225,7 @@ class DriverDSLImpl(
                                     maximumHeapSize: String = "512m",
                                     p2pAddress: NetworkHostAndPort = portAllocation.nextHostAndPort(),
                                     packages: List<String> = emptyList(),
-                                    packageToGeneratedJarNames: Map<String,String> = emptyMap()): CordaFuture<NodeHandle> {
+                                    packageToGeneratedJarName: Map<String,String> = emptyMap()): CordaFuture<NodeHandle> {
         val rpcAddress = portAllocation.nextHostAndPort()
         val rpcAdminAddress = portAllocation.nextHostAndPort()
         val webAddress = portAllocation.nextHostAndPort()
@@ -253,7 +253,7 @@ class DriverDSLImpl(
                 allowMissingConfig = true,
                 configOverrides = if (overrides.hasPath("devMode")) overrides else overrides + mapOf("devMode" to true)
         )).checkAndOverrideForInMemoryDB()
-        return startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize, localNetworkMap, packages, packageToGeneratedJarNames))
+        return startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize, localNetworkMap, packages, packageToGeneratedJarName)
     }
 
     private fun startNodeRegistration(providedName: CordaX500Name, rootCert: X509Certificate, compatibilityZoneURL: URL): CordaFuture<NodeConfig> {
@@ -634,7 +634,7 @@ class DriverDSLImpl(
                                   maximumHeapSize: String,
                                   localNetworkMap: LocalNetworkMap?,
                                   packages: List<String> = emptyList(),
-                                  packageToGeneratedJarNames: Map<String,String> = emptyMap()): CordaFuture<NodeHandle> {
+                                  packageToGeneratedJarName: Map<String,String> = emptyMap()): CordaFuture<NodeHandle> {
         val visibilityHandle = networkVisibilityController.register(config.corda.myLegalName)
         val baseDirectory = config.corda.baseDirectory.createDirectories()
         localNetworkMap?.networkParametersCopier?.install(baseDirectory)
@@ -648,7 +648,7 @@ class DriverDSLImpl(
         val useHTTPS = config.typesafe.run { hasPath("useHTTPS") && getBoolean("useHTTPS") }
 
         if (startInProcess ?: startNodesInProcess) {
-            val nodeAndThreadFuture = startInProcessNode(executorService, config, cordappPackages + packages, packageToGeneratedJarNames)
+            val nodeAndThreadFuture = startInProcessNode(executorService, config, cordappPackages + packages, packageToGeneratedJarName)
             shutdownManager.registerShutdown(
                     nodeAndThreadFuture.map { (node, thread) ->
                         {
@@ -773,7 +773,7 @@ class DriverDSLImpl(
                 executorService: ScheduledExecutorService,
                 config: NodeConfig,
                 cordappPackages: List<String>,
-                packageToGeneratedJarNames: Map<String,String> = emptyMap()
+                packageToGeneratedJarName: Map<String,String> = emptyMap()
         ): CordaFuture<Pair<StartedNode<Node>, Thread>> {
             return executorService.fork {
                 log.info("Starting in-process Node ${config.corda.myLegalName.organisation}")
@@ -783,7 +783,7 @@ class DriverDSLImpl(
                 // Write node.conf
                 writeConfig(config.corda.baseDirectory, "node.conf", config.typesafe.toNodeOnly())
                 // TODO pass the version in?
-                val node = InProcessNode(config.corda, MOCK_VERSION_INFO, cordappPackages, packageToGeneratedJarNames).start()
+                val node = InProcessNode(config.corda, MOCK_VERSION_INFO, cordappPackages, packageToGeneratedJarName).start()
                 val nodeThread = thread(name = config.corda.myLegalName.organisation) {
                     node.internals.run()
                 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -193,7 +193,8 @@ class DriverDSLImpl(
             verifierType: VerifierType,
             customOverrides: Map<String, Any?>,
             startInSameProcess: Boolean?,
-            maximumHeapSize: String
+            maximumHeapSize: String,
+            packages: List<String>
     ): CordaFuture<NodeHandle> {
         val p2pAddress = portAllocation.nextHostAndPort()
         // TODO: Derive name from the full picked name, don't just wrap the common name
@@ -209,7 +210,7 @@ class DriverDSLImpl(
         return registrationFuture.flatMap {
             networkMapAvailability.flatMap {
                 // But starting the node proper does require the network map
-                startRegisteredNode(name, it, rpcUsers, verifierType, customOverrides, startInSameProcess, maximumHeapSize, p2pAddress)
+                startRegisteredNode(name, it, rpcUsers, verifierType, customOverrides, startInSameProcess, maximumHeapSize, p2pAddress, packages)
             }
         }
     }
@@ -221,7 +222,8 @@ class DriverDSLImpl(
                                     customOverrides: Map<String, Any?>,
                                     startInSameProcess: Boolean? = null,
                                     maximumHeapSize: String = "512m",
-                                    p2pAddress: NetworkHostAndPort = portAllocation.nextHostAndPort()): CordaFuture<NodeHandle> {
+                                    p2pAddress: NetworkHostAndPort = portAllocation.nextHostAndPort(),
+                                    packages: List<String> = emptyList()): CordaFuture<NodeHandle> {
         val rpcAddress = portAllocation.nextHostAndPort()
         val rpcAdminAddress = portAllocation.nextHostAndPort()
         val webAddress = portAllocation.nextHostAndPort()
@@ -249,7 +251,7 @@ class DriverDSLImpl(
                 allowMissingConfig = true,
                 configOverrides = if (overrides.hasPath("devMode")) overrides else overrides + mapOf("devMode" to true)
         )).checkAndOverrideForInMemoryDB()
-        return startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize, localNetworkMap)
+        return startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize, localNetworkMap, packages)
     }
 
     private fun startNodeRegistration(providedName: CordaX500Name, rootCert: X509Certificate, compatibilityZoneURL: URL): CordaFuture<NodeConfig> {
@@ -628,7 +630,8 @@ class DriverDSLImpl(
                                   webAddress: NetworkHostAndPort,
                                   startInProcess: Boolean?,
                                   maximumHeapSize: String,
-                                  localNetworkMap: LocalNetworkMap?): CordaFuture<NodeHandle> {
+                                  localNetworkMap: LocalNetworkMap?,
+                                  packages: List<String> = emptyList()): CordaFuture<NodeHandle> {
         val visibilityHandle = networkVisibilityController.register(config.corda.myLegalName)
         val baseDirectory = config.corda.baseDirectory.createDirectories()
         localNetworkMap?.networkParametersCopier?.install(baseDirectory)
@@ -642,7 +645,7 @@ class DriverDSLImpl(
         val useHTTPS = config.typesafe.run { hasPath("useHTTPS") && getBoolean("useHTTPS") }
 
         if (startInProcess ?: startNodesInProcess) {
-            val nodeAndThreadFuture = startInProcessNode(executorService, config, cordappPackages)
+            val nodeAndThreadFuture = startInProcessNode(executorService, config, cordappPackages + packages)
             shutdownManager.registerShutdown(
                     nodeAndThreadFuture.map { (node, thread) ->
                         {
@@ -669,7 +672,7 @@ class DriverDSLImpl(
         } else {
             val debugPort = if (isDebug) debugPortAllocation.nextPort() else null
             val monitorPort = if (jmxPolicy.startJmxHttpServer) jmxPolicy.jmxHttpServerPortAllocation?.nextPort() else null
-            val process = startOutOfProcessNode(config, quasarJarPath, debugPort, jolokiaJarPath, monitorPort, systemProperties, cordappPackages, maximumHeapSize)
+            val process = startOutOfProcessNode(config, quasarJarPath, debugPort, jolokiaJarPath, monitorPort, systemProperties, cordappPackages + packages, maximumHeapSize)
 
             // Destroy the child process when the parent exits.This is needed even when `waitForAllNodesToFinish` is
             // true because we don't want orphaned processes in the case that the parent process is terminated by the

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
@@ -131,7 +131,7 @@ abstract class NodeBasedTest(private val cordappPackages: List<String> = emptyLi
 }
 
 class InProcessNode(
-        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: List<String>, packageToGeneratedJarNames: Map<String,String> = emptyMap()) : Node(
-        configuration, versionInfo, false, CordappLoader.createDefaultWithTestPackages(configuration, cordappPackages, packageToGeneratedJarNames)) {
+        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: List<String>, packageToGeneratedJarName: Map<String,String> = emptyMap()) : Node(
+        configuration, versionInfo, false, CordappLoader.createDefaultWithTestPackages(configuration, cordappPackages, packageToGeneratedJarName)) {
     override fun getRxIoScheduler() = CachedThreadScheduler(testThreadFactory()).also { runOnStop += it::shutdown }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
@@ -131,7 +131,7 @@ abstract class NodeBasedTest(private val cordappPackages: List<String> = emptyLi
 }
 
 class InProcessNode(
-        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: List<String>) : Node(
-        configuration, versionInfo, false, CordappLoader.createDefaultWithTestPackages(configuration, cordappPackages)) {
+        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: List<String>, packageToGeneratedJarNames: Map<String,String> = emptyMap()) : Node(
+        configuration, versionInfo, false, CordappLoader.createDefaultWithTestPackages(configuration, cordappPackages, packageToGeneratedJarNames)) {
     override fun getRxIoScheduler() = CachedThreadScheduler(testThreadFactory()).also { runOnStop += it::shutdown }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
@@ -131,7 +131,7 @@ abstract class NodeBasedTest(private val cordappPackages: List<String> = emptyLi
 }
 
 class InProcessNode(
-        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: List<String>, packageToGeneratedJarName: Map<String,String> = emptyMap()) : Node(
+        configuration: NodeConfiguration, versionInfo: VersionInfo, cordappPackages: List<String>, packageToGeneratedJarName: Map<String,String?> = emptyMap()) : Node(
         configuration, versionInfo, false, CordappLoader.createDefaultWithTestPackages(configuration, cordappPackages, packageToGeneratedJarName)) {
     override fun getRxIoScheduler() = CachedThreadScheduler(testThreadFactory()).also { runOnStop += it::shutdown }
 }


### PR DESCRIPTION
Follow up of https://github.com/corda/corda/pull/3561 (there was a spiel test using existing `DriverDsl`).
`startNode` of `DriverDsl` can load own packages under choose name - this enables to test cases like:
* the same `Flow`/`cordapp`  reloaded in new JAR  file with the same file name but slightly different content (hash constraint violation)
* the same `Flow`/`cordapp` reloaded in the identical JAR with the same content (as current impossible due to CordappLoader)

The code could be refactored a bit, let me know if this is a right/acceptable direction for modifying `DriverDsl` ?

@sollecitom I'm adding you as you may be working on something related and opposite (to make Jar names constant in `DriverDsl`).