### PR TITLE
CORDA-2097 - Add missing Node Explorer artefact publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,6 +324,7 @@ bintrayConfig {
             'corda-shell',
             'corda-serialization',
             'corda-tools-blob-inspector',
+            'corda-tools-explorer',
             'corda-tools-network-bootstrapper'
     ]
     license {

--- a/tools/explorer/capsule/build.gradle
+++ b/tools/explorer/capsule/build.gradle
@@ -2,6 +2,8 @@
  * This build.gradle exists to package Node Explorer as an executable fat jar.
  */
 apply plugin: 'us.kirchmeier.capsule'
+apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
 
 description 'Node Explorer'
 
@@ -42,4 +44,21 @@ task buildExplorerJAR(type: FatCapsule, dependsOn: project(':tools:explorer').co
     }
 }
 
-build.dependsOn buildExplorerJAR
+assemble.dependsOn buildExplorerJAR
+
+artifacts {
+    runtimeArtifacts buildExplorerJAR
+    publish buildExplorerJAR {
+        classifier ""
+    }
+}
+
+jar {
+    classifier "ignore"
+    enabled = false
+}
+
+publish {
+    disableDefaultJar = true
+    name 'corda-tools-explorer'
+}


### PR DESCRIPTION
Bug ticket raised as result of 3.3 testing: [CORDA-2097](https://r3-cev.atlassian.net/browse/CORDA-2097)
Backport of https://github.com/corda/corda/pull/3437