### PR TITLE
Corda 1916: signature attachment constraints

### DIFF
--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.convertValue
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.client.jackson.internal.childrenAs
@@ -18,9 +19,11 @@ import net.corda.core.crypto.*
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.PartialMerkleTree.PartialTree
 import net.corda.core.identity.*
+import net.corda.core.internal.AbstractAttachment
 import net.corda.core.internal.DigitalSignatureWithCert
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceHub
+import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.serialize
@@ -80,10 +83,18 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
 
     @Before
     fun setup() {
+        val unsignedAttachment = object : AbstractAttachment({ byteArrayOf() }) {
+            override val id: SecureHash get() = throw UnsupportedOperationException()
+        }
+
+        val attachments = rigorousMock<AttachmentStorage>().also {
+            doReturn(unsignedAttachment).whenever(it).openAttachment(any())
+        }
         services = rigorousMock()
         cordappProvider = rigorousMock()
         doReturn(cordappProvider).whenever(services).cordappProvider
         doReturn(testNetworkParameters()).whenever(services).networkParameters
+        doReturn(attachments).whenever(services).attachments
     }
 
     @Test

--- a/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
@@ -3,6 +3,7 @@ package net.corda.core.contracts
 import net.corda.core.DoNotImplement
 import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint.isSatisfiedBy
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.AttachmentWithContext
 import net.corda.core.internal.isUploaderTrusted
@@ -66,4 +67,18 @@ object AutomaticHashConstraint : AttachmentConstraint {
     override fun isSatisfiedBy(attachment: Attachment): Boolean {
         throw UnsupportedOperationException("Contracts cannot be satisfied by an AutomaticHashConstraint placeholder")
     }
+}
+
+/**
+ * An [AttachmentConstraint] that verifies that the attachment has signers that satisfy the provided [CompositeKey].
+ * See: corda/docs/source/design/data-model-upgrades/signature-constraints.md
+ *
+ * @param key A [CompositeKey] that must be satisfied by the owning keys of the attachment's signing parties.
+ */
+@KeepForDJVM
+data class SignatureAttachmentConstraint(
+        val key: CompositeKey
+) : AttachmentConstraint {
+    override fun isSatisfiedBy(attachment: Attachment): Boolean =
+        key.isFulfilledBy(attachment.signers.map { it.owningKey })
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
@@ -5,9 +5,11 @@ import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.AlwaysAcceptAttachmentConstraint.isSatisfiedBy
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.internal.AttachmentWithContext
 import net.corda.core.internal.isUploaderTrusted
 import net.corda.core.serialization.CordaSerializable
+import java.security.PublicKey
 
 /** Constrain which contract-code-containing attachment can be used with a [ContractState]. */
 @CordaSerializable
@@ -70,14 +72,14 @@ object AutomaticHashConstraint : AttachmentConstraint {
 }
 
 /**
- * An [AttachmentConstraint] that verifies that the attachment has signers that satisfy the provided [CompositeKey].
+ * An [AttachmentConstraint] that verifies that the attachment has signers that fulfil the provided [PublicKey].
  * See: corda/docs/source/design/data-model-upgrades/signature-constraints.md
  *
- * @param key A [CompositeKey] that must be satisfied by the owning keys of the attachment's signing parties.
+ * @param key A [PublicKey] that must be fulfilled by the owning keys of the attachment's signing parties.
  */
 @KeepForDJVM
 data class SignatureAttachmentConstraint(
-        val key: CompositeKey
+        val key: PublicKey
 ) : AttachmentConstraint {
     override fun isSatisfiedBy(attachment: Attachment): Boolean =
         key.isFulfilledBy(attachment.signers.map { it.owningKey })

--- a/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
@@ -14,6 +14,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.security.CodeSigner
 import java.security.cert.X509Certificate
+import java.util.jar.JarEntry
 import java.util.jar.JarInputStream
 
 const val DEPLOYED_CORDAPP_UPLOADER = "app"
@@ -35,9 +36,6 @@ abstract class AbstractAttachment(dataLoader: () -> ByteArray) : Attachment {
                 (a as? AbstractAttachment)?.attachmentData ?: a.open().readFully()
             }
         }
-
-        /** @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File> */
-        private val unsignableEntryName = "META-INF/(?:.*[.](?:SF|DSA|RSA)|SIG-.*)".toRegex()
     }
 
     protected val attachmentData: ByteArray by lazy(dataLoader)
