### PR TITLE
ENT-2569: Perform better clean-up of DB, Hibernate mappings and IdentityService.

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3004,7 +3004,7 @@ public interface net.corda.core.node.services.ContractUpgradeService
 public @interface net.corda.core.node.services.CordaService
 ##
 @DoNotImplement
-public interface net.corda.core.node.services.IdentityService
+public interface net.corda.core.node.services.IdentityService extends net.corda.core.node.services.WellKnownPartyTranslator
   public abstract void assertOwnership(net.corda.core.identity.Party, net.corda.core.identity.AnonymousParty)
   @Nullable
   public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
@@ -3371,6 +3371,12 @@ public interface net.corda.core.node.services.VaultService
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> whenConsumed(net.corda.core.contracts.StateRef)
 ##
 public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
+##
+public interface net.corda.core.node.services.WellKnownPartyTranslator
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
 @CordaSerializable
 public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3004,7 +3004,7 @@ public interface net.corda.core.node.services.ContractUpgradeService
 public @interface net.corda.core.node.services.CordaService
 ##
 @DoNotImplement
-public interface net.corda.core.node.services.IdentityService extends net.corda.core.node.services.WellKnownPartyTranslator
+public interface net.corda.core.node.services.IdentityService
   public abstract void assertOwnership(net.corda.core.identity.Party, net.corda.core.identity.AnonymousParty)
   @Nullable
   public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
@@ -3371,12 +3371,6 @@ public interface net.corda.core.node.services.VaultService
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> whenConsumed(net.corda.core.contracts.StateRef)
 ##
 public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
-##
-public interface net.corda.core.node.services.WellKnownPartyTranslator
-  @Nullable
-  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
-  @Nullable
-  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
 ##
 @CordaSerializable
 public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -19,7 +19,7 @@ import java.security.cert.*
  * a transaction being built). See [NetworkMapCache] for retrieving well known identities from the network map.
  */
 @DoNotImplement
-interface IdentityService : WellKnownPartyTranslator {
+interface IdentityService {
     val trustRoot: X509Certificate
     val trustAnchor: TrustAnchor
     val caCertStore: CertStore
@@ -80,7 +80,7 @@ interface IdentityService : WellKnownPartyTranslator {
      * @param name The [CordaX500Name] to determine well known identity for.
      * @return If known the canonical [Party] with that name, else null.
      */
-    override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party?
+    fun wellKnownPartyFromX500Name(name: CordaX500Name): Party?
 
     /**
      * Resolves a (optionally) confidential identity to the corresponding well known identity [Party].
@@ -89,7 +89,7 @@ interface IdentityService : WellKnownPartyTranslator {
      * @param party identity to determine well known identity for.
      * @return well known identity, if found.
      */
-    override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
+    fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
         // The original version of this would return the party as-is if it was a Party (rather than AnonymousParty),
         // however that means that we don't verify that we know who owns the key. As such as now enforce turning the key
         // into a party, and from there figure out the well known party.

--- a/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/IdentityService.kt
@@ -19,7 +19,7 @@ import java.security.cert.*
  * a transaction being built). See [NetworkMapCache] for retrieving well known identities from the network map.
  */
 @DoNotImplement
-interface IdentityService {
+interface IdentityService : WellKnownPartyTranslator {
     val trustRoot: X509Certificate
     val trustAnchor: TrustAnchor
     val caCertStore: CertStore
@@ -51,8 +51,7 @@ interface IdentityService {
     }
 
     /**
-     * Get all identities known to the service. This is expensive, and [partyFromKey] or [partyFromX500Name] should be
-     * used in preference where possible.
+     * Get all identities known to the service. This is expensive [partyFromKey] should be used in preference where possible.
      */
     fun getAllIdentities(): Iterable<PartyAndCertificate>
 
@@ -81,7 +80,7 @@ interface IdentityService {
      * @param name The [CordaX500Name] to determine well known identity for.
      * @return If known the canonical [Party] with that name, else null.
      */
-    fun wellKnownPartyFromX500Name(name: CordaX500Name): Party?
+    override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party?
 
     /**
      * Resolves a (optionally) confidential identity to the corresponding well known identity [Party].
@@ -90,7 +89,7 @@ interface IdentityService {
      * @param party identity to determine well known identity for.
      * @return well known identity, if found.
      */
-    fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
+    override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
         // The original version of this would return the party as-is if it was a Party (rather than AnonymousParty),
         // however that means that we don't verify that we know who owns the key. As such as now enforce turning the key
         // into a party, and from there figure out the well known party.

--- a/core/src/main/kotlin/net/corda/core/node/services/WellKnownPartyTranslator.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/WellKnownPartyTranslator.kt
@@ -1,0 +1,26 @@
+package net.corda.core.node.services
+
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+
+interface WellKnownPartyTranslator {
+    /**
+     * Resolves a party name to the well known identity [Party] instance for this name. Where possible well known identity
+     * lookup from name should be done from the network map (via [NetworkMapCache]) instead, as it is the authoritative
+     * source of well known identities.
+     *
+     * @param name The [CordaX500Name] to determine well known identity for.
+     * @return If known the canonical [Party] with that name, else null.
+     */
+    fun wellKnownPartyFromX500Name(name: CordaX500Name): Party?
+
+    /**
+     * Resolves a (optionally) confidential identity to the corresponding well known identity [Party].
+     * It transparently handles returning the well known identity back if a well known identity is passed in.
+     *
+     * @param party identity to determine well known identity for.
+     * @return well known identity, if found.
+     */
+    fun wellKnownPartyFromAnonymous(party: AbstractParty): Party?
+}

--- a/experimental/notary-raft/src/test/kotlin/net/corda/notary/raft/RaftTransactionCommitLogTests.kt
+++ b/experimental/notary-raft/src/test/kotlin/net/corda/notary/raft/RaftTransactionCommitLogTests.kt
@@ -1,5 +1,6 @@
 package net.corda.notary.raft
 
+import com.nhaarman.mockito_kotlin.mock
 import io.atomix.catalyst.transport.Address
 import io.atomix.copycat.client.ConnectionStrategies
 import io.atomix.copycat.client.CopycatClient
@@ -154,7 +155,7 @@ class RaftTransactionCommitLogTests {
     private fun createReplica(myAddress: NetworkHostAndPort, clusterAddress: NetworkHostAndPort? = null): CompletableFuture<Member> {
         val storage = Storage.builder().withStorageLevel(StorageLevel.MEMORY).build()
         val address = Address(myAddress.host, myAddress.port)
-        val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null }, NodeSchemaService(extraSchemas = setOf(RaftNotarySchemaV1)))
+        val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock(), NodeSchemaService(extraSchemas = setOf(RaftNotarySchemaV1)))
         databases.add(database)
         val stateMachineFactory = { RaftTransactionCommitLog(database, Clock.systemUTC(), { RaftUniquenessProvider.createMap(TestingNamedCacheFactory()) }) }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/CordaPersistence.kt
@@ -61,6 +61,10 @@ class CordaPersistence(
         private val log = contextLogger()
     }
 
+    init {
+        typeDescriptors.forEach { JavaTypeDescriptorRegistry.INSTANCE.addDescriptor(it) }
+    }
+
     private val defaultIsolationLevel = databaseConfig.transactionIsolationLevel
     val hibernateConfig: HibernateConfiguration by lazy {
         transaction {
@@ -182,7 +186,7 @@ class CordaPersistence(
         (_dataSource as? AutoCloseable)?.close()
 
         fun Collection<*>.closeAutoCloseables() {
-            mapNotNull { it as? AutoCloseable }.forEach { it.close() }
+            forEach { (it as? AutoCloseable)?.close() }
         }
 
         attributeConverters.closeAutoCloseables()

--- a/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
@@ -2,6 +2,7 @@ package net.corda.node.services.messaging
 
 import com.codahale.metrics.MetricRegistry
 import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.crypto.generateKeyPair
 import net.corda.core.internal.div
@@ -89,7 +90,7 @@ class ArtemisMessagingTest {
             doReturn(FlowTimeoutConfiguration(5.seconds, 3, backoffBase = 1.0)).whenever(it).flowTimeout
         }
         LogHelper.setLevel(PersistentUniquenessProvider::class)
-        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
+        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock())
         networkMapCache = PersistentNetworkMapCache(TestingNamedCacheFactory(), database, rigorousMock()).apply { start(emptyList()) }
     }
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/PersistentNetworkMapCacheTest.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.network
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.node.NodeInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.internal.configureDatabase
@@ -27,7 +28,7 @@ class PersistentNetworkMapCacheTest {
     val testSerialization = SerializationEnvironmentRule()
 
     private var portCounter = 1000
-    private val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
+    private val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock())
     private val charlieNetMapCache = PersistentNetworkMapCache(TestingNamedCacheFactory(), database, InMemoryIdentityService(trustRoot = DEV_ROOT_CA.certificate))
 
     @After

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -34,6 +34,8 @@ import net.corda.node.VersionInfo
 import net.corda.node.cordapp.CordappLoader
 import net.corda.node.internal.classloading.requireAnnotation
 import net.corda.node.internal.cordapp.*
+import net.corda.node.internal.identity.IdentityServiceWellKnownPartyTranslatorAdaptor
+import net.corda.node.internal.identity.WellKnownPartyTranslator
 import net.corda.node.internal.rpc.proxies.AuthenticatedRpcOpsProxy
 import net.corda.node.internal.rpc.proxies.ExceptionMaskingRpcOpsProxy
 import net.corda.node.internal.rpc.proxies.ExceptionSerialisingRpcOpsProxy
@@ -145,7 +147,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     val identityService = PersistentIdentityService(cacheFactory).tokenize()
     val database: CordaPersistence = createCordaPersistence(
             configuration.database,
-            identityService,
+            IdentityServiceWellKnownPartyTranslatorAdaptor(identityService),
             schemaService,
             configuration.dataSourceProperties
     )

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -80,7 +80,6 @@ import net.corda.nodeapi.internal.persistence.*
 import net.corda.nodeapi.internal.storeLegalIdentity
 import net.corda.tools.shell.InteractiveShell
 import org.apache.activemq.artemis.utils.ReusableLatch
-import org.hibernate.type.descriptor.java.JavaTypeDescriptorRegistry
 import org.slf4j.Logger
 import rx.Observable
 import rx.Scheduler
@@ -1020,10 +1019,10 @@ fun createCordaPersistence(databaseConfig: DatabaseConfig,
     // Hibernate warns about not being able to find a descriptor if we don't provide one, but won't use it by default
     // so we end up providing both descriptor and converter. We should re-examine this in later versions to see if
     // either Hibernate can be convinced to stop warning, use the descriptor by default, or something else.
-    JavaTypeDescriptorRegistry.INSTANCE.addDescriptor(AbstractPartyDescriptor(wellKnownPartyFromX500Name, wellKnownPartyFromAnonymous))
+    val typeDescriptors = listOf(AbstractPartyDescriptor(wellKnownPartyFromX500Name, wellKnownPartyFromAnonymous))
     val attributeConverters = listOf(AbstractPartyToX500NameAsStringConverter(wellKnownPartyFromX500Name, wellKnownPartyFromAnonymous))
     val jdbcUrl = hikariProperties.getProperty("dataSource.url", "")
-    return CordaPersistence(databaseConfig, schemaService.schemaOptions.keys, jdbcUrl, attributeConverters)
+    return CordaPersistence(databaseConfig, schemaService.schemaOptions.keys, jdbcUrl, attributeConverters, typeDescriptors)
 }
 
 fun CordaPersistence.startHikariPool(hikariProperties: Properties, databaseConfig: DatabaseConfig, schemas: Set<MappedSchema>, metricRegistry: MetricRegistry? = null) {

--- a/node/src/main/kotlin/net/corda/node/internal/identity/IdentityServiceWellKnownPartyTranslatorAdaptor.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/identity/IdentityServiceWellKnownPartyTranslatorAdaptor.kt
@@ -1,0 +1,19 @@
+package net.corda.node.internal.identity
+
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.node.services.IdentityService
+
+/**
+ * Since `IdentityService` cannot implement internal interface of `WellKnownPartyTranslator` this adaptor is there to fill the gap.
+ */
+class IdentityServiceWellKnownPartyTranslatorAdaptor(private val identityService: IdentityService) : WellKnownPartyTranslator {
+    override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? {
+        return identityService.wellKnownPartyFromX500Name(name)
+    }
+
+    override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? {
+        return identityService.wellKnownPartyFromAnonymous(party)
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/internal/identity/WellKnownPartyTranslator.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/identity/WellKnownPartyTranslator.kt
@@ -1,4 +1,4 @@
-package net.corda.core.node.services
+package net.corda.node.internal.identity
 
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name

--- a/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
@@ -14,7 +14,7 @@ import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
 import java.security.cert.TrustAnchor
 
-interface IdentityServiceInternal : IdentityService {
+interface IdentityServiceInternal : IdentityService, AutoCloseable {
 
     private companion object {
         val log = contextLogger()

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -68,4 +68,9 @@ class InMemoryIdentityService(identities: List<PartyAndCertificate> = emptyList(
         }
         return results
     }
+
+    override fun close() {
+        keyToParties.clear()
+        principalToParties.clear()
+    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -4,6 +4,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.*
 import net.corda.core.internal.hash
 import net.corda.core.node.services.UnknownAnonymousPartyException
+import net.corda.core.node.services.WellKnownPartyTranslator
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.MAX_HASH_HEX_SIZE
 import net.corda.core.utilities.contextLogger
@@ -30,7 +31,7 @@ import javax.persistence.Lob
  * cached for efficient lookup.
  */
 @ThreadSafe
-class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSerializeAsToken(), IdentityServiceInternal {
+class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSerializeAsToken(), IdentityServiceInternal, WellKnownPartyTranslator {
     companion object {
         private val log = contextLogger()
 

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -4,7 +4,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.*
 import net.corda.core.internal.hash
 import net.corda.core.node.services.UnknownAnonymousPartyException
-import net.corda.core.node.services.WellKnownPartyTranslator
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.MAX_HASH_HEX_SIZE
 import net.corda.core.utilities.contextLogger
@@ -31,7 +30,7 @@ import javax.persistence.Lob
  * cached for efficient lookup.
  */
 @ThreadSafe
-class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSerializeAsToken(), IdentityServiceInternal, WellKnownPartyTranslator {
+class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSerializeAsToken(), IdentityServiceInternal {
     companion object {
         private val log = contextLogger()
 

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -102,7 +102,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     override val trustAnchor: TrustAnchor get() = _trustAnchor
 
     // CordaPersistence is not a c'tor parameter to work around the cyclic dependency
-    lateinit var database: CordaPersistence
+    var database: CordaPersistence? = null
 
     private val keyToParties = createPKMap(cacheFactory)
     private val principalToParties = createX500Map(cacheFactory)
@@ -132,7 +132,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
 
     @Throws(CertificateExpiredException::class, CertificateNotYetValidException::class, InvalidAlgorithmParameterException::class)
     override fun verifyAndRegisterIdentity(identity: PartyAndCertificate, isNewRandomIdentity: Boolean): PartyAndCertificate? {
-        return database.transaction {
+        return database!!.transaction {
             verifyAndRegisterIdentity(trustAnchor, identity, isNewRandomIdentity)
         }
     }
@@ -153,10 +153,10 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
         return keyToParties[parentId]
     }
 
-    override fun certificateFromKey(owningKey: PublicKey): PartyAndCertificate? = database.transaction { keyToParties[mapToKey(owningKey)] }
+    override fun certificateFromKey(owningKey: PublicKey): PartyAndCertificate? = database!!.transaction { keyToParties[mapToKey(owningKey)] }
 
     private fun certificateFromCordaX500Name(name: CordaX500Name): PartyAndCertificate? {
-        return database.transaction {
+        return database!!.transaction {
             val partyId = principalToParties[name]
             if (partyId != null) {
                 keyToParties[partyId]
@@ -165,14 +165,14 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     // We give the caller a copy of the data set to avoid any locking problems
-    override fun getAllIdentities(): Iterable<PartyAndCertificate> = database.transaction { keyToParties.allPersisted().map { it.second }.asIterable() }
+    override fun getAllIdentities(): Iterable<PartyAndCertificate> = database!!.transaction { keyToParties.allPersisted().map { it.second }.asIterable() }
 
     override fun wellKnownPartyFromX500Name(name: CordaX500Name): Party? = certificateFromCordaX500Name(name)?.party
 
-    override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? = database.transaction { super.wellKnownPartyFromAnonymous(party) }
+    override fun wellKnownPartyFromAnonymous(party: AbstractParty): Party? = database!!.transaction { super.wellKnownPartyFromAnonymous(party) }
 
     override fun partiesFromName(query: String, exactMatch: Boolean): Set<Party> {
-        return database.transaction {
+        return database!!.transaction {
             val results = LinkedHashSet<Party>()
             for ((x500name, partyId) in principalToParties.allPersisted()) {
                 partiesFromName(query, exactMatch, x500name, results, keyToParties[partyId]!!.party)
@@ -182,7 +182,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     }
 
     @Throws(UnknownAnonymousPartyException::class)
-    override fun assertOwnership(party: Party, anonymousParty: AnonymousParty) = database.transaction { super.assertOwnership(party, anonymousParty) }
+    override fun assertOwnership(party: Party, anonymousParty: AnonymousParty) = database!!.transaction { super.assertOwnership(party, anonymousParty) }
 
     lateinit var ourNames: Set<CordaX500Name>
 
@@ -194,4 +194,8 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
         }
     }
 
+    override fun close() {
+        log.info("Closing PersistentIdentityService")
+        database = null
+    }
 }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyDescriptor.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyDescriptor.kt
@@ -3,7 +3,7 @@ package net.corda.node.services.persistence
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.uncheckedCast
-import net.corda.core.node.services.WellKnownPartyTranslator
+import net.corda.node.internal.identity.WellKnownPartyTranslator
 import net.corda.core.utilities.contextLogger
 import org.hibernate.type.descriptor.WrapperOptions
 import org.hibernate.type.descriptor.java.AbstractTypeDescriptor

--- a/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/AbstractPartyToX500NameAsStringConverter.kt
@@ -2,8 +2,7 @@ package net.corda.node.services.persistence
 
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.identity.Party
-import net.corda.core.node.services.WellKnownPartyTranslator
+import net.corda.node.internal.identity.WellKnownPartyTranslator
 import net.corda.core.utilities.contextLogger
 import javax.persistence.AttributeConverter
 import javax.persistence.Converter

--- a/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/AbstractNodeTests.kt
@@ -32,7 +32,7 @@ class AbstractNodeTests {
     @Test
     fun `logVendorString does not leak connection`() {
         // Note this test also covers a transaction that CordaPersistence does while it's instantiating:
-        val database = configureDatabase(hikariProperties(freshURL()), DatabaseConfig(), { null }, { null })
+        val database = configureDatabase(hikariProperties(freshURL()), DatabaseConfig(), mock())
         val log = mock<Logger>() // Don't care what happens here.
         // Actually 10 is enough to reproduce old code hang, as pool size is 10 and we leaked 9 connections and 1 is in flight:
         repeat(100) {

--- a/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeTest.kt
@@ -1,6 +1,7 @@
 package net.corda.node.internal
 
 import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.delete
@@ -59,7 +60,7 @@ class NodeTest {
     fun `generateAndSaveNodeInfo works`() {
         val configuration = createConfig(ALICE_NAME)
         val info = VersionInfo(789, "3.0", "SNAPSHOT", "R3")
-        configureDatabase(configuration.dataSourceProperties, configuration.database, { null }, { null }).use {
+        configureDatabase(configuration.dataSourceProperties, configuration.database, mock()).use {
             val node = Node(configuration, info, initialiseSerialization = false)
             assertEquals(node.generateNodeInfo(), node.generateNodeInfo())  // Node info doesn't change (including the serial)
         }
@@ -69,7 +70,7 @@ class NodeTest {
     fun `clear network map cache works`() {
         val configuration = createConfig(ALICE_NAME)
         val (nodeInfo, _) = createNodeInfoAndSigned(ALICE_NAME)
-        configureDatabase(configuration.dataSourceProperties, configuration.database, { null }, { null }).use {
+        configureDatabase(configuration.dataSourceProperties, configuration.database, mock()).use {
             it.transaction {
                 val persistentNodeInfo = NodeInfoSchemaV1.PersistentNodeInfo(
                         id = 0,
@@ -121,7 +122,7 @@ class NodeTest {
                 serial = nodeInfo1.serial
         )
 
-        configureDatabase(configuration.dataSourceProperties, configuration.database, { null }, { null }).use {
+        configureDatabase(configuration.dataSourceProperties, configuration.database, mock()).use {
             it.transaction {
                 session.save(persistentNodeInfo1)
             }

--- a/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/NodeSchedulerServiceTest.kt
@@ -128,7 +128,7 @@ class MockScheduledFlowRepository : ScheduledFlowRepository {
 }
 
 class NodeSchedulerServiceTest : NodeSchedulerServiceTestBase() {
-    private val database = configureDatabase(MockServices.makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
+    private val database = configureDatabase(MockServices.makeTestDataSourceProperties(), DatabaseConfig(), mock())
 
     @After
     fun closeDatabase() {
@@ -279,7 +279,7 @@ class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
     @Test
     fun `test that correct item is returned`() {
         val dataSourceProps = MockServices.makeTestDataSourceProperties()
-        val database = configureDatabase(dataSourceProps, databaseConfig, { null }, { null })
+        val database = configureDatabase(dataSourceProps, databaseConfig, mock())
         database.transaction {
             val repo = PersistentScheduledFlowRepository(database)
             val stateRef = StateRef(SecureHash.randomSHA256(), 0)
@@ -298,7 +298,7 @@ class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
         val timeInTheFuture = mark + 1.days
         val stateRef = StateRef(SecureHash.zeroHash, 0)
 
-        configureDatabase(dataSourceProps, databaseConfig, { null }, { null }).use { database ->
+        configureDatabase(dataSourceProps, databaseConfig, mock()).use { database ->
             val scheduler = database.transaction {
                 createScheduler(database)
             }
@@ -320,7 +320,7 @@ class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
         transactionStates[stateRef] = transactionStateMock(logicRef, timeInTheFuture)
         flows[logicRef] = flowLogic
 
-        configureDatabase(dataSourceProps, DatabaseConfig(), { null }, { null }).use { database ->
+        configureDatabase(dataSourceProps, DatabaseConfig(), mock()).use { database ->
             val newScheduler = database.transaction {
                 createScheduler(database)
             }
@@ -343,7 +343,7 @@ class NodeSchedulerPersistenceTest : NodeSchedulerServiceTestBase() {
         val logicRef = rigorousMock<FlowLogicRef>()
         val flowLogic = rigorousMock<FlowLogic<*>>()
 
-        configureDatabase(dataSourceProps, databaseConfig, { null }, { null }).use { database ->
+        configureDatabase(dataSourceProps, databaseConfig, mock()).use { database ->
             val scheduler = database.transaction {
                 createScheduler(database)
             }

--- a/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/PersistentScheduledFlowRepositoryTest.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.events
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.contracts.ScheduledStateRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
@@ -21,7 +22,7 @@ class PersistentScheduledFlowRepositoryTest {
     fun `test that earliest item is returned`() {
         val laterTime = mark + 1.days
         val dataSourceProps = MockServices.makeTestDataSourceProperties()
-        val database = configureDatabase(dataSourceProps, databaseConfig, { null }, { null })
+        val database = configureDatabase(dataSourceProps, databaseConfig, mock())
 
         database.transaction {
             val repo = PersistentScheduledFlowRepository(database)
@@ -43,7 +44,7 @@ class PersistentScheduledFlowRepositoryTest {
     fun `test that item is rescheduled`() {
         val laterTime = mark + 1.days
         val dataSourceProps = MockServices.makeTestDataSourceProperties()
-        val database = configureDatabase(dataSourceProps, databaseConfig, { null }, { null })
+        val database = configureDatabase(dataSourceProps, databaseConfig, mock())
         database.transaction {
             val repo = PersistentScheduledFlowRepository(database)
             val stateRef = StateRef(SecureHash.randomSHA256(), 0)

--- a/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
@@ -8,6 +8,7 @@ import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.node.services.UnknownAnonymousPartyException
 import net.corda.node.internal.configureDatabase
+import net.corda.node.internal.identity.IdentityServiceWellKnownPartyTranslatorAdaptor
 import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509Utilities
@@ -51,7 +52,7 @@ class PersistentIdentityServiceTests {
         database = configureDatabase(
                 makeTestDataSourceProperties(),
                 DatabaseConfig(),
-                identityService
+                IdentityServiceWellKnownPartyTranslatorAdaptor(identityService)
         )
         identityService.database = database
         identityService.ourNames = setOf(ALICE_NAME)

--- a/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/identity/PersistentIdentityServiceTests.kt
@@ -51,8 +51,7 @@ class PersistentIdentityServiceTests {
         database = configureDatabase(
                 makeTestDataSourceProperties(),
                 DatabaseConfig(),
-                identityService::wellKnownPartyFromX500Name,
-                identityService::wellKnownPartyFromAnonymous
+                identityService
         )
         identityService.database = database
         identityService.ourNames = setOf(ALICE_NAME)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/AppendOnlyPersistentMapTest.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.persistence
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.utilities.loggerFor
 import net.corda.node.internal.configureDatabase
@@ -57,7 +58,7 @@ class AppendOnlyPersistentMapTest(var scenario: Scenario) {
 
     private val database = configureDatabase(makeTestDataSourceProperties(),
             DatabaseConfig(),
-            { null }, { null },
+            mock(),
             NodeSchemaService(setOf(MappedSchema(AppendOnlyPersistentMapTest::class.java, 1, listOf(PersistentMapEntry::class.java)))))
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.persistence
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.context.InvocationContext
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
@@ -50,7 +51,7 @@ class DBCheckpointStorageTests {
     @Before
     fun setUp() {
         LogHelper.setLevel(PersistentUniquenessProvider::class)
-        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
+        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock())
         newCheckpointStorage()
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBTransactionStorageTests.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.persistence
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
@@ -40,7 +41,7 @@ class DBTransactionStorageTests {
     fun setUp() {
         LogHelper.setLevel(PersistentUniquenessProvider::class)
         val dataSourceProps = makeTestDataSourceProperties()
-        database = configureDatabase(dataSourceProps, DatabaseConfig(), { null }, { null })
+        database = configureDatabase(dataSourceProps, DatabaseConfig(), mock())
         newTransactionStorage()
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -30,6 +30,7 @@ import net.corda.finance.schemas.SampleCashSchemaV2
 import net.corda.finance.schemas.SampleCashSchemaV3
 import net.corda.finance.utils.sumCash
 import net.corda.node.internal.configureDatabase
+import net.corda.node.internal.identity.IdentityServiceWellKnownPartyTranslatorAdaptor
 import net.corda.node.services.api.IdentityServiceInternal
 import net.corda.node.services.api.WritableTransactionStorage
 import net.corda.node.services.schema.ContractStateAndRef
@@ -113,7 +114,7 @@ class HibernateConfigurationTest {
             }
         }
         val schemaService = NodeSchemaService(extraSchemas = setOf(CashSchemaV1, SampleCashSchemaV1, SampleCashSchemaV2, SampleCashSchemaV3, DummyLinearStateSchemaV1, DummyLinearStateSchemaV2, DummyDealStateSchemaV1))
-        database = configureDatabase(dataSourceProps, DatabaseConfig(), identityService, schemaService)
+        database = configureDatabase(dataSourceProps, DatabaseConfig(), IdentityServiceWellKnownPartyTranslatorAdaptor(identityService), schemaService)
         database.transaction {
             hibernateConfig = database.hibernateConfig
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -113,7 +113,7 @@ class HibernateConfigurationTest {
             }
         }
         val schemaService = NodeSchemaService(extraSchemas = setOf(CashSchemaV1, SampleCashSchemaV1, SampleCashSchemaV2, SampleCashSchemaV3, DummyLinearStateSchemaV1, DummyLinearStateSchemaV2, DummyDealStateSchemaV1))
-        database = configureDatabase(dataSourceProps, DatabaseConfig(), identityService::wellKnownPartyFromX500Name, identityService::wellKnownPartyFromAnonymous, schemaService)
+        database = configureDatabase(dataSourceProps, DatabaseConfig(), identityService, schemaService)
         database.transaction {
             hibernateConfig = database.hibernateConfig
 

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import com.codahale.metrics.MetricRegistry
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowLogic
@@ -50,7 +51,7 @@ class NodeAttachmentServiceTest {
         LogHelper.setLevel(PersistentUniquenessProvider::class)
 
         val dataSourceProperties = makeTestDataSourceProperties()
-        database = configureDatabase(dataSourceProperties, DatabaseConfig(), { null }, { null })
+        database = configureDatabase(dataSourceProperties, DatabaseConfig(), mock())
         fs = Jimfs.newFileSystem(Configuration.unix())
         storage = NodeAttachmentService(MetricRegistry(), TestingNamedCacheFactory(), database).also {
             database.transaction {

--- a/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/TransactionCallbackTest.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.persistence
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.node.internal.configureDatabase
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
@@ -9,7 +10,7 @@ import kotlin.test.assertEquals
 
 
 class TransactionCallbackTest {
-    private val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
+    private val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock())
 
     @After
     fun closeDatabase() {

--- a/node/src/test/kotlin/net/corda/node/services/schema/PersistentStateServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/schema/PersistentStateServiceTests.kt
@@ -7,7 +7,6 @@ import net.corda.core.contracts.TransactionState
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.node.services.Vault
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.QueryableState
@@ -22,9 +21,7 @@ import net.corda.testing.internal.rigorousMock
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
-import rx.subjects.PublishSubject
 import kotlin.test.assertEquals
 
 class PersistentStateServiceTests {
@@ -66,7 +63,7 @@ class PersistentStateServiceTests {
                 return parent
             }
         }
-        val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), rigorousMock(), rigorousMock(), schemaService)
+        val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), rigorousMock(), schemaService)
         val persistentStateService = PersistentStateService(schemaService)
         database.transaction {
             val MEGA_CORP = TestIdentity(CordaX500Name("MegaCorp", "London", "GB")).party

--- a/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/PersistentUniquenessProviderTests.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.transactions
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.crypto.DigitalSignature
 import net.corda.core.crypto.NullKeys
 import net.corda.core.crypto.SecureHash
@@ -39,7 +40,7 @@ class PersistentUniquenessProviderTests {
     @Before
     fun setUp() {
         LogHelper.setLevel(PersistentUniquenessProvider::class)
-        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null }, NodeSchemaService(extraSchemas = setOf(NodeNotarySchemaV1)))
+        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock(), NodeSchemaService(extraSchemas = setOf(NodeNotarySchemaV1)))
     }
 
     @After

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -186,7 +186,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     @Ignore
     @Test
     fun createPersistentTestDb() {
-        val database = configureDatabase(makePersistentDataSourceProperties(), DatabaseConfig(), identitySvc::wellKnownPartyFromX500Name, identitySvc::wellKnownPartyFromAnonymous)
+        val database = configureDatabase(makePersistentDataSourceProperties(), DatabaseConfig(), identitySvc)
         setUpDb(database, 5000)
 
         database.close()

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -25,6 +25,7 @@ import net.corda.finance.schemas.CommercialPaperSchemaV1
 import net.corda.finance.schemas.SampleCashSchemaV2
 import net.corda.finance.schemas.SampleCashSchemaV3
 import net.corda.node.internal.configureDatabase
+import net.corda.node.internal.identity.IdentityServiceWellKnownPartyTranslatorAdaptor
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.nodeapi.internal.persistence.DatabaseTransaction
@@ -186,7 +187,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     @Ignore
     @Test
     fun createPersistentTestDb() {
-        val database = configureDatabase(makePersistentDataSourceProperties(), DatabaseConfig(), identitySvc)
+        val database = configureDatabase(makePersistentDataSourceProperties(), DatabaseConfig(), IdentityServiceWellKnownPartyTranslatorAdaptor(identitySvc))
         setUpDb(database, 5000)
 
         database.close()

--- a/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/ObservablesTests.kt
@@ -1,6 +1,7 @@
 package net.corda.node.utilities
 
 import com.google.common.util.concurrent.SettableFuture
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.tee
 import net.corda.node.internal.configureDatabase
@@ -19,7 +20,7 @@ class ObservablesTests {
     private val toBeClosed = mutableListOf<Closeable>()
 
     private fun createDatabase(): CordaPersistence {
-        val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
+        val database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock())
         toBeClosed += database
         return database
     }

--- a/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt
+++ b/node/src/test/kotlin/net/corda/node/utilities/PersistentMapTests.kt
@@ -1,5 +1,6 @@
 package net.corda.node.utilities
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.crypto.SecureHash
 import net.corda.node.internal.configureDatabase
 import net.corda.node.services.upgrade.ContractUpgradeServiceImpl
@@ -10,7 +11,7 @@ import kotlin.test.assertEquals
 
 class PersistentMapTests {
     private val databaseConfig = DatabaseConfig()
-    private val database get() = configureDatabase(dataSourceProps, databaseConfig, { null }, { null })
+    private val database get() = configureDatabase(dataSourceProps, databaseConfig, mock())
     private val dataSourceProps = MockServices.makeTestDataSourceProperties()
 
     //create a test map using an existing db table

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/api/NodeInterestRatesTest.kt
@@ -1,5 +1,6 @@
 package net.corda.irs.api
 
+import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.contracts.Command
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.TransactionState
@@ -67,7 +68,7 @@ class NodeInterestRatesTest {
 
     @Before
     fun setUp() {
-        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), { null }, { null })
+        database = configureDatabase(makeTestDataSourceProperties(), DatabaseConfig(), mock())
         database.transaction {
             oracle = createMockCordaService(services, NodeInterestRates::Oracle)
             oracle.knownFixes = TEST_DATA

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -23,6 +23,7 @@ import net.corda.node.cordapp.CordappLoader
 import net.corda.node.internal.ServicesForResolutionImpl
 import net.corda.node.internal.configureDatabase
 import net.corda.node.internal.cordapp.JarScanningCordappLoader
+import net.corda.node.internal.identity.IdentityServiceWellKnownPartyTranslatorAdaptor
 import net.corda.node.services.api.*
 import net.corda.node.services.identity.InMemoryIdentityService
 import net.corda.node.services.schema.NodeSchemaService
@@ -111,7 +112,8 @@ open class MockServices private constructor(
             val cordappLoader = cordappLoaderForPackages(cordappPackages)
             val dataSourceProps = makeTestDataSourceProperties()
             val schemaService = NodeSchemaService(cordappLoader.cordappSchemas)
-            val database = configureDatabase(dataSourceProps, DatabaseConfig(), identityService, schemaService, schemaService.internalSchemas())
+            val database = configureDatabase(dataSourceProps, DatabaseConfig(),
+                    IdentityServiceWellKnownPartyTranslatorAdaptor(identityService), schemaService, schemaService.internalSchemas())
             val mockService = database.transaction {
                 object : MockServices(cordappLoader, identityService, networkParameters, initialIdentity, moreKeys) {
                     override val vaultService: VaultService = makeVaultService(schemaService, database)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -111,7 +111,7 @@ open class MockServices private constructor(
             val cordappLoader = cordappLoaderForPackages(cordappPackages)
             val dataSourceProps = makeTestDataSourceProperties()
             val schemaService = NodeSchemaService(cordappLoader.cordappSchemas)
-            val database = configureDatabase(dataSourceProps, DatabaseConfig(), identityService::wellKnownPartyFromX500Name, identityService::wellKnownPartyFromAnonymous, schemaService, schemaService.internalSchemas())
+            val database = configureDatabase(dataSourceProps, DatabaseConfig(), identityService, schemaService, schemaService.internalSchemas())
             val mockService = database.transaction {
                 object : MockServices(cordappLoader, identityService, networkParameters, initialIdentity, moreKeys) {
                     override val vaultService: VaultService = makeVaultService(schemaService, database)


### PR DESCRIPTION
This is not super-important for `AbstractNode` as when node shuts down - JVM shuts down,
but for more light-weight node-like constructs developed as part of project Maximus this can be an important improvement allowing to tidy-up the heap upon shutdown.