### PR TITLE
CORDA-2157 Hash to  Signature constraints migration

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -3463,22 +3463,45 @@ public static final class net.corda.core.node.services.vault.AttachmentQueryCrit
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>)
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<String> component1()
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<String> component2()
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> component3()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>> component4()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>> component5()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Boolean> component6()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>> component7()
   @NotNull
   public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria copy(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria copy(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>)
   public boolean equals(Object)
   @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>> getContractClassNamesCondition()
+  @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<String> getFilenameCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>> getSignersCondition()
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> getUploadDateCondition()
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<String> getUploaderCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>> getVersionCondition()
   public int hashCode()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Boolean> isSignedCondition()
+  @NotNull
   public String toString()
   @NotNull
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)

--- a/core-deterministic/testing/data/src/test/kotlin/net/corda/deterministic/data/TransactionGenerator.kt
+++ b/core-deterministic/testing/data/src/test/kotlin/net/corda/deterministic/data/TransactionGenerator.kt
@@ -71,7 +71,8 @@ object TransactionGenerator {
             TransactionVerificationRequest(
                     wtx3.serialize(),
                     arrayOf(wtx1.serialize(), wtx2.serialize()),
-                    arrayOf(contractAttachment.serialize().bytes))
+                    arrayOf(contractAttachment.serialize().bytes),
+                    ledgerServices.networkParameters.serialize())
                 .serialize()
                 .writeTo(output)
         }
@@ -104,7 +105,8 @@ object TransactionGenerator {
             TransactionVerificationRequest(
                     wtx3.serialize(),
                     arrayOf(wtx1.serialize(), wtx2.serialize()),
-                    arrayOf(contractAttachment.serialize().bytes))
+                    arrayOf(contractAttachment.serialize().bytes),
+                    ledgerServices.networkParameters.serialize())
                 .serialize()
                 .writeTo(output)
         }

