### PR TITLE
CORDA-1862: Allow MockNetwork to create StartedMockNode from UnstartedMockNode.

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -135,6 +135,11 @@ class UnstartedMockNode private constructor(private val node: InternalMockNetwor
      */
     val started: StartedMockNode
         get() = StartedMockNode.create(node.started ?: throw IllegalStateException("Node ID=$id is not running"))
+
+    /**
+     * Whether this node has been started yet.
+     */
+    val isStarted: Boolean get() = node.started != null
 }
 
 /** A class that represents a started mock node for testing. */

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -131,9 +131,10 @@ class UnstartedMockNode private constructor(private val node: InternalMockNetwor
 
     /**
      * A [StartedMockNode] object for this running node.
+     * @throws [IllegalStateException] if the node is not running yet.
      */
     val started: StartedMockNode
-        get() = StartedMockNode.create(node.started ?: throw NoSuchElementException("Node ID=$id is not running"))
+        get() = StartedMockNode.create(node.started ?: throw IllegalStateException("Node ID=$id is not running"))
 }
 
 /** A class that represents a started mock node for testing. */

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -329,6 +329,25 @@ open class MockNetwork(
      */
     val notaryNodes get(): List<StartedMockNode> = internalMockNetwork.notaryNodes.map { StartedMockNode.create(it) }
 
+    /**
+     * Returns a [StartedMockNode] for node [id] running on the mock network,
+     * or throws [NoSuchElementException] if no such node has started yet.
+     * @param id Internal ID number of this node.
+     */
+    @Throws(NoSuchElementException::class)
+    fun findStartedNode(id: Int): StartedMockNode {
+        val started = internalMockNetwork.nodes.find { it.id == id }?.started ?: throw NoSuchElementException("No node with ID=$id")
+        return StartedMockNode.create(started)
+    }
+
+    /**
+     * Returns a [StartedMockNode] for unstarted [node] created for the mock network,
+     * or throws [NoSuchElementException] if no such node has started yet.
+     * @param node [UnstartedMockNode] element for this node.
+     */
+    @Throws(NoSuchElementException::class)
+    fun findStartedNode(node: UnstartedMockNode): StartedMockNode = findStartedNode(node.id)
+
     /** Create a started node with the given identity. **/
     fun createPartyNode(legalName: CordaX500Name? = null): StartedMockNode = StartedMockNode.create(internalMockNetwork.createPartyNode(legalName))
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -128,6 +128,12 @@ class UnstartedMockNode private constructor(private val node: InternalMockNetwor
      * @return A [StartedMockNode] object.
      */
     fun start(): StartedMockNode = StartedMockNode.create(node.start())
+
+    /**
+     * A [StartedMockNode] object for this running node.
+     */
+    val started: StartedMockNode
+        get() = StartedMockNode.create(node.started ?: throw NoSuchElementException("Node ID=$id is not running"))
 }
 
 /** A class that represents a started mock node for testing. */
@@ -328,25 +334,6 @@ open class MockNetwork(
      * Returns the list of notary nodes started by the network.
      */
     val notaryNodes get(): List<StartedMockNode> = internalMockNetwork.notaryNodes.map { StartedMockNode.create(it) }
-
-    /**
-     * Returns a [StartedMockNode] for node [id] running on the mock network,
-     * or throws [NoSuchElementException] if no such node has started yet.
-     * @param id Internal ID number of this node.
-     */
-    @Throws(NoSuchElementException::class)
-    fun findStartedNode(id: Int): StartedMockNode {
-        val started = internalMockNetwork.nodes.find { it.id == id }?.started ?: throw NoSuchElementException("No node with ID=$id")
-        return StartedMockNode.create(started)
-    }
-
-    /**
-     * Returns a [StartedMockNode] for unstarted [node] created for the mock network,
-     * or throws [NoSuchElementException] if no such node has started yet.
-     * @param node [UnstartedMockNode] element for this node.
-     */
-    @Throws(NoSuchElementException::class)
-    fun findStartedNode(node: UnstartedMockNode): StartedMockNode = findStartedNode(node.id)
 
     /** Create a started node with the given identity. **/
     fun createPartyNode(legalName: CordaX500Name? = null): StartedMockNode = StartedMockNode.create(internalMockNetwork.createPartyNode(legalName))

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/MockNetworkTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/MockNetworkTest.kt
@@ -1,7 +1,6 @@
-package net.corda.testing.node.internal
+package net.corda.testing.node
 
 import net.corda.testing.core.*
-import net.corda.testing.node.MockNetwork
 import org.assertj.core.api.Assertions.*
 import org.junit.After
 import org.junit.Assert.*
@@ -39,7 +38,7 @@ class MockNetworkTest {
     @Test
     fun `with an unstarted node`() {
         val unstarted = mockNetwork.createUnstartedNode(DUMMY_BANK_A_NAME, forcedID = NODE_ID)
-        val ex = assertFailsWith<NoSuchElementException> { unstarted.started }
+        val ex = assertFailsWith<IllegalStateException> { unstarted.started }
         assertThat(ex).hasMessage("Node ID=$NODE_ID is not running")
     }
 }

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/MockNetworkTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/MockNetworkTest.kt
@@ -27,7 +27,10 @@ class MockNetworkTest {
     @Test
     fun `with a started node`() {
         val unstarted = mockNetwork.createUnstartedNode(DUMMY_BANK_A_NAME, forcedID = NODE_ID)
+        assertFalse(unstarted.isStarted)
+
         mockNetwork.startNodes()
+        assertTrue(unstarted.isStarted)
 
         val started = unstarted.started
         assertEquals(NODE_ID, started.id)

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/MockNetworkTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/MockNetworkTest.kt
@@ -26,19 +26,20 @@ class MockNetworkTest {
     }
 
     @Test
-    fun `finding a started node`() {
+    fun `with a started node`() {
         val unstarted = mockNetwork.createUnstartedNode(DUMMY_BANK_A_NAME, forcedID = NODE_ID)
         mockNetwork.startNodes()
 
-        val started = mockNetwork.findStartedNode(unstarted)
+        val started = unstarted.started
         assertEquals(NODE_ID, started.id)
         assertEquals(DUMMY_BANK_A_NAME, started.info.identityFromX500Name(DUMMY_BANK_A_NAME).name)
         assertFailsWith<IllegalArgumentException> { started.info.identityFromX500Name(DUMMY_BANK_B_NAME) }
     }
 
     @Test
-    fun `failing to find a node`() {
-        val ex = assertFailsWith<NoSuchElementException>{ mockNetwork.findStartedNode(NODE_ID) }
-        assertThat(ex).hasMessage("No node with ID=$NODE_ID")
+    fun `with an unstarted node`() {
+        val unstarted = mockNetwork.createUnstartedNode(DUMMY_BANK_A_NAME, forcedID = NODE_ID)
+        val ex = assertFailsWith<NoSuchElementException> { unstarted.started }
+        assertThat(ex).hasMessage("Node ID=$NODE_ID is not running")
     }
 }

--- a/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/MockNetworkTest.kt
+++ b/testing/node-driver/src/test/kotlin/net/corda/testing/node/internal/MockNetworkTest.kt
@@ -1,0 +1,44 @@
+package net.corda.testing.node.internal
+
+import net.corda.testing.core.*
+import net.corda.testing.node.MockNetwork
+import org.assertj.core.api.Assertions.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class MockNetworkTest {
+    private companion object {
+        private const val NODE_ID = 101
+    }
+    private lateinit var mockNetwork: MockNetwork
+
+    @Before
+    fun setup() {
+        mockNetwork = MockNetwork(cordappPackages = emptyList())
+    }
+
+    @After
+    fun done() {
+        mockNetwork.stopNodes()
+    }
+
+    @Test
+    fun `finding a started node`() {
+        val unstarted = mockNetwork.createUnstartedNode(DUMMY_BANK_A_NAME, forcedID = NODE_ID)
+        mockNetwork.startNodes()
+
+        val started = mockNetwork.findStartedNode(unstarted)
+        assertEquals(NODE_ID, started.id)
+        assertEquals(DUMMY_BANK_A_NAME, started.info.identityFromX500Name(DUMMY_BANK_A_NAME).name)
+        assertFailsWith<IllegalArgumentException> { started.info.identityFromX500Name(DUMMY_BANK_B_NAME) }
+    }
+
+    @Test
+    fun `failing to find a node`() {
+        val ex = assertFailsWith<NoSuchElementException>{ mockNetwork.findStartedNode(NODE_ID) }
+        assertThat(ex).hasMessage("No node with ID=$NODE_ID")
+    }
+}


### PR DESCRIPTION
Create `StartedMockNode` objects for nodes created by `MockNetwork.startNodes()`.