### PR TITLE
More descriptive message on latest "supported" Java version that might cause confusion.

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -68,13 +68,15 @@ open class NodeStartup: CordaCliWrapper("corda", "Runs a Corda Node") {
     override fun runProgram(): Int {
         val startTime = System.currentTimeMillis()
         if (!canNormalizeEmptyPath()) {
-            println("You are using a version of Java that is not supported (${System.getProperty("java.version")}). Please upgrade to the latest version.")
+            println("You are using a version of Java that is not supported (${System.getProperty("java.version")}). Please upgrade to the latest supported version.")
             println("Corda will now exit...")
             return ExitCodes.FAILURE
         }
 
         val registrationMode = checkRegistrationMode()
 
+        // TODO: Reconsider if automatic re-registration should be applied when something failed during initial registration.
+        //      There might be cases where the node user should investigate what went wrong before registering again.
         if (registrationMode && !cmdLineOptions.isRegistration) {
             println("Node was started before with `--initial-registration`, but the registration was not completed.\nResuming registration.")
             // Pretend that the node was started with `--initial-registration` to help prevent user error.


### PR DESCRIPTION
Our error message on old Java version, used to mention "update to latest Java release" (which implies Java 10+). However it should point to the latest Corda-"supported" version.

Also, added a TODO to reconsider the auto-resume registration functionality, especially when used in production. The rationale is auto-resume is great UX-wise, but some node owners might want to investigate what went wrong before re-registering (and at the moment this is happening automatically without prompting).