### PR TITLE
CORDA-2187 reverting maxTransactionSize <= maxMessageSize

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
@@ -85,7 +85,6 @@ data class NetworkParameters(
         require(epoch > 0) { "epoch must be at least 1" }
         require(maxMessageSize > 0) { "maxMessageSize must be at least 1" }
         require(maxTransactionSize > 0) { "maxTransactionSize must be at least 1" }
-        require(maxTransactionSize <= maxMessageSize) { "maxTransactionSize cannot be bigger than maxMessageSize" }
         require(!eventHorizon.isNegative) { "eventHorizon must be positive value" }
         require(noOverlap(packageOwnership.keys)) { "multiple packages added to the packageOwnership overlap." }
     }

--- a/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
@@ -77,19 +77,6 @@ class NetworkParametersTest {
     }
 
     @Test
-    fun `maxTransactionSize must be bigger than maxMesssageSize`() {
-        assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-            NetworkParameters(1,
-                    emptyList(),
-                    2000,
-                    2001,
-                    Instant.now(),
-                    1,
-                    emptyMap())
-        }.withMessage("maxTransactionSize cannot be bigger than maxMessageSize")
-    }
-
-    @Test
     fun `package ownership checks are correct`() {
         val key1 = generateKeyPair().public
         val key2 = generateKeyPair().public


### PR DESCRIPTION
This PR removes the `maxTransactionSize` constraint from the network parameters.