### PR TITLE
Add forceNotarySignature to FinalityFlow to provide a way for a developer to force the notary to sign a transaction

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -28,10 +28,15 @@ import net.corda.core.utilities.ProgressTracker
 @InitiatingFlow
 class FinalityFlow(val transaction: SignedTransaction,
                    private val extraRecipients: Set<Party>,
+                   private val forceNotarySignature: Boolean,
                    override val progressTracker: ProgressTracker) : FlowLogic<SignedTransaction>() {
-    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(transaction, extraParticipants, tracker())
-    constructor(transaction: SignedTransaction) : this(transaction, emptySet(), tracker())
-    constructor(transaction: SignedTransaction, progressTracker: ProgressTracker) : this(transaction, emptySet(), progressTracker)
+    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>, progressTracker: ProgressTracker) : this(transaction, extraParticipants, false, progressTracker)
+    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>) : this(transaction, extraParticipants, false, tracker())
+    constructor(transaction: SignedTransaction, extraParticipants: Set<Party>, forceNotarySignature: Boolean) : this(transaction, extraParticipants, forceNotarySignature, tracker())
+    constructor(transaction: SignedTransaction) : this(transaction, emptySet(), false, tracker())
+    constructor(transaction: SignedTransaction, forceNotarySignature: Boolean) : this(transaction, emptySet(), forceNotarySignature, tracker())
+    constructor(transaction: SignedTransaction, progressTracker: ProgressTracker) : this(transaction, emptySet(), false, progressTracker)
+    constructor(transaction: SignedTransaction, forceNotarySignature: Boolean, progressTracker: ProgressTracker) : this(transaction, emptySet(), forceNotarySignature, progressTracker)
 
     companion object {
         object NOTARISING : ProgressTracker.Step("Requesting signature by notary service") {
@@ -92,7 +97,7 @@ class FinalityFlow(val transaction: SignedTransaction,
 
     private fun needsNotarySignature(stx: SignedTransaction): Boolean {
         val wtx = stx.tx
-        val needsNotarisation = wtx.inputs.isNotEmpty() || wtx.references.isNotEmpty() || wtx.timeWindow != null
+        val needsNotarisation = forceNotarySignature || wtx.inputs.isNotEmpty() || wtx.references.isNotEmpty() || wtx.timeWindow != null
         return needsNotarisation && hasNoNotarySignature(stx)
     }
 

--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -66,4 +66,14 @@ class FinalityFlowTests : WithFinality {
         return services.signInitialTransaction(builder)
     }
 
+    @Test
+    fun `setting forceNotarySignature to true adds the notaries signature to the transaction`() {
+        val stx = aliceNode.signCashTransactionWith(bob)
+        assert.that(
+                aliceNode.startFlowAndRunNetwork(FinalityFlow(stx, true)),
+                willReturn(
+                        requiredSignatures(2)
+                                and visibleTo(bobNode)))
+    }
+
 }


### PR DESCRIPTION
This change is in response to issue [https://github.com/corda/corda/issues/2913](https://github.com/corda/corda/issues/2913).

If it is decided that this is not something that should be done, then just reject this PR.

`forceNotarySignature` has been added to `FinalityFlow` so that a developer can decide whether to notarise a transaction that doesn't require notarisation (base on transaction's properties).

Extra constructors were added and the existing ones simply set `forceNotarySignature` to `false`.

The downside to this code is the ugliness of all the constructors that `FinalityFlow` now has.

If this solution of allowing devs to force notarisation, then let me know and I can add some extra tests if required as I have only put a very basic test in place at the moment.