@@ -47,24 +45,7 @@ abstract class AbstractAttachment(dataLoader: () -> ByteArray) : Attachment {
 
     override fun open(): InputStream = attachmentData.inputStream()
     override val signers by lazy {
-        // Can't start with empty set if we're doing intersections. Logically the null means "all possible signers":
-        var attachmentSigners: MutableSet<CodeSigner>? = null
-        openAsJAR().use { jar ->
-            val shredder = ByteArray(1024)
-            while (true) {
-                val entry = jar.nextJarEntry ?: break
-                if (entry.isDirectory || unsignableEntryName.matches(entry.name)) continue
-                while (jar.read(shredder) != -1) { // Must read entry fully for codeSigners to be valid.
-                    // Do nothing.
-                }
-                val entrySigners = entry.codeSigners ?: emptyArray()
-                attachmentSigners?.retainAll(entrySigners) ?: run { attachmentSigners = entrySigners.toMutableSet() }
-                if (attachmentSigners!!.isEmpty()) break // Performance short-circuit.
-            }
-        }
-        (attachmentSigners ?: emptySet<CodeSigner>()).map {
-            Party(it.signerCertPath.certificates[0] as X509Certificate)
-        }.sortedBy { it.name.toString() } // Determinism.
+        openAsJAR().use(JarSignatureCollector::collectSigningParties)
     }
 
     override fun equals(other: Any?) = other === this || other is Attachment && other.id == this.id
@@ -85,4 +66,58 @@ fun JarInputStream.extractFile(path: String, outputTo: OutputStream) {
         closeEntry()
     }
     throw FileNotFoundException(path)
+}
+
+private object JarSignatureCollector {
+
+    /** @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File> */
+    private val unsignableEntryName = "META-INF/(?:.*[.](?:SF|DSA|RSA)|SIG-.*)".toRegex()
+
+    /**
+     * An array which essentially serves as /dev/null for reading through a jar and obtaining its code signers.
+     */
+    private val shredder = ByteArray(1024)
+
+    /**
+     * Returns an ordered list of every [Party] which has signed every signable item in the given [JarInputStream].
+     * Any party which has signed some but not all signable items is eliminated.
+     *
+     * @param jar The open [JarInputStream] to collect signing parties from.
+     */
+    fun collectSigningParties(jar: JarInputStream): List<Party> {
+        // Can't start with empty set if we're doing intersections. Logically the null means "all possible signers":
+        var attachmentSigners: MutableSet<CodeSigner>? = null
+
+        for (signers in jar.getSignerSets()) {
+            attachmentSigners = attachmentSigners?.intersect(signers) ?: signers.toMutableSet()
+
+            if (attachmentSigners.isEmpty()) return emptyList() // Performance short-circuit.
+        }
+
+        return attachmentSigners?.toPartiesOrderedByName() ?: emptyList()
+    }
+
+    private fun <T> MutableSet<T>.intersect(others: Iterable<T>) = apply { retainAll(others) }
+
+    private fun JarInputStream.getSignerSets() =
+            entries().thatAreSignable().shreddedFrom(this).toSignerSets()
+
+    private fun Sequence<JarEntry>.thatAreSignable() =
+            filterNot { entry -> entry.isDirectory || unsignableEntryName.matches(entry.name) }
+
+    private fun Sequence<JarEntry>.shreddedFrom(jar: JarInputStream) = map { entry ->
+        entry.apply {
+            while (jar.read(shredder) != -1) { // Must read entry fully for codeSigners to be valid.
+                // Do nothing.
+            }
+        }
+    }
+
+    private fun Sequence<JarEntry>.toSignerSets() = map { entry -> entry.codeSigners?.toList() ?: emptyList() }
+
+    private fun Set<CodeSigner>.toPartiesOrderedByName() = map {
+        Party(it.signerCertPath.certificates[0] as X509Certificate)
+    }.sortedBy { it.name.toString() } // Sorted for determinism.
+
+    private fun JarInputStream.entries() = generateSequence(nextJarEntry) { nextJarEntry }
 }

