### PR TITLE
CORDA-2030: Resolve build warnings created by adding kotlin-stdlib-jre8 to node.

### DIFF
--- a/testing/test-utils/build.gradle
+++ b/testing/test-utils/build.gradle
@@ -9,7 +9,10 @@ description 'Testing utilities for Corda'
 
 dependencies {
     compile project(':test-common')
-    compile project(':node')
+    compile(project(':node')) {
+        // The Node only needs this for binary compatibility with Cordapps written in Kotlin 1.1.
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jre8'
+    }
     compile project(':client:mock')
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/tools/network-bootstrapper/build.gradle
+++ b/tools/network-bootstrapper/build.gradle
@@ -16,6 +16,9 @@ configurations {
     compile {
         exclude group: "log4j", module: "log4j"
         exclude group: "org.apache.logging.log4j"
+
+        // The Node only needs this for binary compatibility with Cordapps written in Kotlin 1.1.
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jre8'
     }
 }
 


### PR DESCRIPTION
Kotlin complains if it sees `kotlin-stdlib-jre8` on the compile classpath, so remove it for those cases where it doesn't need to be there.