### PR TITLE
CORDA-2150 Non downgrade contract version - test infrastructure part 1

### DIFF
--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -155,6 +155,10 @@ data class TestTransactionDSLInterpreter private constructor(
         attachment((services.cordappProvider as MockCordappProvider).addMockCordapp(contractClassName, services.attachments as MockAttachmentStorage, attachmentId, signers))
     }
 
+    override fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List<PublicKey>, jarManifestAttributes: Map<String,String>){
+        attachment((services.cordappProvider as MockCordappProvider).addMockCordapp(contractClassName, services.attachments as MockAttachmentStorage, attachmentId, signers, jarManifestAttributes))
+    }
+
 }
 
 data class TestLedgerDSLInterpreter private constructor(

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt
@@ -97,6 +97,15 @@ interface TransactionDSLInterpreter : Verifies, OutputStateLookup {
      * @param attachmentId The attachment
      */
     fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List<PublicKey>)
+
+    /**
+     * Attaches an attachment containing the named contract to the transaction
+     * @param contractClassName The contract class to attach
+     * @param attachmentId The attachment
+     * @param attachmentId The signers
+     * @param jarManifestAttributes The JAR manifest file attributes.
+     */
+    fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List<PublicKey>, jarManifestAttributes: Map<String,String>)
 }
 
 /**
@@ -203,7 +212,7 @@ class TransactionDSL<out T : TransactionDSLInterpreter>(interpreter: T, private 
      */
     fun attachment(contractClassName: ContractClassName) = _attachment(contractClassName)
 
-    fun attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List<PublicKey>) = _attachment(contractClassName, attachmentId, signers)
+    fun attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List<PublicKey>, jarManifestAttributes: Map<String,String> = emptyMap()) = _attachment(contractClassName, attachmentId, signers, jarManifestAttributes)
     fun attachment(contractClassName: ContractClassName, attachmentId: AttachmentId) = _attachment(contractClassName, attachmentId, emptyList())
 
     fun attachments(vararg contractClassNames: ContractClassName) = contractClassNames.forEach { attachment(it) }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TransactionDSLInterpreter.kt
@@ -99,10 +99,10 @@ interface TransactionDSLInterpreter : Verifies, OutputStateLookup {
     fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List<PublicKey>)
 
     /**
-     * Attaches an attachment containing the named contract to the transaction
-     * @param contractClassName The contract class to attach
-     * @param attachmentId The attachment
-     * @param attachmentId The signers
+     * Attaches an attachment containing the named contract to the transaction.
+     * @param contractClassName The contract class to attach.
+     * @param attachmentId The attachment.
+     * @param signers The signers.
      * @param jarManifestAttributes The JAR manifest file attributes.
      */
     fun _attachment(contractClassName: ContractClassName, attachmentId: AttachmentId, signers: List<PublicKey>, jarManifestAttributes: Map<String,String>)


### PR DESCRIPTION
This is preliminary addition to test `"Implementation-Version"` entry from `META-INF/MANIFEST.MF` in `TestDSL.kt`.
`MockCordappProvider` was creating JAR with manifest file.
Added the manifest file with the obligatory (by JAR spec) attribute `"Manifest-Version"`, other attributes can be added.