### PR TITLE
Don't check signers of META-INF/LIST.INDEX file (workaround for CORDA-2116)

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/JarSignatureCollector.kt
@@ -14,9 +14,10 @@ object JarSignatureCollector {
 
     /**
      * @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File>
-     * also accepting *.EC as this can be created and accepted by jarsigner tool @see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html
-     * and Java Security Manager. */
-    private val unsignableEntryName = "META-INF/(?:.*[.](?:SF|DSA|RSA|EC)|SIG-.*)".toRegex()
+     * Additionally accepting *.EC as its valid for [java.util.jar.JarVerifier] and jarsigner @see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html,
+     * temporally treating META-INF/INDEX.LIST as unsignable entry because [java.util.jar.JarVerifier] doesn't load its signers.
+     */
+    private val unsignableEntryName = "META-INF/(?:(?:.*[.](?:SF|DSA|RSA|EC)|SIG-.*)|INDEX\\.LIST)".toRegex()
 
     /**
      * Returns an ordered list of every [Party] which has signed every signable item in the given [JarInputStream].

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/JarSignatureTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/JarSignatureTestUtils.kt
@@ -31,6 +31,10 @@ object JarSignatureTestUtils {
     fun Path.createJar(fileName: String, vararg contents: String) =
             executeProcess(*(arrayOf("jar", "cvf", fileName) + contents))
 
+    fun Path.addIndexList(fileName: String) {
+        executeProcess(*(arrayOf("jar", "i", fileName)))
+    }
+
     fun Path.updateJar(fileName: String, vararg contents: String) =
             executeProcess(*(arrayOf("jar", "uvf", fileName) + contents))
 

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -38,6 +38,7 @@ class JarSignatureCollectorTest {
         fun beforeClass() {
             dir.generateKey(ALICE, "storepass", ALICE_NAME.toString(), keyPassword = ALICE_PASS)
             dir.generateKey(BOB, "storepass", BOB_NAME.toString(), keyPassword = BOB_PASS)
+            dir.generateKey(CHARLIE, "storepass", CHARLIE_NAME.toString(), "EC", CHARLIE_PASS)
 
             (dir / "_signable1").writeLines(listOf("signable1"))
             (dir / "_signable2").writeLines(listOf("signable2"))
@@ -136,14 +137,13 @@ class JarSignatureCollectorTest {
     // and our JarSignatureCollector
     @Test
     fun `one signer with EC algorithm`() {
-        dir.generateKey(CHARLIE, "storepass", CHARLIE_NAME.toString(), "EC", CHARLIE_PASS)
         dir.createJar(FILENAME, "_signable1", "_signable2")
         val key = dir.signJar(FILENAME, CHARLIE, "storepass", CHARLIE_PASS)
         assertEquals(listOf(key), dir.getJarSigners(FILENAME)) // We only used CHARLIE's distinguished name, so the keys will be different.
     }
 
     @Test
-    fun `one signer jar with INDEX_LIST`() {
+    fun `jar with jar index file`() {
         dir.createJar(FILENAME, "_signable1")
         dir.addIndexList(FILENAME)
         val key = signAsAlice()

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -143,15 +143,11 @@ class JarSignatureCollectorTest {
     }
 
     @Test
-    fun `one signer jar with META-INF INDEX dot LIST`() {
-        dir.createJar(FILENAME, "_signable1", "_signable2")
+    fun `one signer jar with INDEX_LIST`() {
+        dir.createJar(FILENAME, "_signable1")
         dir.addIndexList(FILENAME)
         val key = signAsAlice()
         assertEquals(listOf(key), dir.getJarSigners(FILENAME))
-
-        (dir / "my-dir").createDirectory()
-        dir.updateJar(FILENAME, "my-dir")
-        assertEquals(listOf(key), dir.getJarSigners(FILENAME)) // Unsigned directory is irrelevant.
     }
 
     private fun signAsAlice() = dir.signJar(FILENAME, ALICE, "storepass", ALICE_PASS)

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -5,10 +5,12 @@ import net.corda.testing.core.JarSignatureTestUtils.generateKey
 import net.corda.testing.core.JarSignatureTestUtils.getJarSigners
 import net.corda.testing.core.JarSignatureTestUtils.signJar
 import net.corda.testing.core.JarSignatureTestUtils.updateJar
+import net.corda.testing.core.JarSignatureTestUtils.addIndexList
 import net.corda.core.identity.Party
 import net.corda.core.internal.*
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.CHARLIE_NAME
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.AfterClass
@@ -138,6 +140,18 @@ class JarSignatureCollectorTest {
         dir.createJar(FILENAME, "_signable1", "_signable2")
         val key = dir.signJar(FILENAME, CHARLIE, "storepass", CHARLIE_PASS)
         assertEquals(listOf(key), dir.getJarSigners(FILENAME)) // We only used CHARLIE's distinguished name, so the keys will be different.
+    }
+
+    @Test
+    fun `one signer jar with META-INF INDEX dot LIST`() {
+        dir.createJar(FILENAME, "_signable1", "_signable2")
+        dir.addIndexList(FILENAME)
+        val key = signAsAlice()
+        assertEquals(listOf(key), dir.getJarSigners(FILENAME))
+
+        (dir / "my-dir").createDirectory()
+        dir.updateJar(FILENAME, "my-dir")
+        assertEquals(listOf(key), dir.getJarSigners(FILENAME)) // Unsigned directory is irrelevant.
     }
 
     private fun signAsAlice() = dir.signJar(FILENAME, ALICE, "storepass", ALICE_PASS)


### PR DESCRIPTION
As discovered in CORDA-2116 Mismatch between signers for files in the `META-INF` directory, the problematic file is META-INF/INDEX.LIST.
Temporally treating META-INF/INDEX.LIST as unsignable entry because java.util.jar.JarVerifier doesn't load its signers. 

Created https://r3-cev.atlassian.net/browse/CORDA-2177 for further investigation, this PR enables to work signed JAR with INDEX.LIST for now.