### PR TITLE
CORDA-1588: Add an extra check in the attachment resolution flow to p…

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/FetchDataFlow.kt
@@ -147,7 +147,13 @@ class FetchAttachmentsFlow(requests: Set<SecureHash>,
 
     override fun maybeWriteToDisk(downloaded: List<Attachment>) {
         for (attachment in downloaded) {
-            serviceHub.attachments.importAttachment(attachment.open(), "$P2P_UPLOADER:${otherSideSession.counterparty.name}", null)
+            with(serviceHub.attachments) {
+                if (!hasAttachment(attachment.id)) {
+                    importAttachment(attachment.open(), "$P2P_UPLOADER:${otherSideSession.counterparty.name}", null)
+                } else {
+                    logger.info("Attachment ${attachment.id} already exists, skipping.")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
…revent duplicate attachment import if multiple transactions with the same attachment are being resolved at the same time.

Backport of https://github.com/corda/corda/pull/3327
