### PR TITLE
CORDA-1969 Retire SECP256K1 for TLS

### DIFF
--- a/docs/source/cipher-suites.rst
+++ b/docs/source/cipher-suites.rst
@@ -73,7 +73,7 @@ are compatible with TLS 1.2, while the default scheme per key type is also shown
 | | and SHA-256           | | vendors.                                                    |     | - tls                   |
 |                         |                                                               |     | - network map (CN)      |
 +-------------------------+---------------------------------------------------------------+-----+-------------------------+
-| | ECDSA using the       | | secp256k1 is the curve adopted by Bitcoin and as such there | YES |                         |
+| | ECDSA using the       | | secp256k1 is the curve adopted by Bitcoin and as such there | NO  |                         |
 | | Koblitz k1 curve      | | is a wealth of infrastructure, code and advanced algorithms |     |                         |
 | | (secp256k1)           | | designed for use with it. This curve is standardised by     |     |                         |
 | | and SHA-256           | | NIST as part of the "Suite B" cryptographic algorithms and  |     |                         |

--- a/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt
@@ -100,22 +100,6 @@ class TLSAuthenticationTests {
         testConnect(serverSocket, clientSocket, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
     }
 
-    @Test
-    fun `All EC K1`() {
-        val (serverSocketFactory, clientSocketFactory) = buildTLSFactories(
-                rootCAScheme = Crypto.ECDSA_SECP256K1_SHA256,
-                intermediateCAScheme = Crypto.ECDSA_SECP256K1_SHA256,
-                client1CAScheme = Crypto.ECDSA_SECP256K1_SHA256,
-                client1TLSScheme = Crypto.ECDSA_SECP256K1_SHA256,
-                client2CAScheme = Crypto.ECDSA_SECP256K1_SHA256,
-                client2TLSScheme = Crypto.ECDSA_SECP256K1_SHA256
-        )
-
-        val (serverSocket, clientSocket) = buildTLSSockets(serverSocketFactory, clientSocketFactory, 0, 0)
-
-        testConnect(serverSocket, clientSocket, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
-    }
-
     // Server's public key type is the one selected if users use different key types (e.g RSA and EC R1).
     @Test
     fun `Server RSA - Client EC R1 - CAs all EC R1`() {
@@ -161,22 +145,6 @@ class TLSAuthenticationTests {
         val (serverSocket, clientSocket) = buildTLSSockets(serverSocketFactory, clientSocketFactory, 0, 0)
         testConnect(serverSocket, clientSocket, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
     }
-
-    @Test
-    fun `Server EC K1 - Client EC R1 - CAs all RSA`() {
-        val (serverSocketFactory, clientSocketFactory) = buildTLSFactories(
-                rootCAScheme = Crypto.RSA_SHA256,
-                intermediateCAScheme = Crypto.RSA_SHA256,
-                client1CAScheme = Crypto.RSA_SHA256,
-                client1TLSScheme = Crypto.ECDSA_SECP256K1_SHA256,
-                client2CAScheme = Crypto.RSA_SHA256,
-                client2TLSScheme = Crypto.ECDSA_SECP256R1_SHA256
-        )
-
-        val (serverSocket, clientSocket) = buildTLSSockets(serverSocketFactory, clientSocketFactory, 0, 0)
-        testConnect(serverSocket, clientSocket, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
-    }
-
 
     @Test
     fun `Server EC R1 - Client RSA - Mixed CAs`() {

--- a/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt
@@ -153,7 +153,7 @@ class TLSAuthenticationTests {
                 intermediateCAScheme = Crypto.RSA_SHA256,
                 client1CAScheme = Crypto.RSA_SHA256,
                 client1TLSScheme = Crypto.ECDSA_SECP256R1_SHA256,
-                client2CAScheme = Crypto.ECDSA_SECP256K1_SHA256,
+                client2CAScheme = Crypto.ECDSA_SECP256R1_SHA256,
                 client2TLSScheme = Crypto.RSA_SHA256
         )
 


### PR DESCRIPTION
Library support for this curve is not as widespread as we'd like it to be for connection security. Note, it will still be supported for Corda crypto operations, just not for the transport layer.