### PR TITLE
ENT-2569: Clean-up content of `registeredShutdowns`.

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ShutdownManager.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/ShutdownManager.kt
@@ -48,7 +48,12 @@ class ShutdownManager(private val executorService: ExecutorService) {
                 emptyList<CordaFuture<() -> Unit>>()
             } else {
                 isShutdown = true
-                registeredShutdowns
+                val result = ArrayList(registeredShutdowns)
+                // It is important to clear `registeredShutdowns` that has been actioned upon as more than 1 driver can be created per test.
+                // Given that `ShutdownManager` is reachable from `ApplicationShutdownHooks`, everything that was scheduled for shutdown
+                // during 1st driver launch will not be eligible for GC during second driver launch therefore retained in memory.
+                registeredShutdowns.clear()
+                result
             }
         }
 


### PR DESCRIPTION
Please see comment in the code for more info.

Also, to prove my point I am including memory profiler snapshot to show how particular object graph remains reachable from GC roots after driver run has finished.

![image](https://user-images.githubusercontent.com/31008341/46622900-e6b95680-cb23-11e8-8a84-f256f79e5c5d.png)