### PR TITLE
Added more descriptive error message for the cases when a transaction context is missing from the flow state machine

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -188,7 +188,9 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
 
     private fun checkDbTransaction(isPresent: Boolean) {
         if (isPresent) {
-            requireNotNull(contextTransactionOrNull)
+§            requireNotNull(contextTransactionOrNull) {
+                "Transaction context is missing. This might happen if a suspendable method is not annotated with @Suspendable annotation."
+            }
         } else {
             require(contextTransactionOrNull == null)
         }


### PR DESCRIPTION
Added more descriptive error message for the cases when a transaction context is missing from the flow state machine