### PR TITLE
CORDA-2115: Straighten-up @Before invocation chain.

### DIFF
--- a/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
+++ b/client/rpc/src/integration-test/java/net/corda/client/rpc/CordaRPCJavaClientTest.java
@@ -45,7 +45,6 @@ public class CordaRPCJavaClientTest extends NodeBasedTest {
     private Set<String> permSet = new HashSet<>(perms);
     private User rpcUser = new User("user1", "test", permSet);
 
-    private NodeWithInfo node;
     private CordaRPCClient client;
     private RPCConnection<CordaRPCOps> connection = null;
     private CordaRPCOps rpcProxy;
@@ -56,8 +55,10 @@ public class CordaRPCJavaClientTest extends NodeBasedTest {
     }
 
     @Before
-    public void setUp() throws Exception {
-        node = startNode(ALICE_NAME, 1000, singletonList(rpcUser));
+    @Override
+    public void setUp() {
+        super.setUp();
+        NodeWithInfo node = startNode(ALICE_NAME, 1000, singletonList(rpcUser));
         client = new CordaRPCClient(requireNonNull(node.getNode().getConfiguration().getRpcOptions().getAddress()));
     }
 

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/CordaRPCClientTest.kt
@@ -9,7 +9,6 @@ import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.location
 import net.corda.core.internal.toPath
 import net.corda.core.messaging.*
-import net.corda.core.node.NotaryInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.getOrThrow
@@ -61,7 +60,8 @@ class CordaRPCClientTest : NodeBasedTest(listOf("net.corda.finance"), notaries =
     }
 
     @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         node = startNode(ALICE_NAME, rpcUsers = listOf(rpcUser))
         client = CordaRPCClient(node.node.configuration.rpcOptions.address, CordaRPCClientConfiguration.DEFAULT.copy(
             maxReconnectAttempts = 5

--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/FlowsExecutionModeRpcTest.kt
@@ -52,7 +52,8 @@ class FlowsExecutionModeTests : NodeBasedTest(listOf("net.corda.finance.contract
     private lateinit var client: CordaRPCClient
 
     @Before
-    fun setup() {
+    override fun setUp() {
+        super.setUp()
         node = startNode(ALICE_NAME, rpcUsers = listOf(rpcUser))
         client = CordaRPCClient(node.node.configuration.rpcOptions.address)
     }

--- a/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/AuthDBTests.kt
@@ -50,7 +50,8 @@ class AuthDBTests : NodeBasedTest() {
     lateinit var passwordEncryption: PasswordEncryption
 
     @Before
-    fun setup() {
+    override fun setUp() {
+        super.setUp()
         db = UsersDB(
                 name = "SecurityDataSourceTestDB",
                 users = listOf(UserAndRoles(username = "user",

--- a/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/services/messaging/MQSecurityTest.kt
@@ -42,13 +42,14 @@ import kotlin.test.assertEquals
  * the attacker to [alice].
  */
 abstract class MQSecurityTest : NodeBasedTest() {
-    val rpcUser = User("user1", "pass", permissions = emptySet())
+    private val rpcUser = User("user1", "pass", permissions = emptySet())
     lateinit var alice: NodeWithInfo
     lateinit var attacker: SimpleMQClient
     private val clients = ArrayList<SimpleMQClient>()
 
     @Before
-    fun start() {
+    override fun setUp() {
+        super.setUp()
         alice = startNode(ALICE_NAME, rpcUsers = extraRPCUsers + rpcUser)
         attacker = createAttacker()
         startAttacker(attacker)

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/NodeBasedTest.kt
@@ -64,7 +64,7 @@ constructor(private val cordappPackages: List<String> = emptyList(), private val
     }
 
     @Before
-    fun init() {
+    open fun setUp() {
         val notaryInfos = notaries.map { NotaryInfo(installNotary(it), true) } // todo only validating ones
         defaultNetworkParameters = NetworkParametersCopier(testNetworkParameters(notaries = notaryInfos))
         notaries.mapTo(notaryNodes) { startNode(it) }


### PR DESCRIPTION
Note: similar sort of changes already made in Ent codebase that fix execution against external DBs.
it will make sense to backport those change to OS to avoid merge conflicts in the future.