### PR TITLE
ENT-1906: Allow sandboxes to share a parent classloader.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -57,7 +57,8 @@ shadowJar {
     // we will generate better versions from deterministic-rt.jar.
     exclude 'sandbox/java/lang/Appendable.class'
     exclude 'sandbox/java/lang/CharSequence.class'
-    exclude 'sandbox/java/lang/Character\$*.class'
+    exclude 'sandbox/java/lang/Character\$Subset.class'
+    exclude 'sandbox/java/lang/Character\$Unicode*.class'
     exclude 'sandbox/java/lang/Comparable.class'
     exclude 'sandbox/java/lang/Enum.class'
     exclude 'sandbox/java/lang/Iterable.class'

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -191,12 +191,14 @@ abstract class ClassCommand : CommandBase() {
                 emitters = ignoreEmitters.emptyListIfTrueOtherwiseNull(),
                 definitionProviders = if (ignoreDefinitionProviders) { emptyList() } else { Discovery.find() },
                 enableTracing = !disableTracing,
-                analysisConfiguration = AnalysisConfiguration(
+                analysisConfiguration = AnalysisConfiguration.createRoot(
                         whitelist = whitelist,
                         minimumSeverityLevel = level,
-                        classPath = getClasspath(),
                         analyzeAnnotations = analyzeAnnotations,
-                        prefixFilters = prefixFilters.toList()
+                        prefixFilters = prefixFilters.toList(),
+                        sourceClassLoaderFactory = { classResolver, bootstrapClassLoader ->
+                            SourceClassLoader(getClasspath(), classResolver, bootstrapClassLoader)
+                        }
                 )
         )
     }

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/WhitelistGenerateCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/WhitelistGenerateCommand.kt
@@ -33,7 +33,7 @@ class WhitelistGenerateCommand : CommandBase() {
     override fun validateArguments() = paths.isNotEmpty()
 
     override fun handleCommand(): Boolean {
-        val entries = AnalysisConfiguration().use { configuration ->
+        val entries = AnalysisConfiguration.createRoot().use { configuration ->
             val entries = mutableListOf<String>()
             val visitor = object : ClassAndMemberVisitor(configuration, null) {
                 override fun visitClass(clazz: ClassRepresentation): ClassRepresentation {

--- a/djvm/src/main/java/sandbox/java/lang/Object.java
+++ b/djvm/src/main/java/sandbox/java/lang/Object.java
@@ -45,8 +45,8 @@ public class Object {
     private static java.lang.Object unwrap(java.lang.Object arg) {
         if (arg instanceof Object) {
             return ((Object) arg).fromDJVM();
-        } else if (Object[].class.isAssignableFrom(arg.getClass())) {
-            return fromDJVM((Object[]) arg);
+        } else if (java.lang.Object[].class.isAssignableFrom(arg.getClass())) {
+            return fromDJVM((java.lang.Object[]) arg);
         } else {
             return arg;
         }

--- a/djvm/src/main/java/sandbox/java/lang/String.java
+++ b/djvm/src/main/java/sandbox/java/lang/String.java
@@ -1,5 +1,6 @@
 package sandbox.java.lang;
 
+import net.corda.djvm.SandboxRuntimeContext;
 import org.jetbrains.annotations.NotNull;
 import sandbox.java.nio.charset.Charset;
 import sandbox.java.util.Comparator;
@@ -8,7 +9,6 @@ import sandbox.java.util.Locale;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
-import java.util.Map;
 
 @SuppressWarnings("unused")
 public final class String extends Object implements Comparable<String>, CharSequence, Serializable {
@@ -24,7 +24,6 @@ public final class String extends Object implements Comparable<String>, CharSequ
     private static final String TRUE = new String("true");
     private static final String FALSE = new String("false");
 
-    private static final Map<java.lang.String, String> INTERNAL = new java.util.HashMap<>();
     private static final Constructor SHARED;
 
     static {
@@ -335,7 +334,7 @@ public final class String extends Object implements Comparable<String>, CharSequ
         return toDJVM(value.trim());
     }
 
-    public String intern() { return INTERNAL.computeIfAbsent(value, s -> this); }
+    public String intern() { return (String) SandboxRuntimeContext.getInstance().intern(value, this); }
 
     public char[] toCharArray() {
         return value.toCharArray();

--- a/djvm/src/main/java/sandbox/java/lang/System.java
+++ b/djvm/src/main/java/sandbox/java/lang/System.java
@@ -1,20 +1,15 @@
 package sandbox.java.lang;
 
+import net.corda.djvm.SandboxRuntimeContext;
+
 @SuppressWarnings({"WeakerAccess", "unused"})
 public final class System extends Object {
 
     private System() {}
 
-    /*
-     * This class is duplicated into every sandbox, where everything is single-threaded.
-     */
-    private static final java.util.Map<java.lang.Integer, java.lang.Integer> objectHashCodes = new java.util.LinkedHashMap<>();
-    private static int objectCounter = 0;
-
     public static int identityHashCode(java.lang.Object obj) {
         int nativeHashCode = java.lang.System.identityHashCode(obj);
-        // TODO Instead of using a magic offset below, one could take in a per-context seed
-        return objectHashCodes.computeIfAbsent(nativeHashCode, i -> ++objectCounter + 0xfed_c0de);
+        return SandboxRuntimeContext.getInstance().getHashCodeFor(nativeHashCode);
     }
 
     public static final String lineSeparator = String.toDJVM("\n");

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
@@ -5,6 +5,7 @@ import net.corda.djvm.code.DefinitionProvider
 import net.corda.djvm.code.EMIT_TRACING
 import net.corda.djvm.code.Emitter
 import net.corda.djvm.execution.ExecutionProfile
+import net.corda.djvm.rewiring.SandboxClassLoader
 import net.corda.djvm.rules.Rule
 import net.corda.djvm.utilities.Discovery
 
@@ -16,24 +17,28 @@ import net.corda.djvm.utilities.Discovery
  * @property definitionProviders The meta-data providers to apply to class and member definitions.
  * @property executionProfile The execution profile to use in the sandbox.
  * @property analysisConfiguration The configuration used in the analysis of classes.
+ * @property parentClassLoader The [SandboxClassLoader] that this sandbox will use as a parent.
  */
-@Suppress("unused")
 class SandboxConfiguration private constructor(
         val rules: List<Rule>,
         val emitters: List<Emitter>,
         val definitionProviders: List<DefinitionProvider>,
         val executionProfile: ExecutionProfile,
-        val analysisConfiguration: AnalysisConfiguration
+        val analysisConfiguration: AnalysisConfiguration,
+        val parentClassLoader: SandboxClassLoader?
 ) {
+    @Suppress("unused")
     companion object {
         /**
          * Default configuration for the deterministic sandbox.
          */
+        @JvmField
         val DEFAULT = SandboxConfiguration.of()
 
         /**
          * Configuration with no emitters, rules, meta-data providers or runtime thresholds.
          */
+        @JvmField
         val EMPTY = SandboxConfiguration.of(
                 ExecutionProfile.UNLIMITED, emptyList(), emptyList(), emptyList()
         )
@@ -47,7 +52,8 @@ class SandboxConfiguration private constructor(
                 emitters: List<Emitter>? = null,
                 definitionProviders: List<DefinitionProvider> = Discovery.find(),
                 enableTracing: Boolean = true,
-                analysisConfiguration: AnalysisConfiguration = AnalysisConfiguration()
+                analysisConfiguration: AnalysisConfiguration = AnalysisConfiguration.createRoot(),
+                parentClassLoader: SandboxClassLoader? = null
         ) = SandboxConfiguration(
                 executionProfile = profile,
                 rules = rules,
@@ -55,7 +61,8 @@ class SandboxConfiguration private constructor(
                     enableTracing || it.priority > EMIT_TRACING
                 },
                 definitionProviders = definitionProviders,
-                analysisConfiguration = analysisConfiguration
+                analysisConfiguration = analysisConfiguration,
+                parentClassLoader = parentClassLoader
         )
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
@@ -1,6 +1,5 @@
 package net.corda.djvm
 
-import net.corda.djvm.analysis.AnalysisContext
 import net.corda.djvm.costing.RuntimeCostSummary
 import net.corda.djvm.rewiring.SandboxClassLoader
 
@@ -14,15 +13,26 @@ class SandboxRuntimeContext(val configuration: SandboxConfiguration) {
     /**
      * The class loader to use inside the sandbox.
      */
-    val classLoader: SandboxClassLoader = SandboxClassLoader(
-            configuration,
-            AnalysisContext.fromConfiguration(configuration.analysisConfiguration)
-    )
+    val classLoader: SandboxClassLoader = SandboxClassLoader.createFor(configuration)
 
     /**
      * A summary of the currently accumulated runtime costs (for, e.g., memory allocations, invocations, etc.).
      */
     val runtimeCosts = RuntimeCostSummary(configuration.executionProfile)
+
+    private val hashCodes: MutableMap<Int, Int> = mutableMapOf()
+    private var objectCounter: Int = 0
+
+    // TODO Instead of using a magic offset below, one could take in a per-context seed
+    fun getHashCodeFor(nativeHashCode: Int): Int {
+        return hashCodes.computeIfAbsent(nativeHashCode) { ++objectCounter + MAGIC_HASH_OFFSET }
+    }
+
+    private val internStrings: MutableMap<String, Any> = mutableMapOf()
+
+    fun intern(key: String, value: Any): Any {
+        return internStrings.computeIfAbsent(key) { value }
+    }
 
     /**
      * Run a set of actions within the provided sandbox context.
@@ -39,10 +49,12 @@ class SandboxRuntimeContext(val configuration: SandboxConfiguration) {
     companion object {
 
         private val threadLocalContext = ThreadLocal<SandboxRuntimeContext?>()
+        private const val MAGIC_HASH_OFFSET = 0xfed_c0de
 
         /**
          * When called from within a sandbox, this returns the context for the current sandbox thread.
          */
+        @JvmStatic
         var instance: SandboxRuntimeContext
             get() = threadLocalContext.get()
                     ?: throw IllegalStateException("SandboxContext has not been initialized before use")

--- a/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
@@ -22,6 +22,7 @@ class MessageCollection(
 
     private val memberMessages = mutableMapOf<String, MutableList<Message>>()
 
+    private val provisional = mutableListOf<Message>()
     private var cachedEntries: List<Message>? = null
 
     /**
@@ -56,6 +57,28 @@ class MessageCollection(
         for (message in messages) {
             add(message)
         }
+    }
+
+    /**
+     * Hold this message until we've decided whether or not it's real.
+     */
+    fun provisionalAdd(message: Message) {
+        provisional.add(message)
+    }
+
+    /**
+     * Discard all provisional messages.
+     */
+    fun clearProvisional() {
+        provisional.clear()
+    }
+
+    /**
+     * Accept all provisional messages.
+     */
+    fun acceptProvisional() {
+        addAll(provisional)
+        clearProvisional()
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -1,6 +1,7 @@
 package net.corda.djvm.rewiring
 
 import net.corda.djvm.SandboxConfiguration
+import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.AnalysisContext
 import net.corda.djvm.analysis.ClassAndMemberVisitor
 import net.corda.djvm.analysis.ExceptionResolver.Companion.getDJVMExceptionOwner
@@ -8,30 +9,32 @@ import net.corda.djvm.analysis.ExceptionResolver.Companion.isDJVMException
 import net.corda.djvm.code.asPackagePath
 import net.corda.djvm.code.asResourcePath
 import net.corda.djvm.references.ClassReference
+import net.corda.djvm.source.AbstractSourceClassLoader
 import net.corda.djvm.source.ClassSource
 import net.corda.djvm.utilities.loggerFor
 import net.corda.djvm.validation.RuleValidator
+import org.objectweb.asm.Type
 
 /**
  * Class loader that enables registration of rewired classes.
  *
- * @param configuration The configuration to use for the sandbox.
+ * @property analysisConfiguration The configuration to use for the analysis.
+ * @property ruleValidator The instance used to validate that any loaded class complies with the specified rules.
+ * @property supportingClassLoader The class loader used to find classes on the extended class path.
+ * @property rewriter The re-writer to use for registered classes.
  * @property context The context in which analysis and processing is performed.
+ * @param throwableClass This sandbox's definition of [sandbox.java.lang.Throwable].
+ * @param parent This classloader's parent classloader.
  */
-class SandboxClassLoader(
-        configuration: SandboxConfiguration,
-        private val context: AnalysisContext
-) : ClassLoader() {
-
-    private val analysisConfiguration = configuration.analysisConfiguration
-
-    /**
-     * The instance used to validate that any loaded class complies with the specified rules.
-     */
-    private val ruleValidator: RuleValidator = RuleValidator(
-            rules = configuration.rules,
-            configuration = analysisConfiguration
-    )
+class SandboxClassLoader private constructor(
+        private val analysisConfiguration: AnalysisConfiguration,
+        private val ruleValidator: RuleValidator,
+        private val supportingClassLoader: AbstractSourceClassLoader,
+        private val rewriter: ClassRewriter,
+        private val context: AnalysisContext,
+        throwableClass: Class<*>?,
+        parent: ClassLoader?
+) : ClassLoader(parent ?: getSystemClassLoader()) {
 
     /**
      * The analyzer used to traverse the class hierarchy.
@@ -50,36 +53,62 @@ class SandboxClassLoader(
     private val loadedClasses = mutableMapOf<String, LoadedClass>()
 
     /**
-     * The class loader used to find classes on the extended class path.
+     * We need to load [sandbox.java.lang.Throwable] up front, so that we can
+     * identify sandboxed exception classes.
      */
-    private val supportingClassLoader = analysisConfiguration.supportingClassLoader
-
-    /**
-     * The re-writer to use for registered classes.
-     */
-    private val rewriter: ClassRewriter = ClassRewriter(configuration, supportingClassLoader)
-
-    /**
-     * We need to load this class up front, so that we can identify sandboxed exception classes.
-     */
-    private val throwableClass: Class<*>
-
-    init {
-        // Bootstrap the loading of the sandboxed Throwable class.
+    private val throwableClass: Class<*> = throwableClass ?: run {
         loadClassAndBytes(ClassSource.fromClassName("sandbox.java.lang.Object"), context)
         loadClassAndBytes(ClassSource.fromClassName("sandbox.java.lang.StackTraceElement"), context)
-        throwableClass = loadClassAndBytes(ClassSource.fromClassName("sandbox.java.lang.Throwable"), context).type
+        loadClassAndBytes(ClassSource.fromClassName("sandbox.java.lang.Throwable"), context).type
     }
+
+    /**
+     * Creates an empty [SandboxClassLoader] with exactly the same
+     * configuration as this one, but with the given [AnalysisContext].
+     * @param newContext
+     */
+    fun copyEmpty(newContext: AnalysisContext) = SandboxClassLoader(
+        analysisConfiguration,
+        ruleValidator,
+        supportingClassLoader,
+        rewriter,
+        newContext,
+        throwableClass,
+        parent
+    )
 
     /**
      * Given a class name, provide its corresponding [LoadedClass] for the sandbox.
+     * This class may have been loaded by a parent classloader really.
      */
-    fun loadForSandbox(name: String, context: AnalysisContext): LoadedClass {
-        return loadClassAndBytes(ClassSource.fromClassName(analysisConfiguration.classResolver.resolveNormalized(name)), context)
+    fun loadForSandbox(className: String): LoadedClass {
+        val sandboxClass = loadClassForSandbox(className)
+        val sandboxName = Type.getInternalName(sandboxClass)
+        var loader = this
+        while(true) {
+            val loaded = loader.loadedClasses[sandboxName]
+            if (loaded != null) {
+                return loaded
+            }
+            loader = loader.parent as? SandboxClassLoader ?: return LoadedClass(sandboxClass, UNMODIFIED)
+        }
     }
 
-    fun loadForSandbox(source: ClassSource, context: AnalysisContext): LoadedClass {
-        return loadForSandbox(source.qualifiedClassName, context)
+    fun loadForSandbox(source: ClassSource): LoadedClass {
+        return loadForSandbox(source.qualifiedClassName)
+    }
+
+    private fun loadClassForSandbox(className: String): Class<*> {
+        val sandboxName = analysisConfiguration.classResolver.resolveNormalized(className)
+        return try {
+            loadClass(sandboxName)
+        } finally {
+            context.messages.acceptProvisional()
+        }
+    }
+
+    fun loadClassForSandbox(source: ClassSource): Class<*> {
+        return loadClassForSandbox(source.qualifiedClassName)
     }
 
     /**
@@ -95,10 +124,19 @@ class SandboxClassLoader(
         var clazz = findLoadedClass(name)
         if (clazz == null) {
             val source = ClassSource.fromClassName(name)
-            clazz = if (analysisConfiguration.isSandboxClass(source.internalClassName)) {
-                loadSandboxClass(source, context).type
-            } else {
-                super.loadClass(name, resolve)
+            val isSandboxClass = analysisConfiguration.isSandboxClass(source.internalClassName)
+
+            if (!isSandboxClass || parent is SandboxClassLoader) {
+                try {
+                    clazz = super.loadClass(name, resolve)
+                } catch (e: ClassNotFoundException) {
+                } catch (e: SandboxClassLoadingException) {
+                    e.messages.clearProvisional()
+                }
+            }
+
+            if (clazz == null && isSandboxClass) {
+                clazz = loadSandboxClass(source, context).type
             }
         }
         if (resolve) {
@@ -107,15 +145,31 @@ class SandboxClassLoader(
         return clazz
     }
 
+    /**
+     * A sandboxed exception class cannot be thrown, and so we may also need to create a
+     * synthetic throwable wrapper for it. Or perhaps we've just been asked to load the
+     * synthetic wrapper class belonging to an exception that we haven't loaded yet?
+     * Either way, we need to load the sandboxed exception first so that we know what
+     * the synthetic wrapper's super-class needs to be.
+     */
     private fun loadSandboxClass(source: ClassSource, context: AnalysisContext): LoadedClass {
         return if (isDJVMException(source.internalClassName)) {
             /**
              * We need to load a DJVMException's owner class before we can create
-             * its wrapper exception. And loading the owner should also create the
-             * wrapper class automatically.
+             * its wrapper exception. And loading the owner should then also create
+             * the wrapper class automatically.
              */
             loadedClasses.getOrElse(source.internalClassName) {
-                loadSandboxClass(ClassSource.fromClassName(getDJVMExceptionOwner(source.qualifiedClassName)), context)
+                val exceptionOwner = ClassSource.fromClassName(getDJVMExceptionOwner(source.qualifiedClassName))
+                if (!analysisConfiguration.isJvmException(exceptionOwner.internalClassName)) {
+                    /**
+                     * JVM Exceptions belong to the parent classloader, and so will never
+                     * be found inside a child classloader. Which means we must not try to
+                     * create a duplicate inside any child classloaders either. Hence we
+                     * re-invoke [loadClass] which will delegate back to the parent.
+                     */
+                    loadClass(exceptionOwner.qualifiedClassName, false)
+                }
                 loadedClasses[source.internalClassName]
             } ?: throw ClassNotFoundException(source.qualifiedClassName)
         } else {
@@ -171,6 +225,7 @@ class SandboxClassLoader(
             }
 
             // Check if any errors were found during analysis.
+            context.messages.acceptProvisional()
             if (context.messages.errorCount > 0) {
                 logger.debug("Errors detected after analyzing class {}", request.qualifiedClassName)
                 throw SandboxClassLoadingException(context)
@@ -214,6 +269,10 @@ class SandboxClassLoader(
         }
     }
 
+    /**
+     * Check whether the synthetic throwable wrapper already
+     * exists for this exception, and create it if it doesn't.
+     */
     private fun loadWrapperFor(throwable: Class<*>): LoadedClass {
         val className = analysisConfiguration.exceptionResolver.getThrowableName(throwable)
         return loadedClasses.getOrPut(className) {
@@ -223,9 +282,30 @@ class SandboxClassLoader(
         }
     }
 
-    private companion object {
+    companion object {
         private val logger = loggerFor<SandboxClassLoader>()
         private val UNMODIFIED = ByteCode(ByteArray(0), false)
+
+        /**
+         * Factory function to create a [SandboxClassLoader].
+         * @param configuration The [SandboxConfiguration] containing the classloader's configuration parameters.
+         */
+        fun createFor(configuration: SandboxConfiguration): SandboxClassLoader {
+            val analysisConfiguration = configuration.analysisConfiguration
+            val supportingClassLoader = analysisConfiguration.supportingClassLoader
+            val parentClassLoader = configuration.parentClassLoader
+
+            return SandboxClassLoader(
+                analysisConfiguration = analysisConfiguration,
+                supportingClassLoader = supportingClassLoader,
+                ruleValidator = RuleValidator(rules = configuration.rules,
+                                              configuration = analysisConfiguration),
+                rewriter = ClassRewriter(configuration, supportingClassLoader),
+                context = AnalysisContext.fromConfiguration(analysisConfiguration),
+                throwableClass = parentClassLoader?.throwableClass,
+                parent = parentClassLoader
+            )
+        }
     }
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -65,7 +65,7 @@ class SandboxClassLoader private constructor(
     /**
      * Creates an empty [SandboxClassLoader] with exactly the same
      * configuration as this one, but with the given [AnalysisContext].
-     * @param newContext
+     * @param newContext The [AnalysisContext] to use for the child classloader.
      */
     fun copyEmpty(newContext: AnalysisContext) = SandboxClassLoader(
         analysisConfiguration,
@@ -81,6 +81,7 @@ class SandboxClassLoader private constructor(
      * Given a class name, provide its corresponding [LoadedClass] for the sandbox.
      * This class may have been loaded by a parent classloader really.
      */
+    @Throws(ClassNotFoundException::class)
     fun loadForSandbox(className: String): LoadedClass {
         val sandboxClass = loadClassForSandbox(className)
         val sandboxName = Type.getInternalName(sandboxClass)
@@ -94,6 +95,7 @@ class SandboxClassLoader private constructor(
         }
     }
 
+    @Throws(ClassNotFoundException::class)
     fun loadForSandbox(source: ClassSource): LoadedClass {
         return loadForSandbox(source.qualifiedClassName)
     }
@@ -107,6 +109,7 @@ class SandboxClassLoader private constructor(
         }
     }
 
+    @Throws(ClassNotFoundException::class)
     fun loadClassForSandbox(source: ClassSource): Class<*> {
         return loadClassForSandbox(source.qualifiedClassName)
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoadingException.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoadingException.kt
@@ -19,7 +19,7 @@ class SandboxClassLoadingException(
         val messages: MessageCollection = context.messages,
         val classes: ClassHierarchy = context.classes,
         val classOrigins: Map<String, Set<EntityReference>> = context.classOrigins
-) : Exception("Failed to load class") {
+) : RuntimeException("Failed to load class") {
 
     /**
      * The detailed description of the exception.
@@ -28,7 +28,7 @@ class SandboxClassLoadingException(
         get() = StringBuilder().apply {
             appendln(super.message)
             for (message in messages.sorted().map(Message::toString).distinct()) {
-                appendln(" - $message")
+                append(" - ").appendln(message)
             }
         }.toString().trimEnd('\r', '\n')
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
@@ -12,13 +12,11 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptySet;
-
 public class SandboxEnumJavaTest extends TestBase {
 
     @Test
     public void testEnumInsideSandbox() {
-        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+        parentedSandbox(WARNING, true, ctx -> {
             SandboxExecutor<Integer, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String[]> output = WithJava.run(executor, TransformEnum.class, 0);
             assertThat(output.getResult())
@@ -29,7 +27,7 @@ public class SandboxEnumJavaTest extends TestBase {
 
     @Test
     public void testReturnEnumFromSandbox() {
-        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+        parentedSandbox(WARNING, true, ctx -> {
             SandboxExecutor<String, ExampleEnum> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<ExampleEnum> output = WithJava.run(executor, FetchEnum.class, "THREE");
             assertThat(output.getResult())
@@ -40,7 +38,7 @@ public class SandboxEnumJavaTest extends TestBase {
 
     @Test
     public void testWeCanIdentifyClassAsEnum() {
-        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+        parentedSandbox(WARNING, true, ctx -> {
             SandboxExecutor<ExampleEnum, Boolean> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Boolean> output = WithJava.run(executor, AssertEnum.class, ExampleEnum.THREE);
             assertThat(output.getResult()).isTrue();
@@ -50,7 +48,7 @@ public class SandboxEnumJavaTest extends TestBase {
 
     @Test
     public void testWeCanCreateEnumMap() {
-        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+        parentedSandbox(WARNING, true, ctx -> {
             SandboxExecutor<ExampleEnum, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, UseEnumMap.class, ExampleEnum.TWO);
             assertThat(output.getResult()).isEqualTo(1);
@@ -60,7 +58,7 @@ public class SandboxEnumJavaTest extends TestBase {
 
     @Test
     public void testWeCanCreateEnumSet() {
-        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+        parentedSandbox(WARNING, true, ctx -> {
             SandboxExecutor<ExampleEnum, Boolean> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Boolean> output = WithJava.run(executor, UseEnumSet.class, ExampleEnum.ONE);
             assertThat(output.getResult()).isTrue();

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -12,14 +12,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
-import static java.util.Collections.emptySet;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     public void testUserExceptionHandling() {
-        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+        parentedSandbox(WARNING, true, ctx -> {
             SandboxExecutor<String, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String[]> output = WithJava.run(executor, ThrowAndCatchJavaExample.class, "Hello World!");
             assertThat(output.getResult())
@@ -30,7 +29,7 @@ public class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     public void testCheckedExceptions() {
-        sandbox(new Object[]{ DEFAULT }, emptySet(), WARNING, true, ctx -> {
+        parentedSandbox(WARNING, true, ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
 
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, JavaWithCheckedExceptions.class, "http://localhost:8080/hello/world");

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
@@ -137,7 +137,7 @@ class MultipleExceptionsTask : SandboxFunction<Any?, sandbox.java.lang.Throwable
 }
 
 private infix operator fun sandbox.java.lang.String.plus(s: String): sandbox.java.lang.String {
-    return (toString() + s).toDJVM()
+    return sandbox.java.lang.String.valueOf(toString() + s)
 }
 
 private fun Array<StackTraceElement>.toLineNumbers(): IntArray {

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
@@ -1,6 +1,7 @@
 package net.corda.djvm
 
 import net.corda.djvm.assertions.AssertionExtensions.assertThatDJVM
+import net.corda.djvm.rewiring.SandboxClassLoadingException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Test
@@ -119,6 +120,30 @@ class DJVMExceptionTest : TestBase() {
         assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { djvm.classFor("sandbox.java.util.LinkedList\$1DJVM") }
             .withMessage("sandbox.java.util.LinkedList\$1DJVM")
+    }
+
+    /**
+     * This scenario should never happen in practice. We just need to be sure
+     * that the classloader can handle it.
+     */
+    @Test
+    fun testWeCannotCreateSyntheticExceptionForImaginaryJavaClass() = parentedSandbox {
+        val djvm = DJVM(classLoader)
+        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+            .isThrownBy { djvm.classFor("sandbox.java.util.DoesNotExist\$1DJVM") }
+            .withMessageContaining("Failed to load class")
+    }
+
+    /**
+     * This scenario should never happen in practice. We just need to be sure
+     * that the classloader can handle it.
+     */
+    @Test
+    fun testWeCannotCreateSyntheticExceptionForImaginaryUserClass() = parentedSandbox {
+        val djvm = DJVM(classLoader)
+        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+            .isThrownBy { djvm.classFor("sandbox.com.example.DoesNotExist\$1DJVM") }
+            .withMessageContaining("Failed to load class")
     }
 }
 

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
@@ -64,12 +64,12 @@ class DJVMExceptionTest : TestBase() {
         val result = djvm.sandbox(Throwable("Hello World"))
         assertThatDJVM(result)
             .hasClassName("sandbox.java.lang.Throwable")
-            .isAssignableFrom(djvm.throwable)
+            .isAssignableFrom(djvm.throwableClass)
             .hasGetterValue("getMessage", helloWorld)
             .hasGetterNullValue("getCause")
 
         assertThat(result.getArray("getStackTrace"))
-            .hasOnlyElementsOfType(djvm.stackTraceElement)
+            .hasOnlyElementsOfType(djvm.stackTraceElementClass)
             .isNotEmpty()
     }
 
@@ -81,12 +81,12 @@ class DJVMExceptionTest : TestBase() {
         val result = djvm.sandbox(RuntimeException("Hello World"))
         assertThatDJVM(result)
             .hasClassName("sandbox.java.lang.RuntimeException")
-            .isAssignableFrom(djvm.throwable)
+            .isAssignableFrom(djvm.throwableClass)
             .hasGetterValue("getMessage", helloWorld)
             .hasGetterNullValue("getCause")
 
         assertThat(result.getArray("getStackTrace"))
-            .hasOnlyElementsOfType(djvm.stackTraceElement)
+            .hasOnlyElementsOfType(djvm.stackTraceElementClass)
             .isNotEmpty()
 
         assertThatExceptionOfType(ClassNotFoundException::class.java)
@@ -101,12 +101,12 @@ class DJVMExceptionTest : TestBase() {
         val result = djvm.sandbox(EmptyStackException())
         assertThatDJVM(result)
             .hasClassName("sandbox.java.util.EmptyStackException")
-            .isAssignableFrom(djvm.throwable)
+            .isAssignableFrom(djvm.throwableClass)
             .hasGetterNullValue("getMessage")
             .hasGetterNullValue("getCause")
 
         assertThat(result.getArray("getStackTrace"))
-            .hasOnlyElementsOfType(djvm.stackTraceElement)
+            .hasOnlyElementsOfType(djvm.stackTraceElementClass)
             .isNotEmpty()
 
         assertThatDJVM(djvm.classFor("sandbox.java.util.EmptyStackException\$1DJVM"))

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
@@ -4,9 +4,8 @@ import org.assertj.core.api.Assertions.*
 import org.junit.Assert.*
 import org.junit.Test
 import sandbox.java.lang.sandbox
-import sandbox.java.lang.unsandbox
 
-class DJVMTest {
+class DJVMTest : TestBase() {
 
     @Test
     fun testDJVMString() {
@@ -16,39 +15,59 @@ class DJVMTest {
     }
 
     @Test
-    fun testSimpleIntegerFormats() {
-        val result = sandbox.java.lang.String.format("%d-%d-%d-%d".toDJVM(),
-                          10.toDJVM(), 999999L.toDJVM(), 1234.toShort().toDJVM(), 108.toByte().toDJVM()).toString()
+    fun testSimpleIntegerFormats() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            string.getMethod("format", string, Array<Any>::class.java)
+                .invoke(null,
+                    stringOf("%d-%d-%d-%d"),
+                    arrayOf(intOf(10), longOf(999999L), shortOf(1234), byteOf(108))
+                ).toString()
+        }
         assertEquals("10-999999-1234-108", result)
     }
 
     @Test
-    fun testHexFormat() {
-        val result = sandbox.java.lang.String.format("%0#6x".toDJVM(), 768.toDJVM()).toString()
+    fun testHexFormat() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            string.getMethod("format", string, Array<Any>::class.java)
+                .invoke(null, stringOf("%0#6x"), arrayOf(intOf(768))).toString()
+        }
         assertEquals("0x0300", result)
     }
 
     @Test
-    fun testDoubleFormat() {
-        val result = sandbox.java.lang.String.format("%9.4f".toDJVM(), 1234.5678.toDJVM()).toString()
+    fun testDoubleFormat() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            string.getMethod("format", string, Array<Any>::class.java)
+                .invoke(null, stringOf("%9.4f"), arrayOf(doubleOf(1234.5678))).toString()
+        }
         assertEquals("1234.5678", result)
     }
 
     @Test
-    fun testFloatFormat() {
-        val result = sandbox.java.lang.String.format("%7.2f".toDJVM(), 1234.5678f.toDJVM()).toString()
+    fun testFloatFormat() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            string.getMethod("format", string, Array<Any>::class.java)
+                .invoke(null, stringOf("%7.2f"), arrayOf(floatOf(1234.5678f))).toString()
+        }
         assertEquals("1234.57", result)
     }
 
     @Test
-    fun testCharFormat() {
-        val result = sandbox.java.lang.String.format("[%c]".toDJVM(), 'A'.toDJVM()).toString()
+    fun testCharFormat() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            string.getMethod("format", string, Array<Any>::class.java)
+                .invoke(null, stringOf("[%c]"), arrayOf(charOf('A'))).toString()
+        }
         assertEquals("[A]", result)
     }
 
     @Test
-    fun testObjectFormat() {
-        val result = sandbox.java.lang.String.format("%s".toDJVM(), object : sandbox.java.lang.Object() {}).toString()
+    fun testObjectFormat() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            string.getMethod("format", string, Array<Any>::class.java)
+                .invoke(null, stringOf("%s"), arrayOf(object : sandbox.java.lang.Object() {})).toString()
+        }
         assertThat(result).startsWith("sandbox.java.lang.Object@")
     }
 
@@ -59,48 +78,60 @@ class DJVMTest {
     }
 
     @Test
-    fun testSandboxingArrays() {
-        val result = arrayOf(1, 10L, "Hello World", '?', false, 1234.56).sandbox()
-        assertThat(result)
-            .isEqualTo(arrayOf(1.toDJVM(), 10L.toDJVM(), "Hello World".toDJVM(), '?'.toDJVM(), false.toDJVM(), 1234.56.toDJVM()))
+    fun testSandboxingArrays() = parentedSandbox {
+        with(DJVM(classLoader)) {
+            val result = sandbox(arrayOf(1, 10L, "Hello World", '?', false, 1234.56))
+            assertThat(result).isEqualTo(
+                arrayOf(intOf(1), longOf(10), stringOf("Hello World"), charOf('?'), booleanOf(false), doubleOf(1234.56)))
+        }
     }
 
     @Test
-    fun testUnsandboxingObjectArray() {
-        val result = arrayOf<sandbox.java.lang.Object>(1.toDJVM(), 10L.toDJVM(), "Hello World".toDJVM(), '?'.toDJVM(), false.toDJVM(), 1234.56.toDJVM()).unsandbox()
+    fun testUnsandboxingObjectArray() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            unsandbox(arrayOf(intOf(1), longOf(10L), stringOf("Hello World"), charOf('?'), booleanOf(false), doubleOf(1234.56)))
+        }
         assertThat(result)
-                .isEqualTo(arrayOf(1, 10L, "Hello World", '?', false, 1234.56))
+            .isEqualTo(arrayOf(1, 10L, "Hello World", '?', false, 1234.56))
     }
 
     @Test
-    fun testSandboxingPrimitiveArray() {
-        val result = intArrayOf(1, 2, 3, 10).sandbox()
+    fun testSandboxingPrimitiveArray() = parentedSandbox {
+        val result = with(DJVM(classLoader)) {
+            sandbox(intArrayOf(1, 2, 3, 10))
+        }
         assertThat(result).isEqualTo(intArrayOf(1, 2, 3, 10))
     }
 
     @Test
-    fun testSandboxingIntegersAsObjectArray() {
-        val result = arrayOf(1, 2, 3, 10).sandbox()
-        assertThat(result).isEqualTo(arrayOf(1.toDJVM(), 2.toDJVM(), 3.toDJVM(), 10.toDJVM()))
+    fun testSandboxingIntegersAsObjectArray() = parentedSandbox {
+        with(DJVM(classLoader)) {
+            val result = sandbox(arrayOf(1, 2, 3, 10))
+            assertThat(result).isEqualTo(
+                arrayOf(intOf(1), intOf(2), intOf(3), intOf(10))
+            )
+        }
     }
 
     @Test
-    fun testUnsandboxingArrays() {
-        val arr = arrayOf(
-            Array(1) { "Hello".toDJVM() },
-            Array(1) { 1234000L.toDJVM() },
-            Array(1) { 1234.toDJVM() },
-            Array(1) { 923.toShort().toDJVM() },
-            Array(1) { 27.toByte().toDJVM() },
-            Array(1) { 'X'.toDJVM() },
-            Array(1) { 987.65f.toDJVM() },
-            Array(1) { 343.282.toDJVM() },
-            Array(1) { true.toDJVM() },
-            ByteArray(1) { 127.toByte() },
-            CharArray(1) { '?'}
-        )
-        val result = arr.unsandbox() as Array<*>
-        assertEquals(arr.size, result.size)
+    fun testUnsandboxingArrays() = parentedSandbox {
+        val (array, result) = with(DJVM(classLoader)) {
+            val arr = arrayOf(
+                objectArrayOf(stringOf("Hello")),
+                objectArrayOf(longOf(1234000L)),
+                objectArrayOf(intOf(1234)),
+                objectArrayOf(shortOf(923)),
+                objectArrayOf(byteOf(27)),
+                objectArrayOf(charOf('X')),
+                objectArrayOf(floatOf(987.65f)),
+                objectArrayOf(doubleOf(343.282)),
+                objectArrayOf(booleanOf(true)),
+                ByteArray(1) { 127.toByte() },
+                CharArray(1) { '?' }
+            )
+            Pair(arr, unsandbox(arr) as Array<*>)
+        }
+        assertEquals(array.size, result.size)
         assertArrayEquals(Array(1) { "Hello" }, result[0] as Array<*>)
         assertArrayEquals(Array(1) { 1234000L }, result[1] as Array<*>)
         assertArrayEquals(Array(1) { 1234 }, result[2] as Array<*>)

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
@@ -17,7 +17,7 @@ class DJVMTest : TestBase() {
     @Test
     fun testSimpleIntegerFormats() = parentedSandbox {
         val result = with(DJVM(classLoader)) {
-            string.getMethod("format", string, Array<Any>::class.java)
+            stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null,
                     stringOf("%d-%d-%d-%d"),
                     arrayOf(intOf(10), longOf(999999L), shortOf(1234), byteOf(108))
@@ -29,7 +29,7 @@ class DJVMTest : TestBase() {
     @Test
     fun testHexFormat() = parentedSandbox {
         val result = with(DJVM(classLoader)) {
-            string.getMethod("format", string, Array<Any>::class.java)
+            stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("%0#6x"), arrayOf(intOf(768))).toString()
         }
         assertEquals("0x0300", result)
@@ -38,7 +38,7 @@ class DJVMTest : TestBase() {
     @Test
     fun testDoubleFormat() = parentedSandbox {
         val result = with(DJVM(classLoader)) {
-            string.getMethod("format", string, Array<Any>::class.java)
+            stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("%9.4f"), arrayOf(doubleOf(1234.5678))).toString()
         }
         assertEquals("1234.5678", result)
@@ -47,7 +47,7 @@ class DJVMTest : TestBase() {
     @Test
     fun testFloatFormat() = parentedSandbox {
         val result = with(DJVM(classLoader)) {
-            string.getMethod("format", string, Array<Any>::class.java)
+            stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("%7.2f"), arrayOf(floatOf(1234.5678f))).toString()
         }
         assertEquals("1234.57", result)
@@ -56,7 +56,7 @@ class DJVMTest : TestBase() {
     @Test
     fun testCharFormat() = parentedSandbox {
         val result = with(DJVM(classLoader)) {
-            string.getMethod("format", string, Array<Any>::class.java)
+            stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("[%c]"), arrayOf(charOf('A'))).toString()
         }
         assertEquals("[A]", result)
@@ -65,7 +65,7 @@ class DJVMTest : TestBase() {
     @Test
     fun testObjectFormat() = parentedSandbox {
         val result = with(DJVM(classLoader)) {
-            string.getMethod("format", string, Array<Any>::class.java)
+            stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("%s"), arrayOf(object : sandbox.java.lang.Object() {})).toString()
         }
         assertThat(result).startsWith("sandbox.java.lang.Object@")

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -280,18 +280,18 @@ abstract class TestBase {
     @Suppress("MemberVisibilityCanBePrivate")
     protected class DJVM(private val classLoader: ClassLoader) {
         private val djvm: Class<*> = classFor("sandbox.java.lang.DJVM")
-        val sandboxObject: Class<*> by lazy { classFor("sandbox.java.lang.Object") }
-        val string: Class<*> by lazy { classFor("sandbox.java.lang.String") }
-        val long: Class<*> by lazy { classFor("sandbox.java.lang.Long") }
-        val integer: Class<*> by lazy { classFor("sandbox.java.lang.Integer") }
-        val short: Class<*> by lazy { classFor("sandbox.java.lang.Short") }
-        val byte: Class<*> by lazy { classFor("sandbox.java.lang.Byte") }
-        val character: Class<*> by lazy { classFor("sandbox.java.lang.Character") }
-        val boolean: Class<*> by lazy { classFor("sandbox.java.lang.Boolean") }
-        val double: Class<*> by lazy { classFor("sandbox.java.lang.Double") }
-        val float: Class<*> by lazy { classFor("sandbox.java.lang.Float") }
-        val throwable: Class<*> by lazy { classFor("sandbox.java.lang.Throwable") }
-        val stackTraceElement: Class<*> by lazy { classFor("sandbox.java.lang.StackTraceElement") }
+        val objectClass: Class<*> by lazy { classFor("sandbox.java.lang.Object") }
+        val stringClass: Class<*> by lazy { classFor("sandbox.java.lang.String") }
+        val longClass: Class<*> by lazy { classFor("sandbox.java.lang.Long") }
+        val integerClass: Class<*> by lazy { classFor("sandbox.java.lang.Integer") }
+        val shortClass: Class<*> by lazy { classFor("sandbox.java.lang.Short") }
+        val byteClass: Class<*> by lazy { classFor("sandbox.java.lang.Byte") }
+        val characterClass: Class<*> by lazy { classFor("sandbox.java.lang.Character") }
+        val booleanClass: Class<*> by lazy { classFor("sandbox.java.lang.Boolean") }
+        val doubleClass: Class<*> by lazy { classFor("sandbox.java.lang.Double") }
+        val floatClass: Class<*> by lazy { classFor("sandbox.java.lang.Float") }
+        val throwableClass: Class<*> by lazy { classFor("sandbox.java.lang.Throwable") }
+        val stackTraceElementClass: Class<*> by lazy { classFor("sandbox.java.lang.StackTraceElement") }
 
         fun classFor(className: String): Class<*> = Class.forName(className, false, classLoader)
 
@@ -304,46 +304,46 @@ abstract class TestBase {
         }
 
         fun stringOf(str: String): Any {
-            return string.getMethod("toDJVM", String::class.java).invoke(null, str)
+            return stringClass.getMethod("toDJVM", String::class.java).invoke(null, str)
         }
 
         fun longOf(l: Long): Any {
-            return long.getMethod("toDJVM", Long::class.javaObjectType).invoke(null, l)
+            return longClass.getMethod("toDJVM", Long::class.javaObjectType).invoke(null, l)
         }
 
         fun intOf(i: Int): Any {
-            return integer.getMethod("toDJVM", Int::class.javaObjectType).invoke(null, i)
+            return integerClass.getMethod("toDJVM", Int::class.javaObjectType).invoke(null, i)
         }
 
         fun shortOf(i: Int): Any {
-            return short.getMethod("toDJVM", Short::class.javaObjectType).invoke(null, i.toShort())
+            return shortClass.getMethod("toDJVM", Short::class.javaObjectType).invoke(null, i.toShort())
         }
 
         fun byteOf(i: Int): Any {
-            return byte.getMethod("toDJVM", Byte::class.javaObjectType).invoke(null, i.toByte())
+            return byteClass.getMethod("toDJVM", Byte::class.javaObjectType).invoke(null, i.toByte())
         }
 
         fun charOf(c: Char): Any {
-            return character.getMethod("toDJVM", Char::class.javaObjectType).invoke(null, c)
+            return characterClass.getMethod("toDJVM", Char::class.javaObjectType).invoke(null, c)
         }
 
         fun booleanOf(bool: Boolean): Any {
-            return boolean.getMethod("toDJVM", Boolean::class.javaObjectType).invoke(null, bool)
+            return booleanClass.getMethod("toDJVM", Boolean::class.javaObjectType).invoke(null, bool)
         }
 
         fun doubleOf(d: Double): Any {
-            return double.getMethod("toDJVM", Double::class.javaObjectType).invoke(null, d)
+            return doubleClass.getMethod("toDJVM", Double::class.javaObjectType).invoke(null, d)
         }
 
         fun floatOf(f: Float): Any {
-            return float.getMethod("toDJVM", Float::class.javaObjectType).invoke(null, f)
+            return floatClass.getMethod("toDJVM", Float::class.javaObjectType).invoke(null, f)
         }
 
         fun objectArrayOf(vararg objs: Any): Array<in Any> {
             @Suppress("unchecked_cast")
-            return (java.lang.reflect.Array.newInstance(sandboxObject, objs.size) as Array<in Any>).also {
+            return (java.lang.reflect.Array.newInstance(objectClass, objs.size) as Array<in Any>).also {
                 for (i in 0 until objs.size) {
-                    it[i] = sandboxObject.cast(objs[i])
+                    it[i] = objectClass.cast(objs[i])
                 }
             }
         }

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -12,13 +12,18 @@ import net.corda.djvm.execution.ExecutionProfile
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.references.ClassHierarchy
 import net.corda.djvm.rewiring.LoadedClass
+import net.corda.djvm.rewiring.SandboxClassLoader
 import net.corda.djvm.rules.Rule
 import net.corda.djvm.rules.implementation.*
+import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.ClassSource
+import net.corda.djvm.source.SandboxSourceClassLoader
 import net.corda.djvm.utilities.Discovery
 import net.corda.djvm.validation.RuleValidator
 import org.junit.After
+import org.junit.AfterClass
 import org.junit.Assert.assertEquals
+import org.junit.BeforeClass
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Type
@@ -39,6 +44,7 @@ abstract class TestBase {
         // We need at least these emitters to handle the Java API classes.
         @JvmField
         val BASIC_EMITTERS: List<Emitter> = listOf(
+            AlwaysInheritFromSandboxedObject(),
             ArgumentUnwrapper(),
             HandleExceptionUnwrapper(),
             ReturnTypeWrapper(),
@@ -51,7 +57,10 @@ abstract class TestBase {
 
         // We need at least these providers to handle the Java API classes.
         @JvmField
-        val BASIC_DEFINITION_PROVIDERS: List<DefinitionProvider> = listOf(StaticConstantRemover())
+        val BASIC_DEFINITION_PROVIDERS: List<DefinitionProvider> = listOf(
+            AlwaysInheritFromSandboxedObject(),
+            StaticConstantRemover()
+        )
 
         @JvmField
         val BLANK = emptySet<Any>()
@@ -63,17 +72,52 @@ abstract class TestBase {
         val DETERMINISTIC_RT: Path = Paths.get(
                 System.getProperty("deterministic-rt.path") ?: throw AssertionError("deterministic-rt.path property not set"))
 
+        private lateinit var parentConfiguration: SandboxConfiguration
+        lateinit var parentClassLoader: SandboxClassLoader
+
         /**
          * Get the full name of type [T].
          */
         inline fun <reified T> nameOf(prefix: String = "") = "$prefix${Type.getInternalName(T::class.java)}"
 
+        @BeforeClass
+        @JvmStatic
+        fun setupParentClassLoader() {
+            val rootConfiguration = AnalysisConfiguration.createRoot(
+                Whitelist.MINIMAL,
+                bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT),
+                sourceClassLoaderFactory = { classResolver, bootstrapClassLoader ->
+                    SandboxSourceClassLoader(classResolver,  bootstrapClassLoader!!)
+                },
+                additionalPinnedClasses = setOf(
+                    Utilities::class.java
+                ).map(Type::getInternalName).toSet()
+            )
+            parentConfiguration = SandboxConfiguration.of(
+                ExecutionProfile.UNLIMITED,
+                ALL_RULES,
+                ALL_EMITTERS,
+                ALL_DEFINITION_PROVIDERS,
+                true,
+                rootConfiguration
+            )
+            parentClassLoader = SandboxClassLoader.createFor(parentConfiguration)
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun destroyRootContext() {
+            parentConfiguration.analysisConfiguration.close()
+        }
     }
 
     /**
      * Default analysis configuration.
      */
-    val configuration = AnalysisConfiguration(Whitelist.MINIMAL, bootstrapJar = DETERMINISTIC_RT)
+    val configuration = AnalysisConfiguration.createRoot(
+        Whitelist.MINIMAL,
+        bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
+    )
 
     /**
      * Default analysis context
@@ -94,9 +138,9 @@ abstract class TestBase {
             noinline block: (RuleValidator.(AnalysisContext) -> Unit)
     ) {
         val reader = ClassReader(T::class.java.name)
-        AnalysisConfiguration(
+        AnalysisConfiguration.createRoot(
             minimumSeverityLevel = minimumSeverityLevel,
-            bootstrapJar = DETERMINISTIC_RT
+            bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
         ).use { analysisConfiguration ->
             val validator = RuleValidator(ALL_RULES, analysisConfiguration)
             val context = AnalysisContext.fromConfiguration(analysisConfiguration)
@@ -110,11 +154,11 @@ abstract class TestBase {
      * the current thread, so this allows inspection of the cost summary object, etc. from within the provided delegate.
      */
     fun sandbox(
-            vararg options: Any,
-            pinnedClasses: Set<java.lang.Class<*>> = emptySet(),
-            minimumSeverityLevel: Severity = Severity.WARNING,
-            enableTracing: Boolean = true,
-            action: SandboxRuntimeContext.() -> Unit
+        vararg options: Any,
+        pinnedClasses: Set<java.lang.Class<*>> = emptySet(),
+        minimumSeverityLevel: Severity = Severity.WARNING,
+        enableTracing: Boolean = true,
+        action: SandboxRuntimeContext.() -> Unit
     ) {
         val rules = mutableListOf<Rule>()
         val emitters = mutableListOf<Emitter>().apply { addAll(BASIC_EMITTERS) }
@@ -141,11 +185,11 @@ abstract class TestBase {
         thread {
             try {
                 val pinnedTestClasses = pinnedClasses.map(Type::getInternalName).toSet()
-                AnalysisConfiguration(
+                AnalysisConfiguration.createRoot(
                     whitelist = whitelist,
-                    bootstrapJar = DETERMINISTIC_RT,
                     additionalPinnedClasses = pinnedTestClasses,
-                    minimumSeverityLevel = minimumSeverityLevel
+                    minimumSeverityLevel = minimumSeverityLevel,
+                    bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
                 ).use { analysisConfiguration ->
                     SandboxRuntimeContext(SandboxConfiguration.of(
                         executionProfile,
@@ -154,6 +198,37 @@ abstract class TestBase {
                         definitionProviders.distinctBy(Any::javaClass),
                         enableTracing,
                         analysisConfiguration
+                    )).use {
+                        assertThat(runtimeCosts).areZero()
+                        action(this)
+                    }
+                }
+            } catch (exception: Throwable) {
+                thrownException = exception
+            }
+        }.join()
+        throw thrownException ?: return
+    }
+
+    fun parentedSandbox(
+        minimumSeverityLevel: Severity = Severity.WARNING,
+        enableTracing: Boolean = true,
+        action: SandboxRuntimeContext.() -> Unit
+    ) {
+        var thrownException: Throwable? = null
+        thread {
+            try {
+                parentConfiguration.analysisConfiguration.createChild(
+                    newMinimumSeverityLevel = minimumSeverityLevel
+                ).use { analysisConfiguration ->
+                    SandboxRuntimeContext(SandboxConfiguration.of(
+                        parentConfiguration.executionProfile,
+                        parentConfiguration.rules,
+                        parentConfiguration.emitters,
+                        parentConfiguration.definitionProviders,
+                        enableTracing,
+                        analysisConfiguration,
+                        parentClassLoader
                     )).use {
                         assertThat(runtimeCosts).areZero()
                         action(this)
@@ -178,8 +253,7 @@ abstract class TestBase {
 
     inline fun <reified T : Any> SandboxRuntimeContext.loadClass(): LoadedClass = loadClass(T::class.jvmName)
 
-    fun SandboxRuntimeContext.loadClass(className: String): LoadedClass =
-            classLoader.loadForSandbox(className, context)
+    fun SandboxRuntimeContext.loadClass(className: String): LoadedClass = classLoader.loadForSandbox(className)
 
     /**
      * Run the entry-point of the loaded [Callable] class.
@@ -203,4 +277,77 @@ abstract class TestBase {
         }
     }
 
+    @Suppress("WeakerAccess")
+    protected class DJVM(private val classLoader: ClassLoader) {
+        private val djvm: Class<*> = classFor("sandbox.java.lang.DJVM")
+        val sandboxObject: Class<*> by lazy { classFor("sandbox.java.lang.Object") }
+        val string: Class<*> by lazy { classFor("sandbox.java.lang.String") }
+        val long: Class<*> by lazy { classFor("sandbox.java.lang.Long") }
+        val integer: Class<*> by lazy { classFor("sandbox.java.lang.Integer") }
+        val short: Class<*> by lazy { classFor("sandbox.java.lang.Short") }
+        val byte: Class<*> by lazy { classFor("sandbox.java.lang.Byte") }
+        val character: Class<*> by lazy { classFor("sandbox.java.lang.Character") }
+        val boolean: Class<*> by lazy { classFor("sandbox.java.lang.Boolean") }
+        val double: Class<*> by lazy { classFor("sandbox.java.lang.Double") }
+        val float: Class<*> by lazy { classFor("sandbox.java.lang.Float") }
+        val throwable: Class<*> by lazy { classFor("sandbox.java.lang.Throwable") }
+        val stackTraceElement: Class<*> by lazy { classFor("sandbox.java.lang.StackTraceElement") }
+
+        fun classFor(className: String): Class<*> = Class.forName(className, false, classLoader)
+
+        fun sandbox(obj: Any): Any {
+            return djvm.getMethod("sandbox", Any::class.java).invoke(null, obj)
+        }
+
+        fun unsandbox(obj: Any): Any {
+            return djvm.getMethod("unsandbox", Any::class.java).invoke(null, obj)
+        }
+
+        fun stringOf(str: String): Any {
+            return string.getMethod("toDJVM", String::class.java).invoke(null, str)
+        }
+
+        fun longOf(l: Long): Any {
+            return long.getMethod("toDJVM", Long::class.javaObjectType).invoke(null, l)
+        }
+
+        fun intOf(i: Int): Any {
+            return integer.getMethod("toDJVM", Int::class.javaObjectType).invoke(null, i)
+        }
+
+        fun shortOf(i: Int): Any {
+            return short.getMethod("toDJVM", Short::class.javaObjectType).invoke(null, i.toShort())
+        }
+
+        fun byteOf(i: Int): Any {
+            return byte.getMethod("toDJVM", Byte::class.javaObjectType).invoke(null, i.toByte())
+        }
+
+        fun charOf(c: Char): Any {
+            return character.getMethod("toDJVM", Char::class.javaObjectType).invoke(null, c)
+        }
+
+        fun booleanOf(bool: Boolean): Any {
+            return boolean.getMethod("toDJVM", Boolean::class.javaObjectType).invoke(null, bool)
+        }
+
+        fun doubleOf(d: Double): Any {
+            return double.getMethod("toDJVM", Double::class.javaObjectType).invoke(null, d)
+        }
+
+        fun floatOf(f: Float): Any {
+            return float.getMethod("toDJVM", Float::class.javaObjectType).invoke(null, f)
+        }
+
+        fun objectArrayOf(vararg objs: Any): Array<in Any> {
+            @Suppress("unchecked_cast")
+            return (java.lang.reflect.Array.newInstance(sandboxObject, objs.size) as Array<in Any>).also {
+                for (i in 0 until objs.size) {
+                    it[i] = sandboxObject.cast(objs[i])
+                }
+            }
+        }
+    }
+
+    fun Any.getArray(methodName: String): Array<*> = javaClass.getMethod(methodName).invoke(this) as Array<*>
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -277,7 +277,7 @@ abstract class TestBase {
         }
     }
 
-    @Suppress("WeakerAccess")
+    @Suppress("MemberVisibilityCanBePrivate")
     protected class DJVM(private val classLoader: ClassLoader) {
         private val djvm: Class<*> = classFor("sandbox.java.lang.DJVM")
         val sandboxObject: Class<*> by lazy { classFor("sandbox.java.lang.Object") }

--- a/djvm/src/test/kotlin/net/corda/djvm/Utilities.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/Utilities.kt
@@ -12,13 +12,3 @@ object Utilities {
 
     fun throwThresholdViolationError(): Nothing = throw ThresholdViolationError("Can't catch this!")
 }
-
-fun String.toDJVM(): sandbox.java.lang.String = sandbox.java.lang.String.toDJVM(this)
-fun Long.toDJVM(): sandbox.java.lang.Long = sandbox.java.lang.Long.toDJVM(this)
-fun Int.toDJVM(): sandbox.java.lang.Integer = sandbox.java.lang.Integer.toDJVM(this)
-fun Short.toDJVM(): sandbox.java.lang.Short = sandbox.java.lang.Short.toDJVM(this)
-fun Byte.toDJVM(): sandbox.java.lang.Byte = sandbox.java.lang.Byte.toDJVM(this)
-fun Float.toDJVM(): sandbox.java.lang.Float = sandbox.java.lang.Float.toDJVM(this)
-fun Double.toDJVM(): sandbox.java.lang.Double = sandbox.java.lang.Double.toDJVM(this)
-fun Char.toDJVM(): sandbox.java.lang.Character = sandbox.java.lang.Character.toDJVM(this)
-fun Boolean.toDJVM(): sandbox.java.lang.Boolean = sandbox.java.lang.Boolean.toDJVM(this)

--- a/djvm/src/test/kotlin/net/corda/djvm/assertions/AssertionExtensions.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/assertions/AssertionExtensions.kt
@@ -36,6 +36,8 @@ object AssertionExtensions {
     fun assertThat(references: ReferenceMap) =
             AssertiveReferenceMap(references)
 
+    fun assertThatDJVM(obj: Any) = AssertiveDJVMObject(obj)
+
     inline fun <reified T> IterableAssert<ClassRepresentation>.hasClass(): IterableAssert<ClassRepresentation> = this
             .`as`("HasClass(${T::class.java.name})")
             .anySatisfy {

--- a/djvm/src/test/kotlin/net/corda/djvm/assertions/AssertiveClassWithByteCode.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/assertions/AssertiveClassWithByteCode.kt
@@ -24,6 +24,11 @@ class AssertiveClassWithByteCode(private val loadedClass: LoadedClass) {
         return this
     }
 
+    fun hasClassLoader(classLoader: ClassLoader): AssertiveClassWithByteCode {
+        assertThat(loadedClass.type.classLoader).isEqualTo(classLoader)
+        return this
+    }
+
     fun hasClassName(className: String): AssertiveClassWithByteCode {
         assertThat(loadedClass.type.name).isEqualTo(className)
         return this

--- a/djvm/src/test/kotlin/net/corda/djvm/assertions/AssertiveDJVMObject.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/assertions/AssertiveDJVMObject.kt
@@ -1,0 +1,26 @@
+package net.corda.djvm.assertions
+
+import org.assertj.core.api.Assertions.*
+
+class AssertiveDJVMObject(private val djvmObj: Any) {
+
+    fun hasClassName(className: String): AssertiveDJVMObject {
+        assertThat(djvmObj.javaClass.name).isEqualTo(className)
+        return this
+    }
+
+    fun isAssignableFrom(clazz: Class<*>): AssertiveDJVMObject {
+        assertThat(djvmObj.javaClass.isAssignableFrom(clazz))
+        return this
+    }
+
+    fun hasGetterValue(methodName: String, value: Any): AssertiveDJVMObject {
+        assertThat(djvmObj.javaClass.getMethod(methodName).invoke(djvmObj)).isEqualTo(value)
+        return this
+    }
+
+    fun hasGetterNullValue(methodName: String): AssertiveDJVMObject {
+        assertThat(djvmObj.javaClass.getMethod(methodName).invoke(djvmObj)).isNull()
+        return this
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxEnumTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxEnumTest.kt
@@ -8,7 +8,7 @@ import java.util.function.Function
 
 class SandboxEnumTest : TestBase() {
     @Test
-    fun `test enum inside sandbox`() = sandbox(DEFAULT) {
+    fun `test enum inside sandbox`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<Int, Array<String>>(configuration)
         contractExecutor.run<TransformEnum>(0).apply {
             assertThat(result).isEqualTo(arrayOf("ONE", "TWO", "THREE"))
@@ -16,7 +16,7 @@ class SandboxEnumTest : TestBase() {
     }
 
     @Test
-    fun `return enum from sandbox`() = sandbox(DEFAULT) {
+    fun `return enum from sandbox`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<String, ExampleEnum>(configuration)
         contractExecutor.run<FetchEnum>("THREE").apply {
             assertThat(result).isEqualTo(ExampleEnum.THREE)
@@ -24,7 +24,7 @@ class SandboxEnumTest : TestBase() {
     }
 
     @Test
-    fun `test we can identify class as Enum`() = sandbox(DEFAULT) {
+    fun `test we can identify class as Enum`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<ExampleEnum, Boolean>(configuration)
         contractExecutor.run<AssertEnum>(ExampleEnum.THREE).apply {
             assertThat(result).isTrue()
@@ -32,7 +32,7 @@ class SandboxEnumTest : TestBase() {
     }
 
     @Test
-    fun `test we can create EnumMap`() = sandbox(DEFAULT) {
+    fun `test we can create EnumMap`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<ExampleEnum, Int>(configuration)
         contractExecutor.run<UseEnumMap>(ExampleEnum.TWO).apply {
             assertThat(result).isEqualTo(1)
@@ -40,7 +40,7 @@ class SandboxEnumTest : TestBase() {
     }
 
     @Test
-    fun `test we can create EnumSet`() = sandbox(DEFAULT) {
+    fun `test we can create EnumSet`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<ExampleEnum, Boolean>(configuration)
         contractExecutor.run<UseEnumSet>(ExampleEnum.ONE).apply {
             assertThat(result).isTrue()

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxThrowableTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxThrowableTest.kt
@@ -8,7 +8,7 @@ import java.util.function.Function
 class SandboxThrowableTest : TestBase() {
 
     @Test
-    fun `test user exception handling`() = sandbox(DEFAULT) {
+    fun `test user exception handling`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
         contractExecutor.run<ThrowAndCatchExample>("Hello World").apply {
             assertThat(result)
@@ -17,7 +17,7 @@ class SandboxThrowableTest : TestBase() {
     }
 
     @Test
-    fun `test rethrowing an exception`() = sandbox(DEFAULT) {
+    fun `test rethrowing an exception`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
         contractExecutor.run<ThrowAndRethrowExample>("Hello World").apply {
             assertThat(result)
@@ -26,7 +26,7 @@ class SandboxThrowableTest : TestBase() {
     }
 
     @Test
-    fun `test JVM exceptions still propagate`() = sandbox(DEFAULT) {
+    fun `test JVM exceptions still propagate`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<Int, String>(configuration)
         contractExecutor.run<TriggerJVMException>(-1).apply {
             assertThat(result)


### PR DESCRIPTION
Allow `deterministic-rt.jar` and the template Java classes to be loaded into a parent `SandboxClassLoader` that can be shared by multiple sandboxes.

Child sandbox configurations inherit the same whitelist and pinned classes as the parent.

This has required the `System.objectHashCodes` and `String.INTERNAL` data structures to be migrated to `SandboxRuntimeContext` so that each sandbox still has its own private copy. It also means that the `DJVM` class must now fetch the correct classloader from `SandboxRuntimeContext` in order to locate user-supplied `Enum` and `Throwable` classes.

Should any other "static state" still exist in the Java API classes then would also be shareable among the child classloaders. But this change has knocked over 2 minutes off the unit test times.

Note that the `SandboxClassLoader` contains a cache of the sandboxed byte-code:
```kotlin
private val loadedClasses = mutableMapOf<String, LoadedClass>()
```
It wouldn't be difficult to "replay" this cache into a new `SandboxClassLoader` instance, c.f..
```kotlin
for (loadedClass in loadedClasses) {
    val byteCode = loadedClass.value.byteCode
    defineClass(loadedClass.key.asQualifiedName, byteCode.bytes, 0, byteCode.bytes.size)
}
```
since `loadedClasses` preserves insertion order.