### PR TITLE
ENT-2763 - Change packageOwnership type

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -516,4 +516,15 @@ fun <K, V> createSimpleCache(maxSize: Int, onEject: (MutableMap.MutableEntry<K, 
     }
 }
 
-fun <K,V> MutableMap<K,V>.toSynchronised(): MutableMap<K,V> = Collections.synchronizedMap(this)
+fun <K, V> MutableMap<K, V>.toSynchronised(): MutableMap<K, V> = Collections.synchronizedMap(this)
+
+private fun isPackageValid(packageName: String): Boolean = packageName.isNotEmpty() && !packageName.endsWith(".") && packageName.split(".").all { token ->
+    Character.isJavaIdentifierStart(token[0]) && token.toCharArray().drop(1).all { Character.isJavaIdentifierPart(it) }
+}
+
+/**
+ * Check if a string is a legal Java package name.
+ */
+fun requirePackageValid(name: String) {
+    require(isPackageValid(name)) { "Invalid Java package name: `$name`." }
+}

--- a/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
@@ -96,7 +96,6 @@ data class NetworkParameters(
         private val nonAutoAcceptableGetters = memberPropertyPartition.second.map { it.javaGetter }
         val autoAcceptablePropertyNames = autoAcceptableNamesAndGetters.keys
 
-
         /**
          * Returns true if the [fullClassName] is in a subpackage of [packageName].
          * E.g.: "com.megacorp" owns "com.megacorp.tokens.MegaToken"
@@ -109,6 +108,10 @@ data class NetworkParameters(
         // Check if a string is a legal Java package name.
         private fun isPackageValid(packageName: String): Boolean = packageName.isNotEmpty() && !packageName.endsWith(".") && packageName.split(".").all { token ->
             Character.isJavaIdentifierStart(token[0]) && token.toCharArray().drop(1).all { Character.isJavaIdentifierPart(it) }
+        }
+
+        fun requirePackageValid(name: String) {
+            require(isPackageValid(name)) { "Invalid Java package name: `$name`." }
         }
 
         // Make sure that packages don't overlap so that ownership is clear.
@@ -128,9 +131,7 @@ data class NetworkParameters(
         require(maxMessageSize > 0) { "maxMessageSize must be at least 1" }
         require(maxTransactionSize > 0) { "maxTransactionSize must be at least 1" }
         require(!eventHorizon.isNegative) { "eventHorizon must be positive value" }
-        packageOwnership.keys.forEach { name ->
-            require(isPackageValid(name)) { "Invalid Java package name: `$name`." }
-        }
+        packageOwnership.keys.forEach(::requirePackageValid)
         require(noOverlap(packageOwnership.keys)) { "multiple packages added to the packageOwnership overlap." }
     }
 

--- a/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
@@ -4,6 +4,7 @@ import net.corda.core.CordaRuntimeException
 import net.corda.core.KeepForDJVM
 import net.corda.core.crypto.toStringShort
 import net.corda.core.identity.Party
+import net.corda.core.internal.requirePackageValid
 import net.corda.core.node.services.AttachmentId
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.DeprecatedConstructorForDeserialization
@@ -104,15 +105,6 @@ data class NetworkParameters(
          * By making the check case insensitive, the node will require that the jar is signed by MegaCorp, so the attack fails.
          */
         private fun owns(packageName: String, fullClassName: String) = fullClassName.startsWith("$packageName.", ignoreCase = true)
-
-        // Check if a string is a legal Java package name.
-        private fun isPackageValid(packageName: String): Boolean = packageName.isNotEmpty() && !packageName.endsWith(".") && packageName.split(".").all { token ->
-            Character.isJavaIdentifierStart(token[0]) && token.toCharArray().drop(1).all { Character.isJavaIdentifierPart(it) }
-        }
-
-        fun requirePackageValid(name: String) {
-            require(isPackageValid(name)) { "Invalid Java package name: `$name`." }
-        }
 
         // Make sure that packages don't overlap so that ownership is clear.
         private fun noOverlap(packages: Collection<String>) = packages.all { currentPackage ->

--- a/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt
@@ -104,6 +104,7 @@ data class NetworkParameters(
         require(maxMessageSize > 0) { "maxMessageSize must be at least 1" }
         require(maxTransactionSize > 0) { "maxTransactionSize must be at least 1" }
         require(!eventHorizon.isNegative) { "eventHorizon must be positive value" }
+        packageOwnership.keys.forEach { JavaPackageName(it) }
         require(noOverlap(packageOwnership.keys)) { "multiple packages added to the packageOwnership overlap." }
     }
 
@@ -204,7 +205,7 @@ class ZoneVersionTooLowException(message: String) : CordaRuntimeException(messag
 @CordaSerializable
 data class JavaPackageName(val name: String) {
     init {
-        require(isPackageValid(name)) { "Invalid Java package name: $name" }
+        require(isPackageValid(name)) { "Invalid Java package name: `$name`." }
     }
 
     /**

--- a/core/src/test/kotlin/net/corda/core/contracts/PackageOwnershipVerificationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/PackageOwnershipVerificationTests.kt
@@ -48,7 +48,7 @@ class PackageOwnershipVerificationTests {
                 doReturn(BOB_PARTY).whenever(it).partyFromKey(BOB_PUBKEY)
             },
             networkParameters = testNetworkParameters()
-                    .copy(packageOwnership = mapOf(JavaPackageName("net.corda.core.contracts") to OWNER_KEY_PAIR.public))
+                    .copy(packageOwnership = mapOf("net.corda.core.contracts" to OWNER_KEY_PAIR.public))
     )
 
     @Test

--- a/core/src/test/kotlin/net/corda/core/contracts/PackageOwnershipVerificationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/PackageOwnershipVerificationTests.kt
@@ -6,11 +6,7 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.node.JavaPackageName
 import net.corda.core.transactions.LedgerTransaction
-import net.corda.finance.POUNDS
-import net.corda.finance.`issued by`
-import net.corda.finance.contracts.asset.Cash
 import net.corda.node.services.api.IdentityServiceInternal
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.DUMMY_NOTARY_NAME

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -190,7 +190,7 @@ internal constructor(private val initSerEnv: Boolean,
     }
 
     /** Entry point for the tool */
-    fun bootstrap(directory: Path, copyCordapps: Boolean, minimumPlatformVersion: Int, packageOwnership: Map<JavaPackageName, PublicKey?> = emptyMap()) {
+    fun bootstrap(directory: Path, copyCordapps: Boolean, minimumPlatformVersion: Int, packageOwnership: Map<String, PublicKey?> = emptyMap()) {
         require(minimumPlatformVersion <= PLATFORM_VERSION) { "Minimum platform version cannot be greater than $PLATFORM_VERSION" }
         // Don't accidently include the bootstrapper jar as a CorDapp!
         val bootstrapperJar = javaClass.location.toPath()
@@ -206,7 +206,7 @@ internal constructor(private val initSerEnv: Boolean,
             copyCordapps: Boolean,
             fromCordform: Boolean,
             minimumPlatformVersion: Int = PLATFORM_VERSION,
-            packageOwnership: Map<JavaPackageName, PublicKey?> = emptyMap()
+            packageOwnership: Map<String, PublicKey?> = emptyMap()
     ) {
         directory.createDirectories()
         println("Bootstrapping local test network in $directory")
@@ -385,7 +385,7 @@ internal constructor(private val initSerEnv: Boolean,
             existingNetParams: NetworkParameters?,
             nodeDirs: List<Path>,
             minimumPlatformVersion: Int,
-            packageOwnership: Map<JavaPackageName, PublicKey?>
+            packageOwnership: Map<String, PublicKey?>
     ): NetworkParameters {
         // TODO Add config for maxMessageSize and maxTransactionSize
         val netParams = if (existingNetParams != null) {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -9,7 +9,6 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.*
 import net.corda.core.internal.concurrent.fork
 import net.corda.core.internal.concurrent.transpose
-import net.corda.core.node.JavaPackageName
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.NotaryInfo

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapperTest.kt
@@ -5,7 +5,6 @@ import net.corda.core.crypto.secureRandomBytes
 import net.corda.core.crypto.sha256
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.*
-import net.corda.core.node.JavaPackageName
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NodeInfo
 import net.corda.core.serialization.serialize
@@ -214,8 +213,8 @@ class NetworkBootstrapperTest {
     private val ALICE = TestIdentity(ALICE_NAME, 70)
     private val BOB = TestIdentity(BOB_NAME, 80)
 
-    private val alicePackageName = JavaPackageName("com.example.alice")
-    private val bobPackageName = JavaPackageName("com.example.bob")
+    private val alicePackageName = "com.example.alice"
+    private val bobPackageName = "com.example.bob"
 
     @Test
     fun `register new package namespace in existing network`() {
@@ -238,7 +237,7 @@ class NetworkBootstrapperTest {
     @Test
     fun `attempt to register overlapping namespaces in existing network`() {
         createNodeConfFile("alice", aliceConfig)
-        val greedyNamespace = JavaPackageName("com.example")
+        val greedyNamespace = "com.example"
         bootstrap(packageOwnership = mapOf(Pair(greedyNamespace, ALICE.publicKey)))
         assertContainsPackageOwner("alice", mapOf(Pair(greedyNamespace, ALICE.publicKey)))
         // register overlapping package name
@@ -293,7 +292,7 @@ class NetworkBootstrapperTest {
         return bytes
     }
 
-    private fun bootstrap(copyCordapps: Boolean = true, packageOwnership : Map<JavaPackageName, PublicKey?> = emptyMap()) {
+    private fun bootstrap(copyCordapps: Boolean = true, packageOwnership : Map<String, PublicKey?> = emptyMap()) {
         providedCordaJar = (rootDir / "corda.jar").let { if (it.exists()) it.readAll() else null }
         bootstrapper.bootstrap(rootDir, copyCordapps, PLATFORM_VERSION, packageOwnership)
     }
@@ -363,7 +362,7 @@ class NetworkBootstrapperTest {
         }
     }
 
-    private fun assertContainsPackageOwner(nodeDirName: String, packageOwners: Map<JavaPackageName, PublicKey>) {
+    private fun assertContainsPackageOwner(nodeDirName: String, packageOwners: Map<String, PublicKey>) {
         val networkParams = (rootDir / nodeDirName).networkParameters
         assertThat(networkParams.packageOwnership).isEqualTo(packageOwners)
     }

--- a/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
@@ -92,7 +92,7 @@ class NetworkParametersTest {
                     emptyMap(),
                     Int.MAX_VALUE.days,
                     mapOf(
-                            JavaPackageName("com.!example.stuff") to key2
+                            "com.!example.stuff" to key2
                     )
             )
         }.withMessageContaining("Invalid Java package name")
@@ -107,8 +107,8 @@ class NetworkParametersTest {
                     emptyMap(),
                     Int.MAX_VALUE.days,
                     mapOf(
-                            JavaPackageName("com.example") to key1,
-                            JavaPackageName("com.example.stuff") to key2
+                            "com.example" to key1,
+                            "com.example.stuff" to key2
                     )
             )
         }.withMessage("multiple packages added to the packageOwnership overlap.")
@@ -122,8 +122,8 @@ class NetworkParametersTest {
                 emptyMap(),
                 Int.MAX_VALUE.days,
                 mapOf(
-                        JavaPackageName("com.example") to key1,
-                        JavaPackageName("com.examplestuff") to key2
+                        "com.example" to key1,
+                        "com.examplestuff" to key2
                 )
         )
 
@@ -135,8 +135,8 @@ class NetworkParametersTest {
     @Test
     fun `auto acceptance checks are correct`() {
         val packageOwnership = mapOf(
-                JavaPackageName("com.example1") to generateKeyPair().public,
-                JavaPackageName("com.example2") to generateKeyPair().public)
+                "com.example1" to generateKeyPair().public,
+                "com.example2" to generateKeyPair().public)
         val whitelistedContractImplementations = mapOf(
                 "example1" to listOf(AttachmentId.randomSHA256()),
                 "example2" to listOf(AttachmentId.randomSHA256()))

--- a/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NetworkParametersTest.kt
@@ -1,7 +1,6 @@
 package net.corda.node.internal
 
 import net.corda.core.crypto.generateKeyPair
-import net.corda.core.node.JavaPackageName
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
 import net.corda.core.node.services.AttachmentId
@@ -29,6 +28,7 @@ import org.junit.After
 import org.junit.Test
 import java.nio.file.Path
 import java.time.Instant
+import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
 class NetworkParametersTest {
@@ -91,9 +91,7 @@ class NetworkParametersTest {
                     1,
                     emptyMap(),
                     Int.MAX_VALUE.days,
-                    mapOf(
-                            "com.!example.stuff" to key2
-                    )
+                    mapOf("com.!example.stuff" to key2)
             )
         }.withMessageContaining("Invalid Java package name")
 
@@ -113,7 +111,7 @@ class NetworkParametersTest {
             )
         }.withMessage("multiple packages added to the packageOwnership overlap.")
 
-        NetworkParameters(1,
+        val params = NetworkParameters(1,
                 emptyList(),
                 2001,
                 2000,
@@ -127,9 +125,10 @@ class NetworkParametersTest {
                 )
         )
 
-        assert(JavaPackageName("com.example").owns("com.example.something.MyClass"))
-        assert(!JavaPackageName("com.example").owns("com.examplesomething.MyClass"))
-        assert(!JavaPackageName("com.exam").owns("com.example.something.MyClass"))
+        assertEquals(params.getOwnerOf("com.example.something.MyClass"), key1)
+        assertEquals(params.getOwnerOf("com.examplesomething.MyClass"), null)
+        assertEquals(params.getOwnerOf("com.examplestuff.something.MyClass"), key2)
+        assertEquals(params.getOwnerOf("com.exam.something.MyClass"), null)
     }
 
     @Test

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -3,6 +3,7 @@ package net.corda.bootstrapper
 import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.start
 import net.corda.core.internal.PLATFORM_VERSION
+import net.corda.core.node.NetworkParameters.Companion.requirePackageValid
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import net.corda.nodeapi.internal.network.NetworkBootstrapper
 import picocli.CommandLine
@@ -76,8 +77,11 @@ class PackageOwnerConverter : CommandLine.ITypeConverter<PackageOwner> {
             val packageOwnerSpec = packageOwner.split(";")
             if (packageOwnerSpec.size < 4)
                 throw IllegalArgumentException("Package owner must specify 4 elements separated by semi-colon: 'java-package-namespace;keyStorePath;keyStorePassword;alias'")
+
             // java package name validation
             val javaPackageName = packageOwnerSpec[0]
+            requirePackageValid(javaPackageName)
+
             // cater for passwords that include the argument delimiter field
             val keyStorePassword =
                 if (packageOwnerSpec.size > 4)

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -3,7 +3,6 @@ package net.corda.bootstrapper
 import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.start
 import net.corda.core.internal.PLATFORM_VERSION
-import net.corda.core.node.JavaPackageName
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import net.corda.nodeapi.internal.network.NetworkBootstrapper
 import picocli.CommandLine
@@ -47,13 +46,12 @@ class NetworkBootstrapperRunner : CordaCliWrapper("bootstrapper", "Bootstrap a l
     var registerPackageOwnership: List<PackageOwner> = mutableListOf()
 
     @Option(names = ["--unregister-package-owner"],
-            converter = [JavaPackageNameConverter::class],
             description = [
                 "Unregister owner of Java package namespace in the network-parameters.",
                 "Format: [java-package-namespace]",
                 "         `java-package-namespace` is case insensitive and cannot be a sub-package of an existing registered namespace"
             ])
-    var unregisterPackageOwnership: List<JavaPackageName> = mutableListOf()
+    var unregisterPackageOwnership: List<String> = mutableListOf()
 
     override fun runProgram(): Int {
         NetworkBootstrapper().bootstrap(dir.toAbsolutePath().normalize(),
@@ -67,10 +65,10 @@ class NetworkBootstrapperRunner : CordaCliWrapper("bootstrapper", "Bootstrap a l
 }
 
 
-data class PackageOwner(val javaPackageName: JavaPackageName, val publicKey: PublicKey)
+data class PackageOwner(val javaPackageName: String, val publicKey: PublicKey)
 
 /**
- * Converter from String to PackageOwner (JavaPackageName and PublicKey)
+ * Converter from String to PackageOwner (String and PublicKey)
  */
 class PackageOwnerConverter : CommandLine.ITypeConverter<PackageOwner> {
     override fun convert(packageOwner: String): PackageOwner {
@@ -79,7 +77,7 @@ class PackageOwnerConverter : CommandLine.ITypeConverter<PackageOwner> {
             if (packageOwnerSpec.size < 4)
                 throw IllegalArgumentException("Package owner must specify 4 elements separated by semi-colon: 'java-package-namespace;keyStorePath;keyStorePassword;alias'")
             // java package name validation
-            val javaPackageName = JavaPackageName(packageOwnerSpec[0])
+            val javaPackageName = packageOwnerSpec[0]
             // cater for passwords that include the argument delimiter field
             val keyStorePassword =
                 if (packageOwnerSpec.size > 4)
@@ -103,14 +101,5 @@ class PackageOwnerConverter : CommandLine.ITypeConverter<PackageOwner> {
             }
         }
         else throw IllegalArgumentException("Must specify package owner argument: 'java-package-namespace;keyStorePath;keyStorePassword;alias'")
-    }
-}
-
-/**
- * Converter from String to JavaPackageName.
- */
-class JavaPackageNameConverter : CommandLine.ITypeConverter<JavaPackageName> {
-    override fun convert(packageName: String): JavaPackageName {
-        return JavaPackageName(packageName)
     }
 }

--- a/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -3,7 +3,7 @@ package net.corda.bootstrapper
 import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.start
 import net.corda.core.internal.PLATFORM_VERSION
-import net.corda.core.node.NetworkParameters.Companion.requirePackageValid
+import net.corda.core.internal.requirePackageValid
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import net.corda.nodeapi.internal.network.NetworkBootstrapper
 import picocli.CommandLine

--- a/tools/bootstrapper/src/test/kotlin/net/corda/bootstrapper/PackageOwnerParsingTest.kt
+++ b/tools/bootstrapper/src/test/kotlin/net/corda/bootstrapper/PackageOwnerParsingTest.kt
@@ -2,7 +2,6 @@ package net.corda.bootstrapper
 
 import net.corda.core.internal.deleteRecursively
 import net.corda.core.internal.div
-import net.corda.core.node.JavaPackageName
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
@@ -55,7 +54,7 @@ class PackageOwnerParsingTest {
         val aliceKeyStorePath = dirAlice / "_teststore"
         val args = arrayOf("--register-package-owner", "com.example.stuff;$aliceKeyStorePath;$ALICE_PASS;$ALICE")
         commandLine.parse(*args)
-        assertThat(networkBootstrapper.registerPackageOwnership[0].javaPackageName).isEqualTo(JavaPackageName("com.example.stuff"))
+        assertThat(networkBootstrapper.registerPackageOwnership[0].javaPackageName).isEqualTo("com.example.stuff")
     }
 
     @Test
@@ -141,7 +140,7 @@ class PackageOwnerParsingTest {
                 "net.something4;$aliceKeyStorePath5;\"\"passw;rd\"\";${ALICE}5")
         packageOwnerSpecs.forEachIndexed { i, packageOwnerSpec ->
             commandLine.parse(*arrayOf("--register-package-owner", packageOwnerSpec))
-            assertThat(networkBootstrapper.registerPackageOwnership[0].javaPackageName).isEqualTo(JavaPackageName("net.something$i"))
+            assertThat(networkBootstrapper.registerPackageOwnership[0].javaPackageName).isEqualTo("net.something$i")
         }
     }
 
@@ -149,7 +148,7 @@ class PackageOwnerParsingTest {
     fun `parse unregister request with single mapping`() {
         val args = arrayOf("--unregister-package-owner", "com.example.stuff")
         commandLine.parse(*args)
-        assertThat(networkBootstrapper.unregisterPackageOwnership).contains(JavaPackageName("com.example.stuff"))
+        assertThat(networkBootstrapper.unregisterPackageOwnership).contains("com.example.stuff")
     }
 
     @Test
@@ -158,8 +157,8 @@ class PackageOwnerParsingTest {
         val args = arrayOf("--register-package-owner", "com.example.stuff;$aliceKeyStorePath;$ALICE_PASS;$ALICE",
                                         "--unregister-package-owner", "com.example.stuff2")
         commandLine.parse(*args)
-        assertThat(networkBootstrapper.registerPackageOwnership.map { it.javaPackageName }).contains(JavaPackageName("com.example.stuff"))
-        assertThat(networkBootstrapper.unregisterPackageOwnership).contains(JavaPackageName("com.example.stuff2"))
+        assertThat(networkBootstrapper.registerPackageOwnership.map { it.javaPackageName }).contains("com.example.stuff")
+        assertThat(networkBootstrapper.unregisterPackageOwnership).contains("com.example.stuff2")
     }
 }
 


### PR DESCRIPTION
Changes the type of the `packageOwnership` to avoid a bug in the old carpenter code