### PR TITLE
Rename column HOST to HOST_NAME in table NODE_INFO_HOSTS - required by ENT-2253

### DIFF
--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -48,6 +48,18 @@ For H2:
 
     ALTER TABLE node_checkpoints ALTER COLUMN checkpoint_value set data type VARBINARY(33554432);
 
+* Database upgrade - a column ``HOST`` in table ``NODE_INFO_HOSTS`` has been renamed to ``HOST_NAME`` table name.
+
+  For H2 database the column name will be automatically changed upon the first startup.
+
+  For any other database run the following command before starting the node:
+
+  .. sourcecode:: sql
+
+     ALTER TABLE [schema].NODE_INFO_HOSTS ALTER COLUMN HOST RENAME TO HOST_NAME;
+
+  .. note::
+    Schema name is optional, run SQL when the node is not running.
 
 * API change: ``net.corda.core.schemas.PersistentStateRef`` fields (``index`` and ``txId``) incorrectly marked as nullable are now non-nullable,
   :doc:`changelog` contains the explanation.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -80,12 +80,11 @@ class CordaPersistence(
             error("Was not expecting to find existing database transaction on current strand when setting database: ${Strand.currentStrand()}, $it")
         }
         _contextDatabase.set(this)
-        // Check not in read-only mode.
         transaction {
             check(!connection.metaData.isReadOnly) { "Database should not be readonly." }
-            validateOrFixIncorrectInfoHostsTableColumnName(connection)
-            checkCorrectAttachmentsContractsTableName(connection)
-            checkCorrectCheckpointTypeOnPostgres(connection)
+            DatabaseMigration.validateOrAlterAttachmentsContractsTableName(connection)
+            DatabaseMigration.validateOrAlterInfoHostsTableColumnName(connection)
+            DatabaseMigration.checkCorrectCheckpointTypeOnPostgres(connection)
         }
     }
 
@@ -274,72 +273,3 @@ private fun Throwable.hasSQLExceptionCause(): Boolean =
 
 class CouldNotCreateDataSourceException(override val message: String?, override val cause: Throwable? = null) : Exception()
 
