### PR TITLE
[CORDA-2294]: Improved exception thrown by AttachmentsClassLoader when attachment uploader is not trusted.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/MissingAttachmentsException.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/MissingAttachmentsException.kt
@@ -7,4 +7,7 @@ import net.corda.core.crypto.SecureHash
 /** Thrown during deserialization to indicate that an attachment needed to construct the [WireTransaction] is not found. */
 @KeepForDJVM
 @CordaSerializable
-class MissingAttachmentsException(val ids: List<SecureHash>) : CordaException()
+class MissingAttachmentsException(val ids: List<SecureHash>, message: String?) : CordaException(message) {
+
+    constructor(ids: List<SecureHash>) : this(ids, null)
+}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -26,6 +26,8 @@ Unreleased
 
 * Fixed a bug resulting in poor vault query performance and incorrect results when sorting.
 
+* Improved exception thrown by `AttachmentsClassLoader` when an attachment cannot be used because its uploader is not trusted.
+
 * Marked the ``Attachment`` interface as ``@DoNotImplement`` because it is not meant to be extended by CorDapp developers. If you have already
   done so, please get in contact on the usual communication channels.
 


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2294