### PR TITLE
CORDA-2099: Define TypeIdentifier

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
@@ -1,0 +1,129 @@
+package net.corda.serialization.internal.model
+
+import com.google.common.reflect.TypeToken
+import java.lang.reflect.*
+
+/**
+ * Used as a key for retrieving cached type information. We need slightly more information than the bare classname,
+ * and slightly less information than is captured by Java's [Type]; we also need an identifier we can use even when the
+ * identified type is not visible from the current classloader.
+ *
+ * [TypeIdentifier] provides a family of type identifiers, together with a [prettyPrint] method for displaying them.
+ */
+sealed class TypeIdentifier {
+
+    /**
+     * The name of the type.
+     */
+    abstract val name: String
+
+    /**
+     * Obtain a nicely-formatted representation of the identified type, for help with debugging.
+     */
+    fun prettyPrint(): String =
+        when(this) {
+            is TypeIdentifier.Unknown -> "?"
+            is TypeIdentifier.Any -> "*"
+            is TypeIdentifier.Unparameterised -> name.simple
+            is TypeIdentifier.Erased -> "${name.simple} (erased)"
+            is TypeIdentifier.ArrayOf -> "${componentType.prettyPrint()}[]"
+            is TypeIdentifier.Parameterised ->
+                this.name.simple + this.parameters.joinToString(", ", "<", ">") {
+                    it.prettyPrint()
+                }
+        }
+
+    private val String.simple: String get() = split(".", "$").last()
+
+    companion object {
+        /**
+         * Obtain the [TypeIdentifier] for an erased Java class.
+         *
+         * @param type The class to get a [TypeIdentifier] for.
+         */
+        fun forClass(type: Class<*>): TypeIdentifier = when {
+            type.name == "java.lang.Object" -> Any
+            type.isArray -> ArrayOf(forClass(type.componentType))
+            type.typeParameters.isEmpty() -> Unparameterised(type.name)
+            else -> Erased(type.name)
+        }
+
+        /**
+         * Obtain the [TypeIdentifier] for a Java [Type] (typically obtained by calling one of
+         * [java.lang.reflect.Parameter.getAnnotatedType],
+         * [java.lang.reflect.Field.getGenericType] or
+         * [java.lang.reflect.Method.getGenericReturnType]). Wildcard types and type variables are converted to [Unknown].
+         */
+        fun forGenericType(type: Type, resolutionContext: Type = type): TypeIdentifier = when(type) {
+            is ParameterizedType -> Parameterised((type.rawType as Class<*>).name, type.actualTypeArguments.map {
+                forGenericType(it.resolveAgainst(resolutionContext))
+            })
+            is Class<*> -> forClass(type)
+            is GenericArrayType -> ArrayOf(forGenericType(type.genericComponentType.resolveAgainst(resolutionContext)))
+            else -> Unknown
+        }
+    }
+
+    /**
+     * The [TypeIdentifier] of [Any] / [java.lang.Object].
+     */
+    object Any: TypeIdentifier() {
+        override val name = "*"
+    }
+
+    /**
+     * The [TypeIdentifier] of an unbounded wildcard.
+     */
+    object Unknown: TypeIdentifier() {
+        override val name = "?"
+    }
+
+    /**
+     * Identifies a class with no type parameters.
+     */
+    data class Unparameterised(override val name: String): TypeIdentifier()
+
+    /**
+     * Identifies a parameterised class such as List<Int>, for which we cannot obtain the type parameters at runtime
+     * because they have been erased.
+     */
+    data class Erased(override val name: String): TypeIdentifier()
+
+    /**
+     * Identifies a type which is an array of some other type.
+     *
+     * @param componentType The [TypeIdentifier] of the component type of this array.
+     */
+    data class ArrayOf(val componentType: TypeIdentifier): TypeIdentifier() {
+        override val name get() = componentType.name + "[]"
+    }
+
+    /**
+     * A parameterised class such as Map<String, String> for which we have resolved type parameter values.
+     *
+     * @param parameters [TypeIdentifier]s for each of the resolved type parameter values of this type.
+     */
+    data class Parameterised(override val name: String, val parameters: List<TypeIdentifier>): TypeIdentifier()
+}
+
+internal fun Type.resolveAgainst(context: Type): Type = when (this) {
+    is WildcardType -> this.upperBound
+    is ParameterizedType,
+    is TypeVariable<*> -> TypeToken.of(context).resolveType(this).type.upperBound
+    else -> this
+}
+
+private val Type.upperBound: Type
+    get() = when (this) {
+        is TypeVariable<*> -> when {
+            this.bounds.isEmpty() ||
+                    this.bounds.size > 1 -> this
+            else -> this.bounds[0]
+        }
+        is WildcardType -> when {
+            this.upperBounds.isEmpty() ||
+                    this.upperBounds.size > 1 -> this
+            else -> this.upperBounds[0]
+        }
+        else -> this
+    }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/TypeIdentifierTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/TypeIdentifierTests.kt
@@ -22,11 +22,16 @@ class TypeIdentifierTests {
         assertIdentified<List<Int>>("List<Integer>")
     }
 
