### PR TITLE
CORDA-2083 Deserialize component groups lazily

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/CordaUtils.kt
@@ -57,3 +57,16 @@ fun Class<out FlowLogic<*>>.isIdempotentFlow(): Boolean {
 internal fun SignedTransaction.pushToLoggingContext() {
     MDC.put("tx_id", id.toString())
 }
+
+/**
+ * List implementation that applies the expensive [transform] function only when the element is accessed and caches calculated values.
+ * Size is very cheap as it doesn't call [transform].
+ */
+class LazyMappedList<T, U>(val originalList: List<T>, val transform: (T, Int) -> U) : AbstractList<U>() {
+    private val partialResolvedList = MutableList<U?>(originalList.size) { null }
+
+    override val size = originalList.size
+
+    override fun get(index: Int) = partialResolvedList[index]
+            ?: transform(originalList[index], index).also { computed -> partialResolvedList[index] = computed }
+}

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -6,6 +6,7 @@ import net.corda.core.contracts.*
 import net.corda.core.contracts.ComponentGroupEnum.*
 import net.corda.core.crypto.*
 import net.corda.core.identity.Party
+import net.corda.core.internal.LazyMappedList
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.*
 import net.corda.core.utilities.OpaqueBytes
@@ -72,23 +73,29 @@ abstract class TraversableTransaction(open val componentGroups: List<ComponentGr
                                                     attachmentsContext: Boolean = false): List<T> {
         val group = componentGroups.firstOrNull { it.groupIndex == groupEnum.ordinal }
 
+        if (group == null || group.components.isEmpty()) {
+            return emptyList()
+        }
+
+        // If the componentGroup is a [LazyMappedList] it means that the original deserialized version is already available.
+        val components = group.components
+        if (components is LazyMappedList<*, OpaqueBytes>) {
+            return components.originalList as List<T>
+        }
+
         val javaClazz = clazz.java // This is needed because the checkpoint serializer can't serialize KClasses.
 
         val factory = SerializationFactory.defaultFactory
         val context = factory.defaultContext.let { if (attachmentsContext) it.withAttachmentsClassLoader(attachments) else it }
 
-        return if (group != null && group.components.isNotEmpty()) {
-            group.components.lazyMapped { component, internalIndex ->
-                try {
-                    factory.deserialize(component, javaClazz, context)
-                } catch (e: MissingAttachmentsException) {
-                    throw e
-                } catch (e: Exception) {
-                    throw Exception("Malformed transaction, $groupEnum at index $internalIndex cannot be deserialised", e)
-                }
+        return group.components.lazyMapped { component, internalIndex ->
+            try {
+                factory.deserialize(component, javaClazz, context)
+            } catch (e: MissingAttachmentsException) {
+                throw e
+            } catch (e: Exception) {
+                throw Exception("Malformed transaction, $groupEnum at index $internalIndex cannot be deserialised", e)
             }
-        } else {
-            emptyList()
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MerkleTransaction.kt
@@ -83,14 +83,12 @@ abstract class TraversableTransaction(open val componentGroups: List<ComponentGr
             return components.originalList as List<T>
         }
 
-        val javaClazz = clazz.java // This is needed because the checkpoint serializer can't serialize KClasses.
-
         val factory = SerializationFactory.defaultFactory
         val context = factory.defaultContext.let { if (attachmentsContext) it.withAttachmentsClassLoader(attachments) else it }
 
-        return group.components.lazyMapped { component, internalIndex ->
+        return components.lazyMapped { component, internalIndex ->
             try {
-                factory.deserialize(component, javaClazz, context)
+                factory.deserialize(component, clazz.java , context)
             } catch (e: MissingAttachmentsException) {
                 throw e
             } catch (e: Exception) {

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -263,18 +263,19 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
                                   notary: Party?,
                                   timeWindow: TimeWindow?,
                                   references: List<StateRef> = emptyList()): List<ComponentGroup> {
+            val serialize = { value: Any, _: Int -> value.serialize() }
             val componentGroupMap: MutableList<ComponentGroup> = mutableListOf()
-            if (inputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(INPUTS_GROUP.ordinal, inputs.map { it.serialize() }))
-            if (references.isNotEmpty()) componentGroupMap.add(ComponentGroup(REFERENCES_GROUP.ordinal, references.map { it.serialize() }))
-            if (outputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(OUTPUTS_GROUP.ordinal, outputs.map { it.serialize() }))
+            if (inputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(INPUTS_GROUP.ordinal, inputs.lazyMapped(serialize)))
+            if (references.isNotEmpty()) componentGroupMap.add(ComponentGroup(REFERENCES_GROUP.ordinal, references.lazyMapped(serialize)))
+            if (outputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(OUTPUTS_GROUP.ordinal, outputs.lazyMapped(serialize)))
             // Adding commandData only to the commands group. Signers are added in their own group.
-            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(COMMANDS_GROUP.ordinal, commands.map { it.value.serialize() }))
-            if (attachments.isNotEmpty()) componentGroupMap.add(ComponentGroup(ATTACHMENTS_GROUP.ordinal, attachments.map { it.serialize() }))
-            if (notary != null) componentGroupMap.add(ComponentGroup(NOTARY_GROUP.ordinal, listOf(notary.serialize())))
-            if (timeWindow != null) componentGroupMap.add(ComponentGroup(TIMEWINDOW_GROUP.ordinal, listOf(timeWindow.serialize())))
+            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(COMMANDS_GROUP.ordinal, commands.lazyMapped { value, _ -> value.value.serialize() }))
+            if (attachments.isNotEmpty()) componentGroupMap.add(ComponentGroup(ATTACHMENTS_GROUP.ordinal, attachments.lazyMapped(serialize)))
+            if (notary != null) componentGroupMap.add(ComponentGroup(NOTARY_GROUP.ordinal, listOf(notary).lazyMapped(serialize)))
+            if (timeWindow != null) componentGroupMap.add(ComponentGroup(TIMEWINDOW_GROUP.ordinal, listOf(timeWindow).lazyMapped(serialize)))
             // Adding signers to their own group. This is required for command visibility purposes: a party receiving
             // a FilteredTransaction can now verify it sees all the commands it should sign.
-            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(SIGNERS_GROUP.ordinal, commands.map { it.signers.serialize() }))
+            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(SIGNERS_GROUP.ordinal, commands.lazyMapped { value, _ -> value.signers.serialize() }))
             return componentGroupMap
         }
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -269,13 +269,13 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
             if (references.isNotEmpty()) componentGroupMap.add(ComponentGroup(REFERENCES_GROUP.ordinal, references.lazyMapped(serialize)))
             if (outputs.isNotEmpty()) componentGroupMap.add(ComponentGroup(OUTPUTS_GROUP.ordinal, outputs.lazyMapped(serialize)))
             // Adding commandData only to the commands group. Signers are added in their own group.
-            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(COMMANDS_GROUP.ordinal, commands.lazyMapped { value, _ -> value.value.serialize() }))
+            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(COMMANDS_GROUP.ordinal, commands.map { it.value }.lazyMapped(serialize)))
             if (attachments.isNotEmpty()) componentGroupMap.add(ComponentGroup(ATTACHMENTS_GROUP.ordinal, attachments.lazyMapped(serialize)))
             if (notary != null) componentGroupMap.add(ComponentGroup(NOTARY_GROUP.ordinal, listOf(notary).lazyMapped(serialize)))
             if (timeWindow != null) componentGroupMap.add(ComponentGroup(TIMEWINDOW_GROUP.ordinal, listOf(timeWindow).lazyMapped(serialize)))
             // Adding signers to their own group. This is required for command visibility purposes: a party receiving
             // a FilteredTransaction can now verify it sees all the commands it should sign.
-            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(SIGNERS_GROUP.ordinal, commands.lazyMapped { value, _ -> value.signers.serialize() }))
+            if (commands.isNotEmpty()) componentGroupMap.add(ComponentGroup(SIGNERS_GROUP.ordinal, commands.map { it.signers }.lazyMapped(serialize)))
             return componentGroupMap
         }
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -14,7 +14,7 @@ import net.corda.core.node.services.AttachmentId
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.OpaqueBytes
-import net.corda.core.utilities.makeLazyResolvedList
+import net.corda.core.utilities.lazyMapped
 import java.security.PublicKey
 import java.security.SignatureException
 import java.util.function.Predicate
