### PR TITLE
CORDA-2175 Fix attachment service tests on Windows

### DIFF
--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -35,6 +35,7 @@ import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.*
 import java.io.ByteArrayOutputStream
+import java.io.Closeable
 import java.io.OutputStream
 import java.net.URI
 import java.nio.charset.StandardCharsets
@@ -80,25 +81,26 @@ class NodeAttachmentServiceTest {
 
     @After
     fun tearDown() {
-        dir.list { subdir ->
-            subdir.forEach(Path::deleteRecursively)
-        }
         database.close()
     }
 
     @Test
     fun `importing a signed jar saves the signers to the storage`() {
-        val jarAndSigner = makeTestSignedContractJar("com.example.MyContract")
-        val signedJar = jarAndSigner.first
-        val attachmentId = storage.importAttachment(signedJar.inputStream(), "test", null)
-        assertEquals(listOf(jarAndSigner.second.hash), storage.openAttachment(attachmentId)!!.signers.map { it.hash })
+        SelfCleaningDir().use { file ->
+            val jarAndSigner = makeTestSignedContractJar(file.path, "com.example.MyContract")
+            val signedJar = jarAndSigner.first
+            val attachmentId = storage.importAttachment(signedJar.inputStream(), "test", null)
+            assertEquals(listOf(jarAndSigner.second.hash), storage.openAttachment(attachmentId)!!.signers.map { it.hash })
+        }
     }
 
     @Test
     fun `importing a non-signed jar will save no signers`() {
-        val jarName = makeTestContractJar("com.example.MyContract")
-        val attachmentId = storage.importAttachment(dir.resolve(jarName).inputStream(), "test", null)
-        assertEquals(0, storage.openAttachment(attachmentId)!!.signers.size)
+        SelfCleaningDir().use {
+            val jarName = makeTestContractJar(it.path, "com.example.MyContract")
+            val attachmentId = storage.importAttachment(it.path.resolve(jarName).inputStream(), "test", null)
+            assertEquals(0, storage.openAttachment(attachmentId)!!.signers.size)
+        }
     }
 
     @Test
@@ -127,25 +129,27 @@ class NodeAttachmentServiceTest {
 
     @Test
     fun `insert contract attachment as an untrusted uploader and then as trusted CorDapp uploader`() {
-        val contractJarName = makeTestContractJar("com.example.MyContract")
-        val testJar = dir.resolve(contractJarName)
-        val expectedHash = testJar.readAll().sha256()
+        SelfCleaningDir().use { file ->
+            val contractJarName = makeTestContractJar(file.path, "com.example.MyContract")
+            val testJar = file.path.resolve(contractJarName)
+            val expectedHash = testJar.readAll().sha256()
 
-        // PRIVILEGED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER, P2P_UPLOADER, UNKNOWN_UPLOADER)
-        // TRUSTED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER)
+            // PRIVILEGED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER, P2P_UPLOADER, UNKNOWN_UPLOADER)
+            // TRUSTED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER)
 
-        database.transaction {
-            val id = testJar.read { storage.privilegedImportOrGetAttachment(it, P2P_UPLOADER, null) }
-            assertEquals(expectedHash, id)
-            val attachment1 = storage.openAttachment(expectedHash)
+            database.transaction {
+                val id = testJar.read { storage.privilegedImportOrGetAttachment(it, P2P_UPLOADER, null) }
+                assertEquals(expectedHash, id)
+                val attachment1 = storage.openAttachment(expectedHash)
 
-            val id2 = testJar.read { storage.privilegedImportOrGetAttachment(it, DEPLOYED_CORDAPP_UPLOADER, null) }
-            assertEquals(expectedHash, id2)
-            val attachment2 = storage.openAttachment(expectedHash)
+                val id2 = testJar.read { storage.privilegedImportOrGetAttachment(it, DEPLOYED_CORDAPP_UPLOADER, null) }
+                assertEquals(expectedHash, id2)
+                val attachment2 = storage.openAttachment(expectedHash)
 
-            assertNotEquals(attachment1, attachment2)
-            assertEquals(P2P_UPLOADER, (attachment1 as ContractAttachment).uploader)
-            assertEquals(DEPLOYED_CORDAPP_UPLOADER, (attachment2 as ContractAttachment).uploader)
+                assertNotEquals(attachment1, attachment2)
+                assertEquals(P2P_UPLOADER, (attachment1 as ContractAttachment).uploader)
+                assertEquals(DEPLOYED_CORDAPP_UPLOADER, (attachment2 as ContractAttachment).uploader)
+            }
         }
     }
 
@@ -350,20 +354,26 @@ class NodeAttachmentServiceTest {
         return Pair(file, file.readAll().sha256())
     }
 
+    /**
+     * Class to create an automatically delete a temporary directory. Will ignore file locking issues on Windows
+     * while deleting the directory contents as they might be locked by the process itself (an annoying property of
+     * NTFS). Note that empty directories might be left if an exception gets suppressed.
+     */
+    class SelfCleaningDir : Closeable {
+        val path = Files.createTempDirectory(NodeAttachmentServiceTest::class.simpleName)
+        override fun close() {
+            try {
+                path.deleteRecursively()
+            } catch (e: java.nio.file.FileSystemException) {
+                // ignore this on windows - the file may still be locked by us but will be gone once the test finishes.
+                if (!System.getProperty("os.name").contains("Windows")) {
+                    throw e
+                }
+            }
+        }
+    }
+
     companion object {
-        private val dir = Files.createTempDirectory(NodeAttachmentServiceTest::class.simpleName)
-
-        @BeforeClass
-        @JvmStatic
-        fun beforeClass() {
-        }
-
-        @AfterClass
-        @JvmStatic
-        fun afterClass() {
-            dir.deleteRecursively()
-        }
-
         private fun makeTestJar(output: OutputStream, extraEntries: List<Pair<String, String>> = emptyList()) {
             output.use {
                 val jar = JarOutputStream(it)
@@ -380,25 +390,25 @@ class NodeAttachmentServiceTest {
             }
         }
 
-        private fun makeTestSignedContractJar(contractName: String): Pair<Path, PublicKey> {
+        private fun makeTestSignedContractJar(workingDir: Path, contractName: String): Pair<Path, PublicKey> {
             val alias = "testAlias"
             val pwd = "testPassword"
-            dir.generateKey(alias, pwd, ALICE_NAME.toString())
-            val jarName = makeTestContractJar(contractName)
-            val signer = dir.signJar(jarName, alias, pwd)
-            return dir.resolve(jarName) to signer
+            workingDir.generateKey(alias, pwd, ALICE_NAME.toString())
+            val jarName = makeTestContractJar(workingDir, contractName)
+            val signer = workingDir.signJar(jarName, alias, pwd)
+            return workingDir.resolve(jarName) to signer
         }
 
-        private fun makeTestContractJar(contractName: String): String {
+        private fun makeTestContractJar(workingDir: Path, contractName: String): String {
             val packages = contractName.split(".")
             val jarName = "testattachment.jar"
             val className = packages.last()
-            createTestClass(className, packages.subList(0, packages.size - 1))
-            dir.createJar(jarName, "${contractName.replace(".", "/")}.class")
+            createTestClass(workingDir, className, packages.subList(0, packages.size - 1))
+            workingDir.createJar(jarName, "${contractName.replace(".", "/")}.class")
             return jarName
         }
 
-        private fun createTestClass(className: String, packages: List<String>): Path {
+        private fun createTestClass(workingDir: Path, className: String, packages: List<String>): Path {
             val newClass = """package ${packages.joinToString(".")};
                 import net.corda.core.contracts.*;
                 import net.corda.core.transactions.*;
@@ -416,7 +426,7 @@ class NodeAttachmentServiceTest {
                 }
             }
             val fileManager = compiler.getStandardFileManager(null, null, null)
-            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, listOf(dir.toFile()))
+            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, listOf(workingDir.toFile()))
 
             val compile = compiler.getTask(System.out.writer(), fileManager, null, null, null, listOf(source)).call()
             return Paths.get(fileManager.list(StandardLocation.CLASS_OUTPUT, "", setOf(JavaFileObject.Kind.CLASS), true).single().name)


### PR DESCRIPTION
The NodeAttachmentService tests were causing issues on windows as cleaning up the temporary directory between tests did not work - it seems that NTFS keeps a lock on the files that have been opened by the NodeAttachementService, so they cannot be deleted. This leads to various file system exceptions being thrown when trying to delete old stuff or creating new temp files for the next test.
As solution, the tests now create a new directory for each test, and swallow any file system exceptions when deleting the temp directory - the files that are earmarked for deletion will be removed by Windows as soon as the lock is removed (i.e. when the test executable stops), but they can't be deleted while the process is still running.