### PR TITLE
Patch for Postgres to reduce the large object table size

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/DBCheckpointStorage.kt
@@ -5,6 +5,7 @@ import net.corda.node.services.api.Checkpoint
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
 import net.corda.nodeapi.internal.persistence.currentDBSession
+import org.hibernate.annotations.Type
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -22,8 +23,8 @@ class DBCheckpointStorage : CheckpointStorage {
             @Column(name = "checkpoint_id", length = 64)
             var checkpointId: String = "",
 
-            @Lob
             @Column(name = "checkpoint_value")
+            @Type(type="org.hibernate.type.ImageType")
             var checkpoint: ByteArray = ByteArray(0)
     )
 


### PR DESCRIPTION
Fix to map the checkpoint to a bytea field on postgres