### PR TITLE
CORDA-1875: backport tweaks made to RPC client for handling loss of node

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -13,12 +13,12 @@ import net.corda.core.utilities.*
 import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.nodeapi.RPCApi
 import net.corda.testing.core.SerializationEnvironmentRule
+import net.corda.testing.driver.PortAllocation
 import net.corda.testing.internal.testThreadFactory
 import net.corda.testing.node.internal.*
 import org.apache.activemq.artemis.api.core.SimpleString
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import rx.Observable
@@ -37,6 +37,8 @@ class RPCStabilityTests {
     @JvmField
     val testSerialization = SerializationEnvironmentRule(true)
     private val pool = Executors.newFixedThreadPool(10, testThreadFactory())
+    private val portAllocation = PortAllocation.Incremental(10000)
+
     @After
     fun shutdown() {
         pool.shutdown()
@@ -251,6 +253,93 @@ class RPCStabilityTests {
             assertEquals("pong", pingFuture.getOrThrow(10.seconds))
             clientFollower.shutdown() // Driver would do this after the new server, causing hang.
         }
+    }
+
+    @Test
+    fun `connection failover fails, rpc calls throw`() {
+        rpcDriver {
+            val ops = object : ReconnectOps {
+                override val protocolVersion = 1000
+                override fun ping() = "pong"
+            }
+
+            val serverFollower = shutdownManager.follower()
+            val serverPort = startRpcServer<ReconnectOps>(ops = ops).getOrThrow().broker.hostAndPort!!
+            serverFollower.unfollow()
+            // Set retry interval to 1s to reduce test duration
+            val clientConfiguration = RPCClientConfiguration.default.copy(connectionRetryInterval = 1.seconds, maxReconnectAttempts = 5)
+            val clientFollower = shutdownManager.follower()
+            val client = startRpcClient<ReconnectOps>(serverPort, configuration = clientConfiguration).getOrThrow()
+            clientFollower.unfollow()
+            assertEquals("pong", client.ping())
+            serverFollower.shutdown()
+            try {
+                client.ping()
+            } catch (e: Exception) {
+                assertTrue(e is RPCException)
+            }
+            clientFollower.shutdown() // Driver would do this after the new server, causing hang.
+        }
+    }
+
+    interface NoOps : RPCOps {
+        fun subscribe(): Observable<Nothing>
+    }
+
+    @Test
+    fun `observables error when connection breaks`() {
+        rpcDriver {
+            val ops = object : NoOps {
+                override val protocolVersion = 1000
+                override fun subscribe(): Observable<Nothing> {
+                    return PublishSubject.create<Nothing>()
+                }
+            }
+            val serverFollower = shutdownManager.follower()
+            val serverPort = startRpcServer<NoOps>(ops = ops).getOrThrow().broker.hostAndPort!!
+            serverFollower.unfollow()
+
+            val clientConfiguration = RPCClientConfiguration.default.copy(connectionRetryInterval = 500.millis, maxReconnectAttempts = 1)
+            val clientFollower = shutdownManager.follower()
+            val client = startRpcClient<NoOps>(serverPort, configuration = clientConfiguration).getOrThrow()
+            clientFollower.unfollow()
+
+            var terminateHandlerCalled = false
+            var errorHandlerCalled = false
+            var exceptionMessage: String? = null
+            val subscription = client.subscribe()
+                    .doOnTerminate{ terminateHandlerCalled = true }
+                    .subscribe({}, {
+                        errorHandlerCalled = true
+                        //log exception
+                        exceptionMessage = it.message
+                    })
+
+            serverFollower.shutdown()
+            Thread.sleep(100)
+
+            assertTrue(terminateHandlerCalled)
+            assertTrue(errorHandlerCalled)
+            assertEquals("Connection failure detected.", exceptionMessage)
+            assertTrue(subscription.isUnsubscribed)
+
+            clientFollower.shutdown() // Driver would do this after the new server, causing hang.
+        }
+    }
+
+    @Test
+    fun `client throws RPCException after initial connection attempt fails`() {
+        val client = CordaRPCClient(portAllocation.nextHostAndPort())
+        var exceptionMessage: String? = null
+        try {
+            client.start("user", "pass").proxy
+        } catch (e1: RPCException) {
+            exceptionMessage = e1.message
+        } catch (e2: Exception) {
+            fail("Expected RPCException to be thrown. Received ${e2.javaClass.simpleName} instead.")
+        }
+        assertNotNull(exceptionMessage)
+        assertEquals("Cannot connect to server(s). Tried with all available servers.", exceptionMessage)
     }
 
     interface TrackSubscriberOps : RPCOps {

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -66,6 +66,10 @@ data class CordaRPCClientConfiguration(val connectionMaxRetryInterval: Duration)
  * with an error, the observable is closed and you can't then re-subscribe again: you'll have to re-request a fresh
  * observable with another RPC.
  *
+ * In case of loss of connection to the server, the client will try to reconnect using the settings provided via
+ * [CordaRPCClientConfiguration]. While attempting failover, current and future RPC calls will throw
+ * [RPCException] and previously returned observables will call onError().
+ *
  * @param hostAndPort The network address to connect to.
  * @param configuration An optional configuration used to tweak client behaviour.
  * @param sslConfiguration An optional [SSLConfiguration] used to enable secure communication with the server.

--- a/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.rpc
 
+import net.corda.client.rpc.RPCException
 import net.corda.client.rpc.internal.RPCClient
 import net.corda.core.context.AuthServiceId
 import net.corda.core.identity.CordaX500Name
@@ -21,7 +22,6 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.internal.RandomFree
 import org.apache.activemq.artemis.api.core.ActiveMQConnectionTimedOutException
-import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -94,7 +94,7 @@ class ArtemisRpcTests {
 //            client.trustStore["cordaclienttls"] = rootCertificate
 
             withKeyStores(server, client) { brokerSslOptions, clientSslOptions ->
-                testSslCommunication(brokerSslOptions, true, clientSslOptions, clientConnectionSpy = expectExceptionOfType(ActiveMQNotConnectedException::class))
+                testSslCommunication(brokerSslOptions, true, clientSslOptions, clientConnectionSpy = expectExceptionOfType(RPCException::class))
             }
         }
     }
@@ -115,7 +115,7 @@ class ArtemisRpcTests {
             client.trustStore["cordaclienttls"] = rootCertificate
 
             withKeyStores(server, client) { brokerSslOptions, clientSslOptions ->
-                testSslCommunication(brokerSslOptions, true, clientSslOptions, clientConnectionSpy = expectExceptionOfType(ActiveMQNotConnectedException::class))
+                testSslCommunication(brokerSslOptions, true, clientSslOptions, clientConnectionSpy = expectExceptionOfType(RPCException::class))
             }
         }
     }
