### PR TITLE
CORDA-1848 Add example alias and autocomplete for CLI tools

### DIFF
--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -47,7 +47,7 @@ class Main : Runnable {
     @Option(names = ["--verbose"], description = ["Enable verbose output."])
     var verbose: Boolean = false
 
-    @Option(names = ["--install-shell-extensions"], description = ["Install bootstrapper alias and autocompletion in bash"])
+    @Option(names = ["--install-shell-extensions"], description = ["Install bootstrapper alias and autocompletion for bash and zsh"])
     var install: Boolean = false
 
     // Return the lines in the file if it exists, else return an empty mutable list
@@ -123,7 +123,7 @@ class Main : Runnable {
 
         println("Installation complete, $alias is available in bash with autocompletion. ")
         println("Type `$alias <options>` from the commandline.")
-        println("Restart bash for this to take effect, or run `. ~/.bashrc` to re-initialise bash now")
+        println("Restart bash for this to take effect, or run `. ~/.bashrc` in bash or `. ~/.zshrc` in zsh to re-initialise your shell now")
     }
 
     private fun checkForAutoCompleteUpdate(alias: String) {

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -29,13 +29,13 @@ fun main(args: Array<String>) {
         versionProvider = CordaVersionProvider::class,
         mixinStandardHelpOptions = true,
         showDefaultValues = true,
-        description = ["Bootstrap a local test Corda network using a set of node conf files and CorDapp JARs"]
+        description = ["Bootstrap a local test Corda network using a set of node configuration files and CorDapp JARs"]
 )
 class Main : Runnable {
     @Option(
             names = ["--dir"],
             description = [
-                "Root directory containing the node conf files and CorDapp JARs that will form the test network.",
+                "Root directory containing the node configuration files and CorDapp JARs that will form the test network.",
                 "It may also contain existing node directories."
             ]
     )
@@ -47,7 +47,7 @@ class Main : Runnable {
     @Option(names = ["--verbose"], description = ["Enable verbose output."])
     var verbose: Boolean = false
 
-    @Option(names = ["--install", "-i"], description = ["Install bootstrapper alias and autocompletion in bash"])
+    @Option(names = ["--install-shell-extensions", "-i"], description = ["Install bootstrapper alias and autocompletion in bash"])
     var install: Boolean = false
 
     // Return the lines in the file if it exists, else return an empty mutable list
@@ -74,29 +74,26 @@ class Main : Runnable {
         }
     }
 
-    // If on windows, Path.toString() returns a path with \ instead of /, but for bash windows users we want to convert those back to /'s
+    // If on Windows, Path.toString() returns a path with \ instead of /, but for bash Windows users we want to convert those back to /'s
     private fun Path.toStringWithDeWindowsfication(): String = this.toAbsolutePath().toString().replace("\\", "/")
 
     private fun install(alias: String) {
         // Get jar location and generate alias command
         val jarLocation = this.javaClass.location.toPath()
-        val command = "alias $alias='java -jar ${jarLocation.toStringWithDeWindowsfication()}'"
+        val command = "alias $alias='java -jar \"${jarLocation.toStringWithDeWindowsfication()}\"'"
 
         val userHome = Paths.get(System.getProperty("user.home"))
 
-        System.out.println("Generating $alias auto completion file")
-        val completionDir = userHome / ".completion"
-        if (!completionDir.exists()) {
-            completionDir.createDirectory()
-        }
-        val autoCompletePath = (completionDir / "$alias").toStringWithDeWindowsfication()
+        println("Generating $alias auto completion file")
+        val completionDir = (userHome / ".completion").createDirectories()
+        val autoCompletePath = (completionDir / "$alias").createDirectories().toStringWithDeWindowsfication()
         picocli.AutoComplete.main("-f", "-n", alias, this.javaClass.name, "-o", autoCompletePath)
 
-        // get bash settings file
+        // Get bash settings file
         val bashSettingsFile = userHome / ".bashrc"
         val bashSettingsFileLines = getFileLines(bashSettingsFile).toMutableList()
 
-        System.out.println("Updating bash settings files")
+        println("Updating bash settings files")
         // Replace any existing bootstrapper alias. There can be only one.
         bashSettingsFileLines.addOrReplaceIfStartsWith("alias $alias", command)
 
@@ -105,9 +102,9 @@ class Main : Runnable {
 
         bashSettingsFile.writeLines(bashSettingsFileLines)
 
-        System.out.println("Installation complete, $alias is available in bash with autocompletion. ")
-        System.out.println("Type `$alias <options>` from the commandline.")
-        System.out.println("Restart bash for this to take effect, or run `. ~/.bashrc` to re-initialise bash now")
+        println("Installation complete, $alias is available in bash with autocompletion. ")
+        println("Type `$alias <options>` from the commandline.")
+        println("Restart bash for this to take effect, or run `. ~/.bashrc` to re-initialise bash now")
     }
 
     override fun run() {

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -117,9 +117,9 @@ class Main : Runnable {
         println("Updating zsh settings files")
         zshSettingsFileLines.addIfNotExists("autoload -U +X compinit && compinit")
         zshSettingsFileLines.addIfNotExists("autoload -U +X bashcompinit && bashcompinit")
-
         zshSettingsFileLines.addOrReplaceIfStartsWith("alias $alias", command)
         zshSettingsFileLines.addIfNotExists(completionFileCommand)
+        zshSettingsFile.writeLines(zshSettingsFileLines)
 
         println("Installation complete, $alias is available in bash with autocompletion. ")
         println("Type `$alias <options>` from the commandline.")

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -97,7 +97,7 @@ class Main : Runnable {
         autoCompleteFile.toFile().appendText(jarSignature(alias, jarHash))
     }
 
-    private fun install(alias: String) {
+    private fun installShellExtensions(alias: String) {
         // Get jar location and generate alias command
         val command = "alias $alias='java -jar \"${jarLocation.toStringWithDeWindowsfication()}\"'"
 
@@ -137,13 +137,17 @@ class Main : Runnable {
         }
     }
 
-    override fun run() {
+    private fun installOrUpdateShellExtensions(alias: String) {
         if (install) {
-            install("bootstrapper")
+            installShellExtensions(alias)
             return
         } else {
-            checkForAutoCompleteUpdate("bootstrapper")
+            checkForAutoCompleteUpdate(alias)
         }
+    }
+
+    override fun run() {
+        installOrUpdateShellExtensions("bootstrapper")
         if (verbose) {
             System.setProperty("logLevel", "trace")
         }

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -48,11 +48,8 @@ class Main : Runnable {
     @Option(names = ["--verbose"], description = ["Enable verbose output."])
     var verbose: Boolean = false
 
-    @Option(names = ["--install-shell-extensions", "-i"], description = ["Install bootstrapper alias and autocompletion in bash"])
+    @Option(names = ["--install-shell-extensions"], description = ["Install bootstrapper alias and autocompletion in bash"])
     var install: Boolean = false
-
-    @Option(names = ["--new-option"], description = ["This is a new option"])
-    var newOption: Boolean = false
 
     // Return the lines in the file if it exists, else return an empty mutable list
     private fun getFileLines(filePath: Path): MutableList<String> {
@@ -90,7 +87,7 @@ class Main : Runnable {
     private fun generateAutoCompleteFile(alias: String) {
         println("Generating $alias auto completion file")
         val autoCompleteFile = getAutoCompleteFileLocation(alias)
-        autoCompleteFile.root.createDirectories()
+        autoCompleteFile.parent.createDirectories()
         picocli.AutoComplete.main("-f", "-n", alias, this.javaClass.name, "-o", autoCompleteFile.toStringWithDeWindowsfication())
 
         // Append hash of file to autocomplete file
@@ -128,7 +125,7 @@ class Main : Runnable {
         if (!autoCompleteFile.exists()) return
 
         var lastLine = ""
-        autoCompleteFile.toFile().forEachLine { lastLine = it.toString() }
+        autoCompleteFile.toFile().forEachLine { lastLine = it }
 
         if (lastLine != jarSignature(alias, jarHash)) {
             println("Old auto completion file detected... regenerating")

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -110,6 +110,16 @@ class Main : Runnable {
         bashSettingsFileLines.addIfNotExists(completionFileCommand)
 
         bashSettingsFile.writeLines(bashSettingsFileLines)
+        // Get zsh settings file
+        val zshSettingsFile = userHome / ".zshrc"
+        val zshSettingsFileLines = getFileLines(zshSettingsFile).toMutableList()
+
+        println("Updating zsh settings files")
+        zshSettingsFileLines.addIfNotExists("autoload -U +X compinit && compinit")
+        zshSettingsFileLines.addIfNotExists("autoload -U +X bashcompinit && bashcompinit")
+
+        zshSettingsFileLines.addOrReplaceIfStartsWith("alias $alias", command)
+        zshSettingsFileLines.addIfNotExists(completionFileCommand)
 
         println("Installation complete, $alias is available in bash with autocompletion. ")
         println("Type `$alias <options>` from the commandline.")


### PR DESCRIPTION
If you run bootstrapper with the `--install-shell-extensions` parameter it will add a line to the `~/.bashrc` settings file creating an alias so that the bootstrapper can be run using `bootstrapper <options>` from the commandline.

It will also create an auto-completion file in `~/.completion/bootstrapper` and add another line to the `~/.bashrc` file which loads all of the files in the `~/.completion` directory.

To test for bash run
```bash
./gradlew clean :tools:bootstrapper:jar
cd ./tools/bootstrapper/build/libs
java -jar network-bootstrapper-4.0-SNAPSHOT.jar --install-shell-extensions
```

Then for bash run:
```bash
. ~/.bashrc
```

For zsh run:
```bash
. ~/.zshrc
```


### TODO
- [x] Test on a unix & mac - I tested on Unix - Tommy tested on mac
- [x] Add support for zsh - done but need to update to picocli 3.3.1 when released to complete
- ~~Merge with @kasiastreich's base class~~ - will do as part of https://r3-cev.atlassian.net/browse/CORDA-1833