### PR TITLE
CORDA-1995 removing DigitalSignatureWithCertPath

### DIFF
--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -197,7 +197,7 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
     fun DigitalSignatureWithCert() {
         val digitalSignature = DigitalSignatureWithCert(MINI_CORP.identity.certificate, secureRandomBytes(128))
         val json = mapper.valueToTree<ObjectNode>(digitalSignature)
-        val (by, bytes) = json.assertHasOnlyFields("by", "bytes")
+        val (by, bytes) = json.assertHasOnlyFields("by", "bytes", "remainingChain")
         assertThat(by.valueAs<X509Certificate>(mapper)).isEqualTo(MINI_CORP.identity.certificate)
         assertThat(bytes.binaryValue()).isEqualTo(digitalSignature.bytes)
         assertThat(mapper.convertValue<DigitalSignatureWithCert>(json)).isEqualTo(digitalSignature)

--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -197,7 +197,7 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
     fun DigitalSignatureWithCert() {
         val digitalSignature = DigitalSignatureWithCert(MINI_CORP.identity.certificate, secureRandomBytes(128))
         val json = mapper.valueToTree<ObjectNode>(digitalSignature)
-        val (by, bytes) = json.assertHasOnlyFields("by", "bytes", "remainingChain")
+        val (by, bytes) = json.assertHasOnlyFields("by", "bytes", "parentCertsChain")
         assertThat(by.valueAs<X509Certificate>(mapper)).isEqualTo(MINI_CORP.identity.certificate)
         assertThat(bytes.binaryValue()).isEqualTo(digitalSignature.bytes)
         assertThat(mapper.convertValue<DigitalSignatureWithCert>(json)).isEqualTo(digitalSignature)

--- a/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
@@ -12,7 +12,7 @@ import java.security.cert.*
 
 // TODO: Rename this to DigitalSignature.WithCert once we're happy for it to be public API. The methods will need documentation
 // and the correct exceptions will be need to be annotated
-/** A digital signature with attached certificate of the public key. */
+/** A digital signature with attached certificate of the public key and (optionally) sthe remaining chain of the certificates from the certificate path. */
 class DigitalSignatureWithCert(val by: X509Certificate, val remainingChain: List<X509Certificate>, bytes: ByteArray) : DigitalSignature(bytes) {
     @DeprecatedConstructorForDeserialization(1)
     constructor(by: X509Certificate, bytes: ByteArray) : this(by, emptyList(), bytes)

--- a/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/DigitalSignatureWithCert.kt
@@ -4,26 +4,32 @@ import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.SignedData
 import net.corda.core.crypto.verify
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.utilities.OpaqueBytes
-import java.security.cert.CertPath
-import java.security.cert.X509Certificate
+import java.security.cert.*
 
 // TODO: Rename this to DigitalSignature.WithCert once we're happy for it to be public API. The methods will need documentation
 // and the correct exceptions will be need to be annotated
 /** A digital signature with attached certificate of the public key. */
-open class DigitalSignatureWithCert(val by: X509Certificate, bytes: ByteArray) : DigitalSignature(bytes) {
+class DigitalSignatureWithCert(val by: X509Certificate, val remainingChain: List<X509Certificate>, bytes: ByteArray) : DigitalSignature(bytes) {
+    @DeprecatedConstructorForDeserialization(1)
+    constructor(by: X509Certificate, bytes: ByteArray) : this(by, emptyList(), bytes)
+
+    val fullCertChain: List<X509Certificate> get() = listOf(by) + remainingChain
+    val fullCertPath: CertPath get() = CertificateFactory.getInstance("X.509").generateCertPath(fullCertChain)
+
     fun verify(content: ByteArray): Boolean = by.publicKey.verify(content, this)
     fun verify(content: OpaqueBytes): Boolean = verify(content.bytes)
-}
 
-/**
- * A digital signature with attached certificate path. The first certificate in the path corresponds to the data signer key.
- * @param path certificate path associated with this signature
- * @param bytes signature bytes
- */
-class DigitalSignatureWithCertPath(val path: List<X509Certificate>, bytes: ByteArray): DigitalSignatureWithCert(path.first(), bytes)
+    init {
+        if (remainingChain.isNotEmpty()) {
+            val parameters = PKIXParameters(setOf(TrustAnchor(remainingChain.last(), null))).apply { isRevocationEnabled = false }
+            CertPathValidator.getInstance("PKIX").validate(fullCertPath, parameters)
+        }
+    }
+}
 
 /** Similar to [SignedData] but instead of just attaching the public key, the certificate for the key is attached instead. */
 @CordaSerializable

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt
@@ -2,8 +2,6 @@ package net.corda.nodeapi.internal.network
 
 import net.corda.core.crypto.SecureHash
 import net.corda.core.internal.CertRole
-import net.corda.core.internal.DigitalSignatureWithCert
-import net.corda.core.internal.DigitalSignatureWithCertPath
 import net.corda.core.internal.SignedDataWithCert
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NodeInfo
@@ -59,9 +57,10 @@ data class ParametersUpdate(
 /** Verify that a Network Map certificate path and its [CertRole] is correct. */
 fun <T : Any> SignedDataWithCert<T>.verifiedNetworkMapCert(rootCert: X509Certificate): T {
     require(CertRole.extract(sig.by) == CertRole.NETWORK_MAP) { "Incorrect cert role: ${CertRole.extract(sig.by)}" }
-    val path = when (this.sig) {
-        is DigitalSignatureWithCertPath -> (sig as DigitalSignatureWithCertPath).path
-        else -> listOf(sig.by, rootCert)
+    val path = if (this.sig.remainingChain.isEmpty()) {
+        listOf(sig.by, rootCert)
+    } else {
+        sig.fullCertChain
     }
     X509Utilities.validateCertificateChain(rootCert, path)
     return verified()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkMap.kt
@@ -57,7 +57,7 @@ data class ParametersUpdate(
 /** Verify that a Network Map certificate path and its [CertRole] is correct. */
 fun <T : Any> SignedDataWithCert<T>.verifiedNetworkMapCert(rootCert: X509Certificate): T {
     require(CertRole.extract(sig.by) == CertRole.NETWORK_MAP) { "Incorrect cert role: ${CertRole.extract(sig.by)}" }
-    val path = if (this.sig.remainingChain.isEmpty()) {
+    val path = if (sig.parentCertsChain.isEmpty()) {
         listOf(sig.by, rootCert)
     } else {
         sig.fullCertChain


### PR DESCRIPTION
This introduces a modification which makes sending the certificate path with signature more efficient.
