### PR TITLE
ENT-1906: Don't transform java.Object[] to sandbox.Object[].

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysInheritFromSandboxedObject.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysInheritFromSandboxedObject.kt
@@ -24,8 +24,12 @@ class AlwaysInheritFromSandboxedObject : ClassDefinitionProvider, Emitter {
 
     override fun emit(context: EmitterContext, instruction: Instruction) = context.emit {
         if (instruction is TypeInstruction &&
-                instruction.typeName == OBJECT_NAME) {
+                instruction.typeName == OBJECT_NAME &&
+                instruction.operation != Opcodes.ANEWARRAY &&
+                instruction.operation != Opcodes.MULTIANEWARRAY) {
             // When creating new objects, make sure the sandboxed type gets used.
+            // However, an array is always [java.lang.Object] so we must exclude
+            // arrays from this so that we can still support arrays of arrays.
             new(SANDBOX_OBJECT_NAME, instruction.operation)
             preventDefault()
         }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/RewriteObjectMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/RewriteObjectMethods.kt
@@ -1,0 +1,29 @@
+package net.corda.djvm.rules.implementation
+
+import net.corda.djvm.code.Emitter
+import net.corda.djvm.code.EmitterContext
+import net.corda.djvm.code.Instruction
+import net.corda.djvm.code.instructions.MemberAccessInstruction
+import org.objectweb.asm.Opcodes.*
+
+/**
+ * We cannot wrap Java array objects - and potentially others - and so these would still
+ * use the non-deterministic [java.lang.Object.hashCode] by default. Therefore we intercept
+ * these invocations and redirect them to our [sandbox.java.lang.DJVM] object.
+ */
+class RewriteObjectMethods : Emitter {
+    override fun emit(context: EmitterContext, instruction: Instruction) = context.emit {
+        if (instruction is MemberAccessInstruction && instruction.owner == "java/lang/Object") {
+            when (instruction.operation) {
+                INVOKEVIRTUAL -> if (instruction.memberName == "hashCode" && instruction.signature == "()I") {
+                    invokeStatic(
+                        owner = "sandbox/java/lang/DJVM",
+                        name = "hashCode",
+                        descriptor = "(Ljava/lang/Object;)I"
+                    )
+                    preventDefault()
+                }
+            }
+        }
+    }
+}

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -43,14 +43,15 @@ fun Any.sandbox(): Any {
 private fun Array<*>.fromDJVMArray(): Array<*> = Object.fromDJVM(this)
 
 /**
- * Use the sandbox's classloader explicitly, because this class
- * might belong to the shared parent classloader.
+ * Use [Class.forName] so that we can also fetch classes for arrays of primitive types.
+ * Also use the sandbox's classloader explicitly here, because this invoking class
+ * might belong to a shared parent classloader.
  */
 @Throws(ClassNotFoundException::class)
-internal fun Class<*>.toDJVMType(): Class<*> = SandboxRuntimeContext.instance.classLoader.loadClass(name.toSandboxPackage())
+internal fun Class<*>.toDJVMType(): Class<*> = Class.forName(name.toSandboxPackage(), false, SandboxRuntimeContext.instance.classLoader)
 
 @Throws(ClassNotFoundException::class)
-internal fun Class<*>.fromDJVMType(): Class<*> = SandboxRuntimeContext.instance.classLoader.loadClass(name.fromSandboxPackage())
+internal fun Class<*>.fromDJVMType(): Class<*> = Class.forName(name.fromSandboxPackage(), false, SandboxRuntimeContext.instance.classLoader)
 
 private fun kotlin.String.toSandboxPackage(): kotlin.String {
     return if (startsWith(SANDBOX_PREFIX)) {

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -141,6 +141,21 @@ private val allEnums: sandbox.java.util.Map<Class<out Enum<*>>, Array<out Enum<*
 private val allEnumDirectories: sandbox.java.util.Map<Class<out Enum<*>>, sandbox.java.util.Map<String, out Enum<*>>> = sandbox.java.util.LinkedHashMap()
 
 /**
+ * Replacement function for Object.hashCode(), because some objects
+ * (i.e. arrays) cannot be replaced by [sandbox.java.lang.Object].
+ */
+fun hashCode(obj: Any?): Int {
+    return if (obj is Object) {
+        obj.hashCode()
+    } else if (obj != null) {
+        System.identityHashCode(obj)
+    } else {
+        // Throw the same exception that the JVM would throw in this case.
+        throw NullPointerException()
+    }
+}
+
+/**
  * Replacement functions for Class<*>.forName(...) which protect
  * against users loading classes from outside the sandbox.
  */

--- a/djvm/src/test/java/net/corda/djvm/WithJava.java
+++ b/djvm/src/test/java/net/corda/djvm/WithJava.java
@@ -1,6 +1,7 @@
 package net.corda.djvm;
 
 import net.corda.djvm.execution.ExecutionSummaryWithResult;
+import net.corda.djvm.execution.SandboxException;
 import net.corda.djvm.execution.SandboxExecutor;
 import net.corda.djvm.source.ClassSource;
 
@@ -13,12 +14,15 @@ public interface WithJava {
         try {
             return executor.run(ClassSource.fromClassName(task.getName(), null), input);
         } catch (Exception e) {
-            if (e instanceof RuntimeException) {
-                throw (RuntimeException) e;
+            if (e instanceof SandboxException) {
+                throw asRuntime(e.getCause());
             } else {
-                throw new RuntimeException(e.getMessage(), e);
+                throw asRuntime(e);
             }
         }
     }
 
+    static RuntimeException asRuntime(Throwable t) {
+        return (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t.getMessage(), t);
+    }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
@@ -78,7 +78,7 @@ public class SandboxObjectHashCodeJavaTest extends TestBase {
         @SuppressWarnings("all")
         @Override
         public Integer apply(Object obj) {
-            return new Object[1].hashCode();
+            return new Object[0].hashCode();
         }
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
@@ -1,0 +1,91 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static net.corda.djvm.messages.Severity.WARNING;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class SandboxObjectHashCodeJavaTest extends TestBase {
+
+    @Test
+    public void testHashForArray() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, ArrayHashCode.class, null);
+            assertThat(output.getResult()).isEqualTo(0xfed_c0de + 1);
+            return null;
+        });
+    }
+
+    @Test
+    public void testHashForObjectInArray() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, ObjectInArrayHashCode.class, null);
+            assertThat(output.getResult()).isEqualTo(0xfed_c0de + 1);
+            return null;
+        });
+    }
+
+    @Test
+    public void testHashForNullObject() {
+        assertThatExceptionOfType(NullPointerException.class)
+            .isThrownBy(() -> new HashCode().apply(null));
+
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> WithJava.run(executor, HashCode.class, null));
+            return null;
+        });
+    }
+
+    @Test
+    public void testHashForWrappedInteger() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, HashCode.class, 1234);
+            assertThat(output.getResult()).isEqualTo(Integer.hashCode(1234));
+            return null;
+        });
+    }
+
+    @Test
+    public void testHashForWrappedString() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, HashCode.class, "Burble");
+            assertThat(output.getResult()).isEqualTo("Burble".hashCode());
+            return null;
+        });
+    }
+
+    public static class ObjectInArrayHashCode implements Function<Object, Integer> {
+        @Override
+        public Integer apply(Object obj) {
+            Object[] arr = new Object[1];
+            arr[0] = new Object();
+            return arr[0].hashCode();
+        }
+    }
+
+    public static class ArrayHashCode implements Function<Object, Integer> {
+        @SuppressWarnings("all")
+        @Override
+        public Integer apply(Object obj) {
+            return new Object[1].hashCode();
+        }
+    }
+
+    public static class HashCode implements Function<Object, Integer> {
+        @Override
+        public Integer apply(Object obj) {
+            return obj.hashCode();
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -49,6 +49,7 @@ abstract class TestBase {
             HandleExceptionUnwrapper(),
             ReturnTypeWrapper(),
             RewriteClassMethods(),
+            RewriteObjectMethods(),
             StringConstantWrapper(),
             ThrowExceptionWrapper()
         )

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -735,7 +735,7 @@ class SandboxExecutorTest : TestBase() {
     }
 
     @Test
-    fun `test creating arrays of arrays`() = sandbox(DEFAULT) {
+    fun `test creating arrays of arrays`() = parentedSandbox {
         val contractExecutor = DeterministicSandboxExecutor<Any, Array<Any>>(configuration)
         contractExecutor.run<ArraysOfArrays>("THINGY").apply {
             assertThat(result).isEqualTo(arrayOf(arrayOf("THINGY")))
@@ -745,6 +745,20 @@ class SandboxExecutorTest : TestBase() {
     class ArraysOfArrays : Function<Any, Array<Any>> {
         override fun apply(input: Any): Array<Any> {
             return arrayOf(arrayOf(input))
+        }
+    }
+
+    @Test
+    fun `test creating arrays of int arrays`() = parentedSandbox {
+        val contractExecutor = DeterministicSandboxExecutor<Int, Array<IntArray>>(configuration)
+        contractExecutor.run<ArrayOfIntArrays>(0).apply {
+            assertThat(result).isEqualTo(arrayOf(intArrayOf(0)))
+        }
+    }
+
+    class ArrayOfIntArrays : Function<Int, Array<IntArray>> {
+        override fun apply(input: Int): Array<IntArray> {
+            return arrayOf(intArrayOf(input))
         }
     }
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -733,4 +733,18 @@ class SandboxExecutorTest : TestBase() {
             return cl.find()
         }
     }
+
+    @Test
+    fun `test creating arrays of arrays`() = sandbox(DEFAULT) {
+        val contractExecutor = DeterministicSandboxExecutor<Any, Array<Any>>(configuration)
+        contractExecutor.run<ArraysOfArrays>("THINGY").apply {
+            assertThat(result).isEqualTo(arrayOf(arrayOf("THINGY")))
+        }
+    }
+
+    class ArraysOfArrays : Function<Any, Array<Any>> {
+        override fun apply(input: Any): Array<Any> {
+            return arrayOf(arrayOf(input))
+        }
+    }
 }


### PR DESCRIPTION
 An array of objects is itself still `java.lang.Object` inside a sandbox, and so it cannot be added to `sandbox.java.lang.Object[]`. So keep all object arrays as `java.lang.Object[]` inside the sandbox.