### PR TITLE
[CORDA-2200][CORDA-2202] More tests for BCCryptoService and CryptoServiceException

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilder.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/crypto/ContentSignerBuilder.kt
@@ -1,5 +1,6 @@
 package net.corda.nodeapi.internal.crypto
 
+import net.corda.core.crypto.Crypto.SPHINCS256_SHA256
 import net.corda.core.crypto.SignatureScheme
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.operator.ContentSigner
@@ -17,7 +18,9 @@ object ContentSignerBuilder {
     fun build(signatureScheme: SignatureScheme, privateKey: PrivateKey, provider: Provider, random: SecureRandom? = null): ContentSigner {
         val sigAlgId = signatureScheme.signatureOID
         val sig = Signature.getInstance(signatureScheme.signatureName, provider).apply {
-            if (random != null) {
+            // TODO special handling for Sphincs due to a known BouncyCastle's Sphincs bug we reported.
+            //      It is fixed in BC 161b12, so consider updating the below if-statement after updating BouncyCastle.
+            if (random != null && signatureScheme != SPHINCS256_SHA256) {
                 initSign(privateKey, random)
             } else {
                 initSign(privateKey)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
@@ -39,4 +39,4 @@ interface CryptoService {
     fun getSigner(alias: String): ContentSigner
 }
 
-open class CryptoServiceException(override val message: String?, override val cause: Throwable? = null) : Exception()
+open class CryptoServiceException(message: String?, cause: Throwable? = null) : Exception(message, cause)

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/cryptoservice/CryptoService.kt
@@ -38,3 +38,5 @@ interface CryptoService {
      */
     fun getSigner(alias: String): ContentSigner
 }
+
+open class CryptoServiceException(override val message: String?, override val cause: Throwable? = null) : Exception()

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -112,8 +112,8 @@ interface NodeConfiguration {
 
     fun makeCryptoService(): CryptoService {
         return when(cryptoServiceName) {
-            SupportedCryptoServices.BC_SIMPLE -> BCCryptoService(this)
-            null -> BCCryptoService(this) // Pick default BCCryptoService when null.
+            // Pick default BCCryptoService when null.
+            SupportedCryptoServices.BC_SIMPLE, null -> BCCryptoService(this.myLegalName.x500Principal, this.signingCertificateStore)
         }
     }
 }
@@ -122,7 +122,7 @@ data class FlowOverrideConfig(val overrides: List<FlowOverride> = listOf())
 data class FlowOverride(val initiator: String, val responder: String)
 
 /**
- * Currently registered JMX Reporters
+ * Currently registered JMX Reporters.
  */
 enum class JmxReporterType {
     JOLOKIA, NEW_RELIC

--- a/node/src/main/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoService.kt
@@ -33,7 +33,7 @@ class BCCryptoService(private val legalName: X500Principal, private val certific
             importKey(alias, keyPair)
             return keyPair.public
         } catch (e: Exception) {
-            throw detailedCryptoServiceException("Cannot generate key for alias $alias and signature scheme with id $schemeNumberID", e)
+            throw CryptoServiceException("Cannot generate key for alias $alias and signature scheme with id $schemeNumberID", e)
         }
     }
 
@@ -45,7 +45,7 @@ class BCCryptoService(private val legalName: X500Principal, private val certific
         try {
             return certificateStore.query { getPublicKey(alias) }
         } catch (e: Exception) {
-            throw detailedCryptoServiceException("Cannot get public key for alias $alias", e)
+            throw CryptoServiceException("Cannot get public key for alias $alias", e)
         }
     }
 
@@ -53,7 +53,7 @@ class BCCryptoService(private val legalName: X500Principal, private val certific
         try {
             return Crypto.doSign(certificateStore.query { getPrivateKey(alias, certificateStore.entryPassword) }, data)
         } catch (e: Exception) {
-            throw detailedCryptoServiceException("Cannot sign using the key with alias $alias. SHA256 of data to be signed: ${data.sha256()}", e)
+            throw CryptoServiceException("Cannot sign using the key with alias $alias. SHA256 of data to be signed: ${data.sha256()}", e)
         }
     }
 
@@ -63,7 +63,7 @@ class BCCryptoService(private val legalName: X500Principal, private val certific
             val signatureScheme = Crypto.findSignatureScheme(privateKey)
             return ContentSignerBuilder.build(signatureScheme, privateKey, Crypto.findProvider(signatureScheme.providerName), newSecureRandom())
         } catch (e: Exception) {
-            throw detailedCryptoServiceException("Cannot get Signer for key with alias $alias", e)
+            throw CryptoServiceException("Cannot get Signer for key with alias $alias", e)
         }
     }
 
@@ -84,13 +84,7 @@ class BCCryptoService(private val legalName: X500Principal, private val certific
             val cert = X509Utilities.createSelfSignedCACertificate(legalName, keyPair)
             certificateStore.query { setPrivateKey(alias, keyPair.private, listOf(cert), certificateStore.entryPassword) }
         } catch (e: Exception) {
-            throw detailedCryptoServiceException("Cannot import key with alias $alias", e)
+            throw CryptoServiceException("Cannot import key with alias $alias", e)
         }
-    }
-
-    // Include causing [e.message] in the message as well for easier debugging.
-    private fun detailedCryptoServiceException(message: String, e: Exception): CryptoServiceException {
-        val finalMessage = e.message?.let { "$message -- ($it)" } ?: message
-        return CryptoServiceException(finalMessage, e.cause)
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoService.kt
@@ -2,11 +2,13 @@ package net.corda.node.services.keys.cryptoservice
 
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.newSecureRandom
+import net.corda.core.crypto.sha256
 import net.corda.node.services.config.NodeConfiguration
 import net.corda.nodeapi.internal.config.CertificateStore
 import net.corda.nodeapi.internal.crypto.ContentSignerBuilder
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.cryptoservice.CryptoService
+import net.corda.nodeapi.internal.cryptoservice.CryptoServiceException
 import org.bouncycastle.operator.ContentSigner
 import java.security.KeyPair
 import java.security.KeyStore
@@ -24,9 +26,13 @@ class BCCryptoService(private val nodeConf: NodeConfiguration) : CryptoService {
     internal var certificateStore: CertificateStore = nodeConf.signingCertificateStore.get(true)
 
     override fun generateKeyPair(alias: String, schemeNumberID: Int): PublicKey {
-        val keyPair = Crypto.generateKeyPair(Crypto.findSignatureScheme(schemeNumberID))
-        importKey(alias, keyPair)
-        return keyPair.public
+        try {
+            val keyPair = Crypto.generateKeyPair(Crypto.findSignatureScheme(schemeNumberID))
+            importKey(alias, keyPair)
+            return keyPair.public
+        } catch (e: Exception) {
+            throw CryptoServiceException("Cannot generate key for alias $alias and signature scheme with id $schemeNumberID -- (${e.message})", e.cause)
+        }
     }
 
     override fun containsKey(alias: String): Boolean {
@@ -34,17 +40,29 @@ class BCCryptoService(private val nodeConf: NodeConfiguration) : CryptoService {
     }
 
     override fun getPublicKey(alias: String): PublicKey {
-        return certificateStore.query { getPublicKey(alias) }
+        try {
+            return certificateStore.query { getPublicKey(alias) }
+        } catch (e: Exception) {
+            throw CryptoServiceException("Cannot get public key for alias $alias -- (${e.message})", e.cause)
+        }
     }
 
     override fun sign(alias: String, data: ByteArray): ByteArray {
-        return Crypto.doSign(certificateStore.query { getPrivateKey(alias, certificateStore.entryPassword) } , data)
+        try {
+            return Crypto.doSign(certificateStore.query { getPrivateKey(alias, certificateStore.entryPassword) }, data)
+        } catch (e: Exception) {
+            throw CryptoServiceException("Cannot sign using the key with alias $alias. SHA256 of data to be signed: ${data.sha256()} -- (${e.message})", e.cause)
+        }
     }
 
     override fun getSigner(alias: String): ContentSigner {
-        val privateKey = certificateStore.query { getPrivateKey(alias, certificateStore.entryPassword) }
-        val signatureScheme = Crypto.findSignatureScheme(privateKey)
-        return ContentSignerBuilder.build(signatureScheme, privateKey, Crypto.findProvider(signatureScheme.providerName), newSecureRandom())
+        try {
+            val privateKey = certificateStore.query { getPrivateKey(alias, certificateStore.entryPassword) }
+            val signatureScheme = Crypto.findSignatureScheme(privateKey)
+            return ContentSignerBuilder.build(signatureScheme, privateKey, Crypto.findProvider(signatureScheme.providerName), newSecureRandom())
+        } catch (e: Exception) {
+            throw CryptoServiceException("Cannot get Signer for key with alias $alias -- (${e.message})", e.cause)
+        }
     }
 
     /**
@@ -58,9 +76,13 @@ class BCCryptoService(private val nodeConf: NodeConfiguration) : CryptoService {
 
     /** Import an already existing [KeyPair] to this [CryptoService]. */
     fun importKey(alias: String, keyPair: KeyPair) {
-        // Store a self-signed certificate, as Keystore requires to store certificates instead of public keys.
-        // We could probably add a null cert, but we store a self-signed cert that will be used to retrieve the public key.
-        val cert = X509Utilities.createSelfSignedCACertificate(nodeConf.myLegalName.x500Principal, keyPair)
-        certificateStore.query { setPrivateKey(alias, keyPair.private, listOf(cert), certificateStore.entryPassword) }
+        try {
+            // Store a self-signed certificate, as Keystore requires to store certificates instead of public keys.
+            // We could probably add a null cert, but we store a self-signed cert that will be used to retrieve the public key.
+            val cert = X509Utilities.createSelfSignedCACertificate(nodeConf.myLegalName.x500Principal, keyPair)
+            certificateStore.query { setPrivateKey(alias, keyPair.private, listOf(cert), certificateStore.entryPassword) }
+        } catch (e: Exception) {
+            throw CryptoServiceException("Cannot import key with alias $alias -- (${e.message})", e.cause)
+        }
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
@@ -41,7 +41,8 @@ class BCCryptoServiceTests {
     @Test
     fun `BCCryptoService generate key pair and sign both data and cert`() {
         val cryptoService = BCCryptoService(ALICE_NAME.x500Principal, signingCertificateStore)
-        Crypto.supportedSignatureSchemes().filter { it != Crypto.COMPOSITE_KEY}.forEach { generateKeyAndSignForScheme(cryptoService, it) }
+        // Testing every supported scheme.
+        Crypto.supportedSignatureSchemes().filter { it != Crypto.COMPOSITE_KEY }.forEach { generateKeyAndSignForScheme(cryptoService, it) }
     }
 
     private fun generateKeyAndSignForScheme(cryptoService: BCCryptoService, signatureScheme: SignatureScheme) {

--- a/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
@@ -28,7 +28,6 @@ class BCCryptoServiceTests {
     companion object {
         const val alias = "keyAlias"
         val clearData = "data".toByteArray()
-        val signatureScheme = Crypto.ECDSA_SECP256K1_SHA256
     }
 
     @Rule

--- a/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
@@ -26,7 +26,6 @@ import kotlin.test.assertTrue
 class BCCryptoServiceTests {
 
     companion object {
-        const val alias = "keyAlias"
         val clearData = "data".toByteArray()
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/keys/cryptoservice/BCCryptoServiceTests.kt
@@ -1,0 +1,95 @@
+package net.corda.node.services.keys.cryptoservice
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SignatureScheme
+import net.corda.core.internal.div
+import net.corda.core.utilities.days
+import net.corda.node.services.config.NodeConfiguration
+import net.corda.nodeapi.internal.crypto.CertificateType
+import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.cryptoservice.CryptoServiceException
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.internal.rigorousMock
+import net.corda.testing.internal.stubs.CertificateStoreStubs
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.time.Duration
+import javax.security.auth.x500.X500Principal
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BCCryptoServiceTests {
+
+    companion object {
+        const val alias = "keyAlias"
+        val clearData = "data".toByteArray()
+        val signatureScheme = Crypto.ECDSA_SECP256K1_SHA256
+    }
+
+    @Rule
+    @JvmField
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var config: NodeConfiguration
+
+    @Before
+    fun setUp() {
+        abstract class AbstractNodeConfiguration : NodeConfiguration
+
+        val baseDirectory = temporaryFolder.root.toPath()
+        val certificatesDirectory = baseDirectory / "certificates"
+        val signingCertificateStore = CertificateStoreStubs.Signing.withCertificatesDirectory(certificatesDirectory)
+
+        config = rigorousMock<AbstractNodeConfiguration>().also {
+            doReturn(signingCertificateStore).whenever(it).signingCertificateStore
+            doReturn(ALICE_NAME).whenever(it).myLegalName
+        }
+    }
+
+    @Test
+    fun `BCCryptoService generate key pair and sign both data and cert`() {
+        val cryptoService = BCCryptoService(config)
+        Crypto.supportedSignatureSchemes().filter { it != Crypto.COMPOSITE_KEY}.forEach { generateKeyAndSignForScheme(cryptoService, it) }
+    }
+
+    private fun generateKeyAndSignForScheme(cryptoService: BCCryptoService, signatureScheme: SignatureScheme) {
+        val schemeNumberID = signatureScheme.schemeNumberID
+        val alias = "signature$schemeNumberID"
+        val pubKey = cryptoService.generateKeyPair(alias, schemeNumberID)
+        assertTrue { cryptoService.containsKey(alias) }
+
+        val signatureData = cryptoService.sign(alias, clearData)
+        assertTrue(Crypto.doVerify(pubKey, signatureData, clearData))
+
+        // Test that getSigner can indeed sign a certificate.
+        val signer = cryptoService.getSigner(alias)
+        val x500Principal = X500Principal("CN=Test")
+        val window = X509Utilities.getCertificateValidityWindow(Duration.ZERO, 3650.days)
+        val certificate = X509Utilities.createCertificate(
+                CertificateType.CONFIDENTIAL_LEGAL_IDENTITY,
+                x500Principal,
+                pubKey,
+                signer,
+                x500Principal,
+                pubKey,
+                window)
+
+        certificate.checkValidity()
+        certificate.verify(pubKey)
+    }
+
+    @Test
+    fun `When key does not exist getPublicKey, sign and getSigner should throw`() {
+        val nonExistingAlias = "nonExistingAlias"
+        val cryptoService = BCCryptoService(config)
+        assertFalse { cryptoService.containsKey(nonExistingAlias) }
+        assertFailsWith<CryptoServiceException> { cryptoService.getPublicKey(nonExistingAlias) }
+        assertFailsWith<CryptoServiceException> { cryptoService.sign(nonExistingAlias, clearData) }
+        assertFailsWith<CryptoServiceException> { cryptoService.getSigner(nonExistingAlias) }
+    }
+}


### PR DESCRIPTION
- More tests for `BCCryptoService`.
- Adding a specific `CryptoServiceException`.
- Fixing `ContentSignerBuilder.build` that failed on signing certs with Sphincs (we reported and fixed the issue in BC's github, so this is a temporal fix until the new BC version is released).
- Change `BCCryptoService`'s constructor, due to CORDA-2202

