### PR TITLE
CORDA-1945: properly support double-width interp stack slots in superclasses when synthesising

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenter.kt
@@ -139,7 +139,7 @@ class ClassCarpenterImpl @JvmOverloads constructor (override val whitelist: Clas
             hierarchy += cursor
             cursor = cursor.superclass
         }
-         
+
         hierarchy.reversed().forEach {
             when (it) {
                 is InterfaceSchema -> generateInterface(it)
@@ -240,7 +240,7 @@ class ClassCarpenterImpl @JvmOverloads constructor (override val whitelist: Clas
             visitMethodInsn(INVOKESTATIC, moreObjects, "toStringHelper",
                     "(L$jlString;)L$toStringHelper;", false)
             // Call the add() methods.
-            schema.fieldsIncludingSuperclasses().forEach { name, field ->
+            for ((name, field) in schema.fieldsIncludingSuperclasses().entries) {
                 visitLdcInsn(name)
                 visitVarInsn(ALOAD, 0)  // this
                 visitFieldInsn(GETFIELD, schema.jvmName, name, schema.descriptorsIncludingSuperclasses()[name])

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTest.kt
@@ -129,6 +129,27 @@ class ClassCarpenterTest {
         assertEquals("B{a=xa, b=xb}", i.toString())
     }
 
+    /**
+     * Tests the fix for [Corda-1945](https://r3-cev.atlassian.net/secure/RapidBoard.jspa?rapidView=83&modal=detail&selectedIssue=CORDA-1945)
+     */
+    @Test
+    fun `superclasses with double-size primitive constructor parameters`() {
+        val schema1 = ClassSchema(
+                "gen.A",
+                mapOf("a" to NonNullableField(Long::class.javaPrimitiveType!!)))
+
+        val schema2 = ClassSchema(
+                "gen.B",
+                mapOf("b" to NonNullableField(String::class.java)),
+                schema1)
+
+        val clazz = cc.build(schema2)
+        val i = clazz.constructors[0].newInstance(1L, "xb") as SimpleFieldAccess
+        assertEquals(1L, i["a"])
+        assertEquals("xb", i["b"])
+        assertEquals("B{a=1, b=xb}", i.toString())
+    }
+
     @Test
     fun interfaces() {
         val schema1 = ClassSchema(


### PR DESCRIPTION
The following test fails, because the `ClassCarpenter` incorrectly calculates the stack size of fields if there are double-size primitive fields (e.g. long or double) in a superclass constructor:

```kotlin
    @Test
    fun `superclasses with double size primitive constructor parameters`() {
        val schema1 = ClassSchema(
                "gen.A",
                mapOf("a" to NonNullableField(Long::class.javaPrimitiveType!!)))

        val schema2 = ClassSchema(
                "gen.B",
                mapOf("b" to NonNullableField(String::class.java)),
                schema1)

        val clazz = cc.build(schema2)
        val i = clazz.constructors[0].newInstance(1L, "xb") as SimpleFieldAccess
        assertEquals(1L, i["a"])
        assertEquals("xb", i["b"])
        assertEquals("B{a=1, b=xb}", i.toString())
    }
```

The fault is in `ClassWriter.generateClassConstructor`, and the solution is to sum the sizes of the fields in the superclass constructor and make sure this value is used to set the initial stack slot correctly for the parameters.