### PR TITLE
CORDA-1832: Configure Quasar dependency using quasar-utils plugin.

### DIFF
--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -13,11 +13,6 @@ description 'Corda Experimental Confidential Identities'
 dependencies {
     compile project(':core')
 
-    // Quasar, for suspendable fibres.
-    compileOnly("$quasar_group:quasar-core:$quasar_version:jdk8") {
-        transitive = false
-    }
-
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "junit:junit:$junit_version"
 

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.27
+gradlePluginsVersion=4.0.28
 kotlinVersion=1.2.51
 platformVersion=4
 guavaVersion=25.1-jre

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,11 +71,6 @@ dependencies {
     // Hamkrest, for fluent, composable matchers
     testCompile "com.natpryce:hamkrest:$hamkrest_version"
 
-    // Quasar, for suspendable fibres.
-    compileOnly("$quasar_group:quasar-core:$quasar_version:jdk8") {
-        transitive = false
-    }
-
     // Thread safety annotations
     compile "com.google.code.findbugs:jsr305:$jsr305_version"
 

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -48,7 +48,7 @@ sourceSets {
 jib.container {
   mainClass = "net.corda.node.Corda"
   args = ['--log-to-console', '--no-local-shell', '--config-file=/config/node.conf']
-  jvmFlags = ['-Xmx1g', '-javaagent:/app/libs/quasar-core-0.7.10.jar']
+  jvmFlags = ['-Xmx1g', "-javaagent:/app/libs/quasar-core-${quasar_version}.jar"]
 }
 
 // Use manual resource copying of log4j2.xml rather than source sets.
@@ -72,8 +72,6 @@ dependencies {
     compile project(':tools:shell')
     compile "net.corda.plugins:cordform-common:$gradle_plugins_version"
 
-    compile group: 'co.paralleluniverse', name: 'quasar-core', version: '0.7.10:jdk8@jar'
-
     // Log4J: logging framework (with SLF4J bindings)
     compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
     compile "org.apache.logging.log4j:log4j-web:${log4j_version}"
@@ -85,7 +83,7 @@ dependencies {
 
     // Kryo: object graph serialization.
     compile "com.esotericsoftware:kryo:4.0.0"
-    compile "de.javakaffee:kryo-serializers:0.41"
+    compile "de.javakaffee:kryo-serializers:0.42"
 
     compile "com.google.guava:guava:$guava_version"
 


### PR DESCRIPTION
Remove explicit dependency on `quasar-core` agent because this is managed by the `quasar-utils` plugin, which does the following:
- Adds `quasar-core` to the `compileOnly` configuration _without_ transitive deps
- Adds `quasar-core` to the `cordaRuntime` configuration _without_ transitive deps
- Adds `quasar-core` to the `runtimeClasspath` configuration _with_ transitive deps

This means that `core` now has `quasar-core` on its compile classpath, but not any of Quasars transitive dependencies. However, these dependencies _are_ still available on the runtime classpath.

Note that we had silently upgraded to `kryo-serializers:0.42` since `quasar-core` 0.7.9, so make this explicit too.