### PR TITLE
Fix unit test failure due to Windows end-of-line characters

### DIFF
--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/ClassCarpentingTypeLoaderTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/ClassCarpentingTypeLoaderTests.kt
@@ -53,6 +53,8 @@ class ClassCarpentingTypeLoaderTests {
 
         val person = personType.make("Arthur Putey", 42, address, listOf(previousAddress))
         val personJson = ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(person)
+                .replace("\r\n", "\n")
+        
         assertEquals("""
             {
               "name" : "Arthur Putey",


### PR DESCRIPTION
Fix for a unit-test failure which is due to Jackson supplying Windows CRLF line-termination when pretty-printing.