### PR TITLE
Fix duplicate index declaration in Cash schema.

### DIFF
--- a/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV1.kt
+++ b/finance/src/test/kotlin/net/corda/finance/schemas/SampleCashSchemaV1.kt
@@ -21,7 +21,7 @@ object CashSchema
  */
 object SampleCashSchemaV1 : MappedSchema(schemaFamily = CashSchema.javaClass, version = 1, mappedTypes = listOf(PersistentCashState::class.java)) {
     @Entity
-    @Table(name = "contract_cash_states_v1", indexes = [Index(name = "ccy_code_idx", columnList = "ccy_code"), Index(name = "pennies_idx", columnList = "pennies")])
+    @Table(name = "contract_cash_states_v1", indexes = [Index(name = "ccy_code_idx1", columnList = "ccy_code"), Index(name = "pennies_idx1", columnList = "pennies")])
     class PersistentCashState(
             @Column(name = "owner_key_hash", length = MAX_HASH_HEX_SIZE, nullable = false)
             var ownerHash: String,


### PR DESCRIPTION
This PR fixes the annoying Exception stacks generated in tests:

```
Caused by: org.h2.jdbc.JdbcSQLException: Index "CCY_CODE_IDX" already exists; SQL statement:
create index ccy_code_idx on contract_cash_states_v1 (ccy_code) [42111-197]
Caused by: org.h2.jdbc.JdbcSQLException: Index "PENNIES_IDX" already exists; SQL statement:
create index pennies_idx on contract_cash_states_v1 (pennies) [42111-197]
```