### PR TITLE
Stop messaging services before node dies, to prevent port hogging when using in process node (#1620)

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -352,7 +352,13 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                 netParams,
                 keyManagementService,
                 configuration.networkParameterAcceptanceSettings)
-        startMessagingService(rpcOps, nodeInfo, myNotaryIdentity, netParams)
+        try {
+            startMessagingService(rpcOps, nodeInfo, myNotaryIdentity, netParams)
+        } catch (e: Exception) {
+            // Try to stop any started messaging services.
+            stop()
+            throw e
+        }
 
         // Do all of this in a database transaction so anything that might need a connection has one.
         return database.transaction {
@@ -838,6 +844,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
                                                  nodeInfo: NodeInfo,
                                                  myNotaryIdentity: PartyAndCertificate?,
                                                  networkParameters: NetworkParameters)
+
     /**
      * Loads or generates the node's legal identity and key-pair.
      * Note that obtainIdentity returns a KeyPair with an [AliasPrivateKey].


### PR DESCRIPTION
(cherry picked from commit 15c11d964f5d8cd80c47aa81c56da6ef1e358bbe)

https://github.com/corda/enterprise/pull/1620