### PR TITLE
CORDA-2239: Clean up Driver.startNode overload which specifies node parameters with default values

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/flows/AsymmetricCorDappsTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/AsymmetricCorDappsTests.kt
@@ -11,6 +11,7 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.internal.cordappForClasses
 import org.junit.Test
@@ -47,8 +48,14 @@ class AsymmetricCorDappsTests {
     @Test
     fun `no shared cordapps with asymmetric specific classes`() {
         driver(DriverParameters(startNodesInProcess = false, cordappsForAllNodes = emptySet())) {
-            val nodeA = startNode(providedName = ALICE_NAME, additionalCordapps = setOf(cordappForClasses(Ping::class.java))).getOrThrow()
-            val nodeB = startNode(providedName = BOB_NAME, additionalCordapps = setOf(cordappForClasses(Ping::class.java, Pong::class.java))).getOrThrow()
+            val nodeA = startNode(NodeParameters(
+                    providedName = ALICE_NAME,
+                    additionalCordapps = setOf(cordappForClasses(Ping::class.java))
+            )).getOrThrow()
+            val nodeB = startNode(NodeParameters(
+                    providedName = BOB_NAME,
+                    additionalCordapps = setOf(cordappForClasses(Ping::class.java, Pong::class.java))
+            )).getOrThrow()
             nodeA.rpc.startFlow(::Ping, nodeB.nodeInfo.singleIdentity(), 1).returnValue.getOrThrow()
         }
     }
@@ -58,8 +65,10 @@ class AsymmetricCorDappsTests {
         val sharedCordapp = cordappForClasses(Ping::class.java)
         val cordappForNodeB = cordappForClasses(Pong::class.java)
         driver(DriverParameters(startNodesInProcess = false, cordappsForAllNodes = setOf(sharedCordapp))) {
-
-            val (nodeA, nodeB) = listOf(startNode(providedName = ALICE_NAME), startNode(providedName = BOB_NAME, additionalCordapps = setOf(cordappForNodeB))).transpose().getOrThrow()
+            val (nodeA, nodeB) = listOf(
+                    startNode(NodeParameters(providedName = ALICE_NAME)),
+                    startNode(NodeParameters(providedName = BOB_NAME, additionalCordapps = setOf(cordappForNodeB)))
+            ).transpose().getOrThrow()
             nodeA.rpc.startFlow(::Ping, nodeB.nodeInfo.singleIdentity(), 1).returnValue.getOrThrow()
         }
     }
@@ -69,8 +78,10 @@ class AsymmetricCorDappsTests {
         val sharedCordapp = cordappForClasses(Ping::class.java)
         val cordappForNodeB = cordappForClasses(Pong::class.java)
         driver(DriverParameters(startNodesInProcess = true, cordappsForAllNodes = setOf(sharedCordapp))) {
-
-            val (nodeA, nodeB) = listOf(startNode(providedName = ALICE_NAME), startNode(providedName = BOB_NAME, additionalCordapps = setOf(cordappForNodeB))).transpose().getOrThrow()
+            val (nodeA, nodeB) = listOf(
+                    startNode(NodeParameters(providedName = ALICE_NAME)),
+                    startNode(NodeParameters(providedName = BOB_NAME, additionalCordapps = setOf(cordappForNodeB)))
+            ).transpose().getOrThrow()
             nodeA.rpc.startFlow(::Ping, nodeB.nodeInfo.singleIdentity(), 1).returnValue.getOrThrow()
         }
     }

--- a/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheckTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/flows/FlowCheckpointVersionNodeStartupCheckTest.kt
@@ -15,6 +15,7 @@ import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverDSL
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.internal.ListenProcessDeathException
@@ -106,7 +107,7 @@ class FlowCheckpointVersionNodeStartupCheckTest {
 
     private fun DriverDSL.createSuspendedFlowInBob(cordapps: Set<TestCordapp>) {
         val (alice, bob) = listOf(ALICE_NAME, BOB_NAME)
-                .map { startNode(providedName = it, additionalCordapps = cordapps) }
+                .map { startNode(NodeParameters(providedName = it, additionalCordapps = cordapps)) }
                 .transpose()
                 .getOrThrow()
         alice.stop()
@@ -118,12 +119,12 @@ class FlowCheckpointVersionNodeStartupCheckTest {
 
     private fun DriverDSL.assertBobFailsToStartWithLogMessage(cordapps: Collection<TestCordapp>, logMessage: String) {
         assertFailsWith(ListenProcessDeathException::class) {
-            startNode(
+            startNode(NodeParameters(
                     providedName = BOB_NAME,
                     customOverrides = mapOf("devMode" to false),
                     additionalCordapps = cordapps,
                     regenerateCordappsOnStart = true
-            ).getOrThrow()
+            )).getOrThrow()
         }
 
         val logDir = baseDirectory(BOB_NAME) / NodeStartup.LOGS_DIRECTORY_NAME

--- a/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
@@ -28,6 +28,7 @@ import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.internal.MockCordappConfigProvider
 import net.corda.testing.internal.rigorousMock
@@ -101,8 +102,9 @@ class AttachmentLoadingTests {
     fun `test that attachments retrieved over the network are not used for code`() {
         withoutTestSerialization {
             driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), cordappsForAllNodes = emptySet())) {
-                val bankA = startNode(providedName = bankAName, additionalCordapps = cordappsForPackages("net.corda.finance.contracts.isolated")).getOrThrow()
-                val bankB = startNode(providedName = bankBName, additionalCordapps = cordappsForPackages("net.corda.finance.contracts.isolated")).getOrThrow()
+                val additionalCordapps = cordappsForPackages("net.corda.finance.contracts.isolated")
+                val bankA = startNode(NodeParameters(providedName = bankAName, additionalCordapps = additionalCordapps)).getOrThrow()
+                val bankB = startNode(NodeParameters(providedName = bankBName, additionalCordapps = additionalCordapps)).getOrThrow()
                 assertFailsWith<CordaRuntimeException>("Party C=CH,L=Zurich,O=BankB rejected session request: Don't know net.corda.finance.contracts.isolated.IsolatedDummyFlow\$Initiator") {
                     bankA.rpc.startFlowDynamic(flowInitiatorClass, bankB.nodeInfo.legalIdentities.first()).returnValue.getOrThrow()
                 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -5,7 +5,6 @@ package net.corda.testing.driver
 import net.corda.core.DoNotImplement
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.flows.FlowLogic
-import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.node.NetworkParameters
@@ -13,7 +12,6 @@ import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceHub
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
-import net.corda.node.internal.Node
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.driver.internal.incrementalPortAllocation
@@ -120,181 +118,6 @@ abstract class PortAllocation {
 
         override fun nextPort() = portCounter.andIncrement
     }
-}
-
-/**
- * Helper builder for configuring a [Node] from Java.
- *
- * @property providedName Optional name of the node, which will be its legal name in [Party]. Defaults to something
- *     random. Note that this must be unique as the driver uses it as a primary key!
- * @property rpcUsers List of users who are authorised to use the RPC system. Defaults to a single user with
- *     all permissions.
- * @property verifierType The type of transaction verifier to use. See: [VerifierType]
- * @property customOverrides A map of custom node configuration overrides.
- * @property startInSameProcess Determines if the node should be started inside the same process the Driver is running
- *     in. If null the Driver-level value will be used.
- * @property maximumHeapSize The maximum JVM heap size to use for the node.
- * @property logLevel Logging level threshold.
- * @property additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
- * @property regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
- */
-@Suppress("unused")
-data class NodeParameters(
-        val providedName: CordaX500Name? = null,
-        val rpcUsers: List<User> = emptyList(),
-        val verifierType: VerifierType = VerifierType.InMemory,
-        val customOverrides: Map<String, Any?> = emptyMap(),
-        val startInSameProcess: Boolean? = null,
-        val maximumHeapSize: String = "512m",
-        val logLevel: String? = null,
-        val additionalCordapps: Collection<TestCordapp> = emptySet(),
-        val regenerateCordappsOnStart: Boolean = false,
-        val flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap()
-) {
-    /**
-     * Helper builder for configuring a [Node] from Java.
-     *
-     * @param providedName Optional name of the node, which will be its legal name in [Party]. Defaults to something
-     *     random. Note that this must be unique as the driver uses it as a primary key!
-     * @param rpcUsers List of users who are authorised to use the RPC system. Defaults to a single user with
-     *     all permissions.
-     * @param verifierType The type of transaction verifier to use. See: [VerifierType]
-     * @param customOverrides A map of custom node configuration overrides.
-     * @param startInSameProcess Determines if the node should be started inside the same process the Driver is running
-     *     in. If null the Driver-level value will be used.
-     * @param maximumHeapSize The maximum JVM heap size to use for the node.
-     * @param logLevel Logging level threshold.
-     */
-    constructor(
-            providedName: CordaX500Name?,
-            rpcUsers: List<User>,
-            verifierType: VerifierType,
-            customOverrides: Map<String, Any?>,
-            startInSameProcess: Boolean?,
-            maximumHeapSize: String,
-            logLevel: String? = null
-    ) : this(
-            providedName,
-            rpcUsers,
-            verifierType,
-            customOverrides,
-            startInSameProcess,
-            maximumHeapSize,
-            logLevel,
-            additionalCordapps = emptySet(),
-            regenerateCordappsOnStart = false
-    )
-
-    /**
-     * Helper builder for configuring a [Node] from Java.
-     *
-     * @param providedName Optional name of the node, which will be its legal name in [Party]. Defaults to something
-     *     random. Note that this must be unique as the driver uses it as a primary key!
-     * @param rpcUsers List of users who are authorised to use the RPC system. Defaults to a single user with
-     *     all permissions.
-     * @param verifierType The type of transaction verifier to use. See: [VerifierType]
-     * @param customOverrides A map of custom node configuration overrides.
-     * @param startInSameProcess Determines if the node should be started inside the same process the Driver is running
-     *     in. If null the Driver-level value will be used.
-     * @param maximumHeapSize The maximum JVM heap size to use for the node.
-     */
-    constructor(
-            providedName: CordaX500Name?,
-            rpcUsers: List<User>,
-            verifierType: VerifierType,
-            customOverrides: Map<String, Any?>,
-            startInSameProcess: Boolean?,
-            maximumHeapSize: String
-    ) : this(
-            providedName,
-            rpcUsers,
-            verifierType,
-            customOverrides,
-            startInSameProcess,
-            maximumHeapSize,
-            null,
-            additionalCordapps = emptySet(),
-            regenerateCordappsOnStart = false)
-
-    /**
-     * Helper builder for configuring a [Node] from Java.
-     *
-     * @param providedName Optional name of the node, which will be its legal name in [Party]. Defaults to something
-     *     random. Note that this must be unique as the driver uses it as a primary key!
-     * @param rpcUsers List of users who are authorised to use the RPC system. Defaults to a single user with
-     *     all permissions.
-     * @param verifierType The type of transaction verifier to use. See: [VerifierType]
-     * @param customOverrides A map of custom node configuration overrides.
-     * @param startInSameProcess Determines if the node should be started inside the same process the Driver is running
-     *     in. If null the Driver-level value will be used.
-     * @param maximumHeapSize The maximum JVM heap size to use for the node.
-     * @param additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
-     * @param regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
-     */
-    constructor(
-            providedName: CordaX500Name?,
-            rpcUsers: List<User>,
-            verifierType: VerifierType,
-            customOverrides: Map<String, Any?>,
-            startInSameProcess: Boolean?,
-            maximumHeapSize: String,
-            additionalCordapps: Set<TestCordapp> = emptySet(),
-            regenerateCordappsOnStart: Boolean = false
-    ) : this(
-            providedName,
-            rpcUsers,
-            verifierType,
-            customOverrides,
-            startInSameProcess,
-            maximumHeapSize,
-            null,
-            additionalCordapps,
-            regenerateCordappsOnStart)
-
-    fun copy(
-            providedName: CordaX500Name?,
-            rpcUsers: List<User>,
-            verifierType: VerifierType,
-            customOverrides: Map<String, Any?>,
-            startInSameProcess: Boolean?,
-            maximumHeapSize: String
-    ) = this.copy(
-            providedName,
-            rpcUsers,
-            verifierType,
-            customOverrides,
-            startInSameProcess,
-            maximumHeapSize,
-            null)
-
-    fun copy(
-            providedName: CordaX500Name?,
-            rpcUsers: List<User>,
-            verifierType: VerifierType,
-            customOverrides: Map<String, Any?>,
-            startInSameProcess: Boolean?,
-            maximumHeapSize: String,
-            logLevel: String?
-    ) = this.copy(
-            providedName,
-            rpcUsers,
-            verifierType,
-            customOverrides,
-            startInSameProcess,
-            maximumHeapSize,
-            logLevel,
-            additionalCordapps = additionalCordapps,
-            regenerateCordappsOnStart = regenerateCordappsOnStart)
-
-    fun withProvidedName(providedName: CordaX500Name?): NodeParameters = copy(providedName = providedName)
-    fun withRpcUsers(rpcUsers: List<User>): NodeParameters = copy(rpcUsers = rpcUsers)
-    fun withVerifierType(verifierType: VerifierType): NodeParameters = copy(verifierType = verifierType)
-    fun withCustomOverrides(customOverrides: Map<String, Any?>): NodeParameters = copy(customOverrides = customOverrides)
-    fun withStartInSameProcess(startInSameProcess: Boolean?): NodeParameters = copy(startInSameProcess = startInSameProcess)
-    fun withMaximumHeapSize(maximumHeapSize: String): NodeParameters = copy(maximumHeapSize = maximumHeapSize)
-    fun withLogLevel(logLevel: String?): NodeParameters = copy(logLevel = logLevel)
-    fun withAdditionalCordapps(additionalCordapps: Set<TestCordapp>): NodeParameters = copy(additionalCordapps = additionalCordapps)
-    fun withDeleteExistingCordappsDirectory(regenerateCordappsOnStart: Boolean): NodeParameters = copy(regenerateCordappsOnStart = regenerateCordappsOnStart)
 }
 
 /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/NodeParameters.kt
@@ -1,0 +1,86 @@
+package net.corda.testing.driver
+
+import net.corda.core.flows.FlowLogic
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.User
+
+/**
+ * Parameters for creating a node for [DriverDSL.startNode].
+ *
+ * @property providedName Optional name of the node, which will be its legal name in [Party]. Defaults to something
+ *     random. Note that this must be unique as the driver uses it as a primary key!
+ * @property rpcUsers List of users who are authorised to use the RPC system. Defaults to a single user with
+ *     all permissions.
+ * @property verifierType The type of transaction verifier to use. See: [VerifierType]
+ * @property customOverrides A map of custom node configuration overrides.
+ * @property startInSameProcess Determines if the node should be started inside the same process the Driver is running
+ *     in. If null the Driver-level value will be used.
+ * @property maximumHeapSize The maximum JVM heap size to use for the node. Defaults to 512 MB.
+ * @property additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes
+ * managed by the [DriverDSL].
+ * @property regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping
+ * and restarting the same node.
+ */
+@Suppress("unused")
+data class NodeParameters(
+        val providedName: CordaX500Name? = null,
+        val rpcUsers: List<User> = emptyList(),
+        val verifierType: VerifierType = VerifierType.InMemory,
+        val customOverrides: Map<String, Any?> = emptyMap(),
+        val startInSameProcess: Boolean? = null,
+        val maximumHeapSize: String = "512m",
+        val additionalCordapps: Collection<TestCordapp> = emptySet(),
+        val regenerateCordappsOnStart: Boolean = false,
+        val flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap()
+) {
+    /**
+     * Create a new node parameters object with default values. Each parameter can be specified with its wither method which returns a copy
+     * with that value.
+     */
+    constructor() : this(providedName = null)
+
+    fun withProvidedName(providedName: CordaX500Name?): NodeParameters = copy(providedName = providedName)
+    fun withRpcUsers(rpcUsers: List<User>): NodeParameters = copy(rpcUsers = rpcUsers)
+    fun withVerifierType(verifierType: VerifierType): NodeParameters = copy(verifierType = verifierType)
+    fun withCustomOverrides(customOverrides: Map<String, Any?>): NodeParameters = copy(customOverrides = customOverrides)
+    fun withStartInSameProcess(startInSameProcess: Boolean?): NodeParameters = copy(startInSameProcess = startInSameProcess)
+    fun withMaximumHeapSize(maximumHeapSize: String): NodeParameters = copy(maximumHeapSize = maximumHeapSize)
+    fun withAdditionalCordapps(additionalCordapps: Set<TestCordapp>): NodeParameters = copy(additionalCordapps = additionalCordapps)
+    fun withRegenerateCordappsOnStart(regenerateCordappsOnStart: Boolean): NodeParameters = copy(regenerateCordappsOnStart = regenerateCordappsOnStart)
+    fun withFlowOverrides(flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>): NodeParameters = copy(flowOverrides = flowOverrides)
+
+    constructor(
+            providedName: CordaX500Name?,
+            rpcUsers: List<User>,
+            verifierType: VerifierType,
+            customOverrides: Map<String, Any?>,
+            startInSameProcess: Boolean?,
+            maximumHeapSize: String
+    ) : this(
+            providedName,
+            rpcUsers,
+            verifierType,
+            customOverrides,
+            startInSameProcess,
+            maximumHeapSize,
+            additionalCordapps = emptySet())
+
+    fun copy(
+            providedName: CordaX500Name?,
+            rpcUsers: List<User>,
+            verifierType: VerifierType,
+            customOverrides: Map<String, Any?>,
+            startInSameProcess: Boolean?,
+            maximumHeapSize: String
+    ) = this.copy(
+            providedName = providedName,
+            rpcUsers = rpcUsers,
+            verifierType = verifierType,
+            customOverrides = customOverrides,
+            startInSameProcess = startInSameProcess,
+            maximumHeapSize = maximumHeapSize,
+            additionalCordapps = additionalCordapps
+    )
+}

--- a/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
+++ b/tools/explorer/src/main/kotlin/net/corda/explorer/ExplorerSimulation.kt
@@ -80,16 +80,16 @@ class ExplorerSimulation(private val options: OptionSet) {
             val bob = startNode(providedName = BOB_NAME, rpcUsers = listOf(user))
             val ukBankName = CordaX500Name(organisation = "UK Bank Plc", locality = "London", country = "GB")
             val usaBankName = CordaX500Name(organisation = "USA Bank Corp", locality = "New York", country = "US")
-            val issuerGBP = startNode(
+            val issuerGBP = startNode(NodeParameters(
                     providedName = ukBankName,
                     rpcUsers = listOf(manager),
                     additionalCordapps = listOf(FINANCE_CORDAPP.withConfig(mapOf("issuableCurrencies" to listOf("GBP"))))
-            )
-            val issuerUSD = startNode(
+            ))
+            val issuerUSD = startNode(NodeParameters(
                     providedName = usaBankName,
                     rpcUsers = listOf(manager),
                     additionalCordapps = listOf(FINANCE_CORDAPP.withConfig(mapOf("issuableCurrencies" to listOf("USD"))))
-            )
+            ))
 
             notaryNode = defaultNotaryNode.get()
             aliceNode = alice.get()


### PR DESCRIPTION
This overload is not useful for Java devs which is why NodeParameters was created in the first place. The startNode(NodeParameters) overload is now used instead.

NodeParameters.logLevel removed as it doesn't do anything and is not in V3.