### PR TITLE
CORDA-535: Remove the old mechanism for loading custom notary service…

### DIFF
--- a/docs/source/tutorial-custom-notary.rst
+++ b/docs/source/tutorial-custom-notary.rst
@@ -4,13 +4,12 @@ Writing a custom notary service (experimental)
 ==============================================
 
 .. warning:: Customising a notary service is still an experimental feature and not recommended for most use-cases. The APIs
-   for writing a custom notary may change in the future. Additionally, customising Raft or BFT notaries is not yet
-   fully supported. If you want to write your own Raft notary you will have to implement a custom database connector
-   (or use a separate database for the notary), and use a custom configuration file.
+   for writing a custom notary may change in the future.
 
-Similarly to writing an oracle service, the first step is to create a service class in your CorDapp and annotate it
-with ``@CordaService``. The Corda node scans for any class with this annotation and initialises them. The custom notary
-service class should provide a constructor with two parameters of types ``AppServiceHub`` and ``PublicKey``.
+The first step is to create a service class in your CorDapp that extends the ``NotaryService`` abstract class.
+This will ensure that it is recognised as a notary service.
+The custom notary service class should provide a constructor with two parameters of types ``ServiceHubInternal`` and ``PublicKey``.
+Note that ``ServiceHubInternal`` does not provide any API stability guarantees.
 
 .. literalinclude:: ../../samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt
    :language: kotlin
@@ -32,5 +31,5 @@ To enable the service, add the following to the node configuration:
 
     notary : {
         validating : true # Set to false if your service is non-validating
-        custom : true
+        className : "net.corda.notarydemo.MyCustomValidatingNotaryService" # The fully qualified name of your service class
     }

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -122,13 +122,12 @@ fun NodeConfiguration.shouldInitCrashShell() = shouldStartLocalShell() || should
 data class NotaryConfig(val validating: Boolean,
                         val raft: RaftConfig? = null,
                         val bftSMaRt: BFTSMaRtConfiguration? = null,
-                        val custom: Boolean = false,
                         val serviceLegalName: CordaX500Name? = null,
                         val className: String = "net.corda.node.services.transactions.SimpleNotaryService"
 ) {
     init {
-        require(raft == null || bftSMaRt == null || !custom) {
-            "raft, bftSMaRt, and custom configs cannot be specified together"
+        require(raft == null || bftSMaRt == null) {
+            "raft and bftSMaRt configs cannot be specified together"
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -88,7 +88,6 @@ class TimedFlowTests {
 
             val networkParameters = NetworkParametersCopier(testNetworkParameters(listOf(NotaryInfo(notaryIdentity, true))))
             val notaryConfig = mock<NotaryConfig> {
-                whenever(it.custom).thenReturn(true)
                 whenever(it.isClusterConfig).thenReturn(true)
                 whenever(it.validating).thenReturn(true)
                 whenever(it.className).thenReturn(TestNotaryService::class.java.name)

--- a/samples/notary-demo/build.gradle
+++ b/samples/notary-demo/build.gradle
@@ -76,7 +76,10 @@ task deployNodesCustom(type: Cordform, dependsOn: 'jar') {
             address "localhost:10010"
             adminAddress "localhost:10110"
         }
-        notary = [validating: true, "custom": true]
+        notary = [
+                validating: true,
+                className: "net.corda.notarydemo.MyCustomValidatingNotaryService"
+        ]
     }
 }
 

--- a/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt
+++ b/samples/notary-demo/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt
@@ -8,8 +8,6 @@ import net.corda.core.internal.ResolveTransactionsFlow
 import net.corda.core.internal.notary.NotaryInternalException
 import net.corda.core.internal.notary.NotaryServiceFlow
 import net.corda.core.internal.notary.TrustedAuthorityNotaryService
-import net.corda.core.node.AppServiceHub
-import net.corda.core.node.services.CordaService
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionWithSignatures
 import net.corda.core.transactions.WireTransaction
@@ -19,13 +17,12 @@ import java.security.PublicKey
 import java.security.SignatureException
 
 /**
- * A custom notary service should provide a constructor that accepts two parameters of types [AppServiceHub] and [PublicKey].
+ * A custom notary service should provide a constructor that accepts two parameters of types [ServiceHubInternal] and [PublicKey].
  *
  * Note that the support for custom notaries is still experimental – at present only a single-node notary service can be customised.
  * The notary-related APIs might change in the future.
  */
 // START 1
-@CordaService
 class MyCustomValidatingNotaryService(override val services: ServiceHubInternal, override val notaryIdentityKey: PublicKey) : TrustedAuthorityNotaryService() {
     override val uniquenessProvider = PersistentUniquenessProvider(services.clock, services.database, services.cacheFactory)
 


### PR DESCRIPTION
… implementations.

All notary service implementations are now assumed to be loaded from CorDapps.

This is a followup clean up PR for https://github.com/corda/corda/pull/3978