### PR TITLE
CORDA-2128: Removed SerializationEnvironmentRule.run

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -6867,7 +6867,6 @@ public final class net.corda.testing.core.SerializationEnvironmentRule extends j
   public static final net.corda.testing.core.SerializationEnvironmentRule$Companion Companion
 ##
 public static final class net.corda.testing.core.SerializationEnvironmentRule$Companion extends java.lang.Object
-  public final T run(String, kotlin.jvm.functions.Function1<? super net.corda.core.serialization.internal.SerializationEnvironment, ? extends T>)
 ##
 public final class net.corda.testing.core.TestConstants extends java.lang.Object
   @NotNull

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt
@@ -33,7 +33,7 @@ fun ServiceHub.ledger(
         (networkParametersStorage as MockNetworkParametersStorage).setCurrentParametersUnverified(newParameters)
     }
 
-    return withTestSerializationEnvIfNotSet("ledgerDSL") {
+    return withTestSerializationEnvIfNotSet {
         val interpreter = TestLedgerDSLInterpreter(this)
         LedgerDSL(interpreter, notary).apply {
             script()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersStorage.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersStorage.kt
@@ -32,7 +32,7 @@ class MockNetworkParametersStorage(private var currentParameters: NetworkParamet
 
     override val currentHash: SecureHash
         get() {
-            return withTestSerializationEnvIfNotSet("networkParameters") {
+            return withTestSerializationEnvIfNotSet {
                 currentParameters.serialize().hash
             }
         }
@@ -47,12 +47,14 @@ class MockNetworkParametersStorage(private var currentParameters: NetworkParamet
 
     override fun getHistoricNotary(party: Party): NotaryInfo? {
         val inCurrentParams = currentParameters.notaries.singleOrNull { it.identity == party }
-        if (inCurrentParams == null) {
+        return if (inCurrentParams == null) {
             val inOldParams = hashToParametersMap.flatMap { (_, parameters) ->
                 parameters.notaries
             }.firstOrNull { it.identity == party }
-            return inOldParams
-        } else return inCurrentParams
+            inOldParams
+        } else {
+            inCurrentParams
+        }
     }
 
     private fun storeCurrentParameters() {

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalSerializationTestHelpers.kt
@@ -8,6 +8,7 @@ import net.corda.node.serialization.amqp.AMQPServerSerializationScheme
 import net.corda.node.serialization.kryo.KRYO_CHECKPOINT_CONTEXT
 import net.corda.node.serialization.kryo.KryoCheckpointSerializer
 import net.corda.serialization.internal.*
+import net.corda.testing.common.internal.asContextEnv
 import net.corda.testing.core.SerializationEnvironmentRule
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
@@ -44,3 +45,10 @@ fun createTestSerializationEnv(): SerializationEnvironment {
     )
 }
 
+fun <T> SerializationEnvironment.asTestContextEnv(inheritable: Boolean = false, callable: (SerializationEnvironment) -> T): T {
+    try {
+        return asContextEnv(inheritable, callable)
+    } finally {
+        inVMExecutors.remove(this)
+    }
+}

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/internal/InternalTestUtils.kt
@@ -198,7 +198,7 @@ fun fakeAttachment(filePath: String, content: String, manifestAttributes: Map<St
 }
 
 /** If [effectiveSerializationEnv] is not set, runs the block with a new [SerializationEnvironmentRule]. */
-fun <R> withTestSerializationEnvIfNotSet(taskName: String, block: () -> R): R {
+fun <R> withTestSerializationEnvIfNotSet(block: () -> R): R {
     val serializationExists = try {
         effectiveSerializationEnv
         true
@@ -207,7 +207,7 @@ fun <R> withTestSerializationEnvIfNotSet(taskName: String, block: () -> R): R {
     }
     return if (serializationExists) {
         block()
-    } else SerializationEnvironmentRule.run(taskName) {
-        block()
+    } else {
+        createTestSerializationEnv().asTestContextEnv { block() }
     }
 }


### PR DESCRIPTION
It exposed the internal SerializationEnvironment class. It previously documented that the SerializationEnvironmentRule JUnit rule should be used instead, and so any existing test code have a migration path.

