### PR TITLE
CORDA-2183: Show root cause of error in console to aid with debugging

### DIFF
--- a/config/dev/log4j2.xml
+++ b/config/dev/log4j2.xml
@@ -12,7 +12,7 @@
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
             <PatternLayout>
-                <ScriptPatternSelector defaultPattern="%highlight{[%level{length=5}] %date{HH:mm:ssZ} [%t] %c{2}.%method - %msg%n%throwable{short.message}}{INFO=white,WARN=red,FATAL=bright red}">
+                <ScriptPatternSelector defaultPattern="%highlight{[%level{length=5}] %date{HH:mm:ssZ} [%t] %c{2}.%method - %msg%n%throwable{short.message}%n}{INFO=white,WARN=red,FATAL=bright red}">
                     <Script name="MDCSelector" language="javascript"><![CDATA[
                     result = null;
                     if (!logEvent.getContextData().size() == 0) {
@@ -23,7 +23,7 @@
                     result;
                ]]>
                     </Script>
-                    <PatternMatch key="WithMDC" pattern="%highlight{[%level{length=5}] %date{HH:mm:ssZ} [%t] %c{2}.%method - %msg %X%n%throwable{short.message}}{INFO=white,WARN=red,FATAL=bright red}"/>
+                    <PatternMatch key="WithMDC" pattern="%highlight{[%level{length=5}] %date{HH:mm:ssZ} [%t] %c{2}.%method - %msg %X%n%throwable{short.message}%n}{INFO=white,WARN=red,FATAL=bright red}"/>
                 </ScriptPatternSelector>
             </PatternLayout>
         </Console>

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -554,7 +554,11 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 log.error("${it.name}, as a Corda service, must have a constructor with a single parameter of type " +
                         ServiceHub::class.java.name)
             } catch (e: ServiceInstantiationException) {
-                log.error("Corda service ${it.name} failed to instantiate. Reason was: ${e.cause?.rootMessage}", e.cause)
+                if (e.cause != null) {
+                    log.error("Corda service ${it.name} failed to instantiate. Reason was: ${e.cause?.rootMessage}", e.cause)
+                } else {
+                    log.error("Corda service ${it.name} failed to instantiate", e)
+                }
             } catch (e: Exception) {
                 log.error("Unable to install Corda service ${it.name}", e)
             }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -554,7 +554,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 log.error("${it.name}, as a Corda service, must have a constructor with a single parameter of type " +
                         ServiceHub::class.java.name)
             } catch (e: ServiceInstantiationException) {
-                log.error("Corda service ${it.name} failed to instantiate", e.cause)
+                log.error("Corda service ${it.name} failed to instantiate (${e.cause?.rootMessage})", e.cause)
             } catch (e: Exception) {
                 log.error("Unable to install Corda service ${it.name}", e)
             }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -554,7 +554,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 log.error("${it.name}, as a Corda service, must have a constructor with a single parameter of type " +
                         ServiceHub::class.java.name)
             } catch (e: ServiceInstantiationException) {
-                log.error("Corda service ${it.name} failed to instantiate (${e.cause?.rootMessage})", e.cause)
+                log.error("Corda service ${it.name} failed to instantiate. Reason was: ${e.cause?.rootMessage}", e.cause)
             } catch (e: Exception) {
                 log.error("Unable to install Corda service ${it.name}", e)
             }


### PR DESCRIPTION
Was:

`[ERROR] 15:29:08+0000 [main] internal.Node.installCordaServices - Corda service net.corda.finance.internal.ConfigHolder failed to instantiate
Cordapp configuration is incorrect due to exception`

Now displays (well it would if the bug still existed):

``[ERROR] 17:07:26+0000 [main] internal.Node.installCordaServices - Corda service net.corda.finance.internal.ConfigHolder failed to instantiate (No configuration setting found for key 'issuableCurrencies') [errorCode=ut8i8s]``

Also fixed an issue with newlines in the default log4j confg when printing throwables in the console.