### PR TITLE
CORDA-1906: Add Servlet 3.x implementation into the WebServer.

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-continuation:${jetty_version}"
 
     compile "org.glassfish.jersey.core:jersey-server:$jersey_version"
-    compile "org.glassfish.jersey.containers:jersey-container-servlet-core:$jersey_version"
+    compile "org.glassfish.jersey.containers:jersey-container-servlet:$jersey_version"
     compile "org.glassfish.jersey.containers:jersey-container-jetty-http:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"
 


### PR DESCRIPTION
Corda includes the Servlet 3.x APIs, but we only include the Servlet 2.0 implementation inside the WebServer. This prevents anyone from writing (say) an asynchronous servlet inside a CorDapp.

Include Jersey's Servlet 3.x implementation, which also includes the 2.0 implementation.