### PR TITLE
CORDA-2030 - ensure the correct kotlin runtime library is used to resolve `AutoCloseable`

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     compile "org.slf4j:jul-to-slf4j:$slf4j_version"
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    runtime "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 


### PR DESCRIPTION
Fixes compatibility issue surfaced as "java.lang.NoClassDefFoundError: kotlin/jdk7/AutoCloseableKt"

