### PR TITLE
CORDA-1839: VaultService.trackBy races with the vault, as does whenConsumed

### DIFF
--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -199,31 +199,6 @@ class StandaloneCordaRPClientTest {
     }
 
     @Test
-    fun `test vault track by after triggering flow`() {
-
-        // Issue some cash
-        rpcProxy.startFlow(::CashIssueFlow, 629.POUNDS, OpaqueBytes.of(0), notaryNodeIdentity)
-
-        // start tracking vault changes
-        val (vault, vaultUpdates) = rpcProxy.vaultTrackBy<Cash.State>(paging = PageSpecification(DEFAULT_PAGE_NUM))
-        assertEquals(0, vault.totalStatesAvailable)
-
-        val updateLatch = CountDownLatch(1)
-        vaultUpdates.subscribe { update ->
-            log.info("Vault>> FlowId=${update.flowId}")
-            updateLatch.countDown()
-        }
-
-        updateLatch.await()
-
-        // Check that this cash exists in the vault
-        val cashBalance = rpcProxy.getCashBalances()
-        log.info("Cash Balances: $cashBalance")
-        assertEquals(1, cashBalance.size)
-        assertEquals(629.POUNDS, cashBalance[Currency.getInstance("GBP")])
-    }
-
-    @Test
     fun `test vault query by`() {
         // Now issue some cash
         rpcProxy.startFlow(::CashIssueFlow, 629.POUNDS, OpaqueBytes.of(0), notaryNodeIdentity)

--- a/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
+++ b/client/rpc/src/smoke-test/kotlin/net/corda/kotlin/rpc/StandaloneCordaRPClientTest.kt
@@ -199,6 +199,31 @@ class StandaloneCordaRPClientTest {
     }
 
     @Test
+    fun `test vault track by after triggering flow`() {
+
+        // Issue some cash
+        rpcProxy.startFlow(::CashIssueFlow, 629.POUNDS, OpaqueBytes.of(0), notaryNodeIdentity)
+
+        // start tracking vault changes
+        val (vault, vaultUpdates) = rpcProxy.vaultTrackBy<Cash.State>(paging = PageSpecification(DEFAULT_PAGE_NUM))
+        assertEquals(0, vault.totalStatesAvailable)
+
+        val updateLatch = CountDownLatch(1)
+        vaultUpdates.subscribe { update ->
+            log.info("Vault>> FlowId=${update.flowId}")
+            updateLatch.countDown()
+        }
+
+        updateLatch.await()
+
+        // Check that this cash exists in the vault
+        val cashBalance = rpcProxy.getCashBalances()
+        log.info("Cash Balances: $cashBalance")
+        assertEquals(1, cashBalance.size)
+        assertEquals(629.POUNDS, cashBalance[Currency.getInstance("GBP")])
+    }
+
+    @Test
     fun `test vault query by`() {
         // Now issue some cash
         rpcProxy.startFlow(::CashIssueFlow, 629.POUNDS, OpaqueBytes.of(0), notaryNodeIdentity)

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -185,6 +185,7 @@ interface VaultService {
         val result = trackBy<ContractState>(query)
         val snapshot = result.snapshot.states
         return if (snapshot.isNotEmpty()) {
+            require(snapshot.size == 1) { "Tracking consumption of single StateRef $ref but snapshot query returned many: $snapshot" }
             doneFuture(Vault.Update(consumed = setOf(snapshot.single()), produced = emptySet()))
         } else {
             result.updates.toFuture()


### PR DESCRIPTION
See details in JIRA.

Effectively there are 3 separate fixes in this PR:
1. Re-written `whenConsumed` in terms of `trackBy` to take into account anything already in the vault.
2. Remove redundant new transaction block.
3. Fix race condition in trackBy() when used concurrently with Vault updates.

Items 1 and 2 are already included in the [Reference States PR](https://github.com/corda/corda/pull/3525).
Item 3 is resolved by alligning the mutex lock closer to transaction commit (in the recordTransactions calling stack) and thus preventing the trackBy() method from acquiring the lock (and associated observable stream) before state is committed to the database.