### PR TITLE
Updated repository lists to reduce dependency on Jitpack and removed …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ buildscript {
     ext.jsr305_version = constants.getProperty("jsr305Version")
     ext.shiro_version = '1.4.0'
     ext.artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')
+    ext.artifactory_contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
     ext.snake_yaml_version = constants.getProperty('snakeYamlVersion')
     ext.docker_compose_rule_version = '0.33.1'
     ext.selenium_version = '3.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,7 @@ allprojects {
         mavenLocal()
         mavenCentral()
         jcenter()
+        maven { url "$artifactory_contextUrl/corda-dependencies" }
         maven { url 'https://jitpack.io' }
     }
 
@@ -211,11 +212,6 @@ allprojects {
 // minor releases, so we can't work with just any Java 8, it has to be a recent one.
 if (!JavaVersion.current().java8Compatible)
     throw new GradleException("Corda requires Java 8, please upgrade to at least 1.8.0_$java8_minUpdateVersion")
-
-repositories {
-    mavenCentral()
-    jcenter()
-}
 
 // Required for building out the fat JAR.
 dependencies {

--- a/docs/source/example-code/build.gradle
+++ b/docs/source/example-code/build.gradle
@@ -3,15 +3,6 @@ apply plugin: 'application'
 apply plugin: 'net.corda.plugins.cordformation'
 apply plugin: 'net.corda.plugins.quasar-utils'
 
-repositories {
-    mavenLocal()
-    mavenCentral()
-    jcenter()
-    maven {
-        url 'http://oss.sonatype.org/content/repositories/snapshots'
-    }
-}
-
 configurations {
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime

--- a/experimental/build.gradle
+++ b/experimental/build.gradle
@@ -3,15 +3,6 @@ version '1.0-SNAPSHOT'
 
 apply plugin: 'kotlin'
 
-repositories {
-    mavenLocal()
-    mavenCentral()
-    maven {
-        url 'http://oss.sonatype.org/content/repositories/snapshots'
-    }
-    jcenter()
-}
-
 compileKotlin {
     kotlinOptions.suppressWarnings = true
 }

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -1,7 +1,3 @@
-repositories {
-    mavenCentral()
-}
-
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'application'

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -5,13 +5,8 @@ apply plugin: 'us.kirchmeier.capsule'
 
 description 'Node Explorer'
 
-repositories {
-    mavenLocal()
-    mavenCentral()
-    maven {
-        url 'http://oss.sonatype.org/content/repositories/snapshots'
-    }
-    jcenter()
+configurations {
+    runtimeArtifacts.extendsFrom runtime
 }
 
 // Force the Caplet to target Java 6. This ensures that running 'java -jar explorer.jar' on any Java 6 VM upwards


### PR DESCRIPTION
…unused repositories.

This fixes the problem with the broken bft-smart dependency