--- a/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
@@ -5,16 +5,12 @@ import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.Attachment
 import net.corda.core.crypto.SecureHash
-import net.corda.core.identity.Party
 import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.SerializeAsTokenContext
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
-import java.security.CodeSigner
-import java.security.cert.X509Certificate
-import java.util.jar.JarEntry
 import java.util.jar.JarInputStream
 
 const val DEPLOYED_CORDAPP_UPLOADER = "app"
@@ -68,56 +64,3 @@ fun JarInputStream.extractFile(path: String, outputTo: OutputStream) {
     throw FileNotFoundException(path)
 }
 
-private object JarSignatureCollector {
-
-    /** @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File> */
-    private val unsignableEntryName = "META-INF/(?:.*[.](?:SF|DSA|RSA)|SIG-.*)".toRegex()
-
-    /**
-     * An array which essentially serves as /dev/null for reading through a jar and obtaining its code signers.
-     */
-    private val shredder = ByteArray(1024)
-
-    /**
-     * Returns an ordered list of every [Party] which has signed every signable item in the given [JarInputStream].
-     * Any party which has signed some but not all signable items is eliminated.
-     *
-     * @param jar The open [JarInputStream] to collect signing parties from.
-     */
-    fun collectSigningParties(jar: JarInputStream): List<Party> {
-        // Can't start with empty set if we're doing intersections. Logically the null means "all possible signers":
-        var attachmentSigners: MutableSet<CodeSigner>? = null
-
-        for (signers in jar.getSignerSets()) {
-            attachmentSigners = attachmentSigners?.intersect(signers) ?: signers.toMutableSet()
-
-            if (attachmentSigners.isEmpty()) return emptyList() // Performance short-circuit.
-        }
-
-        return attachmentSigners?.toPartiesOrderedByName() ?: emptyList()
-    }
-
-    private fun <T> MutableSet<T>.intersect(others: Iterable<T>) = apply { retainAll(others) }
-
-    private fun JarInputStream.getSignerSets() =
-            entries().thatAreSignable().shreddedFrom(this).toSignerSets()
-
-    private fun Sequence<JarEntry>.thatAreSignable() =
-            filterNot { entry -> entry.isDirectory || unsignableEntryName.matches(entry.name) }
-
-    private fun Sequence<JarEntry>.shreddedFrom(jar: JarInputStream) = map { entry ->
-        entry.apply {
-            while (jar.read(shredder) != -1) { // Must read entry fully for codeSigners to be valid.
-                // Do nothing.
-            }
-        }
-    }
-
-    private fun Sequence<JarEntry>.toSignerSets() = map { entry -> entry.codeSigners?.toList() ?: emptyList() }
-
-    private fun Set<CodeSigner>.toPartiesOrderedByName() = map {
-        Party(it.signerCertPath.certificates[0] as X509Certificate)
-    }.sortedBy { it.name.toString() } // Sorted for determinism.
-
-    private fun JarInputStream.entries() = generateSequence(nextJarEntry) { nextJarEntry }
-}