-    interface HasArray<T> {
-        val array: Array<List<T>>
+    @Test
+    fun `nested parameterised`() {
+        assertIdentified<List<List<Int>>>("List<List<Integer>>")
     }
 
-    class HasStringArray(override val array: Array<List<String>>): HasArray<String>
+    interface HasArray<T> {
+        val array: Array<out List<T>>
+    }
+
+    class HasStringArray(override val array: Array<out List<String>>): HasArray<String>
 
     @Test
     fun `resolved against an owning type`() {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/TypeIdentifierTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/TypeIdentifierTests.kt
@@ -1,0 +1,48 @@
+package net.corda.serialization.internal.model
+
+import com.google.common.reflect.TypeToken
+import net.corda.serialization.internal.model.TypeIdentifier.*
+import org.junit.Test
+import java.lang.reflect.Type
+import kotlin.test.assertEquals
+
+class TypeIdentifierTests {
+
+    @Test
+    fun `primitive types and arrays`() {
+        assertIdentified(Int::class.javaPrimitiveType!!, "int")
+        assertIdentified<Int>("Integer")
+        assertIdentified<IntArray>("int[]")
+        assertIdentified<Array<Int>>("Integer[]")
+    }
+
+    @Test
+    fun `erased and unerased`() {
+        assertIdentified(List::class.java, "List (erased)")
+        assertIdentified<List<Int>>("List<Integer>")
+    }
+
+    interface HasArray<T> {
+        val array: Array<List<T>>
+    }
+
+    class HasStringArray(override val array: Array<List<String>>): HasArray<String>
+
+    @Test
+    fun `resolved against an owning type`() {
+        val fieldType = HasArray::class.java.getDeclaredMethod("getArray").genericReturnType
+        assertIdentified(fieldType, "List<*>[]")
+
+        assertEquals(
+                "List<String>[]",
+                TypeIdentifier.forGenericType(fieldType, HasStringArray::class.java).prettyPrint())
+    }
+
+    private fun assertIdentified(type: Type, expected: String) =
+            assertEquals(expected, TypeIdentifier.forGenericType(type).prettyPrint())
+
+    private inline fun <reified T> assertIdentified(expected: String) =
+            assertEquals(expected, TypeIdentifier.forGenericType(typeOf<T>()).prettyPrint())
+
+    private inline fun <reified T> typeOf() = object : TypeToken<T>() {}.type
+}


### PR DESCRIPTION
This is the first in a series of PRs relating to [CORDA-2099](https://r3-cev.atlassian.net/browse/CORDA-2099). In this PR, we introduce a type, `TypeIdentifier`, which serves to identify a generic type in the absence of the Java `Type` to which the identifier refers. This is useful when we have received information about types which may not be visible from the current classloader.

The story to which this PR belongs involves some fairly wide-ranging changes to the way the serialisation code models and compares types, and the early PRs (such as this one) will be introducing some pieces of equipment which are intended to help with the heavy lifting later. Without the context, it might not be obvious what they're _for_, so I'm going to try to give a quick outline of the approach I'm taking here.

The basic idea is to represent a graph of types as a first-class object, called a "type model", which is defined separately from any particular implementation of serialisation, fingerprinting, class carpenting etc. The type model represents all the information about each type that we care about: what its type parameters are, what interfaces it implements, how to take it apart into a collection of typed values and how to put a collection of typed values together to form an instance of the type.

All of the logic involved in reflecting over types to find out how to identify and serialise them is concentrated in the type model. We can write tests that look like the following:

```kotlin
assertInformation<Concrete>("""
    Concrete(a: Integer[], b: String, c: List<Integer[]>): Super<Integer[]>, SuperSuper<Integer[], String>
      a: Integer[]
      b: String
      c: List<Integer[]>
""")
```

to validate that our type model correctly captures and resolves all of the type information that is available at runtime.

We distinguish between a "local type model", in which type information is associated with actual types, methods, constructors etc. observable from the local classloader, and a "remote type model", in which type information is received from a remote party, and has to be compared against the local type model to figure out whether evolution, carpentry etc is necessary.

We then backport these abstractions into the existing code, so that:

* The fingerprinter traverses the local type model for a type to generate a fingerprint.
* Serialisers and deserialisers for a local type are generated from its type model.
* The AMQP schema for a local type is generated from its type model.
* A remote type model can be generated from a received AMQP schema.
* Deserialisers for a remote type can be generated by constructing a remote type model for that type, checking it against the local type model for the "same" type (performing class carpentry where necessary to generate a matching local type), and determining what if any evolution needs to be performed.

The ultimate purpose is that we should be able to maintain type information for _multiple versions_ of the "same" type, received from multiple remote sources, and determine a correct deserialisation strategy for each version.

This also lays the groundwork for two potential future improvements:

* It breaks the close coupling between the code that manages our model of types  and the specifics of AMQP serialisation, so that we can more easily introduce other serialisation methods in future.
* It prepares the ground for genuine two-way evolution, where we can have strategies for converting values that have been deserialised into local types back into the remote types to which they originally belonged.