### PR TITLE
ENT-2320 enforce state contract identification

### DIFF
--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -51,6 +51,7 @@ task patchCore(type: Zip, dependsOn: coreJarTask) {
         exclude 'net/corda/core/internal/*ToggleField*.class'
         exclude 'net/corda/core/serialization/*SerializationFactory*.class'
         exclude 'net/corda/core/serialization/internal/CheckpointSerializationFactory*.class'
+        exclude 'net/corda/core/transactions/*StateContractValidationEnforcementRule*.class'
     }
 
     reproducibleFileOrder = true

--- a/core-deterministic/build.gradle
+++ b/core-deterministic/build.gradle
@@ -51,7 +51,7 @@ task patchCore(type: Zip, dependsOn: coreJarTask) {
         exclude 'net/corda/core/internal/*ToggleField*.class'
         exclude 'net/corda/core/serialization/*SerializationFactory*.class'
         exclude 'net/corda/core/serialization/internal/CheckpointSerializationFactory*.class'
-        exclude 'net/corda/core/transactions/*StateContractValidationEnforcementRule*.class'
+        exclude 'net/corda/core/internal/rules/*.class'
     }
 
     reproducibleFileOrder = true

--- a/core-deterministic/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
@@ -1,0 +1,12 @@
+package net.corda.core.internal.rules
+
+import net.corda.core.contracts.ContractState
+
+// This file provides rules that depend on the targetVersion of the current Contract or Flow.
+// In core, this is determined by means which are unavailable in the DJVM,
+// so we must provide deterministic alternatives here.
+
+@Suppress("unused")
+object StateContractValidationEnforcementRule {
+    fun shouldEnforce(state: ContractState): Boolean = true
+}

--- a/core-deterministic/src/main/kotlin/net/corda/core/transactions/StateContractValidationEnforcementRule.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/transactions/StateContractValidationEnforcementRule.kt
@@ -1,6 +1,0 @@
-package net.corda.core.transactions
-
-@Suppress("unused")
-object StateContractValidationEnforcementRule {
-    val shouldEnforce = true
-}

--- a/core-deterministic/src/main/kotlin/net/corda/core/transactions/StateContractValidationEnforcementRule.kt
+++ b/core-deterministic/src/main/kotlin/net/corda/core/transactions/StateContractValidationEnforcementRule.kt
@@ -1,0 +1,6 @@
+package net.corda.core.transactions
+
+@Suppress("unused")
+object StateContractValidationEnforcementRule {
+    val shouldEnforce = true
+}

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -166,6 +166,7 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             """.trimIndent().replace('\n', ' '), null)
 
     // TODO: add reference to documentation
+    @KeepForDJVM
     class TransactionRequiredContractUnspecifiedException(txId: SecureHash, state: TransactionState<ContractState>)
         : TransactionVerificationException(txId,
             """

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -149,6 +149,31 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             "is not satisfied. Encumbered states should also be referenced as an encumbrance of another state to form " +
             "a full cycle. Offending indices $nonMatching", null)
 
+    /**
+     * If a state is identified as belonging to a contract, either because the state class is defined as an inner class
+     * of the contract class or because the state class is annotated with [BelongsToContract], then it must not be
+     * bundled in a [TransactionState] with a different contract.
+     *
+     * @param state The [TransactionState] whose bundled state and contract are in conflict.
+     * @param requiredContractClassName The class name of the contract to which the state belongs.
+     */
+    @KeepForDJVM
+    class TransactionContractConflictException(txId: SecureHash, state: TransactionState<ContractState>, requiredContractClassName: String)
+        : TransactionVerificationException(txId,
+            """
+            State of class ${state.data::class.java.typeName} belongs to contract $requiredContractClassName, but
+            is bundled in TransactionState with ${state.contract}.
+            """.trimIndent().replace('\n', ' '), null)
+
+    // TODO: add reference to documentation
+    class TransactionRequiredContractUnspecifiedException(txId: SecureHash, state: TransactionState<ContractState>)
+        : TransactionVerificationException(txId,
+            """
+            State of class ${state.data::class.java.typeName} does not have a specified owning contract.
+            Add the @BelongsToContract annotation to this class to ensure that it can only be bundled in a TransactionState
+            with the correct contract.
+            """.trimIndent(), null)
+
     /** Whether the inputs or outputs list contains an encumbrance issue, see [TransactionMissingEncumbranceException]. */
     @CordaSerializable
     @KeepForDJVM

