### PR TITLE
Finance CorDapp jar includes confidential-identities

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,8 @@ Unreleased
   .. note:: V3 and V4 of confidential-identities are not compatible and confidential-identities V3 will not work with a V4 Corda node. CorDapps
      in such scenarios using confidential-identities must be updated.
 
+  The ``confidential-identities`` dependency in your CorDapp must now be ``compile`` and not ``cordaCompile``.
+
 * Marked the ``Attachment`` interface as ``@DoNotImplement`` because it is not meant to be extended by CorDapp developers. If you have already
   done so, please get in contact on the usual communication channels.
 

--- a/finance/build.gradle
+++ b/finance/build.gradle
@@ -27,10 +27,7 @@ dependencies {
     // Note the :finance module is a CorDapp in its own right
     // and CorDapps using :finance features should use 'cordapp' not 'compile' linkage.
     cordaCompile project(':core')
-    cordaCompile project(':confidential-identities')
-
-    // TODO Remove this once we have app configs
-    compile "com.typesafe:config:$typesafe_config_version"
+    compile project(':confidential-identities')
 
     // For JSON
     compile "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"


### PR DESCRIPTION
https://github.com/corda/corda/pull/4260 removed the dependency that node had to confidential-identities which means CorDapps using it must now use compile and not cordaCompile. This resolves the failing smoke test.
