### PR TITLE
CORDA-1997 Added constraint type information to vault states table.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -19,6 +19,7 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.toFuture
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.utilities.NonEmptySet
+import net.corda.core.utilities.toHexString
 import rx.Observable
 import java.time.Instant
 import java.util.*
@@ -157,7 +158,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
             fun constraintInfo(type: Type, data: ByteArray?): ConstraintInfo {
                 return when (type) {
                     Type.ALWAYS_ACCEPT -> ConstraintInfo(AlwaysAcceptAttachmentConstraint)
-                    Type.HASH -> ConstraintInfo(HashAttachmentConstraint(SecureHash.sha256(data!!)))
+                    Type.HASH -> ConstraintInfo(HashAttachmentConstraint(SecureHash.parse(data!!.toHexString())))
                     Type.CZ_WHITELISTED -> ConstraintInfo(WhitelistedByZoneAttachmentConstraint)
                     Type.SIGNATURE -> ConstraintInfo(SignatureAttachmentConstraint(Crypto.decodePublicKey(data!!)))
                 }
@@ -261,8 +262,9 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
 
 /**
  * The maximum permissible size of contract constraint type data (for storage in vault states database table).
+ * Maximum value equates to a CompositeKey with 10 EDDSA_ED25519_SHA512 keys stored in.
  */
-const val MAX_CONSTRAINT_DATA_SIZE = 1074
+const val MAX_CONSTRAINT_DATA_SIZE = 563
 
 /**
  * A [VaultService] is responsible for securely and safely persisting the current state of a vault to storage. The

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -261,7 +261,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
 /**
  * The maximum permissible size of contract constraint type data (for storage in vault states database table).
  */
-const val MAX_CONSTRAINT_DATA_SIZE = 1024
+const val MAX_CONSTRAINT_DATA_SIZE = 1074
 
 /**
  * A [VaultService] is responsible for securely and safely persisting the current state of a vault to storage. The

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -132,6 +132,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
      */
     @CordaSerializable
     data class ConstraintInfo(val constraint: AttachmentConstraint) {
+        @CordaSerializable
         enum class Type {
             ALWAYS_ACCEPT, HASH, CZ_WHITELISTED, SIGNATURE
         }

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -140,7 +140,6 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
         fun type(): Type {
             return when (constraint::class.java) {
                 AlwaysAcceptAttachmentConstraint::class.java -> Type.ALWAYS_ACCEPT
-                AutomaticHashConstraint::class.java,
                 HashAttachmentConstraint::class.java -> Type.HASH
                 WhitelistedByZoneAttachmentConstraint::class.java -> Type.CZ_WHITELISTED
                 SignatureAttachmentConstraint::class.java -> Type.SIGNATURE

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -201,7 +201,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
             val lockId: String?,
             val lockUpdateTime: Instant?,
             val relevancyStatus: Vault.RelevancyStatus? = null,
-            val constraintInfo: ConstraintInfo = ConstraintInfo(AlwaysAcceptAttachmentConstraint)
+            val constraintInfo: ConstraintInfo? = null
     ) {
         fun copy(
                 ref: StateRef = this.ref,

--- a/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt
@@ -192,7 +192,7 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
                                            val otherResults: List<Any>)
 
     @CordaSerializable
-    data class StateMetadata constructor(
+    data class StateMetadata @JvmOverloads constructor(
             val ref: StateRef,
             val contractStateClassName: String,
             val recordedTime: Instant,
@@ -201,19 +201,9 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
             val notary: AbstractParty?,
             val lockId: String?,
             val lockUpdateTime: Instant?,
-            val relevancyStatus: Vault.RelevancyStatus?,
-            val constraintInfo: ConstraintInfo
+            val relevancyStatus: Vault.RelevancyStatus? = null,
+            val constraintInfo: ConstraintInfo = ConstraintInfo(AlwaysAcceptAttachmentConstraint)
     ) {
-        constructor(ref: StateRef,
-                    contractStateClassName: String,
-                    recordedTime: Instant,
-                    consumedTime: Instant?,
-                    status: Vault.StateStatus,
-                    notary: AbstractParty?,
-                    lockId: String?,
-                    lockUpdateTime: Instant?
-        ) : this(ref, contractStateClassName, recordedTime, consumedTime, status, notary, lockId, lockUpdateTime, null)
-
         fun copy(
                 ref: StateRef = this.ref,
                 contractStateClassName: String = this.contractStateClassName,
@@ -226,17 +216,6 @@ class Vault<out T : ContractState>(val states: Iterable<StateAndRef<T>>) {
         ): StateMetadata {
             return StateMetadata(ref, contractStateClassName, recordedTime, consumedTime, status, notary, lockId, lockUpdateTime, null)
         }
-        constructor(ref: StateRef,
-                    contractStateClassName: String,
-                    recordedTime: Instant,
-                    consumedTime: Instant?,
-                    status: Vault.StateStatus,
-                    notary: AbstractParty?,
-                    lockId: String?,
-                    lockUpdateTime: Instant?,
-                    relevancyStatus: Vault.RelevancyStatus?
-        ) : this(ref, contractStateClassName, recordedTime, consumedTime, status, notary, lockId, lockUpdateTime, relevancyStatus, ConstraintInfo(AlwaysAcceptAttachmentConstraint))
-
         fun copy(
                 ref: StateRef = this.ref,
                 contractStateClassName: String = this.contractStateClassName,

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -74,6 +74,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
     abstract class CommonQueryCriteria : QueryCriteria() {
         abstract val status: Vault.StateStatus
         open val relevancyStatus: Vault.RelevancyStatus = Vault.RelevancyStatus.ALL
+        open val constraintTypes: Set<Vault.ConstraintInfo.Type> = emptySet()
         abstract val contractStateTypes: Set<Class<out ContractState>>?
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this)
@@ -90,7 +91,8 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val notary: List<AbstractParty>? = null,
             val softLockingCondition: SoftLockingCondition? = null,
             val timeCondition: TimeCondition? = null,
-            override val relevancyStatus: Vault.RelevancyStatus = Vault.RelevancyStatus.ALL
+            override val relevancyStatus: Vault.RelevancyStatus = Vault.RelevancyStatus.ALL,
+            override val constraintTypes: Set<Vault.ConstraintInfo.Type> = emptySet()
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -75,6 +75,7 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
         abstract val status: Vault.StateStatus
         open val relevancyStatus: Vault.RelevancyStatus = Vault.RelevancyStatus.ALL
         open val constraintTypes: Set<Vault.ConstraintInfo.Type> = emptySet()
+        open val constraints: Set<Vault.ConstraintInfo> = emptySet()
         abstract val contractStateTypes: Set<Class<out ContractState>>?
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this)
@@ -92,7 +93,8 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
             val softLockingCondition: SoftLockingCondition? = null,
             val timeCondition: TimeCondition? = null,
             override val relevancyStatus: Vault.RelevancyStatus = Vault.RelevancyStatus.ALL,
-            override val constraintTypes: Set<Vault.ConstraintInfo.Type> = emptySet()
+            override val constraintTypes: Set<Vault.ConstraintInfo.Type> = emptySet(),
+            override val constraints: Set<Vault.ConstraintInfo> = emptySet()
     ) : CommonQueryCriteria() {
         override fun visit(parser: IQueryCriteriaParser): Collection<Predicate> {
             super.visit(parser)

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -184,7 +184,8 @@ data class Sort(val columns: Collection<SortColumn>) : BaseSort() {
         STATE_STATUS("stateStatus"),
         RECORDED_TIME("recordedTime"),
         CONSUMED_TIME("consumedTime"),
-        LOCK_ID("lockId")
+        LOCK_ID("lockId"),
+        CONSTRAINT_TYPE("constraintType")
     }
 
     enum class LinearStateAttribute(val attributeName: String) : Attribute {

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -51,6 +51,8 @@ upgrade approach is that you can upgrade states regardless of their constraint, 
 anticipate a need to do so. But it requires everyone to sign, requires everyone to manually authorise the upgrade,
 consumes notary and ledger resources, and is just in general more complex.
 
+.. _implicit_constraint_types:
+
 How constraints work
 --------------------
 

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -78,7 +78,8 @@ and/or composition and a rich set of operators to include:
 There are four implementations of this interface which can be chained together to define advanced filters.
 
 1. ``VaultQueryCriteria`` provides filterable criteria on attributes within the Vault states table: status (UNCONSUMED,
-   CONSUMED), state reference(s), contract state type(s), notaries, soft locked states, timestamps (RECORDED, CONSUMED).
+   CONSUMED), state reference(s), contract state type(s), notaries, soft locked states, timestamps (RECORDED, CONSUMED),
+   state constraint data by type (see :ref:`Constraint Types <implicit_constraint_types>`).
 
 	.. note:: Sensible defaults are defined for frequently used attributes (status = UNCONSUMED, always include soft
 	   locked states).
@@ -258,6 +259,14 @@ Query for unconsumed states for several contract state types:
     :language: kotlin
     :start-after: DOCSTART VaultQueryExample3
     :end-before: DOCEND VaultQueryExample3
+    :dedent: 12
+
+Query for unconsumed states for specified contract state constraint types and sorted in ascending alphabetical order:
+
+.. literalinclude:: ../../node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+    :language: kotlin
+    :start-after: DOCSTART VaultQueryExample30
+    :end-before: DOCEND VaultQueryExample30
     :dedent: 12
 
 Query for unconsumed states for a given notary:

--- a/docs/source/api-vault-query.rst
+++ b/docs/source/api-vault-query.rst
@@ -79,7 +79,7 @@ There are four implementations of this interface which can be chained together t
 
 1. ``VaultQueryCriteria`` provides filterable criteria on attributes within the Vault states table: status (UNCONSUMED,
    CONSUMED), state reference(s), contract state type(s), notaries, soft locked states, timestamps (RECORDED, CONSUMED),
-   state constraint data by type (see :ref:`Constraint Types <implicit_constraint_types>`).
+   state constraints (see :ref:`Constraint Types <implicit_constraint_types>`).
 
 	.. note:: Sensible defaults are defined for frequently used attributes (status = UNCONSUMED, always include soft
 	   locked states).
@@ -267,6 +267,14 @@ Query for unconsumed states for specified contract state constraint types and so
     :language: kotlin
     :start-after: DOCSTART VaultQueryExample30
     :end-before: DOCEND VaultQueryExample30
+    :dedent: 12
+
+Query for unconsumed states for specified contract state constraints (type and data):
+
+.. literalinclude:: ../../node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+    :language: kotlin
+    :start-after: DOCSTART VaultQueryExample31
+    :end-before: DOCEND VaultQueryExample31
     :dedent: 12
 
 Query for unconsumed states for a given notary:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,8 @@ Unreleased
 
 * Introduce minimum and target platform version for CorDapps.
 
+* Vault storage of contract state constraints metadata and associated vault query functions to retrieve and sort by constraint type.
+
 * New overload for ``CordaRPCClient.start()`` method allowing to specify target legal identity to use for RPC call.
 
 * Case insensitive vault queries can be specified via a boolean on applicable SQL criteria builder operators. By default queries will be case sensitive.

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -553,7 +553,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                 val existingTypes = (commonPredicates[predicateID]!!.expressions[0] as InPredicate<*>).values.map { (it as LiteralExpression).literal }.toSet()
                 if (existingTypes != criteria.constraintTypes) {
                     log.warn("Enriching previous attribute [${VaultSchemaV1.VaultStates::constraintType.name}] values [$existingTypes] with [${criteria.constraintTypes}]")
-                    commonPredicates.replace(predicateID, criteriaBuilder.and(vaultStates.get<Vault.ConstraintInfo.Type>(VaultSchemaV1.VaultStates::contractStateClassName.name).`in`(criteria.constraintTypes.plus(existingTypes))))
+                    commonPredicates.replace(predicateID, criteriaBuilder.and(vaultStates.get<Vault.ConstraintInfo.Type>(VaultSchemaV1.VaultStates::constraintType.name).`in`(criteria.constraintTypes.plus(existingTypes))))
                 }
             } else {
                 commonPredicates[predicateID] = criteriaBuilder.and(vaultStates.get<Vault.ConstraintInfo.Type>(VaultSchemaV1.VaultStates::constraintType.name).`in`(criteria.constraintTypes))

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -11,8 +11,12 @@ import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.*
 import net.corda.core.node.services.vault.*
+import net.corda.core.node.services.Vault.ConstraintInfo.Companion.constraintInfo
 import net.corda.core.schemas.PersistentStateRef
+import net.corda.core.serialization.SerializationDefaults.STORAGE_CONTEXT
 import net.corda.core.serialization.SingletonSerializeAsToken
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.serialize
 import net.corda.core.transactions.*
 import net.corda.core.utilities.*
 import net.corda.node.services.api.SchemaService
@@ -132,12 +136,15 @@ class NodeVaultService(
                 // Adding a new column in the "VaultStates" table was considered the best approach.
                 val keys = stateOnly.participants.map { it.owningKey }
                 val isRelevant = isRelevant(stateOnly, keyManagementService.filterMyKeys(keys).toSet())
+                val constraintInfo = Vault.ConstraintInfo(stateAndRef.value.state.constraint)
                 val stateToAdd = VaultSchemaV1.VaultStates(
                         notary = stateAndRef.value.state.notary,
                         contractStateClassName = stateAndRef.value.state.data.javaClass.name,
                         stateStatus = Vault.StateStatus.UNCONSUMED,
                         recordedTime = clock.instant(),
-                        relevancyStatus = if (isRelevant) Vault.RelevancyStatus.RELEVANT else Vault.RelevancyStatus.NOT_RELEVANT
+                        relevancyStatus = if (isRelevant) Vault.RelevancyStatus.RELEVANT else Vault.RelevancyStatus.NOT_RELEVANT,
+                        constraintType = constraintInfo.type(),
+                        constraintData = constraintInfo.data()?.serialize(context = STORAGE_CONTEXT)!!.bytes
                 )
                 stateToAdd.stateRef = PersistentStateRef(stateAndRef.key)
                 session.save(stateToAdd)
@@ -513,7 +520,9 @@ class NodeVaultService(
                                     vaultState.notary,
                                     vaultState.lockId,
                                     vaultState.lockUpdateTime,
-                                    vaultState.relevancyStatus))
+                                    vaultState.relevancyStatus,
+                                    constraintInfo(vaultState.constraintType, vaultState.constraintData?.deserialize(context = STORAGE_CONTEXT))
+                            ))
                         } else {
                             // TODO: improve typing of returned other results
                             log.debug { "OtherResults: ${Arrays.toString(result.toArray())}" }

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -144,7 +144,7 @@ class NodeVaultService(
                         recordedTime = clock.instant(),
                         relevancyStatus = if (isRelevant) Vault.RelevancyStatus.RELEVANT else Vault.RelevancyStatus.NOT_RELEVANT,
                         constraintType = constraintInfo.type(),
-                        constraintData = constraintInfo.data()?.serialize(context = STORAGE_CONTEXT)?.bytes
+                        constraintData = constraintInfo.data()
                 )
                 stateToAdd.stateRef = PersistentStateRef(stateAndRef.key)
                 session.save(stateToAdd)
@@ -521,7 +521,7 @@ class NodeVaultService(
                                     vaultState.lockId,
                                     vaultState.lockUpdateTime,
                                     vaultState.relevancyStatus,
-                                    constraintInfo(vaultState.constraintType, vaultState.constraintData?.deserialize(context = STORAGE_CONTEXT))
+                                    constraintInfo(vaultState.constraintType, vaultState.constraintData)
                             ))
                         } else {
                             // TODO: improve typing of returned other results

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -144,7 +144,7 @@ class NodeVaultService(
                         recordedTime = clock.instant(),
                         relevancyStatus = if (isRelevant) Vault.RelevancyStatus.RELEVANT else Vault.RelevancyStatus.NOT_RELEVANT,
                         constraintType = constraintInfo.type(),
-                        constraintData = constraintInfo.data()?.serialize(context = STORAGE_CONTEXT)!!.bytes
+                        constraintData = constraintInfo.data()?.serialize(context = STORAGE_CONTEXT)?.bytes
                 )
                 stateToAdd.stateRef = PersistentStateRef(stateAndRef.key)
                 session.save(stateToAdd)

--- a/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/VaultSchema.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.MAX_ISSUER_REF_SIZE
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
+import net.corda.core.node.services.MAX_CONSTRAINT_DATA_SIZE
 import net.corda.core.node.services.Vault
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
@@ -66,7 +67,16 @@ object VaultSchemaV1 : MappedSchema(schemaFamily = VaultSchema.javaClass, versio
 
             /** refers to the last time a lock was taken (reserved) or updated (released, re-reserved) */
             @Column(name = "lock_timestamp", nullable = true)
-            var lockUpdateTime: Instant? = null
+            var lockUpdateTime: Instant? = null,
+
+            /** refers to constraint type (none, hash, whitelisted, signature) associated with a contract state */
+            @Column(name = "constraint_type", nullable = false)
+            var constraintType: Vault.ConstraintInfo.Type,
+
+            /** associated constraint type data (if any) */
+            @Column(name = "constraint_data", length = MAX_CONSTRAINT_DATA_SIZE, nullable = true)
+            @Type(type = "corda-wrapper-binary")
+            var constraintData: ByteArray? = null
     ) : PersistentState()
 
     @Entity

--- a/node/src/main/resources/migration/vault-schema.changelog-master.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-master.xml
@@ -9,4 +9,5 @@
     <include file="migration/vault-schema.changelog-v4.xml"/>
     <include file="migration/vault-schema.changelog-pkey.xml"/>
     <include file="migration/vault-schema.changelog-v5.xml"/>
+    <include file="migration/vault-schema.changelog-v6.xml"/>
 </databaseChangeLog>

--- a/node/src/main/resources/migration/vault-schema.changelog-v6.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-v6.xml
@@ -12,7 +12,7 @@
 	    </update>
 	    <addNotNullConstraint tableName="vault_states" columnName="constraint_type" columnDataType="INT" />
         <addColumn tableName="vault_states">
-            <column name="constraint_data" type="NVARCHAR(255)">
+            <column name="constraint_data" type="NVARCHAR(1074)">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/node/src/main/resources/migration/vault-schema.changelog-v6.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-v6.xml
@@ -1,0 +1,20 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3.Corda" id="add_is_constraint_information_columns">
+        <preConditions onFail="MARK_RAN"><not><columnExists tableName="vault_states" columnName="is_relevant"/></not></preConditions>
+        <addColumn tableName="vault_states">
+            <column name="constraint_type" type="INT"/>
+	    </addColumn>
+	    <update tableName="vault_states">
+	        <column name="constraint_type" valueNumeric="0"/>
+	    </update>
+	    <addNotNullConstraint tableName="vault_states" columnName="constraint_type" columnDataType="INT" />
+        <addColumn tableName="vault_states">
+            <column name="constraint_data" type="NVARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/node/src/main/resources/migration/vault-schema.changelog-v6.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-v6.xml
@@ -12,7 +12,7 @@
 	    </update>
 	    <addNotNullConstraint tableName="vault_states" columnName="constraint_type" columnDataType="INT" />
         <addColumn tableName="vault_states">
-            <column name="constraint_data" type="NVARCHAR(1074)">
+            <column name="constraint_data" type="varbinary(563)">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/node/src/main/resources/migration/vault-schema.changelog-v6.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-v6.xml
@@ -3,14 +3,11 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
     <changeSet author="R3.Corda" id="add_is_constraint_information_columns">
-        <preConditions onFail="MARK_RAN"><not><columnExists tableName="vault_states" columnName="is_relevant"/></not></preConditions>
         <addColumn tableName="vault_states">
-            <column name="constraint_type" type="INT"/>
-	    </addColumn>
-	    <update tableName="vault_states">
-	        <column name="constraint_type" valueNumeric="0"/>
-	    </update>
-	    <addNotNullConstraint tableName="vault_states" columnName="constraint_type" columnDataType="INT" />
+            <column name="constraint_type" type="INT" defaultValue="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
         <addColumn tableName="vault_states">
             <column name="constraint_data" type="varbinary(563)">
                 <constraints nullable="true"/>

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -501,9 +501,13 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             assertThat(constraintResults2.states).hasSize(2)
 
             // search for states with [Vault.ConstraintInfo.Type] either HASH or CZ_WHITELISED
-            val constraintTypeCriteria3 = VaultQueryCriteria(constraintTypes = setOf(HASH, CZ_WHITELISTED))
-            val constraintResults3 = vaultService.queryBy<LinearState>(constraintTypeCriteria3)
-            assertThat(constraintResults3.states).hasSize(3)
+            // DOCSTART VaultQueryExample30
+            val constraintTypeCriteria = VaultQueryCriteria(constraintTypes = setOf(HASH, CZ_WHITELISTED))
+            val sortAttribute = SortAttribute.Standard(Sort.VaultStateAttribute.CONSTRAINT_TYPE)
+            val sorter = Sort(setOf(Sort.SortColumn(sortAttribute, Sort.Direction.ASC)))
+            val constraintResults = vaultService.queryBy<LinearState>(constraintTypeCriteria, sorter)
+            // DOCEND VaultQueryExample30
+            assertThat(constraintResults.states).hasSize(3)
 
             // search for states with [Vault.ConstraintInfo.Type] = SIGNATURE
             val constraintTypeCriteria4 = VaultQueryCriteria(constraintTypes = setOf(SIGNATURE))

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -479,8 +479,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             // insert states with different constraint types
             vaultFiller.fillWithSomeTestLinearStates(1)
             vaultFiller.fillWithSomeTestLinearStates(1, constraint = AlwaysAcceptAttachmentConstraint)
-            val contractAttachmentId = SecureHash.randomSHA256()
-            vaultFiller.fillWithSomeTestLinearStates(1, constraint = HashAttachmentConstraint(contractAttachmentId))
+            vaultFiller.fillWithSomeTestLinearStates(1, constraint = HashAttachmentConstraint(SecureHash.randomSHA256()))
             vaultFiller.fillWithSomeTestLinearStates(1, constraint = WhitelistedByZoneAttachmentConstraint)
             vaultFiller.fillWithSomeTestLinearStates(1, constraint = SignatureAttachmentConstraint(alice.publicKey))
             val compositeKey = CompositeKey.Builder().addKeys(alice.publicKey,  bob.publicKey).build()

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -2269,11 +2269,11 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             vaultFiller.fillWithSomeTestLinearStates(1, constraint = AlwaysAcceptAttachmentConstraint)
 
             // Base criteria
-            val baseCriteria = VaultQueryCriteria(status = Vault.StateStatus.CONSUMED)
+            val baseCriteria = VaultQueryCriteria(constraintTypes = setOf(ALWAYS_ACCEPT))
 
             // Enrich and override QueryCriteria with additional default attributes (contract constraints)
-            val enrichedCriteria = VaultQueryCriteria(constraintTypes = setOf(SIGNATURE, HASH, ALWAYS_ACCEPT), // enrich
-                    status = Vault.StateStatus.UNCONSUMED)  // override
+            val enrichedCriteria = VaultQueryCriteria(constraintTypes = setOf(SIGNATURE, HASH, ALWAYS_ACCEPT)) // enrich
+
             // Sorting
             val sortAttribute = SortAttribute.Standard(Sort.VaultStateAttribute.CONSTRAINT_TYPE)
             val sorter = Sort(setOf(Sort.SortColumn(sortAttribute, Sort.Direction.ASC)))

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
@@ -102,7 +102,8 @@ class VaultFiller @JvmOverloads constructor(
                                      linearString: String = "",
                                      linearNumber: Long = 0L,
                                      linearBoolean: Boolean = false,
-                                     linearTimestamp: Instant = now()): Vault<LinearState> {
+                                     linearTimestamp: Instant = now(),
+                                     constraint: AttachmentConstraint = AutomaticHashConstraint): Vault<LinearState> {
         val myKey: PublicKey = services.myInfo.chooseIdentity().owningKey
         val me = AnonymousParty(myKey)
         val issuerKey = defaultNotary.keyPair
@@ -116,7 +117,8 @@ class VaultFiller @JvmOverloads constructor(
                         linearString = linearString,
                         linearNumber = linearNumber,
                         linearBoolean = linearBoolean,
-                        linearTimestamp = linearTimestamp), DUMMY_LINEAR_CONTRACT_PROGRAM_ID)
+                        linearTimestamp = linearTimestamp), DUMMY_LINEAR_CONTRACT_PROGRAM_ID,
+                        constraint = constraint)
                 addCommand(dummyCommand())
             }
             return@map services.signInitialTransaction(dummyIssue).withAdditionalSignature(issuerKey, signatureMetadata)


### PR DESCRIPTION
Vault storage of contract state constraints metadata and associated vault query functions to retrieve and sort by constraint type.

Note: a follow-up PR will address performance improvements as per
https://r3-cev.atlassian.net/browse/CORDA-2013