### PR TITLE
[CORDA-2285]: Enabled jUnit parallel execution.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,6 +265,14 @@ allprojects {
     }
 }
 
+subprojects {
+    tasks.withType(Test) {
+        if (project.getProperty('test.parallel').toBoolean()) {
+            maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        }
+    }
+}
+
 // Check that we are running on a Java 8 JDK. The source/targetCompatibility values above aren't sufficient to
 // guarantee this because those are properties checked by the Java plugin, but we're using Kotlin.
 //

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 owasp.failOnError=false
 owasp.failBuildOnCVSS=11.0
+test.parallel=false


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2285

Gradle property "test.parallel" controls this feature, default to `false`.