### PR TITLE
Fix docs on branching verify with commands

### DIFF
--- a/docs/source/api-contracts.rst
+++ b/docs/source/api-contracts.rst
@@ -204,7 +204,7 @@ the single command of type ``XContract.Commands`` from the transaction, and bran
             override fun verify(tx: LedgerTransaction) {
                 val command = tx.findCommand<Commands> { true }
 
-                when (command) {
+                when (command.value) {
                     is Commands.Issue -> {
                         // Issuance verification logic.
                     }
@@ -225,7 +225,7 @@ the single command of type ``XContract.Commands`` from the transaction, and bran
 
             @Override
             public void verify(LedgerTransaction tx) {
-                final Command<Commands> command = tx.findCommand(Commands.class, cmd -> true);
+                final Commands command = tx.findCommand(Commands.class, cmd -> true).getValue();
 
                 if (command instanceof Commands.Issue) {
                     // Issuance verification logic.


### PR DESCRIPTION
Retrieving the value from the Command is necessary to do a proper type check.

Prior to this change, implementing the code as suggested in the docs resulted in the following errors:
Kotlin: 
`Incompatible types: XContract.Commands.Create and Command<XContract.Commands>`
Java: 
`Inconvertible types; cannot cast 'net.corda.core.contracts.Command<com.template.XContract.Commands>' to 'com.template.XContract.Commands.Create'`

After this change, implementing the code as suggested results in a successful build and run of the CorDapp.

# PR Checklist:

- [X] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
This is not necessary as I am only providing a fix to documentation.
- [X] If you added public APIs, did you write the JavaDocs?
No changes to public APIs.
- [X] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
No changes of interest to application developers.
- [X] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
This PR is in accordance with the Developer's Certificate of Origin.

Thanks for your code, it's appreciated! :)
