### PR TITLE
 CORDA-2016 Add unit tests to ensure SNI header generation will not be changed by accident

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelper.kt
@@ -167,5 +167,5 @@ internal fun x500toHostName(x500Name: CordaX500Name): String {
     val secureHash = SecureHash.sha256(x500Name.toString())
     // RFC 1035 specifies a limit 255 bytes for hostnames with each label being 63 bytes or less. Due to this, the string
     // representation of the SHA256 hash is truncated to 32 characters.
-    return String.format(HOSTNAME_FORMAT, secureHash.toString().substring(0..32).toLowerCase())
+    return String.format(HOSTNAME_FORMAT, secureHash.toString().take(32).toLowerCase())
 }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelperTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelperTest.kt
@@ -1,0 +1,32 @@
+package net.corda.nodeapi.internal.protonwrapper.netty
+
+import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.nodeapi.internal.config.CertificateStore
+import net.corda.testing.internal.configureTestSSL
+import org.junit.Test
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SNIHostName
+import javax.net.ssl.TrustManagerFactory
+import kotlin.test.assertEquals
+
+class SSLHelperTest {
+    @Test
+    fun `ensure SNI header in correct format`() {
+        val legalName = CordaX500Name("Test", "London", "GB")
+        val sslConfig = configureTestSSL(legalName)
+
+        val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+
+        keyManagerFactory.init(CertificateStore.fromFile(sslConfig.keyStore.path, sslConfig.keyStore.password, false))
+        trustManagerFactory.init(initialiseTrustStoreAndEnableCrlChecking(CertificateStore.fromFile(sslConfig.trustStore.path, sslConfig.trustStore.password, false), false))
+
+        val sslHandler = createClientSslHelper(NetworkHostAndPort("localhost", 1234), setOf(legalName), keyManagerFactory, trustManagerFactory)
+        val legalNameHash = SecureHash.sha256(legalName.toString()).toString().take(32).toLowerCase()
+
+        assertEquals(1, sslHandler.engine().sslParameters.serverNames.size)
+        assertEquals("$legalNameHash.corda.net", (sslHandler.engine().sslParameters.serverNames.first() as SNIHostName).asciiName)
+    }
+}

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelperTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/protonwrapper/netty/SSLHelperTest.kt
@@ -26,6 +26,9 @@ class SSLHelperTest {
         val sslHandler = createClientSslHelper(NetworkHostAndPort("localhost", 1234), setOf(legalName), keyManagerFactory, trustManagerFactory)
         val legalNameHash = SecureHash.sha256(legalName.toString()).toString().take(32).toLowerCase()
 
+        // These hardcoded values must not be changed, something is broken if you have to change these hardcoded values.
+        assertEquals("O=Test, L=London, C=GB", legalName.toString())
+        assertEquals("f3df3c01a5f5aa5b9d394680cde3a414", legalNameHash)
         assertEquals(1, sslHandler.engine().sslParameters.serverNames.size)
         assertEquals("$legalNameHash.corda.net", (sslHandler.engine().sslParameters.serverNames.first() as SNIHostName).asciiName)
     }


### PR DESCRIPTION
* Add test for SNI header to prevent changing it accidentally.

* bug fix