--- a/core-deterministic/testing/verifier/src/main/kotlin/net/corda/deterministic/verifier/TransactionVerificationRequest.kt
+++ b/core-deterministic/testing/verifier/src/main/kotlin/net/corda/deterministic/verifier/TransactionVerificationRequest.kt
@@ -4,6 +4,7 @@ import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.internal.DEPLOYED_CORDAPP_UPLOADER
+import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
@@ -14,7 +15,8 @@ import net.corda.core.transactions.WireTransaction
 @CordaSerializable
 class TransactionVerificationRequest(val wtxToVerify: SerializedBytes<WireTransaction>,
                                      val dependencies: Array<SerializedBytes<WireTransaction>>,
-                                     val attachments: Array<ByteArray>) {
+                                     val attachments: Array<ByteArray>,
+                                     val networkParameters: SerializedBytes<NetworkParameters>) {
     fun toLedgerTransaction(): LedgerTransaction {
         val deps = dependencies.map { it.deserialize() }.associateBy(WireTransaction::id)
         val attachments = attachments.map { it.deserialize<Attachment>() }
@@ -27,7 +29,8 @@ class TransactionVerificationRequest(val wtxToVerify: SerializedBytes<WireTransa
             resolveIdentity = { null },
             resolveAttachment = { attachmentMap[it] },
             resolveStateRef = { deps[it.txhash]?.outputs?.get(it.index) },
-            resolveContractAttachment = { contractAttachmentMap[it.contract]?.id }
+            resolveContractAttachment = { contractAttachmentMap[it.contract]?.id },
+            networkParameters = networkParameters.deserialize()
         )
     }
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/AttachmentConstraint.kt
@@ -8,6 +8,7 @@ import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.crypto.keys
 import net.corda.core.internal.AttachmentWithContext
 import net.corda.core.internal.isUploaderTrusted
+import net.corda.core.node.JavaPackageName
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.warnOnce
 import org.slf4j.LoggerFactory
@@ -39,13 +40,15 @@ interface AttachmentConstraint {
      * Rules:
      *  * It is allowed for output states to inherit the exact same constraint as the input states.
      *  * The [AlwaysAcceptAttachmentConstraint] is not allowed to transition to a different constraint, as that could be used to hide malicious behaviour.
-     *  * Nothing can be migrated from the [HashAttachmentConstraint] except a [HashAttachmentConstraint] with the same hash.
      *  * Anything (except the [AlwaysAcceptAttachmentConstraint]) can be transitioned to a [HashAttachmentConstraint].
      *  * You can transition from the [WhitelistedByZoneAttachmentConstraint] to the [SignatureAttachmentConstraint] only if all signers of the JAR are required to sign in the future.
+     *  * You can transition from a [HashAttachmentConstraint] to a [SignatureAttachmentConstraint] when the following conditions are met:
+     *      1. Both original "hash-constrained" contract jar and signed "signature-constrained" contract jar are whitelisted in the CZ network map
+     *      2. Java package namespace of signed contract jar is registered in the CZ network map with same public keys (as used to sign contract jar)
      *
      * TODO - SignatureConstraint third party signers.
      */
-    fun canBeTransitionedFrom(input: AttachmentConstraint, attachment: ContractAttachment): Boolean {
+    fun canBeTransitionedFrom(input: AttachmentConstraint, attachment: AttachmentWithContext): Boolean {
         val output = this
         return when {
             // These branches should not happen, as this has been already checked.
@@ -59,9 +62,7 @@ interface AttachmentConstraint {
             input is AlwaysAcceptAttachmentConstraint && output !is AlwaysAcceptAttachmentConstraint -> false
 
             // Nothing can be migrated from the HashConstraint except a HashConstraint with the same Hash. (This check is redundant, but added for clarity)
-            // TODO - this might change if we decide to allow migration to the SignatureConstraint.
             input is HashAttachmentConstraint && output is HashAttachmentConstraint -> input == output
-            input is HashAttachmentConstraint && output !is HashAttachmentConstraint -> false
 
             // Anything (except the AlwaysAcceptAttachmentConstraint) can be transformed to a HashAttachmentConstraint.
             input !is HashAttachmentConstraint && output is HashAttachmentConstraint -> true
@@ -73,6 +74,32 @@ interface AttachmentConstraint {
             // You can transition from the WhitelistConstraint to the SignatureConstraint only if all signers of the JAR are required to sign in the future.
             input is WhitelistedByZoneAttachmentConstraint && output is SignatureAttachmentConstraint ->
                 attachment.signers.isNotEmpty() && output.key.keys.containsAll(attachment.signers)
+
+            // Transition from Hash to Signature constraint (via CZ whitelisting) requires
+            // 1. Hashcode of both original (unsigned) and signed contract JARS are registered in the NP CZ whitelist
+            // 2. Signer(s) of signature-constrained JAR is same as signer(s) of registered package namespace
+            // 3. Signer(s) associated with signature constraint match those of signed contract JAR.
+            input is HashAttachmentConstraint && output is SignatureAttachmentConstraint -> {
+                val signedAttachment = attachment.signedContractAttachment
+                signedAttachment?.let {
+                    // rule 1
+                    val attachmentIdsToVerify = listOf(input.attachmentId, signedAttachment.attachment.id)
+                    val attachmentClassName = signedAttachment.contract
+                    val czAttachmentIdsForContractClass = attachment.networkParameters.whitelistedContractImplementations[attachmentClassName] ?: return false
+                    attachmentIdsToVerify.forEach { attachmentId ->
+                        if (!czAttachmentIdsForContractClass.contains(attachmentId)) return false
+                    }
+                    // rule 2
+                    val signedAttachmentSigners = signedAttachment.signers
+                    if (signedAttachmentSigners.isEmpty()) return false
+                    signedAttachmentSigners.forEach { signer ->
+                        if (attachment.networkParameters.packageOwnership[JavaPackageName(attachmentClassName)] != signer) return false
+                    }
+                    // rule 3
+                    if (output.key.keys.containsAll(signedAttachment.signers)) return true
+                    return false
+                } ?: false
+            }
 
             else -> false
         }
@@ -108,9 +135,8 @@ data class HashAttachmentConstraint(val attachmentId: SecureHash) : AttachmentCo
 object WhitelistedByZoneAttachmentConstraint : AttachmentConstraint {
     override fun isSatisfiedBy(attachment: Attachment): Boolean {
         return if (attachment is AttachmentWithContext) {
-            val whitelist = attachment.whitelistedContractImplementations
-                    ?: throw IllegalStateException("Unable to verify WhitelistedByZoneAttachmentConstraint - whitelist not specified")
-            attachment.id in (whitelist[attachment.stateContract] ?: emptyList())
+            val whitelist = attachment.networkParameters.whitelistedContractImplementations
+            attachment.id in (whitelist[attachment.contract] ?: emptyList())
         } else false
     }
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt
@@ -3,6 +3,7 @@ package net.corda.core.contracts
 import net.corda.core.KeepForDJVM
 import net.corda.core.serialization.CordaSerializable
 import java.security.PublicKey
+import java.util.jar.Attributes
 
 /**
  * Wrap an attachment in this if it is to be used as an executable contract attachment
@@ -22,7 +23,14 @@ class ContractAttachment @JvmOverloads constructor(
 
     val allContracts: Set<ContractClassName> get() = additionalContracts + contract
 
+    val isSigned: Boolean get() = signers.isNotEmpty()
+
+    /**
+     * Contract version
+     */
+    val version: String = try { attachment.openAsJAR().manifest?.mainAttributes?.getValue(Attributes.Name.IMPLEMENTATION_VERSION) ?: "1.0" } catch (e: Exception) { "1.0" }
+
     override fun toString(): String {
-        return "ContractAttachment(attachment=${attachment.id}, contracts='$allContracts', uploader='$uploader')"
+        return "ContractAttachment(attachment=${attachment.id}, contracts='$allContracts', uploader='$uploader', signed='$isSigned', version='$version')"
     }
 }

--- a/core/src/main/kotlin/net/corda/core/internal/AttachmentWithContext.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AttachmentWithContext.kt
@@ -1,21 +1,21 @@
 package net.corda.core.internal
 
-import net.corda.core.contracts.Attachment
-import net.corda.core.contracts.ContractAttachment
-import net.corda.core.contracts.ContractClassName
-import net.corda.core.node.services.AttachmentId
+import net.corda.core.contracts.*
+import net.corda.core.node.NetworkParameters
 
 /**
  * Used only for passing to the Attachment constraint verification.
  */
 class AttachmentWithContext(
         val contractAttachment: ContractAttachment,
-        val stateContract: ContractClassName,
-        /** Required for verifying [WhitelistedByZoneAttachmentConstraint] */
-        val whitelistedContractImplementations: Map<String, List<AttachmentId>>?
+        val contract: ContractClassName,
+        /** Required for verifying [WhitelistedByZoneAttachmentConstraint] and [HashAttachmentConstraint] migration to [SignatureAttachmentConstraint] */
+        val networkParameters: NetworkParameters,
+        /** Required for Hash constraints migration to Signature constraints */
+        val signedContractAttachment: ContractAttachment? = null
 ) : Attachment by contractAttachment {
     init {
-        require(stateContract in contractAttachment.allContracts) {
+        require(contract in contractAttachment.allContracts) {
             "This AttachmentWithContext was not initialised properly"
         }
     }

--- a/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
@@ -64,6 +64,15 @@ interface AttachmentStorage {
     fun queryAttachments(criteria: AttachmentQueryCriteria, sorting: AttachmentSort? = null): List<AttachmentId>
 
     /**
+     * Searches attachment using given criteria and optional sort rules
+     * @param criteria Query criteria to use as a filter
+     * @param sorting Sorting definition, if not given, order is undefined
+     *
+     * @return List of Attachments matching criteria, sorted according to given sorting parameter
+     */
+    fun queryAttachmentsFully(criteria: AttachmentQueryCriteria, sorting: AttachmentSort? = null): List<Attachment>
+
+    /**
      * Searches for an attachment already in the store
      * @param attachmentId The attachment Id
      * @return true if it's in there

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -3,6 +3,7 @@
 package net.corda.core.node.services.vault
 
 import net.corda.core.DoNotImplement
+import net.corda.core.contracts.ContractClassName
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.UniqueIdentifier
@@ -11,6 +12,7 @@ import net.corda.core.node.services.Vault
 import net.corda.core.schemas.PersistentState
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
+import java.security.PublicKey
 import java.time.Instant
 import java.util.*
 import javax.persistence.criteria.Predicate
@@ -273,11 +275,23 @@ sealed class AttachmentQueryCriteria : GenericQueryCriteria<AttachmentQueryCrite
     /**
      * AttachmentsQueryCriteria:
      */
-    data class AttachmentsQueryCriteria @JvmOverloads constructor (val uploaderCondition: ColumnPredicate<String>? = null,
-                                                                   val filenameCondition: ColumnPredicate<String>? = null,
-                                                                   val uploadDateCondition: ColumnPredicate<Instant>? = null) : AttachmentQueryCriteria() {
+    data class AttachmentsQueryCriteria @JvmOverloads constructor(val uploaderCondition: ColumnPredicate<String>? = null,
+                                                                  val filenameCondition: ColumnPredicate<String>? = null,
+                                                                  val uploadDateCondition: ColumnPredicate<Instant>? = null,
+                                                                  val contractClassNamesCondition: ColumnPredicate<List<ContractClassName>>? = null,
+                                                                  val signersCondition: ColumnPredicate<List<PublicKey>>? = null,
+                                                                  val isSignedCondition: ColumnPredicate<Boolean>? = null,
+                                                                  val versionCondition: ColumnPredicate<List<String>>? = null) : AttachmentQueryCriteria() {
         override fun visit(parser: AttachmentsQueryCriteriaParser): Collection<Predicate> {
             return parser.parseCriteria(this)
+        }
+
+        fun copy(
+                uploaderCondition: ColumnPredicate<String>? = this.uploaderCondition,
+                filenameCondition: ColumnPredicate<String>? = this.filenameCondition,
+                uploadDateCondition: ColumnPredicate<Instant>? = this.uploadDateCondition
+        ): AttachmentsQueryCriteria {
+            return AttachmentsQueryCriteria(uploaderCondition, filenameCondition, uploadDateCondition)
         }
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -250,12 +250,12 @@ data class ContractUpgradeLedgerTransaction(
     }
 
     private fun verifyConstraints() {
+        checkNotNull(networkParameters)
         val attachmentForConstraintVerification = AttachmentWithContext(
                 legacyContractAttachment as? ContractAttachment
                         ?: ContractAttachment(legacyContractAttachment, legacyContractClassName, signers = legacyContractAttachment.signers),
                 upgradedContract.legacyContract,
-                networkParameters.whitelistedContractImplementations
-        )
+                networkParameters)
 
         // TODO: exclude encumbrance states from this check
         check(inputs.all { it.state.constraint.isSatisfiedBy(attachmentForConstraintVerification) }) {

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -279,7 +279,7 @@ open class TransactionBuilder @JvmOverloads constructor(
         val defaultOutputConstraint = selectAttachmentConstraint(contractClassName, inputStates, attachmentToUse, services)
 
         // Sanity check that the selected attachment actually passes.
-        val constraintAttachment = AttachmentWithContext(attachmentToUse, contractClassName, services.networkParameters.whitelistedContractImplementations)
+        val constraintAttachment = AttachmentWithContext(attachmentToUse, contractClassName, services.networkParameters)
         require(defaultOutputConstraint.isSatisfiedBy(constraintAttachment)) { "Selected output constraint: $defaultOutputConstraint not satisfying $selectedAttachmentId" }
 
         val resolvedOutputStates = outputStates.map {
@@ -289,7 +289,7 @@ open class TransactionBuilder @JvmOverloads constructor(
             } else {
                 // If the constraint on the output state is already set, and is not a valid transition or can't be transitioned, then fail early.
                 inputStates?.forEach { input ->
-                    require(outputConstraint.canBeTransitionedFrom(input.constraint, attachmentToUse)) { "Output state constraint $outputConstraint cannot be transitions from ${input.constraint}" }
+                    require(outputConstraint.canBeTransitionedFrom(input.constraint, constraintAttachment)) { "Output state constraint $outputConstraint cannot be transitioned from ${input.constraint}" }
                 }
                 require(outputConstraint.isSatisfiedBy(constraintAttachment)) { "Output state constraint check fails. $outputConstraint" }
                 it

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -128,9 +128,8 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
             @Suppress("UNUSED_PARAMETER") resolveContractAttachment: (TransactionState<ContractState>) -> AttachmentId?
     ): LedgerTransaction {
         // This reverts to serializing the resolved transaction state.
-        return toLedgerTransactionInternal(resolveIdentity, resolveAttachment, { stateRef -> resolveStateRef(stateRef)?.serialize() }, null)
+        return toLedgerTransactionInternal(resolveIdentity, resolveAttachment, { stateRef -> resolveStateRef(stateRef)?.serialize() }, null, null)
     }
-
 
     private fun toLedgerTransactionInternal(
             resolveIdentity: (PublicKey) -> Party?,

--- a/core/src/test/kotlin/net/corda/core/contracts/ConstraintsPropagationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/ConstraintsPropagationTests.kt
@@ -4,10 +4,14 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SecureHash.Companion.allOnesHash
+import net.corda.core.crypto.SecureHash.Companion.zeroHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.internal.AbstractAttachment
+import net.corda.core.internal.AttachmentWithContext
+import net.corda.core.node.JavaPackageName
 import net.corda.core.transactions.LedgerTransaction
-import net.corda.core.transactions.MissingContractAttachments
 import net.corda.finance.POUNDS
 import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
@@ -21,6 +25,7 @@ import net.corda.testing.node.MockServices
 import net.corda.testing.node.ledger
 import org.junit.Rule
 import org.junit.Test
+import java.security.PublicKey
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -36,6 +41,7 @@ class ConstraintsPropagationTests {
         val BOB_PARTY get() = BOB.party
         val BOB_PUBKEY get() = BOB.publicKey
         val noPropagationContractClassName = "net.corda.core.contracts.NoPropagationContract"
+        val propagatingContractClassName = "net.corda.core.contracts.PropagationContract"
     }
 
     @Rule
@@ -219,10 +225,50 @@ class ConstraintsPropagationTests {
         }
     }
 
+    private class MockAttachment(dataLoader: () -> ByteArray, override val id: SecureHash, override val signers: List<PublicKey>) : AbstractAttachment(dataLoader)
+
+    @Test
+    fun `Signature Constraints canBeTransitionedFrom Hash Constraints behaves as expected`() {
+
+        // signature constrained attachment
+        val attachmentSignatureConstraintsJar = mock<AttachmentWithContext>()
+        whenever(attachmentSignatureConstraintsJar.signers).thenReturn(listOf(ALICE_PARTY.owningKey))
+
+        // hash constrained attachments
+        val attachmentSigned = mock<ContractAttachment>()
+        val attachmentIdSigned = zeroHash       // NP CZ whitelisted
+        whenever(attachmentSigned.signers).thenReturn(listOf(ALICE_PARTY.owningKey))
+        whenever(attachmentSigned.contract).thenReturn(propagatingContractClassName)
+        val attachment = MockAttachment({ ByteArray(0) }, attachmentIdSigned, listOf(ALICE_PARTY.owningKey))
+        whenever(attachmentSigned.attachment).thenReturn(attachment)
+
+        val attachmentUnsigned = mock<ContractAttachment>()
+        val attachmentIdUnsigned = allOnesHash  // NP CZ whitelisted
+        whenever(attachmentUnsigned.contract).thenReturn(propagatingContractClassName)
+
+        // network parameters
+        val netParams = testNetworkParameters(minimumPlatformVersion = 4,
+                whitelistedContractImplementations = mapOf(propagatingContractClassName to listOf(attachmentIdSigned, attachmentIdUnsigned)),
+                packageOwnership = mapOf(JavaPackageName(propagatingContractClassName) to ALICE_PARTY.owningKey))
+
+        val attachmentUnsignedWithContext = mock<AttachmentWithContext>()
+        whenever(attachmentUnsignedWithContext.contractAttachment).thenReturn(attachmentUnsigned)
+        whenever(attachmentUnsignedWithContext.contract).thenReturn(propagatingContractClassName)
+        whenever(attachmentUnsignedWithContext.networkParameters).thenReturn(netParams)
+        whenever(attachmentUnsignedWithContext.signedContractAttachment).thenReturn(attachmentSigned)
+
+        ledgerServices.attachments.importContractAttachment(attachmentIdSigned, attachmentSigned)
+        ledgerServices.attachments.importContractAttachment(attachmentIdUnsigned, attachmentUnsigned)
+
+        // propagation check
+        assertTrue(SignatureAttachmentConstraint(ALICE_PUBKEY).canBeTransitionedFrom(HashAttachmentConstraint(allOnesHash), attachmentUnsignedWithContext))
+
+    }
+
     @Test
     fun `Attachment canBeTransitionedFrom behaves as expected`() {
 
-        val attachment = mock<ContractAttachment>()
+        val attachment = mock<AttachmentWithContext>()
         whenever(attachment.signers).thenReturn(listOf(ALICE_PARTY.owningKey))
 
         // Exhaustive positive check

--- a/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/AttachmentTests.kt
@@ -89,7 +89,7 @@ class AttachmentTests : WithMockNet {
         val corruptBytes = "arggghhhh".toByteArray()
         System.arraycopy(corruptBytes, 0, attachment, 0, corruptBytes.size)
 
-        val corruptAttachment = NodeAttachmentService.DBAttachment(attId = id.toString(), content = attachment)
+        val corruptAttachment = NodeAttachmentService.DBAttachment(attId = id.toString(), content = attachment, version = "1.0")
         badAliceNode.updateAttachment(corruptAttachment)
 
         // Get n1 to fetch the attachment. Should receive corrupted bytes.

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -1,5 +1,6 @@
 package net.corda.node.services.vault
 
+import net.corda.core.contracts.ContractClassName
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateRef
 import net.corda.core.identity.AbstractParty
@@ -25,6 +26,7 @@ import org.hibernate.query.criteria.internal.expression.LiteralExpression
 import org.hibernate.query.criteria.internal.path.SingularAttributePath
 import org.hibernate.query.criteria.internal.predicate.ComparisonPredicate
 import org.hibernate.query.criteria.internal.predicate.InPredicate
+import java.security.PublicKey
 import java.time.Instant
 import java.util.*
 import javax.persistence.Tuple
@@ -205,7 +207,37 @@ class HibernateAttachmentQueryCriteriaParser(override val criteriaBuilder: Crite
         }
 
         criteria.uploadDateCondition?.let {
-            predicateSet.add(columnPredicateToPredicate(root.get<Instant>("upload_date"), it))
+            predicateSet.add(columnPredicateToPredicate(root.get<Instant>("insertionDate"), it))
+        }
+
+        criteria.contractClassNamesCondition?.let {
+            val contractClassNames =
+                if (criteria.contractClassNamesCondition is EqualityComparison)
+                    (criteria.contractClassNamesCondition as EqualityComparison<List<ContractClassName>>).rightLiteral
+                else emptyList()
+            val joinDBAttachmentToContractClassNames = root.joinList<NodeAttachmentService.DBAttachment, ContractClassName>("contractClassNames")
+            predicateSet.add(criteriaBuilder.and(joinDBAttachmentToContractClassNames.`in`(contractClassNames)))
+        }
+
+        criteria.signersCondition?.let {
+            val signers =
+                    if (criteria.signersCondition is EqualityComparison)
+                        (criteria.signersCondition as EqualityComparison<List<PublicKey>>).rightLiteral
+                    else emptyList()
+            val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers")
+            predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.`in`(signers)))
+        }
+
+        criteria.isSignedCondition?.let { isSigned ->
+            val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers")
+            if (isSigned == Builder.equal(true))
+                predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNotNull))
+            else
+                predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNull))
+        }
+
+        criteria.versionCondition?.let {
+            predicateSet.add(columnPredicateToPredicate(root.get<String>("version"), it))
         }
 
         return predicateSet

--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -12,5 +12,6 @@
     <include file="migration/node-core.changelog-postgres-blob.xml"/>
     <include file="migration/node-core.changelog-v8.xml"/>
     <include file="migration/node-core.changelog-tx-mapping.xml"/>
+    <include file="migration/node-core.changelog-v9.xml"/>
 
 </databaseChangeLog>

--- a/node/src/main/resources/migration/node-core.changelog-v9.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v9.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   logicalFilePath="migration/node-services.changelog-init.xml">
+
+    <changeSet author="R3.Corda" id="add_version_column">
+        <addColumn tableName="node_attachments">
+            <column name="version" type="NVARCHAR(64)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -6,13 +6,17 @@ import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.whenever
+import net.corda.testing.core.ContractJarTestUtils.makeTestContractJar
+import net.corda.testing.core.ContractJarTestUtils.makeTestJar
+import net.corda.testing.core.ContractJarTestUtils.makeTestSignedContractJar
+import net.corda.testing.core.SelfCleaningDir
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
 import net.corda.core.flows.FlowLogic
 import net.corda.core.internal.*
 import net.corda.core.node.ServicesForResolution
-import net.corda.core.node.services.vault.AttachmentQueryCriteria
+import net.corda.core.node.services.vault.AttachmentQueryCriteria.AttachmentsQueryCriteria
 import net.corda.core.node.services.vault.AttachmentSort
 import net.corda.core.node.services.vault.Builder
 import net.corda.core.node.services.vault.Sort
@@ -21,10 +25,6 @@ import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.core.ALICE_NAME
-import net.corda.testing.core.JarSignatureTestUtils.createJar
-import net.corda.testing.core.JarSignatureTestUtils.generateKey
-import net.corda.testing.core.JarSignatureTestUtils.signJar
 import net.corda.testing.internal.LogHelper
 import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.configureDatabase
@@ -33,25 +33,19 @@ import net.corda.testing.node.MockServices.Companion.makeTestDataSourcePropertie
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.junit.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
 import java.io.ByteArrayOutputStream
-import java.io.Closeable
-import java.io.OutputStream
-import java.net.URI
 import java.nio.charset.StandardCharsets
-import java.nio.file.*
-import java.security.PublicKey
-import java.util.jar.JarEntry
-import java.util.jar.JarOutputStream
-import javax.tools.JavaFileObject
-import javax.tools.SimpleJavaFileObject
-import javax.tools.StandardLocation
-import javax.tools.ToolProvider
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.FileSystem
+import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
-
 
 class NodeAttachmentServiceTest {
 
@@ -204,13 +198,63 @@ class NodeAttachmentServiceTest {
 
         assertEquals(
                 listOf(hashB),
-                storage.queryAttachments(AttachmentQueryCriteria.AttachmentsQueryCriteria(Builder.equal("uploaderB")))
+                storage.queryAttachments(AttachmentsQueryCriteria(Builder.equal("uploaderB")))
         )
 
         assertEquals(
                 listOf(hashB, hashC),
-                storage.queryAttachments(AttachmentQueryCriteria.AttachmentsQueryCriteria(Builder.like("%uploader%")))
+                storage.queryAttachments(AttachmentsQueryCriteria(Builder.like("%uploader%")))
         )
+    }
+
+    @Test
+    fun `contract class, versioning and signing metadata can be used to search`() {
+        SelfCleaningDir().use { file ->
+            val (sampleJar, _) = makeTestJar()
+            val contractJar = makeTestContractJar(file.path, "com.example.MyContract")
+            val (signedContractJar, publicKey) = makeTestSignedContractJar(file.path, "com.example.MyContract")
+            val (anotherSignedContractJar, _) = makeTestSignedContractJar(file.path,"com.example.AnotherContract")
+            val contractJarV2 = makeTestContractJar(file.path,"com.example.MyContract", version = "2.0")
+            val (signedContractJarV2, publicKeyV2) = makeTestSignedContractJar(file.path,"com.example.MyContract", version = "2.0")
+
+            sampleJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
+            contractJar.read { storage.importAttachment(it, "uploaderB", "contract.jar") }
+            signedContractJar.read { storage.importAttachment(it, "uploaderC", "contract-signed.jar") }
+            anotherSignedContractJar.read { storage.importAttachment(it, "uploaderD", "another-contract-signed.jar") }
+            contractJarV2.read { storage.importAttachment(it, "uploaderB", "contract-V2.jar") }
+            signedContractJarV2.read { storage.importAttachment(it, "uploaderC", "contract-signed-V2.jar") }
+
+            assertEquals(
+                    4,
+                    storage.queryAttachmentsFully(AttachmentsQueryCriteria(contractClassNamesCondition = Builder.equal(listOf("com.example.MyContract")))).size
+            )
+
+            assertEquals(
+                    1,
+                    storage.queryAttachments(AttachmentsQueryCriteria(signersCondition = Builder.equal(listOf(publicKey)))).size
+            )
+
+            assertEquals(
+                    3,
+                    storage.queryAttachments(AttachmentsQueryCriteria(isSignedCondition = Builder.equal(true))).size
+            )
+
+            assertEquals(
+                    1,
+                    storage.queryAttachmentsFully(AttachmentsQueryCriteria(
+                            contractClassNamesCondition = Builder.equal(listOf("com.example.MyContract")),
+                            versionCondition = Builder.equal(listOf("2.0")),
+                            isSignedCondition = Builder.equal(true))).size
+            )
+
+            assertEquals(
+                    2,
+                    storage.queryAttachmentsFully(AttachmentsQueryCriteria(
+                            contractClassNamesCondition = Builder.equal(listOf("com.example.MyContract", "com.example.AnotherContract")),
+                            versionCondition = Builder.equal(listOf("1.0")),
+                            isSignedCondition = Builder.equal(true))).size
+            )
+        }
     }
 
     @Test
@@ -219,8 +263,8 @@ class NodeAttachmentServiceTest {
         val (jarB, hashB) = makeTestJar(listOf(Pair("b", "b")))
         val (jarC, hashC) = makeTestJar(listOf(Pair("c", "c")))
 
-        fun uploaderCondition(s: String) = AttachmentQueryCriteria.AttachmentsQueryCriteria(uploaderCondition = Builder.equal(s))
-        fun filenamerCondition(s: String) = AttachmentQueryCriteria.AttachmentsQueryCriteria(filenameCondition = Builder.equal(s))
+        fun uploaderCondition(s: String) = AttachmentsQueryCriteria(uploaderCondition = Builder.equal(s))
+        fun filenamerCondition(s: String) = AttachmentsQueryCriteria(filenameCondition = Builder.equal(s))
 
         fun filenameSort(direction: Sort.Direction) = AttachmentSort(listOf(AttachmentSort.AttachmentSortColumn(AttachmentSort.AttachmentSortAttribute.FILENAME, direction)))
 
@@ -233,16 +277,15 @@ class NodeAttachmentServiceTest {
         assertEquals(
                 emptyList(),
                 storage.queryAttachments(
-                        AttachmentQueryCriteria.AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexA"))
-                                .and(AttachmentQueryCriteria.AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexB"))))
+                        AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexA"))
+                                .and(AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexB"))))
         )
 
         assertEquals(
                 listOf(hashA, hashB),
                 storage.queryAttachments(
-
-                        AttachmentQueryCriteria.AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexA"))
-                                .or(AttachmentQueryCriteria.AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexB"))))
+                        AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexA"))
+                                .or(AttachmentsQueryCriteria(uploaderCondition = Builder.equal("complexB"))))
         )
 
         val complexCondition =
@@ -284,7 +327,7 @@ class NodeAttachmentServiceTest {
             val bytes = testJar.readAll()
             val corruptBytes = "arggghhhh".toByteArray()
             System.arraycopy(corruptBytes, 0, bytes, 0, corruptBytes.size)
-            val corruptAttachment = NodeAttachmentService.DBAttachment(attId = id.toString(), content = bytes)
+            val corruptAttachment = NodeAttachmentService.DBAttachment(attId = id.toString(), content = bytes, version = "1.0")
             session.merge(corruptAttachment)
             id
         }
@@ -357,75 +400,4 @@ class NodeAttachmentServiceTest {
         makeTestJar(file.outputStream(), extraEntries)
         return Pair(file, file.readAll().sha256())
     }
-
-    /**
-     * Class to create an automatically delete a temporary directory.
-     */
-    class SelfCleaningDir : Closeable {
-        val path: Path = Files.createTempDirectory(NodeAttachmentServiceTest::class.simpleName)
-        override fun close() {
-            path.deleteRecursively()
-        }
-    }
-
-    companion object {
-        private fun makeTestJar(output: OutputStream, extraEntries: List<Pair<String, String>> = emptyList()) {
-            output.use {
-                val jar = JarOutputStream(it)
-                jar.putNextEntry(JarEntry("test1.txt"))
-                jar.write("This is some useful content".toByteArray())
-                jar.closeEntry()
-                jar.putNextEntry(JarEntry("test2.txt"))
-                jar.write("Some more useful content".toByteArray())
-                extraEntries.forEach { entry ->
-                    jar.putNextEntry(JarEntry(entry.first))
-                    jar.write(entry.second.toByteArray())
-                }
-                jar.closeEntry()
-            }
-        }
-
-        private fun makeTestSignedContractJar(workingDir: Path, contractName: String): Pair<Path, PublicKey> {
-            val alias = "testAlias"
-            val pwd = "testPassword"
-            workingDir.generateKey(alias, pwd, ALICE_NAME.toString())
-            val jarName = makeTestContractJar(workingDir, contractName)
-            val signer = workingDir.signJar(jarName, alias, pwd)
-            return workingDir.resolve(jarName) to signer
-        }
-
-        private fun makeTestContractJar(workingDir: Path, contractName: String): String {
-            val packages = contractName.split(".")
-            val jarName = "testattachment.jar"
-            val className = packages.last()
-            createTestClass(workingDir, className, packages.subList(0, packages.size - 1))
-            workingDir.createJar(jarName, "${contractName.replace(".", "/")}.class")
-            return jarName
-        }
-
-        private fun createTestClass(workingDir: Path, className: String, packages: List<String>): Path {
-            val newClass = """package ${packages.joinToString(".")};
-                import net.corda.core.contracts.*;
-                import net.corda.core.transactions.*;
-
-                public class $className implements Contract {
-                    @Override
-                    public void verify(LedgerTransaction tx) throws IllegalArgumentException {
-                    }
-                }
-            """.trimIndent()
-            val compiler = ToolProvider.getSystemJavaCompiler()
-            val source = object : SimpleJavaFileObject(URI.create("string:///${packages.joinToString("/")}/$className.java"), JavaFileObject.Kind.SOURCE) {
-                override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence {
-                    return newClass
-                }
-            }
-            val fileManager = compiler.getStandardFileManager(null, null, null)
-            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, listOf(workingDir.toFile()))
-
-            compiler.getTask(System.out.writer(), fileManager, null, null, null, listOf(source)).call()
-            return Paths.get(fileManager.list(StandardLocation.CLASS_OUTPUT, "", setOf(JavaFileObject.Kind.CLASS), true).single().name)
-        }
-    }
-
 }

--- a/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
+++ b/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
@@ -1,9 +1,11 @@
 package net.corda.testing.common.internal
 
+import net.corda.core.node.JavaPackageName
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
 import net.corda.core.node.services.AttachmentId
 import net.corda.core.utilities.days
+import java.security.PublicKey
 import java.time.Duration
 import java.time.Instant
 
@@ -16,7 +18,8 @@ fun testNetworkParameters(
         maxTransactionSize: Int = maxMessageSize * 50,
         whitelistedContractImplementations: Map<String, List<AttachmentId>> = emptyMap(),
         epoch: Int = 1,
-        eventHorizon: Duration = 30.days
+        eventHorizon: Duration = 30.days,
+        packageOwnership: Map<JavaPackageName, PublicKey> = emptyMap()
 ): NetworkParameters {
     return NetworkParameters(
             minimumPlatformVersion = minimumPlatformVersion,
@@ -26,6 +29,7 @@ fun testNetworkParameters(
             whitelistedContractImplementations = whitelistedContractImplementations,
             modifiedTime = modifiedTime,
             epoch = epoch,
-            eventHorizon = eventHorizon
+            eventHorizon = eventHorizon,
+            packageOwnership = packageOwnership
     )
 }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/ContractJarTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/ContractJarTestUtils.kt
@@ -1,0 +1,86 @@
+package net.corda.testing.core
+
+import net.corda.testing.core.JarSignatureTestUtils.addManifest
+import net.corda.testing.core.JarSignatureTestUtils.createJar
+import net.corda.testing.core.JarSignatureTestUtils.generateKey
+import net.corda.testing.core.JarSignatureTestUtils.signJar
+import net.corda.core.internal.delete
+import net.corda.core.internal.div
+import java.io.OutputStream
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.security.PublicKey
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import javax.tools.JavaFileObject
+import javax.tools.SimpleJavaFileObject
+import javax.tools.StandardLocation
+import javax.tools.ToolProvider
+
+object ContractJarTestUtils {
+
+    fun makeTestJar(output: OutputStream, extraEntries: List<Pair<String, String>> = emptyList()) {
+        output.use {
+            val jar = JarOutputStream(it)
+            jar.putNextEntry(JarEntry("test1.txt"))
+            jar.write("This is some useful content".toByteArray())
+            jar.closeEntry()
+            jar.putNextEntry(JarEntry("test2.txt"))
+            jar.write("Some more useful content".toByteArray())
+            extraEntries.forEach {
+                jar.putNextEntry(JarEntry(it.first))
+                jar.write(it.second.toByteArray())
+            }
+            jar.closeEntry()
+        }
+    }
+
+    fun makeTestSignedContractJar(workingDir: Path, contractName: String, version: String = "1.0"): Pair<Path, PublicKey> {
+        val alias = "testAlias"
+        val pwd = "testPassword"
+        workingDir.generateKey(alias, pwd, ALICE_NAME.toString())
+        val jarName = makeTestContractJar(workingDir, contractName, true, version)
+        val signer = workingDir.signJar(jarName.toAbsolutePath().toString(), alias, pwd)
+        (workingDir / "_shredder").delete()
+        (workingDir / "_teststore").delete()
+        return workingDir.resolve(jarName) to signer
+    }
+
+    fun makeTestContractJar(workingDir: Path, contractName: String, signed: Boolean = false, version: String = "1.0"): Path {
+        val packages = contractName.split(".")
+        val jarName = "attachment-${packages.last()}-$version-${(if (signed) "signed" else "")}.jar"
+        val className = packages.last()
+        createTestClass(workingDir, className, packages.subList(0, packages.size - 1))
+        workingDir.createJar(jarName, "${contractName.replace(".", "/")}.class")
+        workingDir.addManifest(jarName, Pair(Attributes.Name.IMPLEMENTATION_VERSION, version))
+        return workingDir.resolve(jarName)
+    }
+
+    private fun createTestClass(workingDir: Path, className: String, packages: List<String>): Path {
+        val newClass = """package ${packages.joinToString(".")};
+                import net.corda.core.contracts.*;
+                import net.corda.core.transactions.*;
+
+                public class $className implements Contract {
+                    @Override
+                    public void verify(LedgerTransaction tx) throws IllegalArgumentException {
+                    }
+                }
+            """.trimIndent()
+        val compiler = ToolProvider.getSystemJavaCompiler()
+        val source = object : SimpleJavaFileObject(URI.create("string:///${packages.joinToString("/")}/$className.java"), JavaFileObject.Kind.SOURCE) {
+            override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence {
+                return newClass
+            }
+        }
+        val fileManager = compiler.getStandardFileManager(null, null, null)
+        fileManager.setLocation(StandardLocation.CLASS_OUTPUT, listOf(workingDir.toFile()))
+
+        compiler.getTask(System.out.writer(), fileManager, null, null, null, listOf(source)).call()
+        val outFile = fileManager.getFileForInput(StandardLocation.CLASS_OUTPUT, packages.joinToString("."), "$className.class")
+        return Paths.get(outFile.name)
+    }
+
+}

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/JarSignatureTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/JarSignatureTestUtils.kt
@@ -1,14 +1,31 @@
 package net.corda.testing.core
 
 import net.corda.core.internal.JarSignatureCollector
+import net.corda.core.internal.deleteRecursively
 import net.corda.core.internal.div
 import net.corda.nodeapi.internal.crypto.loadKeyStore
+import java.io.Closeable
 import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.PublicKey
+import java.util.jar.Attributes
 import java.util.jar.JarInputStream
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
 import kotlin.test.assertEquals
+
+/**
+ * Class to create an automatically delete a temporary directory.
+ */
+class SelfCleaningDir : Closeable {
+    val path: Path = Files.createTempDirectory(JarSignatureTestUtils::class.simpleName)
+    override fun close() {
+        path.deleteRecursively()
+    }
+}
 
 object JarSignatureTestUtils {
     val bin = Paths.get(System.getProperty("java.home")).let { if (it.endsWith("jre")) it.parent else it } / "bin"
@@ -46,4 +63,41 @@ object JarSignatureTestUtils {
 
     fun Path.getJarSigners(fileName: String) =
             JarInputStream(FileInputStream((this / fileName).toFile())).use(JarSignatureCollector::collectSigners)
+
+    fun Path.printJar(fileName: String) {
+        JarInputStream(FileInputStream((this / fileName).toFile())).use {
+            println("Manifest = ${it.manifest.mainAttributes.toList()}")
+            var count = 0
+            while (true) {
+                val entry = it.nextJarEntry ?: break
+                println("$entry, timestamps: CT=${entry.creationTime}, LAT=${entry.lastAccessTime}, LMT=${entry.lastModifiedTime}")
+                count++
+            }
+            println("\n$fileName has $count entries\n")
+        }
+    }
+
+    fun Path.addManifest(fileName: String, vararg entry: Pair<Attributes.Name, String>) {
+        JarInputStream(FileInputStream((this / fileName).toFile())).use { input ->
+            val manifest = input.manifest ?: Manifest()
+            entry.forEach { (attributeName, value) ->
+                // eg. Attributes.Name.IMPLEMENTATION_VERSION, version
+                manifest.mainAttributes[attributeName] = value
+            }
+            val output = JarOutputStream(FileOutputStream((this / fileName).toFile()), manifest)
+            var entry= input.nextEntry
+            val buffer = ByteArray(1 shl 14)
+            while (true) {
+                output.putNextEntry(entry)
+                var nr: Int
+                while (true) {
+                    nr = input.read(buffer)
+                    if (nr < 0) break
+                    output.write(buffer, 0, nr)
+                }
+                entry = input.nextEntry ?: break
+            }
+            output.close()
+        }
+    }
 }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt
@@ -5,9 +5,7 @@ import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.ContractClassName
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.sha256
-import net.corda.core.identity.Party
 import net.corda.core.internal.AbstractAttachment
-import net.corda.core.internal.JarSignatureCollector
 import net.corda.core.internal.UNKNOWN_UPLOADER
 import net.corda.core.internal.readFully
 import net.corda.core.node.services.AttachmentId
@@ -26,7 +24,10 @@ import java.util.jar.JarInputStream
  */
 class MockAttachmentStorage : AttachmentStorage, SingletonSerializeAsToken() {
 
+    private data class ContractAttachmentMetadata(val name: ContractClassName, val version: String, val isSigned: Boolean)
+
     private val _files = HashMap<SecureHash, Pair<Attachment, ByteArray>>()
+    private val _contractClasses = HashMap<ContractAttachmentMetadata, SecureHash>()
     /** A map of the currently stored files by their [SecureHash] */
     val files: Map<SecureHash, Pair<Attachment, ByteArray>> get() = _files
 
@@ -41,8 +42,15 @@ class MockAttachmentStorage : AttachmentStorage, SingletonSerializeAsToken() {
 
     override fun openAttachment(id: SecureHash): Attachment? = files[id]?.first
 
-    override fun queryAttachments(criteria: AttachmentQueryCriteria, sorting: AttachmentSort?): List<AttachmentId> {
-        throw NotImplementedError("Querying for attachments not implemented")
+    override fun queryAttachmentsFully(criteria: AttachmentQueryCriteria, sorting: AttachmentSort?): List<Attachment> {
+        val contractMetadataList = emptyList<ContractAttachmentMetadata>()
+        val attachmentIds = _contractClasses.filterKeys { contractMetadataList.contains(it) }.values.toList()
+        return _files.filterKeys { attachmentIds.contains(it) }.values.map { it.first }
+    }
+
+    override fun queryAttachments(criteria: AttachmentQueryCriteria, sorting: AttachmentSort?): List<SecureHash> {
+        val contractMetadataList = emptyList<ContractAttachmentMetadata>()
+        return _contractClasses.filterKeys { contractMetadataList.contains(it) }.values.toList()
     }
 
     override fun hasAttachment(attachmentId: AttachmentId) = files.containsKey(attachmentId)
@@ -59,6 +67,10 @@ class MockAttachmentStorage : AttachmentStorage, SingletonSerializeAsToken() {
     @JvmOverloads
     fun importContractAttachment(contractClassNames: List<ContractClassName>, uploader: String, jar: InputStream, attachmentId: AttachmentId? = null,  signers: List<PublicKey> = emptyList()): AttachmentId = importAttachmentInternal(jar, uploader, contractClassNames, attachmentId, signers)
 
+    fun importContractAttachment(attachmentId: AttachmentId, contractAttachment: ContractAttachment) {
+        _files[attachmentId] = Pair(contractAttachment, ByteArray(1))
+    }
+
     fun getAttachmentIdAndBytes(jar: InputStream): Pair<AttachmentId, ByteArray> = jar.readFully().let { bytes -> Pair(bytes.sha256(), bytes) }
 
     private class MockAttachment(dataLoader: () -> ByteArray, override val id: SecureHash, override val signers: List<PublicKey>) : AbstractAttachment(dataLoader)
@@ -72,7 +84,15 @@ class MockAttachmentStorage : AttachmentStorage, SingletonSerializeAsToken() {
         val sha256 = attachmentId ?: bytes.sha256()
         if (sha256 !in files.keys) {
             val baseAttachment = MockAttachment({ bytes }, sha256, signers)
-            val attachment = if (contractClassNames == null || contractClassNames.isEmpty()) baseAttachment else ContractAttachment(baseAttachment, contractClassNames.first(), contractClassNames.toSet(), uploader, signers)
+            val attachment =
+                    if (contractClassNames == null || contractClassNames.isEmpty()) baseAttachment
+                    else {
+                        contractClassNames.map {contractClassName ->
+                            val contractClassMetadata = ContractAttachmentMetadata(contractClassName, "1.0", signers.isNotEmpty())
+                            _contractClasses[contractClassMetadata] = sha256
+                        }
+                        ContractAttachment(baseAttachment, contractClassNames.first(), contractClassNames.toSet(), uploader, signers)
+                    }
             _files[sha256] = Pair(attachment, bytes)
         }
         return sha256

--- a/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
+++ b/testing/test-utils/src/test/kotlin/net/corda/testing/core/JarSignatureCollectorTest.kt
@@ -8,9 +8,6 @@ import net.corda.testing.core.JarSignatureTestUtils.updateJar
 import net.corda.testing.core.JarSignatureTestUtils.addIndexList
 import net.corda.core.identity.Party
 import net.corda.core.internal.*
-import net.corda.testing.core.ALICE_NAME
-import net.corda.testing.core.BOB_NAME
-import net.corda.testing.core.CHARLIE_NAME
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.AfterClass


### PR DESCRIPTION
This implementation follows a variation of the two approaches defined in the "[Migration from hash to signature constraint"](https://github.com/corda/corda-private/blob/496a1a366622d7dac8c7a52e3a2d01bdb39e971b/docs/source/design/data-model-upgrades/migrate-to-signature-constraint.md) design document.

Specifically, 
- both the original (used by Hash constrained states) and signed (used by Signature constrained states) Contract JAR must be CZ whitelisted
- the contract package namespace used in the signed Contract JAR must be registered in the Network Parameters.

Constraint transitioning validation checks are then made to ensure:
1. Hash-codes of respective Contract Jars (unsigned/signed) are registered in CZ whitelist
2. Signature (eg. public key) of Signed Jar matches the signature (eg. public key) used to register the Java package namespace.
3. Signature constraint specified keys (in transaction outputs) match the Signed Jar keys.

**I think both the above checks are excessive and require additional operational overhead, so perhaps we should agree to relax one of them. Please comment in this PR.**

The ledger transaction will contain both signed/unsigned attachments (by version) for all associated input/output states.

This PR also introduces the notion of a 'version' identifier associated with Contract Attachment Jars (stored in the database) and associated Contract Jar CorDapps (stored in the jar manifest). 
Further changes are required to populate and use this version id in transaction building and ledger verification (to be completed in https://r3-cev.atlassian.net/browse/CORDA-2150).

**Note**:  An original objective was to implement a function that returned the hash of the signed version of the original hash constrained jar, and verify it matches the original. Experimentation proved this not to be a reproducible task (see summary in https://r3-cev.atlassian.net/browse/CORDA-2156 and code in `colljos-spike-jar-stripping-hashing` branch)

