### PR TITLE
CORDA-1964: Unify versioning of the shadow plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ buildscript {
     ext.crash_version = 'cadb53544fbb3c0fb901445da614998a6a419488'
     ext.jsr305_version = constants.getProperty("jsr305Version")
     ext.shiro_version = '1.4.0'
-    ext.shadow_version = '2.0.4'
     ext.artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')
     ext.liquibase_version = '3.5.5'
     ext.artifactory_contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
@@ -117,6 +116,9 @@ plugins {
     // but the DSL has some restrictions e.g can't be used on the allprojects section. So we should revisit this if there are improvements in Gradle.
     // Version 1.0.2 of this plugin uses capsule:1.0.1
     id "us.kirchmeier.capsule" version "1.0.2"
+
+    // Add the shadow plugin to the plugins classpath for the entire project.
+    id 'com.github.johnrengelman.shadow' version '2.0.4' apply false
 }
 
 ext {

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '2.0.4'
+    id 'com.github.johnrengelman.shadow'
 }
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'com.jfrog.artifactory'

--- a/experimental/avalanche/build.gradle
+++ b/experimental/avalanche/build.gradle
@@ -1,24 +1,19 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:$shadow_version"
-    }
-}
-
 apply plugin: 'kotlin'
 apply plugin: 'application'
+// We need to set mainClassName before applying the shadow plugin.
+mainClassName = "net.corda.avalanche.MainKt"
+
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "info.picocli:picocli:3.0.1"
+    compile "info.picocli:picocli:$picocli_version"
     testCompile "junit:junit:$junit_version"
 }
 
-mainClassName = "net.corda.avalanche.MainKt"
+jar.enabled = false
+
 shadowJar {
     baseName = "avalanche"
 }
+assemble.dependsOn shadowJar

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -191,6 +191,11 @@ dependencies {
     compile "com.palominolabs.metrics:metrics-new-relic:${metrics_new_relic_version}"
 }
 
+tasks.withType(JavaCompile) {
+    // Resolves a Gradle warning about not scanning for pre-processors.
+    options.compilerArgs << '-proc:none'
+}
+
 task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath

--- a/tools/demobench/build.gradle
+++ b/tools/demobench/build.gradle
@@ -1,22 +1,15 @@
-buildscript {
-    ext {
-        tornadofx_version = '1.7.15'
-        jna_version = '4.1.0'
-        purejavacomm_version = '0.0.18'
-        controlsfx_version = '8.40.12'
+ext {
+    tornadofx_version = '1.7.15'
+    jna_version = '4.1.0'
+    purejavacomm_version = '0.0.18'
+    controlsfx_version = '8.40.12'
 
-        java_home = System.properties.'java.home'
-        pkg_source = "$buildDir/packagesrc"
-        pkg_outDir = "$buildDir/javapackage"
-        dist_source = "$pkg_source/demobench-$version"
-        pkg_version = version.indexOf('-') >= 0 ? version.substring(0, version.indexOf('-')) : version
-        pkg_macosxKeyUserName = 'R3CEV'
-    }
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
+    java_home = System.properties.'java.home'
+    pkg_source = "$buildDir/packagesrc"
+    pkg_outDir = "$buildDir/javapackage"
+    dist_source = "$pkg_source/demobench-$version"
+    pkg_version = version.indexOf('-') >= 0 ? version.substring(0, version.indexOf('-')) : version
+    pkg_macosxKeyUserName = 'R3CEV'
 }
 
 apply plugin: 'java'
@@ -82,6 +75,11 @@ dependencies {
     testCompile "junit:junit:$junit_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.assertj:assertj-core:$assertj_version"
+}
+
+tasks.withType(JavaCompile) {
+    // Resolves a Gradle warning about not scanning for pre-processors.
+    options.compilerArgs << '-proc:none'
 }
 
 jar {

--- a/tools/explorer/build.gradle
+++ b/tools/explorer/build.gradle
@@ -57,6 +57,11 @@ dependencies {
     compile 'com.yuvimasory:orange-extensions:1.3.0'
 }
 
+tasks.withType(JavaCompile) {
+    // Resolves a Gradle warning about not scanning for pre-processors.
+    options.compilerArgs << '-proc:none'
+}
+
 task runDemoNodes(dependsOn: 'classes', type: JavaExec) {
     main = 'net.corda.explorer.MainKt'
     classpath = sourceSets.main.runtimeClasspath

--- a/tools/network-bootstrapper/build.gradle
+++ b/tools/network-bootstrapper/build.gradle
@@ -1,25 +1,23 @@
-buildscript {
-
-    ext.tornadofx_version = '1.7.15'
-    ext.controlsfx_version = '8.40.12'
-
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-        jcenter()
-    }
-
-    dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:$shadow_version"
-    }
+ext {
+    tornadofx_version = '1.7.15'
+    controlsfx_version = '8.40.12'
 }
 
 apply plugin: 'kotlin'
 apply plugin: 'idea'
 apply plugin: 'java'
 apply plugin: 'application'
+// We need to set mainClassName before applying the shadow plugin.
+mainClassName = 'net.corda.bootstrapper.Main'
+
 apply plugin: 'com.github.johnrengelman.shadow'
+
+configurations {
+    compile {
+        exclude group: "log4j", module: "log4j"
+        exclude group: "org.apache.logging.log4j"
+    }
+}
 
 dependencies {
     compile "com.microsoft.azure:azure:1.8.0"
@@ -35,7 +33,7 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
-    compile 'info.picocli:picocli:3.0.1'
+    compile "info.picocli:picocli:$picocli_version"
 
     // TornadoFX: A lightweight Kotlin framework for working with JavaFX UI's.
     compile "no.tornado:tornadofx:$tornadofx_version"
@@ -44,18 +42,19 @@ dependencies {
     compile "org.controlsfx:controlsfx:$controlsfx_version"
 }
 
+tasks.withType(JavaCompile) {
+    // Resolves a Gradle warning about not scanning for pre-processors.
+    options.compilerArgs << '-proc:none'
+}
+
+jar.enabled = false
+
 shadowJar {
     baseName = 'network-bootstrapper'
     classifier = null
     version = null
     zip64 true
-    mainClassName = 'net.corda.bootstrapper.Main'
 }
 
-task buildNetworkBootstrapper(dependsOn: shadowJar) {
-}
-
-configurations {
-    compile.exclude group: "log4j", module: "log4j"
-    compile.exclude group: "org.apache.logging.log4j"
-}
+task buildNetworkBootstrapper(dependsOn: shadowJar)
+assemble.dependsOn buildNetworkBootstrapper

--- a/tools/shell-cli/build.gradle
+++ b/tools/shell-cli/build.gradle
@@ -1,14 +1,5 @@
 description 'Corda Shell CLI'
 
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:$shadow_version"
-    }
-}
-
 apply plugin: 'application'
 // We need to set mainClassName before applying the shadow plugin.
 mainClassName = 'net.corda.tools.shell.StandaloneShellKt'


### PR DESCRIPTION
Ensure that every module uses the same version of the `shadow` plugin by controlling this from the root project.
Also resolve a few more Gradle warnings that will become errors with Gradle 5.0.