### PR TITLE
Replaced dependency to jolokia-war by jolokia-core.

### DIFF
--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-servlet:$jetty_version"
     compile "org.eclipse.jetty:jetty-webapp:$jetty_version"
     compile "javax.servlet:javax.servlet-api:3.1.0"
-    compile "org.jolokia:jolokia-war:$jolokia_version"
+    compile "org.jolokia:jolokia-core:$jolokia_version"
     compile "commons-fileupload:commons-fileupload:$fileupload_version"
 
     // Log4J: logging framework (with SLF4J bindings)


### PR DESCRIPTION
This fixes the issue #3813
https://github.com/corda/corda/issues/3813

The dependency jolokia-war exits only as a WAR files and not as a JAR. However, with the old specification maven was searching for a JAR file, such that a maven build having a dependency to corda-webserver-impl fails.
Replacing jolokia-war by jolokia-core fixes this issue.

Changed -war to -core in build.gradle.


# PR Checklist:

- [X] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [X] If you added public APIs, did you write the JavaDocs? DOES NOT APPLY
- [X] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [X] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
