### PR TITLE
CORDA-2266 match old fingerprinter on Any type

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeModellingFingerPrinter.kt
@@ -68,7 +68,8 @@ internal class FingerprintWriter(debugEnabled: Boolean) {
     fun writeArray() = append(ARRAY_HASH)
     fun writeNullable() = append(NULLABLE_HASH)
     fun writeNotNullable() = append(NOT_NULLABLE_HASH)
-    fun writeAny() = append(ANY_TYPE_HASH)
+    fun writeUnknown() = append(ANY_TYPE_HASH)
+    fun writeTop() = append(Any::class.java.name)
 
     private fun append(chars: CharSequence) = apply {
         debugBuffer?.append(chars)
@@ -123,8 +124,8 @@ private class FingerPrintingState(
         when (type) {
             is LocalTypeInformation.Cycle ->
                 throw IllegalStateException("Cyclic references must be dereferenced before fingerprinting")
-            is LocalTypeInformation.Unknown,
-            is LocalTypeInformation.Top -> writer.writeAny()
+            is LocalTypeInformation.Unknown -> writer.writeUnknown()
+            is LocalTypeInformation.Top -> writer.writeTop()
             is LocalTypeInformation.AnArray -> {
                 fingerprintType(type.componentType)
                 writer.writeArray()
@@ -204,7 +205,7 @@ private class FingerPrintingState(
 
     // Compensate for the serialisation framework's forcing of char to Character
     private fun adjustType(propertyType: LocalTypeInformation): Pair<Boolean, LocalTypeInformation> =
-        if (propertyType.typeIdentifier.name == "char") true to CHARACTER_TYPE else false to propertyType
+            if (propertyType.typeIdentifier.name == "char") true to CHARACTER_TYPE else false to propertyType
 
     private fun fingerprintInterfaces(interfaces: List<LocalTypeInformation>) =
             interfaces.forEach { fingerprintType(it) }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/TypeModellingFingerPrinterTests.kt
@@ -1,0 +1,22 @@
+package net.corda.serialization.internal.amqp
+
+import net.corda.serialization.internal.model.LocalTypeInformation
+import net.corda.serialization.internal.model.TypeModellingFingerPrinter
+import org.junit.Test
+import kotlin.test.assertNotEquals
+
+class TypeModellingFingerPrinterTests {
+
+    val descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry()
+    val customRegistry = CachingCustomSerializerRegistry(descriptorBasedSerializerRegistry)
+    val fingerprinter = TypeModellingFingerPrinter(customRegistry, true)
+
+    // See https://r3-cev.atlassian.net/browse/CORDA-2266
+    @Test
+    fun `Object and wildcard are fingerprinted differently`() {
+        val objectType = LocalTypeInformation.Top
+        val anyType = LocalTypeInformation.Unknown
+
+        assertNotEquals(fingerprinter.fingerprint(objectType), fingerprinter.fingerprint(anyType))
+    }
+}


### PR DESCRIPTION
As per [CORDA-2266](https://r3-cev.atlassian.net/browse/CORDA-2266), notaries using pre-v4 code will fall into evolution serialisation (and fail) if the type descriptor of a `NotarisationPayload` sent to them doesn't match their own fingerprint. Prior to v4, the fingerprinter treated `Any` differently to `?`, and as `NotarisationPayload` has a parameter of type `Any` this results in an incompatible fingerprint being generated. The solution is to make the new fingerprinter do the same thing as the old one with these two types.