### PR TITLE
CORDA-2000 isRelevant to work for composite ownership.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -102,7 +102,11 @@ fun PublicKey.isValid(content: ByteArray, signature: DigitalSignature): Boolean 
 /** Render a public key to its hash (in Base58) of its serialised form using the DL prefix. */
 fun PublicKey.toStringShort(): String = "DL" + this.toSHA256Bytes().toBase58()
 
-/** Return a [Set] of the contained keys if this is a [CompositeKey]; otherwise, return a [Set] with a single element (this [PublicKey]). */
+/**
+ * Return a [Set] of the contained leaf keys if this is a [CompositeKey].
+ * Otherwise, return a [Set] with a single element (this [PublicKey]).
+ * <i>Note that leaf keys cannot be of type [CompositeKey].</i>
+ */
 val PublicKey.keys: Set<PublicKey> get() = (this as? CompositeKey)?.leafKeys ?: setOf(this)
 
 /** Return true if [otherKey] fulfils the requirements of this [PublicKey]. */
@@ -110,7 +114,12 @@ fun PublicKey.isFulfilledBy(otherKey: PublicKey): Boolean = isFulfilledBy(setOf(
 /** Return true if [otherKeys] fulfil the requirements of this [PublicKey]. */
 fun PublicKey.isFulfilledBy(otherKeys: Iterable<PublicKey>): Boolean = (this as? CompositeKey)?.isFulfilledBy(otherKeys) ?: (this in otherKeys)
 
-/** Checks whether any of the given [keys] matches a leaf on the [CompositeKey] tree or a single [PublicKey]. */
+/**
+ * Checks whether any of the given [keys] matches a leaf on the [CompositeKey] tree or a single [PublicKey].
+ *
+ * <i>Note that this function checks against leaves, which cannot be of type [CompositeKey]. Due to that, if any of the
+ * [otherKeys] is a [CompositeKey], this function will not find a match.</i>
+ */
 fun PublicKey.containsAny(otherKeys: Iterable<PublicKey>): Boolean {
     return if (this is CompositeKey) keys.intersect(otherKeys).isNotEmpty()
     else this in otherKeys

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.Strand
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.containsAny
 import net.corda.core.internal.*
 import net.corda.core.messaging.DataFeed
 import net.corda.core.node.ServicesForResolution
@@ -433,7 +434,7 @@ class NodeVaultService(
             is OwnableState -> (state.participants.map { it.owningKey } + state.owner.owningKey).toSet()
             else -> state.participants.map { it.owningKey }
         }
-        return keysToCheck.any { it in myKeys }
+        return keysToCheck.any { it.containsAny(myKeys) }
     }
 
     @Throws(VaultQueryException::class)


### PR DESCRIPTION
This feature is required for composite ownership, for instance in HTLC.
I've also commented that `PublicKey.containsAny(otherKeys)` does not return a match if any of the `otherKeys` is of type `CompositeKey`, which means that we only check matching against leaves (non-Composite) and not looking for sub-trees inside the composite key structure.
_Note that this works assuming user's keys are not of `CompositeKey` type._