### PR TITLE
CORDA-1982: Convert the --base-directory to an absolute path to avoid issues on start up

### DIFF
--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -18,7 +18,7 @@ class NodeCmdLineOptions {
             names = ["-b", "--base-directory"],
             description = ["The node working directory where all the files are kept."]
     )
-    var baseDirectory: Path = Paths.get(".")
+    var baseDirectory: Path = Paths.get(".").toAbsolutePath().normalize()
 
     @Option(
             names = ["-f", "--config-file"],
@@ -57,7 +57,7 @@ class NodeCmdLineOptions {
             names = ["-t", "--network-root-truststore"],
             description = ["Network root trust store obtained from network operator."]
     )
-    var networkRootTrustStorePath = Paths.get("certificates") / "network-root-truststore.jks"
+    var networkRootTrustStorePath: Path = baseDirectory / "certificates" / "network-root-truststore.jks"
 
     @Option(
             names = ["-p", "--network-root-truststore-password"],

--- a/node/src/test/kotlin/net/corda/node/NodeCmdLineOptionsTest.kt
+++ b/node/src/test/kotlin/net/corda/node/NodeCmdLineOptionsTest.kt
@@ -15,20 +15,18 @@ class NodeCmdLineOptionsTest {
 
     companion object {
         private lateinit var workingDirectory: Path
-        private lateinit var buildDirectory: Path
 
         @BeforeClass
         @JvmStatic
         fun initDirectories() {
             workingDirectory = Paths.get(".").normalize().toAbsolutePath()
-            buildDirectory = workingDirectory.resolve("build")
         }
     }
 
     @Test
     fun `no command line arguments`() {
-        assertThat(parser.cmdLineOptions.baseDirectory.normalize().toAbsolutePath()).isEqualTo(workingDirectory)
-        assertThat(parser.cmdLineOptions.configFile.normalize().toAbsolutePath()).isEqualTo(workingDirectory / "node.conf")
+        assertThat(parser.cmdLineOptions.baseDirectory).isEqualTo(workingDirectory)
+        assertThat(parser.cmdLineOptions.configFile).isEqualTo(workingDirectory / "node.conf")
         assertThat(parser.verbose).isEqualTo(false)
         assertThat(parser.loggingLevel).isEqualTo(Level.INFO)
         assertThat(parser.cmdLineOptions.nodeRegistrationOption).isEqualTo(null)
@@ -40,5 +38,6 @@ class NodeCmdLineOptionsTest {
         assertThat(parser.cmdLineOptions.unknownConfigKeysPolicy).isEqualTo(UnknownConfigKeysPolicy.FAIL)
         assertThat(parser.cmdLineOptions.devMode).isEqualTo(null)
         assertThat(parser.cmdLineOptions.clearNetworkMapCache).isEqualTo(false)
+        assertThat(parser.cmdLineOptions.networkRootTrustStorePath).isEqualTo(workingDirectory / "certificates" / "network-root-truststore.jks")
     }
 }


### PR DESCRIPTION
Also the --network-root-truststore default value has been corrected to be relative to the base dir.

The cliutils has been updated to always convert Path cmd line params to be absolute


