### PR TITLE
CORDA-195 - allow META-INF/*.EC block signature 

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
@@ -11,8 +11,11 @@ import java.util.jar.JarInputStream
  */
 object JarSignatureCollector {
 
-    /** @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File> */
-    private val unsignableEntryName = "META-INF/(?:.*[.](?:SF|DSA|RSA)|SIG-.*)".toRegex()
+    /**
+     * @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File>
+     * also accepting *.EC as this can be created and accepted by jarsigner tool @see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html
+     * and Java Security Manager. */
+    private val unsignableEntryName = "META-INF/(?:.*[.](?:SF|DSA|RSA|EC)|SIG-.*)".toRegex()
 
     /**
      * Returns an ordered list of every [Party] which has signed every signable item in the given [JarInputStream].


### PR DESCRIPTION
(Copy from discussion under https://github.com/corda/corda-gradle-plugins/pull/119):

Signature block file name in JAR file spec can be https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html
```
META-INF/*.DSA
META-INF/*.RSA
META-INF/SIG-*
```

and ` Digital Signatures` paragraph states: 
 ```
 The extension varies depending on the type of digital signature.
.RSA (PKCS7 signature, SHA-256 + RSA)
.DSA (PKCS7 signature, DSA)
Digital signature files for signature algorithms not listed 
above must reside in the META-INF directory and have the prefix "SIG-"
```

However JarSigner (https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html) paragraph:  `The Signed JAR File` can produce (and it does):
```
A signature block file with a .DSA, .RSA, or .EC extension
```

So it produces invalid file name, and Corda internally checks for valid file names otherwise it throws exception (specifically it doesn't recognise that file).


I checked Java Security Manager using RSA and EC (following this tutorial https://docs.oracle.com/javase/tutorial/security/toolsign/index.html).  Signature block file `META-INF/*.EC` is accepted and works for Security Manager.  `jarsigner` verifies JARs with  `*.EC` as being signed correctly. It's only the JAR file spec that states otherwise.  If we follow `jarsigner`way it's just matter to add `EC` to regex here https://github.com/corda/corda/blob/f81428eb53dcbc89462c052a94e893bb61e24749/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt#L15

The first commit with the test of EC signature fails as expected https://ci-master.corda.r3cev.com/viewLog.html?buildId=115916&buildTypeId=Corda_PullRequests