### PR TITLE
CORDA-2005: FinalityFlow has been made into an inlined flow to resolve issue with FinalityHandler

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2301,7 +2301,7 @@ public final class net.corda.core.flows.ReceiveStateAndRefFlow extends net.corda
   @NotNull
   public java.util.List<net.corda.core.contracts.StateAndRef<T>> call()
 ##
-public final class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.flows.FlowLogic
+public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, boolean)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)

--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesFlow.kt
@@ -28,6 +28,9 @@ import java.util.*
  */
 @StartableByRPC
 @InitiatingFlow
+// TODO Make this non-initiating as otherwise any CorDapp using confidential identities will cause its node to have an
+// open door where any counterparty will be able to swap identities at will. Instead SwapIdentitiesFlow and its counterpart,
+// SwapIdentitiesHandler, should be in-lined and called by CorDapp specfic-flows.
 class SwapIdentitiesFlow(private val otherParty: Party,
                          private val revocationEnabled: Boolean,
                          override val progressTracker: ProgressTracker) : FlowLogic<LinkedHashMap<Party, AnonymousParty>>() {

--- a/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/IdentitySyncFlowTests.kt
@@ -18,8 +18,8 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.singleIdentity
+import net.corda.testing.node.internal.FINANCE_CORDAPP
 import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.cordappsForPackages
 import net.corda.testing.node.internal.startFlow
 import org.junit.After
 import org.junit.Before
@@ -35,7 +35,7 @@ class IdentitySyncFlowTests {
     fun before() {
         // We run this in parallel threads to help catch any race conditions that may exist.
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts.asset", "net.corda.finance.schemas"),
+                cordappsForAllNodes = listOf(FINANCE_CORDAPP),
                 networkSendManuallyPumped = false,
                 threadPerNode = true
         )

--- a/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
@@ -187,9 +187,9 @@ class CollectSignatureFlow(val partiallySignedTx: SignedTransaction, val session
  *              }
  *
  *              // Invoke the subFlow, in response to the counterparty calling [CollectSignaturesFlow].
- *              val stx = subFlow(flow)
+ *              val expectedTxId = subFlow(flow).id
  *
- *              return waitForLedgerCommit(stx.id)
+ *              return subFlow(ReceiveFinalityFlow(otherPartySession, expectedTxId))
  *          }
  *      }
  *

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -23,9 +23,9 @@ import java.security.SignatureException
  * @property checkSufficientSignatures if true checks all required signatures are present. See [SignedTransaction.verify].
  * @property statesToRecord which transaction states should be recorded in the vault, if any.
  */
