### PR TITLE
Corda can run against not migrated node_attachments_contracts table name

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentsContractsTableBackwardCompatibleNamingStrategy.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentsContractsTableBackwardCompatibleNamingStrategy.kt
@@ -1,0 +1,47 @@
+package net.corda.nodeapi.internal.persistence
+
+import org.hibernate.boot.model.naming.Identifier
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment
+import java.sql.Connection
+
+/**
+ * Database table mapping [PhysicalNamingStrategy] to allow running against not migrated database from Corda 3.0/3.1 to newer versions.
+ */
+object AttachmentsContractsTableBackwardCompatibleNamingStrategy {
+    private const val correctName = "NODE_ATTACHMENTS_CONTRACTS"
+    private const val incorrectV30Name = "NODE_ATTACHMENTS_CONTRACT_CLASS_NAME"
+    private const val incorrectV31Name = "NODE_ATTCHMENTS_CONTRACTS"
+    private var detectedIncorrectName: String? = null
+
+    private fun createStartegy(tableFromMapping: String, existingTable: String, databaseConfig: DatabaseConfig): PhysicalNamingStrategy? =
+            object : PhysicalNamingStrategyStandardImpl() {
+                override fun toPhysicalTableName(name: Identifier?, context: JdbcEnvironment?): Identifier {
+                    val default = super.toPhysicalTableName(name, context)
+                    val text = if (default.text.equals(tableFromMapping, true))
+                        existingTable
+                    else
+                        default.text
+                    return Identifier.toIdentifier(databaseConfig.serverNameTablePrefix + text, default.isQuoted)
+                }
+            }
+
+    fun getNamingStrategy(connection: Connection, databaseConfig: DatabaseConfig): PhysicalNamingStrategy? =
+            when {
+                connection.metaData.getTables(null, null, correctName, null).next() -> null
+                connection.metaData.getTables(null, null, incorrectV30Name, null).next() -> {
+                    detectedIncorrectName = incorrectV30Name
+                    createStartegy(correctName, incorrectV30Name, databaseConfig)
+                }
+                connection.metaData.getTables(null, null, incorrectV31Name, null).next() -> {
+                    detectedIncorrectName = incorrectV31Name
+                    createStartegy(correctName, incorrectV31Name, databaseConfig)
+                }
+                else -> null
+            }
+
+    fun incorrectNameDetected() = detectedIncorrectName != null
+
+    fun getWarning() = if (incorrectNameDetected()) "Not migrated table name $detectedIncorrectName is found, try to migrate name $correctName, see Upgrade Notes." else ""
+}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -61,7 +61,7 @@ class CordaPersistence(
     private val defaultIsolationLevel = databaseConfig.transactionIsolationLevel
     val hibernateConfig: HibernateConfiguration by lazy {
         transaction {
-            HibernateConfiguration(schemas, databaseConfig, attributeConverters)
+            HibernateConfiguration(schemas, databaseConfig, attributeConverters, tableNamingStrategyOverride = AttachmentsContractsTableBackwardCompatibleNamingStrategy.getNamingStrategy(connection, databaseConfig))
         }
     }
     val entityManagerFactory get() = hibernateConfig.sessionFactoryForRegisteredSchemas

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/ReuseNotMigratedAttachmentContractsTableNameTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/ReuseNotMigratedAttachmentContractsTableNameTests.kt
@@ -1,0 +1,75 @@
+package net.corda.node.persistence
+
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.internal.packageName
+import net.corda.core.messaging.startFlow
+import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.Permissions
+import net.corda.testMessage.Message
+import net.corda.testMessage.MessageState
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.driver.internal.RandomFree
+import net.corda.testing.node.User
+import org.junit.Test
+import java.nio.file.Path
+import java.sql.DriverManager
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ReuseNotMigratedAttachmentContractsTableNameTests {
+    @Test
+    fun `test node is backward campatible with table name in version 3 dot 0`() {
+        `node uses exisitng table name different from mapping`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTACHMENTS_CONTRACT_CLASS_NAME")
+    }
+
+    @Test
+    fun `test node is backward campatible with table name in version 3 dot 1`() {
+        `node uses exisitng table name different from mapping`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTCHMENTS_CONTRACTS")
+    }
+
+    fun `node uses exisitng table name different from mapping`(tableNameFromMapping: String, tableNameInDB: String) {
+        val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlow>(), Permissions.invokeRpc("vaultQuery")))
+        val message = Message("Hello world!")
+        val (stateAndRef: StateAndRef<MessageState>?, baseDir: Path) = driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(),
+                portAllocation = RandomFree, extraCordappPackagesToScan = listOf(MessageState::class.packageName))) {
+            val (nodeName, baseDir) = {
+                val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
+                val nodeName = nodeHandle.nodeInfo.singleIdentity().name
+                CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                    it.proxy.startFlow(::SendMessageFlow, message, defaultNotaryIdentity).returnValue.getOrThrow()
+                }
+                nodeHandle.stop()
+                Pair(nodeName, nodeHandle.baseDirectory)
+            }()
+
+            // replace the correct table name with one from the former release
+            DriverManager.getConnection("jdbc:h2:file://$baseDir/persistence", "sa", "").use {
+                it.createStatement().execute("ALTER TABLE $tableNameFromMapping RENAME TO $tableNameInDB")
+                it.commit()
+            }
+            val nodeHandle = startNode(providedName = nodeName, rpcUsers = listOf(user)).getOrThrow()
+            val result = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                val page = it.proxy.vaultQuery(MessageState::class.java)
+                page.states.singleOrNull()
+            }
+            nodeHandle.stop()
+            Pair(result, baseDir)
+        }
+        assertNotNull(stateAndRef)
+        val retrievedMessage = stateAndRef!!.state.data.message
+        assertEquals(message, retrievedMessage)
+
+        // check that the node didn't recreated the correct table matching it's entity mapping and continou using table name from the former release
+        val (hasTableFromMapping, hasTableFromDB) = DriverManager.getConnection("jdbc:h2:file://$baseDir/persistence", "sa", "").use {
+            Pair(it.metaData.getTables(null, null, tableNameFromMapping, null).next(),
+                    it.metaData.getTables(null, null, tableNameInDB, null).next())
+        }
+        assertFalse(hasTableFromMapping)
+        assertTrue(hasTableFromDB)
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -56,6 +56,7 @@ import net.corda.nodeapi.internal.bridging.BridgeControlListener
 import net.corda.nodeapi.internal.config.User
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.persistence.CordaPersistence
+import net.corda.nodeapi.internal.persistence.AttachmentsContractsTableBackwardCompatibleNamingStrategy
 import net.corda.serialization.internal.AMQP_P2P_CONTEXT
 import net.corda.serialization.internal.AMQP_RPC_CLIENT_CONTEXT
 import net.corda.serialization.internal.AMQP_RPC_SERVER_CONTEXT
@@ -352,7 +353,12 @@ open class Node(configuration: NodeConfiguration,
                 printBasicNodeInfo("Database connection url is", "jdbc:h2:$url/node")
             }
         }
-        return super.initialiseDatabasePersistence(schemaService, wellKnownPartyFromX500Name, wellKnownPartyFromAnonymous)
+        val persistence = super.initialiseDatabasePersistence(schemaService, wellKnownPartyFromX500Name, wellKnownPartyFromAnonymous)
+        if (AttachmentsContractsTableBackwardCompatibleNamingStrategy.incorrectNameDetected()) {
+            log.warn(AttachmentsContractsTableBackwardCompatibleNamingStrategy.getWarning())
+            printWarning(AttachmentsContractsTableBackwardCompatibleNamingStrategy.getWarning())
+        }
+        return persistence
     }
 
     private val _startupComplete = openFuture<Unit>()


### PR DESCRIPTION
Added PhysicalNamingStrategy to switch node_attachments_contracts table name to older version if the older version is detected at startup. Print a warning in console and logs. 
This allows Corda to run against not migrated database from Corda 3.0/3.1 to newer versions.