### PR TITLE
ENT-2489: Additional optional parameter to specify target for RPC invocation.

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -4,6 +4,7 @@ import net.corda.client.rpc.internal.RPCClient
 import net.corda.client.rpc.internal.serialization.amqp.AMQPClientSerializationScheme
 import net.corda.core.context.Actor
 import net.corda.core.context.Trace
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.serialization.internal.effectiveSerializationEnv
 import net.corda.core.utilities.NetworkHostAndPort
@@ -337,11 +338,44 @@ class CordaRPCClient private constructor(
      *
      * @param username The username to authenticate with.
      * @param password The password to authenticate with.
+     * @param targetLegalIdentity in case of multi-identity RPC endpoint specific legal identity to which the calls must be addressed.
+     * @throws RPCException if the server version is too low or if the server isn't reachable within a reasonable timeout.
+     */
+    fun start(username: String, password: String, targetLegalIdentity: CordaX500Name): CordaRPCConnection {
+        return start(username, password, null, null, targetLegalIdentity)
+    }
+
+    /**
+     * Logs in to the target server and returns an active connection. The returned connection is a [java.io.Closeable]
+     * and can be used with a try-with-resources statement. If you don't use that, you should use the
+     * [RPCConnection.notifyServerAndClose] or [RPCConnection.forceClose] methods to dispose of the connection object
+     * when done.
+     *
+     * @param username The username to authenticate with.
+     * @param password The password to authenticate with.
      * @param externalTrace external [Trace] for correlation.
+     * @param impersonatedActor the actor on behalf of which all the invocations will be made.
      * @throws RPCException if the server version is too low or if the server isn't reachable within a reasonable timeout.
      */
     fun start(username: String, password: String, externalTrace: Trace?, impersonatedActor: Actor?): CordaRPCConnection {
-        return CordaRPCConnection(getRpcClient().start(CordaRPCOps::class.java, username, password, externalTrace, impersonatedActor))
+        return start(username, password, externalTrace, impersonatedActor, null)
+    }
+
+    /**
+     * Logs in to the target server and returns an active connection. The returned connection is a [java.io.Closeable]
+     * and can be used with a try-with-resources statement. If you don't use that, you should use the
+     * [RPCConnection.notifyServerAndClose] or [RPCConnection.forceClose] methods to dispose of the connection object
+     * when done.
+     *
+     * @param username The username to authenticate with.
+     * @param password The password to authenticate with.
+     * @param externalTrace external [Trace] for correlation.
+     * @param impersonatedActor the actor on behalf of which all the invocations will be made.
+     * @param targetLegalIdentity in case of multi-identity RPC endpoint specific legal identity to which the calls must be addressed.
+     * @throws RPCException if the server version is too low or if the server isn't reachable within a reasonable timeout.
+     */
+    fun start(username: String, password: String, externalTrace: Trace?, impersonatedActor: Actor?, targetLegalIdentity: CordaX500Name?): CordaRPCConnection {
+        return CordaRPCConnection(getRpcClient().start(CordaRPCOps::class.java, username, password, externalTrace, impersonatedActor, targetLegalIdentity))
     }
 
     /**

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/internal/RPCClient.kt
@@ -6,6 +6,7 @@ import net.corda.client.rpc.RPCException
 import net.corda.core.context.Actor
 import net.corda.core.context.Trace
 import net.corda.core.crypto.random63BitValue
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.logElapsedTime
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.ClientRpcSslOptions
@@ -65,7 +66,8 @@ class RPCClient<I : RPCOps>(
             username: String,
             password: String,
             externalTrace: Trace? = null,
-            impersonatedActor: Actor? = null
+            impersonatedActor: Actor? = null,
+            targetLegalIdentity: CordaX500Name? = null
     ): RPCConnection<I> {
         return log.logElapsedTime("Startup") {
             val clientAddress = SimpleString("${RPCApi.RPC_CLIENT_QUEUE_NAME_PREFIX}.$username.${random63BitValue()}")
@@ -85,7 +87,8 @@ class RPCClient<I : RPCOps>(
                 isUseGlobalPools = nodeSerializationEnv != null
             }
             val sessionId = Trace.SessionId.newInstance()
-            val proxyHandler = RPCClientProxyHandler(rpcConfiguration, username, password, serverLocator, clientAddress, rpcOpsClass, serializationContext, sessionId, externalTrace, impersonatedActor)
+            val proxyHandler = RPCClientProxyHandler(rpcConfiguration, username, password, serverLocator, clientAddress,
+                    rpcOpsClass, serializationContext, sessionId, externalTrace, impersonatedActor, targetLegalIdentity)
             try {
                 proxyHandler.start()
                 val ops: I = uncheckedCast(Proxy.newProxyInstance(rpcOpsClass.classLoader, arrayOf(rpcOpsClass), proxyHandler))

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,8 @@ release, see :doc:`upgrade-notes`.
 Unreleased
 ----------
 
+* New overload for ``CordaRPCClient.start()`` method allowing to specify target legal identity to use for RPC call.
+
 * Case insensitive vault queries can be specified via a boolean on applicable SQL criteria builder operators. By default queries will be case sensitive.
 
 * Getter added to ``CordaRPCOps`` for the node's network parameters.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
@@ -5,4 +5,4 @@ import net.corda.core.CordaException
 /**
  * An exception propagated and thrown in case a session initiation fails.
  */
-class SessionRejectException(reason: String) : CordaException(reason)
+class SessionRejectException(val reason: String) : CordaException(reason)

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
@@ -5,4 +5,4 @@ import net.corda.core.CordaException
 /**
  * An exception propagated and thrown in case a session initiation fails.
  */
-class SessionRejectException(val reason: String) : CordaException(reason)
+class SessionRejectException(reason: String) : CordaException(reason)


### PR DESCRIPTION
This is a split-out change from an enterprise feature, but since we do have: `RPCApi.RPC_TARGET_LEGAL_IDENTITY` header constant even in OS, it would make sense to extend RPC client API to populate this.