### PR TITLE
CORDA-1548 - Hibernate session not flushed before handing over raw JDBC session to user code (e.g. coin selection) (#3266)

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -109,6 +109,7 @@ class CordaPersistence(
     fun createSession(): Connection {
         // We need to set the database for the current [Thread] or [Fiber] here as some tests share threads across databases.
         _contextDatabase.set(this)
+        currentDBSession().flush()
         return contextTransaction.connection
     }
 


### PR DESCRIPTION
* Hibernate session flushed before handing over raw JDBC session to user code + test - inserting and selecting cash in the same transaction
* Additional two tests copied from Enterprise repo

Backport cherry-pick of https://github.com/corda/corda/pull/3266