### PR TITLE
[CORDA-2185]: Added link to network-bootstrapper Maven page from the docs.

### DIFF
--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -24,7 +24,7 @@ You can find out more about network maps and network parameters from :doc:`netwo
 Bootstrapping a test network
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Corda Network Bootstrapper can be downloaded from `here <https://corda.net/resources>`_.
+The Corda Network Bootstrapper can be downloaded from `Maven <https://mvnrepository.com/artifact/net.corda/corda-tools-network-bootstrapper>`_.
 
 Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. Then run the
 following command:


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2185

Notes:

- Currently `https://mvnrepository.com/artifact/net.corda/corda-tools-network-bootstrapper` does not exist, because we renamed the module from `corda-network-bootstrapper` to `corda-tools-network-bootstrapper` (`https://mvnrepository.com/artifact/net.corda/corda-network-bootstrapper` works). It will work after the release though.