### PR TITLE
CORDA-2012 Copying all certificates from the network-turst-store

### DIFF
--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -294,13 +294,16 @@ class NodeRegistrationHelper(private val config: NodeConfiguration, certService:
     private fun createTruststore(rootCertificate: X509Certificate) {
         // Save root certificates to trust store.
         config.p2pSslOptions.trustStore.get(createNew = true).update {
+            if (this.aliases().hasNext()) {
+                logger.warn("The node's trust store already exists. The following certificates will be overridden: ${this.aliases().asSequence()}")
+            }
             println("Generating trust store for corda node.")
             // Assumes certificate chain always starts with client certificate and end with root certificate.
             setCertificate(CORDA_ROOT_CA, rootCertificate)
             // Copy remaining certificates from the network-trust-store
             rootTrustStore.aliases().asSequence().filter { it != CORDA_ROOT_CA }.forEach {
                 val certificate = rootTrustStore.getCertificate(it)
-                logger.debug("Copying trusted certificate to the node's trust store: Alias: $it, Certificate: $certificate")
+                logger.info("Copying trusted certificate to the node's trust store: Alias: $it, Certificate: $certificate")
                 setCertificate(it, certificate)
             }
         }

--- a/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/registration/NetworkRegistrationHelper.kt
@@ -51,7 +51,7 @@ open class NetworkRegistrationHelper(private val certificatesDirectory: Path,
     }
 
     private val requestIdStore = certificatesDirectory / "certificate-request-id.txt"
-    private val rootTrustStore: X509KeyStore
+    protected val rootTrustStore: X509KeyStore
     protected val rootCert: X509Certificate
 
     init {
@@ -297,6 +297,12 @@ class NodeRegistrationHelper(private val config: NodeConfiguration, certService:
             println("Generating trust store for corda node.")
             // Assumes certificate chain always starts with client certificate and end with root certificate.
             setCertificate(CORDA_ROOT_CA, rootCertificate)
+            // Copy remaining certificates from the network-trust-store
+            rootTrustStore.aliases().asSequence().filter { it != CORDA_ROOT_CA }.forEach {
+                val certificate = rootTrustStore.getCertificate(it)
+                logger.debug("Copying trusted certificate to the node's trust store: Alias: $it, Certificate: $certificate")
+                setCertificate(it, certificate)
+            }
         }
         println("Node trust store stored in ${config.p2pSslOptions.trustStore.path}.")
     }


### PR DESCRIPTION
This PR ensures that **ALL** the certificates present in the `network-trust-store` are copied into the node's trust store.