### PR TITLE
CORDA-916: Add registerFlowFactory method to public test API

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6219,6 +6219,10 @@ public static final class net.corda.testing.node.InMemoryMessagingNetwork$Servic
   public final java.util.SplittableRandom getRandom()
   public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
 ##
+@FunctionalInterface
+public interface ResponderFlowFactory<F extends net.corda.core.flows.FlowLogic<?>>
+  public F invoke(net.corda.core.flows.FlowSession)
+##
 @DoNotImplement
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
   public <init>()

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6219,10 +6219,6 @@ public static final class net.corda.testing.node.InMemoryMessagingNetwork$Servic
   public final java.util.SplittableRandom getRandom()
   public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
 ##
-@FunctionalInterface
-public interface ResponderFlowFactory<F extends net.corda.core.flows.FlowLogic<?>>
-  public F invoke(net.corda.core.flows.FlowSession)
-##
 @DoNotImplement
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
   public <init>()
@@ -6520,6 +6516,10 @@ public final class net.corda.testing.node.NotarySpec extends java.lang.Object
   public final net.corda.testing.driver.VerifierType getVerifierType()
   public int hashCode()
   public String toString()
+##
+public interface net.corda.testing.node.ResponderFlowFactory
+  @NotNull
+  public abstract F invoke(net.corda.core.flows.FlowSession)
 ##
 public final class net.corda.testing.node.StartedMockNode extends java.lang.Object
   @NotNull

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ release, see :doc:`upgrade-notes`.
 
 Unreleased
 ----------
+* Added ``registerResponderFlow`` method to ``StartedMockNode``, to support isolated testing of responder flow behaviour.
+
 * Introduced ``TestCorDapp`` and utilities to support asymmetric setups for nodes through ``DriverDSL``, ``MockNetwork`` and ``MockServices``.
 
 * Change type of the `checkpoint_value` column. Please check the upgrade-notes on how to update your database.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -186,9 +186,9 @@ class StartedMockNode private constructor(private val node: TestStartedNode) {
      * Register an [InitiatedFlowFactory], to control relationship between initiating and receiving flow classes
      * explicitly on a node-by-node basis.
      */
-    fun <F : FlowLogic<*>> registerFlowFactory(initiatingFlowClass: Class<out FlowLogic<*>>,
-                                               flowFactory: InitiatedFlowFactory<F>,
-                                               initiatedFlowClass: Class<F>): CordaFuture<F> =
+    fun <F : FlowLogic<*>> registerResponderFlow(initiatingFlowClass: Class<out FlowLogic<*>>,
+                                                 flowFactory: InitiatedFlowFactory<F>,
+                                                 initiatedFlowClass: Class<F>): CordaFuture<F> =
             node.registerFlowFactory(initiatingFlowClass, flowFactory, initiatedFlowClass, true)
                     .toFuture()
 }
