### PR TITLE
CORDA-1925: Include Requirements object in core-deterministic.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractsDSL.kt
@@ -18,6 +18,7 @@ import java.util.*
 
 //// Requirements /////////////////////////////////////////////////////////////////////////////////////////////////////
 
+@KeepForDJVM
 object Requirements {
     /** Throws [IllegalArgumentException] if the given expression evaluates to false. */
     @Suppress("NOTHING_TO_INLINE")   // Inlining this takes it out of our committed ABI.


### PR DESCRIPTION
The `Requirements` object needs its own `@KeepForDJVM` annotation because it's has its own `.class` file. It does not inherit the `@file:KeepForDJVM` annotation applied to the `ContractsDSL.class`.