@@ -128,17 +128,17 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
             networkParameters: NetworkParameters?
     ): LedgerTransaction {
         // Look up public keys to authenticated identities.
-        val authenticatedArgs = makeLazyResolvedList(commands) { cmd, _ ->
+        val authenticatedArgs = commands.lazyMapped { cmd, _ ->
             val parties = cmd.signers.mapNotNull { pk -> resolveIdentity(pk) }
             CommandWithParties(cmd.signers, parties, cmd.value)
         }
-        val resolvedInputs = makeLazyResolvedList(inputs) { ref, _ ->
+        val resolvedInputs = inputs.lazyMapped { ref, _ ->
             resolveStateRef(ref)?.let { StateAndRef(it, ref) } ?: throw TransactionResolutionException(ref.txhash)
         }
-        val resolvedReferences = makeLazyResolvedList(references) { ref, _ ->
+        val resolvedReferences = references.lazyMapped { ref, _ ->
             resolveStateRef(ref)?.let { StateAndRef(it, ref) } ?: throw TransactionResolutionException(ref.txhash)
         }
-        val attachments = makeLazyResolvedList(attachments) { att, _ ->
+        val attachments = attachments.lazyMapped { att, _ ->
             resolveAttachment(att) ?: throw AttachmentResolutionException(att)
         }
         val ltx = LedgerTransaction(resolvedInputs, outputs, authenticatedArgs, attachments, id, notary, timeWindow, privacySalt, networkParameters, resolvedReferences)

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -155,7 +155,7 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
             remainingTransactionSize -= size
         }
 
-        // TODO - does it matter if it is slightly lower than the actual re-serialized version?
+        // This calculates a value that is slightly lower than the actual re-serialized version. But it is stable and does not depend on the classloader.
         fun componentGroupSize(componentGroup: ComponentGroupEnum): Int {
             return this.componentGroups.firstOrNull { it.groupIndex == componentGroup.ordinal }?.let { cg -> cg.components.sumBy { it.size } + 4 } ?: 0
         }

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -51,7 +51,8 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
 
     @Deprecated("Required only in some unit-tests and for backwards compatibility purposes.", ReplaceWith("WireTransaction(val componentGroups: List<ComponentGroup>, override val privacySalt: PrivacySalt)"), DeprecationLevel.WARNING)
     @DeleteForDJVM
-    @JvmOverloads constructor(
+    @JvmOverloads
+    constructor(
             inputs: List<StateRef>,
             attachments: List<SecureHash>,
             outputs: List<TransactionState<ContractState>>,
@@ -155,7 +156,9 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         }
 
         // TODO - does it matter if it is slightly lower than the actual re-serialized version?
-        fun componentGroupSize(componentGroup: ComponentGroup) = componentGroup.components.sumBy { it.size } + 4
+        fun componentGroupSize(componentGroup: ComponentGroupEnum): Int {
+            return this.componentGroups.firstOrNull { it.groupIndex == componentGroup.ordinal }?.let { cg -> cg.components.sumBy { it.size } + 4 } ?: 0
+        }
 
         // Check attachments size first as they are most likely to go over the limit. With ContractAttachment instances
         // it's likely that the same underlying Attachment CorDapp will occur more than once so we dedup on the attachment id.
@@ -166,8 +169,8 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         minus(ltx.inputs.serialize().size)
 
         // For Commands and outputs we can use the component groups as they are already serialized.
-        minus(componentGroupSize(this.componentGroups.firstOrNull { it.groupIndex == COMMANDS_GROUP.ordinal }!!))
-        minus(componentGroupSize(this.componentGroups.firstOrNull { it.groupIndex == OUTPUTS_GROUP.ordinal }!!))
+        minus(componentGroupSize(COMMANDS_GROUP))
+        minus(componentGroupSize(OUTPUTS_GROUP))
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -166,8 +166,8 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
         minus(ltx.inputs.serialize().size)
 
         // For Commands and outputs we can use the component groups as they are already serialized.
-        minus(componentGroupSize(this.componentGroups[COMMANDS_GROUP.ordinal]))
-        minus(componentGroupSize(this.componentGroups[OUTPUTS_GROUP.ordinal]))
+        minus(componentGroupSize(this.componentGroups.firstOrNull { it.groupIndex == COMMANDS_GROUP.ordinal }!!))
+        minus(componentGroupSize(this.componentGroups.firstOrNull { it.groupIndex == OUTPUTS_GROUP.ordinal }!!))
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
@@ -136,7 +136,7 @@ fun <V> Future<V>.getOrThrow(timeout: Duration? = null): V = try {
     throw e.cause!!
 }
 
-private class LazyResolvedList<T, U>(val originalList: List<T>, val transform: (T, Int) -> U) : AbstractList<U>() {
+private class LazyMappedList<T, U>(val originalList: List<T>, val transform: (T, Int) -> U) : AbstractList<U>() {
     private val partialResolvedList = MutableList<U?>(originalList.size) { null }
 
     override val size = originalList.size
@@ -148,4 +148,4 @@ private class LazyResolvedList<T, U>(val originalList: List<T>, val transform: (
 /**
  * Creates a lazy list that applies the [transform] function only when the element is accessed.
  */
-fun <T, U> makeLazyResolvedList(originalList: List<T>, transform: (T, Int) -> U): List<U> = LazyResolvedList(originalList, transform)
+fun <T, U> List<T>.lazyMapped(transform: (T, Int) -> U): List<U> = LazyMappedList(this, transform)

--- a/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/CompatibleTransactionTests.kt
@@ -138,7 +138,7 @@ class CompatibleTransactionTests {
                 timeWindowGroup,
                 signersGroup
         )
-        assertFails { WireTransaction(componentGroupsB, privacySalt) }
+        assertFails { WireTransaction(componentGroupsB, privacySalt).attachments.toList() }
 
         // Malformed tx - duplicated component group detected.
         val componentGroupsDuplicatedCommands = listOf(

--- a/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
@@ -1,0 +1,35 @@
+package net.corda.core.utilities
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class LazyMappedListTest {
+
+    @Test
+    fun `LazyMappedList works`() {
+        val originalList = (1 until 10).toList()
+
+        var callCounter = 0
+
+        val lazyList = originalList.lazyMapped { value, index ->
+            callCounter++
+            value * value
+        }
+
+        // No transform called when created.
+        assertEquals(0, callCounter)
+
+        // No transform called when calling 'size'.
+        assertEquals(9, lazyList.size)
+        assertEquals(0, callCounter)
+
+        // Called once when getting an element.
+        assertEquals(16, lazyList[3])
+        assertEquals(1, callCounter)
+
+        // Not called again when getting the same element.
+        assertEquals(16, lazyList[3])
+        assertEquals(1, callCounter)
+    }
+
+}

--- a/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
@@ -11,7 +11,7 @@ class LazyMappedListTest {
 
         var callCounter = 0
 
-        val lazyList = originalList.lazyMapped { value, index ->
+        val lazyList = originalList.lazyMapped { value, _ ->
             callCounter++
             value * value
         }

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/DefaultKryoCustomizer.kt
@@ -18,6 +18,7 @@ import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.AbstractAttachment
+import net.corda.core.internal.LazyMappedList
 import net.corda.core.internal.readFully
 import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.SerializationWhitelist
@@ -82,6 +83,7 @@ object DefaultKryoCustomizer {
             // TODO: re-organise registrations into logical groups before v1.0
 
             register(Arrays.asList("").javaClass, ArraysAsListSerializer())
+            register(LazyMappedList::class.java, LazyMappedListSerializer)
             register(SignedTransaction::class.java, SignedTransactionSerializer)
             register(WireTransaction::class.java, WireTransactionSerializer)
             register(SerializedBytes::class.java, SerializedBytesSerializer)

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
@@ -488,8 +488,6 @@ class ThrowableSerializer<T>(kryo: Kryo, type: Class<T>) : Serializer<Throwable>
 }
 
 /** For serializing the utility [LazyMappedList]. It will serialize the fully resolved object.*/
-typealias Transform = (Any, Int) -> Any
-
 @ThreadSafe
 @SuppressWarnings("ALL")
 object LazyMappedListSerializer : Serializer<List<*>>() {

--- a/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/kryo/Kryo.kt
@@ -487,18 +487,12 @@ class ThrowableSerializer<T>(kryo: Kryo, type: Class<T>) : Serializer<Throwable>
     private fun Throwable.setSuppressedToSentinel() = suppressedField.set(this, sentinelValue)
 }
 
-/** For serializing the utility [LazyMappedList]. */
+/** For serializing the utility [LazyMappedList]. It will serialize the fully resolved object.*/
 typealias Transform = (Any, Int) -> Any
 
 @ThreadSafe
 @SuppressWarnings("ALL")
-object LazyMappedListSerializer : Serializer<LazyMappedList<*, *>>() {
-    override fun write(kryo: Kryo, output: Output, obj: LazyMappedList<*, *>) {
-        kryo.writeClassAndObject(output, obj.originalList)
-        kryo.writeClassAndObject(output, obj.transform)
-    }
-
-    override fun read(kryo: Kryo, input: Input, type: Class<LazyMappedList<*, *>>) =
-            LazyMappedList(kryo.readClassAndObject(input) as List<Any>, kryo.readClassAndObject(input) as Transform)
-
+object LazyMappedListSerializer : Serializer<List<*>>() {
+    override fun write(kryo: Kryo, output: Output, obj: List<*>) = kryo.writeClassAndObject(output, obj.toList())
+    override fun read(kryo: Kryo, input: Input, type: Class<List<*>>) = kryo.readClassAndObject(input) as List<*>
 }


### PR DESCRIPTION
This adds a simple "LazyMappedList" and wires it into the Transaction componentGroups to make deserialization lazy.

Also small change to the "checkTransactionSize" to use the existing componentGroups to avoid unnecessary serializations/deserializations.

Also, remove the unnecessary serialization/deserialization step when creating a WireTransaction.