### PR TITLE
[CORDA-1676] Adjust progress tracking rendering for skipped elements

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/Emoji.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/Emoji.kt
@@ -54,6 +54,8 @@ object Emoji {
     val CODE_WARNING_SIGN: String = codePointsString(0x26A0, 0xFE0F)
     @JvmStatic
     val CROSS_MARK_BUTTON: String = codePointsString(0x274E)
+    @JvmStatic
+    val BALLOT_BOX_WITH_CHECK_BUTTON: String = codePointsString(0x2611)
 
     /**
      * When non-null, toString() methods are allowed to use emoji in the output as we're going to render them to a
@@ -81,7 +83,7 @@ object Emoji {
     val rightArrow: String get() = if (emojiMode.get() != null) "$CODE_RIGHT_ARROW  " else "▶︎"
     val skullAndCrossbones: String get() = if (emojiMode.get() != null) "$CODE_SKULL_AND_CROSSBONES  " else "☂"
     val noEntry: String get() = if (emojiMode.get() != null) "$CODE_NO_ENTRY  " else "✘"
-    val notRun: String get() = if (emojiMode.get() != null) "$CROSS_MARK_BUTTON  " else "-"
+    val notRun: String get() = if (emojiMode.get() != null) "$BALLOT_BOX_WITH_CHECK_BUTTON  " else "-"
 
     inline fun <T> renderIfSupported(body: () -> T): T {
         if (hasEmojiTerminal)

--- a/core/src/main/kotlin/net/corda/core/internal/Emoji.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/Emoji.kt
@@ -52,10 +52,6 @@ object Emoji {
     val CODE_DEVELOPER: String = codePointsString(0x1F469, 0x200D, 0x1F4BB)
     @JvmStatic
     val CODE_WARNING_SIGN: String = codePointsString(0x26A0, 0xFE0F)
-    @JvmStatic
-    val CROSS_MARK_BUTTON: String = codePointsString(0x274E)
-    @JvmStatic
-    val BALLOT_BOX_WITH_CHECK_BUTTON: String = codePointsString(0x2611)
 
     /**
      * When non-null, toString() methods are allowed to use emoji in the output as we're going to render them to a
@@ -83,7 +79,6 @@ object Emoji {
     val rightArrow: String get() = if (emojiMode.get() != null) "$CODE_RIGHT_ARROW  " else "▶︎"
     val skullAndCrossbones: String get() = if (emojiMode.get() != null) "$CODE_SKULL_AND_CROSSBONES  " else "☂"
     val noEntry: String get() = if (emojiMode.get() != null) "$CODE_NO_ENTRY  " else "✘"
-    val notRun: String get() = if (emojiMode.get() != null) "$BALLOT_BOX_WITH_CHECK_BUTTON  " else "-"
 
     inline fun <T> renderIfSupported(body: () -> T): T {
         if (hasEmojiTerminal)

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -153,7 +153,7 @@ abstract class ANSIProgressRenderer {
 
                 val marker = when {
                     processedStep -> " ${Emoji.greenTick} "
-                    skippedStep -> " ${Emoji.notRun} "
+                    skippedStep -> "      "
                     activeStep -> "${Emoji.rightArrow} "
                     error -> "${Emoji.noEntry} "
                     else -> "    "   // Not reached yet.

--- a/tools/shell/src/test/kotlin/net/corda/tools/shell/utilities/ANSIProgressRendererTest.kt
+++ b/tools/shell/src/test/kotlin/net/corda/tools/shell/utilities/ANSIProgressRendererTest.kt
@@ -1,0 +1,64 @@
+package net.corda.tools.shell.utilities
+
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.internal.concurrent.openFuture
+import net.corda.core.messaging.DataFeed
+import net.corda.core.messaging.FlowProgressHandleImpl
+import net.corda.tools.shell.utlities.ANSIProgressRenderer
+import net.corda.tools.shell.utlities.CRaSHANSIProgressRenderer
+import org.assertj.core.api.Assertions.assertThat
+import org.crsh.text.RenderPrintWriter
+import org.junit.Test
+import rx.Observable
+import org.fusesource.jansi.Ansi
+import org.junit.Before
+import rx.subjects.PublishSubject
+
+class ANSIProgressRendererTest {
+
+    companion object {
+        private const val INTENSITY_BOLD_ON_ASCII = "[1m"
+        private const val INTENSITY_OFF_ASCII = "[22m"
+        private const val INTENSITY_FAINT_ON_ASCII = "[2m"
+
+        private const val STEP_1_LABEL = "Running step 1"
+        private const val STEP_2_LABEL = "Running step 2"
+        private const val STEP_3_LABEL = "Running step 3"
+
+        private const val STEP_1_SUCCESS_OUTPUT = """✓ $STEP_1_LABEL"""
+        private const val STEP_2_SKIPPED_OUTPUT = """- $INTENSITY_FAINT_ON_ASCII$STEP_2_LABEL$INTENSITY_OFF_ASCII"""
+        private const val STEP_3_ACTIVE_OUTPUT = """✓ $INTENSITY_BOLD_ON_ASCII$STEP_3_LABEL$INTENSITY_OFF_ASCII"""
+    }
+
+    lateinit var printWriter: RenderPrintWriter
+    lateinit var progressRenderer: ANSIProgressRenderer
+
+    @Before
+    fun setup() {
+        printWriter = mock()
+        progressRenderer = CRaSHANSIProgressRenderer(printWriter)
+    }
+
+    @Test
+    fun `test that steps are rendered appropriately depending on their status`() {
+        val indexSubject = PublishSubject.create<Int>()
+        val feedSubject = PublishSubject.create<List<Pair<Int, String>>>()
+        val stepsTreeIndexFeed = DataFeed<Int, Int>(0, indexSubject)
+        val stepsTreeFeed = DataFeed<List<Pair<Int, String>>, List<Pair<Int, String>>>(listOf(), feedSubject)
+        val flowProgressHandle = FlowProgressHandleImpl(StateMachineRunId.createRandom(), openFuture<String>(), Observable.empty(), stepsTreeIndexFeed, stepsTreeFeed)
+
+        progressRenderer.render(flowProgressHandle)
+        // The flow is currently at step 3, while step 1 has been completed and step 2 has been skipped.
+        indexSubject.onNext(2)
+        feedSubject.onNext(listOf(Pair(0, STEP_1_LABEL), Pair(0, STEP_2_LABEL), Pair(0, STEP_3_LABEL)))
+
+        val captor = argumentCaptor<Ansi>()
+        verify(printWriter).print(captor.capture())
+        assertThat(captor.firstValue.toString()).containsSequence(STEP_1_SUCCESS_OUTPUT, STEP_2_SKIPPED_OUTPUT, STEP_3_ACTIVE_OUTPUT)
+        verify(printWriter).flush()
+    }
+
+}

--- a/tools/shell/src/test/kotlin/net/corda/tools/shell/utilities/ANSIProgressRendererTest.kt
+++ b/tools/shell/src/test/kotlin/net/corda/tools/shell/utilities/ANSIProgressRendererTest.kt
@@ -29,8 +29,8 @@ class ANSIProgressRendererTest {
         private const val STEP_3_LABEL = "Running step 3"
 
         private const val STEP_1_SUCCESS_OUTPUT = """✓ $STEP_1_LABEL"""
-        private const val STEP_2_SKIPPED_OUTPUT = """- $INTENSITY_FAINT_ON_ASCII$STEP_2_LABEL$INTENSITY_OFF_ASCII"""
-        private const val STEP_3_ACTIVE_OUTPUT = """✓ $INTENSITY_BOLD_ON_ASCII$STEP_3_LABEL$INTENSITY_OFF_ASCII"""
+        private const val STEP_2_SKIPPED_OUTPUT = """  $INTENSITY_FAINT_ON_ASCII$STEP_2_LABEL$INTENSITY_OFF_ASCII"""
+        private const val STEP_3_ACTIVE_OUTPUT  = """✓ $INTENSITY_BOLD_ON_ASCII$STEP_3_LABEL$INTENSITY_OFF_ASCII"""
     }
 
     lateinit var printWriter: RenderPrintWriter


### PR DESCRIPTION
## Changes
I adjusted the rendering for flow stages that have been skipped, so that user is not misled into thinking they failed (by the X symbol). 

Notes:
* I initially went for strikethrough, but realised it's not working for most terminals, so went for the faint effect. Also, could not find a more appropriate symbol, so used the ballot box check. Open to suggestions.
* I took the liberty of removing the `treeIndex == tree.lastIndex` condition, since I believe it's dead code and I think it's also confusing. The reason is it's comparing the index of the steps in progress with the `tree.lastIndex`, which corresponds to the number of times the structure of the progress tracker has changed. I run a few more tests, as shown below to make sure this does not introduce regressions. Let me know if I am missing something.

## Testing
* Run the `heartbeat`, `bank-of-corda-demo`, `trader-demo` projects and the output is the same (content-wise)
* The style of the new output can be seen below:
<img width="464" alt="success" src="https://user-images.githubusercontent.com/6065016/49578492-cea65d80-f941-11e8-91c2-6d2a18656177.png">