### PR TITLE
CORDA-2255 suppress warnings on read-only properties

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -308,10 +308,10 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                                               name: String,
                                               descriptor: PropertyDescriptor,
                                               constructorInformation: LocalConstructorInformation): LocalPropertyInformation? {
-        val constructorIndex = constructorParameterIndices[name] ?:
         // In some very rare cases we have a constructor parameter matched by a getter with no backing field,
         // and cannot infer whether the property name should be capitalised or not.
-        constructorParameterIndices[name.decapitalize()] ?: return null
+        val constructorIndex = constructorParameterIndices[name] ?: constructorParameterIndices[name.decapitalize()]
+        if (constructorIndex == null) return null
 
         if (descriptor.getter == null) {
             if (descriptor.field == null) return null


### PR DESCRIPTION
Sometimes the `LocalTypeInformationBuilder` will observe types that are non-composable (i.e. we can't find a unique deserialisation constructor for them, or we can't match their constructor's signature with their observable properties) while analysing read-only properties of abstract classes or interfaces. Because we will never deserialize these properties directly (they will typically be handled by a custom serializer, or else we will be using the deserializer for a concrete implementation of that abstract type), it doesn't matter that they can't be deserialized by an `ObjectSerializer`, and we don't need to warn the user that we've encountered a non-composable type.

This PR extends warning-suppression so that it covers the following cases:

* The type is flagged as `Opaque`.
* The type is abstract or an interface, so we are just looking at its read-only properties.
* The type extends `Exception`, in which case it will be handled by the special Exception serialization code.

This removes the spurious warnings observed when running `samples:bank-of-corda-demo:deployNodes` (see [Corda-2255](https://r3-cev.atlassian.net/browse/CORDA-2255) for details).