### PR TITLE
ENT-1906: Allow DJVM code to throw and catch sandbox exceptions.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -62,6 +62,7 @@ shadowJar {
     exclude 'sandbox/java/lang/Comparable.class'
     exclude 'sandbox/java/lang/Enum.class'
     exclude 'sandbox/java/lang/Iterable.class'
+    exclude 'sandbox/java/lang/StackTraceElement.class'
     exclude 'sandbox/java/lang/StringBuffer.class'
     exclude 'sandbox/java/lang/StringBuilder.class'
     exclude 'sandbox/java/nio/**'

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
     // ASM: byte code manipulation library
     compile "org.ow2.asm:asm:$asm_version"
-    compile "org.ow2.asm:asm-tree:$asm_version"
     compile "org.ow2.asm:asm-commons:$asm_version"
 
     // ClassGraph: classpath scanning

--- a/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
+++ b/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
@@ -1,0 +1,25 @@
+package sandbox.java.lang;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Pinned exceptions inherit from [java.lang.Throwable], but we
+ * still need to be able to pass them through the sandbox's
+ * exception handlers. In which case we will wrap them inside
+ * one of these.
+ *
+ * Exceptions wrapped inside one of these cannot be caught.
+ */
+final class DJVMThrowableWrapper extends Throwable {
+    private final java.lang.Throwable throwable;
+
+    DJVMThrowableWrapper(java.lang.Throwable t) {
+        throwable = t;
+    }
+
+    @Override
+    @NotNull
+    final java.lang.Throwable fromDJVM() {
+        return throwable;
+    }
+}

--- a/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
+++ b/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
@@ -17,6 +17,14 @@ final class DJVMThrowableWrapper extends Throwable {
         throwable = t;
     }
 
+    /**
+     * Prevent this wrapper from creating its own stack trace.
+     */
+    @Override
+    public final Throwable fillInStackTrace() {
+        return this;
+    }
+
     @Override
     @NotNull
     final java.lang.Throwable fromDJVM() {

--- a/djvm/src/main/java/sandbox/java/lang/Enum.java
+++ b/djvm/src/main/java/sandbox/java/lang/Enum.java
@@ -1,11 +1,13 @@
 package sandbox.java.lang;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.Serializable;
 
 /**
  * This is a dummy class. We will load the actual Enum class at run-time.
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "WeakerAccess"})
 public abstract class Enum<E extends Enum<E>> extends Object implements Comparable<E>, Serializable {
 
     private final String name;
@@ -22,6 +24,12 @@ public abstract class Enum<E extends Enum<E>> extends Object implements Comparab
 
     public int ordinal() {
         return ordinal;
+    }
+
+    @Override
+    @NotNull
+    final java.lang.Enum<?> fromDJVM() {
+        throw new UnsupportedOperationException("Dummy implementation");
     }
 
 }

--- a/djvm/src/main/java/sandbox/java/lang/Object.java
+++ b/djvm/src/main/java/sandbox/java/lang/Object.java
@@ -54,8 +54,7 @@ public class Object {
 
     private static Class<?> fromDJVM(Class<?> type) {
         try {
-            java.lang.String name = type.getName();
-            return Class.forName(name.startsWith("sandbox.") ? name.substring(8) : name);
+            return DJVM.fromDJVMType(type);
         } catch (ClassNotFoundException e) {
             throw new RuleViolationError(e.getMessage());
         }

--- a/djvm/src/main/java/sandbox/java/lang/StackTraceElement.java
+++ b/djvm/src/main/java/sandbox/java/lang/StackTraceElement.java
@@ -1,0 +1,37 @@
+package sandbox.java.lang;
+
+import java.util.Objects;
+
+/**
+ * This is a dummy class. We will load the genuine class at runtime.
+ */
+public final class StackTraceElement extends Object implements java.io.Serializable {
+
+    private final String declaringClass;
+    private final String methodName;
+    private final String fileName;
+    private final int lineNumber;
+
+    public StackTraceElement(String declaringClass, String methodName, String fileName, int lineNumber) {
+        this.declaringClass = declaringClass;
+        this.methodName     = methodName;
+        this.fileName       = fileName;
+        this.lineNumber     = lineNumber;
+    }
+
+    public String getDeclaringClass() {
+        return declaringClass;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+}

--- a/djvm/src/main/java/sandbox/java/lang/StackTraceElement.java
+++ b/djvm/src/main/java/sandbox/java/lang/StackTraceElement.java
@@ -1,26 +1,26 @@
 package sandbox.java.lang;
 
-import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This is a dummy class. We will load the genuine class at runtime.
  */
 public final class StackTraceElement extends Object implements java.io.Serializable {
 
-    private final String declaringClass;
+    private final String className;
     private final String methodName;
     private final String fileName;
     private final int lineNumber;
 
-    public StackTraceElement(String declaringClass, String methodName, String fileName, int lineNumber) {
-        this.declaringClass = declaringClass;
-        this.methodName     = methodName;
-        this.fileName       = fileName;
-        this.lineNumber     = lineNumber;
+    public StackTraceElement(String className, String methodName, String fileName, int lineNumber) {
+        this.className = className;
+        this.methodName = methodName;
+        this.fileName = fileName;
+        this.lineNumber = lineNumber;
     }
 
-    public String getDeclaringClass() {
-        return declaringClass;
+    public String getClassName() {
+        return className;
     }
 
     public String getMethodName() {
@@ -33,5 +33,14 @@ public final class StackTraceElement extends Object implements java.io.Serializa
 
     public int getLineNumber() {
         return lineNumber;
+    }
+
+    @Override
+    @NotNull
+    public String toDJVMString() {
+        return String.toDJVM(
+            className.toString() + ':' + methodName.toString()
+                + (fileName != null ? '(' + fileName.toString() + ':' + lineNumber + ')' : "")
+        );
     }
 }

--- a/djvm/src/main/java/sandbox/java/lang/String.java
+++ b/djvm/src/main/java/sandbox/java/lang/String.java
@@ -7,6 +7,7 @@ import sandbox.java.util.Locale;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Constructor;
 
 @SuppressWarnings("unused")
 public final class String extends Object implements Comparable<String>, CharSequence, Serializable {
@@ -21,6 +22,17 @@ public final class String extends Object implements Comparable<String>, CharSequ
 
     private static final String TRUE = new String("true");
     private static final String FALSE = new String("false");
+
+    private static final Constructor SHARED;
+
+    static {
+        try {
+            SHARED = java.lang.String.class.getDeclaredConstructor(char[].class, java.lang.Boolean.TYPE);
+            SHARED.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new NoSuchMethodError(e.getMessage());
+        }
+    }
 
     private final java.lang.String value;
 
@@ -86,6 +98,17 @@ public final class String extends Object implements Comparable<String>, CharSequ
 
     public String(StringBuilder builder) {
         this.value = builder.toString();
+    }
+
+    String(char[] value, boolean share) {
+        java.lang.String newValue;
+        try {
+            // This is (presumably) an optimisation for memory usage.
+            newValue = (java.lang.String) SHARED.newInstance(value, share);
+        } catch (Exception e) {
+            newValue = new java.lang.String(value);
+        }
+        this.value = newValue;
     }
 
     @Override

--- a/djvm/src/main/java/sandbox/java/lang/Throwable.java
+++ b/djvm/src/main/java/sandbox/java/lang/Throwable.java
@@ -1,0 +1,93 @@
+package sandbox.java.lang;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class Throwable extends Object implements Serializable {
+    private static final StackTraceElement[] NO_STACK_TRACE = new StackTraceElement[0];
+
+    private String message;
+    private Throwable cause;
+    private StackTraceElement[] stackTrace;
+
+    public Throwable() {
+        this.cause = this;
+        this.stackTrace = NO_STACK_TRACE;
+    }
+
+    public Throwable(String message) {
+        this();
+        this.message = message;
+    }
+
+    public Throwable(Throwable cause) {
+        this.cause = cause;
+        this.message = (cause == null) ? null : cause.toDJVMString();
+        this.stackTrace = NO_STACK_TRACE;
+    }
+
+    public Throwable(String message, Throwable cause) {
+        this.message = message;
+        this.cause = cause;
+        this.stackTrace = NO_STACK_TRACE;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getLocalizedMessage() {
+        return getMessage();
+    }
+
+    public Throwable getCause() {
+        return (cause == this) ? null : cause;
+    }
+
+    public Throwable initCause(Throwable cause) {
+        if (this.cause != this) {
+            throw new java.lang.IllegalStateException(
+                    "Can't overwrite cause with " + java.util.Objects.toString(cause, "a null"), fromDJVM());
+        }
+        if (cause == this) {
+            throw new java.lang.IllegalArgumentException("Self-causation not permitted", fromDJVM());
+        }
+        this.cause = cause;
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public String toDJVMString() {
+        java.lang.String s = getClass().getName();
+        String localized = getLocalizedMessage();
+        return String.valueOf((localized != null) ? (s + ": " + localized.toString()) : s);
+    }
+
+    public StackTraceElement[] getStackTrace() {
+        return stackTrace.clone();
+    }
+
+    public void setStackTrace(StackTraceElement[] stackTrace) {
+        StackTraceElement[] traceCopy = stackTrace.clone();
+
+        for (int i = 0; i < traceCopy.length; ++i) {
+            if (traceCopy[i] == null) {
+                throw new java.lang.NullPointerException("stackTrace[" + i + "]");
+            }
+        }
+
+        this.stackTrace = traceCopy;
+    }
+
+    public void printStackTrace() {}
+    public Throwable fillInStackTrace() { return this; }
+
+    @Override
+    @NotNull
+    java.lang.Throwable fromDJVM() {
+        return DJVM.fromDJVM(this);
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
@@ -2,6 +2,7 @@ package net.corda.djvm
 
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.code.DefinitionProvider
+import net.corda.djvm.code.EMIT_TRACING
 import net.corda.djvm.code.Emitter
 import net.corda.djvm.execution.ExecutionProfile
 import net.corda.djvm.rules.Rule
@@ -51,7 +52,7 @@ class SandboxConfiguration private constructor(
                 executionProfile = profile,
                 rules = rules,
                 emitters = (emitters ?: Discovery.find()).filter {
-                    enableTracing || !it.isTracer
+                    enableTracing || it.priority > EMIT_TRACING
                 },
                 definitionProviders = definitionProviders,
                 analysisConfiguration = analysisConfiguration

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -59,9 +59,19 @@ class AnalysisConfiguration(
     val stitchedInterfaces: Map<String, List<Member>> get() = STITCHED_INTERFACES
 
     /**
+     * These classes have extra methods added as they are mapped into the sandbox.
+     */
+    val stitchedClasses: Map<String, List<Member>> get() = STITCHED_CLASSES
+
+    /**
      * Functionality used to resolve the qualified name and relevant information about a class.
      */
     val classResolver: ClassResolver = ClassResolver(pinnedClasses, TEMPLATE_CLASSES, whitelist, SANDBOX_PREFIX)
+
+    /**
+     * Resolves the internal names of synthetic exception classes.
+     */
+    val exceptionResolver: ExceptionResolver = ExceptionResolver(JVM_EXCEPTIONS, pinnedClasses, SANDBOX_PREFIX)
 
     private val bootstrapClassLoader = bootstrapJar?.let { BootstrapClassLoader(it, classResolver) }
     val supportingClassLoader = SourceClassLoader(classPath, classResolver, bootstrapClassLoader)
@@ -76,11 +86,14 @@ class AnalysisConfiguration(
     fun isTemplateClass(className: String): Boolean = className in TEMPLATE_CLASSES
     fun isPinnedClass(className: String): Boolean = className in pinnedClasses
 
+    fun isJvmException(className: String): Boolean = className in JVM_EXCEPTIONS
+    fun isSandboxClass(className: String): Boolean = className.startsWith(SANDBOX_PREFIX) && !isPinnedClass(className)
+
     companion object {
         /**
          * The package name prefix to use for classes loaded into a sandbox.
          */
-        private const val SANDBOX_PREFIX: String = "sandbox/"
+        const val SANDBOX_PREFIX: String = "sandbox/"
 
         /**
          * These class must belong to the application class loader.
@@ -111,14 +124,77 @@ class AnalysisConfiguration(
             java.lang.String.CASE_INSENSITIVE_ORDER::class.java,
             java.lang.System::class.java,
             java.lang.ThreadLocal::class.java,
+            java.lang.Throwable::class.java,
             kotlin.Any::class.java,
             sun.misc.JavaLangAccess::class.java,
             sun.misc.SharedSecrets::class.java
         ).sandboxed() + setOf(
             "sandbox/Task",
             "sandbox/java/lang/DJVM",
+            "sandbox/java/lang/DJVMException",
+            "sandbox/java/lang/DJVMThrowableWrapper",
             "sandbox/sun/misc/SharedSecrets\$1",
             "sandbox/sun/misc/SharedSecrets\$JavaLangAccessImpl"
+        )
+
+        /**
+         * These are thrown by the JVM itself, and so
+         * we need to handle them without wrapping them.
+         *
+         * Note that this set is closed, i.e. every one
+         * of these exceptions' [Throwable] super classes
+         * is also within this set.
+         *
+         * The full list of exceptions is determined by:
+         * hotspot/src/share/vm/classfile/vmSymbols.hpp
+         */
+        val JVM_EXCEPTIONS: Set<String> = setOf(
+            java.io.IOException::class.java,
+            java.lang.AbstractMethodError::class.java,
+            java.lang.ArithmeticException::class.java,
+            java.lang.ArrayIndexOutOfBoundsException::class.java,
+            java.lang.ArrayStoreException::class.java,
+            java.lang.ClassCastException::class.java,
+            java.lang.ClassCircularityError::class.java,
+            java.lang.ClassFormatError::class.java,
+            java.lang.ClassNotFoundException::class.java,
+            java.lang.CloneNotSupportedException::class.java,
+            java.lang.Error::class.java,
+            java.lang.Exception::class.java,
+            java.lang.ExceptionInInitializerError::class.java,
+            java.lang.IllegalAccessError::class.java,
+            java.lang.IllegalAccessException::class.java,
+            java.lang.IllegalArgumentException::class.java,
+            java.lang.IllegalStateException::class.java,
+            java.lang.IncompatibleClassChangeError::class.java,
+            java.lang.IndexOutOfBoundsException::class.java,
+            java.lang.InstantiationError::class.java,
+            java.lang.InstantiationException::class.java,
+            java.lang.InternalError::class.java,
+            java.lang.LinkageError::class.java,
+            java.lang.NegativeArraySizeException::class.java,
+            java.lang.NoClassDefFoundError::class.java,
+            java.lang.NoSuchFieldError::class.java,
+            java.lang.NoSuchFieldException::class.java,
+            java.lang.NoSuchMethodError::class.java,
+            java.lang.NoSuchMethodException::class.java,
+            java.lang.NullPointerException::class.java,
+            java.lang.OutOfMemoryError::class.java,
+            java.lang.ReflectiveOperationException::class.java,
+            java.lang.RuntimeException::class.java,
+            java.lang.StackOverflowError::class.java,
+            java.lang.StringIndexOutOfBoundsException::class.java,
+            java.lang.ThreadDeath::class.java,
+            java.lang.Throwable::class.java,
+            java.lang.UnknownError::class.java,
+            java.lang.UnsatisfiedLinkError::class.java,
+            java.lang.UnsupportedClassVersionError::class.java,
+            java.lang.UnsupportedOperationException::class.java,
+            java.lang.VerifyError::class.java,
+            java.lang.VirtualMachineError::class.java
+        ).sandboxed() + setOf(
+            // Mentioned here to prevent the DJVM from generating a synthetic wrapper.
+            "sandbox/java/lang/DJVMThrowableWrapper"
         )
 
         /**
@@ -127,44 +203,82 @@ class AnalysisConfiguration(
          *
          * <code>interface sandbox.A extends A</code>
          */
-        private val STITCHED_INTERFACES: Map<String, List<Member>> = mapOf(
-            sandboxed(CharSequence::class.java) to listOf(
-                object : MethodBuilder(
-                    access = ACC_PUBLIC or ACC_SYNTHETIC or ACC_BRIDGE,
-                    className = "sandbox/java/lang/CharSequence",
-                    memberName = "subSequence",
-                    descriptor = "(II)Ljava/lang/CharSequence;"
-                ) {
-                    override fun writeBody(emitter: EmitterModule) = with(emitter) {
-                        pushObject(0)
-                        pushInteger(1)
-                        pushInteger(2)
-                        invokeInterface(className, memberName, "(II)L$className;")
-                        returnObject()
-                    }
-                }.withBody()
-                 .build(),
-                MethodBuilder(
-                    access = ACC_PUBLIC or ACC_ABSTRACT,
-                    className = "sandbox/java/lang/CharSequence",
-                    memberName = "toString",
-                    descriptor = "()Ljava/lang/String;"
-                ).build()
-            ),
+        private val STITCHED_INTERFACES: Map<String, List<Member>> = listOf(
+            object : MethodBuilder(
+                access = ACC_PUBLIC or ACC_SYNTHETIC or ACC_BRIDGE,
+                className = sandboxed(CharSequence::class.java),
+                memberName = "subSequence",
+                descriptor = "(II)Ljava/lang/CharSequence;"
+            ) {
+                override fun writeBody(emitter: EmitterModule) = with(emitter) {
+                    pushObject(0)
+                    pushInteger(1)
+                    pushInteger(2)
+                    invokeInterface(className, memberName, "(II)L$className;")
+                    returnObject()
+                }
+            }.withBody()
+             .build(),
+
+            MethodBuilder(
+                access = ACC_PUBLIC or ACC_ABSTRACT,
+                className = sandboxed(CharSequence::class.java),
+                memberName = "toString",
+                descriptor = "()Ljava/lang/String;"
+            ).build()
+        ).mapByClassName() + mapOf(
             sandboxed(Comparable::class.java) to emptyList(),
             sandboxed(Comparator::class.java) to emptyList(),
             sandboxed(Iterable::class.java) to emptyList()
         )
 
-        private fun sandboxed(clazz: Class<*>) = SANDBOX_PREFIX + Type.getInternalName(clazz)
+        /**
+         * These classes have extra methods added when mapped into the sandbox.
+         */
+        private val STITCHED_CLASSES: Map<String, List<Member>> = listOf(
+            object : MethodBuilder(
+                access = ACC_FINAL,
+                className = sandboxed(Enum::class.java),
+                memberName = "fromDJVM",
+                descriptor = "()Ljava/lang/Enum;",
+                signature = "()Ljava/lang/Enum<*>;"
+            ) {
+                override fun writeBody(emitter: EmitterModule) = with(emitter) {
+                    pushObject(0)
+                    invokeStatic("sandbox/java/lang/DJVM", "fromDJVMEnum", "(Lsandbox/java/lang/Enum;)Ljava/lang/Enum;")
+                    returnObject()
+                }
+            }.withBody()
+             .build(),
+
+            object : MethodBuilder(
+                access = ACC_BRIDGE or ACC_SYNTHETIC,
+                className = sandboxed(Enum::class.java),
+                memberName = "fromDJVM",
+                descriptor = "()Ljava/lang/Object;"
+            ) {
+                override fun writeBody(emitter: EmitterModule) = with(emitter) {
+                    pushObject(0)
+                    invokeVirtual(className, memberName, "()Ljava/lang/Enum;")
+                    returnObject()
+                }
+            }.withBody()
+             .build()
+        ).mapByClassName()
+
+        private fun sandboxed(clazz: Class<*>): String = (SANDBOX_PREFIX + Type.getInternalName(clazz)).intern()
         private fun Set<Class<*>>.sandboxed(): Set<String> = map(Companion::sandboxed).toSet()
+        private fun Iterable<Member>.mapByClassName(): Map<String, List<Member>>
+                      = groupBy(Member::className).mapValues(Map.Entry<String, List<Member>>::value)
     }
 
     private open class MethodBuilder(
             protected val access: Int,
             protected val className: String,
             protected val memberName: String,
-            protected val descriptor: String) {
+            protected val descriptor: String,
+            protected val signature: String = ""
+    ) {
         private val bodies = mutableListOf<MethodBody>()
 
         protected open fun writeBody(emitter: EmitterModule) {}
@@ -179,7 +293,7 @@ class AnalysisConfiguration(
             className = className,
             memberName = memberName,
             signature = descriptor,
-            genericsDetails = "",
+            genericsDetails = signature,
             body = bodies
         )
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -130,6 +130,7 @@ class AnalysisConfiguration(
             sun.misc.SharedSecrets::class.java
         ).sandboxed() + setOf(
             "sandbox/Task",
+            "sandbox/TaskTypes",
             "sandbox/java/lang/DJVM",
             "sandbox/java/lang/DJVMException",
             "sandbox/java/lang/DJVMThrowableWrapper",

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ExceptionResolver.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ExceptionResolver.kt
@@ -1,0 +1,41 @@
+package net.corda.djvm.analysis
+
+import org.objectweb.asm.Type
+
+class ExceptionResolver(
+    private val jvmExceptionClasses: Set<String>,
+    private val pinnedClasses: Set<String>,
+    private val sandboxPrefix: String
+) {
+    companion object {
+        private const val DJVM_EXCEPTION_NAME = "\$1DJVM"
+
+        fun isDJVMException(className: String): Boolean = className.endsWith(DJVM_EXCEPTION_NAME)
+        fun getDJVMException(className: String): String = className + DJVM_EXCEPTION_NAME
+        fun getDJVMExceptionOwner(className: String): String = className.dropLast(DJVM_EXCEPTION_NAME.length)
+    }
+
+    fun getThrowableName(clazz: Class<*>): String {
+        return getDJVMException(Type.getInternalName(clazz))
+    }
+
+    fun getThrowableSuperName(clazz: Class<*>): String {
+        return getThrowableOwnerName(Type.getInternalName(clazz.superclass))
+    }
+
+    fun getThrowableOwnerName(className: String): String {
+        return if (className in jvmExceptionClasses) {
+            className.unsandboxed
+        } else if (className in pinnedClasses) {
+            className
+        } else {
+            getDJVMException(className)
+        }
+    }
+
+    private val String.unsandboxed: String get() = if (startsWith(sandboxPrefix)) {
+        drop(sandboxPrefix.length)
+    } else {
+        this
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/PrefixTree.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/PrefixTree.kt
@@ -1,7 +1,7 @@
 package net.corda.djvm.analysis
 
 /**
- * Trie data structure to make prefix matching more efficient.
+ * Tree data structure to make prefix matching more efficient.
  */
 class PrefixTree {
 

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
@@ -100,9 +100,6 @@ open class Whitelist private constructor(
             "^java/lang/Cloneable(\\..*)?\$".toRegex(),
             "^java/lang/Object(\\..*)?\$".toRegex(),
             "^java/lang/Override(\\..*)?\$".toRegex(),
-                // TODO: sandbox exception handling!
-                "^java/lang/StackTraceElement\$".toRegex(),
-                "^java/lang/Throwable\$".toRegex(),
             "^java/lang/Void\$".toRegex(),
             "^java/lang/invoke/LambdaMetafactory\$".toRegex(),
             "^java/lang/invoke/MethodHandles(\\\$.*)?\$".toRegex(),

--- a/djvm/src/main/kotlin/net/corda/djvm/code/Emitter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/Emitter.kt
@@ -18,10 +18,10 @@ interface Emitter {
     fun emit(context: EmitterContext, instruction: Instruction)
 
     /**
-     * Indication of whether or not the emitter performs instrumentation for tracing inside the sandbox.
+     * Determines the order in which emitters are executed within the sandbox.
      */
     @JvmDefault
-    val isTracer: Boolean
-        get() = false
+    val priority: Int
+        get() = EMIT_DEFAULT
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -169,6 +169,14 @@ class EmitterModule(
     inline fun <reified T : Throwable> throwException(message: String) = throwException(T::class.java, message)
 
     /**
+     * Attempt to cast the object on the top of the stack to the given class.
+     */
+    fun castObjectTo(className: String) {
+        methodVisitor.visitTypeInsn(CHECKCAST, className)
+        hasEmittedCustomCode = true
+    }
+
+    /**
      * Emit instruction for returning from "void" method.
      */
     fun returnVoid() {

--- a/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
@@ -2,11 +2,17 @@
 package net.corda.djvm.code
 
 import org.objectweb.asm.Type
+import sandbox.java.lang.DJVMException
 import sandbox.net.corda.djvm.costing.ThresholdViolationError
 import sandbox.net.corda.djvm.rules.RuleViolationError
 
+const val EMIT_TRACING: Int = 0
+const val EMIT_TRAPPING_EXCEPTIONS: Int = 1
+const val EMIT_DEFAULT: Int = 10
+
 val ruleViolationError: String = Type.getInternalName(RuleViolationError::class.java)
 val thresholdViolationError: String = Type.getInternalName(ThresholdViolationError::class.java)
+val djvmException: String = Type.getInternalName(DJVMException::class.java)
 
 /**
  * Local extension method for normalizing a class name.

--- a/djvm/src/main/kotlin/net/corda/djvm/code/instructions/TryBlock.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/instructions/TryBlock.kt
@@ -1,0 +1,8 @@
+package net.corda.djvm.code.instructions
+
+import org.objectweb.asm.Label
+
+open class TryBlock(
+        val handler: Label,
+        val typeName: String
+) : NoOperationInstruction()

--- a/djvm/src/main/kotlin/net/corda/djvm/code/instructions/TryCatchBlock.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/instructions/TryCatchBlock.kt
@@ -9,6 +9,6 @@ import org.objectweb.asm.Label
  * @property handler The label of the exception handler.
  */
 class TryCatchBlock(
-        val typeName: String,
-        val handler: Label
-) : NoOperationInstruction()
+        typeName: String,
+        handler: Label
+) : TryBlock(handler, typeName)

--- a/djvm/src/main/kotlin/net/corda/djvm/code/instructions/TryFinallyBlock.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/instructions/TryFinallyBlock.kt
@@ -7,7 +7,6 @@ import org.objectweb.asm.Label
  *
  * @property handler The handler for the finally-block.
  */
-@Suppress("MemberVisibilityCanBePrivate")
 class TryFinallyBlock(
-        val handler: Label
-) : NoOperationInstruction()
+        handler: Label
+) : TryBlock(handler, "")

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
@@ -1,7 +1,6 @@
 package net.corda.djvm.rewiring
 
 import net.corda.djvm.SandboxConfiguration
-import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.AnalysisContext
 import net.corda.djvm.analysis.ClassAndMemberVisitor.Companion.API_VERSION
 import net.corda.djvm.code.ClassMutator
@@ -11,6 +10,8 @@ import net.corda.djvm.references.Member
 import net.corda.djvm.utilities.loggerFor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
 
 /**
  * Functionality for rewriting parts of a class as it is being loaded.
@@ -22,6 +23,7 @@ open class ClassRewriter(
         private val configuration: SandboxConfiguration,
         private val classLoader: ClassLoader
 ) {
+    private val analysisConfig = configuration.analysisConfiguration
 
     /**
      * Process class and allow user to rewrite parts/all of its content through provided hooks.
@@ -32,11 +34,13 @@ open class ClassRewriter(
     fun rewrite(reader: ClassReader, context: AnalysisContext): ByteCode {
         logger.debug("Rewriting class {}...", reader.className)
         val writer = SandboxClassWriter(reader, classLoader)
-        val analysisConfiguration = configuration.analysisConfiguration
-        val classRemapper = SandboxClassRemapper(InterfaceStitcher(writer, analysisConfiguration), analysisConfiguration)
+        val classRemapper = SandboxClassRemapper(
+            ClassExceptionRemapper(SandboxStitcher(writer)),
+            analysisConfig
+        )
         val visitor = ClassMutator(
                 classRemapper,
-                analysisConfiguration,
+                analysisConfig,
                 configuration.definitionProviders,
                 configuration.emitters
         )
@@ -50,25 +54,30 @@ open class ClassRewriter(
 
     /**
      * Extra visitor that is applied after [SandboxRemapper]. This "stitches" the original
-     * unmapped interface as a super-interface of the mapped version.
+     * unmapped interface as a super-interface of the mapped version, as well as adding
+     * any extra methods that are needed.
      */
-    private class InterfaceStitcher(parent: ClassVisitor, private val configuration: AnalysisConfiguration)
+    private inner class SandboxStitcher(parent: ClassVisitor)
         : ClassVisitor(API_VERSION, parent)
     {
         private val extraMethods = mutableListOf<Member>()
 
         override fun visit(version: Int, access: Int, className: String, signature: String?, superName: String?, interfaces: Array<String>?) {
-            val stitchedInterfaces = configuration.stitchedInterfaces[className]?.let { methods ->
+            val stitchedInterfaces = analysisConfig.stitchedInterfaces[className]?.let { methods ->
                 extraMethods += methods
-                arrayOf(*(interfaces ?: emptyArray()), configuration.classResolver.reverse(className))
+                arrayOf(*(interfaces ?: emptyArray()), analysisConfig.classResolver.reverse(className))
             } ?: interfaces
+
+            analysisConfig.stitchedClasses[className]?.also { methods ->
+                extraMethods += methods
+            }
 
             super.visit(version, access, className, signature, superName, stitchedInterfaces)
         }
 
         override fun visitEnd() {
             for (method in extraMethods) {
-                method.apply {
+                with(method) {
                     visitMethod(access, memberName, signature, genericsDetails.emptyAsNull, exceptions.toTypedArray())?.also { mv ->
                         mv.visitCode()
                         EmitterModule(mv).writeByteCode(body)
@@ -79,6 +88,22 @@ open class ClassRewriter(
             }
             extraMethods.clear()
             super.visitEnd()
+        }
+    }
+
+    private inner class ClassExceptionRemapper(parent: ClassVisitor) : ClassVisitor(API_VERSION, parent) {
+        override fun visitMethod(access: Int, name: String, descriptor: String, signature: String?, exceptions: Array<out String>?): MethodVisitor? {
+            val mappedExceptions = exceptions?.map(analysisConfig.exceptionResolver::getThrowableOwnerName)?.toTypedArray()
+            return super.visitMethod(access, name, descriptor, signature, mappedExceptions)?.let {
+                MethodExceptionRemapper(it)
+            }
+        }
+    }
+
+    private inner class MethodExceptionRemapper(parent: MethodVisitor) : MethodVisitor(API_VERSION, parent) {
+        override fun visitTryCatchBlock(start: Label, end: Label, handler: Label, exceptionType: String?) {
+            val mappedExceptionType = exceptionType?.let(analysisConfig.exceptionResolver::getThrowableOwnerName)
+            super.visitTryCatchBlock(start, end, handler, mappedExceptionType)
         }
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
@@ -39,10 +39,10 @@ open class ClassRewriter(
             analysisConfig
         )
         val visitor = ClassMutator(
-                classRemapper,
-                analysisConfig,
-                configuration.definitionProviders,
-                configuration.emitters
+            classRemapper,
+            analysisConfig,
+            configuration.definitionProviders,
+            configuration.emitters
         )
         visitor.analyze(reader, context, options = ClassReader.EXPAND_FRAMES)
         return ByteCode(writer.toByteArray(), visitor.hasBeenModified)
@@ -91,6 +91,9 @@ open class ClassRewriter(
         }
     }
 
+    /**
+     * Map exceptions in method signatures to their sandboxed equivalents.
+     */
     private inner class ClassExceptionRemapper(parent: ClassVisitor) : ClassVisitor(API_VERSION, parent) {
         override fun visitMethod(access: Int, name: String, descriptor: String, signature: String?, exceptions: Array<out String>?): MethodVisitor? {
             val mappedExceptions = exceptions?.map(analysisConfig.exceptionResolver::getThrowableOwnerName)?.toTypedArray()
@@ -100,6 +103,9 @@ open class ClassRewriter(
         }
     }
 
+    /**
+     * Map exceptions in method try-catch blocks to their sandboxed equivalents.
+     */
     private inner class MethodExceptionRemapper(parent: MethodVisitor) : MethodVisitor(API_VERSION, parent) {
         override fun visitTryCatchBlock(start: Label, end: Label, handler: Label, exceptionType: String?) {
             val mappedExceptionType = exceptionType?.let(analysisConfig.exceptionResolver::getThrowableOwnerName)

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
@@ -3,7 +3,6 @@ package net.corda.djvm.rewiring
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.ClassAndMemberVisitor.Companion.API_VERSION
 import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.commons.ClassRemapper
 
@@ -33,11 +32,6 @@ class SandboxClassRemapper(cv: ClassVisitor, private val configuration: Analysis
         override fun visitMethodInsn(opcode: Int, owner: String, name: String, descriptor: String, isInterface: Boolean) {
             val method = Element(owner, name, descriptor)
             return mapperFor(method).visitMethodInsn(opcode, owner, name, descriptor, isInterface)
-        }
-
-        override fun visitTryCatchBlock(start: Label, end: Label, handler: Label, type: String?) {
-            // Don't map caught exception names - these could be thrown by the JVM itself.
-            nonmapper.visitTryCatchBlock(start, end, handler, type)
         }
 
         override fun visitFieldInsn(opcode: Int, owner: String, name: String, descriptor: String) {

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/ThrowableWrapperFactory.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/ThrowableWrapperFactory.kt
@@ -1,0 +1,138 @@
+package net.corda.djvm.rewiring
+
+import net.corda.djvm.analysis.ExceptionResolver.Companion.isDJVMException
+import net.corda.djvm.code.djvmException
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes.*
+
+/**
+ * Generates a synthetic [Throwable] class that will wrap a [sandbox.java.lang.Throwable].
+ * Only exceptions which are NOT thrown by the JVM will be accompanied one of these.
+ */
+class ThrowableWrapperFactory(
+    private val className: String,
+    private val superName: String
+) {
+    companion object {
+        const val CONSTRUCTOR_DESCRIPTOR = "(Lsandbox/java/lang/Throwable;)V"
+        const val FIELD_TYPE = "Lsandbox/java/lang/Throwable;"
+        const val THROWABLE_FIELD = "t"
+
+        fun toByteCode(className: String, superName: String): ByteCode {
+            val bytecode: ByteArray = with(ClassWriter(0)) {
+                ThrowableWrapperFactory(className, superName).accept(this)
+                toByteArray()
+            }
+            return ByteCode(bytecode, true)
+        }
+    }
+
+    /**
+     * Write bytecode for synthetic throwable wrapper class. All of
+     * these classes implement [sandbox.java.lang.DJVMException],
+     * either directly or indirectly.
+     */
+    fun accept(writer: ClassWriter) = with(writer) {
+        if (isDJVMException(superName)) {
+            childClass()
+        } else {
+            baseClass()
+        }
+    }
+
+    /**
+     * This is a "base" wrapper class that inherits from a JVM exception.
+     *
+     * <code>
+     *     public class CLASSNAME extends JAVA_EXCEPTION implements DJVMException {
+     *         private final sandbox.java.lang.Throwable t;
+     *
+     *         public CLASSNAME(sandbox.java.lang.Throwable t) {
+     *             this.t = t;
+     *         }
+     *
+     *         @Override
+     *         public final sandbox.java.lang.Throwable getThrowable() {
+     *             return t;
+     *         }
+     *     }
+     * </code>
+     */
+    private fun ClassWriter.baseClass() {
+        // Class definition
+        visit(
+            V1_8,
+            ACC_SYNTHETIC or ACC_PUBLIC,
+            className,
+            null,
+            superName,
+            arrayOf(djvmException)
+        )
+
+        // Private final field to hold the sandbox throwable object.
+        visitField(ACC_PRIVATE or ACC_FINAL, THROWABLE_FIELD, FIELD_TYPE, null, null)
+
+        // Constructor
+        visitMethod(ACC_PUBLIC, "<init>", CONSTRUCTOR_DESCRIPTOR, null, null).also { mv ->
+            mv.visitCode()
+            mv.visitVarInsn(ALOAD, 0)
+            mv.visitMethodInsn(INVOKESPECIAL, superName, "<init>", "()V", false)
+            mv.visitVarInsn(ALOAD, 0)
+            mv.visitVarInsn(ALOAD, 1)
+            mv.visitFieldInsn(PUTFIELD, className, THROWABLE_FIELD, FIELD_TYPE)
+            mv.visitInsn(RETURN)
+            mv.visitMaxs(2, 2)
+            mv.visitEnd()
+        }
+
+        // Getter method for the sandbox throwable object.
+        visitMethod(ACC_PUBLIC or ACC_FINAL, "getThrowable", "()$FIELD_TYPE", null, null).also { mv ->
+            mv.visitCode()
+            mv.visitVarInsn(ALOAD, 0)
+            mv.visitFieldInsn(GETFIELD, className, THROWABLE_FIELD, FIELD_TYPE)
+            mv.visitInsn(ARETURN)
+            mv.visitMaxs(1, 1)
+            mv.visitEnd()
+        }
+
+        // End of class
+        visitEnd()
+    }
+
+    /**
+     * This wrapper class inherits from another wrapper class.
+     *
+     * <code>
+     *     public class CLASSNAME extends SUPERNAME {
+     *         public CLASSNAME(sandbox.java.lang.Throwable t) {
+     *             super(t);
+     *         }
+     *     }
+     * </code>
+     */
+    private fun ClassWriter.childClass() {
+        // Class definition
+        visit(
+            V1_8,
+            ACC_SYNTHETIC or ACC_PUBLIC,
+            className,
+            null,
+            superName,
+            arrayOf()
+        )
+
+        // Constructor
+        visitMethod(ACC_PUBLIC, "<init>", CONSTRUCTOR_DESCRIPTOR, null, null).also { mv ->
+            mv.visitCode()
+            mv.visitVarInsn(ALOAD, 0)
+            mv.visitVarInsn(ALOAD, 1)
+            mv.visitMethodInsn(INVOKESPECIAL, superName, "<init>", CONSTRUCTOR_DESCRIPTOR, false)
+            mv.visitInsn(RETURN)
+            mv.visitMaxs(2, 2)
+            mv.visitEnd()
+        }
+
+        // End of class
+        visitEnd()
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/ThrowableWrapperFactory.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/ThrowableWrapperFactory.kt
@@ -55,6 +55,11 @@ class ThrowableWrapperFactory(
      *         public final sandbox.java.lang.Throwable getThrowable() {
      *             return t;
      *         }
+     *
+     *         @Override
+     *         public final java.lang.Throwable fillInStackTrace() {
+     *             return this;
+     *         }
      *     }
      * </code>
      */
@@ -90,6 +95,15 @@ class ThrowableWrapperFactory(
             mv.visitCode()
             mv.visitVarInsn(ALOAD, 0)
             mv.visitFieldInsn(GETFIELD, className, THROWABLE_FIELD, FIELD_TYPE)
+            mv.visitInsn(ARETURN)
+            mv.visitMaxs(1, 1)
+            mv.visitEnd()
+        }
+
+        // Prevent these wrappers from generating their own stack traces.
+        visitMethod(ACC_PUBLIC or ACC_FINAL, "fillInStackTrace", "()Ljava/lang/Throwable;", null, null).also { mv ->
+            mv.visitCode()
+            mv.visitVarInsn(ALOAD, 0)
             mv.visitInsn(ARETURN)
             mv.visitMaxs(1, 1)
             mv.visitEnd()

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
@@ -27,30 +27,36 @@ class DisallowCatchingBlacklistedExceptions : Emitter {
 
     companion object {
         private val disallowedExceptionTypes = setOf(
-                ruleViolationError,
-                thresholdViolationError,
+            ruleViolationError,
+            thresholdViolationError,
 
-                /**
-                 * These errors indicate that the JVM is failing,
-                 * so don't allow these to be caught either.
-                 */
-                "java/lang/StackOverflowError",
-                "java/lang/OutOfMemoryError",
+            /**
+             * These errors indicate that the JVM is failing,
+             * so don't allow these to be caught either.
+             */
+            "java/lang/StackOverflowError",
+            "java/lang/OutOfMemoryError",
 
-                /**
-                 * These are immediate super-classes for our explicit errors.
-                 */
-                "java/lang/VirtualMachineError",
-                "java/lang/ThreadDeath",
+            /**
+             * These are immediate super-classes for our explicit errors.
+             */
+            "java/lang/VirtualMachineError",
+            "java/lang/ThreadDeath",
 
-                /**
-                 * Any of [ThreadDeath] and [VirtualMachineError]'s throwable
-                 * super-classes also need explicit checking.
-                 */
-                "java/lang/Throwable",
-                "java/lang/Error"
+            /**
+             * Any of [ThreadDeath] and [VirtualMachineError]'s throwable
+             * super-classes also need explicit checking.
+             */
+            "java/lang/Throwable",
+            "java/lang/Error"
         )
 
     }
 
+    /**
+     * We need to invoke this emitter before the [HandleExceptionUnwrapper]
+     * so that we don't unwrap exceptions we don't want to catch.
+     */
+    override val priority: Int
+        get() = EMIT_TRAPPING_EXCEPTIONS
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/HandleExceptionUnwrapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/HandleExceptionUnwrapper.kt
@@ -1,0 +1,46 @@
+package net.corda.djvm.rules.implementation
+
+import net.corda.djvm.code.EMIT_TRAPPING_EXCEPTIONS
+import net.corda.djvm.code.Emitter
+import net.corda.djvm.code.EmitterContext
+import net.corda.djvm.code.Instruction
+import net.corda.djvm.code.instructions.CodeLabel
+import net.corda.djvm.code.instructions.TryBlock
+import org.objectweb.asm.Label
+
+/**
+ * Converts an exception from [java.lang.Throwable] to [sandbox.java.lang.Throwable]
+ * at the beginning of either a catch block or a finally block.
+ */
+class HandleExceptionUnwrapper : Emitter {
+    private val handlers = mutableMapOf<Label, String>()
+
+    override fun emit(context: EmitterContext, instruction: Instruction) = context.emit {
+        if (instruction is TryBlock) {
+            handlers[instruction.handler] = instruction.typeName
+        } else if (instruction is CodeLabel) {
+            handlers[instruction.label]?.let { exceptionType ->
+                if (exceptionType.isNotEmpty()) {
+                    /**
+                     * This is a catch block; the wrapping function is allowed to throw exceptions.
+                     */
+                    invokeStatic("sandbox/java/lang/DJVM", "catch", "(Ljava/lang/Throwable;)Lsandbox/java/lang/Throwable;")
+
+                    /**
+                     * When catching exceptions, we also need to tell the verifier which
+                     * which kind of [sandbox.java.lang.Throwable] to expect this to be.
+                     */
+                    castObjectTo(exceptionType)
+                } else {
+                    /**
+                     * This is a finally block; the wrapping function MUST NOT throw exceptions.
+                     */
+                    invokeStatic("sandbox/java/lang/DJVM", "finally", "(Ljava/lang/Throwable;)Lsandbox/java/lang/Throwable;")
+                }
+            }
+        }
+    }
+
+    override val priority: Int
+        get() = EMIT_TRAPPING_EXCEPTIONS + 1
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/ThrowExceptionWrapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/ThrowExceptionWrapper.kt
@@ -1,0 +1,20 @@
+package net.corda.djvm.rules.implementation
+
+import net.corda.djvm.code.Emitter
+import net.corda.djvm.code.EmitterContext
+import net.corda.djvm.code.Instruction
+import org.objectweb.asm.Opcodes.ATHROW
+
+/**
+ * Converts a [sandbox.java.lang.Throwable] into a [java.lang.Throwable]
+ * so that the JVM can throw it.
+ */
+class ThrowExceptionWrapper : Emitter {
+    override fun emit(context: EmitterContext, instruction: Instruction) = context.emit {
+        when (instruction.operation) {
+            ATHROW -> {
+                invokeStatic("sandbox/java/lang/DJVM", "fromDJVM", "(Lsandbox/java/lang/Throwable;)Ljava/lang/Throwable;")
+            }
+        }
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceAllocations.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceAllocations.kt
@@ -1,5 +1,6 @@
 package net.corda.djvm.rules.implementation.instrumentation
 
+import net.corda.djvm.code.EMIT_TRACING
 import net.corda.djvm.code.Emitter
 import net.corda.djvm.code.EmitterContext
 import net.corda.djvm.code.Instruction
@@ -40,7 +41,7 @@ class TraceAllocations : Emitter {
         }
     }
 
-    override val isTracer: Boolean
-        get() = true
+    override val priority: Int
+        get() = EMIT_TRACING
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceInvocations.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceInvocations.kt
@@ -1,5 +1,6 @@
 package net.corda.djvm.rules.implementation.instrumentation
 
+import net.corda.djvm.code.EMIT_TRACING
 import net.corda.djvm.code.Emitter
 import net.corda.djvm.code.EmitterContext
 import net.corda.djvm.code.Instruction
@@ -17,7 +18,7 @@ class TraceInvocations : Emitter {
         }
     }
 
-    override val isTracer: Boolean
-        get() = true
+    override val priority: Int
+        get() = EMIT_TRACING
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceJumps.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceJumps.kt
@@ -1,5 +1,6 @@
 package net.corda.djvm.rules.implementation.instrumentation
 
+import net.corda.djvm.code.EMIT_TRACING
 import net.corda.djvm.code.Emitter
 import net.corda.djvm.code.EmitterContext
 import net.corda.djvm.code.Instruction
@@ -17,7 +18,7 @@ class TraceJumps : Emitter {
         }
     }
 
-    override val isTracer: Boolean
-        get() = true
+    override val priority: Int
+        get() = EMIT_TRACING
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceThrows.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/instrumentation/TraceThrows.kt
@@ -1,5 +1,6 @@
 package net.corda.djvm.rules.implementation.instrumentation
 
+import net.corda.djvm.code.EMIT_TRACING
 import net.corda.djvm.code.Emitter
 import net.corda.djvm.code.EmitterContext
 import net.corda.djvm.code.Instruction
@@ -17,7 +18,7 @@ class TraceThrows : Emitter {
         }
     }
 
-    override val isTracer: Boolean
-        get() = true
+    override val priority: Int
+        get() = EMIT_TRACING
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/source/ClassSource.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/ClassSource.kt
@@ -21,12 +21,14 @@ class ClassSource private constructor(
         /**
          * Instantiate a [ClassSource] from a fully qualified class name.
          */
+        @JvmStatic
         fun fromClassName(className: String, origin: String? = null) =
                 ClassSource(className, origin)
 
         /**
          * Instantiate a [ClassSource] from a file on disk.
          */
+        @JvmStatic
         fun fromPath(path: Path) = PathClassSource(path)
 
         /**

--- a/djvm/src/main/kotlin/sandbox/Task.kt
+++ b/djvm/src/main/kotlin/sandbox/Task.kt
@@ -6,7 +6,10 @@ import sandbox.java.lang.unsandbox
 
 typealias SandboxFunction<TInput, TOutput> = sandbox.java.util.function.Function<TInput, TOutput>
 
-@Suppress("unused")
+internal fun isEntryPoint(elt: java.lang.StackTraceElement): Boolean {
+    return elt.className == "sandbox.Task" && elt.methodName == "apply"
+}
+
 class Task(private val function: SandboxFunction<in Any?, out Any?>?) : SandboxFunction<Any?, Any?> {
 
     /**

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -97,10 +97,11 @@ fun getEnumConstants(clazz: Class<out Enum<*>>): Array<*>? {
 
 internal fun enumConstantDirectory(clazz: Class<out Enum<*>>): sandbox.java.util.Map<String, out Enum<*>>? {
     // DO NOT replace get with Kotlin's [] because Kotlin would use java.util.Map.
+    @Suppress("ReplaceGetOrSet")
     return allEnumDirectories.get(clazz) ?: createEnumDirectory(clazz)
 }
 
-@Suppress("unchecked_cast")
+@Suppress("unchecked_cast", "ReplaceGetOrSet")
 internal fun getEnumConstantsShared(clazz: Class<out Enum<*>>): Array<out Enum<*>>? {
     return if (isEnum(clazz)) {
         // DO NOT replace get with Kotlin's [] because Kotlin would use java.util.Map.
@@ -110,7 +111,7 @@ internal fun getEnumConstantsShared(clazz: Class<out Enum<*>>): Array<out Enum<*
     }
 }
 
-@Suppress("unchecked_cast")
+@Suppress("unchecked_cast", "ReplacePutWithAssignment" )
 private fun createEnum(clazz: Class<out Enum<*>>): Array<out Enum<*>>? {
     return clazz.getMethod("values").let { method ->
         method.isAccessible = true
@@ -119,6 +120,7 @@ private fun createEnum(clazz: Class<out Enum<*>>): Array<out Enum<*>>? {
     }?.apply { allEnums.put(clazz, this) }
 }
 
+@Suppress("ReplacePutWithAssignment")
 private fun createEnumDirectory(clazz: Class<out Enum<*>>): sandbox.java.util.Map<String, out Enum<*>> {
     val universe = getEnumConstantsShared(clazz) ?: throw IllegalArgumentException("${clazz.name} is not an enum type")
     val directory = sandbox.java.util.LinkedHashMap<String, Enum<*>>(2 * universe.size)

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVMException.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVMException.kt
@@ -1,0 +1,12 @@
+package sandbox.java.lang
+
+/**
+ * All synthetic [Throwable] classes wrapping non-JVM exceptions
+ * will implement this interface.
+ */
+interface DJVMException {
+    /**
+     * Returns the [sandbox.java.lang.Throwable] instance inside the wrapper.
+     */
+    fun getThrowable(): Throwable
+}

--- a/djvm/src/main/kotlin/sandbox/net/corda/djvm/rules/RuleViolationError.kt
+++ b/djvm/src/main/kotlin/sandbox/net/corda/djvm/rules/RuleViolationError.kt
@@ -7,4 +7,4 @@ package sandbox.net.corda.djvm.rules
  *
  * @property message The description of the condition causing the problem.
  */
-class RuleViolationError(override val message: String) : ThreadDeath()
+class RuleViolationError(override val message: String?) : ThreadDeath()

--- a/djvm/src/test/java/net/corda/djvm/WithJava.java
+++ b/djvm/src/test/java/net/corda/djvm/WithJava.java
@@ -1,0 +1,24 @@
+package net.corda.djvm;
+
+import net.corda.djvm.execution.ExecutionSummaryWithResult;
+import net.corda.djvm.execution.SandboxExecutor;
+import net.corda.djvm.source.ClassSource;
+
+import java.util.function.Function;
+
+public interface WithJava {
+
+    static <T,R> ExecutionSummaryWithResult<R> run(
+            SandboxExecutor<T, R> executor, Class<? extends Function<T,R>> task, T input) {
+        try {
+            return executor.run(ClassSource.fromClassName(task.getName(), null), input);
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            } else {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
@@ -1,0 +1,106 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import static net.corda.djvm.messages.Severity.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import org.junit.Test;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptySet;
+
+public class SandboxEnumJavaTest extends TestBase {
+
+    @Test
+    public void testEnumInsideSandbox() {
+        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+            SandboxExecutor<Integer, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<String[]> output = WithJava.run(executor, TransformEnum.class, 0);
+            assertThat(output.getResult())
+                    .isEqualTo(new String[]{ "ONE", "TWO", "THREE" });
+            return null;
+        });
+    }
+
+    @Test
+    public void testReturnEnumFromSandbox() {
+        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+            SandboxExecutor<String, ExampleEnum> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<ExampleEnum> output = WithJava.run(executor, FetchEnum.class, "THREE");
+            assertThat(output.getResult())
+                    .isEqualTo(ExampleEnum.THREE);
+            return null;
+        });
+    }
+
+    @Test
+    public void testWeCanIdentifyClassAsEnum() {
+        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+            SandboxExecutor<ExampleEnum, Boolean> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<Boolean> output = WithJava.run(executor, AssertEnum.class, ExampleEnum.THREE);
+            assertThat(output.getResult()).isTrue();
+            return null;
+        });
+    }
+
+    @Test
+    public void testWeCanCreateEnumMap() {
+        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+            SandboxExecutor<ExampleEnum, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, UseEnumMap.class, ExampleEnum.TWO);
+            assertThat(output.getResult()).isEqualTo(1);
+            return null;
+        });
+    }
+
+    @Test
+    public void testWeCanCreateEnumSet() {
+        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+            SandboxExecutor<ExampleEnum, Boolean> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<Boolean> output = WithJava.run(executor, UseEnumSet.class, ExampleEnum.ONE);
+            assertThat(output.getResult()).isTrue();
+            return null;
+        });
+    }
+
+    public static class AssertEnum implements Function<ExampleEnum, Boolean> {
+        @Override
+        public Boolean apply(ExampleEnum input) {
+            return input.getClass().isEnum();
+        }
+    }
+
+    public static class TransformEnum implements Function<Integer, String[]> {
+        @Override
+        public String[] apply(Integer input) {
+            return Stream.of(ExampleEnum.values()).map(ExampleEnum::name).toArray(String[]::new);
+        }
+    }
+
+    public static class FetchEnum implements Function<String, ExampleEnum> {
+        public ExampleEnum apply(String input) {
+            return ExampleEnum.valueOf(input);
+        }
+    }
+
+    public static class UseEnumMap implements Function<ExampleEnum, Integer> {
+        @Override
+        public Integer apply(ExampleEnum input) {
+            Map<ExampleEnum, String> map = new EnumMap<>(ExampleEnum.class);
+            map.put(input, input.name());
+            return map.size();
+        }
+    }
+
+    public static class UseEnumSet implements Function<ExampleEnum, Boolean> {
+        @Override
+        public Boolean apply(ExampleEnum input) {
+            return EnumSet.allOf(ExampleEnum.class).contains(input);
+        }
+    }
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -1,0 +1,79 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import static net.corda.djvm.messages.Severity.*;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class SandboxThrowableJavaTest extends TestBase {
+
+    @Test
+    public void testUserExceptionHandling() {
+        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+            SandboxExecutor<String, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<String[]> output = WithJava.run(executor, ThrowAndCatchJavaExample.class, "Hello World!");
+            assertThat(output.getResult())
+                    .isEqualTo(new String[]{ "FIRST FINALLY", "BASE EXCEPTION", "Hello World!", "SECOND FINALLY" });
+            return null;
+        });
+    }
+
+    @Test
+    public void testCheckedExceptions() {
+        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+            SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+
+            ExecutionSummaryWithResult<String> success = WithJava.run(executor, JavaWithCheckedExceptions.class, "http://localhost:8080/hello/world");
+            assertThat(success.getResult()).isEqualTo("/hello/world");
+
+            ExecutionSummaryWithResult<String> failure = WithJava.run(executor, JavaWithCheckedExceptions.class, "nasty string");
+            assertThat(failure.getResult()).isEqualTo("CATCH:Illegal character in path at index 5: nasty string");
+
+            return null;
+        });
+    }
+
+    public static class ThrowAndCatchJavaExample implements Function<String, String[]> {
+        @Override
+        public String[] apply(String input) {
+            List<String> data = new LinkedList<>();
+            try {
+                try {
+                    throw new MyExampleException(input);
+                } finally {
+                    data.add("FIRST FINALLY");
+                }
+            } catch (MyBaseException e) {
+                data.add("BASE EXCEPTION");
+                data.add(e.getMessage());
+            } catch (Exception e) {
+                data.add("NOT THIS ONE!");
+            } finally {
+                data.add("SECOND FINALLY");
+            }
+
+            return data.toArray(new String[0]);
+        }
+    }
+
+    public static class JavaWithCheckedExceptions implements Function<String, String> {
+        @Override
+        public String apply(String input) {
+            try {
+                return new URI(input).getPath();
+            } catch (URISyntaxException e) {
+                return "CATCH:" + e.getMessage();
+            }
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
@@ -1,0 +1,100 @@
+package net.corda.djvm
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Test
+import sandbox.SandboxFunction
+import sandbox.Task
+import sandbox.java.lang.sandbox
+
+class DJVMExceptionTest {
+    @Test
+    fun testSingleException() {
+        val result = Task(SingleExceptionTask()).apply("Hello World")
+        assertThat(result).isInstanceOf(Throwable::class.java)
+        result as Throwable
+
+        assertThat(result.message).isEqualTo("Hello World")
+        assertThat(result.cause).isNull()
+        assertThat(result.stackTrace)
+            .hasSize(2)
+            .allSatisfy { it is StackTraceElement && it.className == result.javaClass.name }
+    }
+
+    @Test
+    fun testMultipleExceptions() {
+        val result = Task(MultipleExceptionsTask()).apply("Hello World")
+        assertThat(result).isInstanceOf(Throwable::class.java)
+        result as Throwable
+
+        assertThat(result.message).isEqualTo("Hello World(1)(2)")
+        assertThat(result.cause).isInstanceOf(Throwable::class.java)
+        assertThat(result.stackTrace)
+            .hasSize(2)
+            .allSatisfy { it is StackTraceElement && it.className == result.javaClass.name }
+        val resultLineNumbers = result.stackTrace.toLineNumbers()
+
+        val firstCause = result.cause as Throwable
+        assertThat(firstCause.message).isEqualTo("Hello World(1)")
+        assertThat(firstCause.cause).isInstanceOf(Throwable::class.java)
+        assertThat(firstCause.stackTrace)
+            .hasSize(2)
+            .allSatisfy { it is StackTraceElement && it.className == result.javaClass.name }
+        val firstCauseLineNumbers = firstCause.stackTrace.toLineNumbers()
+
+        val rootCause = firstCause.cause as Throwable
+        assertThat(rootCause.message).isEqualTo("Hello World")
+        assertThat(rootCause.cause).isNull()
+        assertThat(rootCause.stackTrace)
+            .hasSize(2)
+            .allSatisfy { it is StackTraceElement && it.className == result.javaClass.name }
+        val rootCauseLineNumbers = rootCause.stackTrace.toLineNumbers()
+
+        // These stack traces should share one line number and have one distinct line number each.
+        assertThat(resultLineNumbers.toSet() + firstCauseLineNumbers.toSet() + rootCauseLineNumbers.toSet())
+            .hasSize(4)
+    }
+
+    @Test
+    fun testJavaThrowableToSandbox() {
+        val result = Throwable("Hello World").sandbox()
+        assertThat(result).isInstanceOf(sandbox.java.lang.Throwable::class.java)
+        result as sandbox.java.lang.Throwable
+
+        assertThat(result.message).isEqualTo("Hello World".toDJVM())
+        assertThat(result.stackTrace).isNotEmpty()
+        assertThat(result.cause).isNull()
+    }
+
+    @Test
+    fun testWeTryToCreateCorrectSandboxExceptionsAtRuntime() {
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
+            .isThrownBy { Exception("Hello World").sandbox() }
+            .withMessage("sandbox.java.lang.Exception")
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
+            .isThrownBy { RuntimeException("Hello World").sandbox() }
+            .withMessage("sandbox.java.lang.RuntimeException")
+    }
+}
+
+class SingleExceptionTask : SandboxFunction<Any?, sandbox.java.lang.Throwable> {
+    override fun apply(input: Any?): sandbox.java.lang.Throwable? {
+        return sandbox.java.lang.Throwable(input as? sandbox.java.lang.String)
+    }
+}
+
+class MultipleExceptionsTask : SandboxFunction<Any?, sandbox.java.lang.Throwable> {
+    override fun apply(input: Any?): sandbox.java.lang.Throwable? {
+        val root = sandbox.java.lang.Throwable(input as? sandbox.java.lang.String)
+        val nested = sandbox.java.lang.Throwable(root.message + "(1)", root)
+        return sandbox.java.lang.Throwable(nested.message + "(2)", nested)
+    }
+}
+
+private infix operator fun sandbox.java.lang.String.plus(s: String): sandbox.java.lang.String {
+    return (toString() + s).toDJVM()
+}
+
+private fun Array<StackTraceElement>.toLineNumbers(): IntArray {
+    return map(StackTraceElement::getLineNumber).toIntArray()
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
@@ -113,14 +113,4 @@ class DJVMTest {
         assertArrayEquals(ByteArray(1) { 127.toByte() }, result[9] as ByteArray)
         assertArrayEquals(CharArray(1) { '?' }, result[10] as CharArray)
     }
-
-    private fun String.toDJVM(): sandbox.java.lang.String = sandbox.java.lang.String.toDJVM(this)
-    private fun Long.toDJVM(): sandbox.java.lang.Long = sandbox.java.lang.Long.toDJVM(this)
-    private fun Int.toDJVM(): sandbox.java.lang.Integer = sandbox.java.lang.Integer.toDJVM(this)
-    private fun Short.toDJVM(): sandbox.java.lang.Short = sandbox.java.lang.Short.toDJVM(this)
-    private fun Byte.toDJVM(): sandbox.java.lang.Byte = sandbox.java.lang.Byte.toDJVM(this)
-    private fun Float.toDJVM(): sandbox.java.lang.Float = sandbox.java.lang.Float.toDJVM(this)
-    private fun Double.toDJVM(): sandbox.java.lang.Double = sandbox.java.lang.Double.toDJVM(this)
-    private fun Char.toDJVM(): sandbox.java.lang.Character = sandbox.java.lang.Character.toDJVM(this)
-    private fun Boolean.toDJVM(): sandbox.java.lang.Boolean = sandbox.java.lang.Boolean.toDJVM(this)
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -37,22 +37,29 @@ abstract class TestBase {
         val ALL_EMITTERS = Discovery.find<Emitter>()
 
         // We need at least these emitters to handle the Java API classes.
+        @JvmField
         val BASIC_EMITTERS: List<Emitter> = listOf(
             ArgumentUnwrapper(),
+            HandleExceptionUnwrapper(),
             ReturnTypeWrapper(),
             RewriteClassMethods(),
-            StringConstantWrapper()
+            StringConstantWrapper(),
+            ThrowExceptionWrapper()
         )
 
         val ALL_DEFINITION_PROVIDERS = Discovery.find<DefinitionProvider>()
 
         // We need at least these providers to handle the Java API classes.
+        @JvmField
         val BASIC_DEFINITION_PROVIDERS: List<DefinitionProvider> = listOf(StaticConstantRemover())
 
+        @JvmField
         val BLANK = emptySet<Any>()
 
+        @JvmField
         val DEFAULT = (ALL_RULES + ALL_EMITTERS + ALL_DEFINITION_PROVIDERS).distinctBy(Any::javaClass)
 
+        @JvmField
         val DETERMINISTIC_RT: Path = Paths.get(
                 System.getProperty("deterministic-rt.path") ?: throw AssertionError("deterministic-rt.path property not set"))
 

--- a/djvm/src/test/kotlin/net/corda/djvm/Utilities.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/Utilities.kt
@@ -7,16 +7,4 @@ object Utilities {
     fun throwRuleViolationError(): Nothing = throw RuleViolationError("Can't catch this!")
 
     fun throwThresholdViolationError(): Nothing = throw ThresholdViolationError("Can't catch this!")
-
-    fun throwContractConstraintViolation(): Nothing = throw IllegalArgumentException("Contract constraint violated")
-
-    fun throwError(): Nothing = throw Error()
-
-    fun throwThrowable(): Nothing = throw Throwable()
-
-    fun throwThreadDeath(): Nothing = throw ThreadDeath()
-
-    fun throwStackOverflowError(): Nothing = throw StackOverflowError("FAKE OVERFLOW!")
-
-    fun throwOutOfMemoryError(): Nothing = throw OutOfMemoryError("FAKE OOM!")
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/Utilities.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/Utilities.kt
@@ -1,10 +1,24 @@
+@file:JvmName("UtilityFunctions")
 package net.corda.djvm
 
 import sandbox.net.corda.djvm.costing.ThresholdViolationError
 import sandbox.net.corda.djvm.rules.RuleViolationError
 
+/**
+ * Allows us to create a [Utilities] object that we can pin inside the sandbox.
+ */
 object Utilities {
     fun throwRuleViolationError(): Nothing = throw RuleViolationError("Can't catch this!")
 
     fun throwThresholdViolationError(): Nothing = throw ThresholdViolationError("Can't catch this!")
 }
+
+fun String.toDJVM(): sandbox.java.lang.String = sandbox.java.lang.String.toDJVM(this)
+fun Long.toDJVM(): sandbox.java.lang.Long = sandbox.java.lang.Long.toDJVM(this)
+fun Int.toDJVM(): sandbox.java.lang.Integer = sandbox.java.lang.Integer.toDJVM(this)
+fun Short.toDJVM(): sandbox.java.lang.Short = sandbox.java.lang.Short.toDJVM(this)
+fun Byte.toDJVM(): sandbox.java.lang.Byte = sandbox.java.lang.Byte.toDJVM(this)
+fun Float.toDJVM(): sandbox.java.lang.Float = sandbox.java.lang.Float.toDJVM(this)
+fun Double.toDJVM(): sandbox.java.lang.Double = sandbox.java.lang.Double.toDJVM(this)
+fun Char.toDJVM(): sandbox.java.lang.Character = sandbox.java.lang.Character.toDJVM(this)
+fun Boolean.toDJVM(): sandbox.java.lang.Boolean = sandbox.java.lang.Boolean.toDJVM(this)

--- a/djvm/src/test/kotlin/net/corda/djvm/analysis/ExceptionResolverTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/analysis/ExceptionResolverTest.kt
@@ -1,0 +1,27 @@
+package net.corda.djvm.analysis
+
+import net.corda.djvm.analysis.AnalysisConfiguration.Companion.JVM_EXCEPTIONS
+import net.corda.djvm.analysis.AnalysisConfiguration.Companion.SANDBOX_PREFIX
+import net.corda.djvm.code.ruleViolationError
+import net.corda.djvm.code.thresholdViolationError
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.objectweb.asm.Type
+
+class ExceptionResolverTest {
+    private companion object {
+        private val Class<*>.sandboxed: String get() = SANDBOX_PREFIX + unsandboxed
+        private val Class<*>.unsandboxed: String get() = Type.getInternalName(this)
+
+        inline fun <reified T> sandboxed(): String = T::class.java.sandboxed
+        inline fun <reified T> unsandboxed(): String = T::class.java.unsandboxed
+    }
+
+    private val exceptionResolver = ExceptionResolver(
+        jvmExceptionClasses = JVM_EXCEPTIONS,
+        pinnedClasses = setOf(ruleViolationError, thresholdViolationError),
+        sandboxPrefix = SANDBOX_PREFIX
+    )
+
+    open class ExampleException : Exception()
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -6,14 +6,8 @@ import foo.bar.sandbox.toNumber
 import net.corda.djvm.TestBase
 import net.corda.djvm.analysis.Whitelist
 import net.corda.djvm.Utilities
-import net.corda.djvm.Utilities.throwContractConstraintViolation
-import net.corda.djvm.Utilities.throwError
-import net.corda.djvm.Utilities.throwOutOfMemoryError
 import net.corda.djvm.Utilities.throwRuleViolationError
-import net.corda.djvm.Utilities.throwStackOverflowError
-import net.corda.djvm.Utilities.throwThreadDeath
 import net.corda.djvm.Utilities.throwThresholdViolationError
-import net.corda.djvm.Utilities.throwThrowable
 import net.corda.djvm.assertions.AssertionExtensions.withProblem
 import net.corda.djvm.rewiring.SandboxClassLoadingException
 import org.assertj.core.api.Assertions.assertThat
@@ -55,7 +49,7 @@ class SandboxExecutorTest : TestBase() {
 
     class Contract : Function<Transaction, Unit> {
         override fun apply(input: Transaction) {
-            throwContractConstraintViolation()
+            throw IllegalArgumentException("Contract constraint violated")
         }
     }
 
@@ -74,11 +68,7 @@ class SandboxExecutorTest : TestBase() {
             val obj = Object()
             val hash1 = obj.hashCode()
             val hash2 = obj.hashCode()
-            //require(hash1 == hash2)
-            // TODO: Replace require() once we have working exception support.
-            if (hash1 != hash2) {
-                throwError()
-            }
+            require(hash1 == hash2)
             return Object().hashCode()
         }
     }
@@ -180,7 +170,7 @@ class SandboxExecutorTest : TestBase() {
     class TestCatchThreadDeath : Function<Int, Int> {
         override fun apply(input: Int): Int {
             return try {
-                throwThreadDeath()
+                throw ThreadDeath()
             } catch (exception: ThreadDeath) {
                 1
             }
@@ -261,8 +251,8 @@ class SandboxExecutorTest : TestBase() {
         override fun apply(input: Int): Int {
             return try {
                 when (input) {
-                    1 -> throwThrowable()
-                    2 -> throwError()
+                    1 -> throw Throwable()
+                    2 -> throw Error()
                     else -> 0
                 }
             } catch (exception: Error) {
@@ -277,20 +267,20 @@ class SandboxExecutorTest : TestBase() {
         override fun apply(input: Int): Int {
             return try {
                 when (input) {
-                    1 -> throwThrowable()
-                    2 -> throwError()
+                    1 -> throw Throwable()
+                    2 -> throw Error()
                     3 -> try {
-                        throwThreadDeath()
+                        throw ThreadDeath()
                     } catch (ex: ThreadDeath) {
                         3
                     }
                     4 -> try {
-                        throwStackOverflowError()
+                        throw StackOverflowError("FAKE OVERFLOW!")
                     } catch (ex: StackOverflowError) {
                         4
                     }
                     5 -> try {
-                        throwOutOfMemoryError()
+                        throw OutOfMemoryError("FAKE OOM!")
                     } catch (ex: OutOfMemoryError) {
                         5
                     }

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxThrowableTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxThrowableTest.kt
@@ -1,0 +1,63 @@
+package net.corda.djvm.execution
+
+import net.corda.djvm.TestBase
+import org.assertj.core.api.Assertions.*
+import org.junit.Test
+import java.util.function.Function
+
+class SandboxThrowableTest : TestBase() {
+
+    @Test
+    fun `test user exception handling`() = sandbox(DEFAULT) {
+        val contractExecutor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
+        contractExecutor.run<ThrowAndCatchExample>("Hello World").apply {
+            assertThat(result)
+                .isEqualTo(arrayOf("FIRST FINALLY", "BASE EXCEPTION", "Hello World", "SECOND FINALLY"))
+        }
+    }
+
+    @Test
+    fun `test JVM exceptions still propagate`() = sandbox(DEFAULT) {
+        val contractExecutor = DeterministicSandboxExecutor<Int, String>(configuration)
+        contractExecutor.run<TriggerJVMException>(-1).apply {
+            assertThat(result)
+                .isEqualTo("sandbox.java.lang.ArrayIndexOutOfBoundsException:-1")
+        }
+    }
+}
+
+class ThrowAndCatchExample : Function<String, Array<String>> {
+    override fun apply(input: String): Array<String> {
+        val data = mutableListOf<String>()
+        try {
+            try {
+                throw MyExampleException(input)
+            } finally {
+                data += "FIRST FINALLY"
+            }
+        } catch (e: MyBaseException) {
+            data += "BASE EXCEPTION"
+            e.message?.apply { data += this }
+        } catch (e: Exception) {
+            data += "NOT THIS ONE!"
+        } finally {
+            data += "SECOND FINALLY"
+        }
+
+        return data.toTypedArray()
+    }
+}
+
+class TriggerJVMException : Function<Int, String> {
+    override fun apply(input: Int): String {
+        return try {
+            arrayOf(0, 1, 2)[input]
+            "No Error"
+        } catch (e: Exception) {
+            e.javaClass.name + ':' + (e.message ?: "<MESSAGE MISSING>")
+        }
+    }
+}
+
+open class MyBaseException(message: String) : Exception(message)
+class MyExampleException(message: String) : MyBaseException(message)


### PR DESCRIPTION
- Support for `throw`, `catch`, `finally` and stack traces.
- Create a template `sandbox.java.lang.Throwable` class that will become the non-throwable base class for sandbox exceptions.
- Create a two-way mapping being non-throwable sandbox exceptions and throwable exception wrappers. For the most part, this involves generating a throwable synthetic counterpart for each exception type. However, exceptions which can be thrown by the JVM itself (including _all_ of their parent exception types) are handled natively. This results in an exception hierarchy like:
```
sandbox.java.lang.Throwable <-> java.lang.Throwable
sandbox.java.lang.Exception <-> java.lang.Exception
sandbox.java.lang.RuntimeException <-> java.lang.RuntimeException
sandbox.java.time.DateTimeException <-> sandbox.java.time.DateTimeException.1DJVM
sandbox.net.corda.core.CordaRuntimeException <-> sandbox.net.corda.core.CordaRuntimeException.1DJVM
...
```
- Ensure that synthetic `.1DJVM` exception classes are generated automatically, immediately after their "owner" classes are loaded. If the JVM attempts to load an unknown `.1DJVM` class then the "owner" class is loaded, which triggers the generation of the synthetic class.
- Exception stack traces are truncated to exclude elements from outside the sandbox.
- Emitters are now ordered by integer "priority", for greater control over which emitters execute first.