### PR TITLE
CORDA-1968 Ensure we check for the trustroot existence and alias validity.

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
@@ -20,7 +20,7 @@ class NodeKeystoreCheckTest {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             assertThatThrownBy {
                 startNode(customOverrides = mapOf("devMode" to false)).getOrThrow()
-            }.hasMessageContaining("Identity certificate not found")
+            }.hasMessageContaining("Identity and/or TLS certificate not found.")
         }
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/NodeKeystoreCheckTest.kt
@@ -20,14 +20,14 @@ class NodeKeystoreCheckTest {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
             assertThatThrownBy {
                 startNode(customOverrides = mapOf("devMode" to false)).getOrThrow()
-            }.hasMessageContaining("Identity and/or TLS certificate not found.")
+            }.hasMessageContaining("One or more keyStores (identity or TLS) or trustStore not found.")
         }
     }
 
     @Test
     fun `node should throw exception if cert path doesn't chain to the trust root`() {
         driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
-            // Create keystores
+            // Create keystores.
             val keystorePassword = "password"
             val certificatesDirectory = baseDirectory(ALICE_NAME) / "certificates"
             val signingCertStore = CertificateStoreStubs.Signing.withCertificatesDirectory(certificatesDirectory, keystorePassword)
@@ -46,7 +46,7 @@ class NodeKeystoreCheckTest {
 
             // Fiddle with node keystore.
             signingCertStore.get().update {
-                // Self signed root
+                // Self signed root.
                 val badRootKeyPair = Crypto.generateKeyPair()
                 val badRoot = X509Utilities.createSelfSignedCACertificate(X500Principal("O=Bad Root,L=Lodnon,C=GB"), badRootKeyPair)
                 val nodeCA = getCertificateAndKeyPair(X509Utilities.CORDA_CLIENT_CA)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -718,15 +718,14 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
 
     private fun validateKeyStores(): X509Certificate {
         // Step 1. Check trustStore, sslKeyStore and identitiesKeyStore exist.
-        val certStores = getCertificateStores()
-        requireNotNull(certStores) {
+        val certStores = requireNotNull(getCertificateStores()) {
             "One or more keyStores (identity or TLS) or trustStore not found. " +
                     "Please either copy your existing keys and certificates from another node, " +
                     "or if you don't have one yet, fill out the config file and run corda.jar --initial-registration. " +
                     "Read more at: https://docs.corda.net/permissioning.html"
         }
         // Step 2. Check that trustStore contains the correct key-alias entry.
-        require(CORDA_ROOT_CA in certStores!!.trustStore) {
+        require(CORDA_ROOT_CA in certStores.trustStore) {
             "Alias for trustRoot key not found. Please ensure you have an updated trustStore file."
         }
         // Step 3. Check that tls keyStore contains the correct key-alias entry.

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -695,41 +695,51 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     @VisibleForTesting
     protected open fun acceptableLiveFiberCountOnStop(): Int = 0
 
-    private fun getCertificateStores(): Triple<CertificateStore, CertificateStore, CertificateStore> {
+    private fun getCertificateStores(): AllCertificateStores? {
         return try {
             // The following will throw IOException if key file not found or KeyStoreException if keystore password is incorrect.
-            val trustStore = configuration.p2pSslOptions.trustStore.get()
             val sslKeyStore = configuration.p2pSslOptions.keyStore.get()
             val identitiesKeyStore = configuration.signingCertificateStore.get()
-            Triple(trustStore, sslKeyStore, identitiesKeyStore)
+            val trustStore = configuration.p2pSslOptions.trustStore.get()
+            AllCertificateStores(trustStore, sslKeyStore, identitiesKeyStore)
         } catch (e: KeyStoreException) {
             log.warn("At least one of the keystores or truststore passwords does not match configuration.")
-            throw e
+            null
         } catch (e: IOException) {
             log.error("IO exception while trying to validate keystores and truststore", e)
-            throw e
+            null
         }
     }
 
+    private data class AllCertificateStores(val trustStore: CertificateStore, val sslKeyStore: CertificateStore, val identitiesKeyStore: CertificateStore)
+
     private fun validateKeyStores(): X509Certificate {
         // Step 1. Check trustStore, sslKeyStore and identitiesKeyStore exist.
-        val (trustStore, sslKeyStore, identitiesKeyStore) = getCertificateStores()
-        // Step 2. Check that trustStore contains the correct key-alias entry.
-        require(X509Utilities.CORDA_ROOT_CA in trustStore) {
-            "Alias for trustRoot key not found. Please ensure you have an updated trustRoot file."
-        }
-        // Step 3. Check that keyStores contain the correct key-alias entries.
-        require(X509Utilities.CORDA_CLIENT_TLS in sslKeyStore
-                && X509Utilities.CORDA_CLIENT_CA in identitiesKeyStore) {
-            "Identity and/or TLS certificate not found. " +
-                    "Please either copy your existing keys and certificate from another node, " +
+        val certStores = getCertificateStores()
+        requireNotNull(certStores) {
+            "One or more keyStores (identity or TLS) or trustStore not found. " +
+                    "Please either copy your existing keys and certificates from another node, " +
                     "or if you don't have one yet, fill out the config file and run corda.jar --initial-registration. " +
                     "Read more at: https://docs.corda.net/permissioning.html"
         }
-        // Step 4. Check all cert paths chain to the trusted root.
-        val trustRoot = trustStore[X509Utilities.CORDA_ROOT_CA]
-        val sslCertChainRoot = sslKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_TLS) }.last()
-        val nodeCaCertChainRoot = identitiesKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_CA) }.last()
+        // Step 2. Check that trustStore contains the correct key-alias entry.
+        require(X509Utilities.CORDA_ROOT_CA in certStores!!.trustStore) {
+            "Alias for trustRoot key not found. Please ensure you have an updated trustStore file."
+        }
+        // Step 3. Check that tls keyStore contains the correct key-alias entry.
+        require(X509Utilities.CORDA_CLIENT_TLS in certStores.sslKeyStore) {
+            "Alias for TLS key not found. Please ensure you have an updated TLS keyStore file."
+        }
+
+        // Step 4. Check that identity keyStores contain the correct key-alias entry for Node CA.
+        require(X509Utilities.CORDA_CLIENT_CA in certStores.identitiesKeyStore) {
+            "Alias for Node CA key not found. Please ensure you have an updated identity keyStore file."
+        }
+
+        // Step 5. Check all cert paths chain to the trusted root.
+        val trustRoot = certStores.trustStore[X509Utilities.CORDA_ROOT_CA]
+        val sslCertChainRoot = certStores.sslKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_TLS) }.last()
+        val nodeCaCertChainRoot = certStores.identitiesKeyStore.query { getCertificateChain(X509Utilities.CORDA_CLIENT_CA) }.last()
 
         require(sslCertChainRoot == trustRoot) { "TLS certificate must chain to the trusted root." }
         require(nodeCaCertChainRoot == trustRoot) { "Client CA certificate must chain to the trusted root." }


### PR DESCRIPTION
There was no check for TrustStore validity during node startup. Apart from adding extra checks, similarly to the other two `KeyStore`s, I slightly refactored `validateKeyStores()` so it gets more readable.