### PR TITLE
CORDA-1480: In Demobench, saving a profile, opening it, and adding a node skips next name

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -200,6 +200,7 @@ see changes to this list.
 * tomtau
 * Tudor Malene (R3)
 * Tushar Singh Bora (Accenture)
+* Vardan Nadkarni (Persistent Systems Limited)
 * varunkm
 * Venelin Stoykov (INDUSTRIA)
 * verymahler

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeData.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/model/NodeData.kt
@@ -25,9 +25,8 @@ object SuggestedDetails {
             "Bank of Golden Gates" to "San Francisco"
     )
 
-    private var cursor = 0
-
-    val nextBank: Pair<String, String> get() = banks[cursor++ % banks.size]
+    var cursor = 0
+    val nextBank: Pair<String, String> get(cursor) = banks[cursor++ % banks.size]
 }
 
 class NodeData {

--- a/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
+++ b/tools/demobench/src/main/kotlin/net/corda/demobench/views/NodeTabView.kt
@@ -194,6 +194,7 @@ class NodeTabView : Fragment() {
         model.webPort.value = nodeController.nextPort
         model.h2Port.value = nodeController.nextPort
 
+        SuggestedDetails.cursor = nodeController.activeNodes.size
         val defaults = SuggestedDetails.nextBank
         model.legalName.value = defaults.first
         model.nearestCity.value = CityDatabase[defaults.second]


### PR DESCRIPTION
Simple fix for #3800 
Jira issue: CORDA-1480

Now Selecting the name based on number of active nodes open.