### PR TITLE
[CORDA-2210] Add matching party on the first X500 attribute match

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
@@ -36,22 +36,17 @@ interface IdentityServiceInternal : IdentityService {
     @Throws(CertificateExpiredException::class, CertificateNotYetValidException::class, InvalidAlgorithmParameterException::class)
     fun verifyAndRegisterIdentity(identity: PartyAndCertificate, isNewRandomIdentity: Boolean): PartyAndCertificate?
 
+    // We can imagine this being a query over a lucene index in future.
+    //
+    // Kostas says: When exactMatch = false, we can easily use the Jaro-Winkler distance metric as it is best suited for short
+    // strings such as entity/company names, and to detect small typos. We can also apply it for city
+    // or any keyword related search in lists of records (not raw text - for raw text we need indexing)
+    // and we can return results in hierarchical order (based on normalised String similarity 0.0-1.0).
     fun partiesFromName(query: String, exactMatch: Boolean, x500name: CordaX500Name, results: LinkedHashSet<Party>, party: Party) {
         val components = listOfNotNull(x500name.commonName, x500name.organisationUnit, x500name.organisation, x500name.locality, x500name.state, x500name.country)
-        components.forEach { component ->
-            if (exactMatch && component == query) {
-                results += party
-            } else if (!exactMatch) {
-                // We can imagine this being a query over a lucene index in future.
-                //
-                // Kostas says: We can easily use the Jaro-Winkler distance metric as it is best suited for short
-                // strings such as entity/company names, and to detect small typos. We can also apply it for city
-                // or any keyword related search in lists of records (not raw text - for raw text we need indexing)
-                // and we can return results in hierarchical order (based on normalised String similarity 0.0-1.0).
-                if (component.contains(query, ignoreCase = true))
-                    results += party
-            }
-        }
+        val haveAMatch = components.any { (exactMatch && it == query)
+                || (!exactMatch && it.contains(query, ignoreCase = true)) }
+        if (haveAMatch) results += party
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
@@ -43,7 +43,7 @@ interface IdentityServiceInternal : IdentityService {
     // or any keyword related search in lists of records (not raw text - for raw text we need indexing)
     // and we can return results in hierarchical order (based on normalised String similarity 0.0-1.0).
     /** Check if [x500name] matches the [query]. */
-    fun x500matches(query: String, exactMatch: Boolean, x500name: CordaX500Name): Boolean {
+    fun x500Matches(query: String, exactMatch: Boolean, x500name: CordaX500Name): Boolean {
         val components = listOfNotNull(x500name.commonName, x500name.organisationUnit, x500name.organisation, x500name.locality, x500name.state, x500name.country)
         return components.any { (exactMatch && it == query)
                 || (!exactMatch && it.contains(query, ignoreCase = true)) }

--- a/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/IdentityServiceInternal.kt
@@ -42,11 +42,11 @@ interface IdentityServiceInternal : IdentityService {
     // strings such as entity/company names, and to detect small typos. We can also apply it for city
     // or any keyword related search in lists of records (not raw text - for raw text we need indexing)
     // and we can return results in hierarchical order (based on normalised String similarity 0.0-1.0).
-    fun partiesFromName(query: String, exactMatch: Boolean, x500name: CordaX500Name, results: LinkedHashSet<Party>, party: Party) {
+    /** Check if [x500name] matches the [query]. */
+    fun x500matches(query: String, exactMatch: Boolean, x500name: CordaX500Name): Boolean {
         val components = listOfNotNull(x500name.commonName, x500name.organisationUnit, x500name.organisation, x500name.locality, x500name.state, x500name.country)
-        val haveAMatch = components.any { (exactMatch && it == query)
+        return components.any { (exactMatch && it == query)
                 || (!exactMatch && it.contains(query, ignoreCase = true)) }
-        if (haveAMatch) results += party
     }
 
     /**

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -63,8 +63,10 @@ class InMemoryIdentityService(identities: List<PartyAndCertificate> = emptyList(
 
     override fun partiesFromName(query: String, exactMatch: Boolean): Set<Party> {
         val results = LinkedHashSet<Party>()
-        for ((x500name, partyAndCertificate) in principalToParties) {
-            partiesFromName(query, exactMatch, x500name, results, partyAndCertificate.party)
+        principalToParties.forEach { (x500name, partyAndCertificate) ->
+            if (x500matches(query, exactMatch, x500name)) {
+                results +=  partyAndCertificate.party
+            }
         }
         return results
     }

--- a/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/InMemoryIdentityService.kt
@@ -64,7 +64,7 @@ class InMemoryIdentityService(identities: List<PartyAndCertificate> = emptyList(
     override fun partiesFromName(query: String, exactMatch: Boolean): Set<Party> {
         val results = LinkedHashSet<Party>()
         principalToParties.forEach { (x500name, partyAndCertificate) ->
-            if (x500matches(query, exactMatch, x500name)) {
+            if (x500Matches(query, exactMatch, x500name)) {
                 results +=  partyAndCertificate.party
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -143,7 +143,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
         val key = mapToKey(identity)
         if (isNewRandomIdentity) {
             // Because this is supposed to be new and random, there's no way we have it in the database already, so skip the pessimistic check.
-            keyToParties.set(key, identity)
+            keyToParties[key] = identity
         } else {
             keyToParties.addWithDuplicatesAllowed(key, identity)
         }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -174,8 +174,10 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
     override fun partiesFromName(query: String, exactMatch: Boolean): Set<Party> {
         return database.transaction {
             val results = LinkedHashSet<Party>()
-            for ((x500name, partyId) in principalToParties.allPersisted()) {
-                partiesFromName(query, exactMatch, x500name, results, keyToParties[partyId]!!.party)
+            principalToParties.allPersisted().forEach { (x500name, partyId) ->
+                if (x500matches(query, exactMatch, x500name)) {
+                    results += keyToParties[partyId]!!.party
+                }
             }
             results
         }

--- a/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/identity/PersistentIdentityService.kt
@@ -175,7 +175,7 @@ class PersistentIdentityService(cacheFactory: NamedCacheFactory) : SingletonSeri
         return database.transaction {
             val results = LinkedHashSet<Party>()
             principalToParties.allPersisted().forEach { (x500name, partyId) ->
-                if (x500matches(query, exactMatch, x500name)) {
+                if (x500Matches(query, exactMatch, x500name)) {
                     results += keyToParties[partyId]!!.party
                 }
             }


### PR DESCRIPTION
Previously, a `partiesFromName` `query` used to traverse all X500 attributes, even if a match had already been found. It's true that because we use a `Set` there were not duplicate entries, but we should indeed stop after the first match.
The following has been applied and the function was renamed to `x500Matches`:
PS: We could also refactor this method to just return true or false and not update the `result`. I didn't do as it's not marked as internal, although its name states so ???