### PR TITLE
[CORDA-2257]: Enable driver to read port allocation initial value from environment

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -13,7 +13,7 @@ import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.eventually
 import net.corda.testing.core.SerializationEnvironmentRule
-import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.testThreadFactory
 import net.corda.testing.node.internal.*
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration
@@ -39,7 +39,7 @@ class RPCStabilityTests {
     val testSerialization = SerializationEnvironmentRule(true)
 
     private val pool = Executors.newFixedThreadPool(10, testThreadFactory())
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
 
     @After
     fun shutdown() {

--- a/experimental/notary-raft/src/test/kotlin/net/corda/notary/raft/RaftTransactionCommitLogTests.kt
+++ b/experimental/notary-raft/src/test/kotlin/net/corda/notary/raft/RaftTransactionCommitLogTests.kt
@@ -15,13 +15,13 @@ import net.corda.core.internal.concurrent.transpose
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.schema.NodeSchemaService
-import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.SerializationEnvironmentRule
-import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.LogHelper
+import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.configureDatabase
 import net.corda.testing.node.MockServices.Companion.makeTestDataSourceProperties
 import org.hamcrest.Matchers.instanceOf
@@ -44,7 +44,7 @@ class RaftTransactionCommitLogTests {
     val testSerialization = SerializationEnvironmentRule(true)
 
     private val databases: MutableList<CordaPersistence> = mutableListOf()
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
 
     private lateinit var cluster: List<Member>
 

--- a/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AddressBindingFailureTests.kt
@@ -1,11 +1,10 @@
 package net.corda.node
 
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.internal.errors.AddressBindingException
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
-import net.corda.core.internal.errors.AddressBindingException
 import net.corda.testing.driver.DriverParameters
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
 import org.assertj.core.api.Assertions.assertThat
@@ -15,10 +14,6 @@ import java.net.InetSocketAddress
 import java.net.ServerSocket
 
 class AddressBindingFailureTests {
-
-    companion object {
-        private val portAllocation = PortAllocation.Incremental(20_000)
-    }
 
     @Test
     fun `p2p address`() = assertBindExceptionForOverrides { address -> mapOf("p2pAddress" to address.toString()) }
@@ -42,8 +37,8 @@ class AddressBindingFailureTests {
             assertThatThrownBy {
                 driver(DriverParameters(startNodesInProcess = false,
                     notarySpecs = listOf(NotarySpec(notaryName)),
-                    notaryCustomOverrides = mapOf("p2pAddress" to address.toString()),
-                        portAllocation = portAllocation)
+                    notaryCustomOverrides = mapOf("p2pAddress" to address.toString())
+                )
                 ) {} }.isInstanceOfSatisfying(IllegalStateException::class.java) { error ->
 
                 assertThat(error.message).contains("Unable to start notaries")
@@ -56,7 +51,7 @@ class AddressBindingFailureTests {
         ServerSocket(0).use { socket ->
 
             val address = InetSocketAddress(socket.localPort).toNetworkHostAndPort()
-            driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), inMemoryDB = false, portAllocation = portAllocation)) {
+            driver(DriverParameters(startNodesInProcess = true, notarySpecs = emptyList(), inMemoryDB = false)) {
 
                 assertThatThrownBy { startNode(customOverrides = overrides(address)).getOrThrow() }.isInstanceOfSatisfying(AddressBindingException::class.java) { exception ->
                     assertThat(exception.addresses).contains(address).withFailMessage("Expected addresses to contain $address but was ${exception.addresses}.")

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/AMQPBridgeTest.kt
@@ -18,9 +18,9 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.MAX_MESSAGE_SIZE
 import net.corda.testing.core.TestIdentity
-import net.corda.testing.driver.PortAllocation
-import net.corda.testing.internal.stubs.CertificateStoreStubs
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.rigorousMock
+import net.corda.testing.internal.stubs.CertificateStoreStubs
 import org.apache.activemq.artemis.api.core.Message.HDR_DUPLICATE_DETECTION_ID
 import org.apache.activemq.artemis.api.core.RoutingType
 import org.apache.activemq.artemis.api.core.SimpleString
@@ -40,7 +40,7 @@ class AMQPBridgeTest {
 
     private val BOB = TestIdentity(BOB_NAME)
 
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
     private val artemisAddress = portAllocation.nextHostAndPort()
     private val amqpAddress = portAllocation.nextHostAndPort()
 

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -25,6 +25,7 @@ import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.MAX_MESSAGE_SIZE
 import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.DEV_INTERMEDIATE_CA
 import net.corda.testing.internal.DEV_ROOT_CA
 import net.corda.testing.internal.rigorousMock
@@ -72,7 +73,7 @@ class CertificateRevocationListNodeTests {
     private val ROOT_CA = DEV_ROOT_CA
     private lateinit var INTERMEDIATE_CA: CertificateAndKeyPair
 
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
     private val serverPort = portAllocation.nextPort()
 
     private lateinit var server: CrlServer

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/ProtonWrapperTests.kt
@@ -29,6 +29,7 @@ import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.CHARLIE_NAME
 import net.corda.testing.core.MAX_MESSAGE_SIZE
 import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.createDevIntermediateCaCertPath
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.internal.stubs.CertificateStoreStubs
@@ -49,7 +50,7 @@ class ProtonWrapperTests {
     @JvmField
     val temporaryFolder = TemporaryFolder()
 
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
     private val serverPort = portAllocation.nextPort()
     private val serverPort2 = portAllocation.nextPort()
     private val artemisPort = portAllocation.nextPort()

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/FlowsDrainingModeContentionTest.kt
@@ -22,8 +22,8 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.node.User
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -33,7 +33,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
 class FlowsDrainingModeContentionTest {
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
     private val user = User("mark", "dadada", setOf(all()))
     private val users = listOf(user)
 

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/P2PFlowsDrainingModeTest.kt
@@ -1,11 +1,7 @@
 package net.corda.node.modes.draining
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
-import net.corda.core.flows.InitiatingFlow
-import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.map
 import net.corda.core.messaging.startFlow
@@ -18,8 +14,8 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.DriverParameters
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.chooseIdentity
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.waitForShutdown
@@ -38,7 +34,7 @@ class P2PFlowsDrainingModeTest {
         private val logger = contextLogger()
     }
 
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
     private val user = User("mark", "dadada", setOf(Permissions.all()))
     private val users = listOf(user)
 

--- a/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/modes/draining/RpcFlowsDrainingModeTest.kt
@@ -8,8 +8,8 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.Permissions
 import net.corda.nodeapi.exceptions.RejectedCommandException
 import net.corda.testing.driver.DriverParameters
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.node.User
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
@@ -17,7 +17,7 @@ import org.junit.Test
 
 class RpcFlowsDrainingModeTest {
 
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
     private val user = User("mark", "dadada", setOf(Permissions.all()))
     private val users = listOf(user)
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/messaging/ArtemisMessagingTest.kt
@@ -18,7 +18,7 @@ import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.MAX_MESSAGE_SIZE
 import net.corda.testing.core.SerializationEnvironmentRule
-import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.LogHelper
 import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.configureDatabase
@@ -58,7 +58,7 @@ class ArtemisMessagingTest {
     val temporaryFolder = TemporaryFolder()
 
     // THe
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
     private val serverPort = portAllocation.nextPort()
     private val identity = generateKeyPair()
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
@@ -16,8 +16,8 @@ import net.corda.nodeapi.internal.network.SignedNetworkParameters
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.*
 import net.corda.testing.driver.NodeHandle
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.internal.NodeHandleInternal
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.node.internal.*
 import net.corda.testing.node.internal.network.NetworkMapServer
 import org.assertj.core.api.Assertions.assertThat
@@ -38,7 +38,7 @@ class NetworkMapTest(var initFunc: (URL, NetworkMapServer) -> CompatibilityZoneP
     val testSerialization = SerializationEnvironmentRule(true)
 
     private val cacheTimeout = 1.seconds
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
 
     private lateinit var networkMapServer: NetworkMapServer
     private lateinit var compatibilityZone: CompatibilityZoneParams

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
@@ -23,6 +23,7 @@ import net.corda.nodeapi.internal.config.MutualSslConfiguration
 import net.corda.nodeapi.internal.config.User
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.fromUserList
 import net.corda.testing.internal.p2pSslOptions
@@ -37,7 +38,7 @@ import java.nio.file.Path
 import javax.security.auth.x500.X500Principal
 
 class ArtemisRpcTests {
-    private val ports: PortAllocation = PortAllocation.Incremental(10000)
+    private val ports: PortAllocation = mainPortAllocation()
 
     private val user = User("mark", "dadada", setOf(all()))
     private val users = listOf(user)

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -17,7 +17,7 @@ import net.corda.nodeapi.internal.crypto.X509Utilities.CORDA_ROOT_CA
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.core.singleIdentity
-import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.DEV_ROOT_CA
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.internal.DriverDSLImpl.Companion.cordappsInCurrentAndAdditionalPackages
@@ -57,7 +57,7 @@ class NodeRegistrationTest {
     @JvmField
     val testSerialization = SerializationEnvironmentRule(true)
 
-    private val portAllocation = PortAllocation.Incremental(13000)
+    private val portAllocation = mainPortAllocation()
     private val registrationHandler = RegistrationHandler(DEV_ROOT_CA)
     private lateinit var server: NetworkMapServer
     private lateinit var serverHostAndPort: NetworkHostAndPort

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/AdditionP2PAddressModeTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/AdditionP2PAddressModeTest.kt
@@ -17,18 +17,18 @@ import net.corda.testing.core.DUMMY_BANK_B_NAME
 import net.corda.testing.core.expect
 import net.corda.testing.core.expectEvents
 import net.corda.testing.driver.DriverParameters
-import net.corda.testing.driver.PortAllocation
 import net.corda.testing.driver.driver
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.node.User
 import org.junit.Test
 import java.util.*
 
 class AdditionP2PAddressModeTest {
-    private val portAllocation = PortAllocation.Incremental(27182)
+    private val portAllocation = mainPortAllocation()
     @Test
     fun `runs nodes with one configured to use additionalP2PAddresses`() {
         val testUser = User("test", "test", setOf(all()))
-        driver(DriverParameters(startNodesInProcess = true, inMemoryDB = true, extraCordappPackagesToScan = listOf("net.corda.finance"))) {
+        driver(DriverParameters(startNodesInProcess = true, inMemoryDB = true, extraCordappPackagesToScan = listOf("net.corda.finance"), portAllocation = portAllocation)) {
             val mainAddress = portAllocation.nextHostAndPort().toString()
             val altAddress = portAllocation.nextHostAndPort().toString()
             val haConfig = mutableMapOf<String, Any?>()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -360,11 +360,11 @@ fun <A> driver(defaultParameters: DriverParameters = DriverParameters(), dsl: Dr
     )
 }
 
-private fun mainPortAllocation(port: Int = 10_000, envVariable: String = "CORDA_CONFIG_TESTS_PORT_ALLOCATION_MAIN"): PortAllocation = PortAllocation.IncrementalConfigurable(envVariable, port)
+fun mainPortAllocation(port: Int = 10_000, envVariable: String = "CORDA_CONFIG_TESTS_PORT_ALLOCATION_MAIN"): PortAllocation = PortAllocation.IncrementalConfigurable(envVariable, port)
 
-private fun debugPortAllocation(port: Int = 5_005, envVariable: String = "CORDA_CONFIG_TESTS_PORT_ALLOCATION_DEBUG"): PortAllocation = PortAllocation.IncrementalConfigurable(envVariable, port)
+fun debugPortAllocation(port: Int = 5_005, envVariable: String = "CORDA_CONFIG_TESTS_PORT_ALLOCATION_DEBUG"): PortAllocation = PortAllocation.IncrementalConfigurable(envVariable, port)
 
-private fun jmxPortAllocation(port: Int = 7_005, envVariable: String = "CORDA_CONFIG_TESTS_PORT_ALLOCATION_JMX"): PortAllocation = PortAllocation.IncrementalConfigurable(envVariable, port)
+fun jmxPortAllocation(port: Int = 7_005, envVariable: String = "CORDA_CONFIG_TESTS_PORT_ALLOCATION_JMX"): PortAllocation = PortAllocation.IncrementalConfigurable(envVariable, port)
 
 /**
  * Builder for configuring a [driver].

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
@@ -19,7 +19,7 @@ import net.corda.nodeapi.internal.config.toConfig
 import net.corda.nodeapi.internal.network.NetworkParametersCopier
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.SerializationEnvironmentRule
-import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.testThreadFactory
 import net.corda.testing.node.User
 import org.apache.commons.lang.SystemUtils
@@ -52,7 +52,7 @@ abstract class NodeBasedTest(private val cordappPackages: List<String> = emptyLi
     private lateinit var defaultNetworkParameters: NetworkParametersCopier
     private val nodes = mutableListOf<NodeWithInfo>()
     private val nodeInfos = mutableListOf<NodeInfo>()
-    private val portAllocation = PortAllocation.Incremental(10000)
+    private val portAllocation = mainPortAllocation()
 
     init {
         System.setProperty("consoleLogLevel", Level.DEBUG.name().toLowerCase())

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -28,6 +28,8 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.MAX_MESSAGE_SIZE
 import net.corda.testing.driver.JmxPolicy
 import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.debugPortAllocation
+import net.corda.testing.driver.mainPortAllocation
 import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.internal.fromUserList
 import net.corda.testing.node.NotarySpec
@@ -102,8 +104,8 @@ val rpcTestUser = User("user1", "test", permissions = emptySet())
 val fakeNodeLegalName = CordaX500Name(organisation = "Not:a:real:name", locality = "Nowhere", country = "GB")
 
 // Use a global pool so that we can run RPC tests in parallel
-private val globalPortAllocation = PortAllocation.Incremental(10000)
-private val globalDebugPortAllocation = PortAllocation.Incremental(5005)
+private val globalPortAllocation = mainPortAllocation()
+private val globalDebugPortAllocation = debugPortAllocation()
 
 fun <A> rpcDriver(
         isDebug: Boolean = false,


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2257

**Not ready, PR is open to run the tests.**

Environment variables:

- CORDA_CONFIG_TESTS_PORT_ALLOCATION_MAIN, default is 10_000
- CORDA_CONFIG_TESTS_PORT_ALLOCATION_DEBUG, default is 5_005
- CORDA_CONFIG_TESTS_PORT_ALLOCATION_JMX, default is 7_005

