### PR TITLE
make sure that the run-corda script is in unix line-ending format

### DIFF
--- a/tools/network-bootstrapper/src/main/resources/node-Dockerfile
+++ b/tools/network-bootstrapper/src/main/resources/node-Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8u151-jre-alpine
 
 RUN apk upgrade --update && \
-    apk add --update --no-cache bash iputils && \
+    apk add --update --no-cache bash iputils dos2unix && \
     rm -rf /var/cache/apk/* && \
     # Add user to run the app && \
     addgroup corda && \
@@ -24,6 +24,7 @@ ADD --chown=corda:corda node_info_watcher.sh    /opt/corda/
 COPY run-corda.sh /run-corda.sh
 
 RUN chmod +x /run-corda.sh && \
+    dos2unix /run-corda.sh && \
     chmod +x /opt/corda/node_info_watcher.sh && \
     sync && \
     chown -R corda:corda /opt/corda

--- a/tools/network-bootstrapper/src/main/resources/notary-Dockerfile
+++ b/tools/network-bootstrapper/src/main/resources/notary-Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8u151-jre-alpine
 
 RUN apk upgrade --update && \
-    apk add --update --no-cache bash iputils && \
+    apk add --update --no-cache bash iputils dos2unix && \
     rm -rf /var/cache/apk/* && \
     # Add user to run the app && \
     addgroup corda && \
@@ -26,6 +26,7 @@ ADD --chown=corda:corda node_info_watcher.sh    /opt/corda/
 COPY run-corda.sh /run-corda.sh
 
 RUN chmod +x /run-corda.sh && \
+    dos2unix /run-corda.sh && \
     chmod +x /opt/corda/node_info_watcher.sh && \
     sync && \
     chown -R corda:corda /opt/corda


### PR DESCRIPTION
Fixes: https://github.com/corda/corda/issues/3961
Raised via: https://stackoverflow.com/questions/52209865/error-in-dockers-when-using-network-builder-to-start-up/52390080#52390080