### PR TITLE
Cherry-pick: CORDA-1604 Node Info file watcher should block and load node info when node startup (#959) (#3333) 

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -78,7 +78,7 @@ class NodeInfoWatcher(private val nodePath: Path,
      * @return an [Observable] returning [NodeInfo]s, at most one [NodeInfo] is returned for each processed file.
      */
     fun nodeInfoUpdates(): Observable<NodeInfo> {
-        return Observable.interval(pollInterval.toMillis(), TimeUnit.MILLISECONDS, scheduler)
+        return Observable.interval(0, pollInterval.toMillis(), TimeUnit.MILLISECONDS, scheduler)
                 .flatMapIterable { loadFromDirectory() }
     }
 


### PR DESCRIPTION
https://github.com/corda/corda/pull/3333