### PR TITLE
CORDA-2150 Non downgrade contract version - test infrastructure 3

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -137,6 +137,7 @@ abstract class PortAllocation {
  * @property logLevel Logging level threshold.
  * @property additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
  * @property regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
+ * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapp are unsigned.
  */
 @Suppress("unused")
 data class NodeParameters(
@@ -149,7 +150,8 @@ data class NodeParameters(
         val logLevel: String? = null,
         val additionalCordapps: Collection<TestCordapp> = emptySet(),
         val regenerateCordappsOnStart: Boolean = false,
-        val flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap()
+        val flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap(),
+        val signCordapp: Boolean = false
 ) {
     /**
      * Helper builder for configuring a [Node] from Java.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -137,7 +137,6 @@ abstract class PortAllocation {
  * @property logLevel Logging level threshold.
  * @property additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
  * @property regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
- * @param signCordapps Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
  */
 @Suppress("unused")
 data class NodeParameters(
@@ -150,8 +149,7 @@ data class NodeParameters(
         val logLevel: String? = null,
         val additionalCordapps: Collection<TestCordapp> = emptySet(),
         val regenerateCordappsOnStart: Boolean = false,
-        val flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap(),
-        val signCordapps: Boolean = false
+        val flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap()
 ) {
     /**
      * Helper builder for configuring a [Node] from Java.
@@ -346,7 +344,8 @@ fun <A> driver(defaultParameters: DriverParameters = DriverParameters(), dsl: Dr
                     networkParameters = defaultParameters.networkParameters,
                     notaryCustomOverrides = defaultParameters.notaryCustomOverrides,
                     inMemoryDB = defaultParameters.inMemoryDB,
-                    cordappsForAllNodes = defaultParameters.cordappsForAllNodes()
+                    cordappsForAllNodes = defaultParameters.cordappsForAllNodes(),
+                    signCordapps = false
             ),
             coerce = { it },
             dsl = dsl,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -137,7 +137,7 @@ abstract class PortAllocation {
  * @property logLevel Logging level threshold.
  * @property additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
  * @property regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
- * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapp are unsigned.
+ * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
  */
 @Suppress("unused")
 data class NodeParameters(

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -137,7 +137,7 @@ abstract class PortAllocation {
  * @property logLevel Logging level threshold.
  * @property additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
  * @property regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
- * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
+ * @param signCordapps Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
  */
 @Suppress("unused")
 data class NodeParameters(
@@ -151,7 +151,7 @@ data class NodeParameters(
         val additionalCordapps: Collection<TestCordapp> = emptySet(),
         val regenerateCordappsOnStart: Boolean = false,
         val flowOverrides: Map<Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap(),
-        val signCordapp: Boolean = false
+        val signCordapps: Boolean = false
 ) {
     /**
      * Helper builder for configuring a [Node] from Java.

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -101,7 +101,7 @@ interface DriverDSL {
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
      * @param additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
      * @param regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
-     * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapp are unsigned.
+     * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      * it sees all previously started nodes, including the notaries.
      */

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -101,6 +101,7 @@ interface DriverDSL {
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
      * @param additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
      * @param regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
+     * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapp are unsigned.
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      * it sees all previously started nodes, including the notaries.
      */
@@ -114,7 +115,8 @@ interface DriverDSL {
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
             additionalCordapps: Collection<TestCordapp> = defaultParameters.additionalCordapps,
             regenerateCordappsOnStart: Boolean = defaultParameters.regenerateCordappsOnStart,
-            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = defaultParameters.flowOverrides
+            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = defaultParameters.flowOverrides,
+            signCordapp: Boolean = defaultParameters.signCordapp
     ): CordaFuture<NodeHandle>
 
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -101,7 +101,7 @@ interface DriverDSL {
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
      * @param additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
      * @param regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
-     * @param signCordapp Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
+     * @param signCordapps Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      * it sees all previously started nodes, including the notaries.
      */
@@ -116,7 +116,7 @@ interface DriverDSL {
             additionalCordapps: Collection<TestCordapp> = defaultParameters.additionalCordapps,
             regenerateCordappsOnStart: Boolean = defaultParameters.regenerateCordappsOnStart,
             flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = defaultParameters.flowOverrides,
-            signCordapp: Boolean = defaultParameters.signCordapp
+            signCordapps: Boolean = defaultParameters.signCordapps
     ): CordaFuture<NodeHandle>
 
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/DriverDSL.kt
@@ -101,7 +101,6 @@ interface DriverDSL {
      *     megabytes, and 'g' or 'G' to indicate gigabytes. The default value is "512m" = 512 megabytes.
      * @param additionalCordapps Additional [TestCordapp]s that this node will have available, in addition to the ones common to all nodes managed by the [DriverDSL].
      * @param regenerateCordappsOnStart Whether existing [TestCordapp]s unique to this node will be re-generated on start. Useful when stopping and restarting the same node.
-     * @param signCordapps Signs Cordapp JARs with a dummy key, required for creating contracts with signature constraint. By default Cordapps are unsigned.
      * @return A [CordaFuture] on the [NodeHandle] to the node. The future will complete when the node is available and
      * it sees all previously started nodes, including the notaries.
      */
@@ -115,8 +114,7 @@ interface DriverDSL {
             maximumHeapSize: String = defaultParameters.maximumHeapSize,
             additionalCordapps: Collection<TestCordapp> = defaultParameters.additionalCordapps,
             regenerateCordappsOnStart: Boolean = defaultParameters.regenerateCordappsOnStart,
-            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = defaultParameters.flowOverrides,
-            signCordapps: Boolean = defaultParameters.signCordapps
+            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = defaultParameters.flowOverrides
     ): CordaFuture<NodeHandle>
 
     /**

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -218,7 +218,7 @@ class DriverDSLImpl(
             additionalCordapps: Collection<TestCordapp>,
             regenerateCordappsOnStart: Boolean,
             flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>,
-            signCordapp: Boolean
+            signCordapps: Boolean
     ): CordaFuture<NodeHandle> {
         val p2pAddress = portAllocation.nextHostAndPort()
         // TODO: Derive name from the full picked name, don't just wrap the common name
@@ -235,7 +235,7 @@ class DriverDSLImpl(
         return registrationFuture.flatMap {
             networkMapAvailability.flatMap {
                 // But starting the node proper does require the network map
-                startRegisteredNode(name, it, rpcUsers, verifierType, customOverrides, startInSameProcess, maximumHeapSize, p2pAddress, additionalCordapps, regenerateCordappsOnStart, flowOverrides, signCordapp)
+                startRegisteredNode(name, it, rpcUsers, verifierType, customOverrides, startInSameProcess, maximumHeapSize, p2pAddress, additionalCordapps, regenerateCordappsOnStart, flowOverrides, signCordapps)
             }
         }
     }
@@ -251,7 +251,7 @@ class DriverDSLImpl(
                                     additionalCordapps: Collection<TestCordapp> = emptySet(),
                                     regenerateCordappsOnStart: Boolean = false,
                                     flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>> = emptyMap(),
-                                    signCordapp: Boolean = false): CordaFuture<NodeHandle> {
+                                    signCordapps: Boolean = false): CordaFuture<NodeHandle> {
         val rpcAddress = portAllocation.nextHostAndPort()
         val rpcAdminAddress = portAllocation.nextHostAndPort()
         val webAddress = portAllocation.nextHostAndPort()
@@ -281,7 +281,7 @@ class DriverDSLImpl(
                 allowMissingConfig = true,
                 configOverrides = if (overrides.hasPath("devMode")) overrides else overrides + mapOf("devMode" to true)
         )).checkAndOverrideForInMemoryDB()
-        return startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize, localNetworkMap, additionalCordapps, regenerateCordappsOnStart, signCordapp)
+        return startNodeInternal(config, webAddress, startInSameProcess, maximumHeapSize, localNetworkMap, additionalCordapps, regenerateCordappsOnStart, signCordapps)
     }
 
     private fun startNodeRegistration(
@@ -586,7 +586,7 @@ class DriverDSLImpl(
                                   localNetworkMap: LocalNetworkMap?,
                                   additionalCordapps: Collection<TestCordapp>,
                                   regenerateCordappsOnStart: Boolean = false,
-                                  signCordapp: Boolean = false): CordaFuture<NodeHandle> {
+                                  signCordapps: Boolean = false): CordaFuture<NodeHandle> {
         val visibilityHandle = networkVisibilityController.register(specifiedConfig.corda.myLegalName)
         val baseDirectory = specifiedConfig.corda.baseDirectory.createDirectories()
         localNetworkMap?.networkParametersCopier?.install(baseDirectory)
@@ -612,7 +612,7 @@ class DriverDSLImpl(
         val appOverrides = additionalCordapps.map { it.name to it.version}.toSet()
         val baseCordapps = cordappsForAllNodes.filter { !appOverrides.contains(it.name to it.version) }
 
-        val cordappDirectories = existingCorDappDirectoriesOption + (baseCordapps + additionalCordapps).map { TestCordappDirectories.getJarDirectory(it, signJar = signCordapp).toString() }
+        val cordappDirectories = existingCorDappDirectoriesOption + (baseCordapps + additionalCordapps).map { TestCordappDirectories.getJarDirectory(it, signJar = signCordapps).toString() }
 
         val config = NodeConfig(specifiedConfig.typesafe.withValue(NodeConfiguration.cordappDirectoriesKey, ConfigValueFactory.fromIterable(cordappDirectories.toSet())))
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -94,7 +94,8 @@ class DriverDSLImpl(
         val networkParameters: NetworkParameters,
         val notaryCustomOverrides: Map<String, Any?>,
         val inMemoryDB: Boolean,
-        val cordappsForAllNodes: Collection<TestCordapp>
+        val cordappsForAllNodes: Collection<TestCordapp>,
+        val signCordapps: Boolean
 ) : InternalDriverDSL {
 
     private var _executorService: ScheduledExecutorService? = null
@@ -217,8 +218,7 @@ class DriverDSLImpl(
             maximumHeapSize: String,
             additionalCordapps: Collection<TestCordapp>,
             regenerateCordappsOnStart: Boolean,
-            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>,
-            signCordapps: Boolean
+            flowOverrides: Map<out Class<out FlowLogic<*>>, Class<out FlowLogic<*>>>
     ): CordaFuture<NodeHandle> {
         val p2pAddress = portAllocation.nextHostAndPort()
         // TODO: Derive name from the full picked name, don't just wrap the common name
@@ -1062,7 +1062,8 @@ fun <DI : DriverDSL, D : InternalDriverDSL, A> genericDriver(
                     networkParameters = defaultParameters.networkParameters,
                     notaryCustomOverrides = defaultParameters.notaryCustomOverrides,
                     inMemoryDB = defaultParameters.inMemoryDB,
-                    cordappsForAllNodes = defaultParameters.cordappsForAllNodes()
+                    cordappsForAllNodes = defaultParameters.cordappsForAllNodes(),
+                    signCordapps = false
             )
     )
     val shutdownHook = addShutdownHook(driverDsl::shutdown)
@@ -1156,6 +1157,7 @@ fun <A> internalDriver(
         notaryCustomOverrides: Map<String, Any?> = DriverParameters().notaryCustomOverrides,
         inMemoryDB: Boolean = DriverParameters().inMemoryDB,
         cordappsForAllNodes: Collection<TestCordapp> = DriverParameters().cordappsForAllNodes(),
+        signCordapps: Boolean = false,
         dsl: DriverDSLImpl.() -> A
 ): A {
     return genericDriver(
@@ -1174,7 +1176,8 @@ fun <A> internalDriver(
                     networkParameters = networkParameters,
                     notaryCustomOverrides = notaryCustomOverrides,
                     inMemoryDB = inMemoryDB,
-                    cordappsForAllNodes = cordappsForAllNodes
+                    cordappsForAllNodes = cordappsForAllNodes,
+                    signCordapps = signCordapps
             ),
             coerce = { it },
             dsl = dsl,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -140,7 +140,8 @@ fun <A> rpcDriver(
                             networkParameters = networkParameters,
                             notaryCustomOverrides = notaryCustomOverrides,
                             inMemoryDB = inMemoryDB,
-                            cordappsForAllNodes = cordappsForAllNodes
+                            cordappsForAllNodes = cordappsForAllNodes,
+                            signCordapps = false
                     ), externalTrace
             ),
             coerce = { it },

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappDirectories.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappDirectories.kt
@@ -20,6 +20,7 @@ object TestCordappDirectories {
 
     private val testCordappsCache = ConcurrentHashMap<TestCordappImpl, Path>()
 
+    //TODO In future, we may wish to associate a signer attribute to TestCordapp interface itself, and trigger signing from that.
     fun getJarDirectory(cordapp: TestCordapp, cordappsDirectory: Path = defaultCordappsDirectory, signJar: Boolean = false): Path {
         cordapp as TestCordappImpl
         return testCordappsCache.computeIfAbsent(cordapp) {
@@ -36,6 +37,7 @@ object TestCordappDirectories {
             val configDir = (cordappDir / "config").createDirectories()
             val jarFile = cordappDir / "$filename.jar"
             cordapp.packageAsJar(jarFile)
+            //TODO in future we may extend the signing with user-defined key-stores/certs/keys.
             if (signJar) {
                 val testKeystore = "_teststore"
                 val alias = "Test"

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappDirectories.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappDirectories.kt
@@ -2,12 +2,11 @@ package net.corda.testing.node.internal
 
 import com.typesafe.config.ConfigValueFactory
 import net.corda.core.crypto.sha256
-import net.corda.core.internal.createDirectories
-import net.corda.core.internal.deleteRecursively
-import net.corda.core.internal.div
-import net.corda.core.internal.writeText
+import net.corda.core.internal.*
 import net.corda.core.utilities.debug
 import net.corda.core.utilities.loggerFor
+import net.corda.testing.core.JarSignatureTestUtils.signJar
+import net.corda.testing.core.JarSignatureTestUtils.generateKey
 import net.corda.testing.node.TestCordapp
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -21,7 +20,7 @@ object TestCordappDirectories {
 
     private val testCordappsCache = ConcurrentHashMap<TestCordappImpl, Path>()
 
-    fun getJarDirectory(cordapp: TestCordapp, cordappsDirectory: Path = defaultCordappsDirectory): Path {
+    fun getJarDirectory(cordapp: TestCordapp, cordappsDirectory: Path = defaultCordappsDirectory, signJar: Boolean = false): Path {
         cordapp as TestCordappImpl
         return testCordappsCache.computeIfAbsent(cordapp) {
             val configString = ConfigValueFactory.fromMap(cordapp.config).toConfig().root().render()
@@ -37,6 +36,16 @@ object TestCordappDirectories {
             val configDir = (cordappDir / "config").createDirectories()
             val jarFile = cordappDir / "$filename.jar"
             cordapp.packageAsJar(jarFile)
+            if (signJar) {
+                val testKeystore = "_teststore"
+                val alias = "Test"
+                val pwd = "secret!"
+                if (!(cordappsDirectory / testKeystore).exists()) {
+                    cordappsDirectory.generateKey(alias, pwd, "O=Test Company Ltd,OU=Test,L=London,C=GB")
+                }
+                (cordappsDirectory / testKeystore).copyTo(cordappDir / testKeystore)
+                cordappDir.signJar("$filename.jar", alias, pwd)
+            }
             (configDir / "$filename.conf").writeText(configString)
             logger.debug { "$cordapp packaged into $jarFile" }
             cordappDir


### PR DESCRIPTION
`internalDriver` can sign CorDapp JAR, disabled by default.