### PR TITLE
[CORDA-2076] Do not remove entropyToKeyPair from DJVM

### DIFF
--- a/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/crypto/TransactionSignatureTest.kt
+++ b/core-deterministic/testing/src/test/kotlin/net/corda/deterministic/crypto/TransactionSignatureTest.kt
@@ -138,7 +138,6 @@ class TransactionSignatureTest {
         val signableData = SignableData(txId, SignatureMetadata(3, Crypto.findSignatureScheme(keyPair.public).schemeNumberID))
         return CheatingSecurityProvider().use {
             CryptoSignUtils.doSign(keyPair, signableData)
-
         }
     }
 }

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -809,7 +809,6 @@ object Crypto {
      * @return a new [KeyPair] from an entropy input.
      * @throws IllegalArgumentException if the requested signature scheme is not supported for KeyPair generation using an entropy input.
      */
-    @DeleteForDJVM
     @JvmStatic
     fun deriveKeyPairFromEntropy(signatureScheme: SignatureScheme, entropy: BigInteger): KeyPair {
         return when (signatureScheme) {
@@ -825,7 +824,6 @@ object Crypto {
      * @param entropy a [BigInteger] value.
      * @return a new [KeyPair] from an entropy input.
      */
-    @DeleteForDJVM
     @JvmStatic
     fun deriveKeyPairFromEntropy(entropy: BigInteger): KeyPair = deriveKeyPairFromEntropy(DEFAULT_SIGNATURE_SCHEME, entropy)
 

--- a/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CryptoUtils.kt
@@ -150,7 +150,6 @@ fun generateKeyPair(): KeyPair = Crypto.generateKeyPair()
  * @param entropy a [BigInteger] value.
  * @return a deterministically generated [KeyPair] for the [Crypto.DEFAULT_SIGNATURE_SCHEME].
  */
-@DeleteForDJVM
 fun entropyToKeyPair(entropy: BigInteger): KeyPair = Crypto.deriveKeyPairFromEntropy(entropy)
 
 /**


### PR DESCRIPTION
`entropyToKeyPair` is deterministic anyway and we might need it:
a) to generate keys in DJVM tests
b) special contracts might require to generate a key inside verify() (i.e., I only send the seed (because it's smaller than the actual key) to prove that I know a private key (i.e., in special commitment schemes).