### PR TITLE
CORDA-1861: Remove default value to make createUnstartedNode() unambiguous.

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -411,7 +411,7 @@ open class MockNetwork(
                             forcedID: Int? = null,
                             entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
                             configOverrides: (NodeConfiguration) -> Any? = {},
-                            additionalCordapps: Set<TestCorDapp> = emptySet()): UnstartedMockNode {
+                            additionalCordapps: Set<TestCorDapp>): UnstartedMockNode {
         val parameters = MockNodeParameters(forcedID, legalName, entropyRoot, configOverrides, additionalCordapps)
         return UnstartedMockNode.create(internalMockNetwork.createUnstartedNode(InternalMockNodeParameters(parameters)))
     }


### PR DESCRIPTION
There are two variants of `MockNetwork.createUnstartedNode(...)`, and their default parameters make
the following call ambiguous:
```kotlin
val node = mockNetwork.createUnstartedNode(DUMMY_BANK_A_NAME)
```
Remove the default value for `additionalCordapps` to align this API with `MockNetwork.createNode(...)`.