### PR TITLE
Document enabling CorDapp signed by dev key to run in production mode (related to CORDA-1915)

### DIFF
--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -239,6 +239,8 @@ absolute path to the node's base directory.
                         .. _Dropwizard: https://metrics.dropwizard.io/3.2.3/manual/third-party.html
                         .. _Introduction to New Relic for Java: https://docs.newrelic.com/docs/agents/java-agent/getting-started/introduction-new-relic-java
 
+.. _corda_configuration_file_signer_blacklist:
+
 :cordappSignerKeyFingerprintBlacklist: List of public keys fingerprints (SHA-256 of public key hash) not allowed as Cordapp JARs signers.
                                        Node will not load Cordapps signed by those keys.
                                        The option takes effect only in production mode and defaults to Corda development keys (``["56CA54E803CB87C8472EBD3FBC6A2F1876E814CEEBF74860BD46997F40729367",

--- a/docs/source/cordapp-build-systems.rst
+++ b/docs/source/cordapp-build-systems.rst
@@ -162,6 +162,9 @@ without need to create a keystore and configure the ``cordapp`` plugin.
 For production deployment ensure to sign the CorDapp using your own certificate e.g. by setting system properties to point to an external keystore
 or by disabling signing in ``cordapp`` plugin and signing the CordDapp JAR downstream in your build pipeline.
 CorDapp signed by Corda development certificate is accepted by Corda node only when running in the development mode.
+In case CordDapp signed by the (default) development key is run on node in the production mode (e.g. for testing),
+the node may be set to accept the development key by adding the ``cordappSignerKeyFingerprintBlacklist = []`` property set to empty list
+(see :ref:`Configuring a node <corda_configuration_file_signer_blacklist>`).
 
 Signing options can be contextually overwritten by the relevant system properties as described above.
 This allows the single ``build.gradle`` file to be used for a development build (defaulting to the Corda development keystore)


### PR DESCRIPTION
Link from signing Cordapp document to node configuration regarding enabling Cordapp signed by dev key to be run in production mode (related to CORDA-1915).