### PR TITLE
CORDA-1497 enum evolution

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModel.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModel.kt
@@ -30,7 +30,7 @@ class AMQPRemoteTypeModel {
         val notationLookup = schema.types.associateBy { it.name.typeIdentifier }
         val byTypeDescriptor = schema.types.associateBy { it.typeDescriptor }
         val enumTransformsLookup = transforms.types.asSequence().map { (name, transformSet) ->
-            name.typeIdentifier to transformSet.interpretForEnum()
+            name.typeIdentifier to transformSet.enumTransforms()
         }.toMap()
 
         val interpretationState = InterpretationState(notationLookup, enumTransformsLookup, cache, emptySet())

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModel.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModel.kt
@@ -31,7 +31,7 @@ class AMQPRemoteTypeModel {
         val notationLookup = schema.types.associateBy { it.name.typeIdentifier }
         val byTypeDescriptor = schema.types.associateBy { it.typeDescriptor }
         val enumTransformsLookup = transforms.types.asSequence().map { (name, transformSet) ->
-            name.typeIdentifier to transformSet.enumTransforms()
+            name.typeIdentifier to EnumTransforms.build(transformSet)
         }.toMap()
 
         val interpretationState = InterpretationState(notationLookup, enumTransformsLookup, cache, emptySet())

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
@@ -132,7 +132,7 @@ class DefaultEvolutionSerializerFactory(
         if (members == localTypeInformation.members) return null
 
         val remoteTransforms = transforms
-        val localTransforms = localTypeInformation.getEnumTransforms(localSerializerFactory)
+        val localTransforms = localTypeInformation.transforms
         val transforms = if (remoteTransforms.size > localTransforms.size) remoteTransforms else localTransforms
 
         val localOrdinals = localTypeInformation.members.asSequence().mapIndexed { ord, member -> member to ord }.toMap()

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -62,14 +62,6 @@ interface LocalSerializerFactory {
      * Use the [FingerPrinter] to create a type descriptor for the given [typeInformation].
      */
     fun createDescriptor(typeInformation: LocalTypeInformation): Symbol
-
-    /**
-     * Obtain or register [Transform]s for the given class [name].
-     *
-     * Eventually this information should be moved into the [LocalTypeInformation] for the type.
-     */
-    fun getOrBuildTransform(name: String, builder: () -> EnumMap<TransformTypes, MutableList<Transform>>):
-            EnumMap<TransformTypes, MutableList<Transform>>
 }
 
 /**
@@ -91,17 +83,12 @@ class DefaultLocalSerializerFactory(
         val logger = contextLogger()
     }
 
-    private val transformsCache: MutableMap<String, EnumMap<TransformTypes, MutableList<Transform>>> = DefaultCacheProvider.createCache()
     private val serializersByType: MutableMap<TypeIdentifier, AMQPSerializer<Any>> = DefaultCacheProvider.createCache()
 
     override fun createDescriptor(typeInformation: LocalTypeInformation): Symbol =
             Symbol.valueOf("$DESCRIPTOR_DOMAIN:${fingerPrinter.fingerprint(typeInformation)}")
 
     override fun getTypeInformation(type: Type): LocalTypeInformation = typeModel.inspect(type)
-
-    override fun getOrBuildTransform(name: String, builder: () -> EnumMap<TransformTypes, MutableList<Transform>>):
-            EnumMap<TransformTypes, MutableList<Transform>> =
-            transformsCache.computeIfAbsent(name) { _ -> builder() }
 
     override fun get(typeInformation: LocalTypeInformation): AMQPSerializer<Any> =
             get(typeInformation.observedType, typeInformation)

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformTypes.kt
@@ -1,7 +1,6 @@
 package net.corda.serialization.internal.amqp
 
 import net.corda.core.KeepForDJVM
-import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.CordaSerializationTransformEnumDefault
 import net.corda.core.serialization.CordaSerializationTransformEnumDefaults
 import net.corda.core.serialization.CordaSerializationTransformRename
@@ -30,108 +29,23 @@ enum class TransformTypes(val build: (Annotation) -> Transform) : DescribedType 
     Unknown({ UnknownTransform() }) {
         override fun getDescriptor(): Any = DESCRIPTOR
         override fun getDescribed(): Any = ordinal
-        override fun validate(list: List<Transform>, constants: Map<String, Int>) {}
     },
     EnumDefault({ a -> EnumDefaultSchemaTransform((a as CordaSerializationTransformEnumDefault).old, a.new) }) {
         override fun getDescriptor(): Any = DESCRIPTOR
         override fun getDescribed(): Any = ordinal
-
-        /**
-         * Validates a list of constant additions to an enumerated type. To be valid a default (the value
-         * that should be used when we cannot use the new value) must refer to a constant that exists in the
-         * enum class as it exists now and it cannot refer to itself.
-         *
-         * @param list The list of transforms representing new constants and the mapping from that constant to an
-         * existing value
-         * @param constants The list of enum constants on the type the transforms are being applied to
-         */
-        override fun validate(list: List<Transform>, constants: Map<String, Int>) {
-            uncheckedCast<List<Transform>, List<EnumDefaultSchemaTransform>>(list).forEach {
-                requireThat(constants.contains(it.new)) {"Unknown enum constant ${it.new}"}
-                requireThat(constants.contains(it.old)) { "Enum extension defaults must be to a valid constant: ${it.new} -> ${it.old}. ${it.old} " +
-                        "doesn't exist in constant set $constants" }
-                requireThat(it.old != it.new) { "Enum extension ${it.new} cannot default to itself" }
-                requireThat(constants[it.old]!! < constants[it.new]!!) { "Enum extensions must default to older constants. ${it.new}[${constants[it.new]}] " +
-                        "defaults to ${it.old}[${constants[it.old]}] which is greater" }
-            }
-        }
     },
     Rename({ a -> RenameSchemaTransform((a as CordaSerializationTransformRename).from, a.to) }) {
         override fun getDescriptor(): Any = DESCRIPTOR
         override fun getDescribed(): Any = ordinal
-
-        /**
-         * Validates a list of rename transforms is valid. Such a list isn't valid if we detect a cyclic chain,
-         * that is a constant is renamed to something that used to exist in the enum. We do this for both
-         * the same constant (i.e. C -> D -> C) and multiple constants (C->D, B->C)
-         *
-         * @param list The list of transforms representing the renamed constants and the mapping between their new
-         * and old values
-         * @param constants The list of enum constants on the type the transforms are being applied to
-         */
-        override fun validate(list: List<Transform>, constants: Map<String, Int>) {
-            @KeepForDJVM
-            data class Node(val transform: RenameSchemaTransform, var next: Node?, var prev: Node?, var visitedBy: Node? = null) {
-                fun visit(visitedBy: Node) {
-                    this.visitedBy = visitedBy
-                }
-                val visited get() = visitedBy != null
-            }
-
-            val graph = mutableListOf<Node>()
-            // Keep two maps of forward links and back links in order to build the graph in one pass
-            val forwardLinks = hashMapOf<String, Node>()
-            val reverseLinks = hashMapOf<String, Node>()
-
-            // build a dependency graph
-            val transforms: List<RenameSchemaTransform> = uncheckedCast(list)
-            transforms.forEach { rename ->
-                requireThat(!forwardLinks.contains(rename.from)) { "There are multiple transformations from ${rename.from}, which is not allowed" }
-                requireThat(!reverseLinks.contains(rename.to)) { "There are multiple transformations to ${rename.to}, which is not allowed" }
-                val node = Node(rename, forwardLinks[rename.to], reverseLinks[rename.from])
-                graph.add(node)
-                node.next?.prev = node
-                node.prev?.next = node
-                forwardLinks[rename.from] = node
-                reverseLinks[rename.to] = node
-            }
-
-            // Check that every property in the current type is at the end of a renaming chain, if it is in one
-            constants.keys.forEach {
-                requireThat(reverseLinks[it]?.next == null) { "$it is specified as a previously evolved type, but it also exists in the current type" }
-            }
-
-            // Check for cyclic dependencies
-            graph.forEach {
-                if (it.visited) return@forEach
-                // Find an unvisited node
-                var currentNode = it
-                currentNode.visit(it)
-                while (currentNode.next != null) {
-                    currentNode = currentNode.next!!
-                    if (currentNode.visited) {
-                        requireThat(currentNode.visitedBy != it) { "Cyclic renames are not allowed (${currentNode.transform.from})" }
-                        // we have found the start of another non-cyclic chain of dependencies
-                        // if they were cyclic we would have gone round in a loop and already thrown
-                        break
-                    }
-                    currentNode.visit(it)
-                }
-            }
-        }
     }
-
     // Transform used to test the unknown handler, leave this at as the final constant, uncomment
     // when regenerating test cases - if Java had a pre-processor this would be much neater
     //
     //,UnknownTest({ a -> UnknownTestTransform((a as UnknownTransformAnnotation).a, a.b, a.c)}) {
     //    override fun getDescriptor(): Any = DESCRIPTOR
     //    override fun getDescribed(): Any = ordinal
-    //    override fun validate(list: List<Transform>, constants: Map<String, Int>) = Unit
     //}
     ;
-
-    abstract fun validate(list: List<Transform>, constants: Map<String, Int>)
 
     companion object : DescribedTypeConstructor<TransformTypes> {
         val DESCRIPTOR = AMQPDescriptorRegistry.TRANSFORM_ELEMENT_KEY.amqpDescriptor
@@ -144,7 +58,9 @@ enum class TransformTypes(val build: (Annotation) -> Transform) : DescribedType 
         override fun newInstance(obj: Any?): TransformTypes {
             val describedType = obj as DescribedType
 
-            requireThat(describedType.descriptor == DESCRIPTOR) { "Unexpected descriptor ${describedType.descriptor}." }
+            if (describedType.descriptor != DESCRIPTOR) {
+                throw NotSerializableWithReasonException("Unexpected descriptor ${describedType.descriptor}.")
+            }
 
             return try {
                 values()[describedType.described as Int]
@@ -154,11 +70,5 @@ enum class TransformTypes(val build: (Annotation) -> Transform) : DescribedType 
         }
 
         override fun getTypeClass(): Class<*> = TransformTypes::class.java
-
-        protected inline fun requireThat(expr: Boolean, errorMessage: () -> String) {
-            if (!expr) {
-                throw NotSerializableWithReasonException(errorMessage())
-            }
-        }
     }
 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt
@@ -210,15 +210,6 @@ object TransformsAnnotationProcessor {
                     supportedTransform.getAnnotations(annotationContainer))
         }
 
-        /*
-        val constants = type.enumConstants.mapIndexed { index, constant -> constant.toString() to index }.toMap()
-        try {
-            EnumTransforms.build(result).validate(constants)
-        } catch (e: InvalidEnumTransformsException) {
-            throw NotSerializableDetailedException(type.name, e.message!!)
-        }
-        */
-
         return result
     }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/TransformsSchema.kt
@@ -210,12 +210,14 @@ object TransformsAnnotationProcessor {
                     supportedTransform.getAnnotations(annotationContainer))
         }
 
