### PR TITLE
Move identity alias prefixes from DevIdentityGenerator to X509Utilities

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/DevIdentityGenerator.kt
@@ -12,6 +12,8 @@ import net.corda.nodeapi.internal.config.SslConfiguration
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509KeyStore
 import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.crypto.X509Utilities.DISTRIBUTED_NOTARY_ALIAS_PREFIX
+import net.corda.nodeapi.internal.crypto.X509Utilities.NODE_IDENTITY_ALIAS_PREFIX
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.security.KeyPair
@@ -24,11 +26,6 @@ import java.security.PublicKey
  */
 object DevIdentityGenerator {
     private val log = LoggerFactory.getLogger(javaClass)
-
-    // TODO These don't need to be prefixes but can be the full aliases
-    // TODO Move these constants out of here as the node needs access to them
-    const val NODE_IDENTITY_ALIAS_PREFIX = "identity"
-    const val DISTRIBUTED_NOTARY_ALIAS_PREFIX = "distributed-notary"
 
     /** Install a node key store for the given node directory using the given legal name. */
     fun installKeyStoreWithNodeIdentity(nodeDir: Path, legalName: CordaX500Name): Party {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/X509Utilities.kt
@@ -48,6 +48,10 @@ object X509Utilities {
     const val CORDA_CLIENT_TLS = "cordaclienttls"
     const val CORDA_CLIENT_CA = "cordaclientca"
 
+    // TODO These don't need to be prefixes, but can be the full aliases.
+    const val NODE_IDENTITY_ALIAS_PREFIX = "identity"
+    const val DISTRIBUTED_NOTARY_ALIAS_PREFIX = "distributed-notary"
+
     val DEFAULT_VALIDITY_WINDOW = Pair(0.millis, 3650.days)
 
     /**

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -67,10 +67,11 @@ import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.JVMAgentRegistry
 import net.corda.node.utilities.NamedThreadFactory
 import net.corda.node.utilities.NodeBuildProperties
-import net.corda.nodeapi.internal.DevIdentityGenerator
 import net.corda.nodeapi.internal.NodeInfoAndSigned
 import net.corda.nodeapi.internal.SignedNodeInfo
 import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.crypto.X509Utilities.DISTRIBUTED_NOTARY_ALIAS_PREFIX
+import net.corda.nodeapi.internal.crypto.X509Utilities.NODE_IDENTITY_ALIAS_PREFIX
 import net.corda.nodeapi.internal.persistence.*
 import net.corda.nodeapi.internal.storeLegalIdentity
 import net.corda.tools.shell.InteractiveShell
@@ -207,7 +208,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
 
     /**
      * Completes once the node has successfully registered with the network map service
-     * or has loaded network map data from local database
+     * or has loaded network map data from local database.
      */
     val nodeReadyFuture: CordaFuture<Unit> get() = networkMapCache.nodeReady.map { Unit }
 
@@ -350,7 +351,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         }
     }
 
-    /** Subclasses must override this to create a [StartedNode] of the desired type, using the provided machinery. */
+    /** Subclasses must override this to create a "started" node of the desired type, using the provided machinery. */
     abstract fun createStartedNode(nodeInfo: NodeInfo, rpcOps: CordaRPCOps, notaryService: NotaryService?): S
 
     private fun verifyCheckpointsCompatible(tokenizableServices: List<Any>) {
@@ -522,7 +523,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     private fun isNotaryService(serviceClass: Class<*>) = NotaryService::class.java.isAssignableFrom(serviceClass)
 
     /**
-     * This customizes the ServiceHub for each CordaService that is initiating flows
+     * This customizes the ServiceHub for each CordaService that is initiating flows.
      */
     // TODO Move this into its own file
     private class AppServiceHubImpl<T : SerializeAsToken>(private val serviceHub: ServiceHub, private val flowStarter: FlowStarter) : AppServiceHub, ServiceHub by serviceHub {
@@ -787,7 +788,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         // Meanwhile, we let the remote service send us updates until the acknowledgment buffer overflows and it
         // unsubscribes us forcibly, rather than blocking the shutdown process.
 
-        // Run shutdown hooks in opposite order to starting
+        // Run shutdown hooks in opposite order to starting.
         for (toRun in runOnStop.reversed()) {
             toRun()
         }
@@ -807,11 +808,11 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         val keyStore = configuration.signingCertificateStore.get()
 
         val (id, singleName) = if (notaryConfig == null || !notaryConfig.isClusterConfig) {
-            // Node's main identity or if it's a single node notary
-            Pair(DevIdentityGenerator.NODE_IDENTITY_ALIAS_PREFIX, configuration.myLegalName)
+            // Node's main identity or if it's a single node notary.
+            Pair(NODE_IDENTITY_ALIAS_PREFIX, configuration.myLegalName)
         } else {
             // The node is part of a distributed notary whose identity must already be generated beforehand.
-            Pair(DevIdentityGenerator.DISTRIBUTED_NOTARY_ALIAS_PREFIX, null)
+            Pair(DISTRIBUTED_NOTARY_ALIAS_PREFIX, null)
         }
         // TODO: Integrate with Key management service?
         val privateKeyAlias = "$id-private-key"

--- a/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelperTest.kt
@@ -16,11 +16,11 @@ import net.corda.core.internal.toX500Name
 import net.corda.core.utilities.seconds
 import net.corda.node.NodeRegistrationOption
 import net.corda.node.services.config.NodeConfiguration
-import net.corda.nodeapi.internal.DevIdentityGenerator
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509KeyStore
 import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.crypto.X509Utilities.DISTRIBUTED_NOTARY_ALIAS_PREFIX
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.internal.stubs.CertificateStoreStubs
 import net.corda.testing.internal.createDevIntermediateCaCertPath
@@ -168,7 +168,7 @@ class NetworkRegistrationHelperTest {
         assertThat(config.p2pSslOptions.keyStore.getOptional()).isNull()
         assertThat(config.p2pSslOptions.trustStore.getOptional()).isNull()
 
-        val serviceIdentityAlias = "${DevIdentityGenerator.DISTRIBUTED_NOTARY_ALIAS_PREFIX}-private-key"
+        val serviceIdentityAlias = "$DISTRIBUTED_NOTARY_ALIAS_PREFIX-private-key"
 
         nodeKeystore.run {
             assertFalse(contains(X509Utilities.CORDA_INTERMEDIATE_CA))
@@ -233,7 +233,7 @@ class NetworkRegistrationHelperTest {
                     certService,
                     config.certificatesDirectory / networkRootTrustStoreFileName,
                     networkRootTrustStorePassword,
-                    "${DevIdentityGenerator.DISTRIBUTED_NOTARY_ALIAS_PREFIX}-private-key",
+                    "$DISTRIBUTED_NOTARY_ALIAS_PREFIX-private-key",
                     CertRole.SERVICE_IDENTITY)
             else -> throw IllegalArgumentException("Unsupported cert role.")
         }


### PR DESCRIPTION
Reasoning, it was used in `AbstractNode.obtainIdentity` and we shouldn't have dev references there.