-class DatabaseIncompatibleException(override val message: String?, override val cause: Throwable? = null) : Exception()
-
-private fun checkCorrectAttachmentsContractsTableName(connection: Connection) {
-    val correctName = "NODE_ATTACHMENTS_CONTRACTS"
-    val incorrectV30Name = "NODE_ATTACHMENTS_CONTRACT_CLASS_NAME"
-    val incorrectV31Name = "NODE_ATTCHMENTS_CONTRACTS"
-
-    fun warning(incorrectName: String, version: String) = "The database contains the older table name $incorrectName instead of $correctName, see upgrade notes to migrate from Corda database version $version https://docs.corda.net/head/upgrade-notes.html."
-
-    if (!connection.metaData.getTables(null, null, correctName, null).next()) {
-        val metaData = connection.metaData
-        if (connection.metaData.getTables(null, null, incorrectV30Name, null).next()) {
-            if (metaData.databaseProductName == "H2") {
-                connection.createStatement().execute("ALTER TABLE $incorrectV30Name RENAME TO $correctName")
-                connection.commit()
-            } else {
-                throw DatabaseIncompatibleException(warning(incorrectV30Name, "3.0"))
-            }
-        }
-        if (connection.metaData.getTables(null, null, incorrectV31Name, null).next()) {
-            if (metaData.databaseProductName == "H2") {
-                connection.createStatement().execute("ALTER TABLE $incorrectV31Name RENAME TO $correctName")
-                connection.commit()
-            } else {
-                throw DatabaseIncompatibleException(warning(incorrectV31Name, "3.1"))
-            }
-        }
-    }
-}
-
-private fun validateOrFixIncorrectInfoHostsTableColumnName(connection: Connection) = validateOrRenameColumn(connection, "NODE_INFO_HOSTS",  "HOST_NAME", "HOST")
-
-private fun validateOrRenameColumn(connection: Connection, table: String, correctColumnName: String, incorrectColumnName: String) {
-
-    fun warning() = "The database table $table contains the older column name $incorrectColumnName instead of $correctColumnName, " +
-            "see upgrade notes to migrate from Corda database version https://docs.corda.net/head/upgrade-notes.html."
-    val metaData = connection.metaData
-    val resultSet = metaData.getColumns(null, null, table, incorrectColumnName)
-    if (resultSet.next()) {
-        val name = resultSet.getString("COLUMN_NAME")
-        if (name == incorrectColumnName) {
-            if (metaData.databaseProductName == "H2") {
-                try {
-                    connection.createStatement().execute("ALTER TABLE $table ALTER COLUMN $incorrectColumnName RENAME TO $correctColumnName")
-                    connection.commit()
-                } catch (exp: SQLException) {
-                    throw DatabaseIncompatibleException("Failed to upgrade table $table. " + warning())
-                }
-            } else {
-                throw DatabaseIncompatibleException(warning())
-            }
-        }
-    }
-}
-
-private fun checkCorrectCheckpointTypeOnPostgres(connection: Connection) {
-    val metaData = connection.metaData
-    if (metaData.databaseProductName != "PostgreSQL") {
-        return
-    }
-
-    val result = metaData.getColumns(null, null, "node_checkpoints", "checkpoint_value")
-    if (result.next()) {
-        val type = result.getString("TYPE_NAME")
-        if (type != "bytea") {
-            throw DatabaseIncompatibleException("The type of the 'checkpoint_value' table must be 'bytea', but 'oid' was found. See upgrade notes to migrate from Corda database version 3.1 https://docs.corda.net/head/upgrade-notes.html.")
-        }
-    }
-}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/DatabaseMigration.kt
@@ -1,0 +1,93 @@
+package net.corda.nodeapi.internal.persistence
+
+import net.corda.core.utilities.contextLogger
+import java.sql.Connection
+import java.sql.SQLException
+
+/**
+ * Function to auto upgrade (for H2 database) or validate (for other databases) changes introduced to database schema.
+ */
+class DatabaseMigration {
+
+    companion object {
+        private val log = contextLogger()
+
+        /** Upgrades (or validates for non H2) NODE_ATTACHMENTS_CONTRACTS table name to version 3.2 */
+        fun validateOrAlterAttachmentsContractsTableName(connection: Connection) {
+            val correctName = "NODE_ATTACHMENTS_CONTRACTS"
+            val incorrectV30Name = "NODE_ATTACHMENTS_CONTRACT_CLASS_NAME"
+            val incorrectV31Name = "NODE_ATTCHMENTS_CONTRACTS"
+
+            fun warning(incorrectName: String, version: String) = "The database contains the older table name $incorrectName" +
+                    " instead of $correctName, see upgrade notes to migrate from Corda database version $version https://docs.corda.net/head/upgrade-notes.html."
+
+            if (!connection.metaData.getTables(null, null, correctName, null).next()) {
+                val metaData = connection.metaData
+                if (connection.metaData.getTables(null, null, incorrectV30Name, null).next()) {
+                    if (metaData.databaseProductName == "H2") {
+                        log.info("Changing table name $incorrectV30Name to $correctName")
+                        connection.createStatement().execute("ALTER TABLE $incorrectV30Name RENAME TO $correctName")
+                        connection.commit()
+                    } else {
+                        throw DatabaseIncompatibleException(warning(incorrectV30Name, "3.0"))
+                    }
+                }
+                if (connection.metaData.getTables(null, null, incorrectV31Name, null).next()) {
+                    if (metaData.databaseProductName == "H2") {
+                        log.info("Changing table name $incorrectV30Name to $correctName")
+                        connection.createStatement().execute("ALTER TABLE $incorrectV31Name RENAME TO $correctName")
+                        connection.commit()
+                    } else {
+                        throw DatabaseIncompatibleException(warning(incorrectV31Name, "3.1"))
+                    }
+                }
+            }
+        }
+
+        /** Upgrades (or validates for non H2) NODE_INFO_HOSTS table column name to version 4.0 */
+        fun validateOrAlterInfoHostsTableColumnName(connection: Connection) =
+                validateOrAlterColumn(connection, "NODE_INFO_HOSTS", "HOST_NAME", "HOST")
+
+        private fun validateOrAlterColumn(connection: Connection, table: String, correctColumnName: String, incorrectColumnName: String) {
+            fun warning() = "The database table $table contains the older column name $incorrectColumnName instead of $correctColumnName, " +
+                    "see upgrade notes to migrate from Corda database version https://docs.corda.net/head/upgrade-notes.html."
+
+            val metaData = connection.metaData
+            val resultSet = metaData.getColumns(null, null, table, incorrectColumnName)
+            if (resultSet.next()) {
+                if (resultSet.getString("COLUMN_NAME") == incorrectColumnName) {
+                    if (metaData.databaseProductName == "H2") {
+                        try {
+                            log.info("Changing column name $incorrectColumnName to $correctColumnName of table $table")
+                            connection.createStatement().execute("ALTER TABLE $table ALTER COLUMN $incorrectColumnName RENAME TO $correctColumnName")
+                            connection.commit()
+                        } catch (exp: SQLException) {
+                            throw DatabaseIncompatibleException("Failed to upgrade table $table. " + warning())
+                        }
+                    } else {
+                        throw DatabaseIncompatibleException(warning())
+                    }
+                }
+            }
+        }
+
+        /** Validates PostgreSQL node_checkpoints column type compatible with version 3.2 */
+        fun checkCorrectCheckpointTypeOnPostgres(connection: Connection) {
+            val metaData = connection.metaData
+            if (metaData.databaseProductName != "PostgreSQL") {
+                return
+            }
+
+            val result = metaData.getColumns(null, null, "node_checkpoints", "checkpoint_value")
+            if (result.next()) {
+                val type = result.getString("TYPE_NAME")
+                if (type != "bytea") {
+                    throw DatabaseIncompatibleException("The type of the 'checkpoint_value' table must be 'bytea', " +
+                            "but 'oid' was found. See upgrade notes to migrate from Corda database version 3.1 https://docs.corda.net/head/upgrade-notes.html.")
+                }
+            }
+        }
+    }
+}
+
+class DatabaseIncompatibleException(override val message: String?, override val cause: Throwable? = null) : Exception()

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/FailNodeOnNotMigratedAttachmentContractsTableNameTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/FailNodeOnNotMigratedAttachmentContractsTableNameTests.kt
@@ -14,22 +14,22 @@ import net.corda.testing.node.User
 import org.junit.Test
 import java.nio.file.Path
 import java.sql.DriverManager
