### PR TITLE
[CORDA-2249]: Specified unique applicationId for Capsule manifest.

### DIFF
--- a/node/capsule/build.gradle
+++ b/node/capsule/build.gradle
@@ -48,7 +48,7 @@ task buildCordaJAR(type: FatCapsule, dependsOn: project(':node').tasks.jar) {
 
     capsuleManifest {
         applicationVersion = corda_release_version
-
+        applicationId = "net.corda.node.Corda"
         // See experimental/quasar-hook/README.md for how to generate.
         def quasarExcludeExpression = "x(antlr**;bftsmart**;ch**;co.paralleluniverse**;com.codahale**;com.esotericsoftware**;com.fasterxml**;com.google**;com.ibm**;com.intellij**;com.jcabi**;com.nhaarman**;com.opengamma**;com.typesafe**;com.zaxxer**;de.javakaffee**;groovy**;groovyjarjarantlr**;groovyjarjarasm**;io.atomix**;io.github**;io.netty**;jdk**;junit**;kotlin**;net.bytebuddy**;net.i2p**;org.apache**;org.assertj**;org.bouncycastle**;org.codehaus**;org.crsh**;org.dom4j**;org.fusesource**;org.h2**;org.hamcrest**;org.hibernate**;org.jboss**;org.jcp**;org.joda**;org.junit**;org.mockito**;org.objectweb**;org.objenesis**;org.slf4j**;org.w3c**;org.xml**;org.yaml**;reflectasm**;rx**;org.jolokia**)"
         javaAgents = ["quasar-core-${quasar_version}-jdk8.jar=${quasarExcludeExpression}"]


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2249

As per the section "The Capsule ID" in http://www.capsule.io/user-guide/#building-capsule, Capsule composite ID must be unique for each application, and it's composed by `applicationId` or `<group>.<artifact>` if unspecified, plus `_<version>`.

Hence, the fix is to specify `applicationId` inside Capsule's manifest for Corda Enterprise, and for it to be different from the one in Open Source. Even if for Open Source `<group>.<artifact>` is good as an implicit `applicationId`, I put it there explicitly to avoid confusion.