### PR TITLE
ENT-2489: Fix serialization for some of the CordaExceptions.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -140,4 +140,4 @@ interface IdentityService {
     fun partiesFromName(query: String, exactMatch: Boolean): Set<Party>
 }
 
-class UnknownAnonymousPartyException(msg: String) : CordaException(msg)
+class UnknownAnonymousPartyException(message: String) : CordaException(message)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -726,7 +726,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     }
 
     // Specific class so that MockNode can catch it.
-    class DatabaseConfigurationException(msg: String) : CordaException(msg)
+    class DatabaseConfigurationException(message: String) : CordaException(message)
 
     protected open fun startDatabase() {
         val props = configuration.dataSourceProperties

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
@@ -5,4 +5,4 @@ import net.corda.core.CordaException
 /**
  * An exception propagated and thrown in case a session initiation fails.
  */
-class SessionRejectException(reason: String) : CordaException(reason)
+class SessionRejectException(message: String) : CordaException(message)

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/ExceptionsSerializationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/ExceptionsSerializationTest.kt
@@ -1,0 +1,45 @@
+package net.corda.node.services.statemachine
+
+import net.corda.core.CordaException
+import net.corda.core.node.services.UnknownAnonymousPartyException
+import net.corda.core.serialization.SerializedBytes
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
+import net.corda.node.internal.AbstractNode
+import net.corda.node.utilities.registration.CertificateRequestException
+import net.corda.testing.core.SerializationEnvironmentRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.assertEquals
+
+@RunWith(Parameterized::class)
+class ExceptionsSerializationTest(private val initialException: CordaException, @Suppress("UNUSED_PARAMETER") description: String) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{1}")
+        fun data(): Collection<Array<Any>> = listOf(
+                arrayOf<Any>(SessionRejectException("test"), "SessionRejectException"),
+                arrayOf<Any>(CertificateRequestException("test"), "CertificateRequestException"),
+                arrayOf<Any>(UnknownAnonymousPartyException("test"), "UnknownAnonymousPartyException"),
+                arrayOf<Any>(AbstractNode.DatabaseConfigurationException("test"), "DatabaseConfigurationException")
+        )
+    }
+
+    @Rule
+    @JvmField
+    val testSerialization = SerializationEnvironmentRule()
+
+    @Test
+    fun testMarshal() {
+        val fromSerialized = performRoundTripSerialization(initialException)
+        assertEquals(initialException.message, fromSerialized.message)
+    }
+
+    private inline fun <reified T : Any> performRoundTripSerialization(obj: T): T {
+        val serializedForm: SerializedBytes<T> = obj.serialize()
+        return serializedForm.deserialize()
+    }
+}


### PR DESCRIPTION
Also add a unit test that exposes the problem.

Without these changes AMQP serialization fails with the following:
```
 net.corda.serialization.internal.amqp.AMQPNotSerializableException: Constructor parameter - "reason" -  doesn't refer to a property of "class net.corda.node.services.statemachine.SessionRejectException"
	at net.corda.serialization.internal.amqp.SerializationHelperKt.toPropertyAccessorConstructor(SerializationHelper.kt:120) ~[corda-serialization-4.0-SNAPSHOT.jar:?]
	at net.corda.serialization.internal.amqp.SerializationHelperKt.propertiesForSerializationFromConstructor(SerializationHelper.kt:107) ~[corda-serialization-4.0-SNAPSHOT.jar:?]
	at net.corda.serialization.internal.amqp.custom.ThrowableSerializer.toProxy(ThrowableSerializer.kt:28) [corda-serialization-4.0-SNAPSHOT.jar:?]
	at net.corda.serialization.internal.amqp.custom.ThrowableSerializer.toProxy(ThrowableSerializer.kt:12) [corda-serialization-4.0-SNAPSHOT.jar:?]
	at net.corda.serialization.internal.amqp.CustomSerializer$Proxy.writeDescribedObject(CustomSerializer.kt:159) [corda-serialization-4.0-SNAPSHOT.jar:?]
```