### PR TITLE
CORDA-2269: Removed DriverParameters.initialiseSerialization as it's not needed

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -5893,8 +5893,6 @@ public interface net.corda.testing.driver.DriverDSL
 public final class net.corda.testing.driver.DriverParameters extends java.lang.Object
   public <init>()
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, boolean)
-  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean, boolean)
   public final boolean component1()
   @NotNull
   public final java.util.List<String> component10()

--- a/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/network/NetworkMapTest.kt
@@ -90,7 +90,6 @@ class NetworkMapTest(var initFunc: (URL, NetworkMapServer) -> CompatibilityZoneP
         internalDriver(
                 portAllocation = portAllocation,
                 compatibilityZone = compatibilityZone,
-                initialiseSerialization = false,
                 notarySpecs = emptyList()
         ) {
             val alice = startNode(providedName = ALICE_NAME, devMode = false).getOrThrow() as NodeHandleInternal
@@ -143,7 +142,6 @@ class NetworkMapTest(var initFunc: (URL, NetworkMapServer) -> CompatibilityZoneP
         internalDriver(
                 portAllocation = portAllocation,
                 compatibilityZone = compatibilityZone,
-                initialiseSerialization = false,
                 notarySpecs = emptyList()
         ) {
             val alice = startNode(providedName = ALICE_NAME, devMode = false).getOrThrow()
@@ -161,7 +159,6 @@ class NetworkMapTest(var initFunc: (URL, NetworkMapServer) -> CompatibilityZoneP
         internalDriver(
                 portAllocation = portAllocation,
                 compatibilityZone = compatibilityZone,
-                initialiseSerialization = false,
                 notarySpecs = emptyList()
         ) {
             val (aliceNode, bobNode) = listOf(
@@ -179,7 +176,6 @@ class NetworkMapTest(var initFunc: (URL, NetworkMapServer) -> CompatibilityZoneP
         internalDriver(
                 portAllocation = portAllocation,
                 compatibilityZone = compatibilityZone,
-                initialiseSerialization = false,
                 notarySpecs = emptyList()
         ) {
             val aliceNode = startNode(providedName = ALICE_NAME, devMode = false).getOrThrow()
@@ -201,7 +197,6 @@ class NetworkMapTest(var initFunc: (URL, NetworkMapServer) -> CompatibilityZoneP
         internalDriver(
                 portAllocation = portAllocation,
                 compatibilityZone = compatibilityZone,
-                initialiseSerialization = false,
                 notarySpecs = emptyList()
         ) {
             val (aliceNode, bobNode) = listOf(
@@ -226,7 +221,6 @@ class NetworkMapTest(var initFunc: (URL, NetworkMapServer) -> CompatibilityZoneP
         internalDriver(
                 portAllocation = portAllocation,
                 compatibilityZone = compatibilityZone,
-                initialiseSerialization = false,
                 notarySpecs = emptyList(),
                 systemProperties = mapOf("net.corda.node.internal.nodeinfo.publish.interval" to 1.seconds.toString())
         ) {

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -87,7 +87,6 @@ class NodeRegistrationTest {
         internalDriver(
                 portAllocation = portAllocation,
                 compatibilityZone = compatibilityZone,
-                initialiseSerialization = false,
                 notarySpecs = listOf(NotarySpec(notaryName)),
                 cordappsForAllNodes = cordappsInCurrentAndAdditionalPackages("net.corda.finance"),
                 notaryCustomOverrides = mapOf("devMode" to false)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -98,8 +98,7 @@ data class WebserverHandle(
 )
 
 /**
- * An abstract helper class which is used within the driver to allocate unused ports for testing. Use either
- * the [Incremental] or [RandomFree] concrete implementations.
+ * An abstract helper class which is used within the driver to allocate unused ports for testing.
  */
 @DoNotImplement
 abstract class PortAllocation {
@@ -159,8 +158,7 @@ fun <A> driver(defaultParameters: DriverParameters = DriverParameters(), dsl: Dr
                     signCordapps = false
             ),
             coerce = { it },
-            dsl = dsl,
-            initialiseSerialization = defaultParameters.initialiseSerialization
+            dsl = dsl
     )
 }
 
@@ -189,7 +187,6 @@ fun <A> driver(defaultParameters: DriverParameters = DriverParameters(), dsl: Dr
  * @property networkParameters The network parameters to be used by all the nodes. [NetworkParameters.notaries] must be
  *     empty as notaries are defined by [notarySpecs].
  * @property notaryCustomOverrides Extra settings that need to be passed to the notary.
- * @property initialiseSerialization Indicates whether to initialized the serialization subsystem.
  * @property inMemoryDB Whether to use in-memory H2 for new nodes rather then on-disk (the node starts quicker, however
  *     the data is not persisted between node restarts). Has no effect if node is configured
  *     in any way to use database other than H2.
@@ -210,7 +207,6 @@ data class DriverParameters(
         @Suppress("DEPRECATION") val jmxPolicy: JmxPolicy = JmxPolicy(),
         val networkParameters: NetworkParameters = testNetworkParameters(notaries = emptyList()),
         val notaryCustomOverrides: Map<String, Any?> = emptyMap(),
-        val initialiseSerialization: Boolean = true,
         val inMemoryDB: Boolean = true,
         val cordappsForAllNodes: Collection<TestCordapp>? = null
     ) {
@@ -228,7 +224,6 @@ data class DriverParameters(
             @Suppress("DEPRECATION") jmxPolicy: JmxPolicy = JmxPolicy(),
             networkParameters: NetworkParameters = testNetworkParameters(notaries = emptyList()),
             notaryCustomOverrides: Map<String, Any?> = emptyMap(),
-            initialiseSerialization: Boolean = true,
             inMemoryDB: Boolean = true
     ) : this(
             isDebug,
@@ -244,7 +239,6 @@ data class DriverParameters(
             jmxPolicy,
             networkParameters,
             notaryCustomOverrides,
-            initialiseSerialization,
             inMemoryDB,
             cordappsForAllNodes = null
     )
@@ -276,7 +270,6 @@ data class DriverParameters(
             jmxPolicy,
             networkParameters,
             emptyMap(),
-            true,
             true,
             cordappsForAllNodes = null
     )
@@ -310,7 +303,6 @@ data class DriverParameters(
             networkParameters,
             emptyMap(),
             true,
-            true,
             cordappsForAllNodes
     )
 
@@ -327,7 +319,6 @@ data class DriverParameters(
             extraCordappPackagesToScan: List<String>,
             jmxPolicy: JmxPolicy,
             networkParameters: NetworkParameters,
-            initialiseSerialization: Boolean,
             inMemoryDB: Boolean
     ) : this(
             isDebug,
@@ -343,7 +334,6 @@ data class DriverParameters(
             jmxPolicy,
             networkParameters,
             emptyMap(),
-            initialiseSerialization,
             inMemoryDB,
             cordappsForAllNodes = null
     )
@@ -361,7 +351,6 @@ data class DriverParameters(
             extraCordappPackagesToScan: List<String>,
             jmxPolicy: JmxPolicy,
             networkParameters: NetworkParameters,
-            initialiseSerialization: Boolean,
             inMemoryDB: Boolean,
             cordappsForAllNodes: Set<TestCordapp>? = null
     ) : this(
@@ -378,7 +367,6 @@ data class DriverParameters(
             jmxPolicy,
             networkParameters,
             emptyMap(),
-            initialiseSerialization,
             inMemoryDB,
             cordappsForAllNodes
     )
@@ -389,7 +377,6 @@ data class DriverParameters(
     fun withDebugPortAllocation(debugPortAllocation: PortAllocation): DriverParameters = copy(debugPortAllocation = debugPortAllocation)
     fun withSystemProperties(systemProperties: Map<String, String>): DriverParameters = copy(systemProperties = systemProperties)
     fun withUseTestClock(useTestClock: Boolean): DriverParameters = copy(useTestClock = useTestClock)
-    fun withInitialiseSerialization(initialiseSerialization: Boolean): DriverParameters = copy(initialiseSerialization = initialiseSerialization)
     fun withStartNodesInProcess(startNodesInProcess: Boolean): DriverParameters = copy(startNodesInProcess = startNodesInProcess)
     fun withWaitForAllNodesToFinish(waitForAllNodesToFinish: Boolean): DriverParameters = copy(waitForAllNodesToFinish = waitForAllNodesToFinish)
     fun withNotarySpecs(notarySpecs: List<NotarySpec>): DriverParameters = copy(notarySpecs = notarySpecs)
@@ -426,39 +413,7 @@ data class DriverParameters(
             extraCordappPackagesToScan = extraCordappPackagesToScan,
             jmxPolicy = jmxPolicy,
             networkParameters = networkParameters,
-            notaryCustomOverrides = emptyMap(),
-            initialiseSerialization = true
-    )
-
-    fun copy(
-            isDebug: Boolean,
-            driverDirectory: Path,
-            portAllocation: PortAllocation,
-            debugPortAllocation: PortAllocation,
-            systemProperties: Map<String, String>,
-            useTestClock: Boolean,
-            startNodesInProcess: Boolean,
-            waitForAllNodesToFinish: Boolean,
-            notarySpecs: List<NotarySpec>,
-            extraCordappPackagesToScan: List<String>,
-            jmxPolicy: JmxPolicy,
-            networkParameters: NetworkParameters,
-            initialiseSerialization: Boolean
-    ) = this.copy(
-            isDebug = isDebug,
-            driverDirectory = driverDirectory,
-            portAllocation = portAllocation,
-            debugPortAllocation = debugPortAllocation,
-            systemProperties = systemProperties,
-            useTestClock = useTestClock,
-            startNodesInProcess = startNodesInProcess,
-            waitForAllNodesToFinish = waitForAllNodesToFinish,
-            notarySpecs = notarySpecs,
-            extraCordappPackagesToScan = extraCordappPackagesToScan,
-            jmxPolicy = jmxPolicy,
-            networkParameters = networkParameters,
-            notaryCustomOverrides = emptyMap(),
-            initialiseSerialization = initialiseSerialization
+            notaryCustomOverrides = emptyMap()
     )
 
     fun copy(
@@ -489,40 +444,6 @@ data class DriverParameters(
             jmxPolicy = jmxPolicy,
             networkParameters = networkParameters,
             notaryCustomOverrides = emptyMap(),
-            initialiseSerialization = true,
-            cordappsForAllNodes = cordappsForAllNodes
-    )
-
-    fun copy(
-            isDebug: Boolean,
-            driverDirectory: Path,
-            portAllocation: PortAllocation,
-            debugPortAllocation: PortAllocation,
-            systemProperties: Map<String, String>,
-            useTestClock: Boolean,
-            startNodesInProcess: Boolean,
-            waitForAllNodesToFinish: Boolean,
-            notarySpecs: List<NotarySpec>,
-            extraCordappPackagesToScan: List<String>,
-            jmxPolicy: JmxPolicy,
-            networkParameters: NetworkParameters,
-            initialiseSerialization: Boolean,
-            cordappsForAllNodes: Set<TestCordapp>?
-    ) = this.copy(
-            isDebug = isDebug,
-            driverDirectory = driverDirectory,
-            portAllocation = portAllocation,
-            debugPortAllocation = debugPortAllocation,
-            systemProperties = systemProperties,
-            useTestClock = useTestClock,
-            startNodesInProcess = startNodesInProcess,
-            waitForAllNodesToFinish = waitForAllNodesToFinish,
-            notarySpecs = notarySpecs,
-            extraCordappPackagesToScan = extraCordappPackagesToScan,
-            jmxPolicy = jmxPolicy,
-            networkParameters = networkParameters,
-            notaryCustomOverrides = emptyMap(),
-            initialiseSerialization = initialiseSerialization,
             cordappsForAllNodes = cordappsForAllNodes
     )
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -10,6 +10,9 @@ import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.times
 import net.corda.core.messaging.CordaRPCOps
+import net.corda.core.serialization.internal.SerializationEnvironment
+import net.corda.core.serialization.internal._allEnabledSerializationEnvs
+import net.corda.core.serialization.internal._driverSerializationEnv
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
@@ -18,6 +21,8 @@ import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.messaging.Message
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.internal.chooseIdentity
+import net.corda.testing.internal.createTestSerializationEnv
+import net.corda.testing.internal.inVMExecutors
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.User
 import net.corda.testing.node.testContext
@@ -115,15 +120,11 @@ fun InMemoryMessagingNetwork.MessageTransfer.getMessage(): Message = message
 
 fun CordaRPCClient.start(user: User) = start(user.username, user.password)
 
-fun NodeHandle.waitForShutdown(): Observable<Unit> {
-
-    return rpc.waitForShutdown().doAfterTerminate(::stop)
-}
+fun NodeHandle.waitForShutdown(): Observable<Unit> = rpc.waitForShutdown().doAfterTerminate(::stop)
 
 fun CordaRPCOps.waitForShutdown(): Observable<Unit> {
-
     val completable = AsyncSubject.create<Unit>()
-    stateMachinesFeed().updates.subscribe({ _ -> }, { error ->
+    stateMachinesFeed().updates.subscribe({ }, { error ->
         if (error is ConnectionFailureException) {
             completable.onCompleted()
         } else {
@@ -131,4 +132,23 @@ fun CordaRPCOps.waitForShutdown(): Observable<Unit> {
         }
     })
     return completable
+}
+
+/**
+ * Should only be used by Driver and MockNode.
+ */
+fun setDriverSerialization(): AutoCloseable? {
+    return if (_allEnabledSerializationEnvs.isEmpty()) {
+        DriverSerializationEnvironment().enable()
+    } else {
+        null
+    }
+}
+
+private class DriverSerializationEnvironment : SerializationEnvironment by createTestSerializationEnv(), AutoCloseable {
+    fun enable() = apply { _driverSerializationEnv.set(this) }
+    override fun close() {
+        _driverSerializationEnv.set(null)
+        inVMExecutors.remove(this)
+    }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -146,8 +146,7 @@ fun <A> rpcDriver(
                     ), externalTrace
             ),
             coerce = { it },
-            dsl = dsl,
-            initialiseSerialization = false
+            dsl = dsl
     )
 }
 


### PR DESCRIPTION
Instead we detect if a serialisation environment already exists and initialise one if not.