-import kotlin.test.assertFailsWith
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FailNodeOnNotMigratedAttachmentContractsTableNameTests {
     @Test
-    fun `node fails when detecting table name not migrated from version 3 dot 0`() {
-        `node fails when not detecting compatible table name`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTACHMENTS_CONTRACT_CLASS_NAME")
+    fun `node fixes table name not migrated from version 3 dot 0`() {
+        `node fixes incompatible table name`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTACHMENTS_CONTRACT_CLASS_NAME")
     }
 
     @Test
-    fun `node fails when detecting table name not migrated from version 3 dot 1`() {
-        `node fails when not detecting compatible table name`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTCHMENTS_CONTRACTS")
+    fun `node fails table name not migrated from version 3 dot 1`() {
+        `node fixes incompatible table name`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTCHMENTS_CONTRACTS")
     }
 
-    private fun `node fails when not detecting compatible table name`(tableNameFromMapping: String, tableNameInDB: String) {
+    private fun `node fixes incompatible table name`(tableNameFromMapping: String, tableNameInDB: String) {
         val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlow>(), Permissions.invokeRpc("vaultQuery")))
         val message = Message("Hello world!")
         val baseDir: Path = driver(DriverParameters(
@@ -52,19 +52,63 @@ class FailNodeOnNotMigratedAttachmentContractsTableNameTests {
                 it.createStatement().execute("ALTER TABLE $tableNameFromMapping RENAME TO $tableNameInDB")
                 it.commit()
             }
-            assertFailsWith(net.corda.nodeapi.internal.persistence.DatabaseIncompatibleException::class) {
-                val nodeHandle = startNode(providedName = nodeName, rpcUsers = listOf(user)).getOrThrow()
-                nodeHandle.stop()
-            }
-             baseDir
+
+            startNode(providedName = nodeName, rpcUsers = listOf(user)).getOrThrow()
+            baseDir
         }
 
-        // check that the node didn't recreated the correct table matching it's entity mapping
-        val (hasTableFromMapping, hasTableFromDB) = DriverManager.getConnection("jdbc:h2:file://$baseDir/persistence", "sa", "").use {
-            Pair(it.metaData.getTables(null, null, tableNameFromMapping, null).next(),
-                    it.metaData.getTables(null, null, tableNameInDB, null).next())
+        // check that the node did recreated the correct table matching it's entity mapping
+        DriverManager.getConnection("jdbc:h2:file://$baseDir/persistence", "sa", "").use {
+            assertTrue(it.metaData.getTables(null, null, tableNameFromMapping, null).next())
+            assertFalse(it.metaData.getTables(null, null, tableNameInDB, null).next())
+            it.createStatement().executeQuery("SELECT COUNT(*) FROM $tableNameFromMapping").use {
+                assertTrue(it.next())
+                assertEquals(1, it.getInt(1))
+            }
         }
-        assertFalse(hasTableFromMapping)
-        assertTrue(hasTableFromDB)
+    }
+
+    @Test
+    fun `node fixes node info hosts column name`() {
+        `node fixes incompatible column name`("NODE_INFO_HOSTS",  "HOST_NAME", "HOST")
+    }
+
+    private fun `node fixes incompatible column name`(tableName: String, columnNameFromMapping: String, columnNameInDB: String) {
+        val user = User("mark", "dadada", setOf(Permissions.startFlow<SendMessageFlow>(), Permissions.invokeRpc("vaultQuery")))
+        val message = Message("Hello world!")
+        val baseDir: Path = driver(DriverParameters(
+                inMemoryDB = false,
+                startNodesInProcess = isQuasarAgentSpecified(),
+                extraCordappPackagesToScan = listOf(MessageState::class.packageName)
+        )) {
+            val (nodeName, baseDir) = {
+                val nodeHandle = startNode(rpcUsers = listOf(user)).getOrThrow()
+                val nodeName = nodeHandle.nodeInfo.singleIdentity().name
+                CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
+                    it.proxy.startFlow(::SendMessageFlow, message, defaultNotaryIdentity).returnValue.getOrThrow()
+                }
+                nodeHandle.stop()
+                Pair(nodeName, nodeHandle.baseDirectory)
+            }()
+
+            // replace the correct column name  with one from the former release
+            DriverManager.getConnection("jdbc:h2:file://$baseDir/persistence", "sa", "").use {
+                it.createStatement().execute("ALTER TABLE $tableName ALTER COLUMN $columnNameFromMapping RENAME TO $columnNameInDB")
+                it.commit()
+            }
+
+            startNode(providedName = nodeName, rpcUsers = listOf(user)).getOrThrow()
+            baseDir
+        }
+
+        // check that the node did recreated the correct table matching it's entity mapping
+        DriverManager.getConnection("jdbc:h2:file://$baseDir/persistence", "sa", "").use {
+            assertTrue(it.metaData.getColumns(null, null, tableName, columnNameFromMapping).next())
+            assertFalse(it.metaData.getColumns(null, null, tableName, columnNameInDB).next())
+            it.createStatement().executeQuery("SELECT COUNT($columnNameFromMapping) FROM $tableName").use {
+                assertTrue(it.next())
+                assertEquals(2, it.getInt(1))
+            }
+        }
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/MigrateIncompatibleDatabaseTableOrColumnNameTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/MigrateIncompatibleDatabaseTableOrColumnNameTests.kt
@@ -18,14 +18,14 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FailNodeOnNotMigratedAttachmentContractsTableNameTests {
+class MigrateIncompatibleDatabaseTableOrColumnNameTests {
     @Test
-    fun `node fixes table name not migrated from version 3 dot 0`() {
+    fun `node migrates node_attachemnts_contranst_class_name table name from version 3 dot 0`() {
         `node fixes incompatible table name`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTACHMENTS_CONTRACT_CLASS_NAME")
     }
 
     @Test
-    fun `node fails table name not migrated from version 3 dot 1`() {
+    fun `node migrates node_attchemnts_contransts table name from version 3 dot 1`() {
         `node fixes incompatible table name`("NODE_ATTACHMENTS_CONTRACTS", "NODE_ATTCHMENTS_CONTRACTS")
     }
 
@@ -69,7 +69,7 @@ class FailNodeOnNotMigratedAttachmentContractsTableNameTests {
     }
 
     @Test
-    fun `node fixes node info hosts column name`() {
+    fun `node migrates to host_name column name`() {
         `node fixes incompatible column name`("NODE_INFO_HOSTS",  "HOST_NAME", "HOST")
     }
 

--- a/node/src/main/kotlin/net/corda/node/internal/schemas/NodeInfoSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/schemas/NodeInfoSchema.kt
@@ -70,6 +70,7 @@ object NodeInfoSchemaV1 : MappedSchema(
             @GeneratedValue
             @Column(name = "hosts_id", nullable = false)
             var id: Int,
+            @Column(name = "host_name")
             val host: String? = null,
             val port: Int? = null
     ) {


### PR DESCRIPTION
* Column HOST renamed to HOST_NAME in table NODE_INFO_HOSTS - required by ENT-2253.
* Added auto-change of column name (HOST to HOST_NAME) at startup.
* Added auto-change of incorrect table name of table NODE_ATTACHMENTS_CONTRACTS - before it required a manual upgrade.

* Some refactoring:
Existing method from file `CordaPersistence.kt` to verify database migrated table names/types were moved to one separate class `DatabaseMigration`:
 method `checkCorrectCheckpointTypeOnPostgres` is unchanged, methods `checkCorrectAttachmentsContractsTableName` renamed to `validateOrAlterAttachmentsContractsTableName` auto-fix table name for H2 now, method  `validateOrAlterInfoHostsTableColumnName` is new one to auto-fix `HOST` column name.
