### PR TITLE
Gradle cache friendly Junit test fix.

### DIFF
--- a/core-deterministic/testing/data/build.gradle
+++ b/core-deterministic/testing/data/build.gradle
@@ -22,6 +22,9 @@ test {
         // Running this class is the whole point, so include it explicitly.
         includeTestsMatching "net.corda.deterministic.data.GenerateData"
     }
+    // force execution of these tests to generate artifacts required by other module (eg. VerifyTransactionTest)
+    // note: required by Gradle Build Cache.
+    outputs.upToDateWhen { false }
 }
 assemble.finalizedBy test
 


### PR DESCRIPTION
Gradle caches artefacts by task execution signature.
A test module of `core-deterministic` depends on the generated artefacts of an associated data module. Once the data module task is cached its generated outputs are no longer available to the test module (and hence 2 unit tests fail).
This fix forces re-execution of the data module prior to running the previously failing test module `VerifyTransactionTest`