--- a/core/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/rules/TargetVersionDependentRules.kt
@@ -1,0 +1,39 @@
+package net.corda.core.internal.rules
+
+import net.corda.core.contracts.ContractState
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import java.util.jar.JarInputStream
+import java.util.jar.Manifest
+
+// This file provides rules that depend on the targetVersion of the current Contract or Flow.
+// Rules defined in this package are automatically removed from the DJVM in core-deterministic,
+// and must be replaced by a deterministic alternative defined within that module.
+
+/**
+ * Rule which determines whether [ContractState]s must declare the [Contract] to which they belong (e.g. via the
+ * [BelongsToContract] annotation), and must be bundled together with that contract in any [TransactionState].
+ *
+ * This rule is consulted during validation by [LedgerTransaction].
+ */
+object StateContractValidationEnforcementRule {
+
+    private val targetVersionCache = ConcurrentHashMap<URL, Int>()
+
+    fun shouldEnforce(state: ContractState): Boolean {
+        val jarLocation = state::class.java.protectionDomain.codeSource.location
+                ?: return false
+        val targetVersion = targetVersionCache.computeIfAbsent(jarLocation) {
+            jarLocation.openStream().use { inputStream ->
+                JarInputStream(inputStream).manifest?.targetPlatformVersion ?: 1
+            }
+        }
+
+        return targetVersion >= 4
+    }
+}
+
+private val Manifest.targetPlatformVersion: Int get() {
+    val minPlatformVersion = mainAttributes.getValue("Min-Platform-Version")?.toInt() ?: 1
+    return mainAttributes.getValue("Target-Platform-Version")?.toInt() ?: minPlatformVersion
+}

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -11,6 +11,7 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.AttachmentWithContext
 import net.corda.core.internal.castIfPossible
 import net.corda.core.internal.cordapp.CordappInfoResolver
+import net.corda.core.internal.rules.StateContractValidationEnforcementRule
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.CordaSerializable
@@ -115,7 +116,7 @@ data class LedgerTransaction @JvmOverloads constructor(
     private fun validateStatesAgainstContract() = allStates.forEach(::validateStateAgainstContract)
 
     private fun validateStateAgainstContract(state: TransactionState<ContractState>) {
-        val shouldEnforce = StateContractValidationEnforcementRule.shouldEnforce
+        val shouldEnforce = StateContractValidationEnforcementRule.shouldEnforce(state.data)
 
         val requiredContractClassName = state.data.requiredContractClassName ?:
             if (shouldEnforce) throw TransactionRequiredContractUnspecifiedException(id, state)
@@ -694,8 +695,4 @@ data class LedgerTransaction @JvmOverloads constructor(
             networkParameters = networkParameters,
             references = references
     )
-}
-
-object StateContractValidationEnforcementRule {
-    val shouldEnforce get() = CordappInfoResolver.getCorDappInfo()?.targetPlatformVersion ?: 4 >= 4
 }

--- a/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
@@ -14,8 +14,6 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.VersionInfo
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.contracts.DummyContract
-import net.corda.testing.contracts.DummyState
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.cordappsForPackages
@@ -106,15 +104,15 @@ internal class UseRefState(private val linearId: UniqueIdentifier) : FlowLogic<S
                 relevancyStatus = Vault.RelevancyStatus.ALL
         )
         val referenceState = serviceHub.vaultService.queryBy<ContractState>(query).states.single()
-        val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
-            addReferenceState(referenceState.referenced())
-            addOutputState(DummyState(), DummyContract.PROGRAM_ID)
-            addCommand(DummyContract.Commands.Create(), listOf(ourIdentity.owningKey))
-        })
-        return subFlow(FinalityFlow(stx))
+        return subFlow(FinalityFlow(
+                transaction = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
+                    addReferenceState(referenceState.referenced())
+                    addOutputState(RefState.State(ourIdentity), RefState.CONTRACT_ID)
+                    addCommand(RefState.Create(), listOf(ourIdentity.owningKey))
+                })
+        ))
     }
 }
