### PR TITLE
In AbstractNode check if an initiating flow already has a flow registered to it and throw exception if one has been

### DIFF
--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/CustomVaultQueryTest.kt
@@ -42,7 +42,6 @@ class CustomVaultQueryTest {
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance", "net.corda.docs", "com.template"))
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
-        nodeA.registerInitiatedFlow(TopupIssuerFlow.TopupIssuer::class.java)
         notary = mockNet.defaultNotaryIdentity
     }
 

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/WorkflowTransactionBuildTutorialTest.kt
@@ -36,7 +36,6 @@ class WorkflowTransactionBuildTutorialTest {
         mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.docs"))
         aliceNode = mockNet.createPartyNode(ALICE_NAME)
         bobNode = mockNet.createPartyNode(BOB_NAME)
-        aliceNode.registerInitiatedFlow(RecordCompletionFlow::class.java)
         alice = aliceNode.services.myInfo.identityFromX500Name(ALICE_NAME)
         bob = bobNode.services.myInfo.identityFromX500Name(BOB_NAME)
     }

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -188,7 +188,6 @@ abstract class MQSecurityTest : NodeBasedTest() {
 
     protected fun startBobAndCommunicateWithAlice(): Party {
         val bob = startNode(BOB_NAME)
-        bob.registerInitiatedFlow(ReceiveFlow::class.java)
         val bobParty = bob.info.singleIdentity()
         // Perform a protocol exchange to force the peer queue to be created
         alice.services.startFlow(SendFlow(bobParty, 0)).resultFuture.getOrThrow()

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -671,8 +671,8 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         } else {
             Observable.empty()
         }
-        if (flowFactories.containsKey(initiatingFlowClass)) {
-            throw IllegalStateException("$initiatingFlowClass is attempting to register multiple initiated flows")
+        check(initiatingFlowClass !in flowFactories.keys) {
+            "$initiatingFlowClass is attempting to register multiple initiated flows"
         }
         flowFactories[initiatingFlowClass] = flowFactory
         return observable

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -671,6 +671,9 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         } else {
             Observable.empty()
         }
+        if (flowFactories.containsKey(initiatingFlowClass)) {
+            throw IllegalStateException("$initiatingFlowClass is attempting to register multiple initiated flows")
+        }
         flowFactories[initiatingFlowClass] = flowFactory
         return observable
     }

--- a/node/src/test/kotlin/net/corda/node/internal/FlowRegistrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/FlowRegistrationTest.kt
@@ -1,0 +1,59 @@
+package net.corda.node.internal
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.identity.CordaX500Name
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.node.StartedMockNode
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class FlowRegistrationTest {
+
+    lateinit var mockNetwork: MockNetwork
+    lateinit var node: StartedMockNode
+
+    @Before
+    fun setup() {
+        // no cordapps scanned so it can be tested in isolation
+        mockNetwork = MockNetwork(emptyList())
+    }
+
+    @After
+    fun tearDown() {
+        mockNetwork.stopNodes()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `startup fails when two flows initiated by the same flow are registered`() {
+        node = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("node", "Reading", "GB")))
+        // register the same flow twice to invoke the error without causing errors in other tests
+        node.registerInitiatedFlow(Responder::class.java)
+        node.registerInitiatedFlow(Responder::class.java)
+    }
+
+    @Test
+    fun `a single initiated flow can be registered without error`() {
+        node = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("node", "Reading", "GB")))
+        node.registerInitiatedFlow(Responder::class.java)
+    }
+}
+
+@InitiatingFlow
+class Initiator : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+    }
+}
+
+@InitiatedBy(Initiator::class)
+private class Responder(val session: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/internal/FlowRegistrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/FlowRegistrationTest.kt
@@ -6,22 +6,31 @@ import net.corda.core.flows.FlowSession
 import net.corda.core.flows.InitiatedBy
 import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.utilities.unwrap
+import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNodeParameters
 import net.corda.testing.node.StartedMockNode
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertNotNull
 
 class FlowRegistrationTest {
 
     lateinit var mockNetwork: MockNetwork
-    lateinit var node: StartedMockNode
+    lateinit var initiator: StartedMockNode
+    lateinit var responder: StartedMockNode
 
     @Before
     fun setup() {
         // no cordapps scanned so it can be tested in isolation
         mockNetwork = MockNetwork(emptyList())
+        initiator = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("initiator", "Reading", "GB")))
+        responder = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("responder", "Reading", "GB")))
+        mockNetwork.runNetwork()
     }
 
     @After
@@ -29,25 +38,28 @@ class FlowRegistrationTest {
         mockNetwork.stopNodes()
     }
 
