### PR TITLE
[CORDA-2192] Corda specific OID for AliasPrivateKey

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -73,10 +73,6 @@
       <module name="core_main" target="1.8" />
       <module name="core_smokeTest" target="1.8" />
       <module name="core_test" target="1.8" />
-      <module name="crypto-service_main" target="1.8" />
-      <module name="crypto-service_test" target="1.8" />
-      <module name="crypto-services_main" target="1.8" />
-      <module name="crypto-services_test" target="1.8" />
       <module name="data_main" target="1.8" />
       <module name="data_test" target="1.8" />
       <module name="demobench_main" target="1.8" />

--- a/core/src/main/kotlin/net/corda/core/CordaOID.kt
+++ b/core/src/main/kotlin/net/corda/core/CordaOID.kt
@@ -1,18 +1,23 @@
 package net.corda.core
 
+import net.corda.core.crypto.internal.AliasPrivateKey
+
 /**
- * OIDs used for the Corda platform. Entries MUST NOT be removed from this file; if an OID is incorrectly assigned it
- * should be marked deprecated.
+ * OIDs used for the Corda platform. All entries MUST be defined in this file only and they MUST NOT be removed.
+ * If an OID is incorrectly assigned, it should be marked deprecated and NEVER be reused again.
  */
 @KeepForDJVM
 object CordaOID {
     /** Assigned to R3, see http://www.oid-info.com/cgi-bin/display?oid=1.3.6.1.4.1.50530&action=display */
     const val R3_ROOT = "1.3.6.1.4.1.50530"
-    /** OIDs issued for the Corda platform */
+    /** OIDs issued for the Corda platform. */
     const val CORDA_PLATFORM = "$R3_ROOT.1"
     /**
      * Identifier for the X.509 certificate extension specifying the Corda role. See
      * https://r3-cev.atlassian.net/wiki/spaces/AWG/pages/156860572/Certificate+identity+type+extension for details.
      */
     const val X509_EXTENSION_CORDA_ROLE = "$CORDA_PLATFORM.1"
+
+    /** OID for [AliasPrivateKey]. */
+    const val ALIAS_PRIVATE_KEY = "$CORDA_PLATFORM.2"
 }

--- a/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
@@ -34,7 +34,9 @@ private fun provideNonDeterministic(provider: Provider) {
 @KeepForDJVM
 object CordaObjectIdentifier {
     // UUID-based OID
-    // TODO: Register for an OID space and issue our own shorter OID.
+    // TODO define and use an official Corda OID in [CordaOID]. We didn't do yet for backwards compatibility purposes,
+    //      because key.encoded (serialised version of keys) and [PublicKey.hash] for already stored [CompositeKey]s
+    //      will not match.
     @JvmField
     val COMPOSITE_KEY = ASN1ObjectIdentifier("2.25.30086077608615255153862931087626791002")
     @JvmField

--- a/core/src/main/kotlin/net/corda/core/crypto/internal/AliasPrivateKey.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/AliasPrivateKey.kt
@@ -1,5 +1,6 @@
 package net.corda.core.crypto.internal
 
+import net.corda.core.CordaOID
 import org.bouncycastle.asn1.*
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
@@ -17,12 +18,7 @@ import java.security.spec.PKCS8EncodedKeySpec
 data class AliasPrivateKey(val alias: String): PrivateKey {
 
     companion object {
-        // UUID-based OID
-        // TODO: Register for an OID space and issue our own shorter OID.
-        @JvmField
-        val ALIAS_PRIVATE_KEY = ASN1ObjectIdentifier("2.26.40086077608615255153862931087626791001")
-
-        const val ALIAS_KEY_ALGORITHM = "ALIAS"
+        const val ALIAS_KEY_ALGORITHM = "AliasPrivateKey"
     }
 
     override fun getAlgorithm() = ALIAS_KEY_ALGORITHM
@@ -30,7 +26,10 @@ data class AliasPrivateKey(val alias: String): PrivateKey {
     override fun getEncoded(): ByteArray {
         val keyVector = ASN1EncodableVector()
         keyVector.add(DERUTF8String(alias))
-        val privateKeyInfoBytes = PrivateKeyInfo(AlgorithmIdentifier(ALIAS_PRIVATE_KEY), DERSequence(keyVector)).getEncoded(ASN1Encoding.DER)
+        val privateKeyInfoBytes = PrivateKeyInfo(
+                AlgorithmIdentifier(ASN1ObjectIdentifier(CordaOID.ALIAS_PRIVATE_KEY)),
+                DERSequence(keyVector)
+        ).getEncoded(ASN1Encoding.DER)
         val keySpec = PKCS8EncodedKeySpec(privateKeyInfoBytes)
         return keySpec.encoded
     }


### PR DESCRIPTION
As noted by @shamsasari we should use an official Corda OID and not a UUID for `AliasPrivateKey`.