@@ -197,10 +197,10 @@ class StartedMockNode private constructor(private val node: TestStartedNode) {
  * Kotlin-only utility function using a reified type parameter and a lambda parameter to simplify the
  * [InitiatedFlowFactory.registerFlowFactory] function.
  */
-inline fun <reified F : FlowLogic<*>> StartedMockNode.registerFlowFactory(
+inline fun <reified F : FlowLogic<*>> StartedMockNode.registerResponderFlow(
         initiatingFlowClass: Class<out FlowLogic<*>>,
         noinline flowFactory: (FlowSession) -> F): Future<F> =
-        registerFlowFactory(
+        registerResponderFlow(
                 initiatingFlowClass,
                 InitiatedFlowFactory.CorDapp(flowVersion = 0, appName = "", factory = flowFactory),
                 F::class.java)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -188,7 +188,7 @@ class StartedMockNode private constructor(private val node: TestStartedNode) {
      */
     fun <F : FlowLogic<*>> registerFlowFactory(initiatingFlowClass: Class<out FlowLogic<*>>,
                                                flowFactory: InitiatedFlowFactory<F>,
-                                               initiatedFlowClass: Class<F>): Future<F> =
+                                               initiatedFlowClass: Class<F>): CordaFuture<F> =
             node.registerFlowFactory(initiatingFlowClass, flowFactory, initiatedFlowClass, true)
                     .toFuture()
 }

--- a/testing/node-driver/src/test/java/net/corda/testing/node/TestResponseFlowInIsolationInJava.java
+++ b/testing/node-driver/src/test/java/net/corda/testing/node/TestResponseFlowInIsolationInJava.java
@@ -1,0 +1,122 @@
+package net.corda.testing.node;
+
+import co.paralleluniverse.fibers.Suspendable;
+import net.corda.core.concurrent.CordaFuture;
+import net.corda.core.flows.*;
+import net.corda.core.identity.Party;
+import net.corda.core.utilities.UntrustworthyData;
+import net.corda.node.internal.InitiatedFlowFactory;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.Future;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Java version of test based on the example given as an answer to this SO question:
+ *
+ * https://stackoverflow.com/questions/48166626/how-can-an-acceptor-flow-in-corda-be-isolated-for-unit-testing/
+ *
+ * but using the `registerFlowFactory` method implemented in response to https://r3-cev.atlassian.net/browse/CORDA-916
+ */
+public class TestResponseFlowInIsolationInJava {
+
+    private final MockNetwork network = new MockNetwork(singletonList("com.template"));
+    private final StartedMockNode a = network.createNode();
+    private final StartedMockNode b = network.createNode();
+
+    @After
+    public void tearDown() {
+        network.stopNodes();
+    }
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void test() throws Exception {
+        // This method returns the Responder flow object used by node B.
+        Future<Responder> initiatedResponderFlowFuture = b.registerFlowFactory(
+                // We tell node B to respond to BadInitiator with Responder.
+                // We want to observe the Responder flow object to check for errors.
+                BadInitiator.class, flowFactory, Responder.class);
+
+        // We run the BadInitiator flow on node A.
+        BadInitiator flow = new BadInitiator(b.getInfo().getLegalIdentities().get(0));
+        CordaFuture<Void> future = a.startFlow(flow);
+        network.runNetwork();
+        future.get();
+
+        // We check that the invocation of the Responder flow object has caused an ExecutionException.
+        Responder initiatedResponderFlow = initiatedResponderFlowFuture.get();
+        CordaFuture initiatedResponderFlowResultFuture = initiatedResponderFlow.getStateMachine().getResultFuture();
+        exception.expectCause(instanceOf(FlowException.class));
+        exception.expectMessage("String did not contain the expected message.");
+        initiatedResponderFlowResultFuture.get();
+    }
+
+    // This is the real implementation of Initiator.
+    @InitiatingFlow
+    @StartableByRPC
+    public static class Initiator extends FlowLogic<Void> {
+        private Party counterparty;
+
+        public Initiator(Party counterparty) {
+            this.counterparty = counterparty;
+        }
+
+        @Suspendable
+        @Override public Void call() {
+            FlowSession session = initiateFlow(counterparty);
+            session.send("goodString");
+            return null;
+        }
+    }
+
+    // This is the response flow that we want to isolate for testing.
+    @InitiatedBy(Initiator.class)
+    public static class Responder extends FlowLogic<Void> {
+        private final FlowSession counterpartySession;
+
+        Responder(FlowSession counterpartySession) {
+            this.counterpartySession = counterpartySession;
+        }
+
+        @Suspendable
+        @Override
+        public Void call() throws FlowException {
+            UntrustworthyData<String> packet = counterpartySession.receive(String.class);
+            String string = packet.unwrap(data -> data);
+            if (!string.equals("goodString")) {
+                throw new FlowException("String did not contain the expected message.");
+            }
+            return null;
+        }
+    }
+
+    private static final InitiatedFlowFactory.CorDapp<Responder> flowFactory = new InitiatedFlowFactory.CorDapp<>(
+            0,
+            "",
+            Responder::new
+    );
+
+    @InitiatingFlow
+    public static final class BadInitiator extends FlowLogic<Void> {
+        private final Party counterparty;
+
+        BadInitiator(Party counterparty) {
+            this.counterparty = counterparty;
+        }
+
+        @Suspendable
+        @Override public Void call() {
+            FlowSession session = initiateFlow(counterparty);
+            session.send("badString");
+            return null;
+        }
+    }
+}

--- a/testing/node-driver/src/test/java/net/corda/testing/node/TestResponseFlowInIsolationInJava.java
+++ b/testing/node-driver/src/test/java/net/corda/testing/node/TestResponseFlowInIsolationInJava.java
@@ -5,7 +5,6 @@ import net.corda.core.concurrent.CordaFuture;
 import net.corda.core.flows.*;
 import net.corda.core.identity.Party;
 import net.corda.core.utilities.UntrustworthyData;
-import net.corda.node.internal.InitiatedFlowFactory;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,13 +24,6 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class TestResponseFlowInIsolationInJava {
 
-    // An InitiatedFlowFactory that initiates a Responder, given a FlowSession.
-    private static final InitiatedFlowFactory.CorDapp<Responder> FLOW_FACTORY = new InitiatedFlowFactory.CorDapp<>(
-            0,
-            "",
-            Responder::new
-    );
-
     private final MockNetwork network = new MockNetwork(singletonList("com.template"));
     private final StartedMockNode a = network.createNode();
     private final StartedMockNode b = network.createNode();
@@ -50,7 +42,7 @@ public class TestResponseFlowInIsolationInJava {
         Future<Responder> initiatedResponderFlowFuture = b.registerResponderFlow(
                 // We tell node B to respond to BadInitiator with Responder.
                 // We want to observe the Responder flow object to check for errors.
-                BadInitiator.class, FLOW_FACTORY, Responder.class);
+                BadInitiator.class, Responder::new, Responder.class);
 
         // We run the BadInitiator flow on node A.
         BadInitiator flow = new BadInitiator(b.getInfo().getLegalIdentities().get(0));

--- a/testing/node-driver/src/test/java/net/corda/testing/node/TestResponseFlowInIsolationInJava.java
+++ b/testing/node-driver/src/test/java/net/corda/testing/node/TestResponseFlowInIsolationInJava.java
@@ -25,6 +25,13 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class TestResponseFlowInIsolationInJava {
 
+    // An InitiatedFlowFactory that initiates a Responder, given a FlowSession.
+    private static final InitiatedFlowFactory.CorDapp<Responder> FLOW_FACTORY = new InitiatedFlowFactory.CorDapp<>(
+            0,
+            "",
+            Responder::new
+    );
+
     private final MockNetwork network = new MockNetwork(singletonList("com.template"));
     private final StartedMockNode a = network.createNode();
     private final StartedMockNode b = network.createNode();
@@ -40,10 +47,10 @@ public class TestResponseFlowInIsolationInJava {
     @Test
     public void test() throws Exception {
         // This method returns the Responder flow object used by node B.
-        Future<Responder> initiatedResponderFlowFuture = b.registerFlowFactory(
+        Future<Responder> initiatedResponderFlowFuture = b.registerResponderFlow(
                 // We tell node B to respond to BadInitiator with Responder.
                 // We want to observe the Responder flow object to check for errors.
-                BadInitiator.class, flowFactory, Responder.class);
+                BadInitiator.class, FLOW_FACTORY, Responder.class);
 
         // We run the BadInitiator flow on node A.
         BadInitiator flow = new BadInitiator(b.getInfo().getLegalIdentities().get(0));
@@ -97,12 +104,6 @@ public class TestResponseFlowInIsolationInJava {
             return null;
         }
     }
-
-    private static final InitiatedFlowFactory.CorDapp<Responder> flowFactory = new InitiatedFlowFactory.CorDapp<>(
-            0,
-            "",
-            Responder::new
-    );
 
     @InitiatingFlow
     public static final class BadInitiator extends FlowLogic<Void> {

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
@@ -1,0 +1,90 @@
+package net.corda.testing.node.internal
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.utilities.unwrap
+import net.corda.node.internal.InitiatedFlowFactory
+import net.corda.testing.internal.chooseIdentity
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.registerFlowFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Test
+import java.util.concurrent.ExecutionException
+import kotlin.test.assertFailsWith
+
+/**
+ * Test based on the example given as an answer to this SO question:
+ *
+ * https://stackoverflow.com/questions/48166626/how-can-an-acceptor-flow-in-corda-be-isolated-for-unit-testing/
+ *
+ * but using the `registerFlowFactory` method implemented in response to https://r3-cev.atlassian.net/browse/CORDA-916
+ */
+class TestResponseFlowInIsolation {
+
+    private val network: MockNetwork = MockNetwork(listOf("com.template"))
+    private val a = network.createNode()
+    private val b = network.createNode()
+
+    @After
+    fun tearDown() = network.stopNodes()
+
+    // This is the real implementation of Initiator.
+    @InitiatingFlow
+    open class Initiator(val counterparty: Party) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val session = initiateFlow(counterparty)
+            session.send("goodString")
+        }
+    }
+
+    // This is the response flow that we want to isolate for testing.
+    @InitiatedBy(Initiator::class)
+    class Responder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val string = counterpartySession.receive<String>().unwrap { contents -> contents }
+            if (string != "goodString") {
+                throw FlowException("String did not contain the expected message.")
+            }
+        }
+    }
+
+    // This is a fake implementation of Initiator to check how Responder responds to non-golden-path scenarios.
+    @InitiatingFlow
+    class BadInitiator(val counterparty: Party): FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val session = initiateFlow(counterparty)
+            session.send("badString")
+        }
+    }
+
+    @Test
+    fun `test`() {
+        // This method returns the Responder flow object used by node B.
+        // We tell node B to respond to BadInitiator with Responder.
+        val initiatedResponderFlowFuture = b.registerFlowFactory(
+                initiatingFlowClass = BadInitiator::class.java,
+                flowFactory = ::Responder)
+
+        // We run the BadInitiator flow on node A.
+        val flow = BadInitiator(b.info.chooseIdentity())
+        val future = a.startFlow(flow)
+        network.runNetwork()
+        future.get()
+
+        // We check that the invocation of the Responder flow object has caused an ExecutionException.
+        val initiatedResponderFlow = initiatedResponderFlowFuture.get()
+        val initiatedResponderFlowResultFuture = initiatedResponderFlow.stateMachine.resultFuture
+
+        val exceptionFromFlow = assertFailsWith<ExecutionException> {
+            initiatedResponderFlowResultFuture.get()
+        }.cause
+        assertThat(exceptionFromFlow)
+                .isInstanceOf(FlowException::class.java)
+                .hasMessage("String did not contain the expected message.")
+    }
+}

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/TestResponseFlowInIsolation.kt
@@ -4,10 +4,9 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.utilities.unwrap
-import net.corda.node.internal.InitiatedFlowFactory
 import net.corda.testing.internal.chooseIdentity
 import net.corda.testing.node.MockNetwork
