### PR TITLE
Fix Attachment overlap check

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -207,5 +207,5 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      */
     @CordaSerializable
     @KeepForDJVM
-    class OverlappingAttachments(path: String) : Exception("Multiple attachments define a file at path `$path`.")
+    class OverlappingAttachmentsException(path: String) : Exception("Multiple attachments define a file at path `$path`.")
 }

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -201,4 +201,11 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
             """The Contract attachment JAR: $attachmentHash containing the contract: $contractClass is not signed by the owner specified in the network parameters.
            Please check the source of this attachment and if it is malicious contact your zone operator to report this incident.
            For details see: https://docs.corda.net/network-map.html#network-parameters""".trimIndent(), null)
+
+    /**
+     * Thrown when multiple attachments provide the same file when building the AttachmentsClassloader for a transaction.
+     */
+    @CordaSerializable
+    @KeepForDJVM
+    class OverlappingAttachments(path: String) : Exception("Multiple attachments define a file at path `$path`.")
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -62,7 +62,7 @@ class AttachmentsClassLoader(attachments: List<Attachment>, parent: ClassLoader 
                         val path = entry.name.toLowerCase().replace('\\', '/')
                         // TODO - If 2 entries are identical, it means the same file is present in both attachments, so that should be ok.
                         if (shouldCheckForNoOverlap(path, targetPlatformVersion)) {
-                            if (path in classLoaderEntries) throw TransactionVerificationException.OverlappingAttachments(path)
+                            if (path in classLoaderEntries) throw TransactionVerificationException.OverlappingAttachmentsException(path)
                             classLoaderEntries.add(path)
                         }
                     }
@@ -88,7 +88,8 @@ class AttachmentsClassLoader(attachments: List<Attachment>, parent: ClassLoader 
     }
 
     /**
-     * Required to prevent Jolokia from being loaded by contract code.
+     * Required to prevent classes that were excluded from the no-overlap check from being loaded by contract code.
+     * As it can lead to non-determinism.
      */
     override fun loadClass(name: String?): Class<*> {
         if (ignorePackages.any { name!!.startsWith(it) }) {

--- a/core/src/test/kotlin/net/corda/core/transactions/AttachmentsClassLoaderTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/AttachmentsClassLoaderTests.kt
@@ -2,6 +2,7 @@ package net.corda.core.transactions
 
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.Contract
+import net.corda.core.contracts.TransactionVerificationException
 import net.corda.core.internal.declaredField
 import net.corda.core.serialization.internal.AttachmentsClassLoader
 import net.corda.testing.internal.fakeAttachment
@@ -65,7 +66,7 @@ class AttachmentsClassLoaderTests {
         val att1 = storage.importAttachment(fakeAttachment("file1.txt", "some data").inputStream(), "app", "file1.jar")
         val att2 = storage.importAttachment(fakeAttachment("file1.txt", "some other data").inputStream(), "app", "file2.jar")
 
-        assertFailsWith(AttachmentsClassLoader.Companion.OverlappingAttachments::class) {
+        assertFailsWith(TransactionVerificationException.OverlappingAttachments::class) {
             AttachmentsClassLoader(arrayOf(att1, att2).map { storage.openAttachment(it)!! })
         }
     }

--- a/core/src/test/kotlin/net/corda/core/transactions/AttachmentsClassLoaderTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/AttachmentsClassLoaderTests.kt
@@ -66,7 +66,7 @@ class AttachmentsClassLoaderTests {
         val att1 = storage.importAttachment(fakeAttachment("file1.txt", "some data").inputStream(), "app", "file1.jar")
         val att2 = storage.importAttachment(fakeAttachment("file1.txt", "some other data").inputStream(), "app", "file2.jar")
 
-        assertFailsWith(TransactionVerificationException.OverlappingAttachments::class) {
+        assertFailsWith(TransactionVerificationException.OverlappingAttachmentsException::class) {
             AttachmentsClassLoader(arrayOf(att1, att2).map { storage.openAttachment(it)!! })
         }
     }


### PR DESCRIPTION
The overlap check was too restrictive causing cordapps that were built with an older version of the cordapp plugin to fail.

This relaxes the checks and introduces a special case.

Also makes the `OverlappingAttachments` exception a TransactionVerificationException.