### PR TITLE
[CORDA-1190]: Removed confusing reference to an attachments directory in LoggingBuyerFlow in trader-demo.

### DIFF
--- a/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/LoggingBuyerFlow.kt
+++ b/samples/trader-demo/src/main/kotlin/net/corda/traderdemo/flow/LoggingBuyerFlow.kt
@@ -40,7 +40,7 @@ class LoggingBuyerFlow(private val otherSideSession: FlowSession) : BuyerFlow(ot
         cpIssuance.attachments.first().let {
             println("""
 
-The issuance of the commercial paper came with an attachment. You can find it in the attachments directory: $it.jar
+The issuance of the commercial paper came with an attachment with hash $it.
 
 ${Emoji.renderIfSupported(cpIssuance)}""")
         }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-1190