### PR TITLE
Use standard Automatic-Module-Name for DemoBench.

### DIFF
--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -88,8 +88,7 @@ jar {
     manifest {
         attributes(
             'Main-Class': mainClassName,
-            'Class-Path': configurations.runtime.collect { it.getName() }.join(' '),
-            'Automatic-Module-Name': 'net.corda.tools.demobench'
+            'Class-Path': configurations.runtimeClasspath.collect { it.name }.join(' '),
         )
     }
 }


### PR DESCRIPTION
Use `Automatic-Module-Name` assigned by the root `build.gradle` file. Also simplify Groovy logic slightly, and use Gradle's up-to-date runtime configuration for jar's classpath.