### PR TITLE
[CORDA-2130] Encumbered states should always be assigned to the same notary

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -137,9 +137,9 @@ sealed class TransactionVerificationException(val txId: SecureHash, message: Str
             "a full cycle. Offending indices $nonMatching", null)
 
     /**
-     * If two encumbered states are assigned to different notaries, then these states cannot be encumbered. This is
-     * due to the fact that multi-notary transactions are not supported yet and thus two encumbered states with different
-     * notaries cannot be consumed in the same transaction.
+     * All encumbered states should be assigned to the same notary. This is due to the fact that multi-notary
+     * transactions are not supported yet and thus two encumbered states with different notaries cannot be consumed
+     * in the same transaction.
      */
     @KeepForDJVM
     class TransactionNotaryMismatchEncumbranceException(txId: SecureHash, encumberedIndex: Int, encumbranceIndex: Int, encumberedNotary: Party, encumbranceNotary: Party)

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -136,6 +136,16 @@ sealed class TransactionVerificationException(val txId: SecureHash, message: Str
             "is not satisfied. Encumbered states should also be referenced as an encumbrance of another state to form " +
             "a full cycle. Offending indices $nonMatching", null)
 
+    /**
+     * If two encumbered states are assigned to different notaries, then these states cannot be encumbered. This is
+     * due to the fact that multi-notary transactions are not supported yet and thus two encumbered states with different
+     * notaries cannot be consumed in the same transaction.
+     */
+    @KeepForDJVM
+    class TransactionNotaryMismatchEncumbranceException(txId: SecureHash, encumberedIndex: Int, encumbranceIndex: Int, encumberedNotary: Party, encumbranceNotary: Party)
+        : TransactionVerificationException(txId, "Encumbered output states assigned to different notaries found. " +
+            "Output state with index $encumberedIndex is assigned to notary [$encumberedNotary], while its encumbrance with index $encumbranceIndex is assigned to notary [$encumbranceNotary]", null)
+
     /** Whether the inputs or outputs list contains an encumbrance issue, see [TransactionMissingEncumbranceException]. */
     @CordaSerializable
     @KeepForDJVM

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -138,7 +138,7 @@ sealed class TransactionVerificationException(val txId: SecureHash, message: Str
 
     /**
      * All encumbered states should be assigned to the same notary. This is due to the fact that multi-notary
-     * transactions are not supported yet and thus two encumbered states with different notaries cannot be consumed
+     * transactions are not supported and thus two encumbered states with different notaries cannot be consumed
      * in the same transaction.
      */
     @KeepForDJVM

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -246,8 +246,8 @@ data class LedgerTransaction @JvmOverloads constructor(
         // Note that if a notary is defined for a transaction, we already check if all outputs are assigned
         // to the same notary (transaction's notary) in [checkNoNotaryChange()].
         if (notary == null) {
-            // Cache for already checked indices.
-            val indicesAlreadyChecked = hashSetOf<Int>()
+            // Cache to bypass already checked indices and to avoid cycles.
+            val indicesAlreadyChecked = HashSet<Int>()
             statesAndEncumbrance.forEach {
                 checkNotary(it.first, indicesAlreadyChecked)
             }

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -255,7 +255,7 @@ data class LedgerTransaction @JvmOverloads constructor(
         }
     }
 
-    private fun checkNotary(index: Int, indicesAlreadyChecked: HashSet<Int>) {
+    private tailrec fun checkNotary(index: Int, indicesAlreadyChecked: HashSet<Int>) {
         if (indicesAlreadyChecked.add(index)) {
             val encumbranceIndex = outputs[index].encumbrance!!
             if (outputs[index].notary != outputs[encumbranceIndex].notary) {

--- a/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt
@@ -339,7 +339,7 @@ class TransactionEncumbranceTests {
         }
 
         // Two different encumbrance chains, where only one fails due to mismatched notary.
-        // 0 -> 1, 1 -> 0, 2 -> 3, 3 -> 2 (where encumbered states with indices 2 and 3, respectively, are assigned
+        // 0 -> 1, 1 -> 0, 2 -> 3, 3 -> 2 where encumbered states with indices 2 and 3, respectively, are assigned
         // to different notaries.
         assertFailsWith<TransactionVerificationException.TransactionNotaryMismatchEncumbranceException> {
             TransactionBuilder()

--- a/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/TransactionEncumbranceTests.kt
@@ -2,10 +2,7 @@ package net.corda.core.transactions
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
-import net.corda.core.contracts.Contract
-import net.corda.core.contracts.ContractState
-import net.corda.core.contracts.TransactionVerificationException
-import net.corda.core.contracts.requireThat
+import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.finance.DOLLARS
@@ -33,6 +30,7 @@ class TransactionEncumbranceTests {
 
     private companion object {
         val DUMMY_NOTARY = TestIdentity(DUMMY_NOTARY_NAME, 20).party
+        val DUMMY_NOTARY2 = TestIdentity(DUMMY_NOTARY_NAME.copy(organisation = "${DUMMY_NOTARY_NAME.organisation}2"), 30).party
         val megaCorp = TestIdentity(CordaX500Name("MegaCorp", "London", "GB"))
         val MINI_CORP = TestIdentity(CordaX500Name("MiniCorp", "London", "GB")).party
         val MEGA_CORP get() = megaCorp.party
@@ -77,7 +75,7 @@ class TransactionEncumbranceTests {
     }
 
     @Test
-    fun `states can be bi-directionally encumbered`() {
+    fun `states must be bi-directionally encumbered`() {
         // Basic encumbrance example for encumbrance index links 0 -> 1 and 1 -> 0
         ledgerServices.ledger(DUMMY_NOTARY) {
             transaction {
@@ -314,6 +312,43 @@ class TransactionEncumbranceTests {
                 timeWindow(FIVE_PM)
                 this `fails with` "Missing required encumbrance 1 in INPUT"
             }
+        }
+    }
+
+    @Test
+    fun `encumbered states cannot be assigned to different notaries`() {
+        // Single encumbrance with different notaries.
+        assertFailsWith<TransactionVerificationException.TransactionNotaryMismatchEncumbranceException> {
+            TransactionBuilder()
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY, 1, AutomaticHashConstraint)
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY2, 0, AutomaticHashConstraint)
+                    .addCommand(Cash.Commands.Issue(), MEGA_CORP.owningKey)
+                    .toLedgerTransaction(ledgerServices)
+        }
+
+        // More complex encumbrance (full cycle of size 4) where one of the encumbered states is assigned to a different notary.
+        // 0 -> 1, 1 -> 3, 3 -> 2, 2 -> 0
+        assertFailsWith<TransactionVerificationException.TransactionNotaryMismatchEncumbranceException> {
+            TransactionBuilder()
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY, 1, AutomaticHashConstraint)
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY, 3, AutomaticHashConstraint)
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY2, 0, AutomaticHashConstraint)
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY, 2, AutomaticHashConstraint)
+                    .addCommand(Cash.Commands.Issue(), MEGA_CORP.owningKey)
+                    .toLedgerTransaction(ledgerServices)
+        }
+
+        // Two different encumbrance chains, where only one fails due to mismatched notary.
+        // 0 -> 1, 1 -> 0, 2 -> 3, 3 -> 2 (where encumbered states with indices 2 and 3, respectively, are assigned
+        // to different notaries.
+        assertFailsWith<TransactionVerificationException.TransactionNotaryMismatchEncumbranceException> {
+            TransactionBuilder()
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY, 1, AutomaticHashConstraint)
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY, 0, AutomaticHashConstraint)
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY, 3, AutomaticHashConstraint)
+                    .addOutputState(stateWithNewOwner, Cash.PROGRAM_ID, DUMMY_NOTARY2, 2, AutomaticHashConstraint)
+                    .addCommand(Cash.Commands.Issue(), MEGA_CORP.owningKey)
+                    .toLedgerTransaction(ledgerServices)
         }
     }
 }


### PR DESCRIPTION
Although we already check that ALL output states should be assigned to the same Notary in `LedgerTransaction.checkNoNotaryChange`, this only applies if transaction's notary is NOT null.
However, in special cases, like issuing transactions, a transaction might have a null Notary.

Previously, it was possible that an issuer could create encumbered output states assigned to different notaries which would result to freezing all encumbered states as we don't yet support multi-notary transactions. Thus, such encumbered states could NOT be consumed in the same transaction in the future.

This PR checks if all related encumbered states are assigned to the same notary (if transaction's notary is null). The word "related" is important as a transaction can have multiple encumbrance chains and we handle each chain/group separately.