### PR TITLE
Network bootstrapper tool: optional configuration setting to specify the minimum plat…

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,8 @@ release, see :doc:`upgrade-notes`.
 Unreleased
 ----------
 
+* Introduced new optional network bootstrapper command line option (--minimum-platform-version) to set as a network parameter
+
 * Introduce minimum and target platform version for CorDapps.
 
 * New overload for ``CordaRPCClient.start()`` method allowing to specify target legal identity to use for RPC call.

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -349,7 +349,7 @@ internal constructor(private val initSerEnv: Boolean,
             whitelist: Map<String, List<AttachmentId>>,
             existingNetParams: NetworkParameters?,
             nodeDirs: List<Path>,
-            defaultMinimumPlatformVersion: Int
+            minimumPlatformVersion: Int
     ): NetworkParameters {
         // TODO Add config for minimumPlatformVersion, maxMessageSize and maxTransactionSize
         val netParams = if (existingNetParams != null) {
@@ -365,7 +365,7 @@ internal constructor(private val initSerEnv: Boolean,
             }
         } else {
             NetworkParameters(
-                    minimumPlatformVersion = defaultMinimumPlatformVersion,
+                    minimumPlatformVersion = minimumPlatformVersion,
                     notaries = notaryInfos,
                     modifiedTime = Instant.now(),
                     maxMessageSize = 10485760,

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -154,8 +154,8 @@ internal constructor(private val initSerEnv: Boolean,
      *
      * TODO: Remove once the gradle plugins are updated to 4.0.30
      */
-    fun bootstrap(directory: Path, cordappJars: List<Path>, defaultMinimumPlatformVersion: Int) {
-        bootstrap(directory, cordappJars, copyCordapps = true, fromCordform = true, defaultMinimumPlatformVersion = defaultMinimumPlatformVersion)
+    fun bootstrap(directory: Path, cordappJars: List<Path>) {
+        bootstrap(directory, cordappJars, copyCordapps = true, fromCordform = true)
     }
 
     /** Entry point for Cordform */

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -163,6 +163,7 @@ internal constructor(private val initSerEnv: Boolean,
 
     /** Entry point for the tool */
     fun bootstrap(directory: Path, copyCordapps: Boolean, minimumPlatformVersion: Int) {
+        require(minimumPlatformVersion <= PLATFORM_VERSION) { "Minimum platform version cannot be greater than $PLATFORM_VERSION" }
         // Don't accidently include the bootstrapper jar as a CorDapp!
         val bootstrapperJar = javaClass.location.toPath()
         val cordappJars = directory.list { paths ->

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -159,8 +159,8 @@ internal constructor(private val initSerEnv: Boolean,
     }
 
     /** Entry point for Cordform */
-    fun bootstrapCordform(directory: Path, cordappJars: List<Path>, defaultMinimumPlatformVersion: Int) {
-        bootstrap(directory, cordappJars, copyCordapps = false, fromCordform = true, defaultMinimumPlatformVersion = defaultMinimumPlatformVersion)
+    fun bootstrapCordform(directory: Path, cordappJars: List<Path>) {
+        bootstrap(directory, cordappJars, copyCordapps = false, fromCordform = true)
     }
 
     /** Entry point for the tool */
@@ -178,7 +178,7 @@ internal constructor(private val initSerEnv: Boolean,
             cordappJars: List<Path>,
             copyCordapps: Boolean,
             fromCordform: Boolean,
-            defaultMinimumPlatformVersion: Int
+            defaultMinimumPlatformVersion: Int = MINIMUM_PLATFORM_VERSION
     ) {
         directory.createDirectories()
         println("Bootstrapping local test network in $directory")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -68,8 +68,6 @@ internal constructor(private val initSerEnv: Boolean,
                 "--just-generate-node-info"
         )
 
-        const val MINIMUM_PLATFORM_VERSION = 4
-
         private const val LOGS_DIR_NAME = "logs"
 
         private fun extractEmbeddedCordaJar(): InputStream {
@@ -164,13 +162,13 @@ internal constructor(private val initSerEnv: Boolean,
     }
 
     /** Entry point for the tool */
-    fun bootstrap(directory: Path, copyCordapps: Boolean, defaultMinimumPlatformVersion: Int) {
+    fun bootstrap(directory: Path, copyCordapps: Boolean, minimumPlatformVersion: Int) {
         // Don't accidently include the bootstrapper jar as a CorDapp!
         val bootstrapperJar = javaClass.location.toPath()
         val cordappJars = directory.list { paths ->
             paths.filter { it.toString().endsWith(".jar") && !it.isSameAs(bootstrapperJar) && it.fileName.toString() != "corda.jar" }.toList()
         }
-        bootstrap(directory, cordappJars, copyCordapps, fromCordform = false, defaultMinimumPlatformVersion = defaultMinimumPlatformVersion)
+        bootstrap(directory, cordappJars, copyCordapps, fromCordform = false, minimumPlatformVersion = minimumPlatformVersion)
     }
 
     private fun bootstrap(
@@ -178,7 +176,7 @@ internal constructor(private val initSerEnv: Boolean,
             cordappJars: List<Path>,
             copyCordapps: Boolean,
             fromCordform: Boolean,
-            defaultMinimumPlatformVersion: Int = MINIMUM_PLATFORM_VERSION
+            minimumPlatformVersion: Int = PLATFORM_VERSION
     ) {
         directory.createDirectories()
         println("Bootstrapping local test network in $directory")
@@ -218,7 +216,7 @@ internal constructor(private val initSerEnv: Boolean,
             val notaryInfos = gatherNotaryInfos(nodeInfoFiles, configs)
             println("Generating contract implementations whitelist")
             val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), cordappJars.filter { !isSigned(it) }.map(contractsJarConverter))
-            val newNetParams = installNetworkParameters(notaryInfos, newWhitelist, existingNetParams, nodeDirs, defaultMinimumPlatformVersion)
+            val newNetParams = installNetworkParameters(notaryInfos, newWhitelist, existingNetParams, nodeDirs, minimumPlatformVersion)
             if (newNetParams != existingNetParams) {
                 println("${if (existingNetParams == null) "New" else "Updated"} $newNetParams")
             } else {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt
@@ -217,7 +217,7 @@ class NetworkBootstrapperTest {
 
     private fun bootstrap(copyCordapps: Boolean = true) {
         providedCordaJar = (rootDir / "corda.jar").let { if (it.exists()) it.readAll() else null }
-        bootstrapper.bootstrap(rootDir, copyCordapps)
+        bootstrapper.bootstrap(rootDir, copyCordapps, NetworkBootstrapper.MINIMUM_PLATFORM_VERSION)
     }
 
     private fun createNodeConfFile(nodeDirName: String, config: FakeNodeConfig) {

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt
@@ -11,6 +11,7 @@ import net.corda.core.serialization.serialize
 import net.corda.node.services.config.NotaryConfig
 import net.corda.nodeapi.internal.DEV_ROOT_CA
 import net.corda.nodeapi.internal.NODE_INFO_DIRECTORY
+import net.corda.nodeapi.internal.PLATFORM_VERSION
 import net.corda.nodeapi.internal.SignedNodeInfo
 import net.corda.nodeapi.internal.config.parseAs
 import net.corda.nodeapi.internal.config.toConfig
@@ -217,7 +218,7 @@ class NetworkBootstrapperTest {
 
     private fun bootstrap(copyCordapps: Boolean = true) {
         providedCordaJar = (rootDir / "corda.jar").let { if (it.exists()) it.readAll() else null }
-        bootstrapper.bootstrap(rootDir, copyCordapps, NetworkBootstrapper.MINIMUM_PLATFORM_VERSION)
+        bootstrapper.bootstrap(rootDir, copyCordapps, PLATFORM_VERSION)
     }
 
     private fun createNodeConfFile(nodeDirName: String, config: FakeNodeConfig) {

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -24,8 +24,11 @@ class NetworkBootstrapperRunner : CordaCliWrapper("bootstrapper", "Bootstrap a l
     @Option(names = ["--no-copy"], description = ["""Don't copy the CorDapp JARs into the nodes' "cordapps" directories."""])
     private var noCopy: Boolean = false
 
+    @Option(names = ["--minimum-platform-version"], description = ["The minimumPlatformVersion to use in network-parameters in case no existing network-parameters file is found"])
+    private var minimumPlatformVersion = NetworkBootstrapper.MINIMUM_PLATFORM_VERSION
+
     override fun runProgram(): Int {
-        NetworkBootstrapper().bootstrap(dir.toAbsolutePath().normalize(), copyCordapps = !noCopy)
+        NetworkBootstrapper().bootstrap(dir.toAbsolutePath().normalize(), copyCordapps = !noCopy, defaultMinimumPlatformVersion = minimumPlatformVersion)
         return 0 //exit code
     }
 }

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -2,6 +2,7 @@ package net.corda.bootstrapper
 
 import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.start
+import net.corda.nodeapi.internal.PLATFORM_VERSION
 import net.corda.nodeapi.internal.network.NetworkBootstrapper
 import picocli.CommandLine.Option
 import java.nio.file.Path
@@ -24,11 +25,11 @@ class NetworkBootstrapperRunner : CordaCliWrapper("bootstrapper", "Bootstrap a l
     @Option(names = ["--no-copy"], description = ["""Don't copy the CorDapp JARs into the nodes' "cordapps" directories."""])
     private var noCopy: Boolean = false
 
-    @Option(names = ["--minimum-platform-version"], description = ["The minimumPlatformVersion to use in network-parameters in case no existing network-parameters file is found"])
-    private var minimumPlatformVersion = NetworkBootstrapper.MINIMUM_PLATFORM_VERSION
+    @Option(names = ["--minimum-platform-version"], description = ["The minimumPlatformVersion to use in the network-parameters"])
+    private var minimumPlatformVersion = PLATFORM_VERSION
 
     override fun runProgram(): Int {
-        NetworkBootstrapper().bootstrap(dir.toAbsolutePath().normalize(), copyCordapps = !noCopy, defaultMinimumPlatformVersion = minimumPlatformVersion)
+        NetworkBootstrapper().bootstrap(dir.toAbsolutePath().normalize(), copyCordapps = !noCopy, minimumPlatformVersion = minimumPlatformVersion)
         return 0 //exit code
     }
 }


### PR DESCRIPTION
…form version to use in the network params file.

This flexibility is required by the Behave CTS framework to configure networks with a minimum Compatibility Version of 3 (for interoperability testing). Current codebase hardcodes MPV to 4.

