### PR TITLE
ENT-1565: Remove Guava code from core.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,9 @@ allprojects {
                 force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
                 force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
+                // Force everything to use the same version of Guava too.
+                force "com.google.guava:guava:$guava_version"
+
                 // Demand that everything uses our given version of Netty.
                 eachDependency { details ->
                     if (details.requested.group == 'io.netty' && details.requested.name.startsWith('netty-')) {

--- a/build.gradle
+++ b/build.gradle
@@ -217,9 +217,6 @@ allprojects {
                 force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
                 force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-                // Force everything to use the same version of Guava too.
-                force "com.google.guava:guava:$guava_version"
-
                 // Demand that everything uses our given version of Netty.
                 eachDependency { details ->
                     if (details.requested.group == 'io.netty' && details.requested.name.startsWith('netty-')) {

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -17,8 +17,6 @@ configurations {
 
 dependencies {
     compileOnly project(':core')
-    compileOnly "com.google.guava:guava:$guava_version"
-    compileOnly "$quasar_group:quasar-core:$quasar_version:jdk8"
 
     // Configure these by hand. It should be a minimal subset of core's dependencies,
     // and without any obviously non-deterministic ones such as Hibernate.
@@ -28,7 +26,6 @@ dependencies {
     runtimeLibraries "org.bouncycastle:bcprov-jdk15on:$bouncycastle_version"
     runtimeLibraries "org.bouncycastle:bcpkix-jdk15on:$bouncycastle_version"
     runtimeLibraries "com.google.code.findbugs:jsr305:$jsr305_version"
-    runtimeLibraries "com.google.guava:guava:$guava_version"
     runtimeLibraries "net.i2p.crypto:eddsa:$eddsa_version"
     runtimeLibraries "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
+++ b/core/src/main/kotlin/net/corda/core/identity/CordaX500Name.kt
@@ -1,6 +1,5 @@
 package net.corda.core.identity
 
-import com.google.common.collect.ImmutableSet
 import net.corda.core.KeepForDJVM
 import net.corda.core.internal.LegalNameValidator
 import net.corda.core.internal.toAttributesMap
@@ -79,7 +78,7 @@ data class CordaX500Name(val commonName: String?,
         const val MAX_LENGTH_COMMON_NAME = 64
 
         private val supportedAttributes = setOf(BCStyle.O, BCStyle.C, BCStyle.L, BCStyle.CN, BCStyle.ST, BCStyle.OU)
-        private val countryCodes: Set<String> = ImmutableSet.copyOf(Locale.getISOCountries() + unspecifiedCountry)
+        private val countryCodes: Set<String> = setOf(*Locale.getISOCountries(), unspecifiedCountry)
 
         @JvmStatic
         fun build(principal: X500Principal): CordaX500Name {

--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -2,8 +2,6 @@
 @file:KeepForDJVM
 package net.corda.core.internal
 
-import com.google.common.hash.Hashing
-import com.google.common.hash.HashingInputStream
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.cordapp.Cordapp
@@ -43,6 +41,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.KeyPair
+import java.security.MessageDigest
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.cert.*
@@ -132,9 +131,16 @@ fun InputStream.readFully(): ByteArray = use { it.readBytes() }
 /** Calculate the hash of the remaining bytes in this input stream. The stream is closed at the end. */
 fun InputStream.hash(): SecureHash {
     return use {
-        val his = HashingInputStream(Hashing.sha256(), it)
-        his.copyTo(NullOutputStream)  // To avoid reading in the entire stream into memory just write out the bytes to /dev/null
-        SecureHash.SHA256(his.hash().asBytes())
+        val md = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val count = it.read(buffer)
+            if (count == -1) {
+                break
+            }
+            md.update(buffer, 0, count)
+        }
+        SecureHash.SHA256(md.digest())
     }
 }
 

--- a/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/InternalUtilsTest.kt
@@ -1,9 +1,11 @@
 package net.corda.core.internal
 
 import net.corda.core.contracts.TimeWindow
+import net.corda.core.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertArrayEquals
 import org.junit.Test
+import java.util.*
 import java.util.stream.IntStream
 import java.util.stream.Stream
 import kotlin.test.assertEquals
@@ -97,6 +99,19 @@ open class InternalUtilsTest {
         assertThat(ProtectedObject::class.java.kotlinObjectInstance).isSameAs(ProtectedObject)
         assertThat(TimeWindow::class.java.kotlinObjectInstance).isNull()
         assertThat(PrivateClass::class.java.kotlinObjectInstance).isNull()
+    }
+
+    @Test
+    fun `test SHA-256 hash for InputStream`() {
+        val contents = arrayOfJunk(DEFAULT_BUFFER_SIZE * 2 + DEFAULT_BUFFER_SIZE / 2)
+        assertThat(contents.inputStream().hash())
+            .isEqualTo(SecureHash.parse("A4759E7AA20338328866A2EA17EAF8C7FE4EC6BBE3BB71CEE7DF7C0461B3C22F"))
+    }
+
+    private fun arrayOfJunk(size: Int) = ByteArray(size).apply {
+        for (i in 0 until size) {
+            this[i] = (i and 0xFF).toByte()
+        }
     }
 
     object PublicObject

--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -17,13 +17,13 @@ configurations {
 
 dependencies {
     compileOnly project(':serialization')
-    compileOnly "$quasar_group:quasar-core:$quasar_version:jdk8"
 
     // Configure these by hand. It should be a minimal subset of dependencies,
     // and without any obviously non-deterministic ones such as Hibernate.
     runtimeLibraries project(path: ':core-deterministic', configuration: 'runtimeArtifacts')
     runtimeLibraries "org.apache.qpid:proton-j:$protonj_version"
     runtimeLibraries "org.iq80.snappy:snappy:$snappy_version"
+    runtimeLibraries "com.google.guava:guava:$guava_version"
 }
 
 jar {


### PR DESCRIPTION
Remove references to Guava code from `core` so that modules that use it are free to use whichever version of Guava they like.