### PR TITLE
Make the shell test pass when it happens to find the Integer constructor

### DIFF
--- a/tools/shell/src/test/kotlin/net/corda/tools/shell/InteractiveShellTest.kt
+++ b/tools/shell/src/test/kotlin/net/corda/tools/shell/InteractiveShellTest.kt
@@ -29,7 +29,7 @@ class InteractiveShellTest {
 
     @Suppress("UNUSED")
     class FlowA(val a: String) : FlowLogic<String>() {
-        constructor(b: Int) : this(b.toString())
+        constructor(b: Int?) : this(b.toString())
         constructor(b: Int?, c: String) : this(b.toString() + c)
         constructor(amount: Amount<Currency>) : this(amount.toString())
         constructor(pair: Pair<Amount<Currency>, SecureHash.SHA256>) : this(pair.toString())
@@ -115,7 +115,7 @@ class InteractiveShellTest {
                 "[b: String[]]: missing parameter b",
                 "[b: Integer, c: String]: missing parameter b",
                 "[a: String]: missing parameter a",
-                "[b: int]: missing parameter b"
+                "[b: Integer]: missing parameter b"
         )
         val errors = e.errors.toHashSet()
         errors.removeAll(correct)


### PR DESCRIPTION
The interactive shell test has a constructor taking an integer that maps to the Java primitive `int` - when trying to get this reflectively with `java.lang.Integer`, the test will fail. Usually, this does not even get run, as the commandline parsing in the shell will happily parse an integer to a string if it finds a constructor taking a string first. But occasionally, this leads to test failure.
This does not fix the parsing in the shell, but at least makes the test pass when the Integer constructor gets found first.