### PR TITLE
[CORDA-2247]: Fixed a bug causing Hibernate to produce cross joins.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Unreleased
 
   The ``confidential-identities`` dependency in your CorDapp must now be ``compile`` and not ``cordaCompile``.
 
-* Fixed a bug causing Hibernate to generate cross join statements. This was evident in poor performance and incorrect results for vault queries with sorting.
+* Fixed a bug resulting in poor vault query performance and incorrect results when sorting.
 
 * Marked the ``Attachment`` interface as ``@DoNotImplement`` because it is not meant to be extended by CorDapp developers. If you have already
   done so, please get in contact on the usual communication channels.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,8 @@ Unreleased
 
   The ``confidential-identities`` dependency in your CorDapp must now be ``compile`` and not ``cordaCompile``.
 
+* Fixed a bug causing Hibernate to generate cross join statements. This was evident in poor performance and incorrect results for vault queries with sorting.
+
 * Marked the ``Attachment`` interface as ``@DoNotImplement`` because it is not meant to be extended by CorDapp developers. If you have already
   done so, please get in contact on the usual communication channels.
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -649,7 +649,6 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             when (direction) {
                 Sort.Direction.ASC -> {
                     if (entityStateAttributeChild != null) {
-                        // TODO sollecitom add asc/desc by stateRef, if not there already
                         orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(entityStateAttributeParent).get<String>(entityStateAttributeChild)))
                         orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
                     }
@@ -661,9 +660,11 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                 Sort.Direction.DESC ->
                     if (entityStateAttributeChild != null) {
                         orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(entityStateAttributeParent).get<String>(entityStateAttributeChild)))
+                        orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
                     }
                     else {
                         orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(entityStateAttributeParent)))
+                        orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
                     }
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -533,7 +533,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                     rootEntities.map { it.value }
                 else
                     aggregateExpressions
-        // TODO sollecitom this results in cross join, and it doesn't work with SORT
+        // TODO sollecitom this results in cross join, and it doesn't work with SORT (cartesian product of table entries, so sort is incorrect)
         criteriaQuery.multiselect(selections)
         val combinedPredicates = commonPredicates.values.plus(predicateSet).plus(constraintPredicates)
         criteriaQuery.where(*combinedPredicates.toTypedArray())

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -625,11 +625,17 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
         return emptySet()
     }
 
-    private fun parse(sorting: Sort) {
-        log.trace { "Parsing sorting specification: $sorting" }
+    private fun parse(sortingArg: Sort) {
+        log.trace { "Parsing sorting specification: $sortingArg" }
 
         val orderCriteria = mutableListOf<Order>()
 
+        // TODO sollecitom, instead of adding to order criteria, add to sorting.columns, if it doesn't contain it already.
+        val sorting = if (sortingArg.columns.none { it.sortAttribute == SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF) }) {
+            sortingArg.copy(columns = sortingArg.columns + Sort.SortColumn(SortAttribute.Standard(Sort.CommonStateAttribute.STATE_REF), Sort.Direction.ASC))
+        } else {
+            sortingArg
+        }
         sorting.columns.map { (sortAttribute, direction) ->
             val (entityStateClass, entityStateAttributeParent, entityStateAttributeChild) =
                     when (sortAttribute) {
@@ -650,21 +656,21 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                 Sort.Direction.ASC -> {
                     if (entityStateAttributeChild != null) {
                         orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(entityStateAttributeParent).get<String>(entityStateAttributeChild)))
-                        orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
+//                        orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
                     }
                     else {
                         orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(entityStateAttributeParent)))
-                        orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
+//                        orderCriteria.add(criteriaBuilder.asc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
                     }
                 }
                 Sort.Direction.DESC ->
                     if (entityStateAttributeChild != null) {
                         orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(entityStateAttributeParent).get<String>(entityStateAttributeChild)))
-                        orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
+//                        orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
                     }
                     else {
                         orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(entityStateAttributeParent)))
