### PR TITLE
h2 cash selection query to support multiple onlyFromIssuerParties and…

### DIFF
--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
@@ -1,5 +1,6 @@
 package net.corda.finance.contracts.asset.cash.selection
 
+import junit.framework.Assert
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
@@ -68,5 +69,14 @@ class CashSelectionH2ImplTest {
         // Make a payment
         val paymentResult = node.startFlow(CashPaymentFlow(999.POUNDS, node.info.legalIdentities[0], false)).getOrThrow()
         assertNotNull(paymentResult.recipient)
+    }
+
+    @Test
+    fun `multiple issuers in issuerConstraint condition`() {
+        val node = mockNet.createNode()
+        node.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(1), mockNet.defaultNotaryIdentity)).getOrThrow()
+        val request = CashPaymentFlow.PaymentRequest(1.POUNDS, node.info.legalIdentities[0], true, setOf(node.info.legalIdentities[0], mockNet.defaultNotaryIdentity))
+        val paymentResult = node.startFlow(CashPaymentFlow(request)).getOrThrow()
+        Assert.assertNotNull(paymentResult.recipient)
     }
 }

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2ImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.finance.contracts.asset.cash.selection
 
-import junit.framework.Assert
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
@@ -77,6 +76,6 @@ class CashSelectionH2ImplTest {
         node.startFlow(CashIssueFlow(1.POUNDS, OpaqueBytes.of(1), mockNet.defaultNotaryIdentity)).getOrThrow()
         val request = CashPaymentFlow.PaymentRequest(1.POUNDS, node.info.legalIdentities[0], true, setOf(node.info.legalIdentities[0], mockNet.defaultNotaryIdentity))
         val paymentResult = node.startFlow(CashPaymentFlow(request)).getOrThrow()
-        Assert.assertNotNull(paymentResult.recipient)
+        assertNotNull(paymentResult.recipient)
     }
 }


### PR DESCRIPTION
… withIssuerRefs

This is the same PR as #3411 which was closed due to merge complications.

Current CashSelectionH2Impl works only if set onlyFromIsuerParties contains 0 or one member.  Looks like with two members, the IN clause becomes ('A, B') instead of ('A', 'B').  The latter is our desired outcome.  
This PR fixes that, and the potential issue with withIssuerRefs as well by explicitly declaring and setting a query parameter for each member in the sets onlyFromIssuerParties and withIssuerRefs. That should be ok since I don't anticipate either set being large - as a matter of fact, Cash masks withIssuerRefs as an empty set as this moment.
I manually tested the onlyFromIssuerParties and withIssuerRefs.