### PR TITLE
CORDA-1825 user-friendly error when serializing non-composable types

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
@@ -14,6 +14,11 @@ interface ObjectSerializer : AMQPSerializer<Any> {
 
     companion object {
         fun make(typeInformation: LocalTypeInformation, factory: LocalSerializerFactory): ObjectSerializer {
+            if (typeInformation is LocalTypeInformation.NonComposable)
+                throw NotSerializableException(
+                        "Trying to build an object serializer for ${typeInformation.typeIdentifier.prettyPrint()}, " +
+                        "but it is not constructible from its public properties, and so requires a custom serialiser.")
+
             val typeDescriptor = factory.createDescriptor(typeInformation)
             val typeNotation = TypeNotationGenerator.getTypeNotation(typeInformation, typeDescriptor)
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
@@ -3,6 +3,7 @@ package net.corda.serialization.internal.amqp
 import net.corda.serialization.internal.amqp.testutils.*
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 
 // Prior to certain fixes being made within the [PropertySerializaer] classes these simple
 // deserialization operations would've blown up with type mismatch errors where the deserlized
@@ -525,6 +526,14 @@ class DeserializeSimpleTypesTests {
 
         // This not throwing is the point of the test
         DeserializationInput(sf2).deserialize(serializedA.obj)
+    }
+
+    @Test
+    fun classHasNoPublicConstructor() {
+        assertFails("Trying to build an object serializer for Optional (erased), " +
+                "but it is not constructible from its public properties, and so requires a custom serialiser.") {
+            TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(java.util.Optional.of(1))
+        }
     }
 
 }


### PR DESCRIPTION
When an attempt is made to serialize a type with no public constructor (e.g. `java.util.Optional`), and no custom serializer, the following message is now returned:

```
Trying to build an object serializer for Optional (erased), but it is not constructible from its public properties, and so requires a custom serialiser.
```