-    @Test(expected = IllegalStateException::class)
+    @Test
     fun `startup fails when two flows initiated by the same flow are registered`() {
-        node = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("node", "Reading", "GB")))
         // register the same flow twice to invoke the error without causing errors in other tests
-        node.registerInitiatedFlow(Responder::class.java)
-        node.registerInitiatedFlow(Responder::class.java)
+        initiator.registerInitiatedFlow(Responder::class.java)
+        assertThatIllegalStateException().isThrownBy { initiator.registerInitiatedFlow(Responder::class.java) }
     }
 
     @Test
     fun `a single initiated flow can be registered without error`() {
-        node = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("node", "Reading", "GB")))
-        node.registerInitiatedFlow(Responder::class.java)
+        initiator.registerInitiatedFlow(Responder::class.java)
+        responder.registerInitiatedFlow(Responder::class.java)
+        val result = initiator.startFlow(Initiator(responder.info.singleIdentity()))
+        mockNetwork.runNetwork()
+        assertNotNull(result.get())
     }
 }
 
 @InitiatingFlow
-class Initiator : FlowLogic<Unit>() {
+class Initiator(val party: Party) : FlowLogic<String>() {
     @Suspendable
-    override fun call() {
+    override fun call(): String {
+        return initiateFlow(party).sendAndReceive<String>("Hello there").unwrap { it }
     }
 }
 
@@ -55,5 +67,7 @@ class Initiator : FlowLogic<Unit>() {
 private class Responder(val session: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
+        session.receive<String>().unwrap { it }
+        session.send("What's up")
     }
 }

--- a/node/src/test/kotlin/net/corda/node/internal/FlowRegistrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/FlowRegistrationTest.kt
@@ -41,13 +41,12 @@ class FlowRegistrationTest {
     @Test
     fun `startup fails when two flows initiated by the same flow are registered`() {
         // register the same flow twice to invoke the error without causing errors in other tests
-        initiator.registerInitiatedFlow(Responder::class.java)
-        assertThatIllegalStateException().isThrownBy { initiator.registerInitiatedFlow(Responder::class.java) }
+        responder.registerInitiatedFlow(Responder::class.java)
+        assertThatIllegalStateException().isThrownBy { responder.registerInitiatedFlow(Responder::class.java) }
     }
 
     @Test
     fun `a single initiated flow can be registered without error`() {
-        initiator.registerInitiatedFlow(Responder::class.java)
         responder.registerInitiatedFlow(Responder::class.java)
         val result = initiator.startFlow(Initiator(responder.info.singleIdentity()))
         mockNetwork.runNetwork()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -65,7 +65,7 @@ class FlowFrameworkTests {
     }
 
     @Before
-    fun before() {
+    fun setUpGlobalMockNet() {
         mockNet = InternalMockNetwork(
                 cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
                 servicePeerAllocationStrategy = RoundRobin()
@@ -87,7 +87,7 @@ class FlowFrameworkTests {
     }
 
     @After
-    fun after() {
+    fun cleanUp() {
         mockNet.stopNodes()
         receivedSessionMessages.clear()
     }
@@ -472,7 +472,7 @@ class FlowFrameworkTripartyTests {
     }
 
     @Before
-    fun before() {
+    fun setUpGlobalMockNet() {
         mockNet = InternalMockNetwork(
                 cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
                 servicePeerAllocationStrategy = RoundRobin()
@@ -493,7 +493,7 @@ class FlowFrameworkTripartyTests {
     }
 
     @After
-    fun after() {
+    fun cleanUp() {
         mockNet.stopNodes()
         receivedSessionMessages.clear()
     }

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -53,19 +53,18 @@ class FlowFrameworkTests {
         init {
             LogHelper.setLevel("+net.corda.flow")
         }
-
-        private lateinit var mockNet: InternalMockNetwork
-        private lateinit var aliceNode: TestStartedNode
-        private lateinit var bobNode: TestStartedNode
-        private lateinit var alice: Party
-        private lateinit var bob: Party
-        private lateinit var notaryIdentity: Party
-        private val receivedSessionMessages = ArrayList<SessionTransfer>()
-
     }
 
+    private lateinit var mockNet: InternalMockNetwork
+    private lateinit var aliceNode: TestStartedNode
+    private lateinit var bobNode: TestStartedNode
+    private lateinit var alice: Party
+    private lateinit var bob: Party
+    private lateinit var notaryIdentity: Party
+    private val receivedSessionMessages = ArrayList<SessionTransfer>()
+
     @Before
-    fun setUpGlobalMockNet() {
+    fun setUpMockNet() {
         mockNet = InternalMockNetwork(
                 cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
                 servicePeerAllocationStrategy = RoundRobin()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -62,38 +62,33 @@ class FlowFrameworkTests {
         private lateinit var notaryIdentity: Party
         private val receivedSessionMessages = ArrayList<SessionTransfer>()
 
-        @BeforeClass
-        @JvmStatic
-        fun beforeClass() {
-            mockNet = InternalMockNetwork(
-                    cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
-                    servicePeerAllocationStrategy = RoundRobin()
-            )
+    }
 
-            aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
-            bobNode = mockNet.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
+    @Before
+    fun before() {
+        mockNet = InternalMockNetwork(
+                cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
+                servicePeerAllocationStrategy = RoundRobin()
+        )
 
-            // Extract identities
-            alice = aliceNode.info.singleIdentity()
-            bob = bobNode.info.singleIdentity()
-            notaryIdentity = mockNet.defaultNotaryIdentity
+        aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
+        bobNode = mockNet.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
 
-            receivedSessionMessagesObservable().forEach { receivedSessionMessages += it }
-        }
+        // Extract identities
+        alice = aliceNode.info.singleIdentity()
+        bob = bobNode.info.singleIdentity()
+        notaryIdentity = mockNet.defaultNotaryIdentity
 
-        private fun receivedSessionMessagesObservable(): Observable<SessionTransfer> {
-            return mockNet.messagingNetwork.receivedMessages.toSessionTransfers()
-        }
+        receivedSessionMessagesObservable().forEach { receivedSessionMessages += it }
+    }
 
-        @AfterClass @JvmStatic
-        fun afterClass() {
-            mockNet.stopNodes()
-        }
-
+    private fun receivedSessionMessagesObservable(): Observable<SessionTransfer> {
+        return mockNet.messagingNetwork.receivedMessages.toSessionTransfers()
     }
 
     @After
-    fun cleanUp() {
+    fun after() {
+        mockNet.stopNodes()
         receivedSessionMessages.clear()
     }
 
@@ -474,45 +469,38 @@ class FlowFrameworkTripartyTests {
         private lateinit var charlie: Party
         private lateinit var notaryIdentity: Party
         private val receivedSessionMessages = ArrayList<SessionTransfer>()
+    }
 
-        @BeforeClass
-        @JvmStatic
-        fun beforeClass() {
-            mockNet = InternalMockNetwork(
-                    cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
-                    servicePeerAllocationStrategy = RoundRobin()
-            )
+    @Before
+    fun before() {
+        mockNet = InternalMockNetwork(
+                cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
+                servicePeerAllocationStrategy = RoundRobin()
+        )
 
-            aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
-            bobNode = mockNet.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
-            charlieNode = mockNet.createNode(InternalMockNodeParameters(legalName = CHARLIE_NAME))
+        aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
+        bobNode = mockNet.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
+        charlieNode = mockNet.createNode(InternalMockNodeParameters(legalName = CHARLIE_NAME))
 
 
-            // Extract identities
-            alice = aliceNode.info.singleIdentity()
-            bob = bobNode.info.singleIdentity()
-            charlie = charlieNode.info.singleIdentity()
-            notaryIdentity = mockNet.defaultNotaryIdentity
+        // Extract identities
+        alice = aliceNode.info.singleIdentity()
+        bob = bobNode.info.singleIdentity()
+        charlie = charlieNode.info.singleIdentity()
+        notaryIdentity = mockNet.defaultNotaryIdentity
 
-            receivedSessionMessagesObservable().forEach { receivedSessionMessages += it }
-        }
-
-        @AfterClass @JvmStatic
-        fun afterClass() {
-            mockNet.stopNodes()
-        }
-
-        private fun receivedSessionMessagesObservable(): Observable<SessionTransfer> {
-            return mockNet.messagingNetwork.receivedMessages.toSessionTransfers()
-        }
-
+        receivedSessionMessagesObservable().forEach { receivedSessionMessages += it }
     }
 
     @After
-    fun cleanUp() {
+    fun after() {
+        mockNet.stopNodes()
         receivedSessionMessages.clear()
     }
 
+    private fun receivedSessionMessagesObservable(): Observable<SessionTransfer> {
+        return mockNet.messagingNetwork.receivedMessages.toSessionTransfers()
+    }
 
     @Test
     fun `sending to multiple parties`() {


### PR DESCRIPTION
In AbstractNode.internalRegisterFlowFactory check if a flow factory already exists for an initiating flow
If a factory does exist, throw an exception
A few tests needed to be fixed due to this change

One extra thing I want to note.

It looks like this is already somewhat handled when loading a Cordapp and that the change I have made is more likely to catch an issue in a test than in an actual application. When the cordapp is loaded with multiple registered flows you will get the following error.
```
java.lang.IllegalArgumentException: net.corda.node.Initiator has been specified as the initiating flow by both net.corda.node.Responder and net.corda.node.AnotherResponder
```
In cases where this error doesn't occur, the change I have made will catch the error.