### PR TITLE
CORDA-2227 Change ? to java.lang.Object in type notation for Any

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifiers.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifiers.kt
@@ -46,8 +46,8 @@ object AMQPTypeIdentifiers {
     fun nameForType(typeIdentifier: TypeIdentifier): String = when(typeIdentifier) {
         is TypeIdentifier.Erased -> typeIdentifier.name
         is TypeIdentifier.Unparameterised -> primitiveTypeNamesByName[typeIdentifier] ?: typeIdentifier.name
-        is TypeIdentifier.UnknownType,
-        is TypeIdentifier.TopType -> "?"
+        is TypeIdentifier.UnknownType -> "?"
+        is TypeIdentifier.TopType -> TypeIdentifier.TopType.name
         is TypeIdentifier.ArrayOf ->
             if (typeIdentifier == primitiveByteArrayType) "binary"
             else nameForType(typeIdentifier.componentType) +

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
@@ -67,7 +67,8 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
         override fun isSerializerFor(clazz: Class<*>): Boolean = clazz == this.clazz
         override val type: Type get() = clazz
         override val typeDescriptor: Symbol by lazy {
-            Symbol.valueOf("$DESCRIPTOR_DOMAIN:${FingerprintWriter(false).write(arrayOf(superClassSerializer.typeDescriptor.toString(), AMQPTypeIdentifiers.nameForType(clazz)).joinToString()).fingerprint}")
+            val descriptors = arrayOf(superClassSerializer.typeDescriptor.toString(), AMQPTypeIdentifiers.nameForType(clazz)).joinToString()
+            Symbol.valueOf("$DESCRIPTOR_DOMAIN:${FingerprintWriter(false).write(descriptors).fingerprint}")
         }
         private val typeNotation: TypeNotation = RestrictedType(
                 AMQPTypeIdentifiers.nameForType(clazz),

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializer.kt
@@ -67,8 +67,7 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
         override fun isSerializerFor(clazz: Class<*>): Boolean = clazz == this.clazz
         override val type: Type get() = clazz
         override val typeDescriptor: Symbol by lazy {
-            val descriptors = arrayOf(superClassSerializer.typeDescriptor.toString(), AMQPTypeIdentifiers.nameForType(clazz)).joinToString()
-            Symbol.valueOf("$DESCRIPTOR_DOMAIN:${FingerprintWriter(false).write(descriptors).fingerprint}")
+            Symbol.valueOf("$DESCRIPTOR_DOMAIN:${FingerprintWriter(false).write(arrayOf(superClassSerializer.typeDescriptor.toString(), AMQPTypeIdentifiers.nameForType(clazz)).joinToString()).fingerprint}")
         }
         private val typeNotation: TypeNotation = RestrictedType(
                 AMQPTypeIdentifiers.nameForType(clazz),

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/LocalTypeInformationBuilder.kt
@@ -103,7 +103,8 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
             Collection::class.java.isAssignableFrom(type) &&
                     !EnumSet::class.java.isAssignableFrom(type) -> LocalTypeInformation.ACollection(type, typeIdentifier, LocalTypeInformation.Unknown)
             Map::class.java.isAssignableFrom(type) -> LocalTypeInformation.AMap(type, typeIdentifier, LocalTypeInformation.Unknown, LocalTypeInformation.Unknown)
-            type.kotlin.javaPrimitiveType != null -> LocalTypeInformation.Atomic(type.kotlin.javaPrimitiveType!!, typeIdentifier)
+            type == String::class.java -> LocalTypeInformation.Atomic(String::class.java, typeIdentifier)
+            type.kotlin.javaPrimitiveType != null ->LocalTypeInformation.Atomic(type.kotlin.javaPrimitiveType!!, typeIdentifier)
             type.isEnum -> LocalTypeInformation.AnEnum(
                     type,
                     typeIdentifier,

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
@@ -71,11 +71,6 @@ class AMQPRemoteTypeModelTests {
         """)
     }
 
-    @Test
-    fun flowException() {
-        Exception("foo").assertRemoteType("""""")
-    }
-
     private fun getRemoteType(obj: Any): RemoteTypeInformation {
         val output = SerializationOutput(factory)
         val schema = output.serializeAndReturnSchema(obj)

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
@@ -18,7 +18,7 @@ class AMQPRemoteTypeModelTests {
     @JvmField
     val serializationEnvRule = SerializationEnvironmentRule()
 
-    private val factory = testDefaultFactory().apply { register(ThrowableSerializer(this)) }
+    private val factory = testDefaultFactory()
     private val typeModel = AMQPRemoteTypeModel()
 
     interface Interface<P, Q, R> {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifierParserTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifierParserTests.kt
@@ -67,7 +67,7 @@ class AMQPTypeIdentifierParserTests {
         assertParsesCompatibly<IntArray>()
         assertParsesCompatibly<Array<Int>>()
         assertParsesCompatibly<List<Int>>()
-        assertParsesTo<WithParameter<*>>("WithParameter<?>")
+        assertParsesCompatibly<WithParameter<*>>()
         assertParsesCompatibly<WithParameter<Int>>()
         assertParsesCompatibly<Array<out WithParameter<Int>>>()
         assertParsesCompatibly<WithParameters<IntArray, WithParameter<Array<WithParameters<Array<Array<Date>>, UUID>>>>>()


### PR DESCRIPTION
Although it doesn't make much difference in practice, v3's AMQP type notation for `List<*>` is `List<java.lang.Object>` while v4's is `List<?>`. I noticed the mismatch while investigating [CORDA-2227](https://r3-cev.atlassian.net/browse/CORDA-2227); although this PR isn't needed to resolve that issue, it eliminates a red herring that held me up while trying to find the cause.

Another irritation I noticed in passing is that `java.lang.String` is treated as `LocalTypeInformation.Opaque` rather than `LocalTypeInformation.Atomic`, which makes the `toString` unnecessarily long and difficult to read (since it includes full `NonComposable` information for `java.lang.String`). That is also fixed here.