-import net.corda.testing.node.registerFlowFactory
+import net.corda.testing.node.registerResponderFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Test
@@ -66,7 +65,7 @@ class TestResponseFlowInIsolation {
     fun `test`() {
         // This method returns the Responder flow object used by node B.
         // We tell node B to respond to BadInitiator with Responder.
-        val initiatedResponderFlowFuture = b.registerFlowFactory(
+        val initiatedResponderFlowFuture = b.registerResponderFlow(
                 initiatingFlowClass = BadInitiator::class.java,
                 flowFactory = ::Responder)
 


### PR DESCRIPTION
An addition (non-breaking change) to the public test API (`MockNet` and `StartedMockNode`) to support a customer use case (see [CORDA-916](https://r3-cev.atlassian.net/browse/CORDA-916) and the associated [StackOverflow query](https://stackoverflow.com/questions/48166626/how-can-an-acceptor-flow-in-corda-be-isolated-for-unit-testing/)).

This PR adds a method, `StartedMockNode.registerFlowFactory` to the `StartedMockNode` API, and includes tests in Java and Kotlin, based on the original use case, which show this method in use.

It also adds a Kotlin-only extension method to `StartedMockNode` which makes use of Kotlin language features (reified type-parameters and lambda parameters) to provide a simplified form of the same functionality for Kotlin users.