### PR TITLE
CORDA-2255 suppress warnings on readonly properties

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -42,7 +42,11 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
         private val logger = contextLogger()
     }
 
-    fun <T> suppressingWarnings(block: LocalTypeInformationBuilder.() -> T): T =
+    /**
+     * If we are examining the type of a read-only property, or a type flagged as [Opaque], then we do not need to warn
+     * if the [LocalTypeInformation] for that type (or any of its related types) is [LocalTypeInformation.NonComposable].
+     */
+    private fun <T> suppressingWarnings(block: LocalTypeInformationBuilder.() -> T): T =
             copy(warnIfNonComposable = false).block()
 
     /**

--- a/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
@@ -37,7 +37,7 @@ public class FlowShellCommand extends InteractiveShellCommand {
             @Usage("The data to pass as input") @Argument(unquote = false) List<String> input
     ) {
         logger.info("Executing command \"flow start {} {}\",", name, (input != null) ? input.stream().collect(joining(" ")) : "<no arguments>");
-        startFlow(name, input, out, ops(), ansiProgressRenderer(), objectMapper());
+        startFlow(name, input, out, ops(), ansiProgressRenderer(), objectMapper(null));
     }
 
     // TODO Limit number of flows shown option?

--- a/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
@@ -38,13 +38,13 @@ public class RunShellCommand extends InteractiveShellCommand {
     @Usage("runs a method from the CordaRPCOps interface on the node.")
     public Object main(InvocationContext<Map> context, @Usage("The command to run") @Argument(unquote = false) List<String> command) {
         logger.info("Executing command \"run {}\",", (command != null) ? command.stream().collect(joining(" ")) : "<no arguments>");
-        StringToMethodCallParser<CordaRPCOps> parser = new StringToMethodCallParser<>(CordaRPCOps.class, objectMapper());
+        StringToMethodCallParser<CordaRPCOps> parser = new StringToMethodCallParser<>(CordaRPCOps.class, objectMapper(InteractiveShell.getCordappsClassloader()));
 
         if (command == null) {
             emitHelp(context, parser);
             return null;
         }
-        return InteractiveShell.runRPCFromString(command, out, context, ops(), objectMapper());
+        return InteractiveShell.runRPCFromString(command, out, context, ops(), objectMapper(InteractiveShell.getCordappsClassloader()));
     }
 
     private void emitHelp(InvocationContext<Map> context, StringToMethodCallParser<CordaRPCOps> parser) {

--- a/tools/shell/src/main/java/net/corda/tools/shell/StartShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/StartShellCommand.java
@@ -23,6 +23,6 @@ public class StartShellCommand extends InteractiveShellCommand {
 
         logger.info("Executing command \"start {} {}\",", name, (input != null) ? input.stream().collect(joining(" ")) : "<no arguments>");
         ANSIProgressRenderer ansiProgressRenderer = ansiProgressRenderer();
-        FlowShellCommand.startFlow(name, input, out, ops(), ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out), objectMapper());
+        FlowShellCommand.startFlow(name, input, out, ops(), ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out), objectMapper(null));
     }
 }

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -78,6 +78,10 @@ object InteractiveShell {
     private var classLoader: ClassLoader? = null
     private lateinit var shellConfiguration: ShellConfiguration
     private var onExit: () -> Unit = {}
+
+    @JvmStatic
+    fun getCordappsClassloader() = classLoader
+
     /**
      * Starts an interactive shell connected to the local terminal. This shell gives administrator access to the node
      * internals.

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShellCommand.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShellCommand.kt
@@ -1,5 +1,7 @@
 package net.corda.tools.shell
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.type.TypeFactory
 import org.crsh.command.BaseCommand
 import org.crsh.shell.impl.command.CRaSHSession
 
@@ -9,6 +11,13 @@ import org.crsh.shell.impl.command.CRaSHSession
 open class InteractiveShellCommand : BaseCommand() {
     fun ops() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).rpcOps
     fun ansiProgressRenderer() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).ansiProgressRenderer
-    fun objectMapper() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).yamlInputMapper
+    fun objectMapper(classLoader: ClassLoader?): ObjectMapper {
+        val om = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).yamlInputMapper
+        if (classLoader != null) {
+            om.typeFactory = TypeFactory.defaultInstance().withClassLoader(classLoader)
+        }
+        return om
+    }
+
     fun isSsh() = ((context.session as CRaSHSession).authInfo as CordaSSHAuthInfo).isSsh
 }


### PR DESCRIPTION
Sometimes the `LocalTypeInformationBuilder` will observe types that are non-composable (i.e. we can't find a unique deserialisation constructor for them, or we can't match their constructor's signature with their observable properties) while analysing read-only properties of abstract classes or interfaces. Because we will never deserialize these properties directly (they will typically be handled by a custom serializer, or else we will be using the deserializer for a concrete implementation of that abstract type), it doesn't matter that they can't be deserialized by an `ObjectSerializer`, and we don't need to warn the user that we've encountered a non-composable type.

This PR extends warning-suppression so that it covers the following cases:

* The type is flagged as `Opaque`.
* The type is abstract or an interface, so we are just looking at its read-only properties.
* The type extends `Exception`, in which case it will be handled by the special Exception serialization code.

This removes the spurious warnings observed when running `samples:bank-of-corda-demo:deployNodes` (see [Corda-2255](https://r3-cev.atlassian.net/browse/CORDA-2255) for details).