### PR TITLE
[CORDA-2044] Allow more signature schemes to TestUtils

### DIFF
--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -610,7 +610,8 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         assertThat(json["serialNumber"].bigIntegerValue()).isEqualTo(cert.serialNumber)
         assertThat(json["issuer"].valueAs<X500Principal>(mapper)).isEqualTo(cert.issuerX500Principal)
         assertThat(json["subject"].valueAs<X500Principal>(mapper)).isEqualTo(cert.subjectX500Principal)
-        assertThat(json["publicKey"].valueAs<PublicKey>(mapper)).isEqualTo(cert.publicKey)
+        // cert.publicKey should be converted to a supported format (this is required because [Certificate] returns keys as SUN EC keys, not BC).
+        assertThat(json["publicKey"].valueAs<PublicKey>(mapper)).isEqualTo(Crypto.toSupportedPublicKey(cert.publicKey))
         assertThat(json["notAfter"].valueAs<Date>(mapper)).isEqualTo(cert.notAfter)
         assertThat(json["notBefore"].valueAs<Date>(mapper)).isEqualTo(cert.notBefore)
         assertThat(json["encoded"].binaryValue()).isEqualTo(cert.encoded)

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestUtils.kt
@@ -127,6 +127,8 @@ class TestIdentity(val name: CordaX500Name, val keyPair: KeyPair) {
          * Creates an identity that won't equal any other. This is mostly useful as a throwaway for test helpers.
          * @param organisation the organisation part of the new identity's name.
          */
+        @JvmStatic
+        @JvmOverloads
         fun fresh(organisation: String, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME): TestIdentity {
             val keyPair = Crypto.generateKeyPair(signatureScheme)
             val name = CordaX500Name(organisation, keyPair.public.toStringShort(), CordaX500Name.unspecifiedCountry)
@@ -135,11 +137,11 @@ class TestIdentity(val name: CordaX500Name, val keyPair: KeyPair) {
     }
 
     /** Creates an identity with a deterministic [keyPair] i.e. same [entropy] same keyPair. */
-    constructor(name: CordaX500Name, entropy: Long, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME)
+    @JvmOverloads constructor(name: CordaX500Name, entropy: Long, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME)
             : this(name, Crypto.deriveKeyPairFromEntropy(signatureScheme, BigInteger.valueOf(entropy)))
 
     /** Creates an identity with the given name and a fresh keyPair. */
-    constructor(name: CordaX500Name, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME)
+    @JvmOverloads constructor(name: CordaX500Name, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME)
             : this(name, Crypto.generateKeyPair(signatureScheme))
 
     val publicKey: PublicKey get() = keyPair.public

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/TestUtils.kt
@@ -5,10 +5,7 @@ package net.corda.testing.core
 
 import net.corda.core.contracts.PartyAndReference
 import net.corda.core.contracts.StateRef
-import net.corda.core.crypto.SecureHash
-import net.corda.core.crypto.entropyToKeyPair
-import net.corda.core.crypto.generateKeyPair
-import net.corda.core.crypto.toStringShort
+import net.corda.core.crypto.*
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
@@ -25,7 +22,6 @@ import java.math.BigInteger
 import java.security.KeyPair
 import java.security.PublicKey
 import java.security.cert.X509Certificate
-import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -46,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger
  *   - The Int.DOLLARS syntax doesn't work from Java.  Use the DOLLARS(int) function instead.
  */
 
-/** Returns a fake state reference for testing purposes **/
+/** Returns a fake state reference for testing purposes. **/
 fun generateStateRef(): StateRef = StateRef(SecureHash.randomSHA256(), 0)
 
 private val freePortCounter = AtomicInteger(30000)
@@ -112,7 +108,7 @@ fun getTestPartyAndCertificate(name: CordaX500Name, publicKey: PublicKey): Party
 
 private val count = AtomicInteger(0)
 /**
- * Randomise a party name to avoid clashes with other tests
+ * Randomise a party name to avoid clashes with other tests.
  */
 fun makeUnique(name: CordaX500Name) = name.copy(commonName =
     if (name.commonName == null) {
@@ -131,24 +127,26 @@ class TestIdentity(val name: CordaX500Name, val keyPair: KeyPair) {
          * Creates an identity that won't equal any other. This is mostly useful as a throwaway for test helpers.
          * @param organisation the organisation part of the new identity's name.
          */
-        fun fresh(organisation: String): TestIdentity {
-            val keyPair = generateKeyPair()
+        fun fresh(organisation: String, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME): TestIdentity {
+            val keyPair = Crypto.generateKeyPair(signatureScheme)
             val name = CordaX500Name(organisation, keyPair.public.toStringShort(), CordaX500Name.unspecifiedCountry)
             return TestIdentity(name, keyPair)
         }
     }
 
-    /** Creates an identity with a deterministic [keyPair] i.e. same [entropy] same keyPair .*/
-    constructor(name: CordaX500Name, entropy: Long) : this(name, entropyToKeyPair(BigInteger.valueOf(entropy)))
+    /** Creates an identity with a deterministic [keyPair] i.e. same [entropy] same keyPair. */
+    constructor(name: CordaX500Name, entropy: Long, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME)
+            : this(name, Crypto.deriveKeyPairFromEntropy(signatureScheme, BigInteger.valueOf(entropy)))
 
     /** Creates an identity with the given name and a fresh keyPair. */
-    constructor(name: CordaX500Name) : this(name, generateKeyPair())
+    constructor(name: CordaX500Name, signatureScheme: SignatureScheme = Crypto.DEFAULT_SIGNATURE_SCHEME)
+            : this(name, Crypto.generateKeyPair(signatureScheme))
 
     val publicKey: PublicKey get() = keyPair.public
     val party: Party = Party(name, publicKey)
     val identity: PartyAndCertificate by lazy { getTestPartyAndCertificate(party) } // Often not needed.
 
-    /** Returns a [PartyAndReference] for this identity and the given reference */
+    /** Returns a [PartyAndReference] for this identity and the given reference. */
     fun ref(vararg bytes: Byte): PartyAndReference = party.ref(*bytes)
 }
 


### PR DESCRIPTION
Required for testing other than EdDSA keys (i.e., ECDSA which is usually the default for HSMs).