### PR TITLE
[CORDA-1681]: It is not possible to run stateMachinesSnapshot from the shell (fixed)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
+++ b/core/src/main/kotlin/net/corda/core/context/InvocationContext.kt
@@ -103,7 +103,8 @@ sealed class InvocationOrigin {
     /**
      * Origin was an RPC call.
      */
-    data class RPC(private val actor: Actor) : InvocationOrigin() {
+    // Field `actor` needs to stay public for AMQP / JSON serialization to work.
+    data class RPC(val actor: Actor) : InvocationOrigin() {
         override fun principal() = Principal { actor.id.value }
     }
 


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-1681

Considerations:

1. We need to be able to test the Shell, or it will always get broken.
2. There's a `CordaSerializableBeanSerializerModifier` in `CordaModule` which computes a difference between the AMQP properties and the renamed ones from Jackson. In this case, if the field is private, AMQP will contain the key, but the renamed ones will not, resulting in a thrown error. Not sure what's going on there.