### PR TITLE
Add tests to confirm that if a Hibernate error occurs the transaction will fail and no states will be persisted

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultFlowTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultFlowTest.kt
@@ -43,11 +43,8 @@ class VaultFlowTest {
                 threadPerNode = true,
                 networkSendManuallyPumped = false
         )
-        partyA =
-                mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("PartyA", "Berlin", "DE")))
-
-        partyB =
-                mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("PartyB", "Berlin", "DE")))
+        partyA = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("PartyA", "Berlin", "DE")))
+        partyB = mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("PartyB", "Berlin", "DE")))
         mockNetwork.startNodes()
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultFlowTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultFlowTest.kt
@@ -1,0 +1,91 @@
+package net.corda.node.services.vault
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.node.services.queryBy
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.testing.core.DummyCommandData
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.internal.vault.DUMMY_DEAL_PROGRAM_ID
+import net.corda.testing.internal.vault.DummyDealContract
+import net.corda.testing.internal.vault.UNIQUE_DUMMY_LINEAR_CONTRACT_PROGRAM_ID
+import net.corda.testing.internal.vault.UniqueDummyLinearContract
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkNotarySpec
+import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.node.StartedMockNode
+import org.assertj.core.api.Assertions
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.ExecutionException
+import kotlin.test.assertEquals
+
+class VaultFlowTest {
+
+    private lateinit var mockNetwork: MockNetwork
+    private lateinit var partyA: StartedMockNode
+    private lateinit var partyB: StartedMockNode
+    private lateinit var notaryNode: MockNetworkNotarySpec
+
+    @Before
+    fun setup() {
+        notaryNode = MockNetworkNotarySpec(CordaX500Name("Notary", "London", "GB"))
+        mockNetwork = MockNetwork(
+                listOf(
+                        "net.corda.node.services.vault", "net.corda.testing.internal.vault"
+                ),
+                notarySpecs = listOf(notaryNode),
+                threadPerNode = true,
+                networkSendManuallyPumped = false
+        )
+        partyA =
+                mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("PartyA", "Berlin", "DE")))
+
+        partyB =
+                mockNetwork.createNode(MockNodeParameters(legalName = CordaX500Name("PartyB", "Berlin", "DE")))
+        mockNetwork.startNodes()
+    }
+
+    @After
+    fun tearDown() {
+        mockNetwork.stopNodes()
+    }
+
+    @Test
+    fun `Unique column constraint failing causes states to not persist to vaults`() {
+        partyA.startFlow(Initiator(listOf(partyA.info.singleIdentity(), partyB.info.singleIdentity()))).get()
+        Assertions.assertThatExceptionOfType(ExecutionException::class.java).isThrownBy {
+            partyA.startFlow(Initiator(listOf(partyA.info.singleIdentity(), partyB.info.singleIdentity()))).get()
+        }
+        assertEquals(1, partyA.transaction {
+            partyA.services.vaultService.queryBy<UniqueDummyLinearContract.State>().states.size
+        })
+        assertEquals(1, partyB.transaction {
+            partyB.services.vaultService.queryBy<UniqueDummyLinearContract.State>().states.size
+        })
+        assertEquals(1, partyA.transaction {
+            partyA.services.vaultService.queryBy<DummyDealContract.State>().states.size
+        })
+        assertEquals(1, partyB.transaction {
+            partyB.services.vaultService.queryBy<DummyDealContract.State>().states.size
+        })
+    }
+}
+
+@InitiatingFlow
+class Initiator(private val participants: List<Party>) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        val stx = serviceHub.signInitialTransaction(TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
+            addOutputState(UniqueDummyLinearContract.State(participants, "Dummy linear id"), UNIQUE_DUMMY_LINEAR_CONTRACT_PROGRAM_ID)
+            addOutputState(DummyDealContract.State(participants, "linear id"), DUMMY_DEAL_PROGRAM_ID)
+            addCommand(DummyCommandData, listOf(ourIdentity.owningKey))
+        })
+        subFlow(FinalityFlow(stx))
+    }
+}

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/UniqueDummyFungibleContract.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/UniqueDummyFungibleContract.kt
@@ -1,0 +1,45 @@
+package net.corda.testing.internal.vault
+
+import net.corda.core.contracts.*
+import net.corda.core.identity.AbstractParty
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import net.corda.core.schemas.QueryableState
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.testing.core.DummyCommandData
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Table
+
+const val UNIQUE_DUMMY_FUNGIBLE_CONTRACT_PROGRAM_ID = "net.corda.testing.internal.vault.UniqueDummyFungibleContract"
+
+class UniqueDummyFungibleContract : Contract {
+    override fun verify(tx: LedgerTransaction) {}
+
+    data class State(override val amount: Amount<Issued<Currency>>,
+                     override val owner: AbstractParty) : FungibleAsset<Currency>, QueryableState {
+
+        override val exitKeys = setOf(owner.owningKey, amount.token.issuer.party.owningKey)
+        override val participants = listOf(owner)
+
+        override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty): FungibleAsset<Currency> = copy(amount = amount.copy(newAmount.quantity), owner = newOwner)
+
+        override fun withNewOwner(newOwner: AbstractParty) = CommandAndState(DummyCommandData, copy(owner = newOwner))
+
+        override fun supportedSchemas(): Iterable<MappedSchema> = listOf(UniqueDummyFungibleStateSchema)
+
+        override fun generateMappedObject(schema: MappedSchema): PersistentState {
+            return UniqueDummyFungibleStateSchema.UniquePersistentDummyFungibleState(currency = amount.token.product.currencyCode)
+        }
+    }
+}
+
+object UniqueDummyFungibleStateSchema : MappedSchema(schemaFamily = UniqueDummyFungibleStateSchema::class.java, version = 1, mappedTypes = listOf(UniquePersistentDummyFungibleState::class.java)) {
+    @Entity
+    @Table(name = "unique_dummy_fungible_state")
+    class UniquePersistentDummyFungibleState(
+            @Column(unique = true)
+            val currency: String
+    ) : PersistentState()
+}

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/UniqueDummyLinearContract.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/UniqueDummyLinearContract.kt
@@ -1,0 +1,41 @@
+package net.corda.testing.internal.vault
+
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.AbstractParty
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import net.corda.core.schemas.QueryableState
+import net.corda.core.transactions.LedgerTransaction
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Table
+
+const val UNIQUE_DUMMY_LINEAR_CONTRACT_PROGRAM_ID = "net.corda.testing.internal.vault.UniqueDummyLinearContract"
+
+class UniqueDummyLinearContract : Contract {
+    override fun verify(tx: LedgerTransaction) {}
+
+    data class State(
+            override val participants: List<AbstractParty>,
+            override val linearId: UniqueIdentifier) : LinearState, QueryableState {
+        constructor(participants: List<AbstractParty> = listOf(),
+                    ref: String) : this(participants, UniqueIdentifier(ref))
+
+        override fun supportedSchemas(): Iterable<MappedSchema> = listOf(UniqueDummyLinearStateSchema)
+
+        override fun generateMappedObject(schema: MappedSchema): PersistentState {
+            return UniqueDummyLinearStateSchema.UniquePersistentLinearDummyState(id = linearId.externalId!!)
+        }
+    }
+}
+
+object UniqueDummyLinearStateSchema : MappedSchema(schemaFamily = UniqueDummyLinearStateSchema::class.java, version = 1, mappedTypes = listOf(UniquePersistentLinearDummyState::class.java)) {
+    @Entity
+    @Table(name = "unique_dummy_linear_state")
+    class UniquePersistentLinearDummyState(
+            @Column(unique = true)
+            val id: String
+    ) : PersistentState()
+}


### PR DESCRIPTION
Add tests to NodeVaultServiceTest
Add VaultFlowTest
Add UniqueDummyFungibleContract and UniqueLinearContract to be used in the constraint tests

This PR was added in response to [https://github.com/corda/corda/issues/3482](https://github.com/corda/corda/issues/3482) which I could not reproduce.

The tests were added to confirm that the above issue is not present and confirms that the current implementation is working as expected.
