### PR TITLE
CORDA-1800: Shrink the Simm Valuation Demo's contract states using ProGuard.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,6 +216,9 @@ allprojects {
                 force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
                 force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
+                // Force dependencies to use the same version of Guava as Corda.
+                force "com.google.guava:guava:$guava_version"
+
                 // Demand that everything uses our given version of Netty.
                 eachDependency { details ->
                     if (details.requested.group == 'io.netty' && details.requested.name.startsWith('netty-')) {

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.25
+gradlePluginsVersion=4.0.26
 kotlinVersion=1.2.51
 platformVersion=4
 guavaVersion=25.1-jre

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     // The SIMM demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')
-    cordapp project(':samples:simm-valuation-demo:contracts-states')
+    cordapp project(path: ':samples:simm-valuation-demo:contracts-states', configuration: 'shrinkArtifacts')
     cordapp project(':samples:simm-valuation-demo:flows')
 
     // Corda integration dependencies
@@ -39,25 +39,25 @@ dependencies {
     cordaCompile project(':webserver')
 
     // Javax is required for webapis
-    compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"
+    compile "org.glassfish.jersey.core:jersey-server:$jersey_version"
 
     // Cordapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps
-    compile "com.opengamma.strata:strata-basics:${strata_version}"
-    compile "com.opengamma.strata:strata-product:${strata_version}"
-    compile "com.opengamma.strata:strata-data:${strata_version}"
-    compile "com.opengamma.strata:strata-calc:${strata_version}"
-    compile "com.opengamma.strata:strata-pricer:${strata_version}"
-    compile "com.opengamma.strata:strata-report:${strata_version}"
-    compile "com.opengamma.strata:strata-market:${strata_version}"
-    compile "com.opengamma.strata:strata-collect:${strata_version}"
-    compile "com.opengamma.strata:strata-loader:${strata_version}"
-    compile "com.opengamma.strata:strata-math:${strata_version}"
+    compile "com.opengamma.strata:strata-basics:$strata_version"
+    compile "com.opengamma.strata:strata-product:$strata_version"
+    compile "com.opengamma.strata:strata-data:$strata_version"
+    compile "com.opengamma.strata:strata-calc:$strata_version"
+    compile "com.opengamma.strata:strata-pricer:$strata_version"
+    compile "com.opengamma.strata:strata-report:$strata_version"
+    compile "com.opengamma.strata:strata-market:$strata_version"
+    compile "com.opengamma.strata:strata-collect:$strata_version"
+    compile "com.opengamma.strata:strata-loader:$strata_version"
+    compile "com.opengamma.strata:strata-math:$strata_version"
 
     // Test dependencies
     testCompile project(':node-driver')
     testCompile "junit:junit:$junit_version"
-    testCompile "org.assertj:assertj-core:${assertj_version}"
+    testCompile "org.assertj:assertj-core:$assertj_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -1,5 +1,5 @@
-buildscript {
-    ext.strata_version = '1.1.2'
+ext {
+    strata_version = '1.1.2'
 }
 
 apply plugin: 'java'

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -1,5 +1,7 @@
-ext {
-    strata_version = '1.1.2'
+allprojects {
+    ext {
+        strata_version = '1.1.2'
+    }
 }
 
 apply plugin: 'java'

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -1,24 +1,81 @@
-buildscript {
-    ext.strata_version = '1.1.2'
-}
-
 apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'net.corda.plugins.cordformation'
 
+def javaHome = System.getProperty('java.home')
+def shrinkJar = file("$buildDir/libs/${project.name}-${project.version}-tiny.jar")
+def strata_version = project(':samples:simm-valuation-demo').strata_version
+
+cordapp {
+    info {
+        vendor = 'R3'
+    }
+}
+
+configurations {
+    shrinkArtifacts
+}
+
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    cordaCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    cordaCompile "org.slf4j:slf4j-api:$slf4j_version"
 
     // The SIMM demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')
 
     // Corda integration dependencies
-    cordaCompile project(path: ":node:capsule", configuration: 'runtimeArtifacts')
     cordaCompile project(':core')
 
 
     // Cordapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps
-    compile "com.opengamma.strata:strata-product:${strata_version}"
-    compile "com.opengamma.strata:strata-market:${strata_version}"
+    compile("com.opengamma.strata:strata-product:$strata_version")
+    compile("com.opengamma.strata:strata-market:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+}
 
+jar {
+    classifier = 'fat'
+}
+
+import proguard.gradle.ProGuardTask
+task shrink(type: ProGuardTask) {
+    injars jar
+    outjars shrinkJar
+
+    libraryjars "$javaHome/lib/rt.jar"
+    libraryjars "$javaHome/lib/jce.jar"
+    configurations.runtime.forEach {
+        libraryjars it.path, filter: '!META-INF/versions/**'
+    }
+
+    dontwarn 'afu.org.checkerframework.**'
+    dontwarn 'co.paralleluniverse.**'
+    dontwarn 'javax.servlet.**'
+    dontwarn 'org.checkerframework.**'
+    dontwarn 'org.joda.**'
+    dontwarn 'org.jolokia.**'
+    dontwarn 'org.slf4j.**'
+    dontnote
+
+    keepattributes '*'
+    keepdirectories
+    dontobfuscate
+    dontoptimize
+    verbose
+
+    // These are our CorDapp classes, so don't change these.
+    keep 'class net.corda.vega.** { *; }', includedescriptorclasses:true
+
+    // Until CorDapps are isolated from each other, we need to ensure that the
+    // versions of the classes that this CorDapp needs are still usable by other
+    // CorDapps. Unfortunately, this means that we cannot shrink them as much as
+    // we'd like to.
+    keepclassmembers 'class com.opengamma.strata.** { *; }', includedescriptorclasses:true
+    keepclassmembers 'class com.google.** { *; }', includedescriptorclasses:true
+    keepclassmembers 'class org.joda.** { *; }', includedescriptorclasses:true
+}
+
+artifacts {
+    shrinkArtifacts file: shrinkJar, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: shrink
 }

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -55,8 +55,10 @@ task shrink(type: ProGuardTask) {
     dontwarn 'org.slf4j.**'
     dontnote
 
+    // We need to preserve our CorDapp's own directory structure so that Corda
+    // can find the contract classes.
+    keepdirectories 'net/corda/**'
     keepattributes '*'
-    keepdirectories
     dontobfuscate
     dontoptimize
     verbose

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'net.corda.plugins.cordapp'
 
 def javaHome = System.getProperty('java.home')
 def shrinkJar = file("$buildDir/libs/${project.name}-${project.version}-tiny.jar")
-def strata_version = project(':samples:simm-valuation-demo').strata_version
 
 cordapp {
     info {

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'net.corda.plugins.cordapp'
-apply plugin: 'net.corda.plugins.cordformation'
 
 def javaHome = System.getProperty('java.home')
 def shrinkJar = file("$buildDir/libs/${project.name}-${project.version}-tiny.jar")
@@ -51,10 +50,8 @@ task shrink(type: ProGuardTask) {
 
     dontwarn 'afu.org.checkerframework.**'
     dontwarn 'co.paralleluniverse.**'
-    dontwarn 'javax.servlet.**'
     dontwarn 'org.checkerframework.**'
     dontwarn 'org.joda.**'
-    dontwarn 'org.jolokia.**'
     dontwarn 'org.slf4j.**'
     dontnote
 
@@ -75,6 +72,7 @@ task shrink(type: ProGuardTask) {
     keepclassmembers 'class com.google.** { *; }', includedescriptorclasses:true
     keepclassmembers 'class org.joda.** { *; }', includedescriptorclasses:true
 }
+jar.finalizedBy shrink
 
 artifacts {
     shrinkArtifacts file: shrinkJar, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: shrink

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -16,7 +16,6 @@ configurations {
 
 dependencies {
     cordaCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    cordaCompile "org.slf4j:slf4j-api:$slf4j_version"
 
     // The SIMM demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')
@@ -27,10 +26,8 @@ dependencies {
 
     // Cordapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps
-    compile("com.opengamma.strata:strata-product:$strata_version")
-    compile("com.opengamma.strata:strata-market:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
+    compile "com.opengamma.strata:strata-product:$strata_version"
+    compile "com.opengamma.strata:strata-market:$strata_version"
 }
 
 jar {
@@ -52,7 +49,6 @@ task shrink(type: ProGuardTask) {
     dontwarn 'co.paralleluniverse.**'
     dontwarn 'org.checkerframework.**'
     dontwarn 'org.joda.**'
-    dontwarn 'org.slf4j.**'
     dontnote
 
     // We need to preserve our CorDapp's own directory structure so that Corda

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -11,7 +11,6 @@ cordapp {
 
 dependencies {
     cordaCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    cordaCompile "org.slf4j:slf4j-api:$slf4j_version"
 
     // The SIMM demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')
@@ -24,26 +23,12 @@ dependencies {
     // Specify your cordapp's dependencies below, including dependent cordapps
     compile "com.opengamma.strata:strata-basics:$strata_version"
     compile "com.opengamma.strata:strata-product:$strata_version"
-    compile("com.opengamma.strata:strata-data:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
-    compile("com.opengamma.strata:strata-calc:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
-    compile("com.opengamma.strata:strata-pricer:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
-    compile("com.opengamma.strata:strata-report:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
-    compile("com.opengamma.strata:strata-market:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
-    compile("com.opengamma.strata:strata-collect:$strata_version")
-    compile("com.opengamma.strata:strata-loader:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
-    compile("com.opengamma.strata:strata-math:$strata_version") {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
+    compile "com.opengamma.strata:strata-data:$strata_version"
+    compile "com.opengamma.strata:strata-calc:$strata_version"
+    compile "com.opengamma.strata:strata-pricer:$strata_version"
+    compile "com.opengamma.strata:strata-report:$strata_version"
+    compile "com.opengamma.strata:strata-market:$strata_version"
+    compile "com.opengamma.strata:strata-collect:$strata_version"
+    compile "com.opengamma.strata:strata-loader:$strata_version"
+    compile "com.opengamma.strata:strata-math:$strata_version"
 }

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -1,33 +1,50 @@
-buildscript {
-    ext.strata_version = '1.1.2'
-}
-
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'net.corda.plugins.cordformation'
 
+def strata_version = project(':samples:simm-valuation-demo').strata_version
+
+cordapp {
+    info {
+        vendor = 'R3'
+    }
+}
+
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    cordaCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    cordaCompile "org.slf4j:slf4j-api:$slf4j_version"
 
     // The SIMM demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance')
-    cordapp project(':samples:simm-valuation-demo:contracts-states')
+    cordapp project(path: ':samples:simm-valuation-demo:contracts-states', configuration: 'shrinkArtifacts')
 
     // Corda integration dependencies
-    cordaCompile project(path: ":node:capsule", configuration: 'runtimeArtifacts')
     cordaCompile project(':core')
 
     // Cordapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps
-    compile "com.opengamma.strata:strata-basics:${strata_version}"
-    compile "com.opengamma.strata:strata-product:${strata_version}"
-    compile "com.opengamma.strata:strata-data:${strata_version}"
-    compile "com.opengamma.strata:strata-calc:${strata_version}"
-    compile "com.opengamma.strata:strata-pricer:${strata_version}"
-    compile "com.opengamma.strata:strata-report:${strata_version}"
-    compile "com.opengamma.strata:strata-market:${strata_version}"
-    compile "com.opengamma.strata:strata-collect:${strata_version}"
-    compile "com.opengamma.strata:strata-loader:${strata_version}"
-    compile "com.opengamma.strata:strata-math:${strata_version}"
-
+    compile "com.opengamma.strata:strata-basics:$strata_version"
+    compile "com.opengamma.strata:strata-product:$strata_version"
+    compile("com.opengamma.strata:strata-data:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    compile("com.opengamma.strata:strata-calc:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    compile("com.opengamma.strata:strata-pricer:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    compile("com.opengamma.strata:strata-report:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    compile("com.opengamma.strata:strata-market:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    compile("com.opengamma.strata:strata-collect:$strata_version")
+    compile("com.opengamma.strata:strata-loader:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    compile("com.opengamma.strata:strata-math:$strata_version") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 }

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordapp'
 
-def strata_version = project(':samples:simm-valuation-demo').strata_version
-
 cordapp {
     info {
         vendor = 'R3'

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'net.corda.plugins.quasar-utils'
 apply plugin: 'net.corda.plugins.cordapp'
-apply plugin: 'net.corda.plugins.cordformation'
 
 def strata_version = project(':samples:simm-valuation-demo').strata_version
 


### PR DESCRIPTION
The `contracts-states` CorDapp is so large that it breaks Corda's 10 MB transaction limit. This is because OpenGamma has a lot of transitive dependencies. For now, use ProGuard to discard all of the classes that we are not using.

We cannot be as aggressive with ProGuard as we'd like, partly for licensing reasons but also because the `flows` CorDapp uses the same classpath and so may try to use these OpenGamma classes too.