### PR TITLE
[CORDA-2218] CryptoService signingCertificateStore alias match

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -231,6 +231,9 @@ data class NodeConfigurationImpl(
         if (cryptoServiceName == null && cryptoServiceConf != null) {
             errors += "'cryptoServiceName' is mandatory when 'cryptoServiceConf' is specified"
         }
+        if (notary != null && !(cryptoServiceName == null || cryptoServiceName == SupportedCryptoServices.BC_SIMPLE)) {
+            errors += "Notary node with a non supported 'cryptoServiceName' has been detected"
+        }
         return errors
     }
 


### PR DESCRIPTION
This is to avoid cases where registration happened in an out of band process or it didn't finish as expected (or when deploying nodes for tests as @florian-f noticed) and in which key aliases exist only in one of the `cryptoService` and `signingCertificateStrore`, respectively. Then, we output a corresponding `IllegalStateException`.
