### PR TITLE
CORDA-1790 Roll back flow transaction on exception

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -147,6 +147,19 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
         }
     }
 
+    internal fun rollbackTransaction() {
+        val transaction = contextTransaction
+        try {
+            logger.trace { "Rolling back transaction $transaction on ${Strand.currentStrand()}." }
+            transaction.rollback()
+        } catch (e: SQLException) {
+            logger.error("Transaction rollback failed: ${e.message}", e)
+            System.exit(1)
+        } finally {
+            transaction.close()
+        }
+    }
+
     @Suspendable
     override fun initiateFlow(otherParty: Party, sessionFlow: FlowLogic<*>): FlowSession {
         val sessionKey = Pair(sessionFlow, otherParty)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -454,12 +454,12 @@ class StateMachineManagerImpl(
             } finally {
                 if (result.isSuccess) {
                     fiber.commitTransaction()
+                    totalFinishedFlows.inc()
+                    unfinishedFibers.countDown()
                 } else {
                     fiber.rollbackTransaction()
                 }
                 decrementLiveFibers()
-                totalFinishedFlows.inc()
-                unfinishedFibers.countDown()
             }
         }
         mutex.locked {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineManagerImpl.kt
@@ -452,7 +452,11 @@ class StateMachineManagerImpl(
                 }
                 endAllFiberSessions(fiber, result, propagated)
             } finally {
-                fiber.commitTransaction()
+                if (result.isSuccess) {
+                    fiber.commitTransaction()
+                } else {
+                    fiber.rollbackTransaction()
+                }
                 decrementLiveFibers()
                 totalFinishedFlows.inc()
                 unfinishedFibers.countDown()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -375,7 +375,7 @@ class FlowFrameworkTests {
                 .withMessage("Nothing useful")
                 .withStackTraceContaining(ReceiveFlow::class.java.name)  // Make sure the stack trace is that of the receiving flow
         bobNode.database.transaction {
-            assertThat(bobNode.checkpointStorage.checkpoints()).isEmpty()
+            assertThat(bobNode.checkpointStorage.checkpoints()).isNotEmpty()
         }
 
         assertThat(receivingFiber.isTerminated).isTrue()


### PR DESCRIPTION
see: https://r3-cev.atlassian.net/browse/CORDA-1790

Basically the issue is that an exception thrown during a flow would cause an inconsistent db.
( node_transactions were inserted but not cash_states)