### PR TITLE
CORDA-1985: Configure Gradle capsule plugin to use Capsule 1.0.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ buildscript {
     ext.quasar_group = 'co.paralleluniverse'
     ext.quasar_version = '0.7.10'
 
-    // gradle-capsule-plugin:1.0.2 contains capsule:1.0.1
-    // TODO: Upgrade gradle-capsule-plugin to a version with capsule:1.0.3
-    ext.capsule_version = '1.0.1'
+    // gradle-capsule-plugin:1.0.2 contains capsule:1.0.1 by default.
+    // We must configure it manually to use the latest capsule version.
+    ext.capsule_version = '1.0.3'
 
     ext.asm_version = '5.0.4'
     ext.artemis_version = '2.6.2'
@@ -114,8 +114,8 @@ buildscript {
 plugins {
     // TODO The capsule plugin requires the newer DSL plugin block.It would be nice if we could unify all the plugins into one style,
     // but the DSL has some restrictions e.g can't be used on the allprojects section. So we should revisit this if there are improvements in Gradle.
-    // Version 1.0.2 of this plugin uses capsule:1.0.1
-    id "us.kirchmeier.capsule" version "1.0.2"
+    // Version 1.0.2 of this plugin uses capsule:1.0.1 by default.
+    id 'us.kirchmeier.capsule' version '1.0.2' apply false
 
     // Add the shadow plugin to the plugins classpath for the entire project.
     id 'com.github.johnrengelman.shadow' version '2.0.4' apply false

--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -28,6 +28,10 @@ targetCompatibility = 1.6
 
 jar.enabled = false
 
+capsule {
+    version capsule_version
+}
+
 task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').tasks.jar) {
     applicationClass 'net.corda.node.Corda'
     archiveName "corda-${corda_release_version}.jar"

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -19,6 +19,10 @@ configurations {
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
+capsule {
+    version capsule_version
+}
+
 task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').tasks.jar) {
     applicationClass 'net.corda.explorer.Main'
     archiveName "node-explorer-${corda_release_version}.jar"

--- a/webserver/webcapsule/build.gradle
+++ b/webserver/webcapsule/build.gradle
@@ -28,6 +28,10 @@ targetCompatibility = 1.6
 
 jar.enabled = false
 
+capsule {
+    version capsule_version
+}
+
 task buildWebserverJar(type: FatCapsule, dependsOn: project(':node').tasks.jar) {
     applicationClass 'net.corda.webserver.WebServer'
     archiveName "corda-webserver-${corda_release_version}.jar"


### PR DESCRIPTION
The Gradle plugin creates a capsule using `capsule:1.0.1` by default. We need to configure the plugin manually to use the latest `capsule:1.0.3`.