### PR TITLE
CORDA-2030: Prevent kotlin-stdlib-jre8 from becoming an accidental transitive dependency.

### DIFF
--- a/node/build.gradle
+++ b/node/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     compile "org.slf4j:jul-to-slf4j:$slf4j_version"
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    runtime "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 


### PR DESCRIPTION
Add `kotlin-stdlib-jre8` to the `runtimeOnly` configuration to keep it from creeping into some other module's compile classpath.