### PR TITLE
ENT-2666: Don't check for network parameter currentness for now

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/CollectSignaturesFlow.kt
@@ -212,11 +212,6 @@ abstract class SignTransactionFlow @JvmOverloads constructor(val otherSideSessio
         progressTracker.currentStep = RECEIVING
         // Receive transaction and resolve dependencies, check sufficient signatures is disabled as we don't have all signatures.
         val stx = subFlow(ReceiveTransactionFlow(otherSideSession, checkSufficientSignatures = false))
-        // TODO ENT-2666: Have time period for checking the parameters (because of the delay of propagation of new network data).
-        check(stx.networkParametersHash == serviceHub.networkParametersStorage.currentHash) {
-            "Received transaction for signing with invalid network parameters hash: ${stx.networkParametersHash}." +
-                    "Node's parameters hash: ${serviceHub.networkParametersStorage.currentHash}"
-        }
         // Receive the signing key that the party requesting the signature expects us to sign with. Having this provided
         // means we only have to check we own that one key, rather than matching all keys in the transaction against all
         // keys we own.

--- a/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/ReceiveTransactionFlow.kt
@@ -3,6 +3,7 @@ package net.corda.core.flows
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.internal.ResolveTransactionsFlow
+import net.corda.core.internal.checkParameterHash
 import net.corda.core.internal.pushToLoggingContext
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
@@ -41,6 +42,7 @@ open class ReceiveTransactionFlow @JvmOverloads constructor(private val otherSid
         val stx = otherSideSession.receive<SignedTransaction>().unwrap {
             it.pushToLoggingContext()
             logger.info("Received transaction acknowledgement request from party ${otherSideSession.counterparty}.")
+            checkParameterHash(it.networkParametersHash)
             subFlow(ResolveTransactionsFlow(it, otherSideSession))
             logger.info("Transaction dependencies resolution completed.")
             try {

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -166,6 +166,8 @@ fun FlowLogic<*>.checkParameterHash(networkParametersHash: SecureHash?) {
     if (networkParametersHash == null) {
         if (serviceHub.networkParameters.minimumPlatformVersion < 4) return
         else throw IllegalArgumentException("Transaction for notarisation doesn't contain network parameters hash.")
+    } else {
+        serviceHub.networkParametersStorage.lookup(networkParametersHash) ?: throw IllegalArgumentException("Transaction for notarisation contains unknown parameters hash: $networkParametersHash")
     }
 
     // TODO: [ENT-2666] Implement network parameters fuzzy checking. By design in Corda network we have propagation time delay.

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -5,6 +5,7 @@ import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
 import net.corda.core.crypto.componentHash
 import net.corda.core.crypto.sha256
+import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
 import net.corda.core.serialization.*
 import net.corda.core.transactions.*
@@ -156,4 +157,16 @@ fun createComponentGroups(inputs: List<StateRef>,
 @KeepForDJVM
 data class SerializedStateAndRef(val serializedState: SerializedBytes<TransactionState<ContractState>>, val ref: StateRef) {
     fun toStateAndRef(): StateAndRef<ContractState> = StateAndRef(serializedState.deserialize(), ref)
+}
+
+/** Check that network parameters hash on this transaction is the current hash for the network. */
+fun FlowLogic<*>.checkParameterHash(networkParametersHash: SecureHash?) {
+    // Transactions created on Corda 3.x or below do not contain network parameters,
+    // so no checking is done until the minimum platform version is at least 4.
+    if (networkParametersHash == null && serviceHub.networkParameters.minimumPlatformVersion < 4) return
+
+    // TODO: [ENT-2666] Implement network parameters fuzzy checking. By design in Corda network we have propagation time delay.
+    //       We will never end up in perfect synchronization with all the nodes. However, network parameters update process
+    //       lets us predict what is the reasonable time window for changing parameters on most of the nodes.
+    //       For now we don't check whether the attached network parameters match the current ones.
 }

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -163,7 +163,10 @@ data class SerializedStateAndRef(val serializedState: SerializedBytes<Transactio
 fun FlowLogic<*>.checkParameterHash(networkParametersHash: SecureHash?) {
     // Transactions created on Corda 3.x or below do not contain network parameters,
     // so no checking is done until the minimum platform version is at least 4.
-    if (networkParametersHash == null && serviceHub.networkParameters.minimumPlatformVersion < 4) return
+    if (networkParametersHash == null) {
+        if (serviceHub.networkParameters.minimumPlatformVersion < 4) return
+        else throw IllegalArgumentException("Transaction for notarisation doesn't contain network parameters hash.")
+    }
 
     // TODO: [ENT-2666] Implement network parameters fuzzy checking. By design in Corda network we have propagation time delay.
     //       We will never end up in perfect synchronization with all the nodes. However, network parameters update process

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -66,7 +66,6 @@ class NotaryServiceTests {
         assertThat(notaryError.cause).hasMessageContaining("Transaction for notarisation doesn't contain network parameters hash.")
     }
 
-    @Ignore("Re-enable the test when parameters currentness checks are in place, ENT-2666.")
     @Test
     fun `should reject when parameters not current`() {
         val hash = SecureHash.randomSHA256()
@@ -75,8 +74,7 @@ class NotaryServiceTests {
         mockNet.runNetwork()
         val ex = assertFailsWith<NotaryException> { future.getOrThrow() }
         val notaryError = ex.error as NotaryError.TransactionInvalid
-        assertThat(notaryError.cause).hasMessageContaining("Transaction for notarisation was tagged with parameters with hash: $hash, " +
-                "but current network parameters are: ${notaryServices.networkParametersStorage.currentHash}")
+        assertThat(notaryError.cause).hasMessageContaining("Transaction for notarisation contains unknown parameters hash: $hash")
     }
 
     internal companion object {

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -22,6 +22,7 @@ import net.corda.testing.node.internal.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
@@ -62,9 +63,10 @@ class NotaryServiceTests {
         mockNet.runNetwork()
         val ex = assertFailsWith<NotaryException> { future.getOrThrow() }
         val notaryError = ex.error as NotaryError.TransactionInvalid
-        assertThat(notaryError.cause).hasMessageContaining("Transaction for notarisation was tagged with parameters with hash: null")
+        assertThat(notaryError.cause).hasMessageContaining("Transaction for notarisation doesn't contain network parameters hash.")
     }
 
+    @Ignore("Re-enable the test when parameters currentness checks are in place, ENT-2666.")
     @Test
     fun `should reject when parameters not current`() {
         val hash = SecureHash.randomSHA256()

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -119,7 +119,7 @@ class ValidatingNotaryServiceTests {
         val future = runNotaryClient(stx)
         val ex = assertFailsWith(NotaryException::class) { future.getOrThrow() }
         val notaryError = ex.error as NotaryError.TransactionInvalid
-        assertThat(notaryError.cause).hasMessageContaining("Transaction for notarisation was tagged with parameters with hash: null")
+        assertThat(notaryError.cause).hasMessageContaining("Transaction for notarisation doesn't contain network parameters hash.")
     }
 
     @Test


### PR DESCRIPTION
At flag day, not all nodes may update their network parameters at the same time. There will be a period of time where the previous version of the parameters should still be accepted. That requires e.g. some timewindow encoded in the parameters, but it needs more thinking.
Until the design work is done, it's better to not check for parameter  "currentness" at all to not cause flow failures right after flag day.