### PR TITLE
Fix CLI verbosity issue with subcommands

### DIFF
--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -97,7 +97,7 @@ fun CordaCliWrapper.start(args: Array<String>) {
         exitProcess(ExitCodes.SUCCESS)
     } catch (e: ExecutionException) {
         val throwable = e.cause ?: e
-        if (this.verbose) {
+        if (this.verbose || this.subCommands().any { it.verbose} ) {
             throwable.printStackTrace()
         } else {
             System.err.println("*ERROR*: ${throwable.rootMessage ?: "Use --verbose for more details"}")


### PR DESCRIPTION
If `verbose` is set on a subcommand the `CordaCliWrapper` wasn't properly throwing the stack trace to the console.