### PR TITLE
H2 database table upgrade notes from 3.0 to 3.2 fix - related to CORDA-1804.

### DIFF
--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -50,7 +50,7 @@ When upgrading from versions 3.0 or 3.1, run the following command:
 
    ALTER TABLE [schema].NODE_ATTCHMENTS_CONTRACTS RENAME TO NODE_ATTACHMENTS_CONTRACTS;
 
-When upgrading from release candidates RC01 and RC02 for version 3.0 (tags M18-RC01 and M18-RC02) run the following command:
+When upgrading from release candidates RC01 and RC02 for version 3.0 (tags M18-RC01 and M18-RC02), run the following command:
 
 .. sourcecode:: sql
 

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -50,12 +50,6 @@ When upgrading from versions 3.0 or 3.1, run the following command:
 
    ALTER TABLE [schema].NODE_ATTCHMENTS_CONTRACTS RENAME TO NODE_ATTACHMENTS_CONTRACTS;
 
-When upgrading from release candidates RC01 and RC02 for version 3.0 (tags M18-RC01 and M18-RC02), run the following command:
-
-.. sourcecode:: sql
-
-   ALTER TABLE [schema].NODE_ATTACHMENTS_CONTRACT_CLASS_NAME RENAME TO NODE_ATTACHMENTS_CONTRACTS;
-
 Schema name is optional, run SQL when the node is not running.
 
 * Postgres database upgrade - Change the type of the ``checkpoint_value`` column to ``bytea``.

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -44,13 +44,13 @@ Database schema changes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 * Database upgrade - a typo has been corrected in the ``NODE_ATTACHMENTS_CONTRACTS`` table name.
-When upgrading from version 3.1, run the following command:
+When upgrading from versions 3.0 or 3.1, run the following command:
 
 .. sourcecode:: sql
 
    ALTER TABLE [schema].NODE_ATTCHMENTS_CONTRACTS RENAME TO NODE_ATTACHMENTS_CONTRACTS;
 
-When upgrading from version 3.0, run the following command:
+When upgrading from release candidates RC01 and RC02 for version 3.0 (tags M18-RC01 and M18-RC02) run the following command:
 
 .. sourcecode:: sql
 


### PR DESCRIPTION
Reassign the release version V3.0 to require running different SQL upgrade - related to CORDA-1804.