### PR TITLE
[CORDA-1822]: Improved error message when too many results are asked with default pagination.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -454,9 +454,9 @@ class NodeVaultService(
             val results = query.resultList
 
             // final pagination check (fail-fast on too many results when no pagination specified)
-            if (!skipPagingChecks && paging.isDefault && results.size > DEFAULT_PAGE_SIZE)
-                throw VaultQueryException("Please specify a `PageSpecification` as there are more results [${results.size}] than the default page size [$DEFAULT_PAGE_SIZE]")
-
+            if (!skipPagingChecks && paging.isDefault && results.size > DEFAULT_PAGE_SIZE) {
+                throw VaultQueryException("There are ${results.size} results, which exceeds the limit of $DEFAULT_PAGE_SIZE for queries that do not specify paging. In order to retrieve these results, provide a `PageSpecification(pageNumber, pageSize)` to the method invoked.")
+            }
             val statesAndRefs: MutableList<StateAndRef<T>> = mutableListOf()
             val statesMeta: MutableList<Vault.StateMetadata> = mutableListOf()
             val otherResults: MutableList<Any> = mutableListOf()

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -1176,7 +1176,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     @Test
     fun `pagination not specified but more than default results available`() {
         expectedEx.expect(VaultQueryException::class.java)
-        expectedEx.expectMessage("Please specify a `PageSpecification`")
+        expectedEx.expectMessage("provide a `PageSpecification(pageNumber, pageSize)`")
 
         database.transaction {
             vaultFiller.fillWithSomeTestCash(201.DOLLARS, notaryServices, 201, DUMMY_CASH_ISSUER)

--- a/webserver/src/main/kotlin/net/corda/webserver/WebServer.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/WebServer.kt
@@ -71,7 +71,7 @@ fun main(args: Array<String>) {
         log.error(e.message)
         exitProcess(1)
     } catch (e: Exception) {
-        log.error("Exception during node startup", e)
+        log.error("Exception during webserver startup", e)
         exitProcess(1)
     }
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-1388

Notes:

- There has been some debate on the best way to address this issue, and the more general one about exposing a query API, see ticket for a summary.
- The work potentially resulting from the point above will be addressed in separate PRs.