### PR TITLE
CORDA-1799: Always use "/" as a path separator inside JARs

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MutableTestCorDapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MutableTestCorDapp.kt
@@ -15,7 +15,7 @@ internal class MutableTestCorDapp private constructor(override val name: String,
         private const val jarExtension = ".jar"
         private const val whitespace = " "
         private const val whitespaceReplacement = "_"
-        private val productionPathSegments = setOf<(String) -> String>({ "out${File.separator}production${File.separator}classes" }, { fullyQualifiedName -> "main${File.separator}${fullyQualifiedName.packageToPath()}" })
+        private val productionPathSegments = setOf<(String) -> String>({ "out${File.separator}production${File.separator}classes" }, { fullyQualifiedName -> "main${File.separator}${fullyQualifiedName.packageToJarPath()}" })
         private val excludedCordaPackages = setOf("net.corda.core", "net.corda.node")
 
         fun filterTestCorDappClass(fullyQualifiedName: String, url: URL): Boolean {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappsUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappsUtils.kt
@@ -7,7 +7,6 @@ import net.corda.core.internal.outputStream
 import net.corda.node.internal.cordapp.createTestManifest
 import net.corda.testing.driver.TestCorDapp
 import org.apache.commons.io.IOUtils
-import java.io.File
 import java.io.OutputStream
 import java.net.URI
 import java.net.URL
@@ -136,7 +135,7 @@ fun simplifyScanPackages(scanPackages: Iterable<String>): List<String> {
 /**
  * Transforms a class or package name into a path segment.
  */
-internal fun String.packageToPath() = replace(".", File.separator)
+internal fun String.packageToJarPath() = replace(".", "/")
 
 private fun Iterable<JarEntryInfo>.zip(outputStream: ZipOutputStream, willResourceBeAddedBeToCorDapp: (String, URL) -> Boolean): Boolean {
 
@@ -177,7 +176,7 @@ internal sealed class JarEntryInfo(val fullyQualifiedName: String, val url: URL)
      */
     class ClassJarEntryInfo(val clazz: Class<*>) : JarEntryInfo(clazz.name, clazz.classFileURL()) {
 
-        override val entryName = "${fullyQualifiedName.packageToPath()}$fileExtensionSeparator$classFileExtension"
+        override val entryName = "${fullyQualifiedName.packageToJarPath()}$fileExtensionSeparator$classFileExtension"
     }
 
     /**
@@ -188,7 +187,7 @@ internal sealed class JarEntryInfo(val fullyQualifiedName: String, val url: URL)
         override val entryName: String
             get() {
                 val extensionIndex = fullyQualifiedName.lastIndexOf(fileExtensionSeparator)
-                return "${fullyQualifiedName.substring(0 until extensionIndex).packageToPath()}${fullyQualifiedName.substring(extensionIndex)}"
+                return "${fullyQualifiedName.substring(0 until extensionIndex).packageToJarPath()}${fullyQualifiedName.substring(extensionIndex)}"
             }
     }
 
@@ -206,7 +205,7 @@ internal sealed class JarEntryInfo(val fullyQualifiedName: String, val url: URL)
         private fun Class<*>.classFileURL(): URL {
 
             require(protectionDomain?.codeSource?.location != null) { "Invalid class $name for test CorDapp. Classes without protection domain cannot be referenced. This typically happens for Java / Kotlin types." }
-            return URI.create("${protectionDomain.codeSource.location}/${name.packageToPath()}$fileExtensionSeparator$classFileExtension".escaped()).toURL()
+            return URI.create("${protectionDomain.codeSource.location}/${name.packageToJarPath()}$fileExtensionSeparator$classFileExtension".escaped()).toURL()
         }
 
         private fun String.escaped(): String = this.replace(whitespace, whitespaceReplacement)


### PR DESCRIPTION
Or else tests are going to fail on Windows, e.g.:
https://ci-master.corda.r3cev.com/viewLog.html?buildId=103027&tab=buildResultsDiv&buildTypeId=Corda_BuildWindowsTest

```
java.lang.IllegalArgumentException: Illegal character in path at index 95: file:/F:/buildAgent/work/f0cf2ea65c8f73ab/finance/build/libs/corda-finance-4.0-SNAPSHOT.jar/net\corda\finance\contracts\asset\BilateralNetState.class
    at java.net.URI.create(URI.java:852)
    at net.corda.testing.node.internal.JarEntryInfo$Companion.classFileURL(TestCordappsUtils.kt:209)
    at net.corda.testing.node.internal.JarEntryInfo$Companion.access$classFileURL(TestCordappsUtils.kt:199)
    at net.corda.testing.node.internal.JarEntryInfo$ClassJarEntryInfo.<init>(TestCordappsUtils.kt:178)
    at net.corda.testing.node.internal.TestCordappsUtilsKt.jarEntryInfo(TestCordappsUtils.kt:56)
    at net.corda.testing.node.internal.MutableTestCorDapp$Companion.jarEntriesFromClasses(MutableTestCorDapp.kt:42)
...
 ```