### PR TITLE
[CORDA-2174] Fix demo node startup

### DIFF
--- a/finance/src/main/kotlin/net/corda/finance/internal/CashConfigDataFlow.kt
+++ b/finance/src/main/kotlin/net/corda/finance/internal/CashConfigDataFlow.kt
@@ -24,7 +24,12 @@ class ConfigHolder(services: AppServiceHub) : SingletonSerializeAsToken() {
     val issuableCurrencies: List<Currency>
 
     init {
-        val issuableCurrenciesStringList: List<String> = uncheckedCast(services.getAppContext().config.get("issuableCurrencies"))
+        val config = services.getAppContext().config
+        val issuableCurrenciesStringList: List<String> = if (config.exists("issuableCurrencies")) {
+            uncheckedCast(config.get("issuableCurrencies"))
+        } else {
+            emptyList()
+        }
         issuableCurrencies = issuableCurrenciesStringList.map(Currency::getInstance)
         (issuableCurrencies - supportedCurrencies).let {
             require(it.isEmpty()) { "$it are not supported currencies" }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -595,7 +595,12 @@ class DriverDSLImpl(
             emptyList()
         }
 
-        val cordappDirectories = existingCorDappDirectoriesOption + (cordappsForAllNodes + additionalCordapps).map { TestCordappDirectories.getJarDirectory(it).toString() }
+        // Instead of using cordappsForAllNodes we get only these that are missing from additionalCordapps
+        // This way we prevent errors when we want the same CordApp but with different config
+        val appOverrides = additionalCordapps.map { it.name to it.version}.toSet()
+        val baseCordapps = cordappsForAllNodes.filter { !appOverrides.contains(it.name to it.version) }
+
+        val cordappDirectories = existingCorDappDirectoriesOption + (baseCordapps + additionalCordapps).map { TestCordappDirectories.getJarDirectory(it).toString() }
 
         val config = NodeConfig(specifiedConfig.typesafe.withValue(NodeConfiguration.cordappDirectoriesKey, ConfigValueFactory.fromIterable(cordappDirectories.toSet())))
 


### PR DESCRIPTION
During investigation of [CORDA-2174](https://r3-cev.atlassian.net/browse/CORDA-2174) was found that running Nodes Explorer's demo nodes fails because of multiple problems.

The first problem was caused by #4100. When app config was implemented for Finance app `issuableCurrencies` was made required. This config was missing from demo setup. With the first commit I made it optional.

The second problem is that by using this app config feature if we want to add one cordapp for all nodes with driver DSL by using `cordappsForAllNodes` and then we want for some of the nodes to have different config for that app we need to pass `additionalCordapps` to `runNode` and the node will complain that there are two different jars for the same app. This is fixed by my second commit.