### PR TITLE
[CORDA-2225] Use platform's non-blocking PRNG when invoking SecureRandom()

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/CordaSecurityProvider.kt
@@ -4,11 +4,9 @@ import net.corda.core.KeepForDJVM
 import net.corda.core.StubOutForDJVM
 import net.corda.core.crypto.CordaObjectIdentifier.COMPOSITE_KEY
 import net.corda.core.crypto.CordaObjectIdentifier.COMPOSITE_SIGNATURE
-import net.corda.core.crypto.internal.platformSecureRandom
+import net.corda.core.crypto.internal.PlatformSecureRandomService
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import java.security.Provider
-import java.security.SecureRandom
-import java.security.SecureRandomSpi
 
 @KeepForDJVM
 class CordaSecurityProvider : Provider(PROVIDER_NAME, 0.1, "$PROVIDER_NAME security provider wrapper") {
@@ -21,28 +19,13 @@ class CordaSecurityProvider : Provider(PROVIDER_NAME, 0.1, "$PROVIDER_NAME secur
         put("Signature.${CompositeSignature.SIGNATURE_ALGORITHM}", CompositeSignature::class.java.name)
         put("Alg.Alias.Signature.$COMPOSITE_SIGNATURE", CompositeSignature.SIGNATURE_ALGORITHM)
         put("Alg.Alias.Signature.OID.$COMPOSITE_SIGNATURE", CompositeSignature.SIGNATURE_ALGORITHM)
+        putPlatformSecureRandomService()
+    }
+
+    @StubOutForDJVM
+    private fun putPlatformSecureRandomService() {
         putService(PlatformSecureRandomService(this))
     }
-}
-
-
-class PlatformSecureRandomService(provider: Provider)
-    : Provider.Service(provider, "SecureRandom", algorithm, PlatformSecureRandomSpi::javaClass.name, null, null) {
-
-    companion object {
-        const val algorithm = "platformPRNG"
-    }
-
-    private val instance: SecureRandomSpi = PlatformSecureRandomSpi()
-    override fun newInstance(constructorParameter: Any?) = instance
-}
-
-private class PlatformSecureRandomSpi : SecureRandomSpi() {
-    private val secureRandom: SecureRandom = platformSecureRandom()
-
-    override fun engineSetSeed(seed: ByteArray) = secureRandom.setSeed(seed)
-    override fun engineNextBytes(bytes: ByteArray) = secureRandom.nextBytes(bytes)
-    override fun engineGenerateSeed(numBytes: Int): ByteArray = secureRandom.generateSeed(numBytes)
 }
 
 /**

--- a/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
@@ -3,8 +3,11 @@
 package net.corda.core.crypto.internal
 
 import net.corda.core.DeleteForDJVM
+import net.corda.core.crypto.newSecureRandom
 import org.apache.commons.lang.SystemUtils
+import java.security.Provider
 import java.security.SecureRandom
+import java.security.SecureRandomSpi
 
 /**
  * This has been migrated into a separate class so that it
@@ -15,4 +18,23 @@ internal val platformSecureRandom: () -> SecureRandom = when {
         { SecureRandom.getInstance("NativePRNGNonBlocking") }
     }
     else -> SecureRandom::getInstanceStrong
+}
+
+class PlatformSecureRandomService(provider: Provider)
+    : Provider.Service(provider, "SecureRandom", algorithm, PlatformSecureRandomSpi::javaClass.name, null, null) {
+
+    companion object {
+        const val algorithm = "CordaPRNG"
+    }
+
+    private val instance: SecureRandomSpi = PlatformSecureRandomSpi()
+    override fun newInstance(constructorParameter: Any?) = instance
+}
+
+private class PlatformSecureRandomSpi : SecureRandomSpi() {
+    private val secureRandom: SecureRandom = newSecureRandom()
+
+    override fun engineSetSeed(seed: ByteArray) = secureRandom.setSeed(seed)
+    override fun engineNextBytes(bytes: ByteArray) = secureRandom.nextBytes(bytes)
+    override fun engineGenerateSeed(numBytes: Int): ByteArray = secureRandom.generateSeed(numBytes)
 }

--- a/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
@@ -20,6 +20,7 @@ val platformSecureRandom: () -> SecureRandom = when {
     else -> SecureRandom::getInstanceStrong
 }
 
+@DeleteForDJVM
 class PlatformSecureRandomService(provider: Provider)
     : Provider.Service(provider, "SecureRandom", algorithm, PlatformSecureRandomSpi::javaClass.name, null, null) {
 
@@ -31,6 +32,7 @@ class PlatformSecureRandomService(provider: Provider)
     override fun newInstance(constructorParameter: Any?) = instance
 }
 
+@DeleteForDJVM
 private class PlatformSecureRandomSpi : SecureRandomSpi() {
     private val secureRandom: SecureRandom = newSecureRandom()
 

--- a/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/PlatformSecureRandom.kt
@@ -13,7 +13,7 @@ import java.security.SecureRandomSpi
  * This has been migrated into a separate class so that it
  * is easier to delete from the core-deterministic module.
  */