-                        orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
+//                        orderCriteria.add(criteriaBuilder.desc(sortEntityRoot.get<String>(PersistentState::stateRef.name)))
                     }
             }
         }

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -452,7 +452,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                 }
 
         val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), vaultLinearStates.get<PersistentStateRef>("stateRef"))
-        joinPredicates.add(joinPredicate)
+        predicateSet.add(joinPredicate)
 
         // linear ids UUID
         criteria.uuid?.let {
@@ -505,7 +505,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                     }
 
             val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
-            joinPredicates.add(joinPredicate)
+            predicateSet.add(joinPredicate)
 
             // resolve general criteria expressions
             @Suppress("UNCHECKED_CAST")
@@ -537,7 +537,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                     aggregateExpressions
         // TODO sollecitom this results in cross join, and it doesn't work with SORT (cartesian product of table entries, so sort is incorrect)
         criteriaQuery.multiselect(selections)
-        val combinedPredicates = joinPredicates.plus(predicateSet).plus(commonPredicates.values).plus(constraintPredicates)
+        val combinedPredicates = joinPredicates.plus(commonPredicates.values).plus(predicateSet)
         criteriaQuery.where(*combinedPredicates.toTypedArray())
 
         return predicateSet

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -533,6 +533,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                     rootEntities.map { it.value }
                 else
                     aggregateExpressions
+        // TODO sollecitom this results in cross join, and it doesn't work with SORT
         criteriaQuery.multiselect(selections)
         val combinedPredicates = commonPredicates.values.plus(predicateSet).plus(constraintPredicates)
         criteriaQuery.where(*combinedPredicates.toTypedArray())

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -345,6 +345,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
 
         // TODO sollecitom these do not work either, fix them
         val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearNumber")
+        // TODO sollecitom this doesn't work: it retrieves data but either less or more than the universe set.
 //        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "stateRef")
         // TODO sollecitom these work, write a test for it
 //        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, "stateRef")

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -343,12 +343,11 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         }
         val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
 
-        // TODO sollecitom this does not work
-//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::linearNumber.name)
         // TODO sollecitom these do not work either, fix them
-        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::stateRef.name)
+        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::linearNumber.name)
 //        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, VaultSchemaV1.VaultStates::stateRef.name)
-         // TODO sollecitom this works, write a test for it
+        // TODO sollecitom these work, write a test for it
+//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, VaultSchemaV1.VaultStates::stateRef.name)
 //        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::stateRef.name)
 
         val sort = Sort.Direction.ASC

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -344,11 +344,10 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
 
         // TODO sollecitom these do not work either, fix them
-        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::linearNumber.name)
-//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, VaultSchemaV1.VaultStates::stateRef.name)
+//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearNumber")
+        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "stateRef")
         // TODO sollecitom these work, write a test for it
-//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::stateRef.name)
-//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, VaultSchemaV1.VaultStates::stateRef.name)
+//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, "stateRef")
 
         val sort = Sort.Direction.ASC
         val sorting = Sort(listOf(Sort.SortColumn(sortAttribute, sort)))

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -345,10 +345,10 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
 
         // TODO sollecitom this does not work
-        val sortAttribute = SortAttribute.Custom(SampleCashSchemaV2.PersistentCashState::class.java, SampleCashSchemaV2.PersistentCashState::quantity.name)
+//        val sortAttribute = SortAttribute.Custom(CashSchemaV1.PersistentCashState::class.java, CashSchemaV1.PersistentCashState::pennies.name)
         // TODO sollecitom these do not work either, fix them
