### PR TITLE
CORDA-2248 fix rpc classloader issue

### DIFF
--- a/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
@@ -37,7 +37,7 @@ public class FlowShellCommand extends InteractiveShellCommand {
             @Usage("The data to pass as input") @Argument(unquote = false) List<String> input
     ) {
         logger.info("Executing command \"flow start {} {}\",", name, (input != null) ? input.stream().collect(joining(" ")) : "<no arguments>");
-        startFlow(name, input, out, ops(), ansiProgressRenderer(), objectMapper());
+        startFlow(name, input, out, ops(), ansiProgressRenderer(), objectMapper(null));
     }
 
     // TODO Limit number of flows shown option?

--- a/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
@@ -38,13 +38,13 @@ public class RunShellCommand extends InteractiveShellCommand {
     @Usage("runs a method from the CordaRPCOps interface on the node.")
     public Object main(InvocationContext<Map> context, @Usage("The command to run") @Argument(unquote = false) List<String> command) {
         logger.info("Executing command \"run {}\",", (command != null) ? command.stream().collect(joining(" ")) : "<no arguments>");
-        StringToMethodCallParser<CordaRPCOps> parser = new StringToMethodCallParser<>(CordaRPCOps.class, objectMapper());
+        StringToMethodCallParser<CordaRPCOps> parser = new StringToMethodCallParser<>(CordaRPCOps.class, objectMapper(InteractiveShell.getCordappsClassloader()));
 
         if (command == null) {
             emitHelp(context, parser);
             return null;
         }
-        return InteractiveShell.runRPCFromString(command, out, context, ops(), objectMapper());
+        return InteractiveShell.runRPCFromString(command, out, context, ops(), objectMapper(InteractiveShell.getCordappsClassloader()));
     }
 
     private void emitHelp(InvocationContext<Map> context, StringToMethodCallParser<CordaRPCOps> parser) {

--- a/tools/shell/src/main/java/net/corda/tools/shell/StartShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/StartShellCommand.java
@@ -23,6 +23,6 @@ public class StartShellCommand extends InteractiveShellCommand {
 
         logger.info("Executing command \"start {} {}\",", name, (input != null) ? input.stream().collect(joining(" ")) : "<no arguments>");
         ANSIProgressRenderer ansiProgressRenderer = ansiProgressRenderer();
-        FlowShellCommand.startFlow(name, input, out, ops(), ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out), objectMapper());
+        FlowShellCommand.startFlow(name, input, out, ops(), ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out), objectMapper(null));
     }
 }

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -78,6 +78,10 @@ object InteractiveShell {
     private var classLoader: ClassLoader? = null
     private lateinit var shellConfiguration: ShellConfiguration
     private var onExit: () -> Unit = {}
+
+    @JvmStatic
+    fun getCordappsClassloader() = classLoader
+
     /**
      * Starts an interactive shell connected to the local terminal. This shell gives administrator access to the node
      * internals.

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShellCommand.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShellCommand.kt
@@ -1,5 +1,7 @@
 package net.corda.tools.shell
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.type.TypeFactory
 import org.crsh.command.BaseCommand
 import org.crsh.shell.impl.command.CRaSHSession
 
@@ -9,6 +11,13 @@ import org.crsh.shell.impl.command.CRaSHSession
 open class InteractiveShellCommand : BaseCommand() {
     fun ops() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).rpcOps
     fun ansiProgressRenderer() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).ansiProgressRenderer
-    fun objectMapper() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).yamlInputMapper
+    fun objectMapper(classLoader: ClassLoader?): ObjectMapper {
+        val om = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).yamlInputMapper
+        if (classLoader != null) {
+            om.typeFactory = TypeFactory.defaultInstance().withClassLoader(classLoader)
+        }
+        return om
+    }
+
     fun isSsh() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).isSsh
 }


### PR DESCRIPTION
This fixes an issue with parsing the shell commands after the cordapps were removed from the system classpath.

To actually get the vault query from shell to work , this: https://r3-cev.atlassian.net/browse/CORDA-2256 needs addressing as well.

