### PR TITLE
[CORDA-2275] Fix DriverTests for windows

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/NodeStartup.kt
@@ -253,7 +253,7 @@ open class NodeStartup : NodeStartupLogging {
         }
     }
 
-    private fun enforceSingleNodeIsRunning(baseDirectory: Path) {
+    internal fun enforceSingleNodeIsRunning(baseDirectory: Path) {
         // Write out our process ID (which may or may not resemble a UNIX process id - to us it's just a string) to a
         // file that we'll do our best to delete on exit. But if we don't, it'll be overwritten next time. If it already
         // exists, we try to take the file lock first before replacing it and if that fails it means we're being started

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupCliTest.kt
@@ -1,0 +1,52 @@
+package net.corda.node.internal
+
+import net.corda.cliutils.CommonCliConstants
+import net.corda.core.internal.div
+import net.corda.nodeapi.internal.config.UnknownConfigKeysPolicy
+import org.assertj.core.api.Assertions
+import org.junit.BeforeClass
+import org.junit.Test
+import org.slf4j.event.Level
+import picocli.CommandLine
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class NodeStartupCliTest {
+    private val startup = NodeStartupCli()
+
+    companion object {
+        private lateinit var workingDirectory: Path
+
+        @BeforeClass
+        @JvmStatic
+        fun initDirectories() {
+            workingDirectory = Paths.get(".").normalize().toAbsolutePath()
+        }
+    }
+
+    @Test
+    fun `no command line arguments`() {
+        CommandLine.populateCommand(startup)
+        Assertions.assertThat(startup.cmdLineOptions.baseDirectory).isEqualTo(workingDirectory)
+        Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo(workingDirectory / "node.conf")
+        Assertions.assertThat(startup.verbose).isEqualTo(false)
+        Assertions.assertThat(startup.loggingLevel).isEqualTo(Level.INFO)
+        Assertions.assertThat(startup.cmdLineOptions.noLocalShell).isEqualTo(false)
+        Assertions.assertThat(startup.cmdLineOptions.sshdServer).isEqualTo(false)
+        Assertions.assertThat(startup.cmdLineOptions.justGenerateNodeInfo).isEqualTo(false)
+        Assertions.assertThat(startup.cmdLineOptions.justGenerateRpcSslCerts).isEqualTo(false)
+        Assertions.assertThat(startup.cmdLineOptions.unknownConfigKeysPolicy)
+                .isEqualTo(UnknownConfigKeysPolicy.FAIL)
+        Assertions.assertThat(startup.cmdLineOptions.devMode).isEqualTo(null)
+        Assertions.assertThat(startup.cmdLineOptions.clearNetworkMapCache).isEqualTo(false)
+        Assertions.assertThat(startup.cmdLineOptions.networkRootTrustStorePathParameter).isEqualTo(null)
+    }
+
+    @Test
+    fun `--base-directory`() {
+        CommandLine.populateCommand(startup, CommonCliConstants.BASE_DIR, (workingDirectory / "another-base-dir").toString())
+        Assertions.assertThat(startup.cmdLineOptions.baseDirectory).isEqualTo(workingDirectory / "another-base-dir")
+        Assertions.assertThat(startup.cmdLineOptions.configFile).isEqualTo(workingDirectory / "another-base-dir" / "node.conf")
+        Assertions.assertThat(startup.cmdLineOptions.networkRootTrustStorePathParameter).isEqualTo(null)
+    }
+}

--- a/node/src/test/kotlin/net/corda/node/internal/NodeStartupTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeStartupTest.kt
@@ -1,51 +1,30 @@
 package net.corda.node.internal
 
-import net.corda.cliutils.CommonCliConstants.BASE_DIR
-import net.corda.core.internal.div
-import net.corda.nodeapi.internal.config.UnknownConfigKeysPolicy
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.BeforeClass
+import com.google.common.io.Files
 import org.junit.Test
-import org.slf4j.event.Level
-import picocli.CommandLine
-import java.nio.file.Path
-import java.nio.file.Paths
+import java.nio.channels.OverlappingFileLockException
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+import kotlin.test.assertFailsWith
 
 class NodeStartupTest {
-    private val startup = NodeStartupCli()
+    @Test
+    fun `test that you cant start two nodes in the same directory`() {
+        val dir = Files.createTempDir().toPath()
 
-    companion object {
-        private lateinit var workingDirectory: Path
+        val latch = CountDownLatch(1)
 
-        @BeforeClass
-        @JvmStatic
-        fun initDirectories() {
-            workingDirectory = Paths.get(".").normalize().toAbsolutePath()
+        thread(start = true) {
+            val node = NodeStartup()
+            node.enforceSingleNodeIsRunning(dir)
+            latch.countDown()
         }
-    }
 
-    @Test
-    fun `no command line arguments`() {
-        CommandLine.populateCommand(startup)
-        assertThat(startup.cmdLineOptions.baseDirectory).isEqualTo(workingDirectory)
-        assertThat(startup.cmdLineOptions.configFile).isEqualTo(workingDirectory / "node.conf")
-        assertThat(startup.verbose).isEqualTo(false)
-        assertThat(startup.loggingLevel).isEqualTo(Level.INFO)
-        assertThat(startup.cmdLineOptions.noLocalShell).isEqualTo(false)
-        assertThat(startup.cmdLineOptions.sshdServer).isEqualTo(false)
-        assertThat(startup.cmdLineOptions.justGenerateNodeInfo).isEqualTo(false)
-        assertThat(startup.cmdLineOptions.justGenerateRpcSslCerts).isEqualTo(false)
-        assertThat(startup.cmdLineOptions.unknownConfigKeysPolicy).isEqualTo(UnknownConfigKeysPolicy.FAIL)
-        assertThat(startup.cmdLineOptions.devMode).isEqualTo(null)
-        assertThat(startup.cmdLineOptions.clearNetworkMapCache).isEqualTo(false)
-        assertThat(startup.cmdLineOptions.networkRootTrustStorePathParameter).isEqualTo(null)
-    }
+        // wait until the file has been created on the other thread
+        latch.await()
 
-    @Test
-    fun `--base-directory`() {
-        CommandLine.populateCommand(startup, BASE_DIR, (workingDirectory / "another-base-dir").toString())
-        assertThat(startup.cmdLineOptions.baseDirectory).isEqualTo(workingDirectory / "another-base-dir")
-        assertThat(startup.cmdLineOptions.configFile).isEqualTo(workingDirectory / "another-base-dir" / "node.conf")
-        assertThat(startup.cmdLineOptions.networkRootTrustStorePathParameter).isEqualTo(null)
+        // Check that I can't start up another node in the same directory
+        val anotherNode = NodeStartup()
+        assertFailsWith<OverlappingFileLockException> { anotherNode.enforceSingleNodeIsRunning(dir) }
     }
 }


### PR DESCRIPTION
The test `started node, which is not waited for in the driver, is shutdown when the driver exits` fails on Windows.

The reason is that the test is assuming that the `process-id` is always deleted when the node is shutdown, however the `addShutdownHook` function isn't guaranteed to run, and seems to consistently not run on Windows, even if the node exits gracefully.

A better test of whether the node is running is that there is a file lock on the {{process-id}} file.