### PR TITLE
CORDA-2096: Migrate finance test classes into .test sub-packages.

### DIFF
--- a/finance/src/integration-test/kotlin/net/corda/finance/compat/CashExceptionSerialisationTest.kt
+++ b/finance/src/integration-test/kotlin/net/corda/finance/compat/CashExceptionSerialisationTest.kt
@@ -1,10 +1,9 @@
 package net.corda.finance.compat
 
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.StartableByRPC
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.flows.CashException
+import net.corda.finance.flows.test.CashExceptionThrowingFlow
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
@@ -24,12 +23,5 @@ class CashExceptionSerialisationTest {
                 assertThat(thrown.stackTrace).isEmpty()
             }
         }
-    }
-}
-
-@StartableByRPC
-class CashExceptionThrowingFlow : FlowLogic<Unit>() {
-    override fun call() {
-        throw CashException("BOOM!", IllegalStateException("Nope dude!"))
     }
 }

--- a/finance/src/integration-test/kotlin/net/corda/finance/flows/test/CashConfigDataFlowTest.kt
+++ b/finance/src/integration-test/kotlin/net/corda/finance/flows/test/CashConfigDataFlowTest.kt
@@ -1,9 +1,10 @@
-package net.corda.finance.flows
+package net.corda.finance.flows.test
 
 import net.corda.core.messaging.startFlow
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.EUR
 import net.corda.finance.USD