+        /*
         val constants = type.enumConstants.mapIndexed { index, constant -> constant.toString() to index }.toMap()
         try {
             EnumTransforms.build(result).validate(constants)
         } catch (e: InvalidEnumTransformsException) {
             throw NotSerializableDetailedException(type.name, e.message!!)
         }
+        */
 
         return result
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/EnumTransforms.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/EnumTransforms.kt
@@ -1,0 +1,57 @@
+package net.corda.serialization.internal.model
+
+import net.corda.serialization.internal.amqp.TransformTypes
+import net.corda.serialization.internal.amqp.TransformsMap
+
+class InvalidEnumTransformsException(message: String): Exception(message)
+
+data class EnumTransforms(
+        val defaults: Map<String, String>,
+        val renames: Map<String, String>,
+        val source: TransformsMap) {
+
+    val size: Int get() = defaults.size + renames.size
+
+    companion object {
+        val empty = EnumTransforms(emptyMap(), emptyMap(), TransformsMap(TransformTypes::class.java))
+    }
+
+    fun validate(constants: Map<String, Int>) {
+        validateNoCycles()
+
+        val constantsBeforeRenaming = constants.asSequence().mapNotNull { (name, index) ->
+            renames[name]?.let { newName -> newName to index }
+        }.toMap()
+        validateDefaults(constants + constantsBeforeRenaming)
+    }
+
+    fun validateNoCycles() {
+        val unchecked = renames.toMutableMap()
+        while (!unchecked.isEmpty()) {
+            val terminals = unchecked.asSequence().filterNot { (_, to) -> to in unchecked.keys }.map { (from, _) -> from }.toList()
+            if (terminals.isEmpty()) throw InvalidEnumTransformsException("Rename cycles detected in rename map: ${unchecked.keys}")
+            terminals.forEach { unchecked.remove(it) }
+        }
+    }
+
+    private fun validateDefaults(constantsBeforeRenaming: Map<String, Int>) {
+        defaults.forEach { (new, old) ->
+            requireThat(constantsBeforeRenaming.contains(new)) { "Unknown enum constant $new" }
+            requireThat(constantsBeforeRenaming.contains(old)) {
+                "Enum extension defaults must be to a valid constant: $new -> $old. $old " +
+                        "doesn't exist in constant set $constantsBeforeRenaming"
+            }
+            requireThat(old != new) { "Enum extension $new cannot default to itself" }
+            requireThat(constantsBeforeRenaming[old]!! < constantsBeforeRenaming[new]!!) {
+                "Enum extensions must default to older constants. $new[${constantsBeforeRenaming[new]}] " +
+                        "defaults to $old[${constantsBeforeRenaming[old]}] which is greater"
+            }
+        }
+    }
+
+    private inline fun requireThat(expr: Boolean, errorMessage: () -> String) {
+        if (!expr) {
+            throw InvalidEnumTransformsException(errorMessage())
+        }
+    }
+}

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/EnumTransforms.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/EnumTransforms.kt
@@ -1,10 +1,19 @@
 package net.corda.serialization.internal.model
 
