### PR TITLE
CORDA-2111: Upgrade to Kotlin 1.2.71.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,5 +1,5 @@
 gradlePluginsVersion=4.0.32
-kotlinVersion=1.2.51
+kotlinVersion=1.2.71
 # ***************************************************************#
 # When incrementing platformVersion make sure to update          #
 # net.corda.core.internal.CordaUtilsKt.PLATFORM_VERSION as well. #


### PR DESCRIPTION
Kotlin 1.2.71 was released on 24th September 2018, and our Gradle plugins are using it successfully.
Here are the [release notes](https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-2-70-is-out)