### PR TITLE
Include the deterministic test-data.jar in the build's assembly.

### DIFF
--- a/core-deterministic/testing/data/build.gradle
+++ b/core-deterministic/testing/data/build.gradle
@@ -23,6 +23,7 @@ test {
         includeTestsMatching "net.corda.deterministic.data.GenerateData"
     }
 }
+assemble.finalizedBy test
 
 artifacts {
     testData file: file("$buildDir/test-data.jar"), type: 'jar', builtBy: test


### PR DESCRIPTION
The `test-data.jar` artifact is added to various test classpaths, but is not generated unless the tests are actually run. This triggers warnings in IntelliJ.

Re-jig Gradle so that this jar is built after the `assemble` task without needing to run the tests.