-//        val sortAttribute = SortAttribute.Custom(SampleCashSchemaV2.PersistentCashState::class.java, SampleCashSchemaV2.PersistentCashState::stateRef.name)
-//        val sortAttribute = SortAttribute.Custom(SampleCashSchemaV2.PersistentCashState::class.java, VaultSchemaV1.VaultStates::stateRef.name)
+        val sortAttribute = SortAttribute.Custom(CashSchemaV1.PersistentCashState::class.java, CashSchemaV1.PersistentCashState::stateRef.name)
+//        val sortAttribute = SortAttribute.Custom(CashSchemaV1.PersistentCashState::class.java, VaultSchemaV1.VaultStates::stateRef.name)
          // TODO sollecitom this works, write a test for it
 //        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, VaultSchemaV1.VaultStates::stateRef.name)
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -344,8 +344,8 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
 
         // TODO sollecitom these do not work either, fix them
-//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearNumber")
-        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "stateRef")
+        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearNumber")
+//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "stateRef")
         // TODO sollecitom these work, write a test for it
 //        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, "stateRef")
 

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -343,12 +343,8 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         }
         val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
 
-        // TODO sollecitom these do not work either, fix them
+        // TODO sollecitom this doesn't work, fix it
         val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearNumber")
-        // TODO sollecitom this doesn't work: it retrieves data but either less or more than the universe set.
-//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "stateRef")
-        // TODO sollecitom these work, write a test for it
-//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, "stateRef")
 
         val sort = Sort.Direction.ASC
         val sorting = Sort(listOf(Sort.SortColumn(sortAttribute, sort)))

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -347,8 +347,8 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::linearNumber.name)
 //        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, VaultSchemaV1.VaultStates::stateRef.name)
         // TODO sollecitom these work, write a test for it
-//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, VaultSchemaV1.VaultStates::stateRef.name)
 //        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::stateRef.name)
+//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, VaultSchemaV1.VaultStates::stateRef.name)
 
         val sort = Sort.Direction.ASC
         val sorting = Sort(listOf(Sort.SortColumn(sortAttribute, sort)))

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -355,6 +355,12 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
         val allStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria).states
         assertThat(allStates.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
 
+        (1..3).forEach {
+            val newAllStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria).states
+            assertThat(newAllStates.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
+            assertThat(newAllStates).containsExactlyElementsOf(allStates)
+        }
+
         val queriedStates = mutableListOf<StateAndRef<*>>()
         var pageNumber = 0
         while(pageNumber * pageSize < numberOfStates) {

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -352,7 +352,7 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
             assertThat(allStates.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
             when (sortDirection) {
                 Sort.Direction.ASC -> assertThat(allStates.sortedBy { it.state.data.linearNumber }.sortedBy { it.ref.txhash }.sortedBy { it.ref.index }).isEqualTo(allStates)
-                Sort.Direction.DESC -> assertThat(allStates.sortedByDescending { it.state.data.linearNumber }.sortedByDescending { it.ref.txhash }.sortedByDescending { it.ref.index }).isEqualTo(allStates)
+                Sort.Direction.DESC -> assertThat(allStates.sortedByDescending { it.state.data.linearNumber }.sortedBy { it.ref.txhash }.sortedBy { it.ref.index }).isEqualTo(allStates)
             }
 
             (1..3).forEach {

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -348,25 +348,28 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
 //        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, "linearNumber")
 
         val sorting = Sort(listOf(Sort.SortColumn(sortAttribute, Sort.Direction.ASC)))
-        val allStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria)
-        assertThat(allStates.states.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
+        val allStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, criteria = criteria).states
+//        val allStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria)
+        assertThat(allStates.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
 
-        (1..3).forEach {
-            val newAllStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria).states
-            assertThat(newAllStates.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
-            assertThat(newAllStates).containsExactlyElementsOf(allStates.states)
-        }
-
-        val queriedStates = mutableListOf<StateAndRef<*>>()
-        var pageNumber = 0
-        while (pageNumber * pageSize < numberOfStates) {
-            val paging = PageSpecification(pageNumber = pageNumber + 1, pageSize = pageSize)
-            val page = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = paging, criteria = criteria)
-            queriedStates += page.states
-            pageNumber++
-        }
-
-        assertThat(queriedStates).containsExactlyElementsOf(allStates.states)
+//        assertThat(allStates.states.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
+//
+//        (1..3).forEach {
+//            val newAllStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria).states
+//            assertThat(newAllStates.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
+//            assertThat(newAllStates).containsExactlyElementsOf(allStates.states)
+//        }
+//
+//        val queriedStates = mutableListOf<StateAndRef<*>>()
+//        var pageNumber = 0
+//        while (pageNumber * pageSize < numberOfStates) {
+//            val paging = PageSpecification(pageNumber = pageNumber + 1, pageSize = pageSize)
+//            val page = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = paging, criteria = criteria)
+//            queriedStates += page.states
+//            pageNumber++
+//        }
+//
+//        assertThat(queriedStates).containsExactlyElementsOf(allStates.states)
     }
 
     @Test

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt
@@ -337,31 +337,31 @@ abstract class VaultQueryTestsBase : VaultQueryParties {
     fun `pagination works when multiple pages have the same value for the sort criteria field`() {
         val numberOfStates = 59
         val pageSize = 13
+
         database.transaction {
-            val vault = vaultFiller.fillWithSomeTestCash(10.DOLLARS, notaryServices, numberOfStates, DUMMY_CASH_ISSUER)
-            vault.states.map { it.ref }.toSet()
+            vaultFiller.fillWithSomeTestLinearStates(numberOfStates, linearNumber = 100L)
         }
         val criteria = VaultQueryCriteria(status = Vault.StateStatus.ALL)
 
         // TODO sollecitom this does not work
-//        val sortAttribute = SortAttribute.Custom(CashSchemaV1.PersistentCashState::class.java, CashSchemaV1.PersistentCashState::pennies.name)
+//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::linearNumber.name)
         // TODO sollecitom these do not work either, fix them
-        val sortAttribute = SortAttribute.Custom(CashSchemaV1.PersistentCashState::class.java, CashSchemaV1.PersistentCashState::stateRef.name)
-//        val sortAttribute = SortAttribute.Custom(CashSchemaV1.PersistentCashState::class.java, VaultSchemaV1.VaultStates::stateRef.name)
+        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::stateRef.name)
+//        val sortAttribute = SortAttribute.Custom(DummyLinearStateSchemaV1.PersistentDummyLinearState::class.java, VaultSchemaV1.VaultStates::stateRef.name)
          // TODO sollecitom this works, write a test for it
-//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, VaultSchemaV1.VaultStates::stateRef.name)
+//        val sortAttribute = SortAttribute.Custom(VaultSchemaV1.VaultStates::class.java, DummyLinearStateSchemaV1.PersistentDummyLinearState::stateRef.name)
 
         val sort = Sort.Direction.ASC
         val sorting = Sort(listOf(Sort.SortColumn(sortAttribute, sort)))
 
-        val allStates = vaultService.queryBy<Cash.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria).states
+        val allStates = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = PageSpecification(1, 200), criteria = criteria).states
         assertThat(allStates.groupBy(StateAndRef<*>::ref)).hasSameSizeAs(allStates)
 
         val queriedStates = mutableListOf<StateAndRef<*>>()
         var pageNumber = 0
         while(pageNumber * pageSize < numberOfStates) {
             val paging = PageSpecification(pageNumber = pageNumber + 1, pageSize = pageSize)
-            val page = vaultService.queryBy<Cash.State>(sorting = sorting, paging = paging, criteria = criteria)
+            val page = vaultService.queryBy<DummyLinearContract.State>(sorting = sorting, paging = paging, criteria = criteria)
             queriedStates += page.states
             pageNumber++
         }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2247

Notes:

1. Fixed a problem that was preventing Hibernate from generating left joins instead of cross joins.
2. Added an additional sort column on `stateRef` to avoid unstable sorts on fields with possible duplicate values. This is added only if no sort columns are based on `stateRef` already.