### PR TITLE
Added checks against the use of the special uploader tokens

### DIFF
--- a/core-deterministic/testing/common/src/main/kotlin/net/corda/deterministic/common/TransactionVerificationRequest.kt
+++ b/core-deterministic/testing/common/src/main/kotlin/net/corda/deterministic/common/TransactionVerificationRequest.kt
@@ -3,7 +3,7 @@ package net.corda.deterministic.common
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.ContractClassName
-import net.corda.core.internal.TEST_UPLOADER
+import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
@@ -18,8 +18,9 @@ class TransactionVerificationRequest(val wtxToVerify: SerializedBytes<WireTransa
     fun toLedgerTransaction(): LedgerTransaction {
         val deps = dependencies.map { it.deserialize() }.associateBy(WireTransaction::id)
         val attachments = attachments.map { it.deserialize<Attachment>() }
-        val attachmentMap = attachments.mapNotNull { it as? MockContractAttachment }
-                .associateBy(Attachment::id) { ContractAttachment(it, it.contract, uploader=TEST_UPLOADER) }
+        val attachmentMap = attachments
+                .mapNotNull { it as? MockContractAttachment }
+                .associateBy(Attachment::id) { ContractAttachment(it, it.contract, uploader = DEPLOYED_CORDAPP_UPLOADER) }
         val contractAttachmentMap = emptyMap<ContractClassName, ContractAttachment>()
         @Suppress("DEPRECATION")
         return wtxToVerify.deserialize().toLedgerTransaction(

--- a/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
@@ -16,15 +16,14 @@ import java.security.CodeSigner
 import java.security.cert.X509Certificate
 import java.util.jar.JarInputStream
 
-// Possible attachment uploaders
 const val DEPLOYED_CORDAPP_UPLOADER = "app"
 const val RPC_UPLOADER = "rpc"
-const val TEST_UPLOADER = "test"
 const val P2P_UPLOADER = "p2p"
 const val UNKNOWN_UPLOADER = "unknown"
 
-fun isUploaderTrusted(uploader: String?) =
-        uploader?.let { it in listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER, TEST_UPLOADER) } ?: false
+private val TRUSTED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER)
+
+fun isUploaderTrusted(uploader: String?): Boolean = uploader in TRUSTED_UPLOADERS
 
 @KeepForDJVM
 abstract class AbstractAttachment(dataLoader: () -> ByteArray) : Attachment {

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,9 @@ release, see :doc:`upgrade-notes`.
 
 Unreleased
 ----------
+* "app", "rpc", "p2p" and "unknown" are no longer allowed as uploader values when importing attachments. These are used
+  internally in security sensitive code.
+
 * Introduced ``TestCorDapp`` and utilities to support asymmetric setups for nodes through ``DriverDSL``, ``MockNetwork`` and ``MockServices``.
 
 * Change type of the `checkpoint_value` column. Please check the upgrade-notes on how to update your database.

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -899,7 +899,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         override val transactionVerifierService: TransactionVerifierService get() = this@AbstractNode.transactionVerifierService
         override val contractUpgradeService: ContractUpgradeService get() = this@AbstractNode.contractUpgradeService
         override val auditService: AuditService get() = this@AbstractNode.auditService
-        override val attachments: AttachmentStorage get() = this@AbstractNode.attachments
+        override val attachments: AttachmentStorageInternal get() = this@AbstractNode.attachments
         override val networkService: MessagingService get() = network
         override val clock: Clock get() = platformClock
         override val configuration: NodeConfiguration get() = this@AbstractNode.configuration

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
@@ -14,6 +14,7 @@ import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.contextLogger
 import net.corda.node.cordapp.CordappLoader
+import net.corda.node.services.persistence.AttachmentStorageInternal
 import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 
@@ -89,7 +90,13 @@ open class CordappProviderImpl(private val cordappLoader: CordappLoader,
             cordapps.filter { !it.contractClassNames.isEmpty() }.map {
                 it.jarPath.openStream().use { stream ->
                     try {
-                        attachmentStorage.importAttachment(stream, DEPLOYED_CORDAPP_UPLOADER, null)
+                        // We can't make attachmentStorage a AttachmentStorageInternal as that ends up requiring
+                        // MockAttachmentStorage to implement it.
+                        if (attachmentStorage is AttachmentStorageInternal) {
+                            attachmentStorage.privilegedImportAttachment(stream, DEPLOYED_CORDAPP_UPLOADER, null)
+                        } else {
+                            attachmentStorage.importAttachment(stream, DEPLOYED_CORDAPP_UPLOADER, null)
+                        }
                     } catch (faee: java.nio.file.FileAlreadyExistsException) {
                         AttachmentId.parse(faee.message!!)
                     }

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -21,6 +21,7 @@ import net.corda.node.internal.cordapp.CordappProviderInternal
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.messaging.MessagingService
 import net.corda.node.services.network.NetworkMapUpdater
+import net.corda.node.services.persistence.AttachmentStorageInternal
 import net.corda.node.services.statemachine.ExternalEvent
 import net.corda.node.services.statemachine.FlowStateMachineImpl
 import net.corda.nodeapi.internal.persistence.CordaPersistence
@@ -105,6 +106,7 @@ interface ServiceHubInternal : ServiceHub {
         }
     }
 
+    override val attachments: AttachmentStorageInternal
     override val vaultService: VaultServiceInternal
     /**
      * A map of hash->tx where tx has been signature/contract validated and the states are known to be correct.

--- a/node/src/main/kotlin/net/corda/node/services/persistence/AttachmentStorageInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/AttachmentStorageInternal.kt
@@ -1,0 +1,13 @@
+package net.corda.node.services.persistence
+
+import net.corda.core.node.services.AttachmentId
+import net.corda.core.node.services.AttachmentStorage
+import java.io.InputStream
+
+interface AttachmentStorageInternal : AttachmentStorage {
+    /**
+     * This is the same as [importAttachment] expect there are no checks done on the uploader field. This API is internal
+     * and is only for the node.
+     */
+    fun privilegedImportAttachment(jar: InputStream, uploader: String, filename: String?): AttachmentId
+}

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -147,7 +147,7 @@ open class InternalMockNetwork(defaultParameters: MockNetworkParameters = MockNe
                                val testDirectory: Path = Paths.get("build", getTimestampAsDirectoryName()),
                                val networkParameters: NetworkParameters = testNetworkParameters(),
                                val defaultFactory: (MockNodeArgs, CordappLoader?) -> MockNode = { args, cordappLoader -> cordappLoader?.let { MockNode(args, it) } ?: MockNode(args) },
-                               val cordappsForAllNodes: Set<TestCorDapp> = emptySet()) {
+                               val cordappsForAllNodes: Set<TestCorDapp> = emptySet()) : AutoCloseable {
     init {
         // Apache SSHD for whatever reason registers a SFTP FileSystemProvider - which gets loaded by JimFS.
         // This SFTP support loads BouncyCastle, which we want to avoid.
@@ -551,6 +551,8 @@ open class InternalMockNetwork(defaultParameters: MockNetworkParameters = MockNe
     fun waitQuiescent() {
         busyLatch.await()
     }
+
+    override fun close() = stopNodes()
 }
 
 abstract class MessagingServiceSpy {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -288,7 +288,7 @@ data class TestLedgerDSLInterpreter private constructor(
             copy().dsl()
 
     override fun attachment(attachment: InputStream): SecureHash {
-        return services.attachments.importAttachment(attachment, UNKNOWN_UPLOADER, null)
+        return services.attachments.importAttachment(attachment, "TestDSL", null)
     }
 
     override fun verifies(): EnforceVerifyOrFail {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappProvider.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/MockCordappProvider.kt
@@ -3,12 +3,11 @@ package net.corda.testing.internal
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.cordapp.Cordapp
 import net.corda.core.crypto.SecureHash
-import net.corda.core.internal.TEST_UPLOADER
+import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
 import net.corda.core.internal.cordapp.CordappImpl
 import net.corda.core.node.services.AttachmentId
 import net.corda.core.node.services.AttachmentStorage
 import net.corda.node.cordapp.CordappLoader
-import net.corda.node.internal.cordapp.JarScanningCordappLoader
 import net.corda.node.internal.cordapp.CordappProviderImpl
 import net.corda.testing.services.MockAttachmentStorage
 import java.nio.file.Paths
@@ -50,7 +49,7 @@ class MockCordappProvider(
         return if (!existingAttachment.isEmpty()) {
             existingAttachment.keys.first()
         } else {
-            attachments.importContractAttachment(contractClassNames, TEST_UPLOADER, data.inputStream())
+            attachments.importContractAttachment(contractClassNames, DEPLOYED_CORDAPP_UPLOADER, data.inputStream())
         }
     }
 }


### PR DESCRIPTION
"app", "rpc", "p2p" and "unknown" have security implications (see isUploaderTrusted method) and thus they are not allowed to be used in the uploader field when importing attachments via the public API.
