### PR TITLE
CORDA-1805 Fixing the NPE with path parent

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/KeyStoreUtilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/KeyStoreUtilities.kt
@@ -30,7 +30,7 @@ fun loadOrCreateKeyStore(keyStoreFilePath: Path, storePassword: String): KeyStor
         keyStoreFilePath.read { keyStore.load(it, pass) }
     } else {
         keyStore.load(null, pass)
-        keyStoreFilePath.parent.createDirectories()
+        keyStoreFilePath.toAbsolutePath().parent?.createDirectories()
         keyStoreFilePath.write { keyStore.store(it, pass) }
     }
     return keyStore


### PR DESCRIPTION
This fixes the issue with path parent returning a null value when path is given just as a file name - e.g. "file.jks" instead of "./file.jks"

There is no unit test for this as it is difficult to manipulate at runtime Java's working directory.