-internal val platformSecureRandom: () -> SecureRandom = when {
+val platformSecureRandom: () -> SecureRandom = when {
     SystemUtils.IS_OS_LINUX -> {
         { SecureRandom.getInstance("NativePRNGNonBlocking") }
     }

--- a/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
@@ -19,6 +19,12 @@ import java.security.SecureRandom
 import java.security.Security
 
 internal val cordaSecurityProvider = CordaSecurityProvider().also {
+    // Among the others, we should register [CordaSecurityProvider] as the first provider, to ensure that when invoking [SecureRandom()]
+    // the [platformSecureRandom] is returned (which is registered in CordaSecurityProvider).
+    // Note that internally, [SecureRandom()] will look through all registered providers.
+    // Then it returns the first PRNG algorithm of the first provider that has registered a SecureRandom
+    // implementation (in our case [CordaSecurityProvider]), or null if none of the registered providers supplies
+    // a SecureRandom implementation.
     Security.insertProviderAt(it, 1) // The position is 1-based.
 }
 // OID taken from https://tools.ietf.org/html/draft-ietf-curdle-pkix-00

--- a/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/internal/ProviderMap.kt
@@ -18,7 +18,7 @@ import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
 import java.security.SecureRandom
 import java.security.Security
 
-internal val cordaSecurityProvider = CordaSecurityProvider().also {
+val cordaSecurityProvider = CordaSecurityProvider().also {
     // Among the others, we should register [CordaSecurityProvider] as the first provider, to ensure that when invoking [SecureRandom()]
     // the [platformSecureRandom] is returned (which is registered in CordaSecurityProvider).
     // Note that internally, [SecureRandom()] will look through all registered providers.
@@ -28,8 +28,8 @@ internal val cordaSecurityProvider = CordaSecurityProvider().also {
     Security.insertProviderAt(it, 1) // The position is 1-based.
 }
 // OID taken from https://tools.ietf.org/html/draft-ietf-curdle-pkix-00
-internal val `id-Curve25519ph` = ASN1ObjectIdentifier("1.3.101.112")
-internal val cordaBouncyCastleProvider = BouncyCastleProvider().apply {
+val `id-Curve25519ph` = ASN1ObjectIdentifier("1.3.101.112")
+val cordaBouncyCastleProvider = BouncyCastleProvider().apply {
     putAll(EdDSASecurityProvider())
     // Override the normal EdDSA engine with one which can handle X509 keys.
     put("Signature.${EdDSAEngine.SIGNATURE_ALGORITHM}", X509EdDSAEngine::class.java.name)
@@ -44,7 +44,7 @@ internal val cordaBouncyCastleProvider = BouncyCastleProvider().apply {
     // TODO: Find a way to make JKS work with bouncy castle provider or implement our own provide so we don't have to register bouncy castle provider.
     Security.addProvider(it)
 }
-internal val bouncyCastlePQCProvider = BouncyCastlePQCProvider().apply {
+val bouncyCastlePQCProvider = BouncyCastlePQCProvider().apply {
     require(name == "BCPQC") // The constant it comes from is not final.
 }.also {
     Security.addProvider(it)
@@ -53,7 +53,7 @@ internal val bouncyCastlePQCProvider = BouncyCastlePQCProvider().apply {
 // that could cause unexpected and suspicious behaviour.
 // i.e. if someone removes a Provider and then he/she adds a new one with the same name.
 // The val is private to avoid any harmful state changes.
-internal val providerMap = listOf(cordaBouncyCastleProvider, cordaSecurityProvider, bouncyCastlePQCProvider).map { it.name to it }.toMap()
+val providerMap = listOf(cordaBouncyCastleProvider, cordaSecurityProvider, bouncyCastlePQCProvider).map { it.name to it }.toMap()
 
 @DeleteForDJVM
-internal fun platformSecureRandomFactory(): SecureRandom = platformSecureRandom() // To minimise diff of CryptoUtils against open-source.
+fun platformSecureRandomFactory(): SecureRandom = platformSecureRandom() // To minimise diff of CryptoUtils against open-source.

--- a/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/CryptoUtilsTest.kt
@@ -6,6 +6,7 @@ import net.corda.core.crypto.Crypto.ECDSA_SECP256R1_SHA256
 import net.corda.core.crypto.Crypto.EDDSA_ED25519_SHA512
 import net.corda.core.crypto.Crypto.RSA_SHA256
 import net.corda.core.crypto.Crypto.SPHINCS256_SHA256
+import net.corda.core.crypto.internal.PlatformSecureRandomService
 import net.corda.core.utilities.OpaqueBytes
 import net.i2p.crypto.eddsa.EdDSAKey
 import net.i2p.crypto.eddsa.EdDSAPrivateKey


### PR DESCRIPTION
Although we've set the default algorithm for BC operations, other classes and methods like `UUID.randomUUID` directly invoke `SecureRandom()` which internally gets a default PRNG algorithm by looking through all registered providers. Then it returns the first PRNG algorithm of the first provider that has registered a SecureRandom implementation, or null if none of the registered providers supplies a SecureRandom implementation.

This means, that some operations in Corda might still use a blocking RNG.

This PR implements and uses a `PlatformSecureRandomService` that is inserted to `CordaSecurityProvider`, which is the first registered `Provider` in Corda, ensuring that all invocations to `SecureRandom()` use our `platformSecureRandom` (which is the same as `newSecureRandom`).