-
 
 class WithReferencedStatesFlowTests {
     companion object {

--- a/core/src/test/kotlin/net/corda/core/transactions/ReferenceInputStateTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/ReferenceInputStateTests.kt
@@ -58,7 +58,18 @@ class ReferenceStateTests {
     // check might not be present in other contracts, like Cash, for example. Cash might have a command
     // called "Share" that allows a party to prove to another that they own over a certain amount of cash.
     // As such, cash can be added to the references list with a "Share" command.
+    @BelongsToContract(ExampleContract::class)
     data class ExampleState(val creator: Party, val data: String) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf(creator)
+    }
+
+    // This state has only been created to serve reference data so it cannot ever be used as an input or
+    // output when it is being referred to. However, we might want all states to be referable, so this
+    // check might not be present in other contracts, like Cash, for example. Cash might have a command
+    // called "Share" that allows a party to prove to another that they own over a certain amount of cash.
+    // As such, cash can be added to the references list with a "Share" command.
+    @BelongsToContract(Cash::class)
+    data class ExampleCashState(val creator: Party, val data: String) : ContractState {
         override val participants: List<AbstractParty> get() = listOf(creator)
     }
 
@@ -169,7 +180,7 @@ class ReferenceStateTests {
             transaction {
                 input("REF DATA")
                 command(ALICE_PUBKEY, ExampleContract.Update())
-                output(Cash.PROGRAM_ID, "UPDATED REF DATA", "REF DATA".output<ExampleState>().copy(data = "NEW STUFF!"))
+                output(ExampleContract::class.java.typeName, "UPDATED REF DATA", "REF DATA".output<ExampleState>().copy(data = "NEW STUFF!"))
                 verifies()
             }
             // Try to use the old one.

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -160,12 +160,17 @@ class CashTests {
         }
     }
 
+    @BelongsToContract(Cash::class)
+    object DummyState: ContractState {
+        override val participants: List<AbstractParty> = emptyList()
+    }
+
     @Test
     fun `issue by move`() {
         // Check we can't "move" money into existence.
         transaction {
             attachment(Cash.PROGRAM_ID)
-            input(Cash.PROGRAM_ID, DummyState())
+            input(Cash.PROGRAM_ID, DummyState)
             output(Cash.PROGRAM_ID, outState)
             command(miniCorp.publicKey, Cash.Commands.Move())
             this `fails with` "there is at least one cash input for this group"

--- a/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt
+++ b/finance/src/test/kotlin/net/corda/finance/contracts/asset/ObligationTests.kt
@@ -21,7 +21,6 @@ import net.corda.finance.contracts.NetType
 import net.corda.finance.contracts.asset.Obligation.Lifecycle
 import net.corda.node.services.api.IdentityServiceInternal
 import net.corda.testing.contracts.DummyContract
-import net.corda.testing.contracts.DummyState
 import net.corda.testing.core.*
 import net.corda.testing.dsl.*
 import net.corda.testing.internal.TEST_TX_TIME
@@ -144,12 +143,17 @@ class ObligationTests {
         }
     }
 
+    @BelongsToContract(DummyContract::class)
+    object DummyState: ContractState {
+        override val participants: List<AbstractParty> = emptyList()
+    }
+
     @Test
     fun `issue debt`() {
         // Check we can't "move" debt into existence.
         transaction {
             attachments(DummyContract.PROGRAM_ID, Obligation.PROGRAM_ID)
-            input(DummyContract.PROGRAM_ID, DummyState())
+            input(DummyContract.PROGRAM_ID, DummyState)
             output(Obligation.PROGRAM_ID, outState)
             command(MINI_CORP_PUBKEY, Obligation.Commands.Move())
             this `fails with` "at least one obligation input"

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/vault/VaultFiller.kt
@@ -310,6 +310,7 @@ class VaultFiller @JvmOverloads constructor(
 
 
 /** A state representing a commodity claim against some party */
+@BelongsToContract(Obligation::class)
 data class CommodityState(
         override val amount: Amount<Issued<Commodity>>,
 


### PR DESCRIPTION
Continuing [ENT-2320](https://r3-cev.atlassian.net/browse/ENT-2320), and following on from [a previous PR](https://github.com/corda/corda-private/pull/1), this PR introduces two new exceptions which are thrown on failing validation  if the `targetPlatform` of the currently-running CorDapp is 4 or higher:

* `TransactionRequiredContractUnspecifiedException`, thrown if there is no `@BelongsToContract` annotation or outer/inner class relationship that can be used to determine the contract to which the state in a `TransactionState<ContractState>` belongs.
* `TransactionContractConflictException`, thrown if the state and contract bundled together in a `TransactionState<ContractState>` disagree.

This is work-in-progress; the documentation needs to be updated, and a docsite link added to the log warnings / error messages associated with this validation.