### PR TITLE
CORDA-2277 Shorten table name

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/PersistentUniquenessProvider.kt
@@ -83,7 +83,7 @@ class PersistentUniquenessProvider(val clock: Clock, val database: CordaPersiste
     )
 
     @Entity
-    @javax.persistence.Table(name = "${NODE_DATABASE_PREFIX}notary_committed_transactions")
+    @javax.persistence.Table(name = "${NODE_DATABASE_PREFIX}notary_committed_txs")
     class CommittedTransaction(
             @Id
             @Column(name = "transaction_id", nullable = false, length = 64)

--- a/node/src/main/resources/migration/node-notary.changelog-committed-transactions-table.xml
+++ b/node/src/main/resources/migration/node-notary.changelog-committed-transactions-table.xml
@@ -4,11 +4,11 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet author="R3.Corda" id="create-notary-committed-transactions-table">
-        <createTable tableName="node_notary_committed_transactions">
+        <createTable tableName="node_notary_committed_txs">
             <column name="transaction_id" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey columnNames="transaction_id" constraintName="node_notary_transactions_pkey" tableName="node_notary_committed_transactions"/>
+        <addPrimaryKey columnNames="transaction_id" constraintName="node_notary_transactions_pkey" tableName="node_notary_committed_txs"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Shorten notary table name for older Oracle deployments. The names can't be longer than 30 characters.