### PR TITLE
CORDA-1958: The node ready future completes on the first poll of the …

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
@@ -88,7 +88,7 @@ class ArtemisMessagingTest {
         }
         LogHelper.setLevel(PersistentUniquenessProvider::class)
         database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
-        networkMapCache = PersistentNetworkMapCache(database, rigorousMock(), ALICE_NAME).apply { start(emptyList()) }
+        networkMapCache = PersistentNetworkMapCache(database, rigorousMock()).apply { start(emptyList()) }
     }
 
     @After

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -1,7 +1,6 @@
 package net.corda.node.services.network
 
 import net.corda.core.node.NodeInfo
-import net.corda.core.serialization.serialize
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.internal.configureDatabase
 import net.corda.node.internal.schemas.NodeInfoSchemaV1
@@ -20,7 +19,6 @@ class PersistentNetworkMapCacheTest {
     private companion object {
         val ALICE = TestIdentity(ALICE_NAME, 70)
         val BOB = TestIdentity(BOB_NAME, 80)
-        val CHARLIE = TestIdentity(CHARLIE_NAME, 90)
     }
 
     @Rule
@@ -29,7 +27,7 @@ class PersistentNetworkMapCacheTest {
 
     private var portCounter = 1000
     private val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
-    private val charlieNetMapCache = PersistentNetworkMapCache(database, InMemoryIdentityService(trustRoot = DEV_ROOT_CA.certificate), CHARLIE.name)
+    private val charlieNetMapCache = PersistentNetworkMapCache(database, InMemoryIdentityService(trustRoot = DEV_ROOT_CA.certificate))
 
     @After
     fun cleanUp() {
@@ -40,7 +38,6 @@ class PersistentNetworkMapCacheTest {
     fun addNode() {
         val alice = createNodeInfo(listOf(ALICE))
         charlieNetMapCache.addNode(alice)
-        assertThat(charlieNetMapCache.nodeReady).isDone()
         val fromDb = database.transaction {
             session.createQuery(
                     "from ${NodeInfoSchemaV1.PersistentNodeInfo::class.java.name}",
@@ -48,32 +45,6 @@ class PersistentNetworkMapCacheTest {
             ).resultList.map { it.toNodeInfo() }
         }
         assertThat(fromDb).containsOnly(alice)
-    }
-
-    @Test
-    fun `adding the node's own node-info doesn't complete the nodeReady future`() {
-        val charlie = createNodeInfo(listOf(CHARLIE))
-        charlieNetMapCache.addNode(charlie)
-        assertThat(charlieNetMapCache.nodeReady).isNotDone()
-        assertThat(charlieNetMapCache.getNodeByLegalName(CHARLIE.name)).isEqualTo(charlie)
-    }
-
-    @Test
-    fun `starting with just the node's own node-info in the db`() {
-        val charlie = createNodeInfo(listOf(CHARLIE))
-        saveNodeInfoIntoDb(charlie)
-        assertThat(charlieNetMapCache.allNodes).containsOnly(charlie)
-        charlieNetMapCache.start(emptyList())
-        assertThat(charlieNetMapCache.nodeReady).isNotDone()
-    }
-
-    @Test
-    fun `starting with another node-info in the db`() {
-        val alice = createNodeInfo(listOf(ALICE))
-        saveNodeInfoIntoDb(alice)
-        assertThat(charlieNetMapCache.allNodes).containsOnly(alice)
-        charlieNetMapCache.start(emptyList())
-        assertThat(charlieNetMapCache.nodeReady).isDone()
     }
 
     @Test
@@ -136,20 +107,5 @@ class PersistentNetworkMapCacheTest {
                 platformVersion = 3,
                 serial = 1
         )
-    }
-
-    private fun saveNodeInfoIntoDb(nodeInfo: NodeInfo) {
-        database.transaction {
-            session.save(NodeInfoSchemaV1.PersistentNodeInfo(
-                    id = 0,
-                    hash = nodeInfo.serialize().hash.toString(),
-                    addresses = nodeInfo.addresses.map { NodeInfoSchemaV1.DBHostAndPort.fromHostAndPort(it) },
-                    legalIdentitiesAndCerts = nodeInfo.legalIdentitiesAndCerts.mapIndexed { idx, elem ->
-                        NodeInfoSchemaV1.DBPartyAndCertificate(elem, isMain = idx == 0)
-                    },
-                    platformVersion = nodeInfo.platformVersion,
-                    serial = nodeInfo.serial
-            ))
-        }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -145,7 +145,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         // TODO Break cyclic dependency
         identityService.database = database
     }
-    val networkMapCache = PersistentNetworkMapCache(database, identityService, configuration.myLegalName).tokenize()
+    val networkMapCache = PersistentNetworkMapCache(database, identityService).tokenize()
     val checkpointStorage = DBCheckpointStorage()
     @Suppress("LeakingThis")
     val transactionStorage = makeTransactionStorage(configuration.transactionCacheSizeBytes).tokenize()
@@ -216,7 +216,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     }
 
     /** Set to non-null once [start] has been successfully called. */
-    open val started get() = _started
+    open val started: S? get() = _started
     @Volatile
     private var _started: S? = null
 
@@ -301,13 +301,13 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             "Node's platform version is lower than network's required minimumPlatformVersion"
         }
         servicesForResolution.start(netParams)
+        networkMapCache.start(netParams.notaries)
 
         startDatabase()
         val (identity, identityKeyPair) = obtainIdentity(notaryConfig = null)
         identityService.start(trustRoot, listOf(identity.certificate, nodeCa))
 
         val (keyPairs, nodeInfoAndSigned, myNotaryIdentity) = database.transaction {
-            networkMapCache.start(netParams.notaries)
             updateNodeInfo(identity, identityKeyPair, publish = true)
         }
 
@@ -455,7 +455,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         } else {
             1.days
         }
-        val executor = Executors.newSingleThreadScheduledExecutor(NamedThreadFactory("Network Map Updater", Executors.defaultThreadFactory()))
+        val executor = Executors.newSingleThreadScheduledExecutor(NamedThreadFactory("Network Map Updater"))
         executor.submit(object : Runnable {
             override fun run() {
                 val republishInterval = try {

--- a/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/ServiceHubInternal.kt
@@ -6,6 +6,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.FlowStateMachine
+import net.corda.core.internal.concurrent.OpenFuture
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.StateMachineTransactionMapping
 import net.corda.core.node.NodeInfo
@@ -28,6 +29,8 @@ import net.corda.nodeapi.internal.persistence.CordaPersistence
 import java.security.PublicKey
 
 interface NetworkMapCacheInternal : NetworkMapCache, NetworkMapCacheBase {
+    override val nodeReady: OpenFuture<Void?>
+
     val allNodeHashes: List<SecureHash>
 
     fun getNodeByHash(nodeHash: SecureHash): NodeInfo?

--- a/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/NamedThreadFactory.kt
@@ -1,6 +1,5 @@
 package net.corda.node.utilities
 
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
@@ -10,19 +9,12 @@ import java.util.concurrent.atomic.AtomicInteger
  * via an executor. It will use an underlying thread factory to create the actual thread
  * and then override the thread name with the prefix and an ever increasing number
  */
-class NamedThreadFactory(private val name: String, private val underlyingFactory: ThreadFactory) : ThreadFactory {
-    val threadNumber = AtomicInteger(1)
-    override fun newThread(runnable: Runnable?): Thread {
-        val thread = underlyingFactory.newThread(runnable)
+class NamedThreadFactory(private val name: String,
+                         private val delegate: ThreadFactory = Executors.defaultThreadFactory()) : ThreadFactory {
+    private val threadNumber = AtomicInteger(1)
+    override fun newThread(runnable: Runnable): Thread {
+        val thread = delegate.newThread(runnable)
         thread.name = name + "-" + threadNumber.getAndIncrement()
         return thread
     }
-}
-
-/**
- * Create a single thread executor with a NamedThreadFactory based on the default thread factory
- * defined in java.util.concurrent.Executors
- */
-fun newNamedSingleThreadExecutor(name: String): ExecutorService {
-    return Executors.newSingleThreadExecutor(NamedThreadFactory(name, Executors.defaultThreadFactory()))
 }


### PR DESCRIPTION
…network map sources, even if they return empty.

This is to allow the first node in a test environment to fully start up.
