### PR TITLE
[CORDA-1971]: Improve error code derivation

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
@@ -1,7 +1,5 @@
 package net.corda.node.internal
 
-import net.corda.core.CordaRuntimeException
-import java.lang.IllegalStateException
 import java.util.*
 
 fun Exception.errorCode(hashedFields: (Throwable) -> Array<out Any?> = Throwable::defaultHashedFields): String {
@@ -13,19 +11,16 @@ private fun Throwable.staticLocationBasedHash(hashedFields: (Throwable) -> Array
     val cause = this.cause
     val fields = hashedFields.invoke(this)
     return when {
-        cause != null && !visited.contains(cause) -> Objects.hash(*fields, cause.staticLocationBasedHash(hashedFields,visited +  cause))
+        cause != null && !visited.contains(cause) -> Objects.hash(*fields, cause.staticLocationBasedHash(hashedFields, visited + cause))
         else -> Objects.hash(*fields)
     }
 }
 
 private fun Int.toBase(base: Int): String = Integer.toUnsignedString(this, base)
 
-private fun Array<StackTraceElement?>?.customHashCode(): Int {
+private fun Array<StackTraceElement?>.customHashCode(maxElementsToConsider: Int = this.size): Int {
 
-    if (this == null) {
-        return 0
-    }
-    return Arrays.hashCode(map { it?.customHashCode() ?: 0 }.toIntArray())
+    return Arrays.hashCode(take(maxElementsToConsider).map { it?.customHashCode() ?: 0 }.toIntArray())
 }
 
 private fun StackTraceElement.customHashCode(hashedFields: (StackTraceElement) -> Array<out Any?> = StackTraceElement::defaultHashedFields): Int {
@@ -35,19 +30,10 @@ private fun StackTraceElement.customHashCode(hashedFields: (StackTraceElement) -
 
 private fun Throwable.defaultHashedFields(): Array<out Any?> {
 
-    return arrayOf(this::class.java.name, stackTrace.customHashCode())
+    return arrayOf(this::class.java.name, stackTrace?.customHashCode(3) ?: 0)
 }
 
 private fun StackTraceElement.defaultHashedFields(): Array<out Any?> {
 
     return arrayOf(className, methodName)
-}
-
-// TODO sollecitom remove when done
-fun main(args: Array<String>) {
-
-    val exception = CordaRuntimeException("Boom!", IllegalStateException("Oops!"))
-    val exception2 = CordaRuntimeException("Boom!", IllegalStateException("Oops!"))
-    println(exception.errorCode())
-    println(exception2.errorCode())
 }

--- a/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
@@ -40,7 +40,7 @@ private fun Throwable.defaultHashedFields(): Array<out Any?> {
 
 private fun StackTraceElement.defaultHashedFields(): Array<out Any?> {
 
-    return arrayOf(className, methodName, lineNumber)
+    return arrayOf(className, methodName)
 }
 
 // TODO sollecitom remove when done

--- a/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
@@ -1,17 +1,20 @@
 package net.corda.node.internal
 
+import net.corda.core.CordaRuntimeException
+import java.lang.IllegalStateException
 import java.util.*
 
-fun Exception.errorCode(): String {
-    val hash = staticLocationBasedHash()
+fun Exception.errorCode(hashedFields: (Throwable) -> Array<out Any?> = Throwable::defaultHashedFields): String {
+    val hash = staticLocationBasedHash(hashedFields)
     return hash.toBase(36)
 }
 
-private fun Throwable.staticLocationBasedHash(visited: Set<Throwable> = setOf(this)): Int {
+private fun Throwable.staticLocationBasedHash(hashedFields: (Throwable) -> Array<out Any?>, visited: Set<Throwable> = setOf(this)): Int {
     val cause = this.cause
+    val fields = hashedFields.invoke(this)
     return when {
-        cause != null && !visited.contains(cause) -> Objects.hash(this::class.java.name, stackTrace.customHashCode(), cause.staticLocationBasedHash(visited +  cause))
-        else -> Objects.hash(this::class.java.name, stackTrace.customHashCode())
+        cause != null && !visited.contains(cause) -> Objects.hash(*fields, cause.staticLocationBasedHash(hashedFields,visited +  cause))
+        else -> Objects.hash(*fields)
     }
 }
 
@@ -25,7 +28,26 @@ private fun Array<StackTraceElement?>?.customHashCode(): Int {
     return Arrays.hashCode(map { it?.customHashCode() ?: 0 }.toIntArray())
 }
 
-private fun StackTraceElement.customHashCode(): Int {
+private fun StackTraceElement.customHashCode(hashedFields: (StackTraceElement) -> Array<out Any?> = StackTraceElement::defaultHashedFields): Int {
 
-    return Objects.hash(StackTraceElement::class.java.name, methodName, lineNumber)
+    return Objects.hash(*hashedFields.invoke(this))
+}
+
+private fun Throwable.defaultHashedFields(): Array<out Any?> {
+
+    return arrayOf(this::class.java.name, stackTrace.customHashCode())
+}
+
+private fun StackTraceElement.defaultHashedFields(): Array<out Any?> {
+
+    return arrayOf(className, methodName, lineNumber)
+}
+
+// TODO sollecitom remove when done
+fun main(args: Array<String>) {
+
+    val exception = CordaRuntimeException("Boom!", IllegalStateException("Oops!"))
+    val exception2 = CordaRuntimeException("Boom!", IllegalStateException("Oops!"))
+    println(exception.errorCode())
+    println(exception2.errorCode())
 }

--- a/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/ExceptionsHashFunction.kt
@@ -1,0 +1,31 @@
+package net.corda.node.internal
+
+import java.util.*
+
+fun Exception.errorCode(): String {
+    val hash = staticLocationBasedHash()
+    return hash.toBase(36)
+}
+
+private fun Throwable.staticLocationBasedHash(visited: Set<Throwable> = setOf(this)): Int {
+    val cause = this.cause
+    return when {
+        cause != null && !visited.contains(cause) -> Objects.hash(this::class.java.name, stackTrace.customHashCode(), cause.staticLocationBasedHash(visited +  cause))
+        else -> Objects.hash(this::class.java.name, stackTrace.customHashCode())
+    }
+}
+
+private fun Int.toBase(base: Int): String = Integer.toUnsignedString(this, base)
+
+private fun Array<StackTraceElement?>?.customHashCode(): Int {
+
+    if (this == null) {
+        return 0
+    }
+    return Arrays.hashCode(map { it?.customHashCode() ?: 0 }.toIntArray())
+}
+
+private fun StackTraceElement.customHashCode(): Int {
+
+    return Objects.hash(StackTraceElement::class.java.name, methodName, lineNumber)
+}


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-1971

- Switched error code encoding to use `base36`, with a workaround to always produce positive values.
- Removed line number from the set of `StackTraceElement` fields hashed as part of error code derivation.
- Limited the number of `StackTraceElement`s hashed as part of error code derivation to 3.
- Refactored error code derivation logic and fixed a bug this refactoring exposed.