### PR TITLE
CORDA-2128: makeTestIdentityService no longer declared to return internal InMemoryIdentityService

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6433,7 +6433,7 @@ public final class net.corda.testing.node.MockServicesKt extends java.lang.Objec
   @NotNull
   public static final T createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1<? super net.corda.core.node.AppServiceHub, ? extends T>)
   @NotNull
-  public static final net.corda.node.services.identity.InMemoryIdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
+  public static final net.corda.core.node.services.IdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
 ##
 public final class net.corda.testing.node.NodeTestUtils extends java.lang.Object
   @NotNull

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -9,7 +9,6 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.SignedDataWithCert
 import net.corda.core.messaging.DataFeed
 import net.corda.core.messaging.FlowHandle
 import net.corda.core.messaging.FlowProgressHandle
@@ -17,12 +16,10 @@ import net.corda.core.messaging.StateMachineTransactionMapping
 import net.corda.core.node.*
 import net.corda.core.node.services.*
 import net.corda.core.serialization.SerializeAsToken
-import net.corda.core.serialization.serialize
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.node.VersionInfo
 import net.corda.node.cordapp.CordappLoader
-import net.corda.node.internal.NetworkParametersStorageInternal
 import net.corda.node.internal.ServicesForResolutionImpl
 import net.corda.node.internal.cordapp.JarScanningCordappLoader
 import net.corda.node.services.api.*
@@ -47,12 +44,11 @@ import java.time.Instant
 import java.util.*
 import java.util.function.Consumer
 import javax.persistence.EntityManager
-import kotlin.collections.HashMap
 
-/**
- * Returns a simple [InMemoryIdentityService] containing the supplied [identities].
- */
-fun makeTestIdentityService(vararg identities: PartyAndCertificate) = InMemoryIdentityService(identities.toList(), DEV_ROOT_CA.certificate)
+/** Returns a simple [IdentityService] containing the supplied [identities]. */
+fun makeTestIdentityService(vararg identities: PartyAndCertificate): IdentityService {
+    return InMemoryIdentityService(identities.toList(), DEV_ROOT_CA.certificate)
+}
 
 /**
  * An implementation of [ServiceHub] that is designed for in-memory unit tests of contract validation logic. It has


### PR DESCRIPTION
While technically a break in the test API, it has no practical implications as InMemoryIdentityService does not provide any extra APIs.

