### PR TITLE
Tidy up DemoBench's fallback logging configuration for JUL.

### DIFF
--- a/tools/demobench/src/main/java/net/corda/demobench/config/LoggingConfig.java
+++ b/tools/demobench/src/main/java/net/corda/demobench/config/LoggingConfig.java
@@ -10,6 +10,7 @@ import java.util.logging.*;
  * to be added to the JVM's command line.
  */
 public class LoggingConfig {
+    private static final String LOGGING_CONFIG = "logging.properties";
 
     public LoggingConfig() throws IOException {
         try (InputStream input = getLoggingProperties()) {
@@ -20,10 +21,11 @@ public class LoggingConfig {
 
     private static InputStream getLoggingProperties() throws IOException {
         ClassLoader classLoader = LoggingConfig.class.getClassLoader();
-        InputStream input = classLoader.getResourceAsStream("logging.properties");
+        InputStream input = classLoader.getResourceAsStream(LOGGING_CONFIG);
         if (input == null) {
-            Path javaHome = Paths.get(System.getProperty("java.home"));
-            input = Files.newInputStream(javaHome.resolve("lib").resolve("logging.properties"));
+            // Use the default JUL logging configuration properties instead.
+            Path logging = Paths.get(System.getProperty("java.home"), "lib", LOGGING_CONFIG);
+            input = Files.newInputStream(logging, StandardOpenOption.READ);
         }
         return input;
     }


### PR DESCRIPTION
DemoBench should use its own `logging.properties` file, but it will fall back to the JVM's defaults if this is unavailable for any (unlikely!) reason. Ensure that this fallback code only opens the JVM's properties file for reading.