### PR TITLE
CORDA-2030: Resolve build warnings about kotlin-stdlib-jre8 in unit tests too.

### DIFF
--- a/confidential-identities/build.gradle
+++ b/confidential-identities/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     testCompile "com.google.guava:guava-testlib:$guava_version"
 
     // Bring in the MockNode infrastructure for writing protocol unit tests.
-    testCompile project(":node")
     testCompile project(":node-driver")
 
     // AssertJ: for fluent assertions for testing

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     testCompile "com.google.guava:guava-testlib:$guava_version"
 
     // Bring in the MockNode infrastructure for writing protocol unit tests.
-    testCompile project(":node")
     testCompile project(":node-driver")
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"


### PR DESCRIPTION
The unit tests are inheriting `kotlin-stdlib-jre8` transitively from `:node`. However, `:node-driver` already includes `:node` _without_ `kotlin-stdlib-jre8` so just use that.