### PR TITLE
CORDA-1932 Fixing network map certificate path verification

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
@@ -7,15 +7,19 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.utilities.OpaqueBytes
+import java.security.cert.CertPath
 import java.security.cert.X509Certificate
 
 // TODO: Rename this to DigitalSignature.WithCert once we're happy for it to be public API. The methods will need documentation
 // and the correct exceptions will be need to be annotated
 /** A digital signature with attached certificate of the public key. */
-class DigitalSignatureWithCert(val by: X509Certificate, bytes: ByteArray) : DigitalSignature(bytes) {
+open class DigitalSignatureWithCert(val by: X509Certificate, bytes: ByteArray) : DigitalSignature(bytes) {
     fun verify(content: ByteArray): Boolean = by.publicKey.verify(content, this)
     fun verify(content: OpaqueBytes): Boolean = verify(content.bytes)
 }
+
+/** A digital signature with attached certificate path. The first certificate in the path corresponds to the data signer key. */
+class DigitalSignatureWithCertPath(val path: List<X509Certificate>, bytes: ByteArray): DigitalSignatureWithCert(path.first(), bytes)
 
 /** Similar to [SignedData] but instead of just attaching the public key, the certificate for the key is attached instead. */
 @CordaSerializable

--- a/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
@@ -18,7 +18,11 @@ open class DigitalSignatureWithCert(val by: X509Certificate, bytes: ByteArray) :
     fun verify(content: OpaqueBytes): Boolean = verify(content.bytes)
 }
 
-/** A digital signature with attached certificate path. The first certificate in the path corresponds to the data signer key. */
+/**
+ * A digital signature with attached certificate path. The first certificate in the path corresponds to the data signer key.
+ * @param path certificate path associated with this signature
+ * @param bytes signature bytes
+ */
 class DigitalSignatureWithCertPath(val path: List<X509Certificate>, bytes: ByteArray): DigitalSignatureWithCert(path.first(), bytes)
 
 /** Similar to [SignedData] but instead of just attaching the public key, the certificate for the key is attached instead. */

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt
@@ -2,13 +2,11 @@ package net.corda.nodeapi.internal.network
 
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.CertRole
-import net.corda.core.internal.DigitalSignatureWithCert
+import net.corda.core.internal.DigitalSignatureWithCertPath
 import net.corda.core.internal.SignedDataWithCert
-import net.corda.core.internal.signWithCert
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.SerializedBytes
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import java.security.cert.X509Certificate
 import java.time.Instant
@@ -58,19 +56,12 @@ data class ParametersUpdate(
 )
 
 /** Verify that a Network Map certificate is issued by Root CA and its [CertRole] is correct. */
-// TODO: Current implementation works under the assumption that there are no intermediate CAs between Root and
-//      Network Map. Consider a more flexible implementation without the above assumption.
-
 fun <T : Any> SignedDataWithCert<T>.verifiedNetworkMapCert(rootCert: X509Certificate): T {
     require(CertRole.extract(sig.by) == CertRole.NETWORK_MAP) { "Incorrect cert role: ${CertRole.extract(sig.by)}" }
-    X509Utilities.validateCertificateChain(rootCert, sig.by, rootCert)
+    if (this.sig is DigitalSignatureWithCertPath) {
+        X509Utilities.validateCertificateChain(rootCert, (sig as DigitalSignatureWithCertPath).path)
+    } else {
+        X509Utilities.validateCertificateChain(rootCert, sig.by, rootCert)
+    }
     return verified()
-}
-
-class NetworkMapAndSigned private constructor(val networkMap: NetworkMap, val signed: SignedNetworkMap) {
-    constructor(networkMap: NetworkMap, signer: (SerializedBytes<NetworkMap>) -> DigitalSignatureWithCert) : this(networkMap, networkMap.signWithCert(signer))
-    constructor(signed: SignedNetworkMap) : this(signed.verified(), signed)
-
-    operator fun component1(): NetworkMap = networkMap
-    operator fun component2(): SignedNetworkMap = signed
 }


### PR DESCRIPTION
This PR fixes the certificate path verification process in case of the incoming network map data. It no longer assumes any specific certificate path length.
