### PR TITLE
CORDA-1892 CRaSH shell flow start fix for similar flow names.

### DIFF
--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -32,7 +32,6 @@ import org.apache.activemq.artemis.api.core.ActiveMQSecurityException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.util.io.Streams
-import org.crsh.text.Color
 import org.crsh.text.RenderPrintWriter
 import org.junit.Ignore
 import org.junit.Rule

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.nhaarman.mockito_kotlin.mock
 import net.corda.client.rpc.RPCException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
-import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.div
 import net.corda.core.messaging.ClientRpcSslOptions
 import net.corda.core.messaging.CordaRPCOps
@@ -23,7 +22,6 @@ import net.corda.node.utilities.saveToKeyStore
 import net.corda.node.utilities.saveToTrustStore
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.testing.core.ALICE_NAME
-import net.corda.testing.core.TestIdentity
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.driver.internal.NodeHandleInternal
@@ -43,13 +41,11 @@ import javax.security.auth.x500.X500Principal
 import kotlin.test.assertTrue
 
 class InteractiveShellIntegrationTest {
-    companion object {
-        private val megaCorp = TestIdentity(CordaX500Name("MegaCorp", "London", "GB"))
-        private val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
-    }
     @Rule
     @JvmField
     val tempFolder = TemporaryFolder()
+
+    private val testName = X500Principal("CN=Test,O=R3 Ltd,L=London,C=GB")
 
     @Test
     fun `shell should not log in with invalid credentials`() {

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -370,7 +370,7 @@ class InteractiveShellIntegrationTest {
     }
 
     @Test
-    fun `shell should fail to start flow with incorrectly matching class name`() {
+    fun `shell should start flow with partially matching class name`() {
         val user = User("u", "p", setOf(all()))
         var successful = false
         driver(DriverParameters(notarySpecs = emptyList())) {
@@ -384,10 +384,10 @@ class InteractiveShellIntegrationTest {
 
             // setup and configure some mocks required by InteractiveShell.runFlowByNameFragment()
             val output = mock<RenderPrintWriter> {
-                on { println(any<String>(), any<Color>()) } doAnswer {
+                on { println(any<String>()) } doAnswer {
                     val line = it.arguments[0]
                     println("$line")
-                    if ((line is String) && (line.startsWith("No matching flow found")))
+                    if ((line is String) && (line.startsWith("Flow completed with result")))
                         successful = true
                 }
             }

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -285,7 +285,7 @@ class InteractiveShellIntegrationTest {
                 on { println(any<String>()) } doAnswer {
                     val line = it.arguments[0]
                     println("$line")
-                    if ((line is String) && (line.startsWith("Executing flow:")))
+                    if ((line is String) && (line.startsWith("Flow completed with result:")))
                         successful = true
                 }
             }

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -228,14 +228,15 @@ object InteractiveShell {
     // TODO: This should become the default renderer rather than something used specifically by commands.
     private val outputMapper by lazy { createOutputMapper() }
 
+    @VisibleForTesting
+    lateinit var latch: CountDownLatch
+        private set
+
     /**
      * Called from the 'flow' shell command. Takes a name fragment and finds a matching flow, or prints out
      * the list of options if the request is ambiguous. Then parses [inputData] as constructor arguments using
      * the [runFlowFromString] method and starts the requested flow. Ctrl-C can be used to cancel.
      */
-    @VisibleForTesting
-    lateinit var latch: CountDownLatch
-
     @JvmStatic
     fun runFlowByNameFragment(nameFragment: String,
                               inputData: String,

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -259,7 +259,6 @@ object InteractiveShell {
         }
 
         val flowName = matches.find { it == nameFragment }
-        output.println("Executing flow: $flowName ")
         val flowClazz: Class<FlowLogic<*>> = if (classLoader != null) {
             uncheckedCast(Class.forName(flowName, true, classLoader))
         } else {

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -252,18 +252,13 @@ object InteractiveShell {
         if (matches.isEmpty()) {
             output.println("No matching flow found, run 'flow list' to see your options.", Color.red)
             return
-        }
-        // nameFragment can represent a fully qualified Flow classname (eg. com.myflow.NoOpFlow)
-        // or just the Flow classname (eg. NoOpFlow)
-        val flowName = matches.find { it.endsWith(nameFragment) } ?: if (matches.size > 1) {
+        } else if (matches.size > 1 && matches.find { it.endsWith(nameFragment)} == null) {
             output.println("Ambiguous name provided, please be more specific. Your options are:")
             matches.forEachIndexed { i, s -> output.println("${i + 1}. $s", Color.yellow) }
             return
-        } else {
-            output.println("No matching flow found, run 'flow list' to see your options.", Color.red)
-            return
         }
 
+        val flowName = matches.find { it.endsWith(nameFragment)} ?: matches.single()
         val flowClazz: Class<FlowLogic<*>> = if (classLoader != null) {
             uncheckedCast(Class.forName(flowName, true, classLoader))
         } else {

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -249,16 +249,16 @@ object InteractiveShell {
         if (matches.isEmpty()) {
             output.println("No matching flow found, run 'flow list' to see your options.", Color.red)
             return
-        } else if (matches.size > 1) {
+        } else if ((matches.size > 1) && (!matches.contains(nameFragment))) {
             output.println("Ambiguous name provided, please be more specific. Your options are:")
             matches.forEachIndexed { i, s -> output.println("${i + 1}. $s", Color.yellow) }
             return
         }
 
         val flowClazz: Class<FlowLogic<*>> = if (classLoader != null) {
-            uncheckedCast(Class.forName(matches.single(), true, classLoader))
+            uncheckedCast(Class.forName(matches.find { it == nameFragment }, true, classLoader))
         } else {
-            uncheckedCast(Class.forName(matches.single()))
+            uncheckedCast(Class.forName(matches.find { it == nameFragment }))
         }
         try {
             // Show the progress tracker on the console until the flow completes or is interrupted with a

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -252,55 +252,54 @@ object InteractiveShell {
         if (matches.isEmpty()) {
             output.println("No matching flow found, run 'flow list' to see your options.", Color.red)
             return
-        } else if ((matches.size > 1) && (!matches.contains(nameFragment))) {
+        }
+        // nameFragment can represent a fully qualified Flow classname (eg. com.myflow.NoOpFlow)
+        // or just the Flow classname (eg. NoOpFlow)
+        val flowName = matches.find { it.endsWith(nameFragment) }
+        if (matches.size > 1 && flowName == null) {
             output.println("Ambiguous name provided, please be more specific. Your options are:")
             matches.forEachIndexed { i, s -> output.println("${i + 1}. $s", Color.yellow) }
             return
         }
 
-        // nameFragment can represent a fully qualified Flow classname (eg. com.myflow.NoOpFlow)
-        // or just the Flow classname (eg. NoOpFlow)
-        val flowName = matches.find { it.endsWith(nameFragment) }
-        flowName?.let {
-            val flowClazz: Class<FlowLogic<*>> = if (classLoader != null) {
-                uncheckedCast(Class.forName(flowName, true, classLoader))
-            } else {
-                uncheckedCast(Class.forName(flowName))
-            }
-            try {
-                // Show the progress tracker on the console until the flow completes or is interrupted with a
-                // Ctrl-C keypress.
-                val stateObservable = runFlowFromString({ clazz, args -> rpcOps.startTrackedFlowDynamic(clazz, *args) }, inputData, flowClazz, om)
+        val flowClazz: Class<FlowLogic<*>> = if (classLoader != null) {
+            uncheckedCast(Class.forName(flowName, true, classLoader))
+        } else {
+            uncheckedCast(Class.forName(flowName))
+        }
+        try {
+            // Show the progress tracker on the console until the flow completes or is interrupted with a
+            // Ctrl-C keypress.
+            val stateObservable = runFlowFromString({ clazz, args -> rpcOps.startTrackedFlowDynamic(clazz, *args) }, inputData, flowClazz, om)
 
-                latch = CountDownLatch(1)
-                ansiProgressRenderer.render(stateObservable, latch::countDown)
-                // Wait for the flow to end and the progress tracker to notice. By the time the latch is released
-                // the tracker is done with the screen.
-                while (!Thread.currentThread().isInterrupted) {
+            latch = CountDownLatch(1)
+            ansiProgressRenderer.render(stateObservable, latch::countDown)
+            // Wait for the flow to end and the progress tracker to notice. By the time the latch is released
+            // the tracker is done with the screen.
+            while (!Thread.currentThread().isInterrupted) {
+                try {
+                    latch.await()
+                    break
+                } catch (e: InterruptedException) {
                     try {
-                        latch.await()
+                        rpcOps.killFlow(stateObservable.id)
+                    } finally {
+                        Thread.currentThread().interrupt()
                         break
-                    } catch (e: InterruptedException) {
-                        try {
-                            rpcOps.killFlow(stateObservable.id)
-                        } finally {
-                            Thread.currentThread().interrupt()
-                            break
-                        }
                     }
                 }
-                output.println("Flow completed with result: ${stateObservable.returnValue.get()}")
-            } catch (e: NoApplicableConstructor) {
-                output.println("No matching constructor found:", Color.red)
-                e.errors.forEach { output.println("- $it", Color.red) }
-            } catch (e: PermissionException) {
-                output.println(e.message ?: "Access denied", Color.red)
-            } catch (e: ExecutionException) {
-                // ignoring it as already logged by the progress handler subscriber
-            } finally {
-                InputStreamDeserializer.closeAll()
             }
-        } ?: output.println("Unable to locate flow for $nameFragment")
+            output.println("Flow completed with result: ${stateObservable.returnValue.get()}")
+        } catch (e: NoApplicableConstructor) {
+            output.println("No matching constructor found:", Color.red)
+            e.errors.forEach { output.println("- $it", Color.red) }
+        } catch (e: PermissionException) {
+            output.println(e.message ?: "Access denied", Color.red)
+        } catch (e: ExecutionException) {
+            // ignoring it as already logged by the progress handler subscriber
+        } finally {
+            InputStreamDeserializer.closeAll()
+        }
     }
 
     class NoApplicableConstructor(val errors: List<String>) : CordaException(this.toString()) {

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -255,10 +255,12 @@ object InteractiveShell {
         }
         // nameFragment can represent a fully qualified Flow classname (eg. com.myflow.NoOpFlow)
         // or just the Flow classname (eg. NoOpFlow)
-        val flowName = matches.find { it.endsWith(nameFragment) }
-        if (matches.size > 1 && flowName == null) {
+        val flowName = matches.find { it.endsWith(nameFragment) } ?: if (matches.size > 1) {
             output.println("Ambiguous name provided, please be more specific. Your options are:")
             matches.forEachIndexed { i, s -> output.println("${i + 1}. $s", Color.yellow) }
+            return
+        } else {
+            output.println("No matching flow found, run 'flow list' to see your options.", Color.red)
             return
         }
 


### PR DESCRIPTION
If a node has two flows, where one's name is a longer version of the other's, they cannot be started