### PR TITLE
CORDA-1837: Reject nodes that have the same organisation name in driver tests

### DIFF
--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -125,22 +125,22 @@ class DriverTests {
     }
 
     @Test
-    fun `driver rejects multiple nodes with the same name`() {
-
+    fun `driver rejects multiple nodes with the same name parallel`() {
         driver(DriverParameters(startNodesInProcess = true)) {
-
-            assertThatThrownBy { listOf(newNode(DUMMY_BANK_A_NAME)(), newNode(DUMMY_BANK_B_NAME)(), newNode(DUMMY_BANK_A_NAME)()).transpose().getOrThrow() }.isInstanceOf(IllegalArgumentException::class.java)
+            val nodes = listOf(newNode(DUMMY_BANK_A_NAME), newNode(DUMMY_BANK_B_NAME), newNode(DUMMY_BANK_A_NAME))
+            assertThatIllegalArgumentException().isThrownBy {
+                nodes.parallelStream().map { it.invoke() }.toList().transpose().getOrThrow()
+            }
         }
     }
 
     @Test
-    fun `driver rejects multiple nodes with the same name parallel`() {
-
-        driver(DriverParameters(startNodesInProcess = true)) {
-
-            val nodes = listOf(newNode(DUMMY_BANK_A_NAME), newNode(DUMMY_BANK_B_NAME), newNode(DUMMY_BANK_A_NAME))
-
-            assertThatThrownBy { nodes.parallelStream().map { it.invoke() }.toList().transpose().getOrThrow() }.isInstanceOf(IllegalArgumentException::class.java)
+    fun `driver rejects multiple nodes with the same organisation name`() {
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+            newNode(CordaX500Name(commonName = "Notary", organisation = "R3CEV", locality = "New York", country = "US"))().getOrThrow()
+            assertThatIllegalArgumentException().isThrownBy {
+                newNode(CordaX500Name(commonName = "Regulator", organisation = "R3CEV", locality = "New York", country = "US"))().getOrThrow()
+            }
         }
     }
 


### PR DESCRIPTION
* Reject nodes that have the same organisation name as a previously registered node rather than the same X500 name

(cherry picked from commit 40b922c1f2e620a5665f6f2385cdafd5e70bd780)
