### PR TITLE
ENT-2188 fix H2 insecure default configuration

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -86,7 +86,7 @@ absolute path to the node's base directory.
 
 :h2Port: Deprecated. Use ``h2Settings`` instead.
 
-:h2Settings:  Sets the H2 JDBC server port. See :doc:`node-database-access-h2`.
+:h2Settings:  Sets the H2 JDBC server host and port. See :doc:`node-database-access-h2`. For non-localhost address the database passowrd needs to be set in ``dataSourceProperties``.
 
 :messagingServerAddress: The address of the ArtemisMQ broker instance. If not provided the node will run one locally.
 

--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -86,7 +86,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             adminAddress "localhost:10013"
         }
         webPort 10004
-        extraConfig = ['h2Settings.address' : 'localhost:100014']
+        extraConfig = ['h2Settings.address' : 'localhost:10014']
         cordapps = []
     }
     node {

--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -86,6 +86,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             adminAddress "localhost:10013"
         }
         webPort 10004
+        extraConfig = ['h2Settings.address' : 'localhost:100014']
         cordapps = []
     }
     node {
@@ -96,6 +97,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             adminAddress "localhost:10016"
         }
         webPort 10007
+        extraConfig = ['h2Settings.address' : 'localhost:10017']
         cordapps = []
         rpcUsers = [
                 ['username' : "user",

--- a/docs/source/node-database-access-h2.rst
+++ b/docs/source/node-database-access-h2.rst
@@ -41,7 +41,7 @@ The node requires a database password to be set when the database is exposed on 
       address: "0.0.0.0:12345"
   }
   dataSourceProperties {
-      dataSource.password : "secret"
+      dataSource.password : "strongpassword"
   }
 
 The previous ``h2Port`` syntax is now deprecated. ``h2Port`` will continue to work but the database

--- a/docs/source/node-database-access-h2.rst
+++ b/docs/source/node-database-access-h2.rst
@@ -32,12 +32,16 @@ If you want H2 to auto-select a port (mimicking the old ``h2Port`` behaviour), y
       address: "localhost:0"
   }
 
-If remote access is required, the address can be changed to ``0.0.0.0``. However it is recommended to change the default username and password before doing so.
+If remote access is required, the address can be changed to ``0.0.0.0``.
+The node requires a database password to be set when the database is exposed on the network interface to listen on.
 
 .. sourcecode:: groovy
 
   h2Settings {
       address: "0.0.0.0:12345"
+  }
+  dataSourceProperties {
+      dataSource.password : "secret"
   }
 
 The previous ``h2Port`` syntax is now deprecated. ``h2Port`` will continue to work but the database

--- a/docs/source/node-database.rst
+++ b/docs/source/node-database.rst
@@ -35,7 +35,8 @@ interface for you to query them using SQL.
 
 The default behaviour is to expose the H2 database on localhost. This can be overridden in the
 node configuration using ``h2Settings.address`` and specifying the address of the network interface to listen on,
-or simply using ``0.0.0.0:0`` to listen on all interfaces.
+or simply using ``0.0.0.0:0`` to listen on all interfaces. The node requires a database password to be set when
+ the database is exposed on the network interface to listen on.
 
 PostgreSQL
 ----------

--- a/docs/source/node-database.rst
+++ b/docs/source/node-database.rst
@@ -3,7 +3,24 @@ Node database
 
 Default in-memory database
 --------------------------
-By default, nodes store their data in an H2 database. You can connect directly to a running node's database to see its
+By default, nodes store their data in an H2 database.
+The database (a file persistence.mv.db) is created at the first node startup with the administrator user 'sa' and a blank password.
+The user name and password can be changed in node configuration:
+
+.. sourcecode:: groovy
+
+    dataSourceProperties = {
+        dataSource.user = [USER]
+        dataSource.password = [PASSWORD]
+    }
+
+Note, changing user/password for the existing node in node.conf will not update them in the H2 database,
+you need to login to the database first to create new user or change the user password.
+The database password is required only when the H2 database is exposed on non-localhost address (which is disabled by default).
+The node requires the user with administrator permissions in order to creates tables upon the first startup
+or after deplying new CorDapps with own tables.
+
+You can connect directly to a running node's database to see its
 stored states, transactions and attachments as follows:
 
 * Enable the H2 database access in the node configuration using the following syntax:
