### PR TITLE
CORDA-2253 Avoid leaking unpatched Cycles via the global type info cache

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
@@ -54,11 +54,12 @@ sealed class LocalTypeInformation {
          * types beginning the with provided [Type] and construct a complete set of [LocalTypeInformation] for that type.
          *
          * @param type The [Type] to obtain [LocalTypeInformation] for.
+         * @param typeIdentifier The [TypeIdentifier] for the [Type] to obtain [LocalTypeInformation] for.
          * @param lookup The [LocalTypeLookup] to use to find previously-constructed [LocalTypeInformation].
          */
-        fun forType(type: Type, lookup: LocalTypeLookup): LocalTypeInformation {
+        fun forType(type: Type, typeIdentifier: TypeIdentifier, lookup: LocalTypeLookup): LocalTypeInformation {
             val builder =  LocalTypeInformationBuilder(lookup)
-            val result = builder.build(type, TypeIdentifier.forGenericType(type))
+            val result = builder.build(type, typeIdentifier)
 
             // Patch every cyclic reference with a `follow` property pointing to the type information it refers to.
             builder.cycles.forEach { cycle ->


### PR DESCRIPTION
This PR fixes the bug described in [CORDA-2253](https://r3-cev.atlassian.net/browse/CORDA-2253), by using a local cache of constructed `LocalTypeInformation` during traversal of the type graph, and merging the local cache into the global cache once all type information has been constructed and cycles have been "patched" with the type information for the types they refer to.