### PR TITLE
CORDA-1915 Simm Valuation demo update for JAR signing

### DIFF
--- a/samples/simm-valuation-demo/build.gradle
+++ b/samples/simm-valuation-demo/build.gradle
@@ -71,9 +71,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask, 
         cordapp project(':samples:simm-valuation-demo:flows')
         rpcUsers = [['username': "default", 'password': "default", 'permissions': [ 'ALL' ]]]
     }
-    signing {
-        enabled false
-    }
     node {
         name "O=Notary Service,L=Zurich,C=CH"
         notary = [validating : true]

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -83,7 +83,8 @@ task sign(type: net.corda.plugins.SignJar) {
     inputJars shrink
 }
 
-jar.finalizedBy sign
+jar.finalizedBy shrink
+shrink.finalizedBy sign
 
 artifacts {
     shrinkArtifacts file: sign.outputJars.singleFile, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: sign

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -8,11 +8,6 @@ cordapp {
         vendor = 'R3'
         targetPlatformVersion = corda_platform_version.toInteger()
     }
-    signing {
-        // We need to sign the output of the "shrink" task,
-        // but the jar signer doesn't support that yet.
-        enabled false
-    }
     sealing {
         // Cannot seal JAR because other module also defines classes in the package net.corda.vega.analytics
         enabled false
@@ -41,6 +36,7 @@ dependencies {
 
 jar {
     classifier = 'fat'
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 import proguard.gradle.ProGuardTask
@@ -80,6 +76,9 @@ task shrink(type: ProGuardTask) {
     keepclassmembers 'class org.joda.** { *; }', includedescriptorclasses:true
 }
 jar.finalizedBy shrink
+
+signJar.inputs.files(shrink.outputs)
+shrink.finalizedBy signJar
 
 artifacts {
     shrinkArtifacts file: shrinkJar, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: shrink

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -2,11 +2,16 @@ apply plugin: 'net.corda.plugins.cordapp'
 
 def javaHome = System.getProperty('java.home')
 def shrinkJar = file("$buildDir/libs/${project.name}-${project.version}-tiny.jar")
+def signedJar = file("$buildDir/libs/${project.name}-${project.version}-tiny-signed.jar")
 
 cordapp {
     info {
         vendor = 'R3'
         targetPlatformVersion = corda_platform_version.toInteger()
+    }
+    signing {
+        // Cordapp is signed after the "shrink" task.
+        enabled false
     }
     sealing {
         // Cannot seal JAR because other module also defines classes in the package net.corda.vega.analytics
@@ -36,7 +41,6 @@ dependencies {
 
 jar {
     classifier = 'fat'
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 import proguard.gradle.ProGuardTask
@@ -75,11 +79,14 @@ task shrink(type: ProGuardTask) {
     keepclassmembers 'class com.google.** { *; }', includedescriptorclasses:true
     keepclassmembers 'class org.joda.** { *; }', includedescriptorclasses:true
 }
-jar.finalizedBy shrink
 
-signJar.inputs.files(shrink.outputs)
-shrink.finalizedBy signJar
+task sign(type: net.corda.plugins.SignJar, dependsOn: shrink) {
+    inputs.file(shrink)
+    outputs.file(signedJar)
+}
+
+jar.finalizedBy sign
 
 artifacts {
-    shrinkArtifacts file: shrinkJar, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: shrink
+    shrinkArtifacts file: signedJar, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: sign
 }

--- a/samples/simm-valuation-demo/contracts-states/build.gradle
+++ b/samples/simm-valuation-demo/contracts-states/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'net.corda.plugins.cordapp'
 
 def javaHome = System.getProperty('java.home')
 def shrinkJar = file("$buildDir/libs/${project.name}-${project.version}-tiny.jar")
-def signedJar = file("$buildDir/libs/${project.name}-${project.version}-tiny-signed.jar")
 
 cordapp {
     info {
@@ -80,13 +79,12 @@ task shrink(type: ProGuardTask) {
     keepclassmembers 'class org.joda.** { *; }', includedescriptorclasses:true
 }
 
-task sign(type: net.corda.plugins.SignJar, dependsOn: shrink) {
-    inputs.file(shrink)
-    outputs.file(signedJar)
+task sign(type: net.corda.plugins.SignJar) {
+    inputJars shrink
 }
 
 jar.finalizedBy sign
 
 artifacts {
-    shrinkArtifacts file: signedJar, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: sign
+    shrinkArtifacts file: sign.outputJars.singleFile, name: project.name, type: 'jar', extension: 'jar', classifier: 'tiny', builtBy: sign
 }

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -6,6 +6,11 @@ cordapp {
         vendor = 'R3'
         targetPlatformVersion = corda_platform_version.toInteger()
     }
+    signing {
+        // We need to sign the output of the "shrink" task,
+        // but the jar signer doesn't support that yet.
+        enabled false
+    }
     sealing {
         // Cannot seal JAR because other module also defines classes in the package net.corda.vega.analytics
         enabled false
@@ -34,8 +39,4 @@ dependencies {
     compile "com.opengamma.strata:strata-collect:$strata_version"
     compile "com.opengamma.strata:strata-loader:$strata_version"
     compile "com.opengamma.strata:strata-math:$strata_version"
-}
-
-jar {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -6,11 +6,6 @@ cordapp {
         vendor = 'R3'
         targetPlatformVersion = corda_platform_version.toInteger()
     }
-    signing {
-        // We need to sign the output of the "shrink" task,
-        // but the jar signer doesn't support that yet.
-        enabled false
-    }
     sealing {
         // Cannot seal JAR because other module also defines classes in the package net.corda.vega.analytics
         enabled false
@@ -39,4 +34,8 @@ dependencies {
     compile "com.opengamma.strata:strata-collect:$strata_version"
     compile "com.opengamma.strata:strata-loader:$strata_version"
     compile "com.opengamma.strata:strata-math:$strata_version"
+}
+
+jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/samples/simm-valuation-demo/flows/build.gradle
+++ b/samples/simm-valuation-demo/flows/build.gradle
@@ -6,9 +6,6 @@ cordapp {
         vendor = 'R3'
         targetPlatformVersion = corda_platform_version.toInteger()
     }
-    signing {
-        enabled false
-    }
     sealing {
         // Cannot seal JAR because other module also defines classes in the package net.corda.vega.analytics
         enabled false
@@ -37,4 +34,8 @@ dependencies {
     compile "com.opengamma.strata:strata-collect:$strata_version"
     compile "com.opengamma.strata:strata-loader:$strata_version"
     compile "com.opengamma.strata:strata-math:$strata_version"
+}
+
+jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }


### PR DESCRIPTION
The build process of demo creates new version fo Cordapp JAR in post 'jar' task.
So far JAR signing was integral part of jar task, now it's also available as a separate task `signJar` (gradle-plugins PR https://github.com/corda/corda-gradle-plugins/pull/130).
Using `signJar` to re-sign Cordapp shrink JAR, fat JAR is also signed.