@@ -36,7 +53,7 @@ interface for you to query them using SQL.
 The default behaviour is to expose the H2 database on localhost. This can be overridden in the
 node configuration using ``h2Settings.address`` and specifying the address of the network interface to listen on,
 or simply using ``0.0.0.0:0`` to listen on all interfaces. The node requires a database password to be set when
- the database is exposed on the network interface to listen on.
+the database is exposed on the network interface to listen on.
 
 PostgreSQL
 ----------

--- a/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
@@ -28,7 +28,7 @@ class AddressBindingFailureTests {
     fun `rpc admin address`() = assertBindExceptionForOverrides { address -> mapOf("rpcSettings" to mapOf("adminAddress" to address.toString())) }
 
     @Test
-    fun `H2 address`() = assertBindExceptionForOverrides { address -> mapOf("h2Settings" to mapOf("address" to address.toString())) }
+    fun `H2 address`() = assertBindExceptionForOverrides { address -> mapOf("h2Settings" to mapOf("address" to address.toString()), "dataSourceProperties.dataSource.password" to "password") }
 
     private fun assertBindExceptionForOverrides(overrides: (NetworkHostAndPort) -> Map<String, Any?>) {
 

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertTrue
 
 class H2SecurityTests {
     companion object {
-        private val port = PortAllocation.Incremental(20_000)
+        private val port = PortAllocation.Incremental(30_000)
         private fun getFreePort() = port.nextPort()
         private const val h2AddressKey = "h2Settings.address"
         private const val dbPasswordKey = "dataSourceProperties.dataSource.password"

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -13,7 +13,7 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import org.junit.Test
 import java.net.InetAddress
-import java.net.ServerSocket
+//import java.net.ServerSocket
 import java.sql.DriverManager
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
@@ -21,7 +21,7 @@ import kotlin.test.assertTrue
 
 class H2SecurityTests {
     companion object {
-        private fun getFreePort() = ServerSocket(0).localPort
+        private fun getFreePort() = 20001 //ServerSocket(0).localPort
         private const val h2AddressKey = "h2Settings.address"
         private const val dbPasswordKey = "dataSourceProperties.dataSource.password"
     }
@@ -30,8 +30,8 @@ class H2SecurityTests {
     fun `h2 server starts when h2Settings are set`() {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
-            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:$port")).getOrThrow()
-            DriverManager.getConnection("jdbc:h2:tcp://127.0.0.1:$port/node", "sa", "").use {
+            startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
+            DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
                 assertTrue(it.createStatement().executeQuery("SELECT 1").next())
             }
         }
@@ -94,9 +94,9 @@ class H2SecurityTests {
         assertNull(System.getProperty("abc"), "Expecting abc property to be not set") //sanity check
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
-            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:$port")).getOrThrow()
+            startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
             assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
-                DriverManager.getConnection("jdbc:h2:tcp://127.0.0.1:$port/node", "sa", "").use {
+                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
                     it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
                     it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
                 }
@@ -111,12 +111,12 @@ class H2SecurityTests {
         val user = User("mark", "dadada", setOf(Permissions.startFlow<MaliciousFlow>()))
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
-            val nodeHandle = startNode(rpcUsers = listOf(user), customOverrides = mapOf(h2AddressKey to "127.0.0.1:$port")).getOrThrow()
+            val nodeHandle = startNode(rpcUsers = listOf(user), customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
             CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(::MaliciousFlow).returnValue.getOrThrow()
             }
             assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
-                DriverManager.getConnection("jdbc:h2:tcp://127.0.0.1:$port/node", "sa", "").use {
+                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
                     it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
                     it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
                 }

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -82,12 +82,12 @@ class H2SecurityTests {
         }
     }
 
-    @Test
-    fun `h2 server to loopback IP runs with the default database password`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
-            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:${getFreePort()}")).getOrThrow()
-        }
-    }
+//    @Test
+//    fun `h2 server to loopback IP runs with the default database password`() {
+//        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+//            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:${getFreePort()}")).getOrThrow()
+//        }
+//    }
 
     @Test
     fun `remote code execution via h2 server is disabled`() {

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -30,8 +30,8 @@ class H2SecurityTests {
     fun `h2 server starts when h2Settings are set`() {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
-            startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
-            DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
+            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:$port")).getOrThrow()
+            DriverManager.getConnection("jdbc:h2:tcp://127.0.0.1:$port/node", "sa", "").use {
                 assertTrue(it.createStatement().executeQuery("SELECT 1").next())
             }
         }
@@ -94,9 +94,9 @@ class H2SecurityTests {
         assertNull(System.getProperty("abc"), "Expecting abc property to be not set") //sanity check
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
-            startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
+            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:$port")).getOrThrow()
             assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
-                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
+                DriverManager.getConnection("jdbc:h2:tcp://127.0.0.1:$port/node", "sa", "").use {
                     it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
                     it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
                 }
@@ -111,12 +111,12 @@ class H2SecurityTests {
         val user = User("mark", "dadada", setOf(Permissions.startFlow<MaliciousFlow>()))
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
-            val nodeHandle = startNode(rpcUsers = listOf(user), customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
+            val nodeHandle = startNode(rpcUsers = listOf(user), customOverrides = mapOf(h2AddressKey to "127.0.0.1:$port")).getOrThrow()
             CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
                 it.proxy.startFlow(::MaliciousFlow).returnValue.getOrThrow()
             }
             assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
-                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
+                DriverManager.getConnection("jdbc:h2:tcp://127.0.0.1:$port/node", "sa", "").use {
                     it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
                     it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
                 }

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertTrue
 
 class H2SecurityTests {
     companion object {
-        private val port = PortAllocation.Incremental(30_000)
+        private val port = PortAllocation.Incremental(21_000)
         private fun getFreePort() = port.nextPort()
         private const val h2AddressKey = "h2Settings.address"
         private const val dbPasswordKey = "dataSourceProperties.dataSource.password"
@@ -83,12 +83,12 @@ class H2SecurityTests {
         }
     }
 
-//    @Test
-//    fun `h2 server to loopback IP runs with the default database password`() {
-//        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
-//            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:${getFreePort()}")).getOrThrow()
-//        }
-//    }
+    @Test
+    fun `h2 server to loopback IP runs with the default database password`() {
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:${getFreePort()}")).getOrThrow()
+        }
+    }
 
     @Test
     fun `remote code execution via h2 server is disabled`() {

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -1,0 +1,74 @@
+package net.corda.node.persistence
+
+import net.corda.core.utilities.getOrThrow
+import net.corda.nodeapi.internal.persistence.CouldNotCreateDataSourceException
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import org.junit.Test
+import java.net.InetAddress
+import java.sql.DriverManager
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class H2SecurityTests {
+
+    @Test
+    fun `node starts h2 server when h2Settings are set`() {
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            val nodeHandle = startNode(customOverrides = mapOf("h2Settings.address" to "localhost:10030")).getOrThrow()
+            DriverManager.getConnection("jdbc:h2:tcp://localhost:10030/node", "sa", "").use {
+                val result = it.createStatement().executeQuery("SELECT 1")
+                assertTrue(result.next())
+            }
+            nodeHandle.stop()
+        }
+    }
+
+    @Test
+    fun `node doesn't start h2 server by the default`() {
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            val nodeHandle = startNode().getOrThrow()
+            assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
+                DriverManager.getConnection("jdbc:h2:tcp://localhost:10030/node", "sa", "").use {
+                    it.createStatement().executeQuery("SELECT 1")
+                }
+            }
+            nodeHandle.stop()
+        }
+    }
+
+    @Test
+    fun `remote access to h2 server can't run java code`() {
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            val nodeHandle = startNode(customOverrides = mapOf("h2Settings.address" to "localhost:10030")).getOrThrow()
+            assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
+                DriverManager.getConnection("jdbc:h2:tcp://localhost:10030/node", "sa", "").use {
+                    it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
+                    it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
+                    it.commit()
+                }
+            }
+            assertNull(System.getProperty("abc"))
+            nodeHandle.stop()
+        }
+    }
+
+    @Test
+    fun `h2 server not bind to localhost require non-default database admin password`() {
+
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            assertFailsWith(CouldNotCreateDataSourceException::class) {
+                startNode(customOverrides = mapOf("h2Settings.address" to "${InetAddress.getLocalHost().hostName}:10030")).getOrThrow()
+            }
+        }
+    }
+
+    @Test
+    fun `h2 serevr bind to localhost allows default database admin password`() {
+
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            startNode(customOverrides = mapOf("h2Settings.address" to "localhost:10030")).getOrThrow()
+        }
+    }
+}

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -9,10 +9,12 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions
 import net.corda.nodeapi.internal.persistence.CouldNotCreateDataSourceException
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import org.junit.Test
 import java.net.InetAddress
+//import java.net.InetSocketAddress
 //import java.net.ServerSocket
 import java.sql.DriverManager
 import kotlin.test.assertFailsWith
@@ -21,13 +23,15 @@ import kotlin.test.assertTrue
 
 class H2SecurityTests {
     companion object {
-        private fun getFreePort() = 20001 //ServerSocket(0).localPort
+        private  val port = PortAllocation.Incremental(20002)
+        private fun getFreePort() = port.nextPort() //ServerSocket(0).localPort
         private const val h2AddressKey = "h2Settings.address"
         private const val dbPasswordKey = "dataSourceProperties.dataSource.password"
     }
 
     @Test
     fun `h2 server starts when h2Settings are set`() {
+        //println(InetSocketAddress.ho)
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
             startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -39,7 +39,7 @@ class H2SecurityTests {
     }
 
     @Test
-    fun `remote access to h2 server can't run java code`() {
+    fun `remote access to h2 server cant run java code`() {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val nodeHandle = startNode(customOverrides = mapOf("h2Settings.address" to "localhost:10030")).getOrThrow()
             assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
@@ -60,6 +60,17 @@ class H2SecurityTests {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
                 startNode(customOverrides = mapOf("h2Settings.address" to "${InetAddress.getLocalHost().hostName}:10030")).getOrThrow()
+            }
+        }
+    }
+
+    @Test
+    fun `h2 server not bind to localhost require non-blank database admin password`() {
+
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            assertFailsWith(CouldNotCreateDataSourceException::class) {
+                startNode(customOverrides = mapOf("h2Settings.address" to "${InetAddress.getLocalHost().hostName}:10030",
+                        "dataSourceProperties.dataSource.password" to " ")).getOrThrow()
             }
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -14,8 +14,6 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.User
 import org.junit.Test
 import java.net.InetAddress
-//import java.net.InetSocketAddress
-//import java.net.ServerSocket
 import java.sql.DriverManager
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
@@ -23,7 +21,7 @@ import kotlin.test.assertTrue
 
 class H2SecurityTests {
     companion object {
-        private  val port = PortAllocation.Incremental(20002)
+        private  val port = PortAllocation.Incremental(20100)
         private fun getFreePort() = port.nextPort() //ServerSocket(0).localPort
         private const val h2AddressKey = "h2Settings.address"
         private const val dbPasswordKey = "dataSourceProperties.dataSource.password"
@@ -31,7 +29,6 @@ class H2SecurityTests {
 
     @Test
     fun `h2 server starts when h2Settings are set`() {
-        //println(InetSocketAddress.ho)
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             val port = getFreePort()
             startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/H2SecurityTests.kt
@@ -1,9 +1,16 @@
 package net.corda.node.persistence
 
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.client.rpc.CordaRPCClient
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
+import net.corda.node.services.Permissions
 import net.corda.nodeapi.internal.persistence.CouldNotCreateDataSourceException
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
+import net.corda.testing.node.User
 import org.junit.Test
 import java.net.InetAddress
 import java.net.ServerSocket
@@ -31,21 +38,6 @@ class H2SecurityTests {
     }
 
     @Test
-    fun `remote access to h2 server can't run java code`() {
-        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
-            val port = getFreePort()
-            startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
-            assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
-                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
-                    it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
-                    it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
-                }
-            }
-            assertNull(System.getProperty("abc"))
-        }
-    }
-
-    @Test
     fun `h2 server on the host name requires non-default database password`() {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
@@ -64,7 +56,7 @@ class H2SecurityTests {
     }
 
     @Test
-    fun `h2 server on host name requires non-blank database admin password`() {
+    fun `h2 server on host name requires non-blank database password`() {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
                 startNode(customOverrides = mapOf(h2AddressKey to "${InetAddress.getLocalHost().hostName}:${getFreePort()}",
@@ -74,7 +66,7 @@ class H2SecurityTests {
     }
 
     @Test
-    fun `h2 server on external host IP requires non-blank database admin password`() {
+    fun `h2 server on external host IP requires non-blank database password`() {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             assertFailsWith(CouldNotCreateDataSourceException::class) {
                 startNode(customOverrides = mapOf(h2AddressKey to "${InetAddress.getLocalHost().hostAddress}:${getFreePort()}",
@@ -94,6 +86,51 @@ class H2SecurityTests {
     fun `h2 server to loopback IP runs with the default database password`() {
         driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
             startNode(customOverrides = mapOf(h2AddressKey to "127.0.0.1:${getFreePort()}")).getOrThrow()
+        }
+    }
+
+    @Test
+    fun `remote code execution via h2 server is disabled`() {
+        assertNull(System.getProperty("abc"), "Expecting abc property to be not set") //sanity check
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            val port = getFreePort()
+            startNode(customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
+            assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
+                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
+                    it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
+                    it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
+                }
+            }
+            assertNull(System.getProperty("abc"))
+        }
+    }
+
+    @Test
+    fun `malicious flow tries to enable remote code execution via h2 server`() {
+        assertNull(System.getProperty("abc"), "Expecting abc property to be not set") //sanity check
+        val user = User("mark", "dadada", setOf(Permissions.startFlow<MaliciousFlow>()))
+        driver(DriverParameters(inMemoryDB = false, startNodesInProcess = isQuasarAgentSpecified(), notarySpecs = emptyList())) {
+            val port = getFreePort()
+            val nodeHandle = startNode(rpcUsers = listOf(user), customOverrides = mapOf(h2AddressKey to "localhost:$port")).getOrThrow()
+            CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                it.proxy.startFlow(::MaliciousFlow).returnValue.getOrThrow()
+            }
+            assertFailsWith(org.h2.jdbc.JdbcSQLException::class) {
+                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
+                    it.createStatement().execute("CREATE ALIAS SET_PROPERTY FOR \"java.lang.System.setProperty\"")
+                    it.createStatement().execute("CALL SET_PROPERTY('abc', '1')")
+                }
+            }
+            assertNull(System.getProperty("abc"))
+        }
+    }
+
+    @StartableByRPC
+    class MaliciousFlow : FlowLogic<Boolean>() {
+        @Suspendable
+        override fun call(): Boolean {
+            System.clearProperty("h2.allowedClasses")
+            return true
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -352,11 +352,11 @@ open class Node(configuration: NodeConfiguration,
                 val url = try {
                     server.start().url
                 } catch (e: JdbcSQLException) {
-                    if (e.cause is BindException) {
-                        throw AddressBindingException(effectiveH2Settings.address)
-                    } else {
+                   // if (e.cause is BindException) {
+                   //     throw AddressBindingException(effectiveH2Settings.address)
+                   // } else {
                         throw e
-                    }
+                   // }
                 }
                 printBasicNodeInfo("Database connection url is", "jdbc:h2:$url/node")
             }

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -336,7 +336,7 @@ open class Node(configuration: NodeConfiguration,
             if (effectiveH2Settings?.address != null) {
                 if (effectiveH2Settings.address.host.equals("localhost", ignoreCase = true).not() &&
                         configuration.dataSourceProperties.getProperty("dataSource.password").isBlank()) {
-                    throw CouldNotCreateDataSourceException("Exposing H2 server address other than localhost requires 'dataSource.password' to be set.")
+                    throw CouldNotCreateDataSourceException("Database password required when H2 server listen to non localhost address.")
                 }
                 val databaseName = databaseUrl.removePrefix(h2Prefix).substringBefore(';')
                 val server = org.h2.tools.Server.createTcpServer(

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -68,6 +68,8 @@ import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
 import javax.management.ObjectName
 import kotlin.system.exitProcess
+import rx.Observable
+import java.nio.file.Paths
 
 class NodeWithInfo(val node: Node, val info: NodeInfo) {
     val services: StartedNodeServices = object : StartedNodeServices, ServiceHubInternal by node.services, FlowStarter by node.flowStarter {}
@@ -341,10 +343,12 @@ open class Node(configuration: NodeConfiguration,
                     throw CouldNotCreateDataSourceException("Database password is required for H2 server listening on ${InetAddress.getByName(effectiveH2Settings.address.host)}.")
                 }
                 val databaseName = databaseUrl.removePrefix(h2Prefix).substringBefore(';')
+                val baseDir = Paths.get(databaseName).parent.toString()
                 val server = org.h2.tools.Server.createTcpServer(
                         "-tcpPort", effectiveH2Settings.address.port.toString(),
                         "-tcpAllowOthers",
                         "-tcpDaemon",
+                        "-baseDir", baseDir,
                         "-key", "node", databaseName)
                 // override interface that createTcpServer listens on (which is always 0.0.0.0)
                 System.setProperty("h2.bindAddress", effectiveH2Settings.address.host)

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -352,11 +352,11 @@ open class Node(configuration: NodeConfiguration,
                 val url = try {
                     server.start().url
                 } catch (e: JdbcSQLException) {
-                   // if (e.cause is BindException) {
-                   //     throw AddressBindingException(effectiveH2Settings.address)
-                   // } else {
+                    if (e.cause is BindException) {
+                        throw AddressBindingException(effectiveH2Settings.address)
+                    } else {
                         throw e
-                   // }
+                    }
                 }
                 printBasicNodeInfo("Database connection url is", "jdbc:h2:$url/node")
             }

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -68,7 +68,6 @@ import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
 import javax.management.ObjectName
 import kotlin.system.exitProcess
-import rx.Observable
 import java.nio.file.Paths
 
 class NodeWithInfo(val node: Node, val info: NodeInfo) {

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -338,7 +338,7 @@ open class Node(configuration: NodeConfiguration,
             if (effectiveH2Settings?.address != null) {
                 if (!InetAddress.getByName(effectiveH2Settings.address.host).isLoopbackAddress
                         && configuration.dataSourceProperties.getProperty("dataSource.password").isBlank()) {
-                    throw CouldNotCreateDataSourceException("Database password is required for H2 server exposed on an external address.")
+                    throw CouldNotCreateDataSourceException("Database password is required for H2 server listening on ${InetAddress.getByName(effectiveH2Settings.address.host)}.")
                 }
                 val databaseName = databaseUrl.removePrefix(h2Prefix).substringBefore(';')
                 val server = org.h2.tools.Server.createTcpServer(

--- a/samples/attachment-demo/build.gradle
+++ b/samples/attachment-demo/build.gradle
@@ -53,6 +53,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address "localhost:10003"
             adminAddress "localhost:10004"
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10012']
     }
     node {
         name "O=Bank A,L=London,C=GB"
@@ -63,6 +64,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address "localhost:10006"
             adminAddress "localhost:10007"
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10013']
     }
     node {
         name "O=Bank B,L=New York,C=US"
@@ -74,6 +76,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         webPort 10010
         cordapps = []
         rpcUsers = ext.rpcUsers
+        extraConfig = ['h2Settings.address' : 'localhost:10014']
     }
 }
 

--- a/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaCordform.kt
+++ b/samples/bank-of-corda-demo/src/main/kotlin/net/corda/bank/BankOfCordaCordform.kt
@@ -44,10 +44,12 @@ class BankOfCordaCordform : CordformDefinition() {
                 adminAddress("localhost:10004")
             }
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:10016"))
         }
         node {
             name(BOC_NAME)
-            extraConfig = mapOf("custom" to mapOf("issuableCurrencies" to listOf("USD")))
+            extraConfig = mapOf("custom" to mapOf("issuableCurrencies" to listOf("USD")),
+                    "h2Settings" to mapOf("address" to "localhost:10017"))
             p2pPort(10005)
             rpcSettings {
                 address("localhost:$BOC_RPC_PORT")
@@ -67,6 +69,7 @@ class BankOfCordaCordform : CordformDefinition() {
             webPort(10010)
             rpcUsers(User(BIGCORP_RPC_USER, BIGCORP_RPC_PWD, setOf(all())))
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:10018"))
         }
     }
 

--- a/samples/cordapp-configuration/build.gradle
+++ b/samples/cordapp-configuration/build.gradle
@@ -22,10 +22,11 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             port 10003
             adminPort 10004
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10005']
     }
     node {
         name "O=Bank A,L=London,C=GB"
-        p2pPort 10005
+        p2pPort 10006
         cordapps = []
         rpcUsers = ext.rpcUsers
         // This configures the default cordapp for this node
@@ -36,10 +37,11 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             port 10007
             adminPort 10008
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10009']
     }
     node {
         name "O=Bank B,L=New York,C=US"
-        p2pPort 10009
+        p2pPort 10010
         cordapps = []
         rpcUsers = ext.rpcUsers
         // This configures the default cordapp for this node
@@ -50,5 +52,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             port 10011
             adminPort 10012
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10013']
     }
 }

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -70,6 +70,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = ["${project(":finance").group}:finance:$corda_release_version"]
         rpcUsers = rpcUsersList
         useTestClock true
+        extraConfig = ['h2Settings.address' : 'localhost:24']
     }
     node {
         name "O=Bank A,L=London,C=GB"
@@ -81,6 +82,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = ["${project(":finance").group}:finance:$corda_release_version"]
         rpcUsers = rpcUsersList
         useTestClock true
+        extraConfig = ['h2Settings.address' : 'localhost:27']
     }
     node {
         name "O=Bank B,L=New York,C=US"
@@ -92,6 +94,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = ["${project.group}:finance:$corda_release_version"]
         rpcUsers = rpcUsersList
         useTestClock true
+        extraConfig = ['h2Settings.address' : 'localhost:10030']
     }
     node {
         name "O=Regulator,L=Moscow,C=RU"
@@ -104,6 +107,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = ["${project(":finance").group}:finance:$corda_release_version"]
         rpcUsers = rpcUsersList
         useTestClock true
+        extraConfig = ['h2Settings.address' : 'localhost:10033']
     }
 
 }

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -70,7 +70,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = ["${project(":finance").group}:finance:$corda_release_version"]
         rpcUsers = rpcUsersList
         useTestClock true
-        extraConfig = ['h2Settings.address' : 'localhost:24']
+        extraConfig = ['h2Settings.address' : 'localhost:10024']
     }
     node {
         name "O=Bank A,L=London,C=GB"
@@ -82,7 +82,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps = ["${project(":finance").group}:finance:$corda_release_version"]
         rpcUsers = rpcUsersList
         useTestClock true
-        extraConfig = ['h2Settings.address' : 'localhost:27']
+        extraConfig = ['h2Settings.address' : 'localhost:10027']
     }
     node {
         name "O=Bank B,L=New York,C=US"

--- a/samples/network-verifier/build.gradle
+++ b/samples/network-verifier/build.gradle
@@ -24,7 +24,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             port 10003
             adminPort 10004
         }
-        h2Port   20004
+        extraConfig = ['h2Settings.address' : 'localhost:20004']
     }
     node {
         name "O=Bank A,L=London,C=GB"
@@ -35,6 +35,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             port 10007
             adminPort 10008
         }
+        extraConfig = ['h2Settings.address' : 'localhost:0']
     }
     node {
         name "O=Bank B,L=New York,C=US"
@@ -45,5 +46,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             port 10011
             adminPort 10012
         }
+        extraConfig = ['h2Settings.address' : 'localhost:0']
     }
 }

--- a/samples/notary-demo/README.md
+++ b/samples/notary-demo/README.md
@@ -52,7 +52,7 @@ by using the H2 web console:
   Each node outputs its connection string in the terminal window as it starts up. In a terminal window where a **notary** node is running,
   look for the following string:
 
-  ``Database connection url is              : jdbc:h2:tcp://10.18.0.150:56736/node``
+  ``Database connection url is              : jdbc:h2:tcp://localhost:56736/node``
 
   You can use the string on the right to connect to the h2 database: just paste it into the `JDBC URL` field and click *Connect*.
   You will be presented with a web application that enumerates all the available tables and provides an interface for you to query them using SQL

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/BFTNotaryCordform.kt
@@ -35,6 +35,7 @@ class BFTNotaryCordform : CordformDefinition() {
             }
             rpcUsers(notaryDemoUser)
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         node {
             name(BOB_NAME)
@@ -44,11 +45,13 @@ class BFTNotaryCordform : CordformDefinition() {
                 adminAddress("localhost:10106")
             }
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         val clusterAddresses = (0 until clusterSize).map { NetworkHostAndPort("localhost", 11000 + it * 10) }
         fun notaryNode(replicaId: Int, configure: CordformNode.() -> Unit) = node {
             name(notaryNames[replicaId])
             notary(NotaryConfig(validating = false, serviceLegalName = clusterName, bftSMaRt = BFTSMaRtConfiguration(replicaId, clusterAddresses)))
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
             configure()
         }
         notaryNode(0) {

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/CustomNotaryCordform.kt
@@ -23,6 +23,7 @@ class CustomNotaryCordform : CordformDefinition() {
             }
             rpcUsers(notaryDemoUser)
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         node {
             name(BOB_NAME)
@@ -32,6 +33,7 @@ class CustomNotaryCordform : CordformDefinition() {
                 adminAddress("localhost:10106")
             }
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         node {
             name(DUMMY_NOTARY_NAME)
@@ -42,6 +44,7 @@ class CustomNotaryCordform : CordformDefinition() {
             }
             notary(NotaryConfig(validating = true, custom = true))
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
     }
 

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/RaftNotaryCordform.kt
@@ -35,6 +35,7 @@ class RaftNotaryCordform : CordformDefinition() {
             }
             rpcUsers(notaryDemoUser)
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         node {
             name(BOB_NAME)
@@ -44,11 +45,13 @@ class RaftNotaryCordform : CordformDefinition() {
                 adminAddress("localhost:10106")
             }
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         fun notaryNode(index: Int, nodePort: Int, clusterPort: Int? = null, configure: CordformNode.() -> Unit) = node {
             name(notaryNames[index])
             val clusterAddresses = if (clusterPort != null) listOf(NetworkHostAndPort("localhost", clusterPort)) else emptyList()
             notary(NotaryConfig(validating = true, serviceLegalName = clusterName, raft = RaftConfig(NetworkHostAndPort("localhost", nodePort), clusterAddresses)))
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
             configure()
             devMode(true)
         }

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/SingleNotaryCordform.kt
@@ -29,6 +29,7 @@ class SingleNotaryCordform : CordformDefinition() {
             }
             rpcUsers(notaryDemoUser)
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         node {
             name(BOB_NAME)
@@ -38,6 +39,7 @@ class SingleNotaryCordform : CordformDefinition() {
                 adminAddress("localhost:10106")
             }
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
         node {
             name(DUMMY_NOTARY_NAME)
@@ -48,6 +50,7 @@ class SingleNotaryCordform : CordformDefinition() {
             }
             notary(NotaryConfig(validating = true))
             devMode(true)
+            extraConfig = mapOf("h2Settings" to mapOf("address" to "localhost:0"))
         }
     }
 

--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -80,7 +80,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         extraConfig = [
                 custom: [
                         jvmArgs: ["-Xmx1g"]
-                ]
+                ],
+               'h2Settings.address' : 'localhost:10038'
         ]
     }
     node {
@@ -98,7 +99,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         extraConfig = [
                 custom: [
                         jvmArgs: ["-Xmx1g"]
-                ]
+                ],
+                'h2Settings.address' : 'localhost:10039'
         ]
     }
     node {
@@ -116,7 +118,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         extraConfig = [
                 custom: [
                         jvmArgs: ["-Xmx1g"]
-                ]
+                ],
+                'h2Settings.address' : 'localhost:10040'
         ]
     }
     node {
@@ -134,7 +137,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         extraConfig = [
                 custom: [
                         jvmArgs: ["-Xmx1g"]
-                ]
+                ],
+                'h2Settings.address' : 'localhost:10041'
         ]
     }
 }

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -54,6 +54,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address "localhost:10003"
             adminAddress "localhost:10004"
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10014']
         cordapps = ["$project.group:finance:$corda_release_version"]
     }
     node {
@@ -65,6 +66,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address "localhost:10006"
             adminAddress "localhost:10007"
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10015']
     }
     node {
         name "O=Bank B,L=New York,C=US"
@@ -75,6 +77,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address "localhost:10009"
             adminAddress "localhost:10010"
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10016']
     }
     node {
         name "O=BankOfCorda,L=New York,C=US"
@@ -85,6 +88,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address "localhost:10012"
             adminAddress "localhost:10013"
         }
+        extraConfig = ['h2Settings.address' : 'localhost:10017']
     }
 }
 


### PR DESCRIPTION
* Set the "h2.allowedClasses" system property
* Require database password when exposing H2 server on non-localhost address
* Samples start H2 server by default (reintroduces the behaviour before `h2Settings.address` configuration option was added)