### PR TITLE
CORDA-1844: Support for high throughput Observables shipped via RPC

### DIFF
--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCHighThroughputObservableTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCHighThroughputObservableTests.kt
@@ -1,6 +1,7 @@
 package net.corda.client.rpc
 
 import net.corda.core.messaging.RPCOps
+import net.corda.core.utilities.millis
 import net.corda.testing.node.internal.RPCDriverDSL
 import net.corda.testing.node.internal.rpcDriver
 import org.junit.Test
@@ -11,10 +12,10 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
-class RPCLargeObservableTests : AbstractRPCTest() {
+class RPCHighThroughputObservableTests : AbstractRPCTest() {
 
     private fun RPCDriverDSL.testProxy(): TestOps {
-        return testProxy<TestOps>(TestOpsImpl()).ops
+        return testProxy<TestOps>(TestOpsImpl(), queueDrainTimeout = 10.millis).ops
     }
 
     internal interface TestOps : RPCOps {

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCLargeObservableTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCLargeObservableTests.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import rx.Observable
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
@@ -24,7 +25,7 @@ class RPCLargeObservableTests : AbstractRPCTest() {
     internal class TestOpsImpl : TestOps {
         override val protocolVersion = 1
 
-        override fun makeObservable(): Observable<Int> = Observable.range(1, Int.MAX_VALUE)
+        override fun makeObservable(): Observable<Int> = Observable.interval(0, TimeUnit.MICROSECONDS).map { it.toInt() + 1 }
     }
 
     @Test

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCLargeObservableTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCLargeObservableTests.kt
@@ -1,0 +1,40 @@
+package net.corda.client.rpc
+
+import net.corda.core.messaging.RPCOps
+import net.corda.testing.node.internal.RPCDriverDSL
+import net.corda.testing.node.internal.rpcDriver
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import rx.Observable
+import kotlin.test.assertEquals
+
+@RunWith(Parameterized::class)
+class RPCLargeObservableTests : AbstractRPCTest() {
+
+    private fun RPCDriverDSL.testProxy(): TestOps {
+        return testProxy<TestOps>(TestOpsImpl()).ops
+    }
+
+    internal interface TestOps : RPCOps {
+
+        fun makeObservable(): Observable<Int>
+    }
+
+    internal class TestOpsImpl : TestOps {
+        override val protocolVersion = 1
+
+        override fun makeObservable(): Observable<Int> = Observable.range(1, Int.MAX_VALUE)
+    }
+
+    @Test
+    fun `simple observable`() {
+        rpcDriver {
+            val proxy = testProxy()
+            // This tests that the observations are transmitted correctly, also check that server side doesn't try to serialize the whole lot
+            // till client consumed some of the output produced.
+            val observations = proxy.makeObservable().take(4).toBlocking().toIterable().toList()
+            assertEquals(listOf(1, 2, 3, 4), observations)
+        }
+    }
+}

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCLargeObservableTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCLargeObservableTests.kt
@@ -34,8 +34,9 @@ class RPCLargeObservableTests : AbstractRPCTest() {
             val proxy = testProxy()
             // This tests that the observations are transmitted correctly, also check that server side doesn't try to serialize the whole lot
             // till client consumed some of the output produced.
-            val observations = proxy.makeObservable().take(4).toBlocking().toIterable().toList()
-            assertEquals(listOf(1, 2, 3, 4), observations)
+            val observations = proxy.makeObservable()
+            val observationsList = observations.take(4).toBlocking().toIterable().toList()
+            assertEquals(listOf(1, 2, 3, 4), observationsList)
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
@@ -18,11 +18,7 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializationDefaults.RPC_SERVER_CONTEXT
 import net.corda.core.serialization.deserialize
-import net.corda.core.utilities.Try
-import net.corda.core.utilities.contextLogger
-import net.corda.core.utilities.days
-import net.corda.core.utilities.debug
-import net.corda.core.utilities.seconds
+import net.corda.core.utilities.*
 import net.corda.node.internal.security.AuthorizingSubject
 import net.corda.node.internal.security.RPCSecurityManager
 import net.corda.node.serialization.amqp.RpcServerObservableSerializer
@@ -247,9 +243,10 @@ class RPCServer(
         }
     }
 
-    fun close() {
+    fun close(queueDrainTimeout: Duration = 1.hours) {
+        // Putting Stop message onto the queue will eventually make senderThread to stop.
         sendJobQueue.put(RpcSendJob.Stop)
-        senderThread?.join()
+        senderThread?.join(queueDrainTimeout.toMillis())
         reaperScheduledFuture?.cancel(false)
         rpcExecutor?.shutdownNow()
         reaperExecutor?.shutdownNow()

--- a/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/messaging/RPCServer.kt
@@ -243,7 +243,7 @@ class RPCServer(
         }
     }
 
-    fun close(queueDrainTimeout: Duration = 1.hours) {
+    fun close(queueDrainTimeout: Duration = 5.seconds) {
         // Putting Stop message onto the queue will eventually make senderThread to stop.
         sendJobQueue.put(RpcSendJob.Stop)
         senderThread?.join(queueDrainTimeout.toMillis())

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -17,6 +17,7 @@ import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.RPCOps
 import net.corda.core.node.NetworkParameters
 import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.core.utilities.millis
 import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.messaging.RPCServer
 import net.corda.node.services.messaging.RPCServerConfiguration
@@ -485,7 +486,7 @@ data class RPCDriverDSL(
                 configuration
         )
         driverDSL.shutdownManager.registerShutdown {
-            rpcServer.close()
+            rpcServer.close(1.millis)
             locator.close()
         }
         rpcServer.start(brokerHandle.serverControl)


### PR DESCRIPTION
Not a proper fix for production code yet, but a testcase exposing the problem.
Also minor extension to RPCServer which will allow to shut it down quicker.