--- a/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
@@ -1,0 +1,64 @@
+package net.corda.core.internal
+
+import net.corda.core.identity.Party
+import java.security.CodeSigner
+import java.security.cert.X509Certificate
+import java.util.jar.JarEntry
+import java.util.jar.JarInputStream
+
+/**
+ * Utility class which provides the ability to extract a list of signing parties from a [JarInputStream].
+ */
+object JarSignatureCollector {
+
+    /** @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File> */
+    private val unsignableEntryName = "META-INF/(?:.*[.](?:SF|DSA|RSA)|SIG-.*)".toRegex()
+
+    /**
+     * An array which essentially serves as /dev/null for reading through a jar and obtaining its code signers.
+     */
+    private val shredder = ByteArray(1024)
+
+    /**
+     * Returns an ordered list of every [Party] which has signed every signable item in the given [JarInputStream].
+     * Any party which has signed some but not all signable items is eliminated.
+     *
+     * @param jar The open [JarInputStream] to collect signing parties from.
+     */
+    fun collectSigningParties(jar: JarInputStream): List<Party> {
+        // Can't start with empty set if we're doing intersections. Logically the null means "all possible signers":
+        var attachmentSigners: MutableSet<CodeSigner>? = null
+
+        for (signers in jar.getSignerSets()) {
+            attachmentSigners = attachmentSigners?.intersect(signers) ?: signers.toMutableSet()
+
+            if (attachmentSigners.isEmpty()) break // Performance short-circuit.
+        }
+
+        return attachmentSigners?.toPartiesOrderedByName() ?: emptyList()
+    }
+
+    private fun <T> MutableSet<T>.intersect(others: Iterable<T>) = apply { retainAll(others) }
+
+    private fun JarInputStream.getSignerSets() =
+            entries().thatAreSignable().shreddedFrom(this).toSignerSets()
+
+    private fun Sequence<JarEntry>.thatAreSignable() =
+            filterNot { entry -> entry.isDirectory || unsignableEntryName.matches(entry.name) }
+
+    private fun Sequence<JarEntry>.shreddedFrom(jar: JarInputStream) = map { entry ->
+        entry.apply {
+            while (jar.read(shredder) != -1) { // Must read entry fully for codeSigners to be valid.
+                // Do nothing.
+            }
+        }
+    }
+
+    private fun Sequence<JarEntry>.toSignerSets() = map { entry -> entry.codeSigners?.toList() ?: emptyList() }
+
+    private fun Set<CodeSigner>.toPartiesOrderedByName() = map {
+        Party(it.signerCertPath.certificates[0] as X509Certificate)
+    }.sortedBy { it.name.toString() } // Sorted for determinism.
+
+    private fun JarInputStream.entries() = generateSequence(nextJarEntry) { nextJarEntry }
+}

