### PR TITLE
IdentitySyncFlow - loadStates of an input only if it is in local storage

### DIFF
--- a/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/IdentitySyncFlow.kt
@@ -2,6 +2,7 @@ package net.corda.confidential
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.TransactionResolutionException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
 import net.corda.core.identity.AbstractParty
@@ -53,7 +54,15 @@ object IdentitySyncFlow {
         }
 
         private fun extractOurConfidentialIdentities(): Map<AbstractParty, PartyAndCertificate?> {
-            val states: List<ContractState> = (serviceHub.loadStates(tx.inputs.toSet()).map { it.state.data } + tx.outputs.map { it.data })
+            val inputStates: List<ContractState> = (tx.inputs.toSet()).mapNotNull {
+                try {
+                    serviceHub.loadState(it).data
+                }
+                catch (e: TransactionResolutionException) {
+                    null
+                }
+            }
+            val states: List<ContractState> = inputStates + tx.outputs.map { it.data }
             val identities: Set<AbstractParty> = states.flatMap(ContractState::participants).toSet()
             // Filter participants down to the set of those not in the network map (are not well known)
             val confidentialIdentities = identities


### PR DESCRIPTION
This PR replaces the identical #3430 which is closed due to github merge issues.
This change makes the IdentitySyncFlow usable in more scenarios.
For example, refer to the issue per corda/obligation-cordapp#5 .
In that example, A has an obligation to B and both A and B are anonymous. B transfers it to anonymous C. To make A and C know each other's identity, we use ISF. But it will throw an TransactionResolutionException when C trying to loadStates since C does not have the input in the local storage.
The proposed fix is to first check if an input is in the local storage and load it if it is.


# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
Yes
- [ ] If you added public APIs, did you write the JavaDocs?
N/A
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
