### PR TITLE
Fixed broken default logging level.

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="debug">
+<Configuration status="info">
 
     <Properties>
         <Property name="log-path">${sys:log-path:-logs}</Property>
         <Property name="log-name">node-${hostName}</Property>
         <Property name="archive">${log-path}/archive</Property>
         <Property name="defaultLogLevel">${sys:log4j2.level:-info}</Property>
-        <Property name="consoleLogLevel">${sys:consoleLogLevel:-$defaultLogLevel}</Property>
-        <Property name="fileLogLevel">${sys:fileLogLevel:-$defaultLogLevel}</Property>
+        <Property name="consoleLogLevel">${sys:consoleLogLevel:-error}</Property>
+        <Property name="fileLogLevel">${sys:fileLogLevel:-${defaultLogLevel}}</Property>
     </Properties>
 
     <Appenders>


### PR DESCRIPTION
net.corda.testing.driver.DriverTests#`debug mode enables debug logging level` works (only tests against logging)