### PR TITLE
Add jib gradle plugin to node

### DIFF
--- a/docs/source/building-container-images.rst
+++ b/docs/source/building-container-images.rst
@@ -29,3 +29,23 @@ preserve the credentials and node data between container restarts.
 
 The JVM options are currently hardcoded in ``node/build.gradle`` in the
 ``jib.container`` section.
+
+Below is an example directory layout and command to run your image with Docker.
+Make sure to run ``touch persistence.mv.db`` befor starting the container,
+otherwise a new directory will be created by Docker.
+
+::
+
+        .
+        ├── certificates
+        ├── config
+        │   └── node.conf
+        ├── network-parameters
+        └── persistence.mv.db
+
+.. sourcecode:: shell
+
+        docker run --rm -it -v ${PWD}/certificates:/certificates \
+                            -v ${PWD}/config:/config \
+                            -v ${PWD}/network-parameters:/network-parameters \
+                            -v ${PWD}/persistence.mv.db:/persistence.mv.db

--- a/docs/source/building-container-images.rst
+++ b/docs/source/building-container-images.rst
@@ -1,0 +1,31 @@
+=========================
+Building Container Images
+=========================
+
+To build a container image of Corda you can use the Jib gradle tasks. See the `documentation of the Jib gradle plugin <https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin>`_ for details.
+
+Building the image
+==================
+
+To build an image locally you can use the following command. Note that you do not require Docker.
+
+.. sourcecode:: shell
+
+        ./gradlew node:jib --image <registry>/<image>:<tag>
+
+If you prefer building to a Docker deamon you can use
+
+.. sourcecode:: shell
+
+        ./gradlew node:jibDockerBuild --image <registry>/<image>:<tag>
+
+Running the image
+=================
+
+The Corda application expects its config file in ``/config/node.conf``, make
+sure you mount the config file to that location. You might also want to mount
+``/credentials`` and ``/persistence.mv.db`` (if you're using H2) in order to
+preserve the credentials and node data between container restarts.
+
+The JVM options are currently hardcoded in ``node/build.gradle`` in the
+``jib.container`` section.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,3 +88,4 @@ We look forward to seeing what you can do with Corda!
       corda-repo-layout.rst
       deterministic-modules.rst
       building-the-docs.rst
+      building-container-images.rst

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -1,3 +1,15 @@
+// Import private compile time constants
+buildscript {
+    def properties = new Properties()
+    file("$projectDir/src/main/resources/build.properties").withInputStream { properties.load(it) }
+
+    ext.jolokia_version = properties.getProperty('jolokiaAgentVersion')
+}
+
+plugins {
+    id 'com.google.cloud.tools.jib' version '0.9.4'
+}
+
 apply plugin: 'kotlin'
 // Java Persistence API support: create no-arg constructor
 // see: http://stackoverflow.com/questions/32038177/kotlin-with-jpa-default-constructor-hell
@@ -8,14 +20,6 @@ apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'com.jfrog.artifactory'
 
 description 'Corda node modules'
-
-// Import private compile time constants
-buildscript {
-    def properties = new Properties()
-    file("$projectDir/src/main/resources/build.properties").withInputStream { properties.load(it) }
-
-    ext.jolokia_version = properties.getProperty('jolokiaAgentVersion')
-}
 
 //noinspection GroovyAssignabilityCheck
 configurations {
@@ -41,6 +45,12 @@ sourceSets {
     }
 }
 
+jib.container {
+  mainClass = "net.corda.node.Corda"
+  args = ['--log-to-console', '--no-local-shell', '--config-file=/config/node.conf']
+  jvmFlags = ['-Xmx1g', '-javaagent:/app/libs/quasar-core-0.7.10.jar']
+}
+
 // Use manual resource copying of log4j2.xml rather than source sets.
 // This prevents problems in IntelliJ with regard to duplicate source roots.
 processResources {
@@ -61,6 +71,8 @@ dependencies {
     compile project(':client:rpc')
     compile project(':tools:shell')
     compile "net.corda.plugins:cordform-common:$gradle_plugins_version"
+
+    compile group: 'co.paralleluniverse', name: 'quasar-core', version: '0.7.10:jdk8@jar'
 
     // Log4J: logging framework (with SLF4J bindings)
     compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"


### PR DESCRIPTION
Create image and upload to the registry without requiring docker:
```
./gradlew node:jib --image <registry>/<image>:<tag>
```