### PR TITLE
CORDA-2150 signature constraints non downgrade rule test infrastructure 2

### DIFF
--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -273,7 +273,7 @@ data class TestLedgerDSLInterpreter private constructor(
         }
         transactionMap[wireTransaction.id] =
                 WireTransactionWithLocation(transactionLabel, wireTransaction, transactionLocation)
-        saveAsMockSignedTransaction(wireTransaction)
+        saveOptionallyAsMockSignedTransaction(wireTransaction)
         return wireTransaction
     }
 
@@ -347,9 +347,12 @@ data class TestLedgerDSLInterpreter private constructor(
     val transactionsToVerify: List<WireTransaction> get() = transactionWithLocations.values.map { it.transaction }
     val transactionsUnverified: List<WireTransaction> get() = nonVerifiedTransactionWithLocations.values.map { it.transaction }
 
-    private fun saveAsMockSignedTransaction (wireTransaction: WireTransaction){
-        val alicePublicKey = TestIdentity(CordaX500Name("ALICE", "London", "GB")).publicKey
-        val signatures = listOf(TransactionSignature(ByteArray(1), alicePublicKey, SignatureMetadata(1, Crypto.findSignatureScheme(alicePublicKey).schemeNumberID)))
-        (services.validatedTransactions as WritableTransactionStorage).addTransaction(SignedTransaction(wireTransaction, signatures))
+    private fun saveOptionallyAsMockSignedTransaction(wireTransaction: WireTransaction) {
+        val transactionStorage = services.validatedTransactions
+        if (transactionStorage is WritableTransactionStorage) {
+            val alicePublicKey = TestIdentity(CordaX500Name("ALICE", "London", "GB")).publicKey
+            val signatures = listOf(TransactionSignature(ByteArray(1), alicePublicKey, SignatureMetadata(1, Crypto.findSignatureScheme(alicePublicKey).schemeNumberID)))
+            transactionStorage.addTransaction(SignedTransaction(wireTransaction, signatures))
+        }
     }
 }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/dsl/TestDSL.kt
@@ -347,11 +347,12 @@ data class TestLedgerDSLInterpreter private constructor(
     val transactionsToVerify: List<WireTransaction> get() = transactionWithLocations.values.map { it.transaction }
     val transactionsUnverified: List<WireTransaction> get() = nonVerifiedTransactionWithLocations.values.map { it.transaction }
 
+    private val alicePublicKey = TestIdentity(CordaX500Name("ALICE", "London", "GB")).publicKey
+    private val signatures = listOf(TransactionSignature(ByteArray(1), alicePublicKey, SignatureMetadata(1, Crypto.findSignatureScheme(alicePublicKey).schemeNumberID)))
+
     private fun saveOptionallyAsMockSignedTransaction(wireTransaction: WireTransaction) {
         val transactionStorage = services.validatedTransactions
         if (transactionStorage is WritableTransactionStorage) {
-            val alicePublicKey = TestIdentity(CordaX500Name("ALICE", "London", "GB")).publicKey
-            val signatures = listOf(TransactionSignature(ByteArray(1), alicePublicKey, SignatureMetadata(1, Crypto.findSignatureScheme(alicePublicKey).schemeNumberID)))
             transactionStorage.addTransaction(SignedTransaction(wireTransaction, signatures))
         }
     }


### PR DESCRIPTION
`TestDSL` doesn't save a transaction to a mock transaction storage. To test the contract class no-downgrade rule, an original transaction of the input state needs to be looked up.
Now `TestLedgerDSLInterpreter._transaction` additionally saves the WiredTransaction as a mocked SignedTransaction if the mock transaction storage is WritableTransactionStorage.