### PR TITLE
CORDA-2206: Some code paths for bridge control are not being acknowledged

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlListener.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/bridging/BridgeControlListener.kt
@@ -55,6 +55,7 @@ class BridgeControlListener(val config: MutualSslConfiguration,
             } catch (ex: Exception) {
                 log.error("Unable to process bridge control message", ex)
             }
+            msg.acknowledge()
         }
         val startupMessage = BridgeControl.BridgeToNodeSnapshotRequest(bridgeId).serialize(context = SerializationDefaults.P2P_CONTEXT).bytes
         val bridgeRequest = artemisSession.createMessage(false)


### PR DESCRIPTION
It has been spotted that some bridge control publish/susbcribe message paths weren't calling acknowledge on the messages and may be leaking some resources.