### PR TITLE
CORDA-1391: Separate out Checkpoint serialization

### DIFF
--- a/core-deterministic/src/main/kotlin/net/corda/core/serialization/CheckpointSerializationFactory.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/serialization/CheckpointSerializationFactory.kt
@@ -1,0 +1,85 @@
+package net.corda.core.serialization
+
+import net.corda.core.KeepForDJVM
+import net.corda.core.serialization.internal.effectiveSerializationEnv
+import net.corda.core.utilities.ByteSequence
+
+/**
+ * An abstraction for serializing and deserializing objects, with support for versioning of the wire format via
+ * a header / prefix in the bytes.
+ */
+@KeepForDJVM
+abstract class CheckpointSerializationFactory {
+    /**
+     * Deserialize the bytes in to an object, using the prefixed bytes to determine the format.
+     *
+     * @param byteSequence The bytes to deserialize, including a format header prefix.
+     * @param clazz The class or superclass or the object to be deserialized, or [Any] or [Object] if unknown.
+     * @param context A context that configures various parameters to deserialization.
+     */
+    abstract fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: CheckpointSerializationContext): T
+
+    /**
+     * Serialize an object to bytes using the preferred serialization format version from the context.
+     *
+     * @param obj The object to be serialized.
+     * @param context A context that configures various parameters to serialization, including the serialization format version.
+     */
+    abstract fun <T : Any> serialize(obj: T, context: CheckpointSerializationContext): SerializedBytes<T>
+
+    /**
+     * If there is a need to nest serialization/deserialization with a modified context during serialization or deserialization,
+     * this will return the current context used to start serialization/deserialization.
+     */
+    val currentContext: CheckpointSerializationContext? get() = _currentContext
+
+    /**
+     * A context to use as a default if you do not require a specially configured context.  It will be the current context
+     * if the use is somehow nested (see [currentContext]).
+     */
+    val defaultContext: CheckpointSerializationContext get() = currentContext ?: effectiveSerializationEnv.checkpointContext
+
+    private var _currentContext: CheckpointSerializationContext? = null
+
+    /**
+     * Change the current context inside the block to that supplied.
+     */
+    fun <T> withCurrentContext(context: CheckpointSerializationContext?, block: () -> T): T {
+        val priorContext = _currentContext
+        if (context != null) _currentContext = context
+        try {
+            return block()
+        } finally {
+            if (context != null) _currentContext = priorContext
+        }
+    }
+
+    /**
+     * Allow subclasses to temporarily mark themselves as the current factory for the current thread during serialization/deserialization.
+     * Will restore the prior context on exiting the block.
+     */
+    fun <T> asCurrent(block: CheckpointSerializationFactory.() -> T): T {
+        val priorContext = _currentFactory
+        _currentFactory = this
+        try {
+            return this.block()
+        } finally {
+            _currentFactory = priorContext
+        }
+    }
+
+    companion object {
+        private var _currentFactory: CheckpointSerializationFactory? = null
+
+        /**
+         * A default factory for serialization/deserialization, taking into account the [currentFactory] if set.
+         */
+        val defaultFactory: CheckpointSerializationFactory get() = currentFactory ?: effectiveSerializationEnv.checkpointSerializationFactory
+
+        /**
+         * If there is a need to nest serialization/deserialization with a modified context during serialization or deserialization,
+         * this will return the current factory used to start serialization/deserialization.
+         */
+        val currentFactory: CheckpointSerializationFactory? get() = _currentFactory
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/CheckpointSerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/CheckpointSerializationAPI.kt
@@ -1,0 +1,190 @@
+package net.corda.core.serialization
+
+import net.corda.core.DoNotImplement
+import net.corda.core.KeepForDJVM
+import net.corda.core.crypto.SecureHash
+import net.corda.core.serialization.internal.effectiveSerializationEnv
+import net.corda.core.utilities.ByteSequence
+import net.corda.core.utilities.sequence
+
+/**
+ * An abstraction for serializing and deserializing objects, with support for versioning of the wire format via
+ * a header / prefix in the bytes.
+ */
+abstract class CheckpointSerializationFactory {
+    /**
+     * Deserialize the bytes in to an object, using the prefixed bytes to determine the format.
+     *
+     * @param byteSequence The bytes to deserialize, including a format header prefix.
+     * @param clazz The class or superclass or the object to be deserialized, or [Any] or [Object] if unknown.
+     * @param context A context that configures various parameters to deserialization.
+     */
+    abstract fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: CheckpointSerializationContext): T
+
+    /**
+     * Serialize an object to bytes using the preferred serialization format version from the context.
+     *
+     * @param obj The object to be serialized.
+     * @param context A context that configures various parameters to serialization, including the serialization format version.
+     */
+    abstract fun <T : Any> serialize(obj: T, context: CheckpointSerializationContext): SerializedBytes<T>
+
+    /**
+     * If there is a need to nest serialization/deserialization with a modified context during serialization or deserialization,
+     * this will return the current context used to start serialization/deserialization.
+     */
+    val currentContext: CheckpointSerializationContext? get() = _currentContext.get()
+
+    /**
+     * A context to use as a default if you do not require a specially configured context.  It will be the current context
+     * if the use is somehow nested (see [currentContext]).
+     */
+    val defaultContext: CheckpointSerializationContext get() = currentContext ?: effectiveSerializationEnv.checkpointContext
+
+    private val _currentContext = ThreadLocal<CheckpointSerializationContext?>()
+
+    /**
+     * Change the current context inside the block to that supplied.
+     */
+    fun <T> withCurrentContext(context: CheckpointSerializationContext?, block: () -> T): T {
+        val priorContext = _currentContext.get()
+        if (context != null) _currentContext.set(context)
+        try {
+            return block()
+        } finally {
+            if (context != null) _currentContext.set(priorContext)
+        }
+    }
+
+    /**
+     * Allow subclasses to temporarily mark themselves as the current factory for the current thread during serialization/deserialization.
+     * Will restore the prior context on exiting the block.
+     */
+    fun <T> asCurrent(block: CheckpointSerializationFactory.() -> T): T {
+        val priorContext = _currentFactory.get()
+        _currentFactory.set(this)
+        try {
+            return this.block()
+        } finally {
+            _currentFactory.set(priorContext)
+        }
+    }
+
+    companion object {
+        private val _currentFactory = ThreadLocal<CheckpointSerializationFactory?>()
+
+        /**
+         * A default factory for serialization/deserialization, taking into account the [currentFactory] if set.
+         */
+        val defaultFactory: CheckpointSerializationFactory get() = currentFactory ?: effectiveSerializationEnv.checkpointSerializationFactory
+
+        /**
+         * If there is a need to nest serialization/deserialization with a modified context during serialization or deserialization,
+         * this will return the current factory used to start serialization/deserialization.
+         */
+        val currentFactory: CheckpointSerializationFactory? get() = _currentFactory.get()
+    }
+}
+
+/**
+ * Parameters to serialization and deserialization.
+ */
+@KeepForDJVM
+@DoNotImplement
+interface CheckpointSerializationContext {
+    /**
+     * If non-null, apply this encoding (typically compression) when serializing.
+     */
+    val encoding: SerializationEncoding?
+    /**
+     * The class loader to use for deserialization.
+     */
+    val deserializationClassLoader: ClassLoader
+    /**
+     * A whitelist that contains (mostly for security purposes) which classes can be serialized and deserialized.
+     */
+    val whitelist: ClassWhitelist
+    /**
+     * A whitelist that determines (mostly for security purposes) whether a particular encoding may be used when deserializing.
+     */
+    val encodingWhitelist: EncodingWhitelist
+    /**
+     * A map of any addition properties specific to the particular use case.
+     */
+    val properties: Map<Any, Any>
+    /**
+     * Duplicate references to the same object preserved in the wire format and when deserialized when this is true,
+     * otherwise they appear as new copies of the object.
+     */
+    val objectReferencesEnabled: Boolean
+
+    /**
+     * Helper method to return a new context based on this context with the property added.
+     */
+    fun withProperty(property: Any, value: Any): CheckpointSerializationContext
+
+    /**
+     * Helper method to return a new context based on this context with object references disabled.
+     */
+    fun withoutReferences(): CheckpointSerializationContext
+
+    /**
+     * Helper method to return a new context based on this context with the deserialization class loader changed.
+     */
+    fun withClassLoader(classLoader: ClassLoader): CheckpointSerializationContext
+
+    /**
+     * Helper method to return a new context based on this context with the appropriate class loader constructed from the passed attachment identifiers.
+     * (Requires the attachment storage to have been enabled).
+     */
+    @Throws(MissingAttachmentsException::class)
+    fun withAttachmentsClassLoader(attachmentHashes: List<SecureHash>): CheckpointSerializationContext
+
+    /**
+     * Helper method to return a new context based on this context with the given class specifically whitelisted.
+     */
+    fun withWhitelisted(clazz: Class<*>): CheckpointSerializationContext
+
+    /**
+     * A shallow copy of this context but with the given (possibly null) encoding.
+     */
+    fun withEncoding(encoding: SerializationEncoding?): CheckpointSerializationContext
+
+    /**
+     * A shallow copy of this context but with the given encoding whitelist.
+     */
+    fun withEncodingWhitelist(encodingWhitelist: EncodingWhitelist): CheckpointSerializationContext
+}
+
+/**
+ * Convenience extension method for deserializing a ByteSequence, utilising the defaults.
+ */
+inline fun <reified T : Any> ByteSequence.deserialize(serializationFactory: CheckpointSerializationFactory = CheckpointSerializationFactory.defaultFactory,
+                                                      context: CheckpointSerializationContext): T {
+    return serializationFactory.deserialize(this, T::class.java, context)
+}
+
+/**
+ * Convenience extension method for deserializing SerializedBytes with type matching, utilising the defaults.
+ */
+inline fun <reified T : Any> SerializedBytes<T>.deserialize(serializationFactory: CheckpointSerializationFactory = CheckpointSerializationFactory.defaultFactory,
+                                                            context: CheckpointSerializationContext): T {
+    return serializationFactory.deserialize(this, T::class.java, context)
+}
+
+/**
+ * Convenience extension method for deserializing a ByteArray, utilising the defaults.
+ */
+inline fun <reified T : Any> ByteArray.deserialize(serializationFactory: CheckpointSerializationFactory = CheckpointSerializationFactory.defaultFactory,
+                                                   context: CheckpointSerializationContext): T {
+    require(isNotEmpty()) { "Empty bytes" }
+    return this.sequence().deserialize(serializationFactory, context)
+}
+
+/**
+ * Convenience extension method for serializing an object of type T, utilising the defaults.
+ */
+fun <T : Any> T.serialize(serializationFactory: CheckpointSerializationFactory = CheckpointSerializationFactory.defaultFactory,
+                          context: CheckpointSerializationContext): SerializedBytes<T> {
+    return serializationFactory.serialize(this, context)
+}

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -207,7 +207,14 @@ interface SerializationContext {
      * The use case that we are serializing for, since it influences the implementations chosen.
      */
     @KeepForDJVM
-    enum class UseCase { P2P, RPCServer, RPCClient, Storage, Checkpoint, Testing }
+    enum class UseCase {
+        P2P,
+        RPCServer,
+        RPCClient,
+        Storage,
+        @Deprecated("Checkpoint use case is no longer supported by the default SerializationContext. Use a CheckpointSerializationContext instead.") Checkpoint,
+        Testing
+    }
 }
 
 /**
@@ -226,6 +233,7 @@ enum class ContextPropertyKeys {
 @KeepForDJVM
 object SerializationDefaults {
     val SERIALIZATION_FACTORY get() = effectiveSerializationEnv.serializationFactory
+    val CHECKPOINT_SERIALIZATION_FACTORY get() = effectiveSerializationEnv.checkpointSerializationFactory
     val P2P_CONTEXT get() = effectiveSerializationEnv.p2pContext
     @DeleteForDJVM val RPC_SERVER_CONTEXT get() = effectiveSerializationEnv.rpcServerContext
     @DeleteForDJVM val RPC_CLIENT_CONTEXT get() = effectiveSerializationEnv.rpcClientContext

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/SerializationEnvironment.kt
@@ -6,17 +6,20 @@ import net.corda.core.internal.InheritableThreadLocalToggleField
 import net.corda.core.internal.SimpleToggleField
 import net.corda.core.internal.ThreadLocalToggleField
 import net.corda.core.internal.VisibleForTesting
+import net.corda.core.serialization.CheckpointSerializationContext
+import net.corda.core.serialization.CheckpointSerializationFactory
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializationFactory
 
 @KeepForDJVM
 interface SerializationEnvironment {
     val serializationFactory: SerializationFactory
+    val checkpointSerializationFactory: CheckpointSerializationFactory
     val p2pContext: SerializationContext
     val rpcServerContext: SerializationContext
     val rpcClientContext: SerializationContext
     val storageContext: SerializationContext
-    val checkpointContext: SerializationContext
+    val checkpointContext: CheckpointSerializationContext
 }
 
 @KeepForDJVM
@@ -26,18 +29,21 @@ open class SerializationEnvironmentImpl(
         rpcServerContext: SerializationContext? = null,
         rpcClientContext: SerializationContext? = null,
         storageContext: SerializationContext? = null,
-        checkpointContext: SerializationContext? = null) : SerializationEnvironment {
+        checkpointContext: CheckpointSerializationContext? = null,
+        checkpointSerializationFactory: CheckpointSerializationFactory? = null) : SerializationEnvironment {
     // Those that are passed in as null are never inited:
     override lateinit var rpcServerContext: SerializationContext
     override lateinit var rpcClientContext: SerializationContext
     override lateinit var storageContext: SerializationContext
-    override lateinit var checkpointContext: SerializationContext
+    override lateinit var checkpointContext: CheckpointSerializationContext
+    override lateinit var checkpointSerializationFactory: CheckpointSerializationFactory
 
     init {
         rpcServerContext?.let { this.rpcServerContext = it }
         rpcClientContext?.let { this.rpcClientContext = it }
         storageContext?.let { this.storageContext = it }
         checkpointContext?.let { this.checkpointContext = it }
+        checkpointSerializationFactory?.let { this.checkpointSerializationFactory = it  }
     }
 }
 

--- a/core/src/test/java/net/corda/core/flows/SerializationApiInJavaTest.java
+++ b/core/src/test/java/net/corda/core/flows/SerializationApiInJavaTest.java
@@ -1,11 +1,13 @@
 package net.corda.core.flows;
 
+import net.corda.core.serialization.CheckpointSerializationFactory;
 import net.corda.core.serialization.SerializationDefaults;
 import net.corda.core.serialization.SerializationFactory;
 import net.corda.testing.core.SerializationEnvironmentRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static net.corda.core.serialization.CheckpointSerializationAPIKt.serialize;
 import static net.corda.core.serialization.SerializationAPIKt.serialize;
 import static org.junit.Assert.assertNull;
 
@@ -28,10 +30,12 @@ public class SerializationApiInJavaTest {
     public void enforceSerializationDefaultsApi() {
         SerializationDefaults defaults = SerializationDefaults.INSTANCE;
         SerializationFactory factory = defaults.getSERIALIZATION_FACTORY();
+
+        CheckpointSerializationFactory checkpointSerializationFactory = defaults.getCHECKPOINT_SERIALIZATION_FACTORY();
         serialize("hello", factory, defaults.getP2P_CONTEXT());
         serialize("hello", factory, defaults.getRPC_SERVER_CONTEXT());
         serialize("hello", factory, defaults.getRPC_CLIENT_CONTEXT());
         serialize("hello", factory, defaults.getSTORAGE_CONTEXT());
-        serialize("hello", factory, defaults.getCHECKPOINT_CONTEXT());
+        serialize("hello", checkpointSerializationFactory, defaults.getCHECKPOINT_CONTEXT());
     }
 }

--- a/core/src/test/kotlin/net/corda/core/utilities/KotlinUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/KotlinUtilsTest.kt
@@ -4,8 +4,7 @@ import com.esotericsoftware.kryo.KryoException
 import net.corda.core.crypto.random63BitValue
 import net.corda.core.serialization.*
 import net.corda.node.serialization.kryo.KRYO_CHECKPOINT_CONTEXT
-import net.corda.node.serialization.kryo.kryoMagic
-import net.corda.serialization.internal.SerializationContextImpl
+import net.corda.serialization.internal.CheckpointSerializationContextImpl
 import net.corda.testing.core.SerializationEnvironmentRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -24,12 +23,11 @@ class KotlinUtilsTest {
     @Rule
     val expectedEx: ExpectedException = ExpectedException.none()
 
-    private val KRYO_CHECKPOINT_NOWHITELIST_CONTEXT = SerializationContextImpl(kryoMagic,
+    private val KRYO_CHECKPOINT_NOWHITELIST_CONTEXT = CheckpointSerializationContextImpl(
             javaClass.classLoader,
             EmptyWhitelist,
             emptyMap(),
             true,
-            SerializationContext.UseCase.Checkpoint,
             null)
 
     @Test

--- a/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CheckpointVerifier.kt
@@ -9,7 +9,7 @@ import net.corda.core.serialization.deserialize
 import net.corda.node.services.api.CheckpointStorage
 import net.corda.node.services.statemachine.SubFlow
 import net.corda.node.services.statemachine.SubFlowVersion
-import net.corda.serialization.internal.SerializeAsTokenContextImpl
+import net.corda.serialization.internal.CheckpointSerializeAsTokenContextImpl
 import net.corda.serialization.internal.withTokenContext
 
 object CheckpointVerifier {
@@ -20,7 +20,7 @@ object CheckpointVerifier {
      */
     fun verifyCheckpointsCompatible(checkpointStorage: CheckpointStorage, currentCordapps: List<Cordapp>, platformVersion: Int, serviceHub: ServiceHub, tokenizableServices: List<Any>) {
         val checkpointSerializationContext = SerializationDefaults.CHECKPOINT_CONTEXT.withTokenContext(
-                SerializeAsTokenContextImpl(tokenizableServices, SerializationDefaults.SERIALIZATION_FACTORY, SerializationDefaults.CHECKPOINT_CONTEXT, serviceHub)
+                CheckpointSerializeAsTokenContextImpl(tokenizableServices, SerializationDefaults.CHECKPOINT_SERIALIZATION_FACTORY, SerializationDefaults.CHECKPOINT_CONTEXT, serviceHub)
         )
         checkpointStorage.getAllCheckpoints().forEach { (_, serializedCheckpoint) ->
 

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -449,8 +449,8 @@ open class Node(configuration: NodeConfiguration,
                 SerializationFactoryImpl().apply {
                     registerScheme(AMQPServerSerializationScheme(cordappLoader.cordapps))
                     registerScheme(AMQPClientSerializationScheme(cordappLoader.cordapps))
-                    registerScheme(KryoServerSerializationScheme())
                 },
+                checkpointSerializationFactory = CheckpointSerializationFactoryImpl(KryoServerSerializationScheme()),
                 p2pContext = AMQP_P2P_CONTEXT.withClassLoader(classloader),
                 rpcServerContext = AMQP_RPC_SERVER_CONTEXT.withClassLoader(classloader),
                 storageContext = AMQP_STORAGE_CONTEXT.withClassLoader(classloader),

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/CordaClassResolver.kt
@@ -8,6 +8,7 @@ import com.esotericsoftware.kryo.util.DefaultClassResolver
 import com.esotericsoftware.kryo.util.Util
 import net.corda.core.internal.kotlinObjectInstance
 import net.corda.core.internal.writer
+import net.corda.core.serialization.CheckpointSerializationContext
 import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.utilities.contextLogger
@@ -25,7 +26,7 @@ import java.util.*
 /**
  * Corda specific class resolver which enables extra customisation for the purposes of serialization using Kryo
  */
-class CordaClassResolver(serializationContext: SerializationContext) : DefaultClassResolver() {
+class CordaClassResolver(serializationContext: CheckpointSerializationContext) : DefaultClassResolver() {
     val whitelist: ClassWhitelist = TransientClassWhiteList(serializationContext.whitelist)
 
     // These classes are assignment-compatible Java equivalents of Kotlin classes.

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
@@ -14,8 +14,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.TransactionSignature
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.SerializationContext
-import net.corda.core.serialization.SerializationContext.UseCase.Checkpoint
-import net.corda.core.serialization.SerializationContext.UseCase.Storage
 import net.corda.core.serialization.SerializeAsTokenContext
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.transactions.*
@@ -275,16 +273,16 @@ object SignedTransactionSerializer : Serializer<SignedTransaction>() {
     }
 }
 
+// Retained because it's part of a public API.
 sealed class UseCaseSerializer<T>(private val allowedUseCases: EnumSet<SerializationContext.UseCase>) : Serializer<T>() {
     protected fun checkUseCase() {
-        net.corda.serialization.internal.checkUseCase(allowedUseCases)
+        // No longer checked.
     }
 }
 
 @ThreadSafe
-object PrivateKeySerializer : UseCaseSerializer<PrivateKey>(EnumSet.of(Storage, Checkpoint)) {
+object PrivateKeySerializer : UseCaseSerializer<PrivateKey>(EnumSet.noneOf(SerializationContext.UseCase::class.java)) {
     override fun write(kryo: Kryo, output: Output, obj: PrivateKey) {
-        checkUseCase()
         output.writeBytesWithLength(obj.encoded)
     }
 

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoSerializationScheme.kt
@@ -10,10 +10,7 @@ import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.pool.KryoPool
 import com.esotericsoftware.kryo.serializers.ClosureSerializer
 import net.corda.core.internal.uncheckedCast
-import net.corda.core.serialization.ClassWhitelist
-import net.corda.core.serialization.SerializationContext
-import net.corda.core.serialization.SerializationDefaults
-import net.corda.core.serialization.SerializedBytes
+import net.corda.core.serialization.*
 import net.corda.core.utilities.ByteSequence
 import net.corda.serialization.internal.*
 import java.security.PublicKey
@@ -32,46 +29,33 @@ private object AutoCloseableSerialisationDetector : Serializer<AutoCloseable>() 
     override fun read(kryo: Kryo, input: Input, type: Class<AutoCloseable>) = throw IllegalStateException("Should not reach here!")
 }
 
-abstract class AbstractKryoSerializationScheme : SerializationScheme {
+abstract class AbstractKryoSerializationScheme : CheckpointSerializationScheme {
     private val kryoPoolsForContexts = ConcurrentHashMap<Pair<ClassWhitelist, ClassLoader>, KryoPool>()
-
-    protected abstract fun rpcClientKryoPool(context: SerializationContext): KryoPool
-    protected abstract fun rpcServerKryoPool(context: SerializationContext): KryoPool
 
     // this can be overridden in derived serialization schemes
     protected open val publicKeySerializer: Serializer<PublicKey> = PublicKeySerializer
 
-    private fun getPool(context: SerializationContext): KryoPool {
+    private fun getPool(context: CheckpointSerializationContext): KryoPool {
         return kryoPoolsForContexts.computeIfAbsent(Pair(context.whitelist, context.deserializationClassLoader)) {
-            when (context.useCase) {
-                SerializationContext.UseCase.Checkpoint ->
-                    KryoPool.Builder {
-                        val serializer = Fiber.getFiberSerializer(false) as KryoSerializer
-                        val classResolver = CordaClassResolver(context).apply { setKryo(serializer.kryo) }
-                        // TODO The ClassResolver can only be set in the Kryo constructor and Quasar doesn't provide us with a way of doing that
-                        val field = Kryo::class.java.getDeclaredField("classResolver").apply { isAccessible = true }
-                        serializer.kryo.apply {
-                            field.set(this, classResolver)
-                            // don't allow overriding the public key serializer for checkpointing
-                            DefaultKryoCustomizer.customize(this)
-                            addDefaultSerializer(AutoCloseable::class.java, AutoCloseableSerialisationDetector)
-                            register(ClosureSerializer.Closure::class.java, CordaClosureSerializer)
-                            classLoader = it.second
-                        }
-                    }.build()
-                SerializationContext.UseCase.RPCClient ->
-                    rpcClientKryoPool(context)
-                SerializationContext.UseCase.RPCServer ->
-                    rpcServerKryoPool(context)
-                else ->
-                    KryoPool.Builder {
-                        DefaultKryoCustomizer.customize(CordaKryo(CordaClassResolver(context)), publicKeySerializer).apply { classLoader = it.second }
-                    }.build()
-            }
+            KryoPool.Builder {
+                val serializer = Fiber.getFiberSerializer(false) as KryoSerializer
+                val classResolver = CordaClassResolver(context).apply { setKryo(serializer.kryo) }
+                // TODO The ClassResolver can only be set in the Kryo constructor and Quasar doesn't provide us with a way of doing that
+                val field = Kryo::class.java.getDeclaredField("classResolver").apply { isAccessible = true }
+                serializer.kryo.apply {
+                    field.set(this, classResolver)
+                    // don't allow overriding the public key serializer for checkpointing
+                    DefaultKryoCustomizer.customize(this)
+                    addDefaultSerializer(AutoCloseable::class.java, AutoCloseableSerialisationDetector)
+                    register(ClosureSerializer.Closure::class.java, CordaClosureSerializer)
+                    classLoader = it.second
+                }
+            }.build()
+
         }
     }
 
-    private fun <T : Any> SerializationContext.kryo(task: Kryo.() -> T): T {
+    private fun <T : Any> CheckpointSerializationContext.kryo(task: Kryo.() -> T): T {
         return getPool(this).run { kryo ->
             kryo.context.ensureCapacity(properties.size)
             properties.forEach { kryo.context.put(it.key, it.value) }
@@ -83,7 +67,7 @@ abstract class AbstractKryoSerializationScheme : SerializationScheme {
         }
     }
 
-    override fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: SerializationContext): T {
+    override fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: CheckpointSerializationContext): T {
         val dataBytes = kryoMagic.consume(byteSequence)
                 ?: throw KryoException("Serialized bytes header does not match expected format.")
         return context.kryo {
@@ -111,7 +95,7 @@ abstract class AbstractKryoSerializationScheme : SerializationScheme {
         }
     }
 
-    override fun <T : Any> serialize(obj: T, context: SerializationContext): SerializedBytes<T> {
+    override fun <T : Any> serialize(obj: T, context: CheckpointSerializationContext): SerializedBytes<T> {
         return context.kryo {
             SerializedBytes(kryoOutput {
                 kryoMagic.writeTo(this)
@@ -131,13 +115,11 @@ abstract class AbstractKryoSerializationScheme : SerializationScheme {
     }
 }
 
-val KRYO_CHECKPOINT_CONTEXT = SerializationContextImpl(
-        kryoMagic,
+val KRYO_CHECKPOINT_CONTEXT = CheckpointSerializationContextImpl(
         SerializationDefaults.javaClass.classLoader,
         QuasarWhitelist,
         emptyMap(),
         true,
-        SerializationContext.UseCase.Checkpoint,
         null,
         AlwaysAcceptEncodingWhitelist
 )

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoServerSerializationScheme.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/KryoServerSerializationScheme.kt
@@ -1,14 +1,4 @@
 package net.corda.node.serialization.kryo
 
-import com.esotericsoftware.kryo.pool.KryoPool
-import net.corda.core.serialization.SerializationContext
-import net.corda.serialization.internal.CordaSerializationMagic
-
-class KryoServerSerializationScheme : AbstractKryoSerializationScheme() {
-    override fun canDeserializeVersion(magic: CordaSerializationMagic, target: SerializationContext.UseCase): Boolean {
-        return magic == kryoMagic && target == SerializationContext.UseCase.Checkpoint
-    }
-
-    override fun rpcClientKryoPool(context: SerializationContext): KryoPool = throw UnsupportedOperationException()
-    override fun rpcServerKryoPool(context: SerializationContext): KryoPool = throw UnsupportedOperationException()
-}
+//TODO: get rid of this entirely
+class KryoServerSerializationScheme : AbstractKryoSerializationScheme()

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/ActionExecutorImpl.kt
@@ -4,9 +4,7 @@ import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import com.codahale.metrics.*
 import net.corda.core.internal.concurrent.thenMatch
-import net.corda.core.serialization.SerializationContext
-import net.corda.core.serialization.SerializedBytes
-import net.corda.core.serialization.serialize
+import net.corda.core.serialization.*
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.trace
 import net.corda.node.services.api.CheckpointStorage
@@ -27,7 +25,7 @@ class ActionExecutorImpl(
         private val checkpointStorage: CheckpointStorage,
         private val flowMessaging: FlowMessaging,
         private val stateMachineManager: StateMachineManagerInternal,
-        private val checkpointSerializationContext: SerializationContext,
+        private val checkpointSerializationContext: CheckpointSerializationContext,
         metrics: MetricRegistry
 ) : ActionExecutor {
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -12,7 +12,7 @@ import net.corda.core.cordapp.Cordapp
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.*
-import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.CheckpointSerializationContext
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.Try
 import net.corda.core.utilities.debug
@@ -69,7 +69,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
             val actionExecutor: ActionExecutor,
             val stateMachine: StateMachine,
             val serviceHub: ServiceHubInternal,
-            val checkpointSerializationContext: SerializationContext,
+            val checkpointSerializationContext: CheckpointSerializationContext,
             val unfinishedFibers: ReusableLatch
     )
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -36,7 +36,7 @@ import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.injectOldProgressTracker
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.wrapWithDatabaseTransaction
-import net.corda.serialization.internal.SerializeAsTokenContextImpl
+import net.corda.serialization.internal.CheckpointSerializeAsTokenContextImpl
 import net.corda.serialization.internal.withTokenContext
 import org.apache.activemq.artemis.utils.ReusableLatch
 import rx.Observable
@@ -103,7 +103,7 @@ class SingleThreadedStateMachineManager(
     private val transitionExecutor = makeTransitionExecutor()
     private val ourSenderUUID = serviceHub.networkService.ourSenderUUID
 
-    private var checkpointSerializationContext: SerializationContext? = null
+    private var checkpointSerializationContext: CheckpointSerializationContext? = null
     private var actionExecutor: ActionExecutor? = null
 
     override val allStateMachines: List<FlowLogic<*>>
@@ -123,7 +123,7 @@ class SingleThreadedStateMachineManager(
     override fun start(tokenizableServices: List<Any>) {
         checkQuasarJavaAgentPresence()
         val checkpointSerializationContext = SerializationDefaults.CHECKPOINT_CONTEXT.withTokenContext(
-                SerializeAsTokenContextImpl(tokenizableServices, SerializationDefaults.SERIALIZATION_FACTORY, SerializationDefaults.CHECKPOINT_CONTEXT, serviceHub)
+                CheckpointSerializeAsTokenContextImpl(tokenizableServices, SerializationDefaults.CHECKPOINT_SERIALIZATION_FACTORY, SerializationDefaults.CHECKPOINT_CONTEXT, serviceHub)
         )
         this.checkpointSerializationContext = checkpointSerializationContext
         this.actionExecutor = makeActionExecutor(checkpointSerializationContext)
@@ -741,7 +741,7 @@ class SingleThreadedStateMachineManager(
         }
     }
 
-    private fun makeActionExecutor(checkpointSerializationContext: SerializationContext): ActionExecutor {
+    private fun makeActionExecutor(checkpointSerializationContext: CheckpointSerializationContext): ActionExecutor {
         return ActionExecutorImpl(
                 serviceHub,
                 checkpointStorage,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/FiberDeserializationCheckingInterceptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/interceptors/FiberDeserializationCheckingInterceptor.kt
@@ -2,9 +2,7 @@ package net.corda.node.services.statemachine.interceptors
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.StateMachineRunId
-import net.corda.core.serialization.SerializationContext
-import net.corda.core.serialization.SerializedBytes
-import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.*
 import net.corda.core.utilities.contextLogger
 import net.corda.node.services.statemachine.ActionExecutor
 import net.corda.node.services.statemachine.Event
@@ -68,7 +66,7 @@ class FiberDeserializationChecker {
     private val jobQueue = LinkedBlockingQueue<Job>()
     private var foundUnrestorableFibers: Boolean = false
 
-    fun start(checkpointSerializationContext: SerializationContext) {
+    fun start(checkpointSerializationContext: CheckpointSerializationContext) {
         require(checkerThread == null)
         checkerThread = thread(name = "FiberDeserializationChecker") {
             while (true) {

--- a/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/RaftTransactionCommitLog.kt
@@ -20,10 +20,7 @@ import net.corda.core.flows.StateConsumptionDetails
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.notary.isConsumedByTheSameTx
 import net.corda.core.internal.notary.validateTimeWindow
-import net.corda.core.serialization.SerializationDefaults
-import net.corda.core.serialization.SerializationFactory
-import net.corda.core.serialization.deserialize
-import net.corda.core.serialization.serialize
+import net.corda.core.serialization.*
 import net.corda.core.utilities.ByteSequence
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.debug
@@ -201,7 +198,7 @@ class RaftTransactionCommitLog<E, EK>(
 
         class CordaKryoSerializer<T : Any> : TypeSerializer<T> {
             private val context = SerializationDefaults.CHECKPOINT_CONTEXT.withEncoding(CordaSerializationEncoding.SNAPPY)
-            private val factory = SerializationFactory.defaultFactory
+            private val factory = CheckpointSerializationFactory.defaultFactory
 
             override fun write(obj: T, buffer: BufferOutput<*>, serializer: Serializer) {
                 val serialized = obj.serialize(context = context)

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/CheckpointSerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/CheckpointSerializationScheme.kt
@@ -1,0 +1,86 @@
+package net.corda.serialization.internal
+
+import net.corda.core.KeepForDJVM
+import net.corda.core.crypto.SecureHash
+import net.corda.core.serialization.*
+import net.corda.core.utilities.ByteSequence
+import java.io.NotSerializableException
+
+@KeepForDJVM
+open class CheckpointSerializationFactoryImpl(
+        private val scheme: CheckpointSerializationScheme
+) : CheckpointSerializationFactory() {
+
+    private val creator: List<StackTraceElement> = Exception().stackTrace.asList()
+
+    @Throws(NotSerializableException::class)
+    override fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: CheckpointSerializationContext): T {
+        return asCurrent { withCurrentContext(context) { scheme.deserialize(byteSequence, clazz, context) } }
+    }
+
+    override fun <T : Any> serialize(obj: T, context: CheckpointSerializationContext): SerializedBytes<T> {
+        return asCurrent { withCurrentContext(context) { scheme.serialize(obj, context) } }
+    }
+
+    override fun toString(): String {
+        return "${this.javaClass.name} scheme=$scheme ${creator.joinToString("\n")}"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is CheckpointSerializationFactoryImpl && other.scheme == this.scheme
+    }
+
+    override fun hashCode(): Int = scheme.hashCode()
+}
+
+@KeepForDJVM
+interface CheckpointSerializationScheme {
+    @Throws(NotSerializableException::class)
+    fun <T : Any> deserialize(byteSequence: ByteSequence, clazz: Class<T>, context: CheckpointSerializationContext): T
+
+    @Throws(NotSerializableException::class)
+    fun <T : Any> serialize(obj: T, context: CheckpointSerializationContext): SerializedBytes<T>
+}
+
+@KeepForDJVM
+data class CheckpointSerializationContextImpl @JvmOverloads constructor(
+                                                              override val deserializationClassLoader: ClassLoader,
+                                                              override val whitelist: ClassWhitelist,
+                                                              override val properties: Map<Any, Any>,
+                                                              override val objectReferencesEnabled: Boolean,
+                                                              override val encoding: SerializationEncoding?,
+                                                              override val encodingWhitelist: EncodingWhitelist = NullEncodingWhitelist) : CheckpointSerializationContext {
+    private val builder = AttachmentsClassLoaderBuilder(properties, deserializationClassLoader)
+
+    /**
+     * {@inheritDoc}
+     *
+     * We need to cache the AttachmentClassLoaders to avoid too many contexts, since the class loader is part of cache key for the context.
+     */
+    override fun withAttachmentsClassLoader(attachmentHashes: List<SecureHash>): CheckpointSerializationContext {
+        properties[attachmentsClassLoaderEnabledPropertyName] as? Boolean == true || return this
+        val classLoader = builder.build(attachmentHashes) ?: return this
+        return withClassLoader(classLoader)
+    }
+
+    override fun withProperty(property: Any, value: Any): CheckpointSerializationContext {
+        return copy(properties = properties + (property to value))
+    }
+
+    override fun withoutReferences(): CheckpointSerializationContext {
+        return copy(objectReferencesEnabled = false)
+    }
+
+    override fun withClassLoader(classLoader: ClassLoader): CheckpointSerializationContext {
+        return copy(deserializationClassLoader = classLoader)
+    }
+
+    override fun withWhitelisted(clazz: Class<*>): CheckpointSerializationContext {
+        return copy(whitelist = object : ClassWhitelist {
+            override fun hasListed(type: Class<*>): Boolean = whitelist.hasListed(type) || type.name == clazz.name
+        })
+    }
+
+    override fun withEncoding(encoding: SerializationEncoding?) = copy(encoding = encoding)
+    override fun withEncodingWhitelist(encodingWhitelist: EncodingWhitelist) = copy(encodingWhitelist = encodingWhitelist)
+}

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/SerializeAsTokenContextImpl.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/SerializeAsTokenContextImpl.kt
@@ -3,14 +3,12 @@ package net.corda.serialization.internal
 
 import net.corda.core.DeleteForDJVM
 import net.corda.core.node.ServiceHub
-import net.corda.core.serialization.SerializationContext
-import net.corda.core.serialization.SerializationFactory
-import net.corda.core.serialization.SerializeAsToken
-import net.corda.core.serialization.SerializeAsTokenContext
+import net.corda.core.serialization.*
 
 val serializationContextKey = SerializeAsTokenContext::class.java
 
 fun SerializationContext.withTokenContext(serializationContext: SerializeAsTokenContext): SerializationContext = this.withProperty(serializationContextKey, serializationContext)
+fun CheckpointSerializationContext.withTokenContext(serializationContext: SerializeAsTokenContext): CheckpointSerializationContext = this.withProperty(serializationContextKey, serializationContext)
 
 /**
  * A context for mapping SerializationTokens to/from SerializeAsTokens.
@@ -24,6 +22,53 @@ fun SerializationContext.withTokenContext(serializationContext: SerializeAsToken
 @DeleteForDJVM
 class SerializeAsTokenContextImpl(override val serviceHub: ServiceHub, init: SerializeAsTokenContext.() -> Unit) : SerializeAsTokenContext {
     constructor(toBeTokenized: Any, serializationFactory: SerializationFactory, context: SerializationContext, serviceHub: ServiceHub) : this(serviceHub, {
+        serializationFactory.serialize(toBeTokenized, context.withTokenContext(this))
+    })
+
+    private val classNameToSingleton = mutableMapOf<String, SerializeAsToken>()
+    private var readOnly = false
+
+    init {
+        /**
+         * Go ahead and eagerly serialize the object to register all of the tokens in the context.
+         *
+         * This results in the toToken() method getting called for any [SingletonSerializeAsToken] instances which
+         * are encountered in the object graph as they are serialized and will therefore register the token to
+         * object mapping for those instances.  We then immediately set the readOnly flag to stop further adhoc or
+         * accidental registrations from occuring as these could not be deserialized in a deserialization-first
+         * scenario if they are not part of this iniital context construction serialization.
+         */
+        init(this)
+        readOnly = true
+    }
+
+    override fun putSingleton(toBeTokenized: SerializeAsToken) {
+        val className = toBeTokenized.javaClass.name
+        if (className !in classNameToSingleton) {
+            // Only allowable if we are in SerializeAsTokenContext init (readOnly == false)
+            if (readOnly) {
+                throw UnsupportedOperationException("Attempt to write token for lazy registered $className. All tokens should be registered during context construction.")
+            }
+            classNameToSingleton[className] = toBeTokenized
+        }
+    }
+
+    override fun getSingleton(className: String) = classNameToSingleton[className]
+            ?: throw IllegalStateException("Unable to find tokenized instance of $className in context $this")
+}
+
+/**
+ * A context for mapping SerializationTokens to/from SerializeAsTokens.
+ *
+ * A context is initialised with an object containing all the instances of [SerializeAsToken] to eagerly register all the tokens.
+ * In our case this can be the [ServiceHub].
+ *
+ * Then it is a case of using the companion object methods on [SerializeAsTokenSerializer] to set and clear context as necessary
+ * when serializing to enable/disable tokenization.
+ */
+@DeleteForDJVM
+class CheckpointSerializeAsTokenContextImpl(override val serviceHub: ServiceHub, init: SerializeAsTokenContext.() -> Unit) : SerializeAsTokenContext {
+    constructor(toBeTokenized: Any, serializationFactory: CheckpointSerializationFactory, context: CheckpointSerializationContext, serviceHub: ServiceHub) : this(serviceHub, {
         serializationFactory.serialize(toBeTokenized, context.withTokenContext(this))
     })
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPSerializationScheme.kt
@@ -163,6 +163,7 @@ abstract class AbstractAMQPSerializationScheme(
         return synchronized(serializerFactoriesForContexts) {
             serializerFactoriesForContexts.computeIfAbsent(Pair(context.whitelist, context.deserializationClassLoader)) {
                 when (context.useCase) {
+                    @Suppress("DEPRECATION")
                     SerializationContext.UseCase.Checkpoint ->
                         throw IllegalStateException("AMQP should not be used for checkpoint serialization.")
                     SerializationContext.UseCase.RPCClient ->

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/PrivateKeySerializer.kt
@@ -2,7 +2,6 @@ package net.corda.serialization.internal.amqp.custom
 
 import net.corda.core.crypto.Crypto
 import net.corda.core.serialization.SerializationContext
-import net.corda.core.serialization.SerializationContext.UseCase.Checkpoint
 import net.corda.core.serialization.SerializationContext.UseCase.Storage
 import net.corda.serialization.internal.amqp.*
 import net.corda.serialization.internal.checkUseCase
@@ -13,7 +12,7 @@ import java.util.*
 
 object PrivateKeySerializer : CustomSerializer.Implements<PrivateKey>(PrivateKey::class.java) {
 
-    private val allowedUseCases = EnumSet.of(Storage, Checkpoint)
+    private val allowedUseCases = EnumSet.of(Storage)
 
     override val schemaForDocumentation = Schema(listOf(RestrictedType(type.toString(), "", listOf(type.toString()), SerializerFactory.primitiveTypeName(ByteArray::class.java)!!, descriptor, emptyList())))
 

--- a/serialization/src/test/java/net/corda/serialization/internal/ForbiddenLambdaSerializationTests.java
+++ b/serialization/src/test/java/net/corda/serialization/internal/ForbiddenLambdaSerializationTests.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Maps;
 import net.corda.core.serialization.SerializationContext;
 import net.corda.core.serialization.SerializationFactory;
 import net.corda.core.serialization.SerializedBytes;
-import net.corda.serialization.internal.amqp.AMQPNotSerializableException;
 import net.corda.serialization.internal.amqp.SchemaKt;
 import net.corda.testing.core.SerializationEnvironmentRule;
 import org.junit.Before;
@@ -20,8 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 public final class ForbiddenLambdaSerializationTests {
+
+    @SuppressWarnings("deprecation")
     private EnumSet<SerializationContext.UseCase> contexts = EnumSet.complementOf(
             EnumSet.of(SerializationContext.UseCase.Checkpoint, SerializationContext.UseCase.Testing));
+
     @Rule
     public final SerializationEnvironmentRule testSerialization = new SerializationEnvironmentRule();
     private SerializationFactory factory;

--- a/serialization/src/test/java/net/corda/serialization/internal/LambdaCheckpointSerializationTest.java
+++ b/serialization/src/test/java/net/corda/serialization/internal/LambdaCheckpointSerializationTest.java
@@ -1,10 +1,7 @@
 package net.corda.serialization.internal;
 
-import net.corda.core.serialization.SerializationContext;
-import net.corda.core.serialization.SerializationFactory;
-import net.corda.core.serialization.SerializedBytes;
+import net.corda.core.serialization.*;
 import net.corda.node.serialization.kryo.CordaClosureSerializer;
-import net.corda.node.serialization.kryo.KryoSerializationSchemeKt;
 import net.corda.testing.core.SerializationEnvironmentRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -20,19 +17,17 @@ import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 public final class LambdaCheckpointSerializationTest {
     @Rule
     public final SerializationEnvironmentRule testSerialization = new SerializationEnvironmentRule();
-    private SerializationFactory factory;
-    private SerializationContext context;
+    private CheckpointSerializationFactory factory;
+    private CheckpointSerializationContext context;
 
     @Before
     public void setup() {
-        factory = testSerialization.getSerializationFactory();
-        context = new SerializationContextImpl(
-                KryoSerializationSchemeKt.getKryoMagic(),
+        factory = testSerialization.getCheckpointSerializationFactory();
+        context = new CheckpointSerializationContextImpl(
                 getClass().getClassLoader(),
                 AllWhitelist.INSTANCE,
                 Collections.emptyMap(),
                 true,
-                SerializationContext.UseCase.Checkpoint,
                 null
         );
     }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/ContractAttachmentSerializerTest.kt
@@ -21,16 +21,16 @@ class ContractAttachmentSerializerTest {
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
 
-    private lateinit var factory: SerializationFactory
-    private lateinit var context: SerializationContext
-    private lateinit var contextWithToken: SerializationContext
+    private lateinit var factory: CheckpointSerializationFactory
+    private lateinit var context: CheckpointSerializationContext
+    private lateinit var contextWithToken: CheckpointSerializationContext
     private val mockServices = MockServices(emptyList(), CordaX500Name("MegaCorp", "London", "GB"), rigorousMock())
 
     @Before
     fun setup() {
-        factory = testSerialization.serializationFactory
+        factory = testSerialization.checkpointSerializationFactory
         context = testSerialization.checkpointContext
-        contextWithToken = context.withTokenContext(SerializeAsTokenContextImpl(Any(), factory, context, mockServices))
+        contextWithToken = context.withTokenContext(CheckpointSerializeAsTokenContextImpl(Any(), factory, context, mockServices))
     }
 
     @Test

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/CordaClassResolverTests.kt
@@ -11,6 +11,7 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
 import net.corda.core.node.services.AttachmentStorage
+import net.corda.core.serialization.CheckpointSerializationContext
 import net.corda.core.serialization.ClassWhitelist
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializationContext
@@ -115,8 +116,8 @@ class CordaClassResolverTests {
         val emptyMapClass = mapOf<Any, Any>().javaClass
     }
 
-    private val emptyWhitelistContext: SerializationContext = SerializationContextImpl(kryoMagic, this.javaClass.classLoader, EmptyWhitelist, emptyMap(), true, SerializationContext.UseCase.P2P, null)
-    private val allButBlacklistedContext: SerializationContext = SerializationContextImpl(kryoMagic, this.javaClass.classLoader, AllButBlacklisted, emptyMap(), true, SerializationContext.UseCase.P2P, null)
+    private val emptyWhitelistContext: CheckpointSerializationContext = CheckpointSerializationContextImpl(this.javaClass.classLoader, EmptyWhitelist, emptyMap(), true, null)
+    private val allButBlacklistedContext: CheckpointSerializationContext = CheckpointSerializationContextImpl(this.javaClass.classLoader, AllButBlacklisted, emptyMap(), true, null)
     @Test
     fun `Annotation on enum works for specialised entries`() {
         CordaClassResolver(emptyWhitelistContext).getRegistration(Foo.Bar::class.java)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationTokenTest.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/SerializationTokenTest.kt
@@ -21,12 +21,12 @@ class SerializationTokenTest {
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
-    private lateinit var factory: SerializationFactory
-    private lateinit var context: SerializationContext
+    private lateinit var factory: CheckpointSerializationFactory
+    private lateinit var context: CheckpointSerializationContext
 
     @Before
     fun setup() {
-        factory = testSerialization.serializationFactory
+        factory = testSerialization.checkpointSerializationFactory
         context = testSerialization.checkpointContext.withWhitelisted(SingletonSerializationToken::class.java)
     }
 
@@ -42,7 +42,7 @@ class SerializationTokenTest {
         override fun equals(other: Any?) = other is LargeTokenizable && other.bytes.size == this.bytes.size
     }
 
-    private fun serializeAsTokenContext(toBeTokenized: Any) = SerializeAsTokenContextImpl(toBeTokenized, factory, context, rigorousMock())
+    private fun serializeAsTokenContext(toBeTokenized: Any) = CheckpointSerializeAsTokenContextImpl(toBeTokenized, factory, context, rigorousMock())
     @Test
     fun `write token and read tokenizable`() {
         val tokenizableBefore = LargeTokenizable()

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationTestHelpers.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationTestHelpers.kt
@@ -45,6 +45,7 @@ class SerializationEnvironmentRule(private val inheritable: Boolean = false) : T
 
     private lateinit var env: SerializationEnvironment
     val serializationFactory get() = env.serializationFactory
+    val checkpointSerializationFactory get() = env.checkpointSerializationFactory
     val checkpointContext get() = env.checkpointContext
 
     override fun apply(base: Statement, description: Description): Statement {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt
@@ -33,8 +33,6 @@ internal fun createTestSerializationEnv(label: String): SerializationEnvironment
     val factory = SerializationFactoryImpl().apply {
         registerScheme(AMQPClientSerializationScheme(emptyList()))
         registerScheme(AMQPServerSerializationScheme(emptyList()))
-        // needed for checkpointing
-        registerScheme(KryoServerSerializationScheme())
     }
     return object : SerializationEnvironmentImpl(
             factory,
@@ -42,7 +40,8 @@ internal fun createTestSerializationEnv(label: String): SerializationEnvironment
             AMQP_RPC_SERVER_CONTEXT,
             AMQP_RPC_CLIENT_CONTEXT,
             AMQP_STORAGE_CONTEXT,
-            KRYO_CHECKPOINT_CONTEXT
+            KRYO_CHECKPOINT_CONTEXT,
+            CheckpointSerializationFactoryImpl(KryoServerSerializationScheme())
     ) {
         override fun toString() = "testSerializationEnv($label)"
     }

--- a/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/BlobInspector.kt
+++ b/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/BlobInspector.kt
@@ -14,10 +14,7 @@ import net.corda.core.serialization.internal._contextSerializationEnv
 import net.corda.core.utilities.base64ToByteArray
 import net.corda.core.utilities.hexToByteArray
 import net.corda.core.utilities.sequence
-import net.corda.serialization.internal.AMQP_P2P_CONTEXT
-import net.corda.serialization.internal.AMQP_STORAGE_CONTEXT
-import net.corda.serialization.internal.CordaSerializationMagic
-import net.corda.serialization.internal.SerializationFactoryImpl
+import net.corda.serialization.internal.*
 import net.corda.serialization.internal.amqp.AbstractAMQPSerializationScheme
 import net.corda.serialization.internal.amqp.DeserializationInput
 import net.corda.serialization.internal.amqp.amqpMagic

--- a/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/serialization/SerializationHelper.kt
+++ b/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/serialization/SerializationHelper.kt
@@ -3,6 +3,7 @@ package net.corda.bootstrapper.serialization
 import net.corda.core.serialization.internal.SerializationEnvironmentImpl
 import net.corda.core.serialization.internal.nodeSerializationEnv
 import net.corda.node.serialization.amqp.AMQPServerSerializationScheme
+import net.corda.node.serialization.kryo.KRYO_CHECKPOINT_CONTEXT
 import net.corda.serialization.internal.AMQP_P2P_CONTEXT
 import net.corda.serialization.internal.AMQP_STORAGE_CONTEXT
 import net.corda.serialization.internal.SerializationFactoryImpl
@@ -20,7 +21,7 @@ class SerializationEngine {
                             p2pContext = AMQP_P2P_CONTEXT.withClassLoader(classloader),
                             rpcServerContext = AMQP_P2P_CONTEXT.withClassLoader(classloader),
                             storageContext = AMQP_STORAGE_CONTEXT.withClassLoader(classloader),
-                            checkpointContext = AMQP_P2P_CONTEXT.withClassLoader(classloader)
+                            checkpointContext = KRYO_CHECKPOINT_CONTEXT.withClassLoader(classloader)
                     )
                 }
             }


### PR DESCRIPTION
As per [Corda-1391](https://r3-cev.atlassian.net/browse/CORDA-1391), separate out checkpoint serialization using Kryo from non-checkpoint serialization using the AMQP serializers.

This PR contains the minimal changes required to introduce new classes for the checkpoint serialization use case, and eliminate all references to `UseCase.CHECKPOINT` when using AMQP serialization. Further simplification of the serialization framework (e.g. removing now-redundant references to `amqpMagic` in the AMQP serialization classes) will be attempted in a follow-up PR.