### PR TITLE
CORDA-2291 enable Finance App 3.x on Corda 4.x

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -79,6 +79,8 @@ class SchemaMigration(
                 val resource = getMigrationResource(mappedSchema, classLoader)
                 when {
                     resource != null -> resource
+                    // Corda OS FinanceApp in v3 has not Liquibase so no error is raised
+                    (mappedSchema::class.qualifiedName == "net.corda.finance.schemas.CashSchemaV1" || mappedSchema::class.qualifiedName == "net.corda.finance.schemas.CommercialPaperSchemaV1") && mappedSchema.migrationResource == null -> null
                     else -> throw MissingMigrationException(mappedSchema)
                 }
             }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -79,7 +79,7 @@ class SchemaMigration(
                 val resource = getMigrationResource(mappedSchema, classLoader)
                 when {
                     resource != null -> resource
-                    // Corda OS FinanceApp in v3 has not Liquibase so no error is raised
+                    // Corda OS FinanceApp in v3 has no Liquibase script, so no error is raised
                     (mappedSchema::class.qualifiedName == "net.corda.finance.schemas.CashSchemaV1" || mappedSchema::class.qualifiedName == "net.corda.finance.schemas.CommercialPaperSchemaV1") && mappedSchema.migrationResource == null -> null
                     else -> throw MissingMigrationException(mappedSchema)
                 }


### PR DESCRIPTION
`Finance CorDapp` `v3.0` doesn't have Liquibase migration script, as `Corda OS 3.0` doesn't use Liquibase.
`Corda OS 4.0` supports Liquibase, but needs to allow run the older `Finance Cordapp v3.0` which doesn't have Liquibase Script.

Run Liquibase setup for schemas of Finance App only if they are present in the Cordapp (so when `FinanceApp v4 is used). 

Tested - trader demo run entirely on `v3` (node/cordpapps), then corda.jar `v4` was dropped and the demo restored - all works, (Liquibase created for core tables), then stopped and dropped new finance jar,  Liquibase for Finance schema created.