--- a/core/src/test/kotlin/net/corda/core/internal/JarSignatureCollectorTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/JarSignatureCollectorTest.kt
@@ -1,5 +1,6 @@
 package net.corda.core.internal
 
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
@@ -21,6 +22,7 @@ class JarSignatureCollectorTest {
         private val dir = Files.createTempDirectory(JarSignatureCollectorTest::class.simpleName)
         private val bin = Paths.get(System.getProperty("java.home")).let { if (it.endsWith("jre")) it.parent else it } / "bin"
         private val shredder = (dir / "_shredder").toFile() // No need to delete after each test.
+
         fun execute(vararg command: String) {
             assertEquals(0, ProcessBuilder()
                     .inheritIO()
@@ -31,18 +33,25 @@ class JarSignatureCollectorTest {
                     .waitFor())
         }
 
+        private const val FILENAME = "attachment.jar"
+        private const val ALICE = "alice"
+        private const val ALICE_PASS = "alicepass"
+        private const val BOB = "bob"
+        private const val BOB_PASS = "bobpass"
+
+        private fun generateKey(alias: String, password: String, name: CordaX500Name) =
+                execute("keytool", "-genkey", "-keystore", "_teststore", "-storepass", "storepass", "-keyalg", "RSA", "-alias", alias, "-keypass", password, "-dname", name.toString())
+
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            execute("keytool", "-genkey", "-keystore", "_teststore", "-storepass", "storepass", "-keyalg", "RSA", "-alias", "alice", "-keypass", "alicepass", "-dname", ALICE_NAME.toString())
-            execute("keytool", "-genkey", "-keystore", "_teststore", "-storepass", "storepass", "-keyalg", "RSA", "-alias", "bob", "-keypass", "bobpass", "-dname", BOB_NAME.toString())
+            generateKey(ALICE, ALICE_PASS, ALICE_NAME)
+            generateKey(BOB, BOB_PASS, BOB_NAME)
+
             (dir / "_signable1").writeLines(listOf("signable1"))
             (dir / "_signable2").writeLines(listOf("signable2"))
             (dir / "_signable3").writeLines(listOf("signable3"))
         }
-
-        private fun getSigners(name: String) =
-            JarInputStream(FileInputStream((dir / name).toFile())).use(JarSignatureCollector::collectSigningParties)
 
         @AfterClass
         @JvmStatic
@@ -64,63 +73,87 @@ class JarSignatureCollectorTest {
     @Test
     fun `empty jar has no signers`() {
         (dir / "META-INF").createDirectory() // At least one arg is required, and jar cvf conveniently ignores this.
-        execute("jar", "cvf", "attachment.jar", "META-INF")
-        assertEquals(emptyList(), getSigners("attachment.jar"))
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "alicepass", "attachment.jar", "alice")
-        assertEquals(emptyList(), getSigners("attachment.jar")) // There needs to have been a file for ALICE to sign.
+        createJar("META-INF")
+        assertEquals(emptyList(), getJarSigners())
+
+        signAsAlice()
+        assertEquals(emptyList(), getJarSigners()) // There needs to have been a file for ALICE to sign.
     }
 
     @Test
     fun `unsigned jar has no signers`() {
-        execute("jar", "cvf", "attachment.jar", "_signable1")
-        assertEquals(emptyList(), getSigners("attachment.jar"))
-        execute("jar", "uvf", "attachment.jar", "_signable2")
-        assertEquals(emptyList(), getSigners("attachment.jar"))
+        createJar("_signable1")
+        assertEquals(emptyList(), getJarSigners())
+
+        updateJar("_signable2")
+        assertEquals(emptyList(), getJarSigners())
     }
 
     @Test
     fun `one signer`() {
-        execute("jar", "cvf", "attachment.jar", "_signable1", "_signable2")
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "alicepass", "attachment.jar", "alice")
-        assertEquals(listOf(ALICE_NAME), getSigners("attachment.jar").names) // We only reused ALICE's distinguished name, so the keys will be different.
+        createJar("_signable1", "_signable2")
+        signAsAlice()
+        assertEquals(listOf(ALICE_NAME), getJarSigners().names) // We only reused ALICE's distinguished name, so the keys will be different.
+
         (dir / "my-dir").createDirectory()
-        execute("jar", "uvf", "attachment.jar", "my-dir")
-        assertEquals(listOf(ALICE_NAME), getSigners("attachment.jar").names) // Unsigned directory is irrelevant.
+        updateJar("my-dir")
+        assertEquals(listOf(ALICE_NAME), getJarSigners().names) // Unsigned directory is irrelevant.
     }
 
     @Test
     fun `two signers`() {
-        execute("jar", "cvf", "attachment.jar", "_signable1", "_signable2")
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "alicepass", "attachment.jar", "alice")
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "bobpass", "attachment.jar", "bob")
-        assertEquals(listOf(ALICE_NAME, BOB_NAME), getSigners("attachment.jar").names)
+        createJar("_signable1", "_signable2")
+        signAsAlice()
+        signAsBob()
+
+        assertEquals(listOf(ALICE_NAME, BOB_NAME), getJarSigners().names)
     }
 
     @Test
     fun `all files must be signed by the same set of signers`() {
-        execute("jar", "cvf", "attachment.jar", "_signable1")
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "alicepass", "attachment.jar", "alice")
-        assertEquals(listOf(ALICE_NAME), getSigners("attachment.jar").names)
-        execute("jar", "uvf", "attachment.jar", "_signable2")
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "bobpass", "attachment.jar", "bob")
+        createJar("_signable1")
+        signAsAlice()
+        assertEquals(listOf(ALICE_NAME), getJarSigners().names)
+
+        updateJar("_signable2")
+        signAsBob()
         assertFailsWith<InvalidJarSignersException>(
             """
             Mismatch between signers [O=Alice Corp, L=Madrid, C=ES, O=Bob Plc, L=Rome, C=IT] for file _signable1
             and signers [O=Bob Plc, L=Rome, C=IT] for file _signable2
             """.trimIndent().replace('\n', ' ')
-        ) { getSigners("attachment.jar") }
+        ) { getJarSigners() }
     }
 
     @Test
     fun `bad signature is caught even if the party would not qualify as a signer`() {
         (dir / "volatile").writeLines(listOf("volatile"))
-        execute("jar", "cvf", "attachment.jar", "volatile")
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "alicepass", "attachment.jar", "alice")
-        assertEquals(listOf(ALICE_NAME), getSigners("attachment.jar").names)
+        createJar("volatile")
+        signAsAlice()
+        assertEquals(listOf(ALICE_NAME), getJarSigners().names)
+
         (dir / "volatile").writeLines(listOf("garbage"))
