### PR TITLE
Stop bootstrapper errors caused by maxTransactionSize > maxMessageSize

### DIFF
--- a/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/volumes/Volume.kt
+++ b/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/volumes/Volume.kt
@@ -46,7 +46,7 @@ interface Volume {
                     minimumPlatformVersion = 1,
                     notaries = it,
                     maxMessageSize = 10485760,
-                    maxTransactionSize = Int.MAX_VALUE,
+                    maxTransactionSize = 10485760,
                     modifiedTime = Instant.now(),
                     epoch = 10,
                     whitelistedContractImplementations = emptyMap())


### PR DESCRIPTION
Since [this](https://github.com/corda/corda/commit/c0207b2219f3dd647f84da72452492d0c3fc15fb) commit, if maxTransactionSize > maxMessageSize the node will fail to start up.