### PR TITLE
CORDA-1814: Remove Quasar's transitive dependencies.

### DIFF
--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -14,7 +14,9 @@ dependencies {
     compile project(':core')
 
     // Quasar, for suspendable fibres.
-    compileOnly "$quasar_group:quasar-core:$quasar_version:jdk8"
+    compileOnly("$quasar_group:quasar-core:$quasar_version:jdk8") {
+        transitive = false
+    }
 
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "junit:junit:$junit_version"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,7 +69,9 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
     // Quasar, for suspendable fibres.
-    compileOnly "$quasar_group:quasar-core:$quasar_version:jdk8"
+    compileOnly("$quasar_group:quasar-core:$quasar_version:jdk8") {
+        transitive = false
+    }
 
     // Thread safety annotations
     compile "com.google.code.findbugs:jsr305:$jsr305_version"


### PR DESCRIPTION
Quasar is only providing its annotations (i.e. @Suspendable) at compile time, so remove its transitive dependencies such as Guava.