### PR TITLE
CORDA-1726 Make sure test frameworks and nodes refuse to start on any…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -156,7 +156,7 @@ open class Node(configuration: NodeConfiguration,
                 val update = SystemUtils.JAVA_VERSION.substringAfter("_").toLong()
                 major == 1.8F && update >= 171
             } catch (e: NumberFormatException) { // custom JDKs may not have the update version (e.g. 1.8.0-adoptopenjdk)
-                return false
+                false
             }
         }
     }

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -55,6 +55,7 @@ import net.corda.nodeapi.internal.config.User
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.persistence.CouldNotCreateDataSourceException
 import net.corda.serialization.internal.*
+import org.apache.commons.lang.SystemUtils
 import org.h2.jdbc.JdbcSQLException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -138,6 +139,26 @@ open class Node(configuration: NodeConfiguration,
 
         // TODO: make this configurable.
         const val MAX_RPC_MESSAGE_SIZE = 10485760
+
+        fun isValidJavaVersion(): Boolean {
+            if (!hasMinimumJavaVersion()) {
+                println("You are using a version of Java that is not supported (${SystemUtils.JAVA_VERSION}). Please upgrade to the latest version of Java 8.")
+                println("Corda will now exit...")
+                return false
+            }
+            return true
+        }
+
+        private fun hasMinimumJavaVersion(): Boolean {
+            // when the ext.java8_minUpdateVersion gradle constant changes, so must this check
+            val major = SystemUtils.JAVA_VERSION_FLOAT
+            return try {
+                val update = SystemUtils.JAVA_VERSION.substringAfter("_").toLong()
+                major == 1.8F && update >= 171
+            } catch (e: NumberFormatException) { // custom JDKs may not have the update version (e.g. 1.8.0-adoptopenjdk)
+                return false
+            }
+        }
     }
 
     override val log: Logger get() = staticLog

--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -15,6 +15,7 @@ import net.corda.core.internal.errors.AddressBindingException
 import net.corda.core.utilities.Try
 import net.corda.core.utilities.loggerFor
 import net.corda.node.*
+import net.corda.node.internal.Node.Companion.isValidJavaVersion
 import net.corda.node.internal.cordapp.MultipleCordappsForFlowException
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.node.services.config.NodeConfigurationImpl
@@ -33,7 +34,6 @@ import net.corda.nodeapi.internal.config.UnknownConfigurationKeysException
 import net.corda.nodeapi.internal.persistence.CouldNotCreateDataSourceException
 import net.corda.nodeapi.internal.persistence.DatabaseIncompatibleException
 import net.corda.tools.shell.InteractiveShell
-import org.apache.commons.lang.SystemUtils
 import org.fusesource.jansi.Ansi
 import org.slf4j.bridge.SLF4JBridgeHandler
 import picocli.CommandLine.Mixin
@@ -45,7 +45,6 @@ import java.io.RandomAccessFile
 import java.lang.management.ManagementFactory
 import java.net.InetAddress
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 import java.util.*
@@ -128,22 +127,6 @@ open class NodeStartup : CordaCliWrapper("corda", "Runs a Corda Node") {
             return true
         }
         return null
-    }
-
-    private fun isValidJavaVersion(): Boolean {
-        if (!hasMinimumJavaVersion()) {
-            println("You are using a version of Java that is not supported (${SystemUtils.JAVA_VERSION}). Please upgrade to the latest version of Java 8.")
-            println("Corda will now exit...")
-            return false
-        }
-        return true
-    }
-
-    private fun hasMinimumJavaVersion(): Boolean {
-        // when the ext.java8_minUpdateVersion gradle constant changes, so must this check
-        val major = SystemUtils.JAVA_VERSION_FLOAT
-        val update = SystemUtils.JAVA_VERSION.substringAfter("_").toLong()
-        return major == 1.8F && update >= 171
     }
 
     // TODO: Reconsider if automatic re-registration should be applied when something failed during initial registration.

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -188,14 +188,5 @@ class DriverTests {
         testFuture.getOrThrow()
     }
 
-    @Test
-    fun `driver start with Java 8 only`() {
-        //pretend other Java version is in use, this would not work for node starting in separate proces (startNodesInProcess=false)
-        System.setProperty("java.version", "1.10.0_001")
-        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
-            assertThatIllegalStateException().isThrownBy { startNode().getOrThrow() }
-        }
-    }
-
     private fun DriverDSL.newNode(name: CordaX500Name) = { startNode(NodeParameters(providedName = name)) }
 }

--- a/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
+++ b/testing/node-driver/src/integration-test/kotlin/net/corda/testing/driver/DriverTests.kt
@@ -188,5 +188,14 @@ class DriverTests {
         testFuture.getOrThrow()
     }
 
+    @Test
+    fun `driver start with Java 8 only`() {
+        //pretend other Java version is in use, this would not work for node starting in separate proces (startNodesInProcess=false)
+        System.setProperty("java.version", "1.10.0_001")
+        driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList())) {
+            assertThatIllegalStateException().isThrownBy { startNode().getOrThrow() }
+        }
+    }
+
     private fun DriverDSL.newNode(name: CordaX500Name) = { startNode(NodeParameters(providedName = name)) }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
@@ -20,6 +20,7 @@ import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.driver.PortAllocation
 import net.corda.testing.internal.testThreadFactory
 import net.corda.testing.node.User
+import org.apache.commons.lang.SystemUtils
 import org.apache.logging.log4j.Level
 import org.junit.After
 import org.junit.Before
@@ -145,6 +146,11 @@ abstract class NodeBasedTest(private val cordappPackages: List<String> = emptyLi
 }
 
 class InProcessNode(configuration: NodeConfiguration, versionInfo: VersionInfo) : Node(configuration, versionInfo, false) {
+
+    override fun start() : NodeInfo {
+        check(isValidJavaVersion()) { "You are using a version of Java that is not supported (${SystemUtils.JAVA_VERSION}). Please upgrade to the latest version of Java 8." }
+        return super.start()
+    }
 
     override val rxIoScheduler get() = CachedThreadScheduler(testThreadFactory()).also { runOnStop += it::shutdown }
 }


### PR DESCRIPTION
…thing except the right Java versions

Move isValidJavaVersion(), hasMinimumJavaVersion() to Node as it can be use for check in DriverDSL for starting in-process node,
in-process node doesn't go via NodeStartup class where the correct Java version is checked.

Added safeguard to hasMinimumJavaVersion as some JDKs distributions may not have the update version number (e.g. AdoptOpenJDK) which causes unintended parse exception.