-        execute("jar", "uvf", "attachment.jar", "volatile", "_signable1") // ALICE's signature on volatile is now bad.
-        execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", "bobpass", "attachment.jar", "bob")
+        updateJar("volatile", "_signable1") // ALICE's signature on volatile is now bad.
+        signAsBob()
         // The JDK doesn't care that BOB has correctly signed the whole thing, it won't let us process the entry with ALICE's bad signature:
-        assertFailsWith<SecurityException> { getSigners("attachment.jar") }
+        assertFailsWith<SecurityException> { getJarSigners() }
     }
+
+    //region Helper functions
+    private fun createJar(vararg contents: String) =
+            execute(*(arrayOf("jar", "cvf", FILENAME) + contents))
+
+    private fun updateJar(vararg contents: String) =
+            execute(*(arrayOf("jar", "uvf", FILENAME) + contents))
+
+    private fun signJar(alias: String, password: String) =
+            execute("jarsigner", "-keystore", "_teststore", "-storepass", "storepass", "-keypass", password, FILENAME, alias)
+
+    private fun signAsAlice() = signJar(ALICE, ALICE_PASS)
+    private fun signAsBob() = signJar(BOB, BOB_PASS)
+
+    private fun getJarSigners() =
+            JarInputStream(FileInputStream((dir / FILENAME).toFile())).use(JarSignatureCollector::collectSigningParties)
+    //endregion
+    
 }

--- a/core/src/test/kotlin/net/corda/core/transactions/TransactionBuilderTest.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/TransactionBuilderTest.kt
@@ -4,16 +4,17 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.contracts.*
 import net.corda.core.cordapp.CordappProvider
