### PR TITLE
* Added "isRelevant" functionality to the vault.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -11,6 +11,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.AbstractParty
 import net.corda.core.internal.concurrent.doneFuture
 import net.corda.core.messaging.DataFeed
+import net.corda.core.node.services.Vault.StateRelevance.*
 import net.corda.core.node.services.Vault.StateStatus
 import net.corda.core.node.services.vault.*
 import net.corda.core.serialization.CordaSerializable
@@ -105,6 +106,11 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
         UNCONSUMED, CONSUMED, ALL
     }
 
+    /**
+     * If the querying node is a participant in a state then it is classed as [RELEVANT]. If the querying node is not
+     * a participant in a state then it is classed as [NOT_RELEVANT]. If both [RELEVANT] and [NOT_RELEVANT] states are
+     * required then the [ALL] flag can be used.
+     */
     @CordaSerializable
     enum class StateRelevance {
         RELEVANT, NOT_RELEVANT, ALL
@@ -215,7 +221,7 @@ interface VaultService {
         val query = QueryCriteria.VaultQueryCriteria(
                 stateRefs = listOf(ref),
                 status = Vault.StateStatus.CONSUMED,
-                isRelevant = Vault.StateRelevance.ALL
+                isParticipant = Vault.StateRelevance.ALL
         )
         val result = trackBy<ContractState>(query)
         val snapshot = result.snapshot.states

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -73,7 +73,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
 
     abstract class CommonQueryCriteria : QueryCriteria() {
         abstract val status: Vault.StateStatus
-        open val isRelevant: Vault.StateRelevance = Vault.StateRelevance.ALL
+        open val isParticipant: Vault.StateRelevance = Vault.StateRelevance.ALL
         abstract val contractStateTypes: Set<Class<out ContractState>>?
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this)
@@ -90,7 +90,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val notary: List<AbstractParty>? = null,
             val softLockingCondition: SoftLockingCondition? = null,
             val timeCondition: TimeCondition? = null,
-            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
@@ -126,15 +126,22 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val externalId: List<String>? = null,
             override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
             override val contractStateTypes: Set<Class<out ContractState>>? = null,
-            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
     ) : CommonQueryCriteria() {
         constructor(
                 participants: List<AbstractParty>? = null,
                 linearId: List<UniqueIdentifier>? = null,
                 status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
                 contractStateTypes: Set<Class<out ContractState>>? = null,
-                isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+                isRelevant: Vault.StateRelevance
         ) : this(participants, linearId?.map { it.id }, linearId?.mapNotNull { it.externalId }, status, contractStateTypes, isRelevant)
+
+        constructor(
+                participants: List<AbstractParty>? = null,
+                linearId: List<UniqueIdentifier>? = null,
+                status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
+                contractStateTypes: Set<Class<out ContractState>>? = null
+        ) : this(participants, linearId?.map { it.id }, linearId?.mapNotNull { it.externalId }, status, contractStateTypes)
 
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
@@ -170,7 +177,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val issuerRef: List<OpaqueBytes>? = null,
             override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
             override val contractStateTypes: Set<Class<out ContractState>>? = null,
-            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
@@ -211,7 +218,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val expression: CriteriaExpression<L, Boolean>,
             override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
             override val contractStateTypes: Set<Class<out ContractState>>? = null,
-            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -73,7 +73,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
 
     abstract class CommonQueryCriteria : QueryCriteria() {
         abstract val status: Vault.StateStatus
-        open val isParticipant: Vault.StateRelevance = Vault.StateRelevance.ALL
+        open val isModifiable: Vault.StateModificationStatus = Vault.StateModificationStatus.ALL
         abstract val contractStateTypes: Set<Class<out ContractState>>?
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this)
@@ -90,7 +90,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val notary: List<AbstractParty>? = null,
             val softLockingCondition: SoftLockingCondition? = null,
             val timeCondition: TimeCondition? = null,
-            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isModifiable: Vault.StateModificationStatus = Vault.StateModificationStatus.ALL
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
@@ -111,8 +111,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
                     stateRefs,
                     notary,
                     softLockingCondition,
-                    timeCondition,
-                    Vault.StateRelevance.RELEVANT
+                    timeCondition
             )
         }
     }