+import net.corda.finance.flows.CashConfigDataFlow
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import org.assertj.core.api.Assertions.assertThat
@@ -12,7 +13,9 @@ import org.junit.Test
 class CashConfigDataFlowTest {
     @Test
     fun `issuable currencies are read in from node config`() {
-        driver(DriverParameters(notarySpecs = emptyList())) {
+        driver(DriverParameters(
+                extraCordappPackagesToScan = listOf("net.corda.finance.flows"),
+                notarySpecs = emptyList())) {
             val node = startNode(customOverrides = mapOf("custom" to mapOf("issuableCurrencies" to listOf("EUR", "USD")))).getOrThrow()
             val config = node.rpc.startFlow(::CashConfigDataFlow).returnValue.getOrThrow()
             assertThat(config.issuableCurrencies).containsExactly(EUR, USD)

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/test/DummyFungibleContract.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/test/DummyFungibleContract.kt
@@ -1,4 +1,4 @@
-package net.corda.finance.contracts.asset
+package net.corda.finance.contracts.asset.test
 
 import net.corda.core.contracts.*
 import net.corda.core.crypto.toStringShort
@@ -8,9 +8,10 @@ import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.QueryableState
 import net.corda.core.transactions.LedgerTransaction
-import net.corda.finance.schemas.SampleCashSchemaV1
-import net.corda.finance.schemas.SampleCashSchemaV2
-import net.corda.finance.schemas.SampleCashSchemaV3
+import net.corda.finance.contracts.asset.OnLedgerAsset
+import net.corda.finance.schemas.test.SampleCashSchemaV1
+import net.corda.finance.schemas.test.SampleCashSchemaV2
+import net.corda.finance.schemas.test.SampleCashSchemaV3
 import net.corda.finance.utils.sumCash
 import net.corda.finance.utils.sumCashOrNull
 import net.corda.finance.utils.sumCashOrZero
@@ -18,7 +19,7 @@ import java.security.PublicKey
 import java.util.*
 
 class DummyFungibleContract : OnLedgerAsset<Currency, DummyFungibleContract.Commands, DummyFungibleContract.State>() {
-    override fun extractCommands(commands: Collection<CommandWithParties<CommandData>>): List<CommandWithParties<DummyFungibleContract.Commands>>
+    override fun extractCommands(commands: Collection<CommandWithParties<CommandData>>): List<CommandWithParties<Commands>>
             = commands.select()
 
     data class State(

--- a/finance/src/test/kotlin/net/corda/finance/flows/test/CashExceptionThrowingFlow.kt
+++ b/finance/src/test/kotlin/net/corda/finance/flows/test/CashExceptionThrowingFlow.kt
@@ -1,0 +1,12 @@
+package net.corda.finance.flows.test
+
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.finance.flows.CashException
+
+@StartableByRPC
+class CashExceptionThrowingFlow : FlowLogic<Unit>() {
+    override fun call() {
+        throw CashException("BOOM!", IllegalStateException("Nope dude!"))
+    }
+}

--- a/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCashSchemaV1.kt
+++ b/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCashSchemaV1.kt
@@ -1,4 +1,4 @@
-package net.corda.finance.schemas
+package net.corda.finance.schemas.test
 
 import net.corda.core.contracts.MAX_ISSUER_REF_SIZE
 import net.corda.core.schemas.MappedSchema

--- a/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCashSchemaV2.kt
+++ b/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCashSchemaV2.kt
@@ -1,4 +1,4 @@
-package net.corda.finance.schemas
+package net.corda.finance.schemas.test
 
 import net.corda.core.identity.AbstractParty
 import net.corda.core.schemas.CommonSchemaV1

--- a/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCashSchemaV3.kt
+++ b/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCashSchemaV3.kt
@@ -1,4 +1,4 @@
-package net.corda.finance.schemas
+package net.corda.finance.schemas.test
 
 import net.corda.core.contracts.MAX_ISSUER_REF_SIZE
 import net.corda.core.identity.AbstractParty

--- a/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCommercialPaperSchemaV1.kt
+++ b/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCommercialPaperSchemaV1.kt
@@ -1,4 +1,4 @@
-package net.corda.finance.schemas
+package net.corda.finance.schemas.test
 
 import net.corda.core.contracts.MAX_ISSUER_REF_SIZE
 import net.corda.core.schemas.MappedSchema

--- a/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCommercialPaperSchemaV2.kt
+++ b/finance/src/test/kotlin/net/corda/finance/schemas/test/SampleCommercialPaperSchemaV2.kt
@@ -1,4 +1,4 @@
-package net.corda.finance.schemas
+package net.corda.finance.schemas.test
 
 import net.corda.core.contracts.MAX_ISSUER_REF_SIZE
 import net.corda.core.identity.AbstractParty

--- a/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
+++ b/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java
@@ -19,7 +19,7 @@ import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria;
 import net.corda.finance.contracts.DealState;
 import net.corda.finance.contracts.asset.Cash;
 import net.corda.finance.schemas.CashSchemaV1;
-import net.corda.finance.schemas.SampleCashSchemaV2;
+import net.corda.finance.schemas.test.SampleCashSchemaV2;
 import net.corda.node.services.api.IdentityServiceInternal;
 import net.corda.nodeapi.internal.persistence.CordaPersistence;
 import net.corda.nodeapi.internal.persistence.DatabaseTransaction;

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt
@@ -23,11 +23,11 @@ import net.corda.finance.DOLLARS
 import net.corda.finance.POUNDS
 import net.corda.finance.SWISS_FRANCS
 import net.corda.finance.contracts.asset.Cash
-import net.corda.finance.contracts.asset.DummyFungibleContract
+import net.corda.finance.contracts.asset.test.DummyFungibleContract
 import net.corda.finance.schemas.CashSchemaV1
-import net.corda.finance.schemas.SampleCashSchemaV1
-import net.corda.finance.schemas.SampleCashSchemaV2
-import net.corda.finance.schemas.SampleCashSchemaV3
+import net.corda.finance.schemas.test.SampleCashSchemaV1
+import net.corda.finance.schemas.test.SampleCashSchemaV2
+import net.corda.finance.schemas.test.SampleCashSchemaV3
 import net.corda.finance.utils.sumCash
 import net.corda.node.internal.configureDatabase
 import net.corda.node.services.api.IdentityServiceInternal

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryExceptionsTests.kt
@@ -6,8 +6,7 @@ import net.corda.core.node.services.vault.*
 import net.corda.core.node.services.vault.QueryCriteria.*
 import net.corda.finance.*
 import net.corda.finance.contracts.asset.Cash
-import net.corda.finance.schemas.SampleCashSchemaV3
-import net.corda.finance.schemas.CashSchemaV1
+import net.corda.finance.schemas.test.SampleCashSchemaV3
 import net.corda.testing.core.*
 import net.corda.testing.internal.vault.DummyLinearStateSchemaV1
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -22,8 +22,8 @@ import net.corda.finance.contracts.asset.cash.selection.AbstractCashSelection
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.finance.schemas.CashSchemaV1.PersistentCashState
 import net.corda.finance.schemas.CommercialPaperSchemaV1
-import net.corda.finance.schemas.SampleCashSchemaV2
-import net.corda.finance.schemas.SampleCashSchemaV3
+import net.corda.finance.schemas.test.SampleCashSchemaV2
+import net.corda.finance.schemas.test.SampleCashSchemaV3
 import net.corda.node.internal.configureDatabase
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig


### PR DESCRIPTION
Move classes in the `:finance` test artifact out of sealed finance packages, in preparation for upgrading our Gradle plugins to v4.0.32.