+import net.corda.serialization.internal.amqp.EnumDefaultSchemaTransform
+import net.corda.serialization.internal.amqp.RenameSchemaTransform
 import net.corda.serialization.internal.amqp.TransformTypes
 import net.corda.serialization.internal.amqp.TransformsMap
 
 class InvalidEnumTransformsException(message: String): Exception(message)
 
+/**
+ * Contains all of the transforms that have been defined against an enum.
+ *
+ * @param defaults A [Map] of "new" to "old" for enum constant defaults
+ * @param renames A [Map] of "to" to "from" for enum constant renames.
+ * @param source The [TransformsMap] from which this data was derived.
+ */
 data class EnumTransforms(
         val defaults: Map<String, String>,
         val renames: Map<String, String>,
@@ -13,6 +22,33 @@ data class EnumTransforms(
     val size: Int get() = defaults.size + renames.size
 
     companion object {
+        /**
+         * Build a set of [EnumTransforms] from a [TransformsMap].
+         */
+        fun build(source: TransformsMap): EnumTransforms {
+            val defaultTransforms = source[TransformTypes.EnumDefault]?.asSequence()
+                    ?.filterIsInstance<EnumDefaultSchemaTransform>()
+                    ?.toList() ?: emptyList()
+
+            val renameTransforms = source[TransformTypes.Rename]?.asSequence()
+                    ?.filterIsInstance<RenameSchemaTransform>()
+                    ?.toList() ?: emptyList()
+
+            // We have to do this validation here, because duplicate keys are discarded in EnumTransforms.
+            renameTransforms.groupingBy { it.from }.eachCount().forEach { from, count ->
+                if (count > 1) throw InvalidEnumTransformsException(
+                        "There are multiple transformations from $from, which is not allowed")
+            }
+            renameTransforms.groupingBy { it.to }.eachCount().forEach { to, count ->
+                if (count > 1) throw InvalidEnumTransformsException(
+                        "There are multiple transformations to $to, which is not allowed")
+            }
+
+            val defaults = defaultTransforms.associate { transform -> transform.new to transform.old }
+            val renames = renameTransforms.associate { transform -> transform.to to transform.from }
+            return EnumTransforms(defaults, renames, source)
+        }
+
         val empty = EnumTransforms(emptyMap(), emptyMap(), TransformsMap(TransformTypes::class.java))
     }
 
@@ -25,15 +61,55 @@ data class EnumTransforms(
         validateDefaults(constants + constantsBeforeRenaming)
     }
 
-    fun validateNoCycles() {
-        val unchecked = renames.toMutableMap()
-        while (!unchecked.isEmpty()) {
-            val terminals = unchecked.asSequence().filterNot { (_, to) -> to in unchecked.keys }.map { (from, _) -> from }.toList()
-            if (terminals.isEmpty()) throw InvalidEnumTransformsException("Rename cycles detected in rename map: ${unchecked.keys}")
-            terminals.forEach { unchecked.remove(it) }
+    /**
+     * Verify that there are no rename cycles, i.e. C -> D -> C, or A -> B -> C -> A.
+     *
+     * This algorithm depends on the precondition (which is validated during construction of [EnumTransforms]) that there is at
+     * most one edge (a rename "from" one constant "to" another) between any two nodes (the constants themselves) in the rename
+     * graph. It makes a single pass over the set of edges, attempting to add each new edge to any existing chain of edges, or
+     * starting a new chain if there is no existing chain.
+     *
+     * For each new edge, one of the following must true:
+     *
+     * 1) There is no existing chain to which the edge can be connected, in which case it starts a new chain.
+     * 2) The edge can be added to one existing chain, either at the start or the end of the chain.
+     * 3) The edge is the "missing link" between two unconnected chains.
+     * 4) The edge is the "missing link" between the start of a chain and the end of that same chain, in which case we have a cycle.
+     *
+     * By detecting each condition, and updating the chains accordingly, we can perform cycle-detection in O(n) time.
+     */
+    private fun validateNoCycles() {
+        // We keep track of chains in both directions
+        val chainStartsToEnds = mutableMapOf<String, String>()
+        val chainEndsToStarts = mutableMapOf<String, String>()
+
+        for ((from, to) in renames) {
+            // If there is an existing chain, starting at the "to" node of this edge, then there is a chain from this edge's
+            // "from" to that chain's end.
+            val newEnd = chainStartsToEnds[to] ?: to
+
+            // If there is an existing chain, ending at the "from" node of this edge, then there is a chain from that chain's start
+            // to this edge's "to".
+            val newStart = chainEndsToStarts[from] ?: from
+
+            // If either chain ends where it begins, we have closed a loop, and detected a cycle.
+            if (newEnd == from || newStart == to) {
+                throw InvalidEnumTransformsException("Rename cycle detected in rename map starting from $newStart")
+            }
+
+            // Either update, or create, the chains in both directions.
+            chainStartsToEnds[from] = newEnd
+            chainEndsToStarts[to] = newStart
+
+            // If we have joined two previously unconnected chains, update their starts and ends accordingly.
+            chainStartsToEnds[newStart] = newEnd
+            chainEndsToStarts[newEnd] = newStart
         }
     }
 
+    /**
+     * Verify that defaults match up to existing constants (prior to their renaming).
+     */
     private fun validateDefaults(constantsBeforeRenaming: Map<String, Int>) {
         defaults.forEach { (new, old) ->
             requireThat(constantsBeforeRenaming.contains(new)) { "Unknown enum constant $new" }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformation.kt
@@ -179,7 +179,8 @@ sealed class LocalTypeInformation {
             override val observedType: Class<*>,
             override val typeIdentifier: TypeIdentifier,
             val members: List<String>,
-            val interfaces: List<LocalTypeInformation>): LocalTypeInformation()
+            val interfaces: List<LocalTypeInformation>,
+            val transforms: EnumTransforms): LocalTypeInformation()
 
     /**
      * Represents a type whose underlying class is an interface.

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -107,7 +107,8 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                     type,
                     typeIdentifier,
                     type.enumConstants.map { it.toString() },
-                    buildInterfaceInformation(type))
+                    buildInterfaceInformation(type),
+                    TransformsAnnotationProcessor.getTransformsSchema(type).interpretForEnum())
             type.kotlinObjectInstance != null -> LocalTypeInformation.Singleton(
                     type,
                     typeIdentifier,

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -6,6 +6,7 @@ import net.corda.core.internal.kotlinObjectInstance
 import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.core.utilities.contextLogger
+import net.corda.serialization.internal.NotSerializableDetailedException
 import net.corda.serialization.internal.amqp.*
 import java.io.NotSerializableException
 import java.lang.reflect.Method
@@ -108,7 +109,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                     typeIdentifier,
                     type.enumConstants.map { it.toString() },
                     buildInterfaceInformation(type),
-                    EnumTransforms.build(TransformsAnnotationProcessor.getTransformsSchema(type)))
+                    getEnumTransforms(type))
             type.kotlinObjectInstance != null -> LocalTypeInformation.Singleton(
                     type,
                     typeIdentifier,
@@ -124,6 +125,15 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                 buildNonAtomic(type, type, typeIdentifier, emptyList())
             }
             else -> buildNonAtomic(type, type, typeIdentifier, emptyList())
+        }
+    }
+
+    private fun getEnumTransforms(type: Class<*>): EnumTransforms {
+        try {
+            val constants = type.enumConstants.asSequence().mapIndexed { index, constant -> constant.toString() to index }.toMap()
+            return EnumTransforms.build(TransformsAnnotationProcessor.getTransformsSchema(type), constants)
+        } catch (e: InvalidEnumTransformsException) {
+            throw NotSerializableDetailedException(type.name, e.message!!)
         }
     }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -108,7 +108,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                     typeIdentifier,
                     type.enumConstants.map { it.toString() },
                     buildInterfaceInformation(type),
-                    TransformsAnnotationProcessor.getTransformsSchema(type).interpretForEnum())
+                    TransformsAnnotationProcessor.getTransformsSchema(type).enumTransforms())
             type.kotlinObjectInstance != null -> LocalTypeInformation.Singleton(
                     type,
                     typeIdentifier,

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -108,7 +108,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                     typeIdentifier,
                     type.enumConstants.map { it.toString() },
                     buildInterfaceInformation(type),
-                    TransformsAnnotationProcessor.getTransformsSchema(type).enumTransforms())
+                    EnumTransforms.build(TransformsAnnotationProcessor.getTransformsSchema(type)))
             type.kotlinObjectInstance != null -> LocalTypeInformation.Singleton(
                     type,
                     typeIdentifier,

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/RemoteTypeInformation.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/RemoteTypeInformation.kt
@@ -1,9 +1,5 @@
 package net.corda.serialization.internal.model
 
-import net.corda.serialization.internal.amqp.TransformTypes
-import net.corda.serialization.internal.amqp.TransformsMap
-import java.util.*
-
 typealias TypeDescriptor = String
 
 /**
@@ -186,14 +182,3 @@ private data class RemoteTypeInformationPrettyPrinter(private val simplifyClassN
                     ": " + prettyPrint(value.type)
 }
 
-data class EnumTransforms(
-        val defaults: Map<String, String>,
-        val renames: Map<String, String>,
-        val source: TransformsMap) {
-
-    val size: Int get() = defaults.size + renames.size
-
-    companion object {
-        val empty = EnumTransforms(emptyMap(), emptyMap(), TransformsMap(TransformTypes::class.java))
-    }
-}

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/RemoteTypeInformation.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/RemoteTypeInformation.kt
@@ -1,5 +1,9 @@
 package net.corda.serialization.internal.model
 
+import net.corda.serialization.internal.amqp.TransformTypes
+import net.corda.serialization.internal.amqp.TransformsMap
+import java.util.*
+
 typealias TypeDescriptor = String
 
 /**
@@ -182,11 +186,14 @@ private data class RemoteTypeInformationPrettyPrinter(private val simplifyClassN
                     ": " + prettyPrint(value.type)
 }
 
-data class EnumTransforms(val defaults: Map<String, String>, val renames: Map<String, String>) {
+data class EnumTransforms(
+        val defaults: Map<String, String>,
+        val renames: Map<String, String>,
+        val source: TransformsMap) {
 
     val size: Int get() = defaults.size + renames.size
 
     companion object {
-        val empty = EnumTransforms(emptyMap(), emptyMap())
+        val empty = EnumTransforms(emptyMap(), emptyMap(), TransformsMap(TransformTypes::class.java))
     }
 }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumEvolvabilityTests.kt
@@ -516,27 +516,6 @@ class EnumEvolvabilityTests {
         }.isInstanceOf(NotSerializableException::class.java)
     }
 
-    //
-    // In this test, like the above, we're looking to ensure repeated renames are rejected as
-    // unserailzble. However, in this case, it isn't a struct cycle, rather one element
-    // is renamed to match what a different element used to be called
-    //
-    @CordaSerializationTransformRenames(
-            CordaSerializationTransformRename(from = "B", to = "C"),
-            CordaSerializationTransformRename(from = "C", to = "D")
-    )
-    enum class RejectCyclicRenameAlt { A, C, D }
-
-    @Test
-    fun rejectCyclicRenameAlt() {
-        data class C(val e: RejectCyclicRenameAlt)
-
-        val sf = testDefaultFactory()
-        assertThatThrownBy {
-            SerializationOutput(sf).serialize(C(RejectCyclicRenameAlt.A))
-        }.isInstanceOf(NotSerializableException::class.java)
-    }
-
     @CordaSerializationTransformRenames(
             CordaSerializationTransformRename("G", "C"),
             CordaSerializationTransformRename("F", "G"),

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
@@ -4,7 +4,6 @@ import net.corda.core.serialization.CordaSerializationTransformEnumDefault
 import net.corda.core.serialization.CordaSerializationTransformEnumDefaults
 import net.corda.core.serialization.CordaSerializationTransformRename
 import net.corda.core.serialization.CordaSerializationTransformRenames
-import net.corda.serialization.internal.NotSerializableDetailedException
 import net.corda.serialization.internal.model.EnumTransforms
 import net.corda.serialization.internal.model.InvalidEnumTransformsException
 import org.junit.Assert.assertEquals
@@ -17,7 +16,10 @@ class EnumTransformationTests {
             CordaSerializationTransformEnumDefault(old = "C", new = "D"),
             CordaSerializationTransformEnumDefault(old = "D", new = "E")
     )
-    @CordaSerializationTransformRename(to = "BOB", from = "E")
+    @CordaSerializationTransformRenames(
+        CordaSerializationTransformRename(to = "BOB", from = "FRED"),
+        CordaSerializationTransformRename(to = "FRED", from = "E")
+    )
     enum class MultiOperations { A, B, C, D, BOB }
 
     // See https://r3-cev.atlassian.net/browse/CORDA-1497
@@ -27,7 +29,7 @@ class EnumTransformationTests {
                 TransformsAnnotationProcessor.getTransformsSchema(MultiOperations::class.java),
                 MultiOperations::class.java.constants)
 
-        assertEquals(mapOf("BOB" to "E"), transforms.renames)
+        assertEquals(mapOf("BOB" to "FRED", "FRED" to "E"), transforms.renames)
         assertEquals(mapOf("D" to "C", "E" to "D"), transforms.defaults)
     }
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
@@ -1,0 +1,21 @@
+package net.corda.serialization.internal.amqp
+
+import net.corda.core.serialization.CordaSerializationTransformEnumDefault
+import net.corda.core.serialization.CordaSerializationTransformEnumDefaults
+import net.corda.core.serialization.CordaSerializationTransformRename
+import org.junit.Test
+
+class EnumTransformationTests {
+
+    @CordaSerializationTransformEnumDefaults(
+            CordaSerializationTransformEnumDefault(old = "C", new = "D"),
+            CordaSerializationTransformEnumDefault(old = "D", new = "E")
+    )
+    @CordaSerializationTransformRename(to = "BOB", from = "E")
+    enum class MultiOperations { A, B, C, D, BOB }
+
+    @Test
+    fun doubleRename() {
+        TransformsAnnotationProcessor.getTransformsSchema(MultiOperations::class.java)
+    }
+}

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
@@ -3,7 +3,13 @@ package net.corda.serialization.internal.amqp
 import net.corda.core.serialization.CordaSerializationTransformEnumDefault
 import net.corda.core.serialization.CordaSerializationTransformEnumDefaults
 import net.corda.core.serialization.CordaSerializationTransformRename
+import net.corda.core.serialization.CordaSerializationTransformRenames
+import net.corda.serialization.internal.NotSerializableDetailedException
+import net.corda.serialization.internal.model.EnumTransforms
+import net.corda.serialization.internal.model.InvalidEnumTransformsException
+import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class EnumTransformationTests {
 
@@ -14,8 +20,28 @@ class EnumTransformationTests {
     @CordaSerializationTransformRename(to = "BOB", from = "E")
     enum class MultiOperations { A, B, C, D, BOB }
 
+    // See https://r3-cev.atlassian.net/browse/CORDA-1497
     @Test
-    fun doubleRename() {
-        TransformsAnnotationProcessor.getTransformsSchema(MultiOperations::class.java)
+    fun defaultAndRename() {
+        val transforms = EnumTransforms.build(TransformsAnnotationProcessor.getTransformsSchema(MultiOperations::class.java))
+
+        assertEquals(mapOf("BOB" to "E"), transforms.renames)
+        assertEquals(mapOf("D" to "C", "E" to "D"), transforms.defaults)
+    }
+
+    @CordaSerializationTransformRenames(
+            CordaSerializationTransformRename(from = "A", to = "C"),
+            CordaSerializationTransformRename(from = "B", to = "D"),
+            CordaSerializationTransformRename(from = "C", to = "E"),
+            CordaSerializationTransformRename(from = "E", to = "B"),
+            CordaSerializationTransformRename(from = "D", to = "A")
+    )
+    enum class RenameCycle { A, B, C, D, E}
+
+    @Test
+    fun cycleDetection() {
+        assertFailsWith<NotSerializableDetailedException> {
+            TransformsAnnotationProcessor.getTransformsSchema(RenameCycle::class.java)
+        }
     }
 }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
@@ -23,7 +23,9 @@ class EnumTransformationTests {
     // See https://r3-cev.atlassian.net/browse/CORDA-1497
     @Test
     fun defaultAndRename() {
-        val transforms = EnumTransforms.build(TransformsAnnotationProcessor.getTransformsSchema(MultiOperations::class.java))
+        val transforms = EnumTransforms.build(
+                TransformsAnnotationProcessor.getTransformsSchema(MultiOperations::class.java),
+                MultiOperations::class.java.constants)
 
         assertEquals(mapOf("BOB" to "E"), transforms.renames)
         assertEquals(mapOf("D" to "C", "E" to "D"), transforms.defaults)
@@ -40,8 +42,13 @@ class EnumTransformationTests {
 
     @Test
     fun cycleDetection() {
-        assertFailsWith<NotSerializableDetailedException> {
-            TransformsAnnotationProcessor.getTransformsSchema(RenameCycle::class.java)
+        assertFailsWith<InvalidEnumTransformsException> {
+            EnumTransforms.build(
+                    TransformsAnnotationProcessor.getTransformsSchema(RenameCycle::class.java),
+                    RenameCycle::class.java.constants)
         }
     }
+
+    private val Class<*>.constants: Map<String, Int> get() =
+        enumConstants.asSequence().mapIndexed { index, constant -> constant.toString() to index }.toMap()
 }


### PR DESCRIPTION
PR addressing [CORDA-1497](https://r3-cev.atlassian.net/browse/CORDA-1497).

When the transform annotations for an enum included both renaming and defaulting of enum constants, the validation was failing if we wanted to rename a defaulted constant.

```kotlin
@CordaSerializationTransformEnumDefaults(
        CordaSerializationTransformEnumDefault(old = "C", new = "D"),
        CordaSerializationTransformEnumDefault(old = "D", new = "E")
)
@CordaSerializationTransformRename(to = "BOB", from = "E")
enum class MultiOperations { A, B, C, D, BOB }
```

In this PR, we clean up the handling of enum transforms a bit, eliminating the transforms cache from `LocalSerializerFactory` and storing transforms directly in `LocalTypeInformation.AnEnum`, and move validation into the `EnumTransforms` class where it is easier to perform.