@@ -158,7 +158,7 @@ class ArtemisRpcTests {
             client.trustStore["cordaclienttls"] = rootCertificate
 
             withKeyStores(server, client) { brokerSslOptions, clientSslOptions ->
-                testSslCommunication(brokerSslOptions, true, clientSslOptions, clientConnectionSpy = expectExceptionOfType(ActiveMQNotConnectedException::class))
+                testSslCommunication(brokerSslOptions, true, clientSslOptions, clientConnectionSpy = expectExceptionOfType(RPCException::class))
             }
         }
     }

--- a/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/IrsDemoWebApplication.kt
+++ b/samples/irs-demo/web/src/main/kotlin/net/corda/irs/web/IrsDemoWebApplication.kt
@@ -3,10 +3,10 @@ package net.corda.irs.web
 import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.client.jackson.JacksonSupport
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.RPCException
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.finance.plugin.registerFinanceJSONMappers
-import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -39,7 +39,7 @@ class IrsDemoWebApplication {
         do {
             try {
                 return CordaRPCClient(NetworkHostAndPort.parse(cordaHost)).start(cordaUser, cordaPassword).proxy
-            } catch (ex: ActiveMQNotConnectedException) {
+            } catch (ex: RPCException) {
                 if (maxRetries-- > 0) {
                     Thread.sleep(1000)
                 } else {

--- a/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
+++ b/webserver/src/main/kotlin/net/corda/webserver/internal/NodeWebServer.kt
@@ -3,13 +3,13 @@ package net.corda.webserver.internal
 import com.google.common.html.HtmlEscapers.htmlEscaper
 import net.corda.client.jackson.JacksonSupport
 import net.corda.client.rpc.CordaRPCClient
+import net.corda.client.rpc.RPCException
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.utilities.contextLogger
 import net.corda.webserver.WebServerConfig
 import net.corda.webserver.converters.CordaConverterProvider
 import net.corda.webserver.services.WebServerPluginRegistry
 import net.corda.webserver.servlets.*
-import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException
 import org.eclipse.jetty.server.*
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.server.handler.HandlerCollection
@@ -170,7 +170,7 @@ class NodeWebServer(val config: WebServerConfig) {
         while (true) {
             try {
                 return connectLocalRpcAsNodeUser()
-            } catch (e: ActiveMQNotConnectedException) {
+            } catch (e: RPCException) {
                 log.debug("Could not connect to ${config.rpcAddress} due to exception: ", e)
                 Thread.sleep(retryDelay)
                 // This error will happen if the server has yet to create the keystore


### PR DESCRIPTION
PR that contains several tweaks made to the RPC client. These changes ensures the client will not hang waiting for a response from the node in case of connection loss. All observables and futures are set to error and cleaned up. Failover will commence based on what config settings are used when the client is created. during failover, any RPC will throw RPCException. Observables will not be re-attached, just set to call onError. Clients will need to query the node for any updates that may have happened during the failover period.