-class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSideSession: FlowSession,
-                                                       private val checkSufficientSignatures: Boolean = true,
-                                                       private val statesToRecord: StatesToRecord = StatesToRecord.NONE) : FlowLogic<SignedTransaction>() {
+open class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSideSession: FlowSession,
+                                                            private val checkSufficientSignatures: Boolean = true,
+                                                            private val statesToRecord: StatesToRecord = StatesToRecord.NONE) : FlowLogic<SignedTransaction>() {
     @Suppress("KDocMissingDocumentation")
     @Suspendable
     @Throws(SignatureException::class,
@@ -40,7 +40,7 @@ class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSideSess
         }
         val stx = otherSideSession.receive<SignedTransaction>().unwrap {
             it.pushToLoggingContext()
-            logger.info("Received transaction acknowledgement request from party ${otherSideSession.counterparty.name}.")
+            logger.info("Received transaction acknowledgement request from party ${otherSideSession.counterparty}.")
             subFlow(ResolveTransactionsFlow(it, otherSideSession))
             logger.info("Transaction dependencies resolution completed.")
             try {
@@ -54,12 +54,21 @@ class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSideSess
         if (checkSufficientSignatures) {
             // We should only send a transaction to the vault for processing if we did in fact fully verify it, and
             // there are no missing signatures. We don't want partly signed stuff in the vault.
+            checkBeforeRecording(stx)
             logger.info("Successfully received fully signed tx. Sending it to the vault for processing.")
             serviceHub.recordTransactions(statesToRecord, setOf(stx))
             logger.info("Successfully recorded received transaction locally.")
         }
         return stx
     }
+
+    /**
+     * Hook to perform extra checks on the received transaction just before it's recorded. The transaction has already
+     * been resolved and verified at this point.
+     */
+    @Suspendable
+    @Throws(FlowException::class)
+    protected open fun checkBeforeRecording(stx: SignedTransaction) = Unit
 }
 
 /**
@@ -74,7 +83,8 @@ class ReceiveStateAndRefFlow<out T : ContractState>(private val otherSideSession
     @Suspendable
     override fun call(): List<StateAndRef<T>> {
         return otherSideSession.receive<List<StateAndRef<T>>>().unwrap {
-            subFlow(ResolveTransactionsFlow(it.map { it.ref.txhash }.toSet(), otherSideSession))
+            val txHashes = it.asSequence().map { it.ref.txhash }.toSet()
+            subFlow(ResolveTransactionsFlow(txHashes, otherSideSession))
             it
         }
     }

--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -4,63 +4,98 @@ import com.natpryce.hamkrest.and
 import com.natpryce.hamkrest.assertion.assert
 import net.corda.core.flows.mixins.WithFinality
 import net.corda.core.identity.Party
+import net.corda.core.internal.cordapp.CordappInfoResolver
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
 import net.corda.finance.POUNDS
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.issuedBy
 import net.corda.testing.core.*
 import net.corda.testing.internal.matchers.flow.willReturn
 import net.corda.testing.internal.matchers.flow.willThrow
-import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.TestStartedNode
-import net.corda.testing.node.internal.cordappsForPackages
-import org.junit.AfterClass
+import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.internal.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.junit.After
 import org.junit.Test
 
 class FinalityFlowTests : WithFinality {
     companion object {
         private val CHARLIE = TestIdentity(CHARLIE_NAME, 90).party
-        private val classMockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(
-                "net.corda.finance.contracts.asset",
-                "net.corda.finance.schemas"
-        ))
-
-        @JvmStatic
-        @AfterClass
-        fun tearDown() = classMockNet.stopNodes()
     }
 
-    override val mockNet = classMockNet
+    override val mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(
+            "net.corda.finance.contracts.asset",
+            "net.corda.finance.schemas",
+            "net.corda.core.flows.mixins"
+    ))
 
     private val aliceNode = makeNode(ALICE_NAME)
-    private val bobNode = makeNode(BOB_NAME)
 
-    private val bob = bobNode.info.singleIdentity()
     private val notary = mockNet.defaultNotaryIdentity
+
+    @After
+    fun tearDown() = mockNet.stopNodes()
 
     @Test
     fun `finalise a simple transaction`() {
-        val stx = aliceNode.signCashTransactionWith(bob)
+        val bob = createBob()
+        val stx = aliceNode.issuesCashTo(bob)
 
         assert.that(
-            aliceNode.finalise(stx),
+            aliceNode.finalise(stx, bob.info.singleIdentity()),
                 willReturn(
                         requiredSignatures(1)
-                                and visibleTo(bobNode)))
+                                and visibleTo(bob)))
     }
 
     @Test
     fun `reject a transaction with unknown parties`() {
         // Charlie isn't part of this network, so node A won't recognise them
-        val stx = aliceNode.signCashTransactionWith(CHARLIE)
+        val stx = aliceNode.issuesCashTo(CHARLIE)
 
         assert.that(
             aliceNode.finalise(stx),
                 willThrow<IllegalArgumentException>())
     }
 
-    private fun TestStartedNode.signCashTransactionWith(other: Party): SignedTransaction {
+    @Test
+    fun `prevent use of the old API if the CorDapp target version is 4`() {
+        val bob = createBob()
+        val stx = aliceNode.issuesCashTo(bob)
+        val resultFuture = CordappInfoResolver.withCordappInfo(targetPlatformVersion = 4) {
+            @Suppress("DEPRECATION")
+            aliceNode.startFlowAndRunNetwork(FinalityFlow(stx)).resultFuture
+        }
+        assertThatIllegalArgumentException().isThrownBy {
+            resultFuture.getOrThrow()
+        }.withMessageContaining("A flow session for each external participant to the transaction must be provided.")
+    }
+
+    @Test
+    fun `allow use of the old API if the CorDapp target version is 3`() {
+        // We need Bob to load at least one old CorDapp so that its FinalityHandler is enabled
+        val bob = createBob(cordapps = listOf(cordappForPackages("com.template").withTargetVersion(3)))
+        val stx = aliceNode.issuesCashTo(bob)
+        val resultFuture = CordappInfoResolver.withCordappInfo(targetPlatformVersion = 3) {
+            @Suppress("DEPRECATION")
+            aliceNode.startFlowAndRunNetwork(FinalityFlow(stx)).resultFuture
+        }
+        resultFuture.getOrThrow()
+        assertThat(bob.services.validatedTransactions.getTransaction(stx.id)).isNotNull()
+    }
+
+    private fun createBob(cordapps: List<TestCordapp> = emptyList()): TestStartedNode {
+        return mockNet.createNode(InternalMockNodeParameters(legalName = BOB_NAME, additionalCordapps = cordapps))
+    }
+
+    private fun TestStartedNode.issuesCashTo(recipient: TestStartedNode): SignedTransaction {
+        return issuesCashTo(recipient.info.singleIdentity())
+    }
+
+    private fun TestStartedNode.issuesCashTo(other: Party): SignedTransaction {
         val amount = 1000.POUNDS.issuedBy(info.singleIdentity().ref(0))
         val builder = TransactionBuilder(notary)
         Cash().generateIssue(builder, amount, other, notary)

--- a/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
@@ -50,7 +50,7 @@ internal class CreateRefState : FlowLogic<SignedTransaction>() {
             addOutputState(RefState.State(ourIdentity), RefState.CONTRACT_ID)
             addCommand(RefState.Create(), listOf(ourIdentity.owningKey))
         })
-        return subFlow(FinalityFlow(stx))
+        return subFlow(FinalityFlow(stx, emptyList()))
     }
 }
 
@@ -64,7 +64,7 @@ internal class UpdateRefState(private val stateAndRef: StateAndRef<RefState.Stat
             addOutputState(stateAndRef.state.data.update(), RefState.CONTRACT_ID)
             addCommand(RefState.Update(), listOf(ourIdentity.owningKey))
         })
-        return subFlow(FinalityFlow(stx))
+        return subFlow(FinalityFlow(stx, emptyList()))
     }
 }
 
@@ -111,7 +111,7 @@ internal class UseRefState(private val linearId: UniqueIdentifier) : FlowLogic<S
             addOutputState(DummyState(), DummyContract.PROGRAM_ID)
             addCommand(DummyContract.Commands.Create(), listOf(ourIdentity.owningKey))
         })
-        return subFlow(FinalityFlow(stx))
+        return subFlow(FinalityFlow(stx, emptyList()))
     }
 }
 

--- a/core/src/test/kotlin/net/corda/core/internal/cordapp/CordappInfoResolverTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/cordapp/CordappInfoResolverTest.kt
@@ -1,42 +1,37 @@
 package net.corda.core.internal.cordapp
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class CordappInfoResolverTest {
-
     @Before
     @After
     fun clearCordappInfoResolver() {
         CordappInfoResolver.clear()
     }
 
-    @Test()
-    fun `The correct cordapp resolver is used after calling withCordappResolution`() {
+    @Test
+    fun `the correct cordapp resolver is used after calling withCordappInfo`() {
         val defaultTargetVersion = 222
 
         CordappInfoResolver.register(listOf(javaClass.name), CordappImpl.Info("test", "test", "2", 3, defaultTargetVersion))
-        assertEquals(defaultTargetVersion, returnCallingTargetVersion())
+        assertEquals(defaultTargetVersion, CordappInfoResolver.currentTargetVersion)
 
         val expectedTargetVersion = 555
-        CordappInfoResolver.withCordappInfoResolution( { CordappImpl.Info("foo", "bar", "1", 2, expectedTargetVersion) })
-        {
-            val actualTargetVersion = returnCallingTargetVersion()
+        CordappInfoResolver.withCordappInfo(targetPlatformVersion = expectedTargetVersion) {
+            val actualTargetVersion = CordappInfoResolver.currentTargetVersion
             assertEquals(expectedTargetVersion, actualTargetVersion)
         }
-        assertEquals(defaultTargetVersion, returnCallingTargetVersion())
+        assertEquals(defaultTargetVersion, CordappInfoResolver.currentTargetVersion)
     }
 
-    @Test()
-    fun `When more than one cordapp is registered for the same class, the resolver returns null`() {
+    @Test
+    fun `when more than one cordapp is registered for the same class, the resolver returns null`() {
         CordappInfoResolver.register(listOf(javaClass.name), CordappImpl.Info("test", "test", "2", 3, 222))
         CordappInfoResolver.register(listOf(javaClass.name), CordappImpl.Info("test1", "test1", "1", 2, 456))
-        assertEquals(0, returnCallingTargetVersion())
-    }
-
-    private fun returnCallingTargetVersion(): Int {
-        return CordappInfoResolver.getCorDappInfo()?.targetPlatformVersion ?: 0
+        assertThat(CordappInfoResolver.currentCordappInfo).isNull()
     }
 }

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -522,6 +522,9 @@ An example is the ``@InitiatingFlow InitiatorFlow``/``@InitiatedBy ResponderFlow
 
 .. note:: Initiating flows are versioned separately from their parents.
 
+.. note:: The only exception to this rule is ``FinalityFlow`` which is annotated with ``@InitiatingFlow`` but is an inlined flow. This flow
+   was previously initiating and the annotation exists to maintain backwards compatibility with old code.
+
 Core initiating subflows
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Corda-provided initiating subflows are a little different to standard ones as they are versioned together with the
@@ -532,8 +535,6 @@ Library flows
 ^^^^^^^^^^^^^
 Corda installs four initiating subflow pairs on each node by default:
 
-* ``FinalityFlow``/``FinalityHandler``, which should be used to notarise and record a transaction and broadcast it to
-  all relevant parties
 * ``NotaryChangeFlow``/``NotaryChangeHandler``, which should be used to change a state's notary
 * ``ContractUpgradeFlow.Initiate``/``ContractUpgradeHandler``, which should be used to change a state's contract
 * ``SwapIdentitiesFlow``/``SwapIdentitiesHandler``, which is used to exchange confidential identities with a
@@ -546,10 +547,13 @@ Corda installs four initiating subflow pairs on each node by default:
 Corda also provides a number of built-in inlined subflows that should be used for handling common tasks. The most
 important are:
 
-* ``CollectSignaturesFlow`` (inlined), which should be used to collect a transaction's required signatures
-* ``SendTransactionFlow`` (inlined), which should be used to send a signed transaction if it needed to be resolved on
+* ``FinalityFlow`` which is used to notarise, record locally and then broadcast a signed transaction to its participants
+  and any extra parties.
+* ``ReceiveFinalityFlow`` to receive these notarised transactions from the ``FinalityFlow`` sender and record locally.
+* ``CollectSignaturesFlow`` , which should be used to collect a transaction's required signatures
+* ``SendTransactionFlow`` , which should be used to send a signed transaction if it needed to be resolved on
   the other side.
-* ``ReceiveTransactionFlow`` (inlined), which should be used receive a signed transaction
+* ``ReceiveTransactionFlow``, which should be used receive a signed transaction
 
 Let's look at some of these flows in more detail.
 
@@ -588,20 +592,26 @@ We can also choose to send the transaction to additional parties who aren't one 
         :end-before: DOCEND 10
         :dedent: 12
 
-Only one party has to call ``FinalityFlow`` for a given transaction to be recorded by all participants. It does
-**not** need to be called by each participant individually.
+Only one party has to call ``FinalityFlow`` for a given transaction to be recorded by all participants. It **must not**
+be called by every participant. Instead, every other particpant **must** call ``ReceiveFinalityFlow`` in their responder
+flow to receive the transaction:
 
-Because the transaction has already been notarised and the input states consumed, if the participants when receiving the
-transaction fail to verify it, or the receiving flow (the finality handler) fails due to some other error, we then have
-the scenario where not all parties have the correct up to date view of the ledger. To recover from this the finality handler
-is automatically sent to the flow hospital where it's suspended and retried from its last checkpoint on node restart.
-This gives the node operator the opportunity to recover from the error. Until the issue is resolved the node will continue
-to retry the flow on each startup.
+.. container:: codeset
 
-.. note:: It's possible to forcibly terminate the erroring finality handler using the ``killFlow`` RPC but at the risk
-   of an inconsistent view of the ledger.
+    .. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/FlowCookbook.kt
+        :language: kotlin
+        :start-after: DOCSTART ReceiveFinalityFlow
+        :end-before: DOCEND ReceiveFinalityFlow
+        :dedent: 8
 
-.. note:: A future release will allow retrying hospitalised flows without restarting the node, i.e. via RPC.
+    .. literalinclude:: ../../docs/source/example-code/src/main/java/net/corda/docs/java/FlowCookbook.java
+        :language: java
+        :start-after: DOCSTART ReceiveFinalityFlow
+        :end-before: DOCEND ReceiveFinalityFlow
+        :dedent: 12
+
+``idOfTxWeSigned`` is an optional parameter used to confirm that we got the right transaction. It comes from using ``SignTransactionFlow``
+which is described below.
 
 CollectSignaturesFlow/SignTransactionFlow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/api-persistence.rst
+++ b/docs/source/api-persistence.rst
@@ -137,23 +137,23 @@ Use the ``ServiceHub`` ``jdbcSession`` function to obtain a JDBC connection as i
   :start-after: DOCSTART JdbcSession
   :end-before: DOCEND JdbcSession
 
-JDBC session's can be used in Flows and Service Plugins (see ":doc:`flow-state-machines`")
+JDBC sessions can be used in flows and services (see ":doc:`flow-state-machines`").
 
-The following example illustrates the creation of a custom corda service using a jdbcSession:
+The following example illustrates the creation of a custom Corda service using a ``jdbcSession``:
 
-.. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/CustomVaultQuery.kt
+.. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/vault/CustomVaultQuery.kt
   :language: kotlin
   :start-after: DOCSTART CustomVaultQuery
   :end-before: DOCEND CustomVaultQuery
 
 which is then referenced within a custom flow:
 
-.. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/CustomVaultQuery.kt
+.. literalinclude:: ../../docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/vault/CustomVaultQuery.kt
   :language: kotlin
   :start-after: DOCSTART TopupIssuer
   :end-before: DOCEND TopupIssuer
 
-For examples on testing ``@CordaService`` implementations, see the oracle example :doc:`here <oracles>`
+For examples on testing ``@CordaService`` implementations, see the oracle example :doc:`here <oracles>`.
 
 JPA Support
 -----------

--- a/docs/source/api-states.rst
+++ b/docs/source/api-states.rst
@@ -24,7 +24,7 @@ are considered to have a stake in the state. Among other things, the ``participa
 
 * Need to sign any notary-change and contract-upgrade transactions involving this state
 
-* Receive any finalised transactions involving this state as part of ``FinalityFlow``
+* Receive any finalised transactions involving this state as part of ``FinalityFlow`` / ``ReceiveFinalityFlow``
 
 ContractState sub-interfaces
 ----------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,9 +12,21 @@ Unreleased
 
 * New "validate-configuration" sub-command to `corda.jar`, allowing to validate the actual node configuration without starting the node.
 
-* Introduced new optional network bootstrapper command line option (--minimum-platform-version) to set as a network parameter
+* CorDapps now have the ability to specify a minimum platform version in their MANIFEST.MF to prevent old nodes from loading them.
 
-* Introduce minimum and target platform version for CorDapps.
+* CorDapps have the ability to specify a target platform version in their MANIFEST.MF as a means of indicating to the node
+  the app was designed and tested on that version.
+
+* Nodes will no longer automatically reject flow initiation requests for flows they don't know about. Instead the request will remain
+  un-acknowledged in the message broker. This enables the recovery scenerio whereby any missing CorDapp can be installed and retried on node
+  restart. As a consequence the initiating flow will be blocked until the receiving node has resolved the issue.
+
+* ``FinalityFlow`` is now an inlined flow and no longer requires a handler flow in the counterparty. This is to fix the
+  security problem with the handler flow as it accepts any transaction it receives without any checks. Existing CorDapp
+  binaries relying on this old behaviour will continue to function as previously. However, it is strongly recommended that
+  CorDapps switch to this new API. See :doc:`upgrade-notes` for further details.
+
+* Introduced new optional network bootstrapper command line option (--minimum-platform-version) to set as a network parameter
 
 * BFT-Smart and Raft notary implementations have been extracted out of node into ``experimental`` CorDapps to emphasise
   their experimental nature. Moreover, the BFT-Smart notary will only work in dev mode due to its use of Java serialization.

--- a/docs/source/contributing-flow-state-machines.rst
+++ b/docs/source/contributing-flow-state-machines.rst
@@ -85,12 +85,12 @@ flow with a full node.
 
 .. container:: codeset
 
-    .. literalinclude:: ../../docs/source/example-code/src/integration-test/kotlin/net/corda/docs/TutorialFlowAsyncOperationTest.kt
+    .. literalinclude:: ../../docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/TutorialFlowAsyncOperationTest.kt
         :language: kotlin
         :start-after: DOCSTART summingWorks
         :end-before: DOCEND summingWorks
 
-    .. literalinclude:: ../../docs/source/example-code/src/integration-test/java/net/corda/docs/java/TutorialFlowAsyncOperationTest.java
+    .. literalinclude:: ../../docs/source/example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/TutorialFlowAsyncOperationTest.java
         :language: java
         :start-after: DOCSTART summingWorks
         :end-before: DOCEND summingWorks

--- a/docs/source/example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java
+++ b/docs/source/example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java
@@ -1,4 +1,4 @@
-package net.corda.docs;
+package net.corda.docs.java.tutorial.test;
 
 import net.corda.client.rpc.CordaRPCClient;
 import net.corda.core.concurrent.CordaFuture;
@@ -18,7 +18,9 @@ import net.corda.testing.node.User;
 import org.junit.Test;
 import rx.Observable;
 
-import java.util.*;
+import java.util.Currency;
+import java.util.HashSet;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -38,7 +40,7 @@ public class JavaIntegrationTestingTutorial {
         // START 1
         driver(new DriverParameters()
                 .withStartNodesInProcess(true)
-                .withExtraCordappPackagesToScan(Arrays.asList("net.corda.finance.contracts.asset", "net.corda.finance.schemas")), dsl -> {
+                .withExtraCordappPackagesToScan(singletonList("net.corda.finance")), dsl -> {
 
             User aliceUser = new User("aliceUser", "testPassword1", new HashSet<>(asList(
                     startFlow(CashIssueAndPaymentFlow.class),

--- a/docs/source/example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/TutorialFlowAsyncOperationTest.java
+++ b/docs/source/example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/TutorialFlowAsyncOperationTest.java
@@ -1,4 +1,4 @@
-package net.corda.docs.java;
+package net.corda.docs.java.tutorial.test;
 
 import kotlin.Unit;
 import net.corda.client.rpc.CordaRPCClient;

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt
@@ -1,4 +1,4 @@
-package net.corda.docs
+package net.corda.docs.kotlin.tutorial.test
 
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.contracts.Amount
@@ -29,10 +29,7 @@ class KotlinIntegrationTestingTutorial {
     @Test
     fun `alice bob cash exchange example`() {
         // START 1
-        driver(DriverParameters(
-                startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.finance.contracts.asset", "net.corda.finance.schemas")
-        )) {
+        driver(DriverParameters(startNodesInProcess = true, extraCordappPackagesToScan = listOf("net.corda.finance"))) {
             val aliceUser = User("aliceUser", "testPassword1", permissions = setOf(
                     startFlow<CashIssueAndPaymentFlow>(),
                     invokeRpc("vaultTrackBy")

--- a/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/TutorialFlowAsyncOperationTest.kt
+++ b/docs/source/example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/TutorialFlowAsyncOperationTest.kt
@@ -1,4 +1,4 @@
-package net.corda.docs
+package net.corda.docs.kotlin.tutorial.test
 
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.messaging.startFlow

--- a/docs/source/example-code/src/main/java/net/corda/docs/java/FinalityFlowMigration.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/FinalityFlowMigration.java
@@ -1,0 +1,134 @@
+package net.corda.docs.java;
+
+import co.paralleluniverse.fibers.Suspendable;
+import net.corda.core.flows.*;
+import net.corda.core.identity.Party;
+import net.corda.core.transactions.SignedTransaction;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Collections.singletonList;
+
+@SuppressWarnings("ALL")
+public class FinalityFlowMigration {
+    public static SignedTransaction dummyTransactionWithParticipant(Party party) {
+        throw new UnsupportedOperationException();
+    }
+
+    // DOCSTART SimpleFlowUsingOldApi
+    public static class SimpleFlowUsingOldApi extends FlowLogic<SignedTransaction> {
+        private final Party counterparty;
+
+        @Suspendable
+        @Override
+        public SignedTransaction call() throws FlowException {
+            SignedTransaction stx = dummyTransactionWithParticipant(counterparty);
+            return subFlow(new FinalityFlow(stx));
+        }
+        // DOCEND SimpleFlowUsingOldApi
+
+        public SimpleFlowUsingOldApi(Party counterparty) {
+            this.counterparty = counterparty;
+        }
+    }
+
+    // DOCSTART SimpleFlowUsingNewApi
+    // Notice how the flow *must* now be an initiating flow even when it wasn't before.
+    @InitiatingFlow
+    public static class SimpleFlowUsingNewApi extends FlowLogic<SignedTransaction> {
+        private final Party counterparty;
+
+        @Suspendable
+        @Override
+        public SignedTransaction call() throws FlowException {
+            SignedTransaction stx = dummyTransactionWithParticipant(counterparty);
+            // For each non-local participant in the transaction we must initiate a flow session with them.
+            FlowSession session = initiateFlow(counterparty);
+            return subFlow(new FinalityFlow(stx, session));
+        }
+        // DOCEND SimpleFlowUsingNewApi
+
+        public SimpleFlowUsingNewApi(Party counterparty) {
+            this.counterparty = counterparty;
+        }
+    }
+    // DOCSTART SimpleNewResponderFlow
+    // All participants will run this flow to receive and record the finalised transaction into their vault.
+    @InitiatedBy(SimpleFlowUsingNewApi.class)
+    public static class SimpleNewResponderFlow extends FlowLogic<Void> {
+        private final FlowSession otherSide;
+
+        @Suspendable
+        @Override
+        public Void call() throws FlowException {
+            subFlow(new ReceiveFinalityFlow(otherSide));
+            return null;
+        }
+        // DOCEND SimpleNewResponderFlow
+
+        public SimpleNewResponderFlow(FlowSession otherSide) {
+            this.otherSide = otherSide;
+        }
+    }
+
+    // DOCSTART ExistingInitiatingFlow
+    // Assuming the previous version of the flow was 1 (the default if none is specified), we increment the version number to 2
+    // to allow for backwards compatibility with nodes running the old CorDapp.
+    @InitiatingFlow(version = 2)
+    public static class ExistingInitiatingFlow extends FlowLogic<SignedTransaction> {
+        private final Party counterparty;
+
+        @Suspendable
+        @Override
+        public SignedTransaction call() throws FlowException {
+            SignedTransaction partiallySignedTx = dummyTransactionWithParticipant(counterparty);
+            FlowSession session = initiateFlow(counterparty);
+            SignedTransaction fullySignedTx = subFlow(new CollectSignaturesFlow(partiallySignedTx, singletonList(session)));
+            // Determine which version of the flow that other side is using.
+            if (session.getCounterpartyFlowInfo().getFlowVersion() == 1) {
+                // Use the old API if the other side is using the previous version of the flow.
+                return subFlow(new FinalityFlow(fullySignedTx));
+            } else {
+                // Otherwise they're at least on version 2 and so we can send the finalised transaction on the existing session.
+                return subFlow(new FinalityFlow(fullySignedTx, session));
+            }
+        }
+        // DOCEND ExistingInitiatingFlow
+
+        public ExistingInitiatingFlow(Party counterparty) {
+            this.counterparty = counterparty;
+        }
+    }
+
+    @InitiatedBy(ExistingInitiatingFlow.class)
+    public static class ExistingResponderFlow extends FlowLogic<Void> {
+        private final FlowSession otherSide;
+
+        public ExistingResponderFlow(FlowSession otherSide) {
+            this.otherSide = otherSide;
+        }
+
+        @Suspendable
+        @Override
+        public Void call() throws FlowException {
+            SignedTransaction txWeJustSigned = subFlow(new SignTransactionFlow(otherSide) {
+                @Suspendable
+                @Override
+                protected void checkTransaction(@NotNull SignedTransaction stx) throws FlowException {
+                    // Do checks here
+                }
+            });
+            // DOCSTART ExistingResponderFlow
+            if (otherSide.getCounterpartyFlowInfo().getFlowVersion() >= 2) {
+                // The other side is not using the old CorDapp so call ReceiveFinalityFlow to record the finalised transaction.
+                // If SignTransactionFlow is used then we can verify the tranaction we receive for recording is the same one
+                // that was just signed.
+                subFlow(new ReceiveFinalityFlow(otherSide, txWeJustSigned.getId()));
+            } else {
+                // Otherwise the other side is running the old CorDapp and so we don't need to do anything further. The node
+                // will automatically record the finalised transaction using the old insecure mechanism.
+            }
+            // DOCEND ExistingResponderFlow
+            return null;
+        }
+    }
+}

--- a/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUFlow.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUFlow.java
@@ -2,16 +2,12 @@ package net.corda.docs.java.tutorial.helloworld;
 
 import co.paralleluniverse.fibers.Suspendable;
 import com.template.TemplateContract;
-import net.corda.core.flows.FlowException;
-import net.corda.core.flows.FlowLogic;
-import net.corda.core.flows.InitiatingFlow;
-import net.corda.core.flows.StartableByRPC;
+import net.corda.core.flows.*;
 import net.corda.core.utilities.ProgressTracker;
 
 // DOCSTART 01
 // Add these imports:
 import net.corda.core.contracts.Command;
-import net.corda.core.flows.FinalityFlow;
 import net.corda.core.identity.Party;
 import net.corda.core.transactions.SignedTransaction;
 import net.corda.core.transactions.TransactionBuilder;
@@ -59,8 +55,11 @@ public class IOUFlow extends FlowLogic<Void> {
         // Signing the transaction.
         SignedTransaction signedTx = getServiceHub().signInitialTransaction(txBuilder);
 
-        // Finalising the transaction.
-        subFlow(new FinalityFlow(signedTx));
+        // Creating a session with the other party.
+        FlowSession otherPartySession = initiateFlow(otherParty);
+
+        // We finalise the transaction and then send it to the counterparty.
+        subFlow(new FinalityFlow(signedTx, otherPartySession));
 
         return null;
     }

--- a/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUFlowResponder.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUFlowResponder.java
@@ -1,0 +1,25 @@
+package net.corda.docs.java.tutorial.helloworld;
+
+import co.paralleluniverse.fibers.Suspendable;
+import net.corda.core.flows.*;
+
+@SuppressWarnings("unused")
+// DOCSTART 01
+// Replace Responder's definition with:
+@InitiatedBy(IOUFlow.class)
+public class IOUFlowResponder extends FlowLogic<Void> {
+    private final FlowSession otherPartySession;
+
+    public IOUFlowResponder(FlowSession otherPartySession) {
+        this.otherPartySession = otherPartySession;
+    }
+
+    @Suspendable
+    @Override
+    public Void call() throws FlowException {
+        subFlow(new ReceiveFinalityFlow(otherPartySession));
+
+        return null;
+    }
+}
+// DOCEND 01

--- a/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlow.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlow.java
@@ -69,7 +69,7 @@ public class IOUFlow extends FlowLogic<Void> {
                 signedTx, Arrays.asList(otherPartySession), CollectSignaturesFlow.tracker()));
 
         // Finalising the transaction.
-        subFlow(new FinalityFlow(fullySignedTx));
+        subFlow(new FinalityFlow(fullySignedTx, otherPartySession));
 
         return null;
         // DOCEND 02

--- a/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlowResponder.java
+++ b/docs/source/example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlowResponder.java
@@ -1,15 +1,14 @@
 package net.corda.docs.java.tutorial.twoparty;
 
-// DOCSTART 01
-// Add these imports:
 import co.paralleluniverse.fibers.Suspendable;
 import net.corda.core.contracts.ContractState;
+import net.corda.core.crypto.SecureHash;
 import net.corda.core.flows.*;
 import net.corda.core.transactions.SignedTransaction;
-import net.corda.core.utilities.ProgressTracker;
 
 import static net.corda.core.contracts.ContractsDSL.requireThat;
 
+@SuppressWarnings("unused")
 // Define IOUFlowResponder:
 @InitiatedBy(IOUFlow.class)
 public class IOUFlowResponder extends FlowLogic<Void> {
@@ -22,9 +21,10 @@ public class IOUFlowResponder extends FlowLogic<Void> {
     @Suspendable
     @Override
     public Void call() throws FlowException {
+        // DOCSTART 01
         class SignTxFlow extends SignTransactionFlow {
-            private SignTxFlow(FlowSession otherPartySession, ProgressTracker progressTracker) {
-                super(otherPartySession, progressTracker);
+            private SignTxFlow(FlowSession otherPartySession) {
+                super(otherPartySession);
             }
 
             @Override
@@ -39,9 +39,11 @@ public class IOUFlowResponder extends FlowLogic<Void> {
             }
         }
 
-        subFlow(new SignTxFlow(otherPartySession, SignTransactionFlow.Companion.tracker()));
+        SecureHash expectedTxId = subFlow(new SignTxFlow(otherPartySession)).getId();
+
+        subFlow(new ReceiveFinalityFlow(otherPartySession, expectedTxId));
 
         return null;
+        // DOCEND 01
     }
 }
-// DOCEND 01

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/FinalityFlowMigration.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/FinalityFlowMigration.kt
@@ -1,0 +1,91 @@
+@file:Suppress("DEPRECATION", "unused", "UNUSED_PARAMETER")
+
+package net.corda.docs.kotlin
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+
+private fun dummyTransactionWithParticipant(party: Party): SignedTransaction = TODO()
+
+// DOCSTART SimpleFlowUsingOldApi
+class SimpleFlowUsingOldApi(private val counterparty: Party) : FlowLogic<SignedTransaction>() {
+    @Suspendable
+    override fun call(): SignedTransaction {
+        val stx = dummyTransactionWithParticipant(counterparty)
+        return subFlow(FinalityFlow(stx))
+    }
+}
+// DOCEND SimpleFlowUsingOldApi
+
+// DOCSTART SimpleFlowUsingNewApi
+// Notice how the flow *must* now be an initiating flow even when it wasn't before.
+@InitiatingFlow
+class SimpleFlowUsingNewApi(private val counterparty: Party) : FlowLogic<SignedTransaction>() {
+    @Suspendable
+    override fun call(): SignedTransaction {
+        val stx = dummyTransactionWithParticipant(counterparty)
+        // For each non-local participant in the transaction we must initiate a flow session with them.
+        val session = initiateFlow(counterparty)
+        return subFlow(FinalityFlow(stx, session))
+    }
+}
+// DOCEND SimpleFlowUsingNewApi
+
+// DOCSTART SimpleNewResponderFlow
+// All participants will run this flow to receive and record the finalised transaction into their vault.
+@InitiatedBy(SimpleFlowUsingNewApi::class)
+class SimpleNewResponderFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        subFlow(ReceiveFinalityFlow(otherSide))
+    }
+}
+// DOCEND SimpleNewResponderFlow
+
+// DOCSTART ExistingInitiatingFlow
+// Assuming the previous version of the flow was 1 (the default if none is specified), we increment the version number to 2
+// to allow for backwards compatibility with nodes running the old CorDapp.
+@InitiatingFlow(version = 2)
+class ExistingInitiatingFlow(private val counterparty: Party) : FlowLogic<SignedTransaction>() {
+    @Suspendable
+    override fun call(): SignedTransaction {
+        val partiallySignedTx = dummyTransactionWithParticipant(counterparty)
+        val session = initiateFlow(counterparty)
+        val fullySignedTx = subFlow(CollectSignaturesFlow(partiallySignedTx, listOf(session)))
+        // Determine which version of the flow that other side is using.
+        return if (session.getCounterpartyFlowInfo().flowVersion == 1) {
+            // Use the old API if the other side is using the previous version of the flow.
+            subFlow(FinalityFlow(fullySignedTx))
+        } else {
+            // Otherwise they're at least on version 2 and so we can send the finalised transaction on the existing session.
+            subFlow(FinalityFlow(fullySignedTx, session))
+        }
+    }
+}
+// DOCEND ExistingInitiatingFlow
+
+@InitiatedBy(ExistingInitiatingFlow::class)
+class ExistingResponderFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        val txWeJustSigned = subFlow(object : SignTransactionFlow(otherSide) {
+            @Suspendable
+            override fun checkTransaction(stx: SignedTransaction) {
+                // Do checks here
+            }
+        })
+        // DOCSTART ExistingResponderFlow
+        if (otherSide.getCounterpartyFlowInfo().flowVersion >= 2) {
+            // The other side is not using the old CorDapp so call ReceiveFinalityFlow to record the finalised transaction.
+            // If SignTransactionFlow is used then we can verify the tranaction we receive for recording is the same one
+            // that was just signed.
+            subFlow(ReceiveFinalityFlow(otherSide, expectedTxId = txWeJustSigned.id))
+        } else {
+            // Otherwise the other side is running the old CorDapp and so we don't need to do anything further. The node
+            // will automatically record the finalised transaction using the old insecure mechanism.
+        }
+        // DOCEND ExistingResponderFlow
+    }
+}

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/FxTransactionBuildTutorial.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/FxTransactionBuildTutorial.kt
@@ -160,7 +160,7 @@ class ForeignExchangeFlow(private val tradeId: String,
         }
 
         // Initiate the standard protocol to notarise and distribute to the involved parties.
-        subFlow(FinalityFlow(allPartySignedTx, setOf(counterparty)))
+        subFlow(FinalityFlow(allPartySignedTx, counterpartySession))
 
         return allPartySignedTx.id
     }
@@ -239,7 +239,8 @@ class ForeignExchangeRemoteFlow(private val source: FlowSession) : FlowLogic<Uni
 
         // send the other side our signature.
         source.send(ourSignature)
-        // N.B. The FinalityProtocol will be responsible for Notarising the SignedTransaction
-        // and broadcasting the result to us.
+
+        // and then finally stored the finalised transaction into our vault
+        subFlow(ReceiveFinalityFlow(source))
     }
 }

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUFlow.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUFlow.kt
@@ -43,8 +43,11 @@ class IOUFlow(val iouValue: Int,
         // We sign the transaction.
         val signedTx = serviceHub.signInitialTransaction(txBuilder)
 
-        // We finalise the transaction.
-        subFlow(FinalityFlow(signedTx))
+        // Creating a session with the other party.
+        val otherPartySession = initiateFlow(otherParty)
+
+        // We finalise the transaction and then send it to the counterparty.
+        subFlow(FinalityFlow(signedTx, otherPartySession))
     }
 }
 // DOCEND 01

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUFlowResponder.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUFlowResponder.kt
@@ -1,0 +1,20 @@
+@file:Suppress("unused")
+
+package net.corda.docs.kotlin.tutorial.helloworld
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.ReceiveFinalityFlow
+
+// DOCSTART 01
+// Replace Responder's definition with:
+@InitiatedBy(IOUFlow::class)
+class IOUFlowResponder(private val otherPartySession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        subFlow(ReceiveFinalityFlow(otherPartySession))
+    }
+}
+// DOCEND 01

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/twoparty/IOUFlow.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/twoparty/IOUFlow.kt
@@ -52,7 +52,7 @@ class IOUFlow(val iouValue: Int,
         val fullySignedTx = subFlow(CollectSignaturesFlow(signedTx, listOf(otherPartySession), CollectSignaturesFlow.tracker()))
 
         // Finalising the transaction.
-        subFlow(FinalityFlow(fullySignedTx))
+        subFlow(FinalityFlow(fullySignedTx, otherPartySession))
         // DOCEND 02
     }
 }

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/twoparty/IOUFlowResponder.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/twoparty/IOUFlowResponder.kt
@@ -17,7 +17,8 @@ import net.corda.core.transactions.SignedTransaction
 class IOUFlowResponder(val otherPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
-        val signTransactionFlow = object : SignTransactionFlow(otherPartySession, SignTransactionFlow.tracker()) {
+        // DOCSTART 01
+        val signTransactionFlow = object : SignTransactionFlow(otherPartySession) {
             override fun checkTransaction(stx: SignedTransaction) = requireThat {
                 val output = stx.tx.outputs.single().data
                 "This must be an IOU transaction." using (output is IOUState)
@@ -26,7 +27,9 @@ class IOUFlowResponder(val otherPartySession: FlowSession) : FlowLogic<Unit>() {
             }
         }
 
-        subFlow(signTransactionFlow)
+        val expectedTxId = subFlow(signTransactionFlow).id
+
+        subFlow(ReceiveFinalityFlow(otherPartySession, expectedTxId))
+        // DOCEND 01
     }
 }
-// DOCEND 01

--- a/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/vault/CustomVaultQuery.kt
+++ b/docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/vault/CustomVaultQuery.kt
@@ -1,6 +1,6 @@
 @file:Suppress("unused", "MemberVisibilityCanBePrivate")
 
-package net.corda.docs.kotlin
+package net.corda.docs.kotlin.vault
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
@@ -68,7 +68,6 @@ object CustomVaultQuery {
  *  This is a slightly modified version of the IssuerFlow, which uses a 3rd party custom query to
  *  retrieve a list of currencies and top up amounts to be used in the issuance.
  */
-
 object TopupIssuerFlow {
     @CordaSerializable
     data class TopupRequest(val issueToParty: Party,

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/kotlin/txbuild/WorkflowTransactionBuildTutorialTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/kotlin/txbuild/WorkflowTransactionBuildTutorialTest.kt
@@ -1,9 +1,10 @@
-package net.corda.docs.kotlin
+package net.corda.docs.kotlin.txbuild
 
 import net.corda.core.contracts.LinearState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.Party
+import net.corda.core.internal.packageName
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
@@ -33,7 +34,7 @@ class WorkflowTransactionBuildTutorialTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.docs"))
+        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf(javaClass.packageName))
         aliceNode = mockNet.createPartyNode(ALICE_NAME)
         bobNode = mockNet.createPartyNode(BOB_NAME)
         alice = aliceNode.services.myInfo.identityFromX500Name(ALICE_NAME)

--- a/docs/source/example-code/src/test/kotlin/net/corda/docs/kotlin/vault/CustomVaultQueryTest.kt
+++ b/docs/source/example-code/src/test/kotlin/net/corda/docs/kotlin/vault/CustomVaultQueryTest.kt
@@ -1,13 +1,14 @@
-package net.corda.docs.kotlin
+package net.corda.docs.kotlin.vault
 
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.ContractState
 import net.corda.core.identity.Party
+import net.corda.core.internal.packageName
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.*
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
-import net.corda.docs.java.tutorial.helloworld.IOUFlow
+import net.corda.docs.kotlin.tutorial.helloworld.IOUFlow
 import net.corda.finance.*
 import net.corda.finance.contracts.getCashBalances
 import net.corda.finance.flows.CashIssueFlow
@@ -17,7 +18,7 @@ import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.StartedMockNode
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import java.util.*
@@ -30,7 +31,7 @@ class CustomVaultQueryTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance", "net.corda.docs", "com.template"))
+        mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance", IOUFlow::class.packageName, javaClass.packageName, "com.template"))
         nodeA = mockNet.createPartyNode()
         nodeB = mockNet.createPartyNode()
         notary = mockNet.defaultNotaryIdentity
@@ -43,7 +44,6 @@ class CustomVaultQueryTest {
 
     @Test
     fun `query by max recorded time`() {
-
         nodeA.startFlow(IOUFlow(1000, nodeB.info.singleIdentity())).getOrThrow()
         nodeA.startFlow(IOUFlow(500, nodeB.info.singleIdentity())).getOrThrow()
 
@@ -69,9 +69,9 @@ class CustomVaultQueryTest {
         topUpCurrencies()
         val (cashBalancesAfterTopup, _) = getBalances()
 
-        Assert.assertEquals(cashBalancesOriginal[GBP]?.times(2), cashBalancesAfterTopup[GBP])
-        Assert.assertEquals(cashBalancesOriginal[USD]?.times(2)  , cashBalancesAfterTopup[USD])
-        Assert.assertEquals(cashBalancesOriginal[CHF]?.times( 2), cashBalancesAfterTopup[CHF])
+        assertEquals(cashBalancesOriginal[GBP]?.times(2), cashBalancesAfterTopup[GBP])
+        assertEquals(cashBalancesOriginal[USD]?.times(2)  , cashBalancesAfterTopup[USD])
+        assertEquals(cashBalancesOriginal[CHF]?.times( 2), cashBalancesAfterTopup[CHF])
     }
 
     private fun issueCashForCurrency(amountToIssue: Amount<Currency>) {
@@ -86,7 +86,8 @@ class CustomVaultQueryTest {
                 nodeA.info.singleIdentity(),
                 OpaqueBytes.of(0x01),
                 nodeA.info.singleIdentity(),
-                notary)).getOrThrow()
+                notary)
+        ).getOrThrow()
     }
 
     private fun getBalances(): Pair<Map<Currency, Amount<Currency>>, Map<Currency, Amount<Currency>>> {

--- a/docs/source/flow-state-machines.rst
+++ b/docs/source/flow-state-machines.rst
@@ -227,8 +227,8 @@ Next, we call another subflow called ``SignTransactionFlow``. ``SignTransactionF
 
 The transaction then needs to be finalized. This is the the process of sending the transaction to a notary to assert
 (with another signature) that the time-window in the transaction (if any) is valid and there are no double spends.
-In this flow, finalization is handled by the buyer, so we just wait for the signed transaction to appear in our
-transaction storage. It will have the same ID as the one we started with but more signatures.
+In this flow, finalization is handled by the buyer, we just wait for them to send it to us. It will have the same ID as
+the one we started with but more signatures.
 
 Implementing the buyer
 ----------------------
@@ -314,9 +314,11 @@ On the buyer side, we use ``FinalityFlow`` to finalise the transaction. It will:
 * Record the transaction in the local vault, if it is relevant (i.e. involves the owner of the node).
 * Send the fully signed transaction to the other participants for recording as well.
 
-.. warning:: If the seller stops before sending the finalised transaction to the buyer, the seller is left with a
-   valid transaction but the buyer isn't, so they can't spend the asset they just purchased! This sort of thing is not
-   always a risk (as the seller may not gain anything from that sort of behaviour except a lawsuit), but if it is, a future
+On the seller side we use ``ReceiveFinalityFlow`` to receive and record the finalised transaction.
+
+.. warning:: If the buyer stops before sending the finalised transaction to the seller, the buyer is left with a
+   valid transaction but the seller isn't, so they don't get the cash! This sort of thing is not
+   always a risk (as the buyer may not gain anything from that sort of behaviour except a lawsuit), but if it is, a future
    version of the platform will allow you to ask the notary to send you the transaction as well, in case your counterparty
    does not. This is not the default because it reveals more private info to the notary.
 

--- a/docs/source/hello-world-flow.rst
+++ b/docs/source/hello-world-flow.rst
@@ -21,11 +21,11 @@ require the following steps:
 
   1. Building the transaction proposal for the issuance of a new IOU onto a ledger
   2. Signing the transaction proposal
-  3. Recording the transaction
-  4. Sending the transaction to the IOU's borrower so that they can record it too
+  3. Recording the transaction and sending it to the IOU's borrower so that they can record it too
 
-At this stage, we do not require the borrower to approve and sign IOU issuance transactions. We will be able to impose
-this requirement when we look at contracts in the next tutorial.
+We also need the borrower to receive the transaction and record it for itself. At this stage, we do not require the borrower
+to approve and sign IOU issuance transactions. We will be able to impose this requirement when we look at contracts in the
+next tutorial.
 
 Subflows
 ^^^^^^^^
@@ -34,13 +34,11 @@ forcing each developer to reimplement their own logic to handle these tasks, Cor
 to handle these tasks. We call these flows that are invoked in the context of a larger flow to handle a repeatable task
 *subflows*.
 
-In our case, we can automate steps 3 and 4 of the IOU issuance flow using ``FinalityFlow``.
-
 FlowLogic
 ---------
 All flows must subclass ``FlowLogic``. You then define the steps taken by the flow by overriding ``FlowLogic.call``.
 
-Let's define our ``IOUFlow``. Delete the existing ``Responder`` flow. Then replace the definition of ``Initiator`` with the following:
+Let's define our ``IOUFlow``. Replace the definition of ``Initiator`` with the following:
 
 .. container:: codeset
 
@@ -54,8 +52,9 @@ Let's define our ``IOUFlow``. Delete the existing ``Responder`` flow. Then repla
         :start-after: DOCSTART 01
         :end-before: DOCEND 01
 
-If you're following along in Java, you'll also need to rename ``Initiator.java`` to ``IOUFlow.java``. Let's walk
-through this code step-by-step.
+If you're following along in Java, you'll also need to rename ``Initiator.java`` to ``IOUFlow.java``.
+
+Let's walk through this code step-by-step.
 
 We've defined our own ``FlowLogic`` subclass that overrides ``FlowLogic.call``. ``FlowLogic.call`` has a return type
 that must match the type parameter passed to ``FlowLogic`` - this is type returned by running the flow.
@@ -73,7 +72,7 @@ annotation out will lead to some very weird error messages!
 There are also a few more annotations, on the ``FlowLogic`` subclass itself:
 
   * ``@InitiatingFlow`` means that this flow is part of a flow pair and that it triggers the other side to run the
-    the counterpart flow.
+    the counterpart flow (which in our case is the ``IOUFlowResponder`` defined below).
   * ``@StartableByRPC`` allows the node owner to start this flow via an RPC call
 
 Let's walk through the steps of ``FlowLogic.call`` itself. This is where we actually describe the procedure for
@@ -145,13 +144,34 @@ We sign the transaction using ``ServiceHub.signInitialTransaction``, which retur
 
 Finalising the transaction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-We now have a valid signed transaction. All that's left to do is to have it recorded by all the relevant parties. By
-doing so, it will become a permanent part of the ledger. As discussed, we'll handle this process automatically using a
-built-in flow called ``FinalityFlow``. ``FinalityFlow`` completely automates the process of:
+We now have a valid signed transaction. All that's left to do is to get the notary to sign it, have that recorded
+locally and then send it to all the relevant parties. Once that happens the transaction will become a permanent part of the
+ledger. We use ``FinalityFlow`` which does all of this for the lender.
 
-* Notarising the transaction if required (i.e. if the transaction contains inputs and/or a time-window)
-* Recording it in our vault
-* Sending it to the other participants (i.e. the lender) for them to record as well
+For the borrower to receive the transaction they just need a flow that responds to the seller's.
+
+Creating the borrower's flow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The borrower has to use ``ReceiveFinalityFlow`` in order to receive and record the transaction; it needs to respond to
+the lender's flow. Let's do that by replacing ``Responder`` from the template with the following:
+
+.. container:: codeset
+
+    .. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/tutorial/helloworld/IOUFlowResponder.kt
+        :language: kotlin
+        :start-after: DOCSTART 01
+        :end-before: DOCEND 01
+
+    .. literalinclude:: example-code/src/main/java/net/corda/docs/java/tutorial/helloworld/IOUFlowResponder.java
+        :language: java
+        :start-after: DOCSTART 01
+        :end-before: DOCEND 01
+
+As with the ``IOUFlow``, our ``IOUFlowResponder`` flow is a ``FlowLogic`` subclass where we've overridden ``FlowLogic.call``.
+
+The flow is annotated with ``InitiatedBy(IOUFlow.class)``, which means that your node will invoke
+``IOUFlowResponder.call`` when it receives a message from a instance of ``Initiator`` running on another node. This message
+will be the finalised transaction which will be recorded in the borrower's vault.
 
 Progress so far
 ---------------

--- a/docs/source/tut-two-party-flow.rst
+++ b/docs/source/tut-two-party-flow.rst
@@ -65,13 +65,10 @@ transaction proposal before finalising it by adding our signature.
 Requesting the borrower's signature
 -----------------------------------
 
-We now need to communicate with the borrower to request their signature over the transaction. Whenever you want to
-communicate with another party in the context of a flow, you first need to establish a flow session with them. If the
-counterparty has a ``FlowLogic`` registered to respond to the ``FlowLogic`` initiating the session, a session will be
-established. All communication between the two ``FlowLogic`` instances will then place as part of this session.
+Previously we wrote a responder flow for the borrower in order to receive the finalised transaction from the lender.
+We use this same flow to first request their signature over the transaction.
 
-Once we have a session with the borrower, we gather the borrower's signature using ``CollectSignaturesFlow``, which
-takes:
+We gather the borrower's signature using ``CollectSignaturesFlow``, which takes:
 
 * A transaction signed by the flow initiator
 * A list of flow-sessions between the flow initiator and the required signers
@@ -80,11 +77,11 @@ And returns a transaction signed by all the required signers.
 
 We can then pass this fully-signed transaction into ``FinalityFlow``.
 
-Creating the borrower's flow
+Updating the borrower's flow
 ----------------------------
-On the lender's side, we used ``CollectSignaturesFlow`` to automate the collection of signatures. To allow the lender
-to respond, we need to write a response flow as well. In a new ``IOUFlowResponder.java`` file in Java, or within the
-``App.kt`` file in Kotlin, add the following class:
+On the lender's side, we used ``CollectSignaturesFlow`` to automate the collection of signatures. To allow the borrower
+to respond, we need to update its responder flow to first receive the partially signed transaction for signing. Update
+``IOUFlowResponder.call`` to be the following:
 
 .. container:: codeset
 
@@ -92,19 +89,13 @@ to respond, we need to write a response flow as well. In a new ``IOUFlowResponde
         :language: kotlin
         :start-after: DOCSTART 01
         :end-before: DOCEND 01
+        :dedent: 8
 
     .. literalinclude:: example-code/src/main/java/net/corda/docs/java/tutorial/twoparty/IOUFlowResponder.java
         :language: java
         :start-after: DOCSTART 01
         :end-before: DOCEND 01
-
-As with the ``IOUFlow``, our ``IOUFlowResponder`` flow is a ``FlowLogic`` subclass where we've overridden
-``FlowLogic.call``.
-
-The flow is annotated with ``InitiatedBy(IOUFlow.class)``, which means that your node will invoke
-``IOUFlowResponder.call`` when it receives a message from a instance of ``Initiator`` running on another node. What
-will this message from the ``IOUFlow`` be? If we look at the definition of ``CollectSignaturesFlow``, we can see that
-we'll be sent a ``SignedTransaction``, and are expected to send back our signature over that transaction.
+        :dedent: 8
 
 We could write our own flow to handle this process. However, there is also a pre-defined flow called
 ``SignTransactionFlow`` that can handle the process automatically. The only catch is that ``SignTransactionFlow`` is an
@@ -127,6 +118,9 @@ signatures are contractually valid.
 
 Once we've defined the ``SignTransactionFlow`` subclass, we invoke it using ``FlowLogic.subFlow``, and the
 communication with the borrower's and the lender's flow is conducted automatically.
+
+``SignedTransactionFlow`` returns the newly signed transaction. We pass in the transaction's ID to ``ReceiveFinalityFlow``
+to ensure we are recording the correct notarised transaction from the lender.
 
 Conclusion
 ----------

--- a/docs/source/tut-two-party-introduction.rst
+++ b/docs/source/tut-two-party-introduction.rst
@@ -7,7 +7,7 @@ In the Hello, World tutorial, we built a CorDapp allowing us to model IOUs on le
 elements:
 
 * An ``IOUState``, representing IOUs on the blockchain
-* An ``IOUFlow``, orchestrating the process of agreeing the creation of an IOU on-ledger
+* An ``IOUFlow`` and ``IOFlowResponder`` flow pair, orchestrating the process of agreeing the creation of an IOU on-ledger
 
 However, our CorDapp did not impose any constraints on the evolution of IOUs on the blockchain over time. Anyone was free
 to create IOUs of any value, between any party.

--- a/docs/source/tutorial-building-transactions.rst
+++ b/docs/source/tutorial-building-transactions.rst
@@ -81,12 +81,10 @@ To give a few more specific details consider two simplified real world
 scenarios. First, a basic foreign exchange cash transaction. This
 transaction needs to locate a set of funds to exchange. A flow
 modelling this is implemented in ``FxTransactionBuildTutorial.kt``
-(see ``docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/FxTransactionBuildTutorial.kt`` in the
-`main Corda repo <https://github.com/corda/corda>`_).
+(in the `main Corda repo <https://github.com/corda/corda>`_).
 Second, a simple business model in which parties manually accept or
 reject each other's trade proposals, which is implemented in
-``WorkflowTransactionBuildTutorial.kt`` (see
-``docs/source/example-code/src/main/kotlin/net/corda/docs/kotlin/WorkflowTransactionBuildTutorial.kt`` in the
+``WorkflowTransactionBuildTutorial.kt`` (in the
 `main Corda repo <https://github.com/corda/corda>`_). To run and explore these
 examples using the IntelliJ IDE one can run/step through the respective unit
 tests in ``FxTransactionBuildTutorialTest.kt`` and
@@ -148,7 +146,7 @@ parameters to the flow to identify the states being operated upon. Thus
 code to gather the latest input state for a given ``StateRef`` would use
 the ``VaultService`` as follows:
 
-.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/WorkflowTransactionBuildTutorial.kt
+.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/txbuild/WorkflowTransactionBuildTutorial.kt
     :language: kotlin
     :start-after: DOCSTART 1
     :end-before: DOCEND 1
@@ -221,7 +219,7 @@ and convert it into a ``SignedTransaction``.
 
 Examples of this process are:
 
-.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/WorkflowTransactionBuildTutorial.kt
+.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/txbuild/WorkflowTransactionBuildTutorial.kt
     :language: kotlin
     :start-after: DOCSTART 2
     :end-before: DOCEND 2
@@ -260,7 +258,7 @@ context. For example, the flow may need to check that the parties are the
 right ones, or that the ``Command`` present on the transaction is as
 expected for this specific flow. An example of this from the demo code is:
 
-.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/WorkflowTransactionBuildTutorial.kt
+.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/txbuild/WorkflowTransactionBuildTutorial.kt
     :language: kotlin
     :start-after: DOCSTART 3
     :end-before: DOCEND 3
@@ -277,7 +275,7 @@ Once all the signatures are applied to the ``SignedTransaction``, the
 final steps are notarisation and ensuring that all nodes record the fully-signed transaction. The
 code for this is standardised in the ``FinalityFlow``:
 
-.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/WorkflowTransactionBuildTutorial.kt
+.. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/txbuild/WorkflowTransactionBuildTutorial.kt
     :language: kotlin
     :start-after: DOCSTART 4
     :end-before: DOCEND 4

--- a/docs/source/tutorial-integration-testing.rst
+++ b/docs/source/tutorial-integration-testing.rst
@@ -21,13 +21,13 @@ a local network where all the nodes see each other and provides safe shutting do
 
 .. container:: codeset
 
-    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/KotlinIntegrationTestingTutorial.kt
+    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt
         :language: kotlin
         :start-after: START 1
         :end-before: END 1
         :dedent: 8
 
-    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/JavaIntegrationTestingTutorial.java
+    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java
         :language: java
         :start-after: START 1
         :end-before: END 1
@@ -49,13 +49,13 @@ the information returned; their respective ``NodeHandles`` s.
 
 .. container:: codeset
 
-    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/KotlinIntegrationTestingTutorial.kt
+    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt
         :language: kotlin
         :start-after: START 2
         :end-before: END 2
         :dedent: 12
 
-    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/JavaIntegrationTestingTutorial.java
+    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java
         :language: java
         :start-after: START 2
         :end-before: END 2
@@ -66,13 +66,13 @@ us to start flows and query state.
 
 .. container:: codeset
 
-    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/KotlinIntegrationTestingTutorial.kt
+    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt
         :language: kotlin
         :start-after: START 3
         :end-before: END 3
         :dedent: 12
 
-    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/JavaIntegrationTestingTutorial.java
+    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java
         :language: java
         :start-after: START 3
         :end-before: END 3
@@ -84,13 +84,13 @@ Now that we're all set up we can finally get some cash action going!
 
 .. container:: codeset
 
-    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/KotlinIntegrationTestingTutorial.kt
+    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt
         :language: kotlin
         :start-after: START 4
         :end-before: END 4
         :dedent: 12
 
-    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/JavaIntegrationTestingTutorial.java
+    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java
         :language: java
         :start-after: START 4
         :end-before: END 4
@@ -106,13 +106,13 @@ is asserting.
 
 .. container:: codeset
 
-    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/KotlinIntegrationTestingTutorial.kt
+    .. literalinclude:: example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt
         :language: kotlin
         :start-after: START 5
         :end-before: END 5
         :dedent: 12
 
-    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/JavaIntegrationTestingTutorial.java
+    .. literalinclude:: example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java
         :language: java
         :start-after: START 5
         :end-before: END 5
@@ -123,6 +123,6 @@ Next we want Bob to send this cash back to Alice.
 That's it! We saw how to start up several corda nodes locally, how to connect to them, and how to test some simple invariants
 about ``CashIssueAndPaymentFlow`` and ``CashPaymentFlow``.
 
-You can find the complete test at ``example-code/src/integration-test/java/net/corda/docs/JavaIntegrationTestingTutorial.java``
-(Java) and ``example-code/src/integration-test/kotlin/net/corda/docs/KotlinIntegrationTestingTutorial.kt`` (Kotlin) in the
+You can find the complete test at ``example-code/src/integration-test/java/net/corda/docs/java/tutorial/test/JavaIntegrationTestingTutorial.java``
+(Java) and ``example-code/src/integration-test/kotlin/net/corda/docs/kotlin/tutorial/test/KotlinIntegrationTestingTutorial.kt`` (Kotlin) in the
 `Corda repo <https://github.com/corda/corda>`_.

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -1,3 +1,9 @@
+.. highlight:: kotlin
+.. raw:: html
+
+   <script type="text/javascript" src="_static/jquery.js"></script>
+   <script type="text/javascript" src="_static/codesets.js"></script>
+
 Upgrading a CorDapp to a new platform version
 =============================================
 
@@ -34,21 +40,120 @@ do this by connecting directly to the node's ``persistence.mv.db`` file. See :re
 UNRELEASED
 ----------
 
-* Database upgrade - Change the type of the ``checkpoint_value``.
-This will address the issue that the `vacuum` function is unable to clean up deleted checkpoints as they are still referenced from the ``pg_shdepend`` table.
+FinalityFlow
+^^^^^^^^^^^^
+
+The previous ``FinalityFlow`` API is insecure. It requires a handler flow in the counterparty node which accepts any and
+all signed transactions that are sent to it, without checks. It is **highly** recommended that existing CorDapps migrate
+away to the new API.
+
+As an example, let's take a very simple flow that finalises a transaction without the involvement of a counterpart flow:
+
+.. container:: codeset
+
+    .. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/FinalityFlowMigration.kt
+        :language: kotlin
+        :start-after: DOCSTART SimpleFlowUsingOldApi
+        :end-before: DOCEND SimpleFlowUsingOldApi
+
+    .. literalinclude:: example-code/src/main/java/net/corda/docs/java/FinalityFlowMigration.java
+        :language: java
+        :start-after: DOCSTART SimpleFlowUsingOldApi
+        :end-before: DOCEND SimpleFlowUsingOldApi
+        :dedent: 4
+
+To use the new API, this flow needs to be annotated with ``InitiatingFlow`` and a ``FlowSession`` to the participant of the transaction must be
+passed to ``FinalityFlow`` :
+
+.. container:: codeset
+
+    .. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/FinalityFlowMigration.kt
+        :language: kotlin
+        :start-after: DOCSTART SimpleFlowUsingNewApi
+        :end-before: DOCEND SimpleFlowUsingNewApi
+
+    .. literalinclude:: example-code/src/main/java/net/corda/docs/java/FinalityFlowMigration.java
+        :language: java
+        :start-after: DOCSTART SimpleFlowUsingNewApi
+        :end-before: DOCEND SimpleFlowUsingNewApi
+        :dedent: 4
+
+If there are more than one transaction participants then a session to each one must be initiated, excluding the local party
+and the notary.
+
+A responder flow has to be introduced, which will automatically run on the other participants' nodes, which will call ``ReceiveFinalityFlow``
+to record the finalised transaction:
+
+.. container:: codeset
+
+    .. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/FinalityFlowMigration.kt
+        :language: kotlin
+        :start-after: DOCSTART SimpleNewResponderFlow
+        :end-before: DOCEND SimpleNewResponderFlow
+
+    .. literalinclude:: example-code/src/main/java/net/corda/docs/java/FinalityFlowMigration.java
+        :language: java
+        :start-after: DOCSTART SimpleNewResponderFlow
+        :end-before: DOCEND SimpleNewResponderFlow
+        :dedent: 4
+
+For flows which are already initiating counterpart flows then it's a simple matter of using the existing flow session.
+Note however, the new ``FinalityFlow`` is inlined and so the sequence of sends and receives between the two flows will
+change and will be incompatible with your current flows. You can use the flow version API to write your flows in a
+backwards compatible way.
+
+Here's what an upgraded initiating flow may look like:
+
+.. container:: codeset
+
+    .. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/FinalityFlowMigration.kt
+        :language: kotlin
+        :start-after: DOCSTART ExistingInitiatingFlow
+        :end-before: DOCEND ExistingInitiatingFlow
+
+    .. literalinclude:: example-code/src/main/java/net/corda/docs/java/FinalityFlowMigration.java
+        :language: java
+        :start-after: DOCSTART ExistingInitiatingFlow
+        :end-before: DOCEND ExistingInitiatingFlow
+        :dedent: 4
+
+For the responder flow, insert a call to ``ReceiveFinalityFlow`` at the location where it's expecting to receive the
+finalised transaction. If the initiator is written in a backwards compatible way then so must the responder.
+
+.. container:: codeset
+
+    .. literalinclude:: example-code/src/main/kotlin/net/corda/docs/kotlin/FinalityFlowMigration.kt
+        :language: kotlin
+        :start-after: DOCSTART ExistingResponderFlow
+        :end-before: DOCEND ExistingResponderFlow
+        :dedent: 8
+
+    .. literalinclude:: example-code/src/main/java/net/corda/docs/java/FinalityFlowMigration.java
+        :language: java
+        :start-after: DOCSTART ExistingResponderFlow
+        :end-before: DOCEND ExistingResponderFlow
+        :dedent: 12
+
+The responder flow may be waiting for the finalised transaction to appear in the local node's vault using ``waitForLedgerCommit``.
+This is no longer necessary with ``ReceiveFinalityFlow`` and the call to ``waitForLedgerCommit`` can be removed.
+
+Database schema changes
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The type of the ``checkpoint_value`` column has changed. This will address the issue that the `vacuum` function is unable
+to clean up deleted checkpoints as they are still referenced from the ``pg_shdepend`` table.
 
 For Postgres:
 
-  .. sourcecode:: sql
+.. sourcecode:: sql
 
     ALTER TABLE node_checkpoints ALTER COLUMN checkpoint_value set data type bytea;
 
 For H2:
 
-  .. sourcecode:: sql
+.. sourcecode:: sql
 
     ALTER TABLE node_checkpoints ALTER COLUMN checkpoint_value set data type VARBINARY(33554432);
-
 
 * API change: ``net.corda.core.schemas.PersistentStateRef`` fields (``index`` and ``txId``) incorrectly marked as nullable are now non-nullable,
   :doc:`changelog` contains the explanation.

--- a/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/Utils.kt
+++ b/experimental/corda-utils/src/main/kotlin/io/cryptoblk/core/Utils.kt
@@ -20,16 +20,6 @@ inline fun <reified T : ContractState> ServiceHub.queryStateByRef(ref: StateRef)
 }
 
 /**
- * Shorthand when a single party signs a TX and then returns a result that uses the signed TX (e.g. includes the TX id)
- */
-@Suspendable
-fun <R> FlowLogic<R>.finalize(tx: TransactionBuilder, returnWithSignedTx: (stx: SignedTransaction) -> R): R {
-    val stx = serviceHub.signInitialTransaction(tx)
-    subFlow(FinalityFlow(stx)) // it'll send to all participants in the state by default
-    return returnWithSignedTx(stx)
-}
-
-/**
  * Corda fails when it tries to store the same attachment hash twice. And it's convenient to also do nothing if no attachment is provided.
  * This doesn't fix the same-attachment problem completely but should at least help in testing with the same file.
  */

--- a/finance/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/AbstractCashFlow.kt
@@ -2,12 +2,8 @@ package net.corda.finance.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowException
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.NotaryException
+import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
@@ -27,9 +23,9 @@ abstract class AbstractCashFlow<out T>(override val progressTracker: ProgressTra
     }
 
     @Suspendable
-    protected fun finaliseTx(tx: SignedTransaction, extraParticipants: Set<Party>, message: String): SignedTransaction {
+    protected fun finaliseTx(tx: SignedTransaction, sessions: Collection<FlowSession>, message: String): SignedTransaction {
         try {
-            return subFlow(FinalityFlow(tx, extraParticipants))
+            return subFlow(FinalityFlow(tx, sessions))
         } catch (e: NotaryException) {
             throw CashException(message, e)
         }

--- a/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/CashPaymentFlow.kt
@@ -4,7 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.confidential.SwapIdentitiesFlow
 import net.corda.core.contracts.Amount
 import net.corda.core.contracts.InsufficientBalanceException
-import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.*
 import net.corda.core.identity.AnonymousParty
 import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
@@ -28,6 +28,7 @@ import java.util.*
  * for testing purposes.
  */
 @StartableByRPC
+@InitiatingFlow
 open class CashPaymentFlow(
         val amount: Amount<Currency>,
         val recipient: Party,
@@ -75,7 +76,8 @@ open class CashPaymentFlow(
 
         progressTracker.currentStep = FINALISING_TX
         logger.info("Finalising transaction for: ${tx.id}")
-        val notarised = finaliseTx(tx, setOf(recipient), "Unable to notarise spend")
+        val sessions = if (serviceHub.myInfo.isLegalIdentity(recipient)) emptyList() else listOf(initiateFlow(recipient))
+        val notarised = finaliseTx(tx, sessions, "Unable to notarise spend")
         logger.info("Finalised transaction for: ${notarised.id}")
         return Result(notarised, anonymousRecipient)
     }
@@ -86,4 +88,12 @@ open class CashPaymentFlow(
                          val anonymous: Boolean,
                          val issuerConstraint: Set<Party> = emptySet(),
                          val notary: Party? = null) : AbstractRequest(amount)
+}
+
+@InitiatedBy(CashPaymentFlow::class)
+class CashPaymentResponderFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        subFlow(ReceiveFinalityFlow(otherSide))
+    }
 }

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
@@ -71,7 +71,7 @@ object TwoPartyDealFlow {
 
             val txId = subFlow(signTransactionFlow).id
 
-            return waitForLedgerCommit(txId)
+            return subFlow(ReceiveFinalityFlow(otherSideSession, expectedTxId = txId))
         }
 
         @Suspendable
@@ -81,8 +81,7 @@ object TwoPartyDealFlow {
     /**
      * Abstracted bilateral deal flow participant that is recipient of initial communication.
      */
-    abstract class Secondary<U>(override val progressTracker: ProgressTracker = Secondary.tracker(),
-                                val regulators: Set<Party> = emptySet()) : FlowLogic<SignedTransaction>() {
+    abstract class Secondary<U>(override val progressTracker: ProgressTracker = Secondary.tracker()) : FlowLogic<SignedTransaction>() {
 
         companion object {
             object RECEIVING : ProgressTracker.Step("Waiting for deal info.")
@@ -124,7 +123,7 @@ object TwoPartyDealFlow {
             logger.trace("Got signatures from other party, verifying ... ")
 
             progressTracker.currentStep = RECORDING
-            val ftx = subFlow(FinalityFlow(stx, regulators + otherSideSession.counterparty))
+            val ftx = subFlow(FinalityFlow(stx, otherSideSession))
             logger.trace("Recorded transaction.")
 
             return ftx

--- a/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
@@ -114,7 +114,7 @@ object TwoPartyTradeFlow {
             val txId = subFlow(signTransactionFlow).id
             // DOCEND 5
 
-            return waitForLedgerCommit(txId)
+            return subFlow(ReceiveFinalityFlow(otherSideSession, expectedTxId = txId))
         }
         // DOCEND 4
 
@@ -188,7 +188,7 @@ object TwoPartyTradeFlow {
 
             // Notarise and record the transaction.
             progressTracker.currentStep = RECORDING
-            return subFlow(FinalityFlow(twiceSignedTx))
+            return subFlow(FinalityFlow(twiceSignedTx, sellerSession))
         }
 
         @Suspendable

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
@@ -33,7 +33,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
 class FlowsDrainingModeContentionTest {
-
     private val portAllocation = PortAllocation.Incremental(10000)
     private val user = User("mark", "dadada", setOf(all()))
     private val users = listOf(user)
@@ -90,7 +89,7 @@ class ProposeTransactionAndWaitForCommit(private val data: String,
         subFlow(SendTransactionFlow(session, signedTx))
         session.send(myRpcInfo)
 
-        return waitForLedgerCommit(signedTx.id)
+        return subFlow(ReceiveFinalityFlow(session, expectedTxId = signedTx.id))
     }
 }
 
@@ -104,7 +103,7 @@ class SignTransactionTriggerDrainingModeAndFinality(private val session: FlowSes
 
         triggerDrainingModeForInitiatingNode(initiatingRpcInfo)
 
-        subFlow(FinalityFlow(signedTx, setOf(session.counterparty)))
+        subFlow(FinalityFlow(signedTx, session))
     }
 
     private fun triggerDrainingModeForInitiatingNode(initiatingRpcInfo: RpcInfo) {

--- a/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/persistence/NodeStatePersistenceTests.kt
@@ -136,6 +136,6 @@ class SendMessageFlow(private val message: Message, private val notary: Party) :
         val signedTx = serviceHub.signInitialTransaction(txBuilder)
 
         progressTracker.currentStep = FINALISING_TRANSACTION
-        return subFlow(FinalityFlow(signedTx, FINALISING_TRANSACTION.childProgressTracker()))
+        return subFlow(FinalityFlow(signedTx, emptyList(), FINALISING_TRANSACTION.childProgressTracker()))
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
@@ -4,9 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import com.google.common.collect.ImmutableList
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.concurrent.CordaFuture
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.messaging.startFlow
@@ -32,6 +30,7 @@ import kotlin.test.assertEquals
 
 class ScheduledFlowIntegrationTests {
     @StartableByRPC
+    @InitiatingFlow
     class InsertInitialStateFlow(private val destination: Party,
                                  private val notary: Party,
                                  private val identity: Int = 1,
@@ -44,11 +43,20 @@ class ScheduledFlowIntegrationTests {
                     .addOutputState(scheduledState, DummyContract.PROGRAM_ID)
                     .addCommand(dummyCommand(ourIdentity.owningKey))
             val tx = serviceHub.signInitialTransaction(builder)
-            subFlow(FinalityFlow(tx))
+            subFlow(FinalityFlow(tx, initiateFlow(destination)))
+        }
+    }
+
+    @InitiatedBy(InsertInitialStateFlow::class)
+    class InsertInitialStateResponderFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            subFlow(ReceiveFinalityFlow(otherSide))
         }
     }
 
     @StartableByRPC
+    @InitiatingFlow
     class AnotherFlow(private val identity: String) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
@@ -64,7 +72,15 @@ class ScheduledFlowIntegrationTests {
                     .addOutputState(outputState, DummyContract.PROGRAM_ID)
                     .addCommand(dummyCommand(ourIdentity.owningKey))
             val tx = serviceHub.signInitialTransaction(builder)
-            subFlow(FinalityFlow(tx, outputState.participants.toSet()))
+            subFlow(FinalityFlow(tx, initiateFlow(state.state.data.destination)))
+        }
+    }
+
+    @InitiatedBy(AnotherFlow::class)
+    class AnotherResponderFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            subFlow(ReceiveFinalityFlow(otherSide))
         }
     }
 

--- a/node/src/integration-test/kotlin/net/corda/testMessage/ScheduledState.kt
+++ b/node/src/integration-test/kotlin/net/corda/testMessage/ScheduledState.kt
@@ -2,10 +2,7 @@ package net.corda.testMessage
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
-import net.corda.core.flows.FinalityFlow
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowLogicRefFactory
-import net.corda.core.flows.SchedulableFlow
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.NonEmptySet
@@ -16,6 +13,7 @@ import java.util.*
 import kotlin.reflect.jvm.jvmName
 
 @SchedulableFlow
+@InitiatingFlow
 class ScheduledFlow(private val stateRef: StateRef) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
@@ -35,7 +33,15 @@ class ScheduledFlow(private val stateRef: StateRef) : FlowLogic<Unit>() {
                 .addOutputState(newStateOutput, DummyContract.PROGRAM_ID)
                 .addCommand(dummyCommand(ourIdentity.owningKey))
         val tx = serviceHub.signInitialTransaction(builder)
-        subFlow(FinalityFlow(tx, setOf(scheduledState.destination)))
+        subFlow(FinalityFlow(tx, initiateFlow(scheduledState.destination)))
+    }
+}
+
+@InitiatedBy(ScheduledFlow::class)
+class ScheduledResponderFlow(private val otherSide: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        subFlow(ReceiveFinalityFlow(otherSide))
     }
 }
 

--- a/node/src/integration-test/kotlin/net/test/cordapp/v1/FlowCheckpointCordapp.kt
+++ b/node/src/integration-test/kotlin/net/test/cordapp/v1/FlowCheckpointCordapp.kt
@@ -49,9 +49,9 @@ class SendMessageFlow(private val message: Message, private val notary: Party, p
         return if (reciepent != null) {
             val session = initiateFlow(reciepent)
             subFlow(SendTransactionFlow(session, signedTx))
-            subFlow(FinalityFlow(signedTx, setOf(reciepent), FINALISING_TRANSACTION.childProgressTracker()))
+            subFlow(FinalityFlow(signedTx, listOf(session), FINALISING_TRANSACTION.childProgressTracker()))
         } else {
-            subFlow(FinalityFlow(signedTx, FINALISING_TRANSACTION.childProgressTracker()))
+            subFlow(FinalityFlow(signedTx, emptyList(), FINALISING_TRANSACTION.childProgressTracker()))
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -649,10 +649,37 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     }
 
     private fun installCoreFlows() {
-        flowManager.registerInitiatedCoreFlowFactory(FinalityFlow::class, FinalityHandler::class, ::FinalityHandler)
+        installFinalityHandler()
         flowManager.registerInitiatedCoreFlowFactory(NotaryChangeFlow::class, NotaryChangeHandler::class, ::NotaryChangeHandler)
         flowManager.registerInitiatedCoreFlowFactory(ContractUpgradeFlow.Initiate::class, NotaryChangeHandler::class, ::ContractUpgradeHandler)
+        // TODO Make this an inlined flow (and remove this flow mapping!), which should be possible now that FinalityFlow is also inlined
         flowManager.registerInitiatedCoreFlowFactory(SwapIdentitiesFlow::class, SwapIdentitiesHandler::class, ::SwapIdentitiesHandler)
+    }
+
+    // The FinalityHandler is insecure as it blindly accepts any and all transactions into the node's local vault without doing any checks.
+    // To plug this hole, the sending-side FinalityFlow has been made inlined with an inlined ReceiveFinalityFlow counterpart. The old
+    // FinalityFlow API is gated to only work with old CorDapps (those whose target platform version < 4), and the FinalityHandler will only
+    // work if there is at least one old CorDapp loaded (to preserve backwards compatibility).
+    //
+    // If an attempt is made to send us a transaction via FinalityHandler, and it's disabled, we will reject the request at the session-init
+    // level by throwing a FinalityHandlerDisabled exception. This is picked up by the flow hospital which will not send the error back
+    // (immediately) and instead pause the request by keeping it un-acknowledged in the message broker. This means the request isn't lost
+    // across node restarts and allows the node operator time to accept or reject the request.
+    // TODO Add public API to allow the node operator to accept or reject
+    private fun installFinalityHandler() {
+        // Disable the insecure FinalityHandler if none of the loaded CorDapps are old enough to require it.
+        val cordappsNeedingFinalityHandler = cordappLoader.cordapps.filter { it.info.targetPlatformVersion < 4 }
+        if (cordappsNeedingFinalityHandler.isEmpty()) {
+            log.info("FinalityHandler is disabled as there are no CorDapps loaded which require it")
+        } else {
+            log.warn("FinalityHandler is enabled as there are CorDapps that require it: ${cordappsNeedingFinalityHandler.map { it.info }}. " +
+                    "This is insecure and it is strongly recommended that newer versions of these CorDapps be used instead.")
+        }
+        val disabled = cordappsNeedingFinalityHandler.isEmpty()
+        flowManager.registerInitiatedCoreFlowFactory(FinalityFlow::class, FinalityHandler::class) {
+            if (disabled) throw SessionRejectException.FinalityHandlerDisabled()
+            FinalityHandler(it)
+        }
     }
 
     protected open fun makeTransactionStorage(transactionCacheSizeBytes: Long): WritableTransactionStorage {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
@@ -12,5 +12,8 @@ open class SessionRejectException(message: String) : CordaException(message) {
     class NotAFlow(val initiatorClass: Class<*>) : SessionRejectException("${initiatorClass.name} is not a flow")
 
     class NotRegistered(val initiatorFlowClass: Class<out FlowLogic<*>>) : SessionRejectException("${initiatorFlowClass.name} is not registered")
-}
 
+    class FinalityHandlerDisabled : SessionRejectException("Counterparty attempting to use the old insecure API of FinalityFlow. However this " +
+            "API is disabled on this node since there no CorDapps installed that require it. It may be that the counterparty is running an " +
+            "older verison of a CorDapp.")
+}

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -42,6 +42,9 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
             // installed on restart, at which point the message will be able proceed as normal. If not then it will need
             // to be dropped manually.
             Outcome.OVERNIGHT_OBSERVATION
+        } else if (error is SessionRejectException.FinalityHandlerDisabled) {
+            // TODO We need a way to be able to give the green light to such a session-init message
+            Outcome.OVERNIGHT_OBSERVATION
         } else {
             Outcome.UNTREATABLE
         }
@@ -284,7 +287,8 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
 
         private fun warn(flowLogic: FinalityHandler, flowFiber: FlowFiber, currentState: StateMachineState) {
             log.warn("Flow ${flowFiber.id} failed to be finalised. Manual intervention may be required before retrying " +
-                    "the flow by re-starting the node. State machine state: $currentState, initiating party was: ${flowLogic.sender().name}")
+                    "the flow by re-starting the node. State machine state: $currentState, initiating party was: " +
+                    "${flowLogic.sender.counterparty}")
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/FinalityHandlerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/FinalityHandlerTest.kt
@@ -1,8 +1,12 @@
 package net.corda.node.services
 
+import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.StateMachineRunId
+import net.corda.core.internal.cordapp.CordappInfoResolver
+import net.corda.core.internal.packageName
 import net.corda.core.toFuture
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -16,8 +20,10 @@ import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.internal.*
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Test
+import rx.Observable
 
 class FinalityHandlerTest {
     private val mockNet = InternalMockNetwork()
@@ -31,51 +37,115 @@ class FinalityHandlerTest {
     fun `sent to flow hospital on error and attempted retry on node restart`() {
         // Setup a network where only Alice has the finance CorDapp and it sends a cash tx to Bob who doesn't have the
         // CorDapp. Bob's FinalityHandler will error when validating the tx.
-        val alice = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME, additionalCordapps = setOf(FINANCE_CORDAPP)))
+        val alice = mockNet.createNode(InternalMockNodeParameters(
+                legalName = ALICE_NAME,
+                additionalCordapps = setOf(FINANCE_CORDAPP)
+        ))
 
-        var bob = mockNet.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
+        var bob = mockNet.createNode(InternalMockNodeParameters(
+                legalName = BOB_NAME,
+                // The node disables the FinalityHandler completely if there are no old CorDapps loaded, so we need to add
+                // a token old CorDapp to keep the handler running.
+                additionalCordapps = setOf(cordappForPackages(javaClass.packageName).withTargetVersion(3))
+        ))
 
-        val stx = TransactionBuilder(mockNet.defaultNotaryIdentity).let {
-            Cash().generateIssue(
-                    it,
-                    1000.POUNDS.issuedBy(alice.info.singleIdentity().ref(0)),
-                    bob.info.singleIdentity(),
-                    mockNet.defaultNotaryIdentity
-            )
-            alice.services.signInitialTransaction(it)
+        val stx = alice.issueCashTo(bob)
+        val finalityHandlerId = bob.trackFinalityHandlerId().run {
+            alice.finaliseWithOldApi(stx)
+            getOrThrow()
         }
 
-        val finalityHandlerIdFuture = bob.smm.track()
-                .updates
-                .filter { it.logic is FinalityHandler }
-                .map { it.logic.runId }
-                .toFuture()
-
-        val finalisedTx = alice.services.startFlow(FinalityFlow(stx)).run {
-            mockNet.runNetwork()
-            resultFuture.getOrThrow()
-        }
-        val finalityHandlerId = finalityHandlerIdFuture.getOrThrow()
-
-        bob.assertFlowSentForObservation(finalityHandlerId)
-        assertThat(bob.getTransaction(finalisedTx.id)).isNull()
+        bob.assertFlowSentForObservationDueToConstraintError(finalityHandlerId)
+        assertThat(bob.getTransaction(stx.id)).isNull()
 
         bob = mockNet.restartNode(bob)
         // Since we've not done anything to fix the orignal error, we expect the finality handler to be sent to the hospital
         // again on restart
-        bob.assertFlowSentForObservation(finalityHandlerId)
-        assertThat(bob.getTransaction(finalisedTx.id)).isNull()
+        bob.assertFlowSentForObservationDueToConstraintError(finalityHandlerId)
+        assertThat(bob.getTransaction(stx.id)).isNull()
     }
 
-    private fun TestStartedNode.assertFlowSentForObservation(runId: StateMachineRunId) {
-        val keptInForObservation = smm.flowHospital
-                .track()
-                .let { it.updates.startWith(it.snapshot) }
-                .ofType(MedicalRecord.Flow::class.java)
-                .filter { it.flowId == runId && it.outcome == Outcome.OVERNIGHT_OBSERVATION }
+    @Test
+    fun `disabled if there are no old CorDapps loaded`() {
+        val alice = mockNet.createNode(InternalMockNodeParameters(
+                legalName = ALICE_NAME,
+                additionalCordapps = setOf(FINANCE_CORDAPP)
+        ))
+
+        val bob = mockNet.createNode(InternalMockNodeParameters(
+                legalName = BOB_NAME,
+                // Make sure the target version is 4, and not the current platform version which may be greater
+                additionalCordapps = setOf(FINANCE_CORDAPP.withTargetVersion(4))
+        ))
+
+        val stx = alice.issueCashTo(bob)
+        val finalityFuture = alice.finaliseWithOldApi(stx)
+
+        val record = bob.medicalRecordsOfType<MedicalRecord.SessionInit>()
                 .toBlocking()
                 .first()
-        assertThat(keptInForObservation.by).contains(FinalityDoctor)
+        assertThat(record.outcome).isEqualTo(Outcome.OVERNIGHT_OBSERVATION)
+        assertThat(record.sender).isEqualTo(alice.info.singleIdentity())
+        assertThat(record.initiatorFlowClassName).isEqualTo(FinalityFlow::class.java.name)
+
+        assertThat(bob.getTransaction(stx.id)).isNull()
+
+        // Drop the session-init so that Alice gets the error message
+        assertThat(finalityFuture).isNotDone()
+        bob.smm.flowHospital.dropSessionInit(record.id)
+        mockNet.runNetwork()
+        assertThatThrownBy {
+            finalityFuture.getOrThrow()
+        }.hasMessageContaining("Counterparty attempting to use the old insecure API of FinalityFlow")
+    }
+
+    private fun TestStartedNode.issueCashTo(recipient: TestStartedNode): SignedTransaction {
+        return TransactionBuilder(mockNet.defaultNotaryIdentity).let {
+            Cash().generateIssue(
+                    it,
+                    1000.POUNDS.issuedBy(info.singleIdentity().ref(0)),
+                    recipient.info.singleIdentity(),
+                    mockNet.defaultNotaryIdentity
+            )
+            services.signInitialTransaction(it)
+        }
+    }
+
+    private fun TestStartedNode.trackFinalityHandlerId(): CordaFuture<StateMachineRunId> {
+        return smm
+                .track()
+                .updates
+                .filter { it.logic is FinalityHandler }
+                .map { it.logic.runId }
+                .toFuture()
+    }
+
+    private fun TestStartedNode.finaliseWithOldApi(stx: SignedTransaction): CordaFuture<SignedTransaction> {
+        return CordappInfoResolver.withCordappInfo(targetPlatformVersion = 3) {
+            @Suppress("DEPRECATION")
+            services.startFlow(FinalityFlow(stx)).resultFuture.apply {
+                mockNet.runNetwork()
+            }
+        }
+    }
+
+    private inline fun <reified R : MedicalRecord> TestStartedNode.medicalRecordsOfType(): Observable<R> {
+        return smm
+                .flowHospital
+                .track()
+                .let { it.updates.startWith(it.snapshot) }
+                .ofType(R::class.java)
+    }
+
+    private fun TestStartedNode.assertFlowSentForObservationDueToConstraintError(runId: StateMachineRunId) {
+        val observation = medicalRecordsOfType<MedicalRecord.Flow>()
+                .filter { it.flowId == runId }
+                .toBlocking()
+                .first()
+        assertThat(observation.outcome).isEqualTo(Outcome.OVERNIGHT_OBSERVATION)
+        assertThat(observation.by).contains(FinalityDoctor)
+        val error = observation.errors.single()
+        assertThat(error).isInstanceOf(TransactionVerificationException.ContractConstraintRejection::class.java)
     }
 
     private fun TestStartedNode.getTransaction(id: SecureHash): SignedTransaction? {

--- a/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt
@@ -65,7 +65,7 @@ class ServiceHubConcurrentUsageTest {
             val issuer = ourIdentity.ref(OpaqueBytes.of(0))
             Cash().generateIssue(builder, 10.DOLLARS.issuedBy(issuer), ourIdentity, notary)
             val stx = serviceHub.signInitialTransaction(builder)
-            return subFlow(FinalityFlow(stx))
+            return subFlow(FinalityFlow(stx, emptyList()))
         }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -143,7 +143,7 @@ class TimedFlowTests {
                 setTimeWindow(services.clock.instant(), 30.seconds)
                 addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
             }
-            val flow = FinalityFlow(issueTx)
+            val flow = FinalityFlow(issueTx, emptyList())
             val progressTracker = flow.progressTracker
             assertNotEquals(ProgressTracker.DONE, progressTracker.currentStep)
             val progressTrackerDone = getDoneFuture(flow.progressTracker)

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -101,12 +101,13 @@ class VaultSoftLockManagerTest {
     object CommandDataImpl : CommandData
 
     class ClientLogic(nodePair: NodePair, val state: ContractState) : NodePair.AbstractClientLogic<List<ContractState>>(nodePair) {
-        override fun callImpl() = run {
-            subFlow(FinalityFlow(serviceHub.signInitialTransaction(TransactionBuilder(notary = ourIdentity).apply {
+        override fun callImpl(): List<ContractState> {
+            val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = ourIdentity).apply {
                 addOutputState(state, ContractImpl::class.jvmName)
                 addCommand(CommandDataImpl, ourIdentity.owningKey)
-            })))
-            serviceHub.vaultService.queryBy<ContractState>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(LOCKED_ONLY))).states.map {
+            })
+            subFlow(FinalityFlow(stx, emptyList()))
+            return serviceHub.vaultService.queryBy<ContractState>(VaultQueryCriteria(softLockingCondition = SoftLockingCondition(LOCKED_ONLY))).states.map {
                 it.state.data
             }
         }

--- a/samples/network-verifier/src/main/kotlin/net/corda/verification/TestCommsFlow.kt
+++ b/samples/network-verifier/src/main/kotlin/net/corda/verification/TestCommsFlow.kt
@@ -44,7 +44,7 @@ class TestCommsFlowInitiator(private val x500Name: CordaX500Name? = null) : Flow
         tx.addOutputState(CommsTestState(responses, serviceHub.myInfo.legalIdentities.first()), CommsTestContract::class.java.name)
         tx.addCommand(CommsTestCommand, serviceHub.myInfo.legalIdentities.first().owningKey)
         val signedTx = serviceHub.signInitialTransaction(tx)
-        subFlow(FinalityFlow(signedTx))
+        subFlow(FinalityFlow(signedTx, emptyList()))
         return responses
     }
 

--- a/samples/network-verifier/src/main/kotlin/net/corda/verification/TestNotaryFlow.kt
+++ b/samples/network-verifier/src/main/kotlin/net/corda/verification/TestNotaryFlow.kt
@@ -32,14 +32,14 @@ class TestNotaryFlow : FlowLogic<String>() {
         issueBuilder.addOutputState(NotaryTestState(notary.name.toString(), myIdentity), NotaryTestContract::class.java.name)
         issueBuilder.addCommand(NotaryTestCommand, myIdentity.owningKey)
         val signedTx = serviceHub.signInitialTransaction(issueBuilder)
-        val issueResult = subFlow(FinalityFlow(signedTx))
+        val issueResult = subFlow(FinalityFlow(signedTx, emptyList()))
         progressTracker.currentStep = ISSUED
         val destroyBuilder = TransactionBuilder()
         destroyBuilder.notary = notary
         destroyBuilder.addInputState(issueResult.tx.outRefsOfType<NotaryTestState>().first())
         destroyBuilder.addCommand(NotaryTestCommand, myIdentity.owningKey)
         val signedDestroyT = serviceHub.signInitialTransaction(destroyBuilder)
-        val result = subFlow(FinalityFlow(signedDestroyT))
+        val result = subFlow(FinalityFlow(signedDestroyT, emptyList()))
         progressTracker.currentStep = DESTROYING
         progressTracker.currentStep = FINALIZED
         return "notarised: ${result.notary}::${result.tx.id}"

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -586,7 +586,7 @@ data class DriverParameters(
     fun withNetworkParameters(networkParameters: NetworkParameters): DriverParameters = copy(networkParameters = networkParameters)
     fun withNotaryCustomOverrides(notaryCustomOverrides: Map<String, Any?>): DriverParameters = copy(notaryCustomOverrides = notaryCustomOverrides)
     fun withInMemoryDB(inMemoryDB: Boolean): DriverParameters = copy(inMemoryDB = inMemoryDB)
-    fun withCordappsForAllNodes(cordappsForAllNodes: Set<TestCordapp>?): DriverParameters = copy(cordappsForAllNodes = cordappsForAllNodes)
+    fun withCordappsForAllNodes(cordappsForAllNodes: Collection<TestCordapp>?): DriverParameters = copy(cordappsForAllNodes = cordappsForAllNodes)
 
     fun copy(
             isDebug: Boolean,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/TestCordapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/TestCordapp.kt
@@ -10,7 +10,7 @@ import net.corda.testing.node.internal.simplifyScanPackages
  */
 @DoNotImplement
 interface TestCordapp {
-    /** Returns the name, defaults to "test-cordapp" if not specified. */
+    /** Returns the name, defaults to "test-name" if not specified. */
     val name: String
 
     /** Returns the title, defaults to "test-title" if not specified. */
@@ -51,17 +51,21 @@ interface TestCordapp {
 
     class Factory {
         companion object {
+            /**
+             * Create a [TestCordapp] object by scanning the given packages. The meta data on the CorDapp will be the
+             * default values, which can be changed with the wither methods.
+             */
             @JvmStatic
             fun fromPackages(vararg packageNames: String): TestCordapp = fromPackages(packageNames.asList())
 
             /**
              * Create a [TestCordapp] object by scanning the given packages. The meta data on the CorDapp will be the
-             * default values, which can be specified with the wither methods.
+             * default values, which can be changed with the wither methods.
              */
             @JvmStatic
             fun fromPackages(packageNames: Collection<String>): TestCordapp {
                 return TestCordappImpl(
-                        name = "test-cordapp",
+                        name = "test-name",
                         version = "1.0",
                         vendor = "test-vendor",
                         title = "test-title",

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -253,12 +253,10 @@ open class InternalMockNetwork(defaultParameters: MockNetworkParameters = MockNe
 
     @VisibleForTesting
     internal open fun createNotaries(): List<TestStartedNode> {
-        val version = VersionInfo(networkParameters.minimumPlatformVersion, "Mock release", "Mock revision", "Mock Vendor")
         return notarySpecs.map { (name, validating) ->
             createNode(InternalMockNodeParameters(
                     legalName = name,
-                    configOverrides = MockNodeConfigOverrides(notary = MockNetNotaryConfig(validating)),
-                    version = version
+                    configOverrides = MockNodeConfigOverrides(notary = MockNetNotaryConfig(validating))
             ))
         }
     }


### PR DESCRIPTION
FinalityHandler is insecure in that it is open to receive any transaction from any party.

Any CorDapp targeting platform version 4 or above is required use the new c'tors which take in FlowSession objects to the counterpart flow. This flow must subcall ReceiveFinalityFlow to receive and record the finalised transaction.

Old CorDapps (with target platform version < 4) will continue to work as previously. However if there are no old CorDapps loaded then the node will disable FinalityHandler.
