### PR TITLE
CORDA-2023 Remove TLS_DHE_RSA cipher family

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
@@ -18,8 +18,7 @@ class ArtemisTcpTransport {
     companion object {
         val CIPHER_SUITES = listOf(
                 "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         )
 
         val TLS_VERSIONS = listOf("TLSv1.2")

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/X509UtilitiesTest.kt
@@ -63,8 +63,7 @@ class X509UtilitiesTest {
         val MEGA_CORP = TestIdentity(CordaX500Name("MegaCorp", "London", "GB")).party
         val CIPHER_SUITES = arrayOf(
                 "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         )
         // We ensure that all of the algorithms are both used (at least once) as first and second in the following [Pair]s.
         // We also add [DEFAULT_TLS_SIGNATURE_SCHEME] and [DEFAULT_IDENTITY_SIGNATURE_SCHEME] combinations for consistency.

--- a/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/TLSAuthenticationTests.kt
@@ -64,8 +64,7 @@ class TLSAuthenticationTests {
     // Default supported TLS schemes for Corda nodes.
     private val CORDA_TLS_CIPHER_SUITES = arrayOf(
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
     )
 
     @Test
@@ -159,27 +158,6 @@ class TLSAuthenticationTests {
 
         val (serverSocket, clientSocket) = buildTLSSockets(serverSocketFactory, clientSocketFactory, 0, 0)
         testConnect(serverSocket, clientSocket, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
-    }
-
-    @Test
-    fun `All RSA - avoid ECC for DH`() {
-        val (serverSocketFactory, clientSocketFactory) = buildTLSFactories(
-                rootCAScheme = Crypto.RSA_SHA256,
-                intermediateCAScheme = Crypto.RSA_SHA256,
-                client1CAScheme = Crypto.RSA_SHA256,
-                client1TLSScheme = Crypto.RSA_SHA256,
-                client2CAScheme = Crypto.RSA_SHA256,
-                client2TLSScheme = Crypto.RSA_SHA256
-        )
-
-        val (serverSocket, clientSocket) = buildTLSSockets(
-                serverSocketFactory,
-                clientSocketFactory,
-                0,
-                0,
-                CORDA_TLS_CIPHER_SUITES,
-                arrayOf("TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")) // Second client accepts DHE only.
-        testConnect(serverSocket, clientSocket, "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
     }
 
     // According to RFC 5246 (TLS 1.2), section 7.4.1.2 ClientHello cipher_suites:


### PR DESCRIPTION
This cipher family is not supported in boring SSL - if we want to use boring SSL for TLS in any version of CORDA,  we cannot support the non-elliptic DHE RSA cipher family  anywhere for TLS.