### PR TITLE
ENT-1906: Fix JavaDoc error for DJVM.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/ThreadLocal.java
+++ b/djvm/src/main/java/sandbox/java/lang/ThreadLocal.java
@@ -4,8 +4,8 @@ import sandbox.java.util.function.Supplier;
 
 /**
  * Everything inside the sandbox is single-threaded, so this
- * implementation of ThreadLocal<T> is sufficient.
- * @param <T>
+ * implementation of ThreadLocal is sufficient.
+ * @param <T> Underlying type of this thread-local variable.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class ThreadLocal<T> extends Object {


### PR DESCRIPTION
Remove `<T>` from comment because JavaDoc thinks it's HTML. And add parameter description.