### PR TITLE
CORDA-1497 replace missing validation

### DIFF
--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/EnumTransformationTests.kt
@@ -51,6 +51,36 @@ class EnumTransformationTests {
         }
     }
 
+    @CordaSerializationTransformRenames(
+            CordaSerializationTransformRename(from = "P", to = "Q"),
+            CordaSerializationTransformRename(from = "Q", to = "R")
+    )
+    enum class DanglingRenames { A, B, C }
+
+    @Test
+    fun renameCycleDoesNotTerminateInConstant() {
+        assertFailsWith<InvalidEnumTransformsException> {
+            EnumTransforms.build(
+                    TransformsAnnotationProcessor.getTransformsSchema(DanglingRenames::class.java),
+                    DanglingRenames::class.java.constants)
+        }
+    }
+
+    @CordaSerializationTransformRenames(
+            CordaSerializationTransformRename(from = "P", to = "Q"),
+            CordaSerializationTransformRename(from = "Q", to = "R")
+    )
+    enum class RenamesExisting { Q, R, S }
+
+    @Test
+    fun renamesRenameExistingConstant() {
+        assertFailsWith<InvalidEnumTransformsException> {
+            EnumTransforms.build(
+                    TransformsAnnotationProcessor.getTransformsSchema(RenamesExisting::class.java),
+                    RenamesExisting::class.java.constants)
+        }
+    }
+
     private val Class<*>.constants: Map<String, Int> get() =
         enumConstants.asSequence().mapIndexed { index, constant -> constant.toString() to index }.toMap()
 }


### PR DESCRIPTION
Reviewing the [previous PR](https://github.com/corda/corda/pull/4343) for [CORDA-1497](https://r3-cev.atlassian.net/projects/CORDA/issues/CORDA-1497), I noticed that I'd accidentally removed a couple of validation rules (they weren't tested, so it didn't break anything, but it's still good to have them). This PR restores those rules, together with tests.