### PR TITLE
Added @jvmoverloads annotation to SignTxnFlow constructor

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
@@ -195,7 +195,7 @@ class CollectSignatureFlow(val partiallySignedTx: SignedTransaction, val session
  *
  * @param otherSideSession The session which is providing you a transaction to sign.
  */
-abstract class SignTransactionFlow(val otherSideSession: FlowSession,
+abstract class SignTransactionFlow @JvmOverloads constructor(val otherSideSession: FlowSession,
                                    override val progressTracker: ProgressTracker = SignTransactionFlow.tracker()) : FlowLogic<SignedTransaction>() {
 
     companion object {


### PR DESCRIPTION
Added a `@JvmOverloads` annotation to the  `SignTransactionFlow` constructor, allowing Java applications to utilize the default parameters (like the provided `ProgressTracker`)

Closes #3725 

# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [x] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