+import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.Party
+import net.corda.core.internal.AbstractAttachment
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.ZoneVersionTooLowException
+import net.corda.core.node.services.AttachmentStorage
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyState
-import net.corda.testing.core.DUMMY_NOTARY_NAME
-import net.corda.testing.core.DummyCommandData
-import net.corda.testing.core.SerializationEnvironmentRule
-import net.corda.testing.core.TestIdentity
+import net.corda.testing.core.*
 import net.corda.testing.internal.rigorousMock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -29,6 +30,7 @@ class TransactionBuilderTest {
     private val notary = TestIdentity(DUMMY_NOTARY_NAME).party
     private val services = rigorousMock<ServicesForResolution>()
     private val contractAttachmentId = SecureHash.randomSHA256()
+    private val attachments = rigorousMock<AttachmentStorage>()
 
     @Before
     fun setup() {
@@ -36,6 +38,7 @@ class TransactionBuilderTest {
         doReturn(cordappProvider).whenever(services).cordappProvider
         doReturn(contractAttachmentId).whenever(cordappProvider).getContractAttachmentID(DummyContract.PROGRAM_ID)
         doReturn(testNetworkParameters()).whenever(services).networkParameters
+        doReturn(attachments).whenever(services).attachments
     }
 
     @Test
@@ -56,6 +59,8 @@ class TransactionBuilderTest {
 
     @Test
     fun `automatic hash constraint`() {
+        doReturn(unsignedAttachment).whenever(attachments).openAttachment(contractAttachmentId)
+
         val outputState = TransactionState(data = DummyState(), contract = DummyContract.PROGRAM_ID, notary = notary)
         val builder = TransactionBuilder()
                 .addOutputState(outputState)
@@ -66,6 +71,8 @@ class TransactionBuilderTest {
 
     @Test
     fun `reference states`() {
+        doReturn(unsignedAttachment).whenever(attachments).openAttachment(contractAttachmentId)
+
         val referenceState = TransactionState(DummyState(), DummyContract.PROGRAM_ID, notary)
         val referenceStateRef = StateRef(SecureHash.randomSHA256(), 1)
         val builder = TransactionBuilder(notary)
@@ -85,12 +92,32 @@ class TransactionBuilderTest {
 
     @Test
     fun `automatic signature constraint`() {
+        val aliceParty = TestIdentity(ALICE_NAME).party
+        val bobParty = TestIdentity(BOB_NAME).party
+        val compositeKey = CompositeKey.Builder().addKeys(aliceParty.owningKey, bobParty.owningKey).build()
+
+        doReturn(signedAttachment(aliceParty, bobParty)).whenever(attachments).openAttachment(contractAttachmentId)
+
         val outputState = TransactionState(data = DummyState(), contract = DummyContract.PROGRAM_ID, notary = notary)
         val builder = TransactionBuilder()
                 .addOutputState(outputState)
                 .addCommand(DummyCommandData, notary.owningKey)
         val wtx = builder.toWireTransaction(services)
+
         assertThat(wtx.outputs).containsOnly(
-                outputState.copy(constraint = HashAttachmentConstraint(contractAttachmentId)))
+                outputState.copy(constraint = SignatureAttachmentConstraint(compositeKey)))
+    }
+
+
+    private val unsignedAttachment = object : AbstractAttachment({ byteArrayOf() }) {
+        override val id: SecureHash get() = throw UnsupportedOperationException()
+
+        override val signers: List<Party> get() = emptyList()
+    }
+
+    private fun signedAttachment(vararg parties: Party) = object : AbstractAttachment({ byteArrayOf() }) {
+        override val id: SecureHash get() = throw UnsupportedOperationException()
+           
+        override val signers: List<Party> get() = parties.toList()
     }
 }

--- a/core/src/test/kotlin/net/corda/core/transactions/TransactionBuilderTest.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/TransactionBuilderTest.kt
@@ -82,4 +82,15 @@ class TransactionBuilderTest {
         val wtx = builder.toWireTransaction(services)
         assertThat(wtx.references).containsOnly(referenceStateRef)
     }
+
+    @Test
+    fun `automatic signature constraint`() {
+        val outputState = TransactionState(data = DummyState(), contract = DummyContract.PROGRAM_ID, notary = notary)
+        val builder = TransactionBuilder()
+                .addOutputState(outputState)
+                .addCommand(DummyCommandData, notary.owningKey)
+        val wtx = builder.toWireTransaction(services)
+        assertThat(wtx.outputs).containsOnly(
+                outputState.copy(constraint = HashAttachmentConstraint(contractAttachmentId)))
+    }
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
@@ -1,12 +1,16 @@
 package net.corda.nodeapi.internal
 
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.contracts.*
+import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.internal.AbstractAttachment
 import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.services.AttachmentStorage
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.LedgerTransaction
@@ -66,11 +70,20 @@ class AttachmentsClassLoaderStaticContractTests {
         }
     }
 
+    private val unsignedAttachment = object : AbstractAttachment({ byteArrayOf() }) {
+        override val id: SecureHash get() = throw UnsupportedOperationException()
+    }
+
+    private val attachments = rigorousMock<AttachmentStorage>().also {
+            doReturn(unsignedAttachment).whenever(it).openAttachment(any())
+    }
+
     private val serviceHub = rigorousMock<ServicesForResolution>().also {
         val cordappProviderImpl = CordappProviderImpl(cordappLoaderForPackages(listOf("net.corda.nodeapi.internal")), MockCordappConfigProvider(), MockAttachmentStorage())
         cordappProviderImpl.start(testNetworkParameters().whitelistedContractImplementations)
         doReturn(cordappProviderImpl).whenever(it).cordappProvider
         doReturn(testNetworkParameters()).whenever(it).networkParameters
+        doReturn(attachments).whenever(it).attachments
     }
 
     @Test


### PR DESCRIPTION
See [design document](https://github.com/corda/corda/blob/e8a15644297335544979fa281d4fa772d4cd782e/docs/source/design/data-model-upgrades/signature-constraints.md) for details of what this is trying to achieve.

We introduce a new type of `AttachmentConstraint`, `SignatureAttachmentConstraint`, which verifies that the attachment has signers that fulfil the provided `PublicKey` (which will typically be a `CompositeKey` stipulating multiple signers).

The function which obtains a list of signing parties for a given jar file is extracted to the object class `JarSignatureCollector` and independently tested in `JarSignatureCollectorTest`.

The `TransactionBuilder`'s automatic constraint selection is extended to load each output state's contract attachment and, if it has any signers, to associate the state with a matching `SignatureAttachmentConstraint`. A new test is added to `TransactionBuilderTest` to verify this behaviour.

Some otherwise unrelated tests which use mock services have to have some additional mocking behaviour defined, since all uses of `TransactionBuilder` now potentially involve trying to load each state's contract attachment's JAR data to find out what signers it has.