### PR TITLE
[CORDA-738] Ensure encumbrances are bi-directional

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -123,7 +123,7 @@ sealed class TransactionVerificationException(val txId: SecureHash, message: Str
     @KeepForDJVM
     class TransactionDuplicateEncumbranceException(txId: SecureHash, index: Int)
         : TransactionVerificationException(txId, "The bi-directionality property of encumbered output states " +
-            "is not satisfied. Index $index is referenced more than one times", null)
+            "is not satisfied. Index $index is referenced more than once", null)
 
     /**
      * An encumbered state should also be referenced as the encumbrance of another state in order to satisfy the
@@ -132,7 +132,7 @@ sealed class TransactionVerificationException(val txId: SecureHash, message: Str
     @KeepForDJVM
     class TransactionNonMatchingEncumbranceException(txId: SecureHash, nonMatching: Collection<Int>)
         : TransactionVerificationException(txId, "The bi-directionality property of encumbered output states " +
-            "is not satisfied. Encumbered states should also be referenced as an encumbrance of an other state to form " +
+            "is not satisfied. Encumbered states should also be referenced as an encumbrance of another state to form " +
             "a full cycle. Offending indices $nonMatching", null)
 
     /** Whether the inputs or outputs list contains an encumbrance issue, see [TransactionMissingEncumbranceException]. */

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -116,6 +116,13 @@ sealed class TransactionVerificationException(val txId: SecureHash, message: Str
     class TransactionMissingEncumbranceException(txId: SecureHash, val missing: Int, val inOut: Direction)
         : TransactionVerificationException(txId, "Missing required encumbrance $missing in $inOut", null)
 
+    /**
+     * Bi-directional encumbrance is enforced. If more than one states are mutually encumbered then a full directed cycle graph
+     * should be present, so that all of the related states can only be consumed in the same transaction.
+     */
+    class TransactionBiDirectionalEncumbranceException(txId: SecureHash)
+        : TransactionVerificationException(txId, "The bi-directionality property of encumbered output states is not satisfied.", null)
+
     /** Whether the inputs or outputs list contains an encumbrance issue, see [TransactionMissingEncumbranceException]. */
     @CordaSerializable
     @KeepForDJVM

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -117,19 +117,31 @@ sealed class TransactionVerificationException(val txId: SecureHash, message: Str
         : TransactionVerificationException(txId, "Missing required encumbrance $missing in $inOut", null)
 
     /**
-     * Bi-directional encumbrance is enforced. If more than one states are mutually encumbered then a full directed cycle graph
-     * should be present, so that all of the related states can only be consumed in the same transaction.
+     * If two or more states refer to another state (as their encumbrance), then the bi-directionality property cannot
+     * be satisfied.
      */
-    class TransactionBiDirectionalEncumbranceException(txId: SecureHash)
-        : TransactionVerificationException(txId, "The bi-directionality property of encumbered output states is not satisfied.", null)
+    @KeepForDJVM
+    class TransactionDuplicateEncumbranceException(txId: SecureHash, index: Int)
+        : TransactionVerificationException(txId, "The bi-directionality property of encumbered output states " +
+            "is not satisfied. Index $index is referenced more than one times", null)
+
+    /**
+     * An encumbered state should also be referenced as the encumbrance of another state in order to satisfy the
+     * bi-directionality property (a full cycle should be present).
+     */
+    @KeepForDJVM
+    class TransactionNonMatchingEncumbranceException(txId: SecureHash, nonMatching: Collection<Int>)
+        : TransactionVerificationException(txId, "The bi-directionality property of encumbered output states " +
+            "is not satisfied. Encumbered states should also be referenced as an encumbrance of an other state to form " +
+            "a full cycle. Offending indices $nonMatching", null)
 
     /** Whether the inputs or outputs list contains an encumbrance issue, see [TransactionMissingEncumbranceException]. */
     @CordaSerializable
     @KeepForDJVM
     enum class Direction {
-        /** Issue in the inputs list */
+        /** Issue in the inputs list. */
         INPUT,
-        /** Issue in the outputs list */
+        /** Issue in the outputs list. */
         OUTPUT
     }
 

--- a/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/AbstractStateReplacementFlow.kt
@@ -62,6 +62,7 @@ abstract class AbstractStateReplacementFlow {
         @Throws(StateReplacementException::class)
         override fun call(): StateAndRef<T> {
             val (stx) = assembleTx()
+            stx.verify(serviceHub, checkSufficientSignatures = false)
             val participantSessions = getParticipantSessions()
             progressTracker.currentStep = SIGNING
 

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt
@@ -46,14 +46,14 @@ class NotaryChangeFlow<out T : ContractState>(
         return AbstractStateReplacementFlow.UpgradeTx(stx)
     }
 
-    /** Resolves the encumbrance state chain for the given [state] */
+    /** Resolves the encumbrance state chain for the given [state]. */
     private fun resolveEncumbrances(state: StateAndRef<T>): List<StateAndRef<T>> {
-        val states = mutableListOf(state)
+        val states = mutableSetOf(state)
         while (states.last().state.encumbrance != null) {
             val encumbranceStateRef = StateRef(states.last().ref.txhash, states.last().state.encumbrance!!)
             val encumbranceState = serviceHub.toStateAndRef<T>(encumbranceStateRef)
-            states.add(encumbranceState)
+            if (!states.add(encumbranceState)) break // Stop if there is a cycle.
         }
-        return states
+        return states.toList()
     }
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -222,17 +222,17 @@ data class LedgerTransaction @JvmOverloads constructor(
         // [Set] of "to" (encumbrance states).
         val encumbranceSet = mutableSetOf<Int>()
         // Update both [Set]s.
-        statesAndEncumbrance.forEach {
+        statesAndEncumbrance.forEach {(statePosition, encumbrance) ->
             // Check it does not refer to itself.
-            if (it.first == it.second || it.second >= outputs.size) {
+            if (statePosition == encumbrance || encumbrance >= outputs.size) {
                 throw TransactionVerificationException.TransactionMissingEncumbranceException(
                         id,
-                        it.second,
+                        encumbrance,
                         TransactionVerificationException.Direction.OUTPUT)
             } else {
-                encumberedSet.add(it.first) // Guaranteed to have unique elements.
-                if (!encumbranceSet.add(it.second)) {
-                    throw TransactionVerificationException.TransactionDuplicateEncumbranceException(id, it.second)
+                encumberedSet.add(statePosition) // Guaranteed to have unique elements.
+                if (!encumbranceSet.add(encumbrance)) {
+                    throw TransactionVerificationException.TransactionDuplicateEncumbranceException(id, encumbrance)
                 }
             }
         }

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -224,10 +224,10 @@ data class LedgerTransaction @JvmOverloads constructor(
         // Update both [Set]s.
         statesAndEncumbrance.forEach {
             // Check it does not refer to itself.
-            if (it.first == it.second || it.first >= outputs.size) {
+            if (it.first == it.second || it.second >= outputs.size) {
                 throw TransactionVerificationException.TransactionMissingEncumbranceException(
                         id,
-                        it.first,
+                        it.second,
                         TransactionVerificationException.Direction.OUTPUT)
             } else {
                 encumberedSet.add(it.first) // Guaranteed to have unique elements.

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -237,11 +237,11 @@ data class LedgerTransaction @JvmOverloads constructor(
             }
         }
         // At this stage we have ensured that "from" and "to" [Set]s are equal in size, but we should check their
-        // elements do indeed match.
-        val intersection = encumberedSet intersect encumbranceSet
-        if (intersection.isNotEmpty()) {
+        // elements do indeed match. If they don't match, we return their symmetric difference (disjunctive union).
+        val symmetricDifference = (encumberedSet union encumbranceSet).subtract(encumberedSet intersect encumbranceSet)
+        if (symmetricDifference.isNotEmpty()) {
             // At least one encumbered state is not in the [encumbranceSet] and vice versa.
-            throw TransactionVerificationException.TransactionNonMatchingEncumbranceException(id, intersection)
+            throw TransactionVerificationException.TransactionNonMatchingEncumbranceException(id, symmetricDifference)
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -222,7 +222,7 @@ data class LedgerTransaction @JvmOverloads constructor(
         // [Set] of "to" (encumbrance states).
         val encumbranceSet = mutableSetOf<Int>()
         // Update both [Set]s.
-        statesAndEncumbrance.forEach {(statePosition, encumbrance) ->
+        statesAndEncumbrance.forEach { (statePosition, encumbrance) ->
             // Check it does not refer to itself.
             if (statePosition == encumbrance || encumbrance >= outputs.size) {
                 throw TransactionVerificationException.TransactionMissingEncumbranceException(

--- a/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
@@ -136,7 +136,7 @@ fun <V> Future<V>.getOrThrow(timeout: Duration? = null): V = try {
 }
 
 /** Check for duplicate elements. */
-fun <T> List<T>.hasDuplicates(): Boolean {
+internal fun <T> List<T>.hasDuplicates(): Boolean {
     val set = mutableSetOf<T>()
     return this.any { !set.add(it) }
 }

--- a/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
@@ -135,3 +135,8 @@ fun <V> Future<V>.getOrThrow(timeout: Duration? = null): V = try {
     throw e.cause!!
 }
 
+/** Check for duplicate elements. */
+fun <T> List<T>.hasDuplicates(): Boolean {
+    val set = mutableSetOf<T>()
+    return this.any { !set.add(it) }
+}

--- a/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
@@ -134,9 +134,3 @@ fun <V> Future<V>.getOrThrow(timeout: Duration? = null): V = try {
 } catch (e: ExecutionException) {
     throw e.cause!!
 }
-
-/** Check for duplicate elements. */
-internal fun <T> List<T>.hasDuplicates(): Boolean {
-    val set = mutableSetOf<T>()
-    return this.any { !set.add(it) }
-}

--- a/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.contracts.requireThat
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
@@ -21,32 +22,42 @@ import org.junit.Rule
 import org.junit.Test
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import kotlin.test.assertFailsWith
 
 const val TEST_TIMELOCK_ID = "net.corda.core.transactions.TransactionEncumbranceTests\$DummyTimeLock"
 
 class TransactionEncumbranceTests {
+    @Rule
+    @JvmField
+    val testSerialization = SerializationEnvironmentRule()
+
     private companion object {
         val DUMMY_NOTARY = TestIdentity(DUMMY_NOTARY_NAME, 20).party
         val megaCorp = TestIdentity(CordaX500Name("MegaCorp", "London", "GB"))
         val MINI_CORP = TestIdentity(CordaX500Name("MiniCorp", "London", "GB")).party
         val MEGA_CORP get() = megaCorp.party
         val MEGA_CORP_PUBKEY get() = megaCorp.publicKey
+
+        val defaultIssuer = MEGA_CORP.ref(1)
+
+        val state = Cash.State(
+                amount = 1000.DOLLARS `issued by` defaultIssuer,
+                owner = MEGA_CORP
+        )
+
+        val stateWithNewOwner = state.copy(owner = MINI_CORP)
+        val extraCashState = state.copy(amount = state.amount * 3)
+
+        val FOUR_PM: Instant = Instant.parse("2015-04-17T16:00:00.00Z")
+        val FIVE_PM: Instant = FOUR_PM.plus(1, ChronoUnit.HOURS)
+        val timeLock = DummyTimeLock.State(FIVE_PM)
+
+
+        val ledgerServices = MockServices(listOf("net.corda.core.transactions", "net.corda.finance.contracts.asset"), MEGA_CORP.name,
+                rigorousMock<IdentityServiceInternal>().also {
+                    doReturn(MEGA_CORP).whenever(it).partyFromKey(MEGA_CORP_PUBKEY)
+                })
     }
-
-    @Rule
-    @JvmField
-    val testSerialization = SerializationEnvironmentRule()
-    val defaultIssuer = MEGA_CORP.ref(1)
-
-    val state = Cash.State(
-            amount = 1000.DOLLARS `issued by` defaultIssuer,
-            owner = MEGA_CORP
-    )
-    val stateWithNewOwner = state.copy(owner = MINI_CORP)
-
-    val FOUR_PM: Instant = Instant.parse("2015-04-17T16:00:00.00Z")
-    val FIVE_PM: Instant = FOUR_PM.plus(1, ChronoUnit.HOURS)
-    val timeLock = DummyTimeLock.State(FIVE_PM)
 
     class DummyTimeLock : Contract {
         override fun verify(tx: LedgerTransaction) {
@@ -65,21 +76,96 @@ class TransactionEncumbranceTests {
         }
     }
 
-    private val ledgerServices = MockServices(listOf("net.corda.core.transactions", "net.corda.finance.contracts.asset"), MEGA_CORP.name,
-            rigorousMock<IdentityServiceInternal>().also {
-                doReturn(MEGA_CORP).whenever(it).partyFromKey(MEGA_CORP_PUBKEY)
-            })
-
     @Test
-    fun `state can be encumbered`() {
+    fun `states can be bi-directionally encumbered`() {
+        // Basic encumbrance example for encumbrance index links 0 -> 1 and 1 -> 0
         ledgerServices.ledger(DUMMY_NOTARY) {
             transaction {
                 attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
                 input(Cash.PROGRAM_ID, state)
-                output(Cash.PROGRAM_ID, encumbrance = 1, contractState = stateWithNewOwner)
-                output(TEST_TIMELOCK_ID, "5pm time-lock", timeLock)
+                output(Cash.PROGRAM_ID, "state encumbered by 5pm time-lock", encumbrance = 1, contractState = stateWithNewOwner)
+                output(TEST_TIMELOCK_ID, "5pm time-lock", 0, timeLock)
                 command(MEGA_CORP.owningKey, Cash.Commands.Move())
                 verifies()
+            }
+        }
+
+        // Full cycle example with 4 elements 0 -> 1, 1 -> 2, 2 -> 3 and 3 -> 0
+        ledgerServices.ledger(DUMMY_NOTARY) {
+            transaction {
+                attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
+                input(Cash.PROGRAM_ID, extraCashState)
+                output(Cash.PROGRAM_ID, "state encumbered by state 1", encumbrance = 1, contractState = stateWithNewOwner)
+                output(Cash.PROGRAM_ID, "state encumbered by state 2", encumbrance = 2, contractState = stateWithNewOwner)
+                output(Cash.PROGRAM_ID, "state encumbered by state 3", encumbrance = 3, contractState = stateWithNewOwner)
+                output(TEST_TIMELOCK_ID, "5pm time-lock", 0, timeLock)
+                command(MEGA_CORP.owningKey, Cash.Commands.Move())
+                verifies()
+            }
+        }
+
+        // Full cycle example with 4 elements (different combination) 0 -> 3, 1 -> 2, 2 -> 0 and 3 -> 1
+        ledgerServices.ledger(DUMMY_NOTARY) {
+            transaction {
+                attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
+                input(Cash.PROGRAM_ID, extraCashState)
+                output(Cash.PROGRAM_ID, "state encumbered by state 3", encumbrance = 3, contractState = stateWithNewOwner)
+                output(Cash.PROGRAM_ID, "state encumbered by state 2", encumbrance = 2, contractState = stateWithNewOwner)
+                output(Cash.PROGRAM_ID, "state encumbered by state 0", encumbrance = 0, contractState = stateWithNewOwner)
+                output(TEST_TIMELOCK_ID, "5pm time-lock", 1, timeLock)
+                command(MEGA_CORP.owningKey, Cash.Commands.Move())
+                verifies()
+            }
+        }
+    }
+
+    @Test
+    fun `non bi-directional encumbrance will fail`() {
+        // Single encumbrance with no back link.
+        assertFailsWith<TransactionVerificationException.TransactionNonMatchingEncumbranceException> {
+            ledgerServices.ledger(DUMMY_NOTARY) {
+                transaction {
+                    attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
+                    input(Cash.PROGRAM_ID, state)
+                    output(Cash.PROGRAM_ID, "state encumbered by 5pm time-lock", encumbrance = 1, contractState = stateWithNewOwner)
+                    output(TEST_TIMELOCK_ID, "5pm time-lock", timeLock)
+                    command(MEGA_CORP.owningKey, Cash.Commands.Move())
+                    verifies()
+                }
+            }
+        }
+
+        // Full cycle fails due to duplicate encumbrance reference.
+        // 0 -> 1, 1 -> 3, 2 -> 3 (thus 3 is referenced two times).
+        assertFailsWith<TransactionVerificationException.TransactionDuplicateEncumbranceException> {
+            ledgerServices.ledger(DUMMY_NOTARY) {
+                transaction {
+                    attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
+                    input(Cash.PROGRAM_ID, state)
+                    output(Cash.PROGRAM_ID, "state encumbered by state 1", encumbrance = 1, contractState = stateWithNewOwner)
+                    output(Cash.PROGRAM_ID, "state encumbered by state 3", encumbrance = 3, contractState = stateWithNewOwner)
+                    output(Cash.PROGRAM_ID, "state encumbered by state 3 again", encumbrance = 3, contractState = stateWithNewOwner)
+                    output(TEST_TIMELOCK_ID, "5pm time-lock", timeLock)
+                    command(MEGA_CORP.owningKey, Cash.Commands.Move())
+                    verifies()
+                }
+            }
+        }
+
+        // No Full cycle due to non-matching encumbered-encumbrance elements.
+        // 0 -> 1, 1 -> 3, 2 -> 0 (thus offending indices [2, 3], because 2 is not referenced and 3 is not encumbered).
+        assertFailsWith<TransactionVerificationException.TransactionNonMatchingEncumbranceException> {
+            ledgerServices.ledger(DUMMY_NOTARY) {
+                transaction {
+                    attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
+                    input(Cash.PROGRAM_ID, state)
+                    output(Cash.PROGRAM_ID, "state encumbered by state 1", encumbrance = 1, contractState = stateWithNewOwner)
+                    output(Cash.PROGRAM_ID, "state encumbered by state 3", encumbrance = 3, contractState = stateWithNewOwner)
+                    output(Cash.PROGRAM_ID, "state encumbered by state 0", encumbrance = 0, contractState = stateWithNewOwner)
+                    output(TEST_TIMELOCK_ID, "5pm time-lock", timeLock)
+                    command(MEGA_CORP.owningKey, Cash.Commands.Move())
+                    verifies()
+                }
             }
         }
     }
@@ -132,7 +218,7 @@ class TransactionEncumbranceTests {
             unverifiedTransaction {
                 attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
                 output(Cash.PROGRAM_ID, "state encumbered by 5pm time-lock", encumbrance = 1, contractState = state)
-                output(TEST_TIMELOCK_ID, "5pm time-lock", timeLock)
+                output(TEST_TIMELOCK_ID, "5pm time-lock",0, timeLock)
             }
             transaction {
                 attachments(Cash.PROGRAM_ID)
@@ -151,7 +237,7 @@ class TransactionEncumbranceTests {
             transaction {
                 attachments(Cash.PROGRAM_ID)
                 input(Cash.PROGRAM_ID, state)
-                output(Cash.PROGRAM_ID, encumbrance = 0, contractState = stateWithNewOwner)
+                output(Cash.PROGRAM_ID, "state encumbered by itself", encumbrance = 0, contractState = stateWithNewOwner)
                 command(MEGA_CORP.owningKey, Cash.Commands.Move())
                 this `fails with` "Missing required encumbrance 0 in OUTPUT"
             }
@@ -164,7 +250,7 @@ class TransactionEncumbranceTests {
             transaction {
                 attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
                 input(Cash.PROGRAM_ID, state)
-                output(TEST_TIMELOCK_ID, encumbrance = 2, contractState = stateWithNewOwner)
+                output(TEST_TIMELOCK_ID, "state encumbered by state 2 which does not exist", encumbrance = 2, contractState = stateWithNewOwner)
                 output(TEST_TIMELOCK_ID, timeLock)
                 command(MEGA_CORP.owningKey, Cash.Commands.Move())
                 this `fails with` "Missing required encumbrance 2 in OUTPUT"
@@ -178,7 +264,7 @@ class TransactionEncumbranceTests {
             unverifiedTransaction {
                 attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
                 output(Cash.PROGRAM_ID, "state encumbered by some other state", encumbrance = 1, contractState = state)
-                output(Cash.PROGRAM_ID, "some other state", state)
+                output(Cash.PROGRAM_ID, "some other state", encumbrance = 0, contractState = state)
                 output(TEST_TIMELOCK_ID, "5pm time-lock", timeLock)
             }
             transaction {


### PR DESCRIPTION
Encumbrances should form a complete directed cycle, otherwise one can spend the "encumbrance" state, which would freeze the "encumbered" state for ever. This should also apply to encumbrance chains with more than two elements. Changes on `NotaryChangeLedgerTransaction` were also required. 
*Note: I didn't touch `ContractUpgradeLedgerTransaction`

For instance, the following settings are valid: 
_a -> b, b -> a_
- - -
_a -> b, b -> c, c -> a_ 
- - -
_a -> c, b -> a, c -> b_

while the following are not:
_a -> b_    (because one can spend _b_, which will freeze _a_ for ever)
- - -
_a -> c, b -> c_    (because, among the others, one can spend _a_ and _c_, which will freeze _b_ for ever)
- - -
_a -> b, b -> c_   (because, among the others, one can spend _c_, which will freeze _a_ and _b_ for ever)