### PR TITLE
Database column rename required by ENT-2253

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/schemas/NodeInfoSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/schemas/NodeInfoSchema.kt
@@ -72,6 +72,7 @@ object NodeInfoSchemaV1 : MappedSchema(
             @GeneratedValue
             @Column(name = "hosts_id", nullable = false)
             var id: Int,
+            @Column(name = "host_name")
             val host: String? = null,
             val port: Int? = null
     ) {

--- a/node/src/main/resources/migration/node-info.changelog-master.xml
+++ b/node/src/main/resources/migration/node-info.changelog-master.xml
@@ -7,5 +7,6 @@
     <include file="migration/node-info.changelog-init.xml"/>
     <include file="migration/node-info.changelog-v1.xml"/>
     <include file="migration/node-info.changelog-v2.xml"/>
+    <include file="migration/node-info.changelog-v3.xml"/>
 
 </databaseChangeLog>

--- a/node/src/main/resources/migration/node-info.changelog-v3.xml
+++ b/node/src/main/resources/migration/node-info.changelog-v3.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="R3.Corda" id="column_host_name">
+        <renameColumn newColumnName="host_name" oldColumnName="host" tableName="node_info_hosts"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Rename column HOST to HOST_NAME in table NODE_INFO_HOSTS - required by ENT-2253