### PR TITLE
ENT-2500: Introduce optional BridgeMetricsService in `nodeApi` module

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeAuditService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeAuditService.kt
@@ -1,9 +1,0 @@
-package net.corda.nodeapi.internal.bridging
-
-import net.corda.nodeapi.internal.protonwrapper.messages.SendableMessage
-import org.apache.activemq.artemis.api.core.client.ClientMessage
-
-interface BridgeAuditService {
-    fun packetDropEvent(artemisMessage: ClientMessage, msg: String)
-    fun packetAcceptedEvent(sendableMessage: SendableMessage)
-}

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlListener.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlListener.kt
@@ -21,10 +21,10 @@ import java.util.*
 class BridgeControlListener(val config: MutualSslConfiguration,
                             maxMessageSize: Int,
                             private val artemisMessageClientFactory: () -> ArtemisSessionProvider,
-                            bridgeAuditService: BridgeAuditService? = null) : AutoCloseable {
+                            bridgeMetricsService: BridgeMetricsService? = null) : AutoCloseable {
     private val bridgeId: String = UUID.randomUUID().toString()
     private val bridgeManager: BridgeManager = AMQPBridgeManager(config, maxMessageSize,
-            artemisMessageClientFactory, bridgeAuditService)
+            artemisMessageClientFactory, bridgeMetricsService)
     private val validInboundQueues = mutableSetOf<String>()
     private var artemis: ArtemisSessionProvider? = null
     private var controlConsumer: ClientConsumer? = null

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeMetricsService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeMetricsService.kt
@@ -1,0 +1,15 @@
+package net.corda.nodeapi.internal.bridging
+
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.protonwrapper.messages.SendableMessage
+import org.apache.activemq.artemis.api.core.client.ClientMessage
+
+interface BridgeMetricsService {
+    fun bridgeCreated(targets: List<NetworkHostAndPort>, legalNames: Set<CordaX500Name>)
+    fun bridgeConnected(targets: List<NetworkHostAndPort>, legalNames: Set<CordaX500Name>)
+    fun packetDropEvent(artemisMessage: ClientMessage, msg: String)
+    fun packetAcceptedEvent(sendableMessage: SendableMessage)
+    fun bridgeDisconnected(targets: List<NetworkHostAndPort>, legalNames: Set<CordaX500Name>)
+    fun bridgeDestroyed(targets: List<NetworkHostAndPort>, legalNames: Set<CordaX500Name>)
+}


### PR DESCRIPTION
This is a split-out from the work done on the Enterprise Jira.

Apparently, all the outbound connections are handled by the Bridge which is part of NodeAPI module in Corda OS.
Therefore it makes sense to introduce an optional `BridgeMetricsService` here such that it will be naturally integrated into Enterprise repo and reduces merging conflicts in the future.