### PR TITLE
CORDA-1093 Deleting node info from directory (#3115)

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NodeInfoWatcherTest.kt
@@ -37,7 +37,7 @@ class NodeInfoWatcherTest {
     val tempFolder = TemporaryFolder()
 
     private val scheduler = TestScheduler()
-    private val testSubscriber = TestSubscriber<NodeInfo>()
+    private val testSubscriber = TestSubscriber<NodeInfoUpdate>()
 
     private lateinit var nodeInfoAndSigned: NodeInfoAndSigned
     private lateinit var nodeInfoPath: Path
@@ -101,7 +101,7 @@ class NodeInfoWatcherTest {
         try {
             val readNodes = testSubscriber.onNextEvents.distinct()
             assertEquals(1, readNodes.size)
-            assertEquals(nodeInfoAndSigned.nodeInfo, readNodes.first())
+            assertEquals(nodeInfoAndSigned.nodeInfo, (readNodes.first() as? NodeInfoUpdate.Add)?.nodeInfo)
         } finally {
             subscription.unsubscribe()
         }
@@ -126,7 +126,7 @@ class NodeInfoWatcherTest {
             testSubscriber.awaitValueCount(1, 5, TimeUnit.SECONDS)
             // The same folder can be reported more than once, so take unique values.
             val readNodes = testSubscriber.onNextEvents.distinct()
-            assertEquals(nodeInfoAndSigned.nodeInfo, readNodes.first())
+            assertEquals(nodeInfoAndSigned.nodeInfo, (readNodes.first() as? NodeInfoUpdate.Add)?.nodeInfo)
         } finally {
             subscription.unsubscribe()
         }

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -60,7 +60,17 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
     fun subscribeToNetworkMap() {
         require(fileWatcherSubscription == null) { "Should not call this method twice." }
         // Subscribe to file based networkMap
-        fileWatcherSubscription = fileWatcher.nodeInfoUpdates().subscribe(networkMapCache::addNode)
+        fileWatcherSubscription = fileWatcher.nodeInfoUpdates().subscribe {
+            when (it) {
+                is NodeInfoUpdate.Add -> {
+                    networkMapCache.addNode(it.nodeInfo)
+                }
+                is NodeInfoUpdate.Remove -> {
+                    val nodeInfo = networkMapCache.getNodeByHash(it.hash)
+                    nodeInfo?.let { networkMapCache.removeNode(it) }
+                }
+            }
+        }
 
         if (networkMapClient == null) return
 

--- a/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NodeInfoWatcher.kt
@@ -26,13 +26,18 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.streams.toList
 
+sealed class NodeInfoUpdate {
+    data class Add(val nodeInfo: NodeInfo) : NodeInfoUpdate()
+    data class Remove(val hash: SecureHash) : NodeInfoUpdate()
+}
+
 /**
  * Class containing the logic to
  * - Serialize and de-serialize a [NodeInfo] to disk and reading it back.
  * - Poll a directory for new serialized [NodeInfo]
  *
  * @param nodePath the base path of a node.
- * @param pollInterval how often to poll the filesystem in milliseconds. Must be longer then 5 seconds.
+ * @param pollInterval how often to poll the filesystem in milliseconds. Must be longer than 5 seconds.
  * @param scheduler a [Scheduler] for the rx [Observable] returned by [nodeInfoUpdates], this is mainly useful for
  *        testing. It defaults to the io scheduler which is the appropriate value for production uses.
  */
@@ -58,10 +63,10 @@ class NodeInfoWatcher(private val nodePath: Path,
         }
     }
 
+    internal data class NodeInfoFromFile(val nodeInfohash: SecureHash, val lastModified: FileTime)
     private val nodeInfosDir = nodePath / CordformNode.NODE_INFO_DIRECTORY
-    private val nodeInfoFiles = HashMap<Path, FileTime>()
-    private val _processedNodeInfoHashes = HashSet<SecureHash>()
-    val processedNodeInfoHashes: Set<SecureHash> get() = _processedNodeInfoHashes
+    private val nodeInfoFilesMap = HashMap<Path, NodeInfoFromFile>()
+    val processedNodeInfoHashes: Set<SecureHash> get() = nodeInfoFilesMap.values.map { it.nodeInfohash }.toSet()
 
     init {
         require(pollInterval >= 5.seconds) { "Poll interval must be 5 seconds or longer." }
@@ -75,33 +80,31 @@ class NodeInfoWatcher(private val nodePath: Path,
      * We simply list the directory content every 5 seconds, the Java implementation of WatchService has been proven to
      * be unreliable on MacOs and given the fairly simple use case we have, this simple implementation should do.
      *
-     * @return an [Observable] returning [NodeInfo]s, at most one [NodeInfo] is returned for each processed file.
+     * @return an [Observable] returning [NodeInfoUpdate]s, at most one [NodeInfo] is returned for each processed file.
      */
-    fun nodeInfoUpdates(): Observable<NodeInfo> {
+    fun nodeInfoUpdates(): Observable<NodeInfoUpdate> {
         return Observable.interval(0, pollInterval.toMillis(), TimeUnit.MILLISECONDS, scheduler)
                 .flatMapIterable { loadFromDirectory() }
     }
 
-    // TODO This method doesn't belong in this class
-    fun saveToFile(nodeInfoAndSigned: NodeInfoAndSigned) {
-        return Companion.saveToFile(nodePath, nodeInfoAndSigned)
-    }
-
-    private fun loadFromDirectory(): List<NodeInfo> {
+    private fun loadFromDirectory(): List<NodeInfoUpdate> {
+        val processedPaths = HashSet<Path>()
         val result = nodeInfosDir.list { paths ->
             paths
                     .filter { it.isRegularFile() }
                     .filter { file ->
                         val lastModifiedTime = file.lastModifiedTime()
-                        val previousLastModifiedTime = nodeInfoFiles[file]
+                        val previousLastModifiedTime = nodeInfoFilesMap[file]?.lastModified
                         val newOrChangedFile = previousLastModifiedTime == null || lastModifiedTime > previousLastModifiedTime
-                        nodeInfoFiles[file] = lastModifiedTime
+                        processedPaths.add(file)
                         newOrChangedFile
                     }
                     .mapNotNull { file ->
                         logger.debug { "Reading SignedNodeInfo from $file" }
                         try {
-                            NodeInfoAndSigned(file.readObject())
+                            val nodeInfoSigned = NodeInfoAndSigned(file.readObject())
+                            nodeInfoFilesMap[file] = NodeInfoFromFile(nodeInfoSigned.signed.raw.hash, file.lastModifiedTime())
+                            nodeInfoSigned
                         } catch (e: Exception) {
                             logger.warn("Unable to read SignedNodeInfo from $file", e)
                             null
@@ -109,10 +112,13 @@ class NodeInfoWatcher(private val nodePath: Path,
                     }
                     .toList()
         }
-
+        val removedFiles = nodeInfoFilesMap.keys - processedPaths
+        val removedHashes = removedFiles.map { file ->
+            NodeInfoUpdate.Remove(nodeInfoFilesMap.remove(file)!!.nodeInfohash)
+        }
         logger.debug { "Read ${result.size} NodeInfo files from $nodeInfosDir" }
-        _processedNodeInfoHashes += result.map { it.signed.raw.hash }
-        return result.map { it.nodeInfo }
+        logger.debug { "Number of removed NodeInfo files ${removedHashes.size}" }
+        return result.map { NodeInfoUpdate.Add(it.nodeInfo) } + removedHashes
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/PersistentNetworkMapCache.kt
@@ -251,8 +251,8 @@ open class PersistentNetworkMapCache(
     }
 
     private fun removeInfoDB(session: Session, nodeInfo: NodeInfo) {
-        val info = findByIdentityKey(session, nodeInfo.legalIdentitiesAndCerts.first().owningKey).single()
-        session.remove(info)
+        val info = findByIdentityKey(session, nodeInfo.legalIdentitiesAndCerts.first().owningKey).singleOrNull()
+        info?.let { session.remove(it) }
         // invalidate cache last - this way, we might serve up the wrong info for a short time, but it will get refreshed
         // on the next load
         invalidateCaches(nodeInfo)


### PR DESCRIPTION
* CORDA-1093 Deleting node info from directory

Deleting NodeInfo from additional-node-infos directory should remove it from cache.

Backport of https://github.com/corda/corda/pull/3115