@@ -126,14 +125,14 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val externalId: List<String>? = null,
             override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
             override val contractStateTypes: Set<Class<out ContractState>>? = null,
-            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isModifiable: Vault.StateModificationStatus = Vault.StateModificationStatus.ALL
     ) : CommonQueryCriteria() {
         constructor(
                 participants: List<AbstractParty>? = null,
                 linearId: List<UniqueIdentifier>? = null,
                 status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
                 contractStateTypes: Set<Class<out ContractState>>? = null,
-                isRelevant: Vault.StateRelevance
+                isRelevant: Vault.StateModificationStatus
         ) : this(participants, linearId?.map { it.id }, linearId?.mapNotNull { it.externalId }, status, contractStateTypes, isRelevant)
 
         constructor(
@@ -160,8 +159,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
                     uuid,
                     externalId,
                     status,
-                    contractStateTypes,
-                    Vault.StateRelevance.RELEVANT
+                    contractStateTypes
             )
         }
     }
@@ -177,7 +175,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val issuerRef: List<OpaqueBytes>? = null,
             override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
             override val contractStateTypes: Set<Class<out ContractState>>? = null,
-            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isModifiable: Vault.StateModificationStatus = Vault.StateModificationStatus.ALL
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
@@ -200,8 +198,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
                     issuer,
                     issuerRef,
                     status,
-                    contractStateTypes,
-                    Vault.StateRelevance.RELEVANT
+                    contractStateTypes
             )
         }
     }
@@ -218,7 +215,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val expression: CriteriaExpression<L, Boolean>,
             override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
             override val contractStateTypes: Set<Class<out ContractState>>? = null,
-            override val isParticipant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+            override val isModifiable: Vault.StateModificationStatus = Vault.StateModificationStatus.ALL
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
@@ -233,8 +230,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             return VaultCustomQueryCriteria(
                     expression,
                     status,
-                    contractStateTypes,
-                    Vault.StateRelevance.RELEVANT
+                    contractStateTypes
             )
         }
     }

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -73,6 +73,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
 
     abstract class CommonQueryCriteria : QueryCriteria() {
         abstract val status: Vault.StateStatus
+        open val isRelevant: Vault.StateRelevance = Vault.StateRelevance.ALL
         abstract val contractStateTypes: Set<Class<out ContractState>>?
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this)
@@ -82,50 +83,119 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
     /**
      * VaultQueryCriteria: provides query by attributes defined in [VaultSchema.VaultStates]
      */
-    data class VaultQueryCriteria @JvmOverloads constructor(override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
-                                                            override val contractStateTypes: Set<Class<out ContractState>>? = null,
-                                                            val stateRefs: List<StateRef>? = null,
-                                                            val notary: List<AbstractParty>? = null,
-                                                            val softLockingCondition: SoftLockingCondition? = null,
-                                                            val timeCondition: TimeCondition? = null) : CommonQueryCriteria() {
+    data class VaultQueryCriteria @JvmOverloads constructor(
+            override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
+            override val contractStateTypes: Set<Class<out ContractState>>? = null,
+            val stateRefs: List<StateRef>? = null,
+            val notary: List<AbstractParty>? = null,
+            val softLockingCondition: SoftLockingCondition? = null,
+            val timeCondition: TimeCondition? = null,
+            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+    ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
             return parser.parseCriteria(this)
+        }
+
+        fun copy(
+                status: Vault.StateStatus = this.status,
+                contractStateTypes: Set<Class<out ContractState>>? = this.contractStateTypes,
+                stateRefs: List<StateRef>? = this.stateRefs,
+                notary: List<AbstractParty>? = this.notary,
+                softLockingCondition: SoftLockingCondition? = this.softLockingCondition,
+                timeCondition: TimeCondition? = this.timeCondition
+        ): VaultQueryCriteria {
+            return VaultQueryCriteria(
+                    status,
+                    contractStateTypes,
+                    stateRefs,
+                    notary,
+                    softLockingCondition,
+                    timeCondition,
+                    Vault.StateRelevance.RELEVANT
+            )
         }
     }
 
     /**
      * LinearStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultLinearState]
      */
-    data class LinearStateQueryCriteria @JvmOverloads constructor(val participants: List<AbstractParty>? = null,
-                                                                  val uuid: List<UUID>? = null,
-                                                                  val externalId: List<String>? = null,
-                                                                  override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
-                                                                  override val contractStateTypes: Set<Class<out ContractState>>? = null) : CommonQueryCriteria() {
-        constructor(participants: List<AbstractParty>? = null,
-                    linearId: List<UniqueIdentifier>? = null,
-                    status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
-                    contractStateTypes: Set<Class<out ContractState>>? = null) : this(participants, linearId?.map { it.id }, linearId?.mapNotNull { it.externalId }, status, contractStateTypes)
+    data class LinearStateQueryCriteria @JvmOverloads constructor(
+            val participants: List<AbstractParty>? = null,
+            val uuid: List<UUID>? = null,
+            val externalId: List<String>? = null,
+            override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
+            override val contractStateTypes: Set<Class<out ContractState>>? = null,
+            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+    ) : CommonQueryCriteria() {
+        constructor(
+                participants: List<AbstractParty>? = null,
+                linearId: List<UniqueIdentifier>? = null,
+                status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
+                contractStateTypes: Set<Class<out ContractState>>? = null,
+                isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+        ) : this(participants, linearId?.map { it.id }, linearId?.mapNotNull { it.externalId }, status, contractStateTypes, isRelevant)
 
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
             return parser.parseCriteria(this)
+        }
+
+        fun copy(
+                participants: List<AbstractParty>? = this.participants,
+                uuid: List<UUID>? = this.uuid,
+                externalId: List<String>? = this.externalId,
+                status: Vault.StateStatus = this.status,
+                contractStateTypes: Set<Class<out ContractState>>? = this.contractStateTypes
+        ): LinearStateQueryCriteria {
+            return LinearStateQueryCriteria(
+                    participants,
+                    uuid,
+                    externalId,
+                    status,
+                    contractStateTypes,
+                    Vault.StateRelevance.RELEVANT
+            )
         }
     }
 
     /**
      * FungibleStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultFungibleStates]
      */
-    data class FungibleAssetQueryCriteria @JvmOverloads constructor(val participants: List<AbstractParty>? = null,
-                                                                    val owner: List<AbstractParty>? = null,
-                                                                    val quantity: ColumnPredicate<Long>? = null,
-                                                                    val issuer: List<AbstractParty>? = null,
-                                                                    val issuerRef: List<OpaqueBytes>? = null,
-                                                                    override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
-                                                                    override val contractStateTypes: Set<Class<out ContractState>>? = null) : CommonQueryCriteria() {
+    data class FungibleAssetQueryCriteria @JvmOverloads constructor(
+            val participants: List<AbstractParty>? = null,
+            val owner: List<AbstractParty>? = null,
+            val quantity: ColumnPredicate<Long>? = null,
+            val issuer: List<AbstractParty>? = null,
+            val issuerRef: List<OpaqueBytes>? = null,
+            override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
+            override val contractStateTypes: Set<Class<out ContractState>>? = null,
+            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+    ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
             return parser.parseCriteria(this)
+        }
+
+        fun copy(
+                participants: List<AbstractParty>? = this.participants,
+                owner: List<AbstractParty>? = this.owner,
+                quantity: ColumnPredicate<Long>? = this.quantity,
+                issuer: List<AbstractParty>? = this.issuer,
+                issuerRef: List<OpaqueBytes>? = this.issuerRef,
+                status: Vault.StateStatus = this.status,
+                contractStateTypes: Set<Class<out ContractState>>? = this.contractStateTypes
+        ): FungibleAssetQueryCriteria {
+            return FungibleAssetQueryCriteria(
+                    participants,
+                    owner,
+                    quantity,
+                    issuer,
+                    issuerRef,
+                    status,
+                    contractStateTypes,
+                    Vault.StateRelevance.RELEVANT
+            )
         }
     }
 
@@ -137,13 +207,28 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
      * Params
      *  [expression] refers to a (composable) type safe [CriteriaExpression]
      */
