### PR TITLE
Prefer files to paths when configuring ProGuard.

### DIFF
--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -59,13 +59,13 @@ task patchCore(type: Zip, dependsOn: coreJarTask) {
 import proguard.gradle.ProGuardTask
 task predeterminise(type: ProGuardTask) {
     injars patchCore
-    outjars "$buildDir/proguard/pre-deterministic-${project.version}.jar"
+    outjars file("$buildDir/proguard/pre-deterministic-${project.version}.jar")
 
-    libraryjars "$javaHome/lib/rt.jar"
-    libraryjars "$javaHome/lib/jce.jar"
+    libraryjars file("$javaHome/lib/rt.jar")
+    libraryjars file("$javaHome/lib/jce.jar")
     configurations.compileOnly.forEach {
-        if (originalJar.path != it.path) {
-            libraryjars it.path, filter: '!META-INF/versions/**'
+        if (originalJar != it) {
+            libraryjars it, filter: '!META-INF/versions/**'
         }
     }
 
@@ -108,12 +108,12 @@ task jarFilter(type: JarFilterTask) {
 
 task determinise(type: ProGuardTask) {
     injars jarFilter
-    outjars "$buildDir/proguard/$jarBaseName-${project.version}.jar"
+    outjars file("$buildDir/proguard/$jarBaseName-${project.version}.jar")
 
-    libraryjars "$javaHome/lib/rt.jar"
-    libraryjars "$javaHome/lib/jce.jar"
+    libraryjars file("$javaHome/lib/rt.jar")
+    libraryjars file("$javaHome/lib/jce.jar")
     configurations.runtimeLibraries.forEach {
-        libraryjars it.path, filter: '!META-INF/versions/**'
+        libraryjars it, filter: '!META-INF/versions/**'
     }
 
     // Analyse the JAR for dead code, and remove (some of) it.
@@ -153,7 +153,7 @@ task checkDeterminism(type: ProGuardTask, dependsOn: jdkTask) {
     libraryjars deterministic_rt_jar
 
     configurations.runtimeLibraries.forEach {
-        libraryjars it.path, filter: '!META-INF/versions/**'
+        libraryjars it, filter: '!META-INF/versions/**'
     }
 
     keepattributes '*'

--- a/serialization-deterministic/build.gradle
+++ b/serialization-deterministic/build.gradle
@@ -59,14 +59,14 @@ task patchSerialization(type: Zip, dependsOn: serializationJarTask) {
 import proguard.gradle.ProGuardTask
 task predeterminise(type: ProGuardTask, dependsOn: project(':core-deterministic').assemble) {
     injars patchSerialization
-    outjars "$buildDir/proguard/pre-deterministic-${project.version}.jar"
+    outjars file("$buildDir/proguard/pre-deterministic-${project.version}.jar")
 
-    libraryjars "$javaHome/lib/rt.jar"
-    libraryjars "$javaHome/lib/jce.jar"
-    libraryjars "$javaHome/lib/ext/sunec.jar"
+    libraryjars file("$javaHome/lib/rt.jar")
+    libraryjars file("$javaHome/lib/jce.jar")
+    libraryjars file("$javaHome/lib/ext/sunec.jar")
     configurations.compileOnly.forEach {
-        if (originalJar.path != it.path) {
-            libraryjars it.path, filter: '!META-INF/versions/**'
+        if (originalJar != it) {
+            libraryjars it, filter: '!META-INF/versions/**'
         }
     }
 
@@ -104,12 +104,12 @@ task jarFilter(type: JarFilterTask) {
 
 task determinise(type: ProGuardTask) {
     injars jarFilter
-    outjars "$buildDir/proguard/$jarBaseName-${project.version}.jar"
+    outjars file("$buildDir/proguard/$jarBaseName-${project.version}.jar")
 
-    libraryjars "$javaHome/lib/rt.jar"
-    libraryjars "$javaHome/lib/jce.jar"
+    libraryjars file("$javaHome/lib/rt.jar")
+    libraryjars file("$javaHome/lib/jce.jar")
     configurations.runtimeLibraries.forEach {
-        libraryjars it.path, filter: '!META-INF/versions/**'
+        libraryjars it, filter: '!META-INF/versions/**'
     }
 
     // Analyse the JAR for dead code, and remove (some of) it.
@@ -143,7 +143,7 @@ task checkDeterminism(type: ProGuardTask, dependsOn: jdkTask) {
     libraryjars deterministic_rt_jar
 
     configurations.runtimeLibraries.forEach {
-        libraryjars it.path, filter: '!META-INF/versions/**'
+        libraryjars it, filter: '!META-INF/versions/**'
     }
 
     keepattributes '*'


### PR DESCRIPTION
Prefer files over path strings, which is hopefully more forgiving on Windows.