### PR TITLE
CORDA-1837: Reject nodes that have the same organisation name in driver tests

### DIFF
--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -136,13 +136,13 @@ class DriverTests {
     @Test
     fun `driver rejects multiple nodes with the same name`() {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
-            assertThatThrownBy {
+            assertThatIllegalArgumentException().isThrownBy {
                 listOf(
                         newNode(DUMMY_BANK_A_NAME)(),
                         newNode(DUMMY_BANK_B_NAME)(),
                         newNode(DUMMY_BANK_A_NAME)()
                 ).transpose().getOrThrow()
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }
         }
     }
 
@@ -150,9 +150,22 @@ class DriverTests {
     fun `driver rejects multiple nodes with the same name parallel`() {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             val nodes = listOf(newNode(DUMMY_BANK_A_NAME), newNode(DUMMY_BANK_B_NAME), newNode(DUMMY_BANK_A_NAME))
-            assertThatThrownBy {
+            assertThatIllegalArgumentException().isThrownBy {
                 nodes.parallelStream().map { it.invoke() }.toList().transpose().getOrThrow()
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `driver rejects multiple nodes with the same organisation name`() {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+            listOf(
+                    newNode(CordaX500Name(commonName = "Notary", organisation = "R3CEV", locality = "New York", country = "US"))(),
+                    newNode(DUMMY_BANK_A_NAME)()
+            ).transpose().getOrThrow()
+            assertThatIllegalArgumentException().isThrownBy {
+                newNode(CordaX500Name(commonName = "Regulator", organisation = "R3CEV", locality = "New York", country = "US"))().getOrThrow()
+            }
         }
     }
 

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -134,19 +134,6 @@ class DriverTests {
     }
 
     @Test
-    fun `driver rejects multiple nodes with the same name`() {
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
-            assertThatIllegalArgumentException().isThrownBy {
-                listOf(
-                        newNode(DUMMY_BANK_A_NAME)(),
-                        newNode(DUMMY_BANK_B_NAME)(),
-                        newNode(DUMMY_BANK_A_NAME)()
-                ).transpose().getOrThrow()
-            }
-        }
-    }
-
-    @Test
     fun `driver rejects multiple nodes with the same name parallel`() {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             val nodes = listOf(newNode(DUMMY_BANK_A_NAME), newNode(DUMMY_BANK_B_NAME), newNode(DUMMY_BANK_A_NAME))
@@ -159,10 +146,7 @@ class DriverTests {
     @Test
     fun `driver rejects multiple nodes with the same organisation name`() {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
-            listOf(
-                    newNode(CordaX500Name(commonName = "Notary", organisation = "R3CEV", locality = "New York", country = "US"))(),
-                    newNode(DUMMY_BANK_A_NAME)()
-            ).transpose().getOrThrow()
+            newNode(CordaX500Name(commonName = "Notary", organisation = "R3CEV", locality = "New York", country = "US"))().getOrThrow()
             assertThatIllegalArgumentException().isThrownBy {
                 newNode(CordaX500Name(commonName = "Regulator", organisation = "R3CEV", locality = "New York", country = "US"))().getOrThrow()
             }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -938,7 +938,10 @@ private class NetworkVisibilityController {
     fun register(name: CordaX500Name): VisibilityHandle {
         val handle = VisibilityHandle()
         nodeVisibilityHandles.locked {
-            require(putIfAbsent(name, handle) == null) { "Node with name $name is already started or starting" }
+            require(name.organisation !in keys.map(CordaX500Name::organisation)) {
+                "Node with organisation name ${name.organisation} is already started or starting"
+            }
+            put(name, handle)
         }
         return handle
     }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -933,15 +933,15 @@ class DriverDSLImpl(
  * current nodes see everyone.
  */
 private class NetworkVisibilityController {
-    private val nodeVisibilityHandles = ThreadBox(HashMap<CordaX500Name, VisibilityHandle>())
+    private val nodeVisibilityHandles = ThreadBox(HashMap<String, VisibilityHandle>())
 
     fun register(name: CordaX500Name): VisibilityHandle {
         val handle = VisibilityHandle()
         nodeVisibilityHandles.locked {
-            require(name.organisation !in keys.map(CordaX500Name::organisation)) {
+            require(name.organisation !in keys) {
                 "Node with organisation name ${name.organisation} is already started or starting"
             }
-            put(name, handle)
+            put(name.organisation, handle)
         }
         return handle
     }


### PR DESCRIPTION
DriverDSLImpl -> NetworkVisibilityController -> register check organisation name rather than X500 name and throw IllegalStateException if already exists
Added test to DriverTests to test multiple organisation names end exceptionally