-    data class VaultCustomQueryCriteria<L : PersistentState> @JvmOverloads constructor
-    (val expression: CriteriaExpression<L, Boolean>,
-     override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
-     override val contractStateTypes: Set<Class<out ContractState>>? = null) : CommonQueryCriteria() {
+    data class VaultCustomQueryCriteria<L : PersistentState> @JvmOverloads constructor(
+            val expression: CriteriaExpression<L, Boolean>,
+            override val status: Vault.StateStatus = Vault.StateStatus.UNCONSUMED,
+            override val contractStateTypes: Set<Class<out ContractState>>? = null,
+            override val isRelevant: Vault.StateRelevance = Vault.StateRelevance.RELEVANT
+    ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)
             return parser.parseCriteria(this)
+        }
+
+        fun copy(
+                expression: CriteriaExpression<L, Boolean> = this.expression,
+                status: Vault.StateStatus = this.status,
+                contractStateTypes: Set<Class<out ContractState>>? = this.contractStateTypes
+        ): VaultCustomQueryCriteria<L> {
+            return VaultCustomQueryCriteria(
+                    expression,
+                    status,
+                    contractStateTypes,
+                    Vault.StateRelevance.RELEVANT
+            )
         }
     }
 

--- a/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
+import net.corda.core.node.services.Vault
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.LedgerTransaction
@@ -102,7 +103,10 @@ internal class UseRefState(val linearId: UniqueIdentifier) : FlowLogic<SignedTra
     @Suspendable
     override fun call(): SignedTransaction {
         val notary = serviceHub.networkMapCache.notaryIdentities.first()
-        val query = QueryCriteria.LinearStateQueryCriteria(linearId = listOf(linearId))
+        val query = QueryCriteria.LinearStateQueryCriteria(
+                linearId = listOf(linearId),
+                isRelevant = Vault.StateRelevance.ALL
+        )
         val referenceState = serviceHub.vaultService.queryBy<ContractState>(query).states.single()
         return subFlow(FinalityFlow(
                 transaction = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {

--- a/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
@@ -105,7 +105,7 @@ internal class UseRefState(val linearId: UniqueIdentifier) : FlowLogic<SignedTra
         val notary = serviceHub.networkMapCache.notaryIdentities.first()
         val query = QueryCriteria.LinearStateQueryCriteria(
                 linearId = listOf(linearId),
-                isRelevant = Vault.StateRelevance.ALL
+                isRelevant = Vault.StateModificationStatus.ALL
         )
         val referenceState = serviceHub.vaultService.queryBy<ContractState>(query).states.single()
         return subFlow(FinalityFlow(

--- a/finance/src/main/kotlin/net/corda/finance/contracts/GetBalances.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/GetBalances.kt
@@ -21,7 +21,8 @@ private fun generateCashSumCriteria(currency: Currency): QueryCriteria {
     val sumCriteria = QueryCriteria.VaultCustomQueryCriteria(sum)
 
     val ccyIndex = builder { CashSchemaV1.PersistentCashState::currency.equal(currency.currencyCode) }
-    val ccyCriteria = QueryCriteria.VaultCustomQueryCriteria(ccyIndex)
+    // This query should only return cash states the calling node is a participant of (meaning they can be modified/spent).
+    val ccyCriteria = QueryCriteria.VaultCustomQueryCriteria(ccyIndex, isModifiable = Vault.StateModificationStatus.MODIFIABLE)
     return sumCriteria.and(ccyCriteria)
 }
 
@@ -30,7 +31,8 @@ private fun generateCashSumsCriteria(): QueryCriteria {
         CashSchemaV1.PersistentCashState::pennies.sum(groupByColumns = listOf(CashSchemaV1.PersistentCashState::currency),
                 orderBy = Sort.Direction.DESC)
     }
-    return QueryCriteria.VaultCustomQueryCriteria(sum)
+    // This query should only return cash states the calling node is a participant of (meaning they can be modified/spent).
+    return QueryCriteria.VaultCustomQueryCriteria(sum, isModifiable = Vault.StateModificationStatus.MODIFIABLE)
 }
 
 private fun rowsToAmount(currency: Currency, rows: Vault.Page<FungibleAsset<*>>): Amount<Currency> {

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionH2Impl.kt
@@ -33,11 +33,14 @@ class CashSelectionH2Impl : AbstractCashSelection() {
     override fun executeQuery(connection: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>, withResultSet: (ResultSet) -> Boolean): Boolean {
         connection.createStatement().use { it.execute("CALL SET(@t, CAST(0 AS BIGINT));") }
 
+        // state_status = 0 -> UNCONSUMED.
+        // is_modifiable = 0 -> MODIFIABLE.
         val selectJoin = """
                     SELECT vs.transaction_id, vs.output_index, ccs.pennies, SET(@t, ifnull(@t,0)+ccs.pennies) total_pennies, vs.lock_id
                     FROM vault_states AS vs, contract_cash_states AS ccs
                     WHERE vs.transaction_id = ccs.transaction_id AND vs.output_index = ccs.output_index
                     AND vs.state_status = 0
+                    AND vs.is_modifiable = 0
                     AND ccs.ccy_code = ? and @t < ?
                     AND (vs.lock_id = ? OR vs.lock_id is null)
                     """ +

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionPostgreSQLImpl.kt
@@ -4,7 +4,9 @@ import net.corda.core.contracts.Amount
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
-import net.corda.core.utilities.*
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.debug
 import java.sql.Connection
 import java.sql.DatabaseMetaData
 import java.sql.ResultSet
@@ -29,6 +31,8 @@ class CashSelectionPostgreSQLImpl : AbstractCashSelection() {
     //          appear in the WHERE clause, hence restricting row selection and adjusting the returned total in the outer query.
     //       3) Currently (version 9.6), FOR UPDATE cannot be specified with window functions
     override fun executeQuery(connection: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>, withResultSet: (ResultSet) -> Boolean): Boolean {
+        // state_status = 0 -> UNCONSUMED.
+        // is_modifiable = 0 -> MODIFIABLE.
         val selectJoin = """SELECT nested.transaction_id, nested.output_index, nested.pennies,
                         nested.total+nested.pennies as total_pennies, nested.lock_id
                        FROM
@@ -38,6 +42,7 @@ class CashSelectionPostgreSQLImpl : AbstractCashSelection() {
                         FROM vault_states AS vs, contract_cash_states AS ccs
                         WHERE vs.transaction_id = ccs.transaction_id AND vs.output_index = ccs.output_index
                         AND vs.state_status = 0
+                        AND vs.is_modifiable = 0
                         AND ccs.ccy_code = ?
                         AND (vs.lock_id = ? OR vs.lock_id is null)
                         """ +

--- a/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionSQLServerImpl.kt
+++ b/finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/CashSelectionSQLServerImpl.kt
@@ -42,6 +42,8 @@ class CashSelectionSQLServerImpl : AbstractCashSelection() {
     //      Query plan does index scan on pennies_idx, which may be unavoidable due to the nature of the query.
     override fun executeQuery(connection: Connection, amount: Amount<Currency>, lockId: UUID, notary: Party?, onlyFromIssuerParties: Set<AbstractParty>, withIssuerRefs: Set<OpaqueBytes>, withResultSet: (ResultSet) -> Boolean): Boolean {
         val sb = StringBuilder()
+        // state_status = 0 -> UNCONSUMED.
+        // is_modifiable = 0 -> MODIFIABLE.
         sb.append( """
             ;WITH CTE AS
             (
@@ -56,6 +58,7 @@ class CashSelectionSQLServerImpl : AbstractCashSelection() {
                 ON vs.transaction_id = ccs.transaction_id AND vs.output_index = ccs.output_index
             WHERE
               vs.state_status = 0
+              vs.is_modifiable = 0
               AND ccs.ccy_code = ?
               AND (vs.lock_id = ? OR vs.lock_id IS NULL)
             """

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -487,16 +487,16 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
         }
 
         // state relevance.
-        if (criteria.isRelevant != Vault.StateRelevance.ALL) {
-            val predicateID = Pair(VaultSchemaV1.VaultStates::isRelevant.name, EqualityComparisonOperator.EQUAL)
+        if (criteria.isParticipant != Vault.StateRelevance.ALL) {
+            val predicateID = Pair(VaultSchemaV1.VaultStates::isParticipant.name, EqualityComparisonOperator.EQUAL)
             if (commonPredicates.containsKey(predicateID)) {
                 val existingStatus = ((commonPredicates[predicateID] as ComparisonPredicate).rightHandOperand as LiteralExpression).literal
-                if (existingStatus != criteria.isRelevant) {
-                    log.warn("Overriding previous attribute [${VaultSchemaV1.VaultStates::isRelevant.name}] value $existingStatus with ${criteria.status}")
-                    commonPredicates.replace(predicateID, criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isRelevant.name), criteria.isRelevant))
+                if (existingStatus != criteria.isParticipant) {
+                    log.warn("Overriding previous attribute [${VaultSchemaV1.VaultStates::isParticipant.name}] value $existingStatus with ${criteria.status}")
+                    commonPredicates.replace(predicateID, criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isParticipant.name), criteria.isParticipant))
                 }
             } else {
-                commonPredicates[predicateID] = criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isRelevant.name), criteria.isRelevant)
+                commonPredicates[predicateID] = criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isParticipant.name), criteria.isParticipant)
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -486,6 +486,20 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             }
         }
 
+        // state relevance.
+        if (criteria.isRelevant != Vault.StateRelevance.ALL) {
+            val predicateID = Pair(VaultSchemaV1.VaultStates::isRelevant.name, EqualityComparisonOperator.EQUAL)
+            if (commonPredicates.containsKey(predicateID)) {
+                val existingStatus = ((commonPredicates[predicateID] as ComparisonPredicate).rightHandOperand as LiteralExpression).literal
+                if (existingStatus != criteria.isRelevant) {
+                    log.warn("Overriding previous attribute [${VaultSchemaV1.VaultStates::isRelevant.name}] value $existingStatus with ${criteria.status}")
+                    commonPredicates.replace(predicateID, criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isRelevant.name), criteria.isRelevant))
+                }
+            } else {
+                commonPredicates[predicateID] = criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isRelevant.name), criteria.isRelevant)
+            }
+        }
+
         // contract state types
         val contractStateTypes = deriveContractStateTypes(criteria.contractStateTypes)
         if (contractStateTypes.isNotEmpty()) {

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -487,16 +487,16 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
         }
 
         // state relevance.
-        if (criteria.isParticipant != Vault.StateRelevance.ALL) {
-            val predicateID = Pair(VaultSchemaV1.VaultStates::isParticipant.name, EqualityComparisonOperator.EQUAL)
+        if (criteria.isModifiable != Vault.StateModificationStatus.ALL) {
+            val predicateID = Pair(VaultSchemaV1.VaultStates::isModifiable.name, EqualityComparisonOperator.EQUAL)
             if (commonPredicates.containsKey(predicateID)) {
                 val existingStatus = ((commonPredicates[predicateID] as ComparisonPredicate).rightHandOperand as LiteralExpression).literal
-                if (existingStatus != criteria.isParticipant) {
-                    log.warn("Overriding previous attribute [${VaultSchemaV1.VaultStates::isParticipant.name}] value $existingStatus with ${criteria.status}")
-                    commonPredicates.replace(predicateID, criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isParticipant.name), criteria.isParticipant))
+                if (existingStatus != criteria.isModifiable) {
+                    log.warn("Overriding previous attribute [${VaultSchemaV1.VaultStates::isModifiable.name}] value $existingStatus with ${criteria.status}")
+                    commonPredicates.replace(predicateID, criteriaBuilder.equal(vaultStates.get<Vault.StateModificationStatus>(VaultSchemaV1.VaultStates::isModifiable.name), criteria.isModifiable))
                 }
             } else {
-                commonPredicates[predicateID] = criteriaBuilder.equal(vaultStates.get<Vault.StateRelevance>(VaultSchemaV1.VaultStates::isParticipant.name), criteria.isParticipant)
+                commonPredicates[predicateID] = criteriaBuilder.equal(vaultStates.get<Vault.StateModificationStatus>(VaultSchemaV1.VaultStates::isModifiable.name), criteria.isModifiable)
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -395,12 +395,15 @@ class NodeVaultService(
             return emptyList()
         }
 
-        // Enrich QueryCriteria with additional default attributes (such as soft locks)
+        // Enrich QueryCriteria with additional default attributes (such as soft locks).
+        // We only want to return MODIFIABLE states here.
         val sortAttribute = SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF)
         val sorter = Sort(setOf(Sort.SortColumn(sortAttribute, Sort.Direction.ASC)))
         val enrichedCriteria = QueryCriteria.VaultQueryCriteria(
                 contractStateTypes = setOf(contractStateType),
-                softLockingCondition = QueryCriteria.SoftLockingCondition(QueryCriteria.SoftLockingType.UNLOCKED_AND_SPECIFIED, listOf(lockId)))
+                softLockingCondition = QueryCriteria.SoftLockingCondition(QueryCriteria.SoftLockingType.UNLOCKED_AND_SPECIFIED, listOf(lockId)),
+                isModifiable = Vault.StateModificationStatus.MODIFIABLE
+        )
         val results = queryBy(contractStateType, enrichedCriteria.and(eligibleStatesQuery), sorter)
 
         var claimedAmount = 0L

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -58,8 +58,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var lockId: String? = null,
 
             /** Used to determine whether a state is modifiable by the recording node */
-            @Column(name = "is_participant", nullable = false)
-            var isParticipant: Vault.StateRelevance,
+            @Column(name = "is_modifiable", nullable = false)
+            var isModifiable: Vault.StateModificationStatus,
 
             /** refers to the last time a lock was taken (reserved) or updated (released, re-reserved) */
             @Column(name = "lock_timestamp", nullable = true)

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -58,8 +58,8 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             var lockId: String? = null,
 
             /** Used to determine whether a state is modifiable by the recording node */
-            @Column(name = "is_relevant", nullable = false)
-            var isRelevant: Vault.StateRelevance,
+            @Column(name = "is_participant", nullable = false)
+            var isParticipant: Vault.StateRelevance,
 
             /** refers to the last time a lock was taken (reserved) or updated (released, re-reserved) */
             @Column(name = "lock_timestamp", nullable = true)

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -57,6 +57,10 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
             @Column(name = "lock_id", nullable = true)
             var lockId: String? = null,
 
+            /** Used to determine whether a state is modifiable by the recording node */
+            @Column(name = "is_relevant", nullable = false)
+            var isRelevant: Vault.StateRelevance,
+
             /** refers to the last time a lock was taken (reserved) or updated (released, re-reserved) */
             @Column(name = "lock_timestamp", nullable = true)
             var lockUpdateTime: Instant? = null

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -528,17 +528,17 @@ class NodeVaultServiceTest {
         val amount = Amount(1000, Issued(BOC.ref(1), GBP))
         val wellKnownCash = Cash.State(amount, identity.party)
         val myKeys = services.keyManagementService.filterMyKeys(listOf(wellKnownCash.owner.owningKey))
-        assertTrue { service.isParticipant(wellKnownCash, myKeys.toSet()) }
+        assertTrue { service.isModifiable(wellKnownCash, myKeys.toSet()) }
 
         val anonymousIdentity = services.keyManagementService.freshKeyAndCert(identity, false)
         val anonymousCash = Cash.State(amount, anonymousIdentity.party)
         val anonymousKeys = services.keyManagementService.filterMyKeys(listOf(anonymousCash.owner.owningKey))
-        assertTrue { service.isParticipant(anonymousCash, anonymousKeys.toSet()) }
+        assertTrue { service.isModifiable(anonymousCash, anonymousKeys.toSet()) }
 
         val thirdPartyIdentity = AnonymousParty(generateKeyPair().public)
         val thirdPartyCash = Cash.State(amount, thirdPartyIdentity)
         val thirdPartyKeys = services.keyManagementService.filterMyKeys(listOf(thirdPartyCash.owner.owningKey))
-        assertFalse { service.isParticipant(thirdPartyCash, thirdPartyKeys.toSet()) }
+        assertFalse { service.isModifiable(thirdPartyCash, thirdPartyKeys.toSet()) }
     }
 
     // TODO: Unit test linear state relevancy checks
@@ -750,21 +750,21 @@ class NodeVaultServiceTest {
         services.recordTransactions(StatesToRecord.NONE, listOf(createTx(7, bankOfCorda.party)))
 
         // Test one.
-        // StateRelevance is RELEVANT by default. This should return two states.
+        // StateModificationStatus is MODIFIABLE by default. This should return two states.
         val resultOne = vaultService.queryBy<DummyState>().states.getNumbers()
-        assertEquals(setOf(1, 3, 6), resultOne)
+        assertEquals(setOf(1, 3, 4, 5, 6), resultOne)
 
         // Test two.
-        // StateRelevance set to NOT_RELEVANT.
-        val criteriaTwo = VaultQueryCriteria(isParticipant = Vault.StateRelevance.NOT_RELEVANT)
+        // StateModificationStatus set to NOT_MODIFIABLE.
+        val criteriaTwo = VaultQueryCriteria(isModifiable = Vault.StateModificationStatus.NOT_MODIFIABLE)
         val resultTwo = vaultService.queryBy<DummyState>(criteriaTwo).states.getNumbers()
         assertEquals(setOf(4, 5), resultTwo)
 
         // Test three.
-        // StateRelevance set to ALL.
-        val criteriaThree = VaultQueryCriteria(isParticipant = Vault.StateRelevance.ALL)
+        // StateModificationStatus set to ALL.
+        val criteriaThree = VaultQueryCriteria(isModifiable = Vault.StateModificationStatus.MODIFIABLE)
         val resultThree = vaultService.queryBy<DummyState>(criteriaThree).states.getNumbers()
-        assertEquals(setOf(1, 3, 4, 5, 6), resultThree)
+        assertEquals(setOf(1, 3, 6), resultThree)
 
         // We should never see 2 or 7.
     }

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -528,17 +528,17 @@ class NodeVaultServiceTest {
         val amount = Amount(1000, Issued(BOC.ref(1), GBP))
         val wellKnownCash = Cash.State(amount, identity.party)
         val myKeys = services.keyManagementService.filterMyKeys(listOf(wellKnownCash.owner.owningKey))
-        assertTrue { service.isRelevant(wellKnownCash, myKeys.toSet()) }
+        assertTrue { service.isParticipant(wellKnownCash, myKeys.toSet()) }
 
         val anonymousIdentity = services.keyManagementService.freshKeyAndCert(identity, false)
         val anonymousCash = Cash.State(amount, anonymousIdentity.party)
         val anonymousKeys = services.keyManagementService.filterMyKeys(listOf(anonymousCash.owner.owningKey))
-        assertTrue { service.isRelevant(anonymousCash, anonymousKeys.toSet()) }
+        assertTrue { service.isParticipant(anonymousCash, anonymousKeys.toSet()) }
 
         val thirdPartyIdentity = AnonymousParty(generateKeyPair().public)
         val thirdPartyCash = Cash.State(amount, thirdPartyIdentity)
         val thirdPartyKeys = services.keyManagementService.filterMyKeys(listOf(thirdPartyCash.owner.owningKey))
-        assertFalse { service.isRelevant(thirdPartyCash, thirdPartyKeys.toSet()) }
+        assertFalse { service.isParticipant(thirdPartyCash, thirdPartyKeys.toSet()) }
     }
 
     // TODO: Unit test linear state relevancy checks
@@ -756,13 +756,13 @@ class NodeVaultServiceTest {
 
         // Test two.
         // StateRelevance set to NOT_RELEVANT.
-        val criteriaTwo = VaultQueryCriteria(isRelevant = Vault.StateRelevance.NOT_RELEVANT)
+        val criteriaTwo = VaultQueryCriteria(isParticipant = Vault.StateRelevance.NOT_RELEVANT)
         val resultTwo = vaultService.queryBy<DummyState>(criteriaTwo).states.getNumbers()
         assertEquals(setOf(4, 5), resultTwo)
 
         // Test three.
         // StateRelevance set to ALL.
-        val criteriaThree = VaultQueryCriteria(isRelevant = Vault.StateRelevance.ALL)
+        val criteriaThree = VaultQueryCriteria(isParticipant = Vault.StateRelevance.ALL)
         val resultThree = vaultService.queryBy<DummyState>(criteriaThree).states.getNumbers()
         assertEquals(setOf(1, 3, 4, 5, 6), resultThree)
 


### PR DESCRIPTION
* Added new Vault Query API: `StateModificationStatus` which ca be `MODIFIABLE`, `NOT_MODIFIABLE` or `ALL`
* Updated "StateMetaData"
* All the query criteria now take `StateModificationStatus` as a new parameter
* Default behaviour is to query for `ALL` states as that is what Corda has previously done
* Added new column to `VaultStates` table called `is_modifiable` which stores the value of the enum which can only be set to RELEVANT or NOT_RELEVANT, never ALL
* Updated `getCashBalances` to only query for `MODIFIABLE` states as we only want to count cash states which we own!
* Added tests

Probably needs some optimisation as we now perform multiple "isModifiable" checks (key lookups).

TODO: Add better docs.