### PR TITLE
Added more descriptive error message for the cases when a transaction…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -188,7 +188,9 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
 
     private fun checkDbTransaction(isPresent: Boolean) {
         if (isPresent) {
-            requireNotNull(contextTransactionOrNull)
+            requireNotNull(contextTransactionOrNull) {
+                "Transaction context is missing. This might happen if a suspendable method is not annotated with @Suspendable annotation."
+            }
         } else {
             require(contextTransactionOrNull == null)
         }


### PR DESCRIPTION
In the most of the cases (all that I've seen so far), missing transaction context indecates that a suspendable method is missing @Suspendable annotation. Added more descriptive message to ease life of the people who encounter such error in the first time.