### PR TITLE
[CORDA-2282]: Ensure global test port allocation prevents port clashes

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/Driver.kt
@@ -48,6 +48,8 @@ interface NodeHandle : AutoCloseable {
     val rpcAddress: NetworkHostAndPort
     /** Get the rpc admin address for this node **/
     val rpcAdminAddress: NetworkHostAndPort
+    /** Get the JMX server address for this node, if JMX is enabled **/
+    val jmxAddress: NetworkHostAndPort?
     /** Get a [List] of [User]'s for this node **/
     val rpcUsers: List<User>
     /** The location of the node's base directory **/

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/DriverInternal.kt
@@ -23,6 +23,7 @@ interface NodeHandleInternal : NodeHandle {
     override val p2pAddress: NetworkHostAndPort get() = configuration.p2pAddress
     override val rpcAddress: NetworkHostAndPort get() = configuration.rpcOptions.address
     override val rpcAdminAddress: NetworkHostAndPort get() = configuration.rpcOptions.adminAddress
+    override val jmxAddress: NetworkHostAndPort? get() = configuration.jmxMonitoringHttpPort?.let { NetworkHostAndPort("localhost", it) }
     override val baseDirectory: Path get() = configuration.baseDirectory
 }
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/GlobalTestPortAllocation.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/driver/internal/GlobalTestPortAllocation.kt
@@ -1,11 +1,15 @@
 package net.corda.testing.driver.internal
 
 import net.corda.testing.driver.PortAllocation
+import net.corda.testing.driver.internal.GlobalTestPortAllocation.enablingEnvVar
+import net.corda.testing.driver.internal.GlobalTestPortAllocation.enablingSystemProperty
+import net.corda.testing.driver.internal.GlobalTestPortAllocation.startingPortEnvVariable
+import net.corda.testing.driver.internal.GlobalTestPortAllocation.startingPortSystemProperty
 
 fun incrementalPortAllocation(startingPortIfNoEnv: Int): PortAllocation {
 
     return when {
-        System.getenv(GlobalTestPortAllocation.enablingEnvVar)?.toBoolean() == true -> GlobalTestPortAllocation
+        System.getProperty(enablingSystemProperty)?.toBoolean() ?: System.getenv(enablingEnvVar)?.toBoolean() == true -> GlobalTestPortAllocation
         else -> PortAllocation.Incremental(startingPortIfNoEnv)
     }
 }
@@ -14,7 +18,9 @@ private object GlobalTestPortAllocation : PortAllocation.Incremental(startingPor
 
     const val enablingEnvVar = "CORDA_TEST_GLOBAL_PORT_ALLOCATION_ENABLED"
     const val startingPortEnvVariable = "CORDA_TEST_GLOBAL_PORT_ALLOCATION_STARTING_PORT"
+    val enablingSystemProperty = enablingEnvVar.toLowerCase().replace("_", ".")
+    val startingPortSystemProperty = startingPortEnvVariable.toLowerCase().replace("_", ".")
     const val startingPortDefaultValue = 5000
 }
 
-private val startingPort: Int = System.getenv(GlobalTestPortAllocation.startingPortEnvVariable)?.toIntOrNull() ?: GlobalTestPortAllocation.startingPortDefaultValue
+private val startingPort: Int = System.getProperty(startingPortSystemProperty)?.toIntOrNull() ?: System.getenv(startingPortEnvVariable)?.toIntOrNull() ?: GlobalTestPortAllocation.startingPortDefaultValue


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2282