### PR TITLE
CORDA-2115: Notary whitelist verification changes

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -2278,8 +2278,6 @@ public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.cor
   @NotNull
   public java.util.List<net.corda.core.crypto.TransactionSignature> call()
   @NotNull
-  protected final net.corda.core.identity.Party checkTransaction()
-  @NotNull
   public net.corda.core.utilities.ProgressTracker getProgressTracker()
   @Suspendable
   @NotNull
@@ -6383,7 +6381,7 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @NotNull
   public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
   @NotNull
-  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
   protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
   @NotNull

--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -1,6 +1,7 @@
 package net.corda.client.rpc;
 
 import net.corda.core.contracts.Amount;
+import net.corda.core.identity.Party;
 import net.corda.core.messaging.CordaRPCOps;
 import net.corda.core.messaging.FlowHandle;
 import net.corda.core.utilities.OpaqueBytes;
@@ -28,10 +29,11 @@ import static net.corda.finance.contracts.GetBalances.getCashBalance;
 import static net.corda.node.services.Permissions.invokeRpc;
 import static net.corda.node.services.Permissions.startFlow;
 import static net.corda.testing.core.TestConstants.ALICE_NAME;
+import static net.corda.testing.core.TestConstants.DUMMY_NOTARY_NAME;
 
 public class CordaRPCJavaClientTest extends NodeBasedTest {
     public CordaRPCJavaClientTest() {
-        super(Arrays.asList("net.corda.finance.contracts", CashSchemaV1.class.getPackage().getName()));
+        super(Arrays.asList("net.corda.finance.contracts", CashSchemaV1.class.getPackage().getName()), Collections.singletonList(DUMMY_NOTARY_NAME));
     }
 
     private List<String> perms = Arrays.asList(
@@ -73,9 +75,10 @@ public class CordaRPCJavaClientTest extends NodeBasedTest {
     public void testCashBalances() throws ExecutionException, InterruptedException {
         login(rpcUser.getUsername(), rpcUser.getPassword());
 
+        Party notaryIdentity = InternalTestUtilsKt.chooseIdentity(getNotaryNodes().get(0).getInfo());
         FlowHandle<AbstractCashFlow.Result> flowHandle = rpcProxy.startFlowDynamic(CashIssueFlow.class,
                 DOLLARS(123), OpaqueBytes.of((byte)0),
-                InternalTestUtilsKt.chooseIdentity(node.getInfo()));
+                notaryIdentity);
         System.out.println("Started issuing cash, waiting on result");
         flowHandle.getReturnValue().get();
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -9,6 +9,7 @@ import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.location
 import net.corda.core.internal.toPath
 import net.corda.core.messaging.*
+import net.corda.core.node.NotaryInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
@@ -45,7 +46,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance")) {
+class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance"), notaries = listOf(DUMMY_NOTARY_NAME)) {
     companion object {
         val rpcUser = User("user1", "test", permissions = setOf(all()))
     }
@@ -65,7 +66,7 @@ class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance")) {
         client = CordaRPCClient(node.node.configuration.rpcOptions.address, CordaRPCClientConfiguration.DEFAULT.copy(
             maxReconnectAttempts = 5
         ))
-        identity = node.info.identityFromX500Name(ALICE_NAME)
+        identity = notaryNodes.first().info.identityFromX500Name(DUMMY_NOTARY_NAME)
     }
 
     @After

--- a/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/FinalityFlow.kt
@@ -102,7 +102,8 @@ class FinalityFlow private constructor(val transaction: SignedTransaction,
 
         transaction.pushToLoggingContext()
         logCommandData()
-        val externalParticipants = extractExternalParticipants(verifyTx())
+        val ledgerTransaction = verifyTx()
+        val externalParticipants = extractExternalParticipants(ledgerTransaction)
 
         if (sessions != null) {
             val missingRecipients = externalParticipants - sessions.map { it.counterparty }

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -9,6 +9,7 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.identity.Party
 import net.corda.core.internal.BackpressureAwareTimedFlow
 import net.corda.core.internal.FetchDataFlow
+import net.corda.core.internal.notary.HistoricNetworkParameterStorage
 import net.corda.core.internal.notary.generateSignature
 import net.corda.core.internal.notary.validateSignatures
 import net.corda.core.internal.pushToLoggingContext
@@ -98,7 +99,7 @@ class NotaryFlow {
                 check(stx.coreTransaction is NotaryChangeWireTransaction) {
                     "Notary $notaryParty is not on the network parameter whitelist. A non-whitelisted notary can only be used for notary change transactions"
                 }
-                val historicNotary = serviceHub.networkParametersStorage.getHistoricNotary(notaryParty)
+                val historicNotary = (serviceHub.networkParametersStorage as HistoricNetworkParameterStorage).getHistoricNotary(notaryParty)
                         ?: throw IllegalStateException("The notary party $notaryParty specified by transaction ${stx.id}, is not recognised as a current or historic notary.")
                 historicNotary.validating
 

--- a/core/src/main/kotlin/net/corda/core/internal/notary/HistoricNetworkParameterStorage.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/HistoricNetworkParameterStorage.kt
@@ -1,0 +1,11 @@
+package net.corda.core.internal.notary
+
+import net.corda.core.identity.Party
+import net.corda.core.node.NotaryInfo
+
+interface HistoricNetworkParameterStorage {
+    /**
+     * Returns the [NotaryInfo] for a notary [party] in the current or any historic network parameter whitelist, or null if not found.
+     */
+    fun getHistoricNotary(party: Party): NotaryInfo?
+}

--- a/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/notary/NotaryServiceFlow.kt
@@ -4,17 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.StateRef
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.crypto.SecureHash
-import net.corda.core.flows.FlowException
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.NotarisationPayload
-import net.corda.core.flows.NotarisationRequest
-import net.corda.core.flows.NotarisationRequestSignature
-import net.corda.core.flows.NotarisationResponse
-import net.corda.core.flows.NotaryError
-import net.corda.core.flows.NotaryException
-import net.corda.core.flows.NotaryFlow
-import net.corda.core.flows.WaitTimeUpdate
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.MIN_PLATFORM_VERSION_FOR_BACKPRESSURE_MESSAGE
 import net.corda.core.internal.checkParameterHash
@@ -55,9 +45,6 @@ abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service:
 
     @Suspendable
     override fun call(): Void? {
-        check(serviceHub.myInfo.legalIdentities.any { serviceHub.networkMapCache.isNotary(it) }) {
-            "We are not a notary on the network"
-        }
         val requestPayload = otherSideSession.receive<NotarisationPayload>().unwrap { it }
 
         try {
@@ -123,6 +110,21 @@ abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service:
         }
     }
 
+    /**
+     * Check that network parameters hash on this transaction is the current hash for the network.
+     */
+    // TODO: ENT-2666 Implement network parameters fuzzy checking. By design in Corda network we have propagation time delay.
+    //     We will never end up in perfect synchronization with all the nodes. However, network parameters update process
+    //     lets us predict what is the reasonable time window for changing parameters on most of the nodes.
+    @Suspendable
+    protected fun checkParametersHash(networkParametersHash: SecureHash?) {
+        if (networkParametersHash == null && serviceHub.networkParameters.minimumPlatformVersion < 4) return
+        val notaryParametersHash = serviceHub.networkParametersStorage.currentHash
+        require(notaryParametersHash == networkParametersHash) {
+            "Transaction for notarisation was tagged with parameters with hash: $networkParametersHash, but current network parameters are: $notaryParametersHash"
+        }
+    }
+
     /** Verifies that the correct notarisation request was signed by the counterparty. */
     private fun validateRequestSignature(request: NotarisationRequest, signature: NotarisationRequestSignature) {
         val requestingParty = otherSideSession.counterparty
@@ -133,8 +135,7 @@ abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service:
      * Override to implement custom logic to perform transaction verification based on validity and privacy requirements.
      */
     @Suspendable
-    protected open fun verifyTransaction(requestPayload: NotarisationPayload) {
-    }
+    abstract fun verifyTransaction(requestPayload: NotarisationPayload)
 
     @Suspendable
     private fun signTransactionAndSendResponse(txId: SecureHash) {
@@ -158,7 +159,7 @@ abstract class NotaryServiceFlow(val otherSideSession: FlowSession, val service:
     private fun logError(error: NotaryError) {
         val errorCause = when (error) {
             is NotaryError.RequestSignatureInvalid -> error.cause
-            is NotaryError.TransactionInvalid ->  error.cause
+            is NotaryError.TransactionInvalid -> error.cause
             is NotaryError.General -> error.cause
             else -> null
         }

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkParametersStorage.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkParametersStorage.kt
@@ -1,10 +1,10 @@
 package net.corda.core.node.services
 
-import net.corda.core.CordaInternal
 import net.corda.core.DoNotImplement
 import net.corda.core.crypto.SecureHash
-import net.corda.core.internal.SignedDataWithCert
+import net.corda.core.identity.Party
 import net.corda.core.node.NetworkParameters
+import net.corda.core.node.NotaryInfo
 
 /**
  * Interface for handling network parameters storage used for resolving transactions according to parameters that were
@@ -27,4 +27,9 @@ interface NetworkParametersStorage {
      * get them from network map.
      */
     fun lookup(hash: SecureHash): NetworkParameters?
+
+    /**
+     * Returns the [NotaryInfo] for a notary [party] in the current or any historic network parameter whitelist, or null if not found.
+     */
+    fun getHistoricNotary(party: Party): NotaryInfo?
 }

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkParametersStorage.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkParametersStorage.kt
@@ -27,9 +27,4 @@ interface NetworkParametersStorage {
      * get them from network map.
      */
     fun lookup(hash: SecureHash): NetworkParameters?
-
-    /**
-     * Returns the [NotaryInfo] for a notary [party] in the current or any historic network parameter whitelist, or null if not found.
-     */
-    fun getHistoricNotary(party: Party): NotaryInfo?
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -250,6 +250,7 @@ data class ContractUpgradeLedgerTransaction(
     private val upgradedContract: UpgradedContract<ContractState, *> = loadUpgradedContract()
 
     init {
+        checkNotaryWhitelisted()
         // TODO: relax this constraint once upgrading encumbered states is supported.
         check(inputs.all { it.state.contract == legacyContractClassName }) {
             "All input states must point to the legacy contract"

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -53,8 +53,6 @@ private constructor(
         val timeWindow: TimeWindow?,
         val privacySalt: PrivacySalt,
         /** Network parameters that were in force when the transaction was notarised. */
-        // TODO Network parameters should never be null on LedgerTransaction, this is left only because of deprecated constructors. We should decide to
-        //  get rid of them.
         override val networkParameters: NetworkParameters?,
         override val references: List<StateAndRef<ContractState>>
         //DOCEND 1
@@ -67,6 +65,7 @@ private constructor(
     init {
         checkBaseInvariants()
         if (timeWindow != null) check(notary != null) { "Transactions with time-windows must be notarised" }
+        checkNotaryWhitelisted()
         checkNoNotaryChange()
         checkEncumbrancesValid()
     }

--- a/core/src/test/kotlin/net/corda/core/contracts/ConstraintsPropagationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/ConstraintsPropagationTests.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.node.NotaryInfo
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.finance.POUNDS
 import net.corda.finance.`issued by`
@@ -48,10 +49,14 @@ class ConstraintsPropagationTests {
                 doReturn(ALICE_PARTY).whenever(it).partyFromKey(ALICE_PUBKEY)
                 doReturn(BOB_PARTY).whenever(it).partyFromKey(BOB_PUBKEY)
             },
-            networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
-                    .copy(whitelistedContractImplementations = mapOf(
+            networkParameters = testNetworkParameters(
+                    minimumPlatformVersion = 4,
+                    whitelistedContractImplementations = mapOf(
                             Cash.PROGRAM_ID to listOf(SecureHash.zeroHash, SecureHash.allOnesHash),
-                            noPropagationContractClassName to listOf(SecureHash.zeroHash)))
+                            noPropagationContractClassName to listOf(SecureHash.zeroHash)
+                    ),
+                    notaries = listOf(NotaryInfo(DUMMY_NOTARY, true))
+            )
     )
 
     @Test

--- a/core/src/test/kotlin/net/corda/core/contracts/PackageOwnershipVerificationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/PackageOwnershipVerificationTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.node.NotaryInfo
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.node.services.api.IdentityServiceInternal
 import net.corda.testing.common.internal.testNetworkParameters
@@ -43,8 +44,10 @@ class PackageOwnershipVerificationTests {
                 doReturn(ALICE_PARTY).whenever(it).partyFromKey(ALICE_PUBKEY)
                 doReturn(BOB_PARTY).whenever(it).partyFromKey(BOB_PUBKEY)
             },
-            networkParameters = testNetworkParameters()
-                    .copy(packageOwnership = mapOf("net.corda.core.contracts" to OWNER_KEY_PAIR.public))
+            networkParameters = testNetworkParameters(
+                    packageOwnership = mapOf("net.corda.core.contracts" to OWNER_KEY_PAIR.public),
+                    notaries = listOf(NotaryInfo(DUMMY_NOTARY, true))
+            )
     )
 
     @Test
@@ -70,7 +73,6 @@ class PackageOwnershipVerificationTests {
             }
         }
     }
-
 }
 
 @BelongsToContract(DummyContract::class)

--- a/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
+++ b/core/src/test/kotlin/net/corda/core/crypto/PartialMerkleTreeTest.kt
@@ -6,6 +6,7 @@ import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash.Companion.zeroHash
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.node.NotaryInfo
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.ReferenceStateRef
@@ -49,6 +50,7 @@ class PartialMerkleTreeTest {
     @Rule
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
+
     private val nodes = "abcdef"
     private lateinit var hashed: List<SecureHash.SHA256>
     private lateinit var expectedRoot: SecureHash
@@ -56,6 +58,7 @@ class PartialMerkleTreeTest {
     private lateinit var testLedger: LedgerDSL<TestTransactionDSLInterpreter, TestLedgerDSLInterpreter>
     private lateinit var txs: List<WireTransaction>
     private lateinit var testTx: WireTransaction
+
     @Before
     fun init() {
         hashed = nodes.map { it.serialize().sha256() }
@@ -66,8 +69,9 @@ class PartialMerkleTreeTest {
                 cordappPackages = emptyList(),
                 initialIdentity = TestIdentity(MEGA_CORP.name),
                 identityService = rigorousMock<IdentityServiceInternal>().also {
-                    doReturn(MEGA_CORP).whenever(it).partyFromKey(MEGA_CORP_PUBKEY) },
-                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+                    doReturn(MEGA_CORP).whenever(it).partyFromKey(MEGA_CORP_PUBKEY)
+                },
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4, notaries = listOf(NotaryInfo(DUMMY_NOTARY, true)))
         ).ledger(DUMMY_NOTARY) {
             unverifiedTransaction {
                 attachments(Cash.PROGRAM_ID)

--- a/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
@@ -120,7 +120,7 @@ class WithReferencedStatesFlowTests {
         private val mockNet = InternalMockNetwork(
                 cordappsForAllNodes = cordappsForPackages("net.corda.core.flows", "net.corda.testing.contracts"),
                 threadPerNode = true,
-                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+                initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
         )
     }
 

--- a/core/src/test/kotlin/net/corda/core/transactions/LedgerTransactionQueryTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/LedgerTransactionQueryTests.kt
@@ -7,7 +7,9 @@ import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.node.NotaryInfo
 import net.corda.node.services.api.IdentityServiceInternal
+import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.*
 import net.corda.testing.internal.rigorousMock
@@ -29,10 +31,15 @@ class LedgerTransactionQueryTests {
     @JvmField
     val testSerialization = SerializationEnvironmentRule()
     private val keyPair = generateKeyPair()
-    private val services = MockServices(listOf("net.corda.testing.contracts"), CordaX500Name("MegaCorp", "London", "GB"),
+    private val services = MockServices(
+            listOf("net.corda.testing.contracts"),
+            TestIdentity(CordaX500Name("MegaCorp", "London", "GB"), keyPair),
             rigorousMock<IdentityServiceInternal>().also {
                 doReturn(null).whenever(it).partyFromKey(keyPair.public)
-            }, keyPair)
+            },
+            testNetworkParameters(notaries = listOf(NotaryInfo(DUMMY_NOTARY, true))),
+            keyPair
+    )
     private val identity: Party = services.myInfo.singleIdentity()
 
     @Before

--- a/core/src/test/kotlin/net/corda/core/transactions/ReferenceInputStateTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/ReferenceInputStateTests.kt
@@ -8,6 +8,7 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
+import net.corda.core.node.NotaryInfo
 import net.corda.finance.DOLLARS
 import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
@@ -49,8 +50,7 @@ class ReferenceStateTests {
                 doReturn(ALICE_PARTY).whenever(it).partyFromKey(ALICE_PUBKEY)
                 doReturn(BOB_PARTY).whenever(it).partyFromKey(BOB_PUBKEY)
             },
-            networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
-
+            networkParameters = testNetworkParameters(minimumPlatformVersion = 4, notaries = listOf(NotaryInfo(DUMMY_NOTARY, true)))
     )
 
     // This state has only been created to serve reference data so it cannot ever be used as an input or

--- a/core/src/test/kotlin/net/corda/core/transactions/TransactionTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/TransactionTests.kt
@@ -6,6 +6,7 @@ import net.corda.core.contracts.*
 import net.corda.core.crypto.*
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.identity.Party
+import net.corda.core.node.NotaryInfo
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.*
@@ -176,7 +177,7 @@ class TransactionTests {
                 notary,
                 timeWindow,
                 privacySalt,
-                testNetworkParameters(),
+                testNetworkParameters(notaries = listOf(NotaryInfo(DUMMY_NOTARY, true))),
                 emptyList()
         )
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
@@ -23,6 +23,7 @@ import net.corda.node.VersionInfo
 import net.corda.node.internal.cordapp.CordappProviderImpl
 import net.corda.node.internal.cordapp.JarScanningCordappLoader
 import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.common.internal.addNotary
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
@@ -67,7 +68,7 @@ class AttachmentLoadingTests {
     }
 
     private val services = object : ServicesForResolution {
-        private val testNetworkParameters = testNetworkParameters()
+        private val testNetworkParameters = testNetworkParameters().addNotary(DUMMY_NOTARY)
         override fun loadState(stateRef: StateRef): TransactionState<*> = throw NotImplementedError()
         override fun loadStates(stateRefs: Set<StateRef>): Set<StateAndRef<ContractState>> = throw NotImplementedError()
         override val identityService = rigorousMock<IdentityService>().apply {

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -13,7 +13,10 @@ import net.corda.node.services.config.MB
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.contracts.DummyState
-import net.corda.testing.core.*
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.core.dummyCommand
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
@@ -27,7 +30,6 @@ import kotlin.test.assertEquals
 class LargeTransactionsTest {
     private companion object {
         val BOB = TestIdentity(BOB_NAME, 80).party
-        val DUMMY_NOTARY = TestIdentity(DUMMY_NOTARY_NAME, 20).party
     }
 
     @StartableByRPC
@@ -38,7 +40,8 @@ class LargeTransactionsTest {
                                    private val hash4: SecureHash) : FlowLogic<Unit>() {
         @Suspendable
         override fun call() {
-            val tx = TransactionBuilder(notary = DUMMY_NOTARY)
+            val notary = serviceHub.networkParameters.notaries.first().identity
+            val tx = TransactionBuilder(notary)
                     .addOutputState(DummyState(), DummyContract.PROGRAM_ID)
                     .addCommand(dummyCommand(ourIdentity.owningKey))
                     .addAttachment(hash1)

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -168,7 +168,8 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     val networkMapClient: NetworkMapClient? = configuration.networkServices?.let { NetworkMapClient(it.networkMapURL, versionInfo) }
     val attachments = NodeAttachmentService(metricRegistry, cacheFactory, database).tokenize()
     val cryptoService = configuration.makeCryptoService()
-    val networkParametersStorage = DBNetworkParametersStorage(cacheFactory, database, networkMapClient).tokenize()
+    @Suppress("LeakingThis")
+    val networkParametersStorage = makeParametersStorage()
     val cordappProvider = CordappProviderImpl(cordappLoader, CordappConfigFileProvider(configuration.cordappDirectories), attachments).tokenize()
     @Suppress("LeakingThis")
     val keyManagementService = makeKeyManagementService(identityService).tokenize()
@@ -362,7 +363,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
 
         // Do all of this in a database transaction so anything that might need a connection has one.
         return database.transaction {
-            networkParametersStorage.start(signedNetParams, trustRoot)
+            networkParametersStorage.setCurrentParameters(signedNetParams, trustRoot)
             identityService.loadIdentities(nodeInfo.legalIdentitiesAndCerts)
             attachments.start()
             cordappProvider.start(netParams.whitelistedContractImplementations)
@@ -701,6 +702,10 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         return DBTransactionStorage(database, cacheFactory)
     }
 
+    protected open fun makeParametersStorage(): NetworkParametersStorageInternal {
+        return DBNetworkParametersStorage(cacheFactory, database, networkMapClient).tokenize()
+    }
+
     @VisibleForTesting
     protected open fun acceptableLiveFiberCountOnStop(): Int = 0
 
@@ -778,7 +783,8 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             /** Some notary implementations only work with Java serialization. */
             maybeInstallSerializationFilter(serviceClass)
 
-            val constructor = serviceClass.getDeclaredConstructor(ServiceHubInternal::class.java, PublicKey::class.java).apply { isAccessible = true }
+            val constructor = serviceClass.getDeclaredConstructor(ServiceHubInternal::class.java, PublicKey::class.java)
+                    .apply { isAccessible = true }
             val service = constructor.newInstance(services, notaryKey) as NotaryService
 
             service.run {

--- a/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
@@ -1,10 +1,12 @@
 package net.corda.node.internal
 
 import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.Party
 import net.corda.core.internal.DigitalSignatureWithCert
 import net.corda.core.internal.NamedCacheFactory
 import net.corda.core.internal.SignedDataWithCert
 import net.corda.core.node.NetworkParameters
+import net.corda.core.node.NotaryInfo
 import net.corda.core.node.services.NetworkParametersStorage
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.SingletonSerializeAsToken
@@ -37,6 +39,8 @@ interface NetworkParametersStorageInternal : NetworkParametersStorage {
      * Hash should always be calculated over the serialized bytes.
      */
     fun saveParameters(signedNetworkParameters: SignedDataWithCert<NetworkParameters>)
+
+    fun setCurrentParameters(currentSignedParameters: SignedDataWithCert<NetworkParameters>, trustRoot: X509Certificate)
 }
 
 class DBNetworkParametersStorage(
@@ -71,7 +75,7 @@ class DBNetworkParametersStorage(
         }
     }
 
-    fun start(currentSignedParameters: SignedDataWithCert<NetworkParameters>, trustRoot: X509Certificate) {
+    override fun setCurrentParameters(currentSignedParameters: SignedDataWithCert<NetworkParameters>, trustRoot: X509Certificate) {
         this.trustRoot = trustRoot
         saveParameters(currentSignedParameters)
         _currentHash = currentSignedParameters.raw.hash
@@ -116,6 +120,22 @@ class DBNetworkParametersStorage(
             log.warn("Tried to download historical network parameters with hash $parametersHash, but network map url isn't configured")
             null
         }
+    }
+
+    /**
+     * Try to obtain notary info from the current network parameters. If not found, look through historical ones.
+     */
+    override fun getHistoricNotary(party: Party): NotaryInfo? {
+        val currentParameters = lookup(currentHash)
+                ?: throw IllegalStateException("Unable to obtain NotaryInfo – current network parameters not set.")
+        val inCurrentParams = currentParameters.notaries.singleOrNull { it.identity == party }
+        if (inCurrentParams == null) {
+            val inOldParams = hashToParameters.allPersisted().flatMap { (_, signedParams) ->
+                val parameters = signedParams.raw.deserialize()
+                parameters.notaries.asSequence()
+            }.firstOrNull { it.identity == party }
+            return inOldParams
+        } else return inCurrentParams
     }
 
     @Entity

--- a/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
@@ -5,6 +5,7 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.DigitalSignatureWithCert
 import net.corda.core.internal.NamedCacheFactory
 import net.corda.core.internal.SignedDataWithCert
+import net.corda.core.internal.notary.HistoricNetworkParameterStorage
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
 import net.corda.core.node.services.NetworkParametersStorage
@@ -49,7 +50,7 @@ class DBNetworkParametersStorage(
         // TODO It's very inefficient solution (at least at the beginning when node joins without historical data)
         // We could have historic parameters endpoint or always add parameters as an attachment to the transaction.
         private val networkMapClient: NetworkMapClient?
-) : NetworkParametersStorageInternal, SingletonSerializeAsToken() {
+) : NetworkParametersStorageInternal, HistoricNetworkParameterStorage, SingletonSerializeAsToken() {
     private lateinit var trustRoot: X509Certificate
 
     companion object {

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -29,16 +29,10 @@ class NotaryChangeHandler(otherSideSession: FlowSession) : AbstractStateReplacem
     override fun verifyProposal(stx: SignedTransaction, proposal: AbstractStateReplacementFlow.Proposal<Party>) {
         val state = proposal.stateRef
         val proposedTx = stx.resolveNotaryChangeTransaction(serviceHub)
-        val newNotary = proposal.modification
+        // TODO: Right now all nodes will automatically approve the notary change. We need to figure out if stricter controls are necessary.
 
         if (state !in proposedTx.inputs.map { it.ref }) {
             throw StateReplacementException("The proposed state $state is not in the proposed transaction inputs")
-        }
-
-        // TODO: load and compare against notary whitelist from config. Remove the check below
-        val isNotary = serviceHub.networkMapCache.isNotary(newNotary)
-        if (!isNotary) {
-            throw StateReplacementException("The proposed node $newNotary does not run a Notary service")
         }
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
+++ b/node/src/main/kotlin/net/corda/node/services/CoreFlowHandlers.kt
@@ -34,6 +34,12 @@ class NotaryChangeHandler(otherSideSession: FlowSession) : AbstractStateReplacem
         if (state !in proposedTx.inputs.map { it.ref }) {
             throw StateReplacementException("The proposed state $state is not in the proposed transaction inputs")
         }
+
+        val newNotary = proposal.modification
+        val isNotary = serviceHub.networkMapCache.isNotary(newNotary)
+        if (!isNotary) {
+            throw StateReplacementException("The proposed node $newNotary does not run a Notary service")
+        }
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -1,11 +1,17 @@
 package net.corda.node.services.transactions
 
 import net.corda.core.contracts.ComponentGroupEnum
+import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FlowSession
 import net.corda.core.flows.NotarisationPayload
+import net.corda.core.flows.NotaryError
+import net.corda.core.identity.Party
+import net.corda.core.internal.notary.NotaryInternalException
 import net.corda.core.internal.notary.NotaryServiceFlow
 import net.corda.core.internal.notary.SinglePartyNotaryService
+import net.corda.core.node.NetworkParameters
 import net.corda.core.transactions.ContractUpgradeFilteredTransaction
+import net.corda.core.transactions.CoreTransaction
 import net.corda.core.transactions.FilteredTransaction
 import net.corda.core.transactions.NotaryChangeWireTransaction
 import java.time.Duration
@@ -19,25 +25,78 @@ import java.time.Duration
  * undo the commit of the input states (the exact mechanism still needs to be worked out).
  */
 class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePartyNotaryService, etaThreshold: Duration) : NotaryServiceFlow(otherSideSession, service, etaThreshold) {
+    private val minPlatformVersion get() = serviceHub.networkParameters.minimumPlatformVersion
+
     override fun extractParts(requestPayload: NotarisationPayload): TransactionParts {
         val tx = requestPayload.coreTransaction
         return when (tx) {
-            is FilteredTransaction -> {
-                tx.apply {
-                    verify()
-                    checkAllComponentsVisible(ComponentGroupEnum.INPUTS_GROUP)
-                    checkAllComponentsVisible(ComponentGroupEnum.TIMEWINDOW_GROUP)
-                    checkAllComponentsVisible(ComponentGroupEnum.REFERENCES_GROUP)
-                    if(serviceHub.networkParameters.minimumPlatformVersion >= 4) checkAllComponentsVisible(ComponentGroupEnum.PARAMETERS_GROUP)
-                }
-                TransactionParts(tx.id, tx.inputs, tx.timeWindow, tx.notary, tx.references, networkParametersHash = tx.networkParametersHash)
-            }
+            is FilteredTransaction -> TransactionParts(tx.id, tx.inputs, tx.timeWindow, tx.notary, tx.references, networkParametersHash = tx.networkParametersHash)
             is ContractUpgradeFilteredTransaction,
             is NotaryChangeWireTransaction -> TransactionParts(tx.id, tx.inputs, null, tx.notary, networkParametersHash = tx.networkParametersHash)
-            else -> {
-                throw IllegalArgumentException("Received unexpected transaction type: ${tx::class.java.simpleName}," +
-                        "expected either ${FilteredTransaction::class.java.simpleName} or ${NotaryChangeWireTransaction::class.java.simpleName}")
-            }
+            else -> throw unexpectedTransactionType(tx)
         }
+    }
+
+    override fun verifyTransaction(requestPayload: NotarisationPayload) {
+        val tx = requestPayload.coreTransaction
+        try {
+            when (tx) {
+                is FilteredTransaction -> {
+                    tx.apply {
+                        verify()
+                        checkAllComponentsVisible(ComponentGroupEnum.INPUTS_GROUP)
+                        checkAllComponentsVisible(ComponentGroupEnum.TIMEWINDOW_GROUP)
+                        checkAllComponentsVisible(ComponentGroupEnum.REFERENCES_GROUP)
+                        if (minPlatformVersion >= 4) checkAllComponentsVisible(ComponentGroupEnum.PARAMETERS_GROUP)
+                    }
+                    val notary = tx.notary ?: throw IllegalArgumentException("Transaction does not specify a notary.")
+                    checkNotaryWhitelisted(notary, tx.networkParametersHash)
+                }
+                is ContractUpgradeFilteredTransaction -> {
+                    checkNotaryWhitelisted(tx.notary, tx.networkParametersHash)
+                }
+                is NotaryChangeWireTransaction -> {
+                    checkNotaryWhitelisted(tx.newNotary, tx.networkParametersHash)
+                }
+                else -> throw unexpectedTransactionType(tx)
+            }
+        } catch (e: Exception) {
+            throw NotaryInternalException(NotaryError.TransactionInvalid(e))
+        }
+    }
+
+    /** Make sure the transaction notary is part of the network parameter whitelist. */
+    private fun checkNotaryWhitelisted(notary: Party, attachedParameterHash: SecureHash?) {
+        if (minPlatformVersion >= 4) {
+            // Expecting network parameters to be attached for platform version 4 or later.
+            if (attachedParameterHash == null) {
+                throw IllegalArgumentException("Transaction must contain network parameters.")
+            }
+            // TODO: If not found, the notary should resolve network parameters from the network map server or the counterparty.
+            val attachedParameters = serviceHub.networkParametersStorage.lookup(attachedParameterHash)
+                    ?: throw IllegalStateException("Unable to resolve network parameters from hash: $attachedParameterHash")
+
+            checkInWhitelist(attachedParameters, notary)
+        } else {
+            // Using default network parameters for platform versions 3 or earlier
+            val defaultParams = with(serviceHub.networkParametersStorage) {
+                lookup(defaultHash)
+                        ?: throw IllegalStateException("Unable to verify whether the notary $notary is whitelisted: default network parameters not set.")
+            }
+            checkInWhitelist(defaultParams, notary)
+        }
+    }
+
+    private fun checkInWhitelist(networkParameters: NetworkParameters, notary: Party) {
+        val notaryWhitelist = networkParameters.notaries.map { it.identity }
+
+        check(notary in notaryWhitelist) {
+            "Notary specified by the transaction ($notary) is not on the network parameter whitelist: ${notaryWhitelist.joinToString()}"
+        }
+    }
+
+    private fun unexpectedTransactionType(tx: CoreTransaction): IllegalArgumentException {
+        return IllegalArgumentException("Received unexpected transaction type: ${tx::class.java.simpleName}," +
+                "expected either ${FilteredTransaction::class.java.simpleName} or ${NotaryChangeWireTransaction::class.java.simpleName}")
     }
 }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -72,7 +72,6 @@ class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePart
             if (attachedParameterHash == null) {
                 throw IllegalArgumentException("Transaction must contain network parameters.")
             }
-            // TODO: If not found, the notary should resolve network parameters from the network map server or the counterparty.
             val attachedParameters = serviceHub.networkParametersStorage.lookup(attachedParameterHash)
                     ?: throw IllegalStateException("Unable to resolve network parameters from hash: $attachedParameterHash")
 

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -77,10 +77,10 @@ class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePart
 
             checkInWhitelist(attachedParameters, notary)
         } else {
-            // Using default network parameters for platform versions 3 or earlier
+            // Using current network parameters for platform versions 3 or earlier.
             val defaultParams = with(serviceHub.networkParametersStorage) {
-                lookup(defaultHash)
-                        ?: throw IllegalStateException("Unable to verify whether the notary $notary is whitelisted: default network parameters not set.")
+                lookup(currentHash)
+                        ?: throw IllegalStateException("Unable to verify whether the notary $notary is whitelisted: current network parameters not set.")
             }
             checkInWhitelist(defaultParams, notary)
         }

--- a/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/ValidatingNotaryFlow.kt
@@ -38,7 +38,7 @@ open class ValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePa
             resolveAndContractVerify(stx)
             verifySignatures(stx)
         } catch (e: Exception) {
-            throw  NotaryInternalException(NotaryError.TransactionInvalid(e))
+            throw NotaryInternalException(NotaryError.TransactionInvalid(e))
         }
     }
 

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -497,7 +497,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
     @Test
     fun `dependency with error on buyer side`() {
         mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages))
-        mockNet.defaultNotaryNode.services.ledger(DUMMY_NOTARY) {
+        mockNet.defaultNotaryNode.services.ledger(mockNet.defaultNotaryIdentity) {
             runWithError(true, false, "at least one cash input")
         }
     }
@@ -505,7 +505,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
     @Test
     fun `dependency with error on seller side`() {
         mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages))
-        mockNet.defaultNotaryNode.services.ledger(DUMMY_NOTARY) {
+        mockNet.defaultNotaryNode.services.ledger(mockNet.defaultNotaryIdentity) {
             runWithError(false, true, "Issuances have a time-window")
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/network/DBNetworkParametersStorageTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/DBNetworkParametersStorageTest.kt
@@ -63,7 +63,7 @@ class DBNetworkParametersStorageTest {
         networkMapClient = createMockNetworkMapClient()
         nodeParametersStorage = DBNetworkParametersStorage(TestingNamedCacheFactory(), database, networkMapClient).apply {
             database.transaction {
-                start(netParams1, DEV_ROOT_CA.certificate)
+                setCurrentParameters(netParams1, DEV_ROOT_CA.certificate)
             }
         }
     }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -38,7 +38,7 @@ class NotaryServiceTests {
         mockNet = InternalMockNetwork(
                 cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"),
                 notarySpecs = listOf(MockNetworkNotarySpec(DUMMY_NOTARY_NAME, validating = false)),
-                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+                initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
         )
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         notaryServices = mockNet.defaultNotaryNode.services //TODO get rid of that

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
@@ -1,0 +1,249 @@
+package net.corda.node.services.transactions
+
+import net.corda.core.concurrent.CordaFuture
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.crypto.*
+import net.corda.core.flows.NotaryChangeFlow
+import net.corda.core.flows.NotaryError
+import net.corda.core.flows.NotaryException
+import net.corda.core.flows.NotaryFlow
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.internal.NotaryChangeTransactionBuilder
+import net.corda.core.transactions.NotaryChangeLedgerTransaction
+import net.corda.core.transactions.NotaryChangeWireTransaction
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.DUMMY_NOTARY_NAME
+import net.corda.testing.core.dummyCommand
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.node.MockNetworkNotarySpec
+import net.corda.testing.node.internal.*
+import org.junit.After
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.security.KeyPair
+import java.time.Instant
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@RunWith(Parameterized::class)
+class NotaryWhitelistTests(
+        /** Specified whether validating notaries should be used. */
+        private val isValidating: Boolean
+) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "Validating = {0}")
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
+
+    private val oldNotaryName = CordaX500Name("Old Notary", "Zurich", "CH")
+    private val newNotaryName = CordaX500Name("New Notary", "Zurich", "CH")
+
+    private lateinit var mockNet: InternalMockNetwork
+    private lateinit var aliceNode: TestStartedNode
+    private lateinit var oldNotary: Party
+    private lateinit var newNotary: Party
+    private lateinit var alice: Party
+
+    @Before
+    fun setup() {
+        mockNet = InternalMockNetwork(
+                cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"),
+                notarySpecs = listOf(MockNetworkNotarySpec(oldNotaryName, validating = isValidating), MockNetworkNotarySpec(newNotaryName, validating = isValidating)),
+                initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+        )
+        aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
+        oldNotary = mockNet.notaryNodes[0].info.legalIdentities.last()
+        newNotary = mockNet.notaryNodes[1].info.legalIdentities.last()
+
+        alice = aliceNode.services.myInfo.singleIdentity()
+    }
+
+    @After
+    fun cleanUp() {
+        mockNet.stopNodes()
+    }
+
+    /**
+     * This test verifies network merging support: when a sub-zone merges into another zone, and _its states are deemed to be low-risk_ by
+     * the network operator, the old notary service can temporarily operate on the new zone to facilitate notary change requests (even though
+     * it's not whitelisted for regular use).
+     */
+    @Test
+    fun `can perform notary change on a de-listed notary`() {
+        // Issue a state using the old notary. It is currently whitelisted.
+        val stateFakeNotary = issueStateOnOldNotary(oldNotary)
+
+        // Remove old notary from the whitelist
+        val parameters = aliceNode.services.networkParameters
+        val newParameters = parameters.copy(notaries = parameters.notaries.drop(1))
+        mockNet.nodes.forEach {
+            (it.networkParametersStorage as MockNetworkParametersStorage).setCurrentParametersUnverified(newParameters)
+        }
+
+        // Re-point the state to the remaining whitelisted notary. The transaction itself should be considered valid, even though the old notary is not whitelisted.
+        val futureChange = aliceNode.services.startFlow(NotaryChangeFlow(stateFakeNotary, newNotary)).resultFuture
+        mockNet.runNetwork()
+        val newSTate = futureChange.getOrThrow()
+
+        // Create a valid transaction consuming the re-pointed state.
+        val validTxBuilder = TransactionBuilder(newNotary)
+                .addInputState(newSTate)
+                .addCommand(dummyCommand(alice.owningKey))
+        val validStx = aliceNode.services.signInitialTransaction(validTxBuilder)
+
+        // The transaction verifies.
+        validStx.verify(aliceNode.services, false)
+
+        // Notarisation should succeed.
+        val future = runNotaryClient(validStx)
+        future.getOrThrow()
+    }
+
+    /**
+     * Following on from the previous one, this test verifies that a non-whitelisted notary cannot be used for regular transactions.
+     */
+    @Test
+    fun `can't perform a regular transaction on a de-listed notary`() {
+        // Issue a state using the old notary. It is currently whitelisted.
+        val state = issueStateOnOldNotary(oldNotary)
+
+        // Remove old notary from the whitelist
+        val parameters = aliceNode.services.networkParameters
+        val newParameters = parameters.copy(notaries = parameters.notaries.drop(1))
+        mockNet.nodes.forEach {
+            (it.networkParametersStorage as MockNetworkParametersStorage).setCurrentParametersUnverified(newParameters)
+        }
+
+        // Create a valid transaction consuming the state.
+        val validTxBuilder = TransactionBuilder(oldNotary)
+                .addInputState(state)
+                .addOutputState(state.state.copy())
+                .addCommand(dummyCommand(alice.owningKey))
+        val validStx = aliceNode.services.signInitialTransaction(validTxBuilder)
+
+        // The transaction does not verify as the notary is no longer whitelisted.
+        assertFailsWith<IllegalStateException> {
+            validStx.verify(aliceNode.services, false)
+        }
+
+        // Notarisation should fail (assuming the unlisted notary is not malicious).
+        val future = runNotaryClient(validStx)
+        val ex = assertFailsWith(NotaryException::class) {
+            future.getOrThrow()
+        }
+        assert(ex.error is NotaryError.TransactionInvalid)
+        assertEquals(validStx.id, ex.txId)
+    }
+
+    private fun issueStateOnOldNotary(oldNotaryParty: Party): StateAndRef<DummyContract.State> {
+        val fakeTxBuilder = DummyContract
+                .generateInitial(Random().nextInt(), oldNotaryParty, alice.ref(0))
+                .setTimeWindow(Instant.now(), 30.seconds)
+        val fakeStx = aliceNode.services.signInitialTransaction(fakeTxBuilder)
+
+        val sigs = runNotaryClient(fakeStx).getOrThrow()
+        aliceNode.services.validatedTransactions.addTransaction(fakeStx + sigs)
+        return fakeStx.tx.outRef(0)
+    }
+
+    private fun runNotaryClient(stx: SignedTransaction): CordaFuture<List<TransactionSignature>> {
+        val flow = NotaryFlow.Client(stx)
+        val future = aliceNode.services.startFlow(flow).resultFuture
+        mockNet.runNetwork()
+        return future
+    }
+
+    @Test
+    fun `should reject transaction when a dependency does not contain notary in whitelist`() {
+        Assume.assumeTrue(isValidating) // Skip the test for non-validating notaries
+
+        val fakeNotaryKeyPair = generateKeyPair()
+        val fakeNotaryParty = Party(DUMMY_NOTARY_NAME.copy(organisation = "Fake notary"), fakeNotaryKeyPair.public)
+
+        // Issue a state using an unlisted notary. This transaction should not verify when checked by counterparties.
+        val stateFakeNotary = issueStateWithFakeNotary(fakeNotaryParty, fakeNotaryKeyPair)
+
+        // Re-point the state to the whitelisted notary. The transaction itself should be considered valid, even though the old notary is not whitelisted.
+        val notaryChangeLtx = changeNotary(stateFakeNotary, fakeNotaryParty, fakeNotaryKeyPair)
+
+        // Create a valid transaction consuming the re-pointed state.
+        val inputStateValidNotary = notaryChangeLtx.outRef<DummyContract.State>(0)
+        val validTxBuilder = TransactionBuilder(oldNotary)
+                .addInputState(inputStateValidNotary)
+                .addCommand(dummyCommand(alice.owningKey))
+        val validStx = aliceNode.services.signInitialTransaction(validTxBuilder)
+
+        // The transaction itself verifies, as no resolution is done here.
+        validStx.verify(aliceNode.services, false)
+
+        val future = runNotaryClient(validStx)
+
+        // The notary should reject this transaction – the issue transaction in the dependencies should not verify.
+        val ex = assertFailsWith(NotaryException::class) {
+            future.getOrThrow()
+        }
+        assert(ex.error is NotaryError.TransactionInvalid)
+        assertEquals(validStx.id, ex.txId)
+    }
+
+    private fun issueStateWithFakeNotary(fakeNotaryParty: Party, fakeNotaryKeyPair: KeyPair): StateAndRef<DummyContract.State> {
+        val fakeTxBuilder = DummyContract
+                .generateInitial(Random().nextInt(), fakeNotaryParty, alice.ref(0))
+                .setTimeWindow(Instant.now(), 30.seconds)
+        val fakeStx = aliceNode.services.signInitialTransaction(fakeTxBuilder)
+        val notarySig = getNotarySig(fakeStx, fakeNotaryKeyPair)
+        aliceNode.services.validatedTransactions.addTransaction(fakeStx + notarySig)
+        return fakeStx.tx.outRef(0)
+    }
+
+    /** Changes the notary service to [notary]. Does not actually communicate with a notary. */
+    private fun changeNotary(inputState: StateAndRef<DummyContract.State>, fakeNotaryParty: Party, fakeNotaryKeyPair: KeyPair): NotaryChangeLedgerTransaction {
+        val notaryChangeTx = NotaryChangeTransactionBuilder(
+                listOf(inputState.ref),
+                fakeNotaryParty,
+                oldNotary,
+                aliceNode.services.networkParametersStorage.currentHash
+        ).build()
+
+        val notaryChangeAliceSig = getAliceSig(notaryChangeTx)
+
+        val notaryChangeNotarySig = run {
+            val metadata = SignatureMetadata(4, Crypto.findSignatureScheme(fakeNotaryParty.owningKey).schemeNumberID)
+            val data = SignableData(notaryChangeTx.id, metadata)
+            fakeNotaryKeyPair.sign(data)
+        }
+        val notaryChangeStx = SignedTransaction(notaryChangeTx, listOf(notaryChangeAliceSig, notaryChangeNotarySig))
+
+        aliceNode.services.validatedTransactions.addTransaction(notaryChangeStx)
+
+        // Resolving the ledger transaction verifies the whitelist checking logic – for notary change transactions the old notary
+        // does not need to be whitelisted.
+        val notaryChangeLtx = notaryChangeStx.resolveNotaryChangeTransaction(aliceNode.services)
+        notaryChangeLtx.verifyRequiredSignatures()
+        return notaryChangeLtx
+    }
+
+    private fun getAliceSig(notaryChangeTx: NotaryChangeWireTransaction): TransactionSignature {
+        val metadata = SignatureMetadata(4, Crypto.findSignatureScheme(alice.owningKey).schemeNumberID)
+        val data = SignableData(notaryChangeTx.id, metadata)
+        return aliceNode.services.keyManagementService.sign(data, alice.owningKey)
+    }
+
+    private fun getNotarySig(fakeStx: SignedTransaction, fakeNotaryKeyPair: KeyPair): TransactionSignature {
+        val metadata = SignatureMetadata(4, Crypto.findSignatureScheme(fakeNotaryKeyPair.public).schemeNumberID)
+        val data = SignableData(fakeStx.id, metadata)
+        return fakeNotaryKeyPair.sign(data)
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
@@ -3,6 +3,7 @@ package net.corda.node.services.transactions
 import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.node.NotaryInfo
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
@@ -58,7 +59,7 @@ class ResolveStatePointersTest {
                 cordappPackages = cordapps,
                 identityService = makeTestIdentityService(notary.identity, myself.identity),
                 initialIdentity = myself,
-                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4, notaries = listOf(NotaryInfo(notary.party, true)))
         )
         services = databaseAndServices.second
     }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -2,7 +2,6 @@ package net.corda.node.services.transactions
 
 import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.Command
-import net.corda.core.contracts.PrivacySalt
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.*
@@ -15,7 +14,6 @@ import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
-import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
@@ -51,7 +49,7 @@ class ValidatingNotaryServiceTests {
     @Before
     fun setup() {
         mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"),
-                networkParameters = testNetworkParameters(minimumPlatformVersion = 4))
+                initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4))
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         notaryNode = mockNet.defaultNotaryNode
         notary = mockNet.defaultNotaryIdentity
@@ -116,6 +114,7 @@ class ValidatingNotaryServiceTests {
         )
         val stx = SignedTransaction(wtx, listOf(sig))
         assertThat(stx.networkParametersHash).isNull()
+
         val future = runNotaryClient(stx)
         val ex = assertFailsWith(NotaryException::class) { future.getOrThrow() }
         val notaryError = ex.error as NotaryError.TransactionInvalid

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -11,6 +11,7 @@ import net.corda.core.crypto.generateKeyPair
 import net.corda.core.identity.*
 import net.corda.core.internal.NotaryChangeTransactionBuilder
 import net.corda.core.internal.packageName
+import net.corda.core.node.NotaryInfo
 import net.corda.core.node.StatesToRecord
 import net.corda.core.node.services.*
 import net.corda.core.node.services.vault.PageSpecification
@@ -91,7 +92,7 @@ class NodeVaultServiceTest {
     @Before
     fun setUp() {
         LogHelper.setLevel(NodeVaultService::class)
-        val parameters = testNetworkParameters()
+        val parameters = testNetworkParameters(notaries = listOf(NotaryInfo(DUMMY_NOTARY, true)))
         val databaseAndServices = MockServices.makeTestDatabaseAndMockServices(
                 cordappPackages,
                 makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, DUMMY_CASH_ISSUER_IDENTITY, DUMMY_NOTARY_IDENTITY),

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -102,7 +102,8 @@ class VaultSoftLockManagerTest {
 
     class ClientLogic(nodePair: NodePair, val state: ContractState) : NodePair.AbstractClientLogic<List<ContractState>>(nodePair) {
         override fun callImpl(): List<ContractState> {
-            val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = ourIdentity).apply {
+            val notary = serviceHub.networkParameters.notaries.first().identity
+            val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary).apply {
                 addOutputState(state, ContractImpl::class.jvmName)
                 addCommand(CommandDataImpl, ourIdentity.owningKey)
             })

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultWithCashTest.kt
@@ -11,7 +11,6 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.fork
 import net.corda.core.internal.concurrent.transpose
 import net.corda.core.internal.packageName
-import net.corda.core.node.services.IdentityService
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.queryBy
@@ -24,6 +23,8 @@ import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.contracts.getCashBalance
 import net.corda.finance.schemas.CashSchemaV1
 import net.corda.nodeapi.internal.persistence.CordaPersistence
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.common.internal.addNotary
 import net.corda.testing.core.*
 import net.corda.testing.internal.LogHelper
 import net.corda.testing.internal.rigorousMock
@@ -74,16 +75,21 @@ class VaultWithCashTest {
     @Before
     fun setUp() {
         LogHelper.setLevel(VaultWithCashTest::class)
+
+        val networkParameters = testNetworkParameters().addNotary(DUMMY_NOTARY)
         val databaseAndServices = makeTestDatabaseAndMockServices(
                 cordappPackages,
                 makeTestIdentityService(MEGA_CORP_IDENTITY, MINI_CORP_IDENTITY, dummyCashIssuer.identity, dummyNotary.identity),
                 TestIdentity(MEGA_CORP.name, servicesKey),
+                networkParameters,
                 moreKeys = *arrayOf(dummyNotary.keyPair))
         database = databaseAndServices.first
         services = databaseAndServices.second
         vaultFiller = VaultFiller(services, dummyNotary)
-        issuerServices = MockServices(cordappPackages, dummyCashIssuer, rigorousMock(), MEGA_CORP_KEY)
-        notaryServices = MockServices(cordappPackages, dummyNotary, rigorousMock<IdentityService>())
+
+
+        issuerServices = MockServices(cordappPackages, dummyCashIssuer, rigorousMock(), networkParameters, MEGA_CORP_KEY)
+        notaryServices = MockServices(cordappPackages, dummyNotary, rigorousMock(), networkParameters)
         notary = notaryServices.myInfo.legalIdentitiesAndCerts.single().party
     }
 

--- a/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt
+++ b/samples/irs-demo/cordapp/src/test/kotlin/net/corda/irs/contract/IRSTests.kt
@@ -229,8 +229,8 @@ class IRSTests {
     private val cordappPackages = listOf("net.corda.irs.contract")
     private val networkParameters = testNetworkParameters().addNotary(dummyNotary.party)
     private val megaCorpServices = MockServices(cordappPackages, megaCorp, rigorousMock(), networkParameters, megaCorp.keyPair)
-    private val miniCorpServices = MockServices(listOf("net.corda.irs.contract"), miniCorp, rigorousMock(), networkParameters,  miniCorp.keyPair)
-    private val notaryServices = MockServices(listOf("net.corda.irs.contract"), dummyNotary, rigorousMock(), networkParameters, dummyNotary.keyPair)
+    private val miniCorpServices = MockServices(cordappPackages, miniCorp, rigorousMock(), networkParameters,  miniCorp.keyPair)
+    private val notaryServices = MockServices(cordappPackages, dummyNotary, rigorousMock(), networkParameters, dummyNotary.keyPair)
     private val ledgerServices = MockServices(
             emptyList(),
             megaCorp,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -308,7 +308,7 @@ open class MockNetwork(
             networkParameters: NetworkParameters = defaultParameters.networkParameters
     ) : this(emptyList(), defaultParameters, networkSendManuallyPumped, threadPerNode, servicePeerAllocationStrategy, notarySpecs, networkParameters, cordappsForAllNodes = cordappsForPackages(cordappPackages))
 
-    private val internalMockNetwork: InternalMockNetwork = InternalMockNetwork(defaultParameters, networkSendManuallyPumped, threadPerNode, servicePeerAllocationStrategy, notarySpecs, networkParameters = networkParameters, cordappsForAllNodes = cordappsForAllNodes)
+    private val internalMockNetwork: InternalMockNetwork = InternalMockNetwork(defaultParameters, networkSendManuallyPumped, threadPerNode, servicePeerAllocationStrategy, notarySpecs, initialNetworkParameters = networkParameters, cordappsForAllNodes = cordappsForAllNodes)
 
     /** In a mock network, nodes have an incrementing integer ID. Real networks do not have this. Returns the next ID that will be used. */
     val nextNodeId get(): Int = internalMockNetwork.nextNodeId

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersStorage.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersStorage.kt
@@ -1,21 +1,40 @@
 package net.corda.testing.node.internal
 
 import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.Party
 import net.corda.core.internal.SignedDataWithCert
 import net.corda.core.node.NetworkParameters
+import net.corda.core.node.NotaryInfo
 import net.corda.core.serialization.serialize
 import net.corda.node.internal.NetworkParametersStorageInternal
+import net.corda.nodeapi.internal.network.verifiedNetworkMapCert
 import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.internal.withTestSerializationEnvIfNotSet
+import java.security.cert.X509Certificate
 import java.time.Instant
 
-class MockNetworkParametersStorage(val currentParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN)) : NetworkParametersStorageInternal {
+class MockNetworkParametersStorage(private var currentParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN)) : NetworkParametersStorageInternal {
     private val hashToParametersMap: HashMap<SecureHash, NetworkParameters> = HashMap()
 
     init {
-        hashToParametersMap[currentHash] = currentParameters
+        storeCurrentParameters()
     }
 
-    override val currentHash: SecureHash get() = currentParameters.serialize().hash
+    fun setCurrentParametersUnverified(networkParameters: NetworkParameters) {
+        currentParameters = networkParameters
+        storeCurrentParameters()
+    }
+
+    override fun setCurrentParameters(currentSignedParameters: SignedDataWithCert<NetworkParameters>, trustRoot: X509Certificate) {
+        setCurrentParametersUnverified(currentSignedParameters.verifiedNetworkMapCert(trustRoot))
+    }
+
+    override val currentHash: SecureHash
+        get() {
+            return withTestSerializationEnvIfNotSet("networkParameters") {
+                currentParameters.serialize().hash
+            }
+        }
     override val defaultHash: SecureHash get() = currentHash
     override fun getEpochFromHash(hash: SecureHash): Int? = lookup(hash)?.epoch
     override fun lookup(hash: SecureHash): NetworkParameters? = hashToParametersMap[hash]
@@ -23,5 +42,19 @@ class MockNetworkParametersStorage(val currentParameters: NetworkParameters = te
         val networkParameters = signedNetworkParameters.verified()
         val hash = signedNetworkParameters.raw.hash
         hashToParametersMap[hash] = networkParameters
+    }
+
+    override fun getHistoricNotary(party: Party): NotaryInfo? {
+        val inCurrentParams = currentParameters.notaries.singleOrNull { it.identity == party }
+        if (inCurrentParams == null) {
+            val inOldParams = hashToParametersMap.flatMap { (_, parameters) ->
+                parameters.notaries
+            }.firstOrNull { it.identity == party }
+            return inOldParams
+        } else return inCurrentParams
+    }
+
+    private fun storeCurrentParameters() {
+        hashToParametersMap[currentHash] = currentParameters
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersStorage.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersStorage.kt
@@ -3,6 +3,7 @@ package net.corda.testing.node.internal
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.Party
 import net.corda.core.internal.SignedDataWithCert
+import net.corda.core.internal.notary.HistoricNetworkParameterStorage
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
 import net.corda.core.serialization.serialize
@@ -13,7 +14,7 @@ import net.corda.testing.internal.withTestSerializationEnvIfNotSet
 import java.security.cert.X509Certificate
 import java.time.Instant
 
-class MockNetworkParametersStorage(private var currentParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN)) : NetworkParametersStorageInternal {
+class MockNetworkParametersStorage(private var currentParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN)) : NetworkParametersStorageInternal, HistoricNetworkParameterStorage {
     private val hashToParametersMap: HashMap<SecureHash, NetworkParameters> = HashMap()
 
     init {

--- a/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
+++ b/testing/test-common/src/main/kotlin/net/corda/testing/common/internal/ParametersUtilities.kt
@@ -1,9 +1,11 @@
 package net.corda.testing.common.internal
 
+import net.corda.core.identity.Party
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
 import net.corda.core.node.services.AttachmentId
 import net.corda.core.utilities.days
+import java.security.PublicKey
 import java.time.Duration
 import java.time.Instant
 
@@ -16,16 +18,31 @@ fun testNetworkParameters(
         maxTransactionSize: Int = maxMessageSize * 50,
         whitelistedContractImplementations: Map<String, List<AttachmentId>> = emptyMap(),
         epoch: Int = 1,
-        eventHorizon: Duration = 30.days
+        eventHorizon: Duration = 30.days,
+        packageOwnership: Map<String, PublicKey> = emptyMap()
 ): NetworkParameters {
     return NetworkParameters(
             minimumPlatformVersion = minimumPlatformVersion,
             notaries = notaries,
             maxMessageSize = maxMessageSize,
             maxTransactionSize = maxTransactionSize,
-            whitelistedContractImplementations = whitelistedContractImplementations,
             modifiedTime = modifiedTime,
             epoch = epoch,
-            eventHorizon = eventHorizon
+            whitelistedContractImplementations = whitelistedContractImplementations,
+            eventHorizon = eventHorizon,
+            packageOwnership = packageOwnership
     )
 }
+
+/**
+ * Includes the specified notary [party] in the network parameter whitelist to ensure transactions verify.
+ * If used when actual notarisation flows are involved, the right notary type (validating/non-validating) should be specified.
+ *
+ * Note that it returns new network parameters with a different hash.
+ */
+fun NetworkParameters.addNotary(party: Party, validating: Boolean = true): NetworkParameters {
+    val notaryInfo = NotaryInfo(party, validating)
+    val notaryList = notaries + notaryInfo
+    return copy(notaries = notaryList)
+}
+


### PR DESCRIPTION
- For regular and contract upgrade transactions: check that the notary is in the network parameter whitelist
- For notary change transactions: check the the new notary is in the network parameter whitelist. This enabled support for network merging: the old notary doesn't have to be in the current network's notary whitelist for re-pointing old states to another notary.

These checks are done during transaction construction/verification and also by the non-validating notary.

(Raising a PR against Kasia's branch but will rebase against master later).