### PR TITLE
Make blobinspector not log to console by default

### DIFF
--- a/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/BlobInspector.kt
+++ b/tools/blobinspector/src/main/kotlin/net/corda/blobinspector/BlobInspector.kt
@@ -52,14 +52,6 @@ class BlobInspector : CordaCliWrapper("blob-inspector", "Convert AMQP serialised
 
     override fun runProgram() = run(System.out)
 
-    override fun initLogging() {
-        if (verbose) {
-            loggingLevel = Level.TRACE
-        }
-        val loggingLevel = loggingLevel.name.toLowerCase(Locale.ENGLISH)
-        System.setProperty("logLevel", loggingLevel) // This property is referenced from the XML config file.
-    }
-
     fun run(out: PrintStream): Int {
         val inputBytes = source!!.readBytes()
         val bytes = parseToBinaryRelaxed(inputFormatType, inputBytes)

--- a/tools/blobinspector/src/main/resources/log4j2.xml
+++ b/tools/blobinspector/src/main/resources/log4j2.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
     <Properties>
-        <Property name="logLevel">off</Property>
+        <Property name="consoleLogLevel">${sys:consoleLogLevel:-error}</Property>
+        <Property name="defaultLogLevel">${sys:defaultLogLevel:-info}</Property>
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT" ignoreExceptions="false">
@@ -9,7 +10,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="${sys:logLevel}">
+        <Root level="${sys:consoleLogLevel}">
             <AppenderRef ref="STDOUT"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
Make the logging levels work the same way as the other CLI applications:

``--logging-level=<level>`` sets the default logging level (in the bootstrapper case no default log is set up, which makes sense since it's a simple utility app)
``--verbose`` displays logging input on the console at the same level as is specified by ``--logging-level`` (or INFO by default)

This gets rid of the logging spam by default and makes blobinspector work like the pre-picocli version.