### PR TITLE
CORDA-2306 backoff on flow retries

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -34,7 +34,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
     })
     private val secureRandom = newSecureRandom()
 
-    private val delayedDischargeTimer = Timer("FlowHospitalDelayedDischargeTimer")
+    private val delayedDischargeTimer = Timer("FlowHospitalDelayedDischargeTimer", true)
     /**
      * The node was unable to initiate the [InitialSessionMessage] from [sender].
      */

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -100,7 +100,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
                 if (it == 0) {
                     0L
                 } else {
-                    (100 * 1.5.pow(it)).toLong()
+                    maxOf(10L, ((1 + Math.random()) * (100 * 1.5.pow(it)) / 2).toLong())
                 }
             }
 

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -138,16 +138,15 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
     }
 
     private fun calculateBackOffForChronicCondition(report: ConsultationReport, medicalHistory: FlowMedicalHistory, currentState: StateMachineState): Duration {
-        if (report.by.any { it is Chronic }) {
-            return medicalHistory.timesDischargedForTheSameThing(DeadlockNurse, currentState).let {
+        return report.by.firstOrNull { it is Chronic }?.let { chronicStaff ->
+            return medicalHistory.timesDischargedForTheSameThing(chronicStaff, currentState).let {
                 if (it == 0) {
                     0.seconds
                 } else {
                     maxOf(10, (10 + (Math.random()) * (10 * 1.5.pow(it)) / 2).toInt()).seconds
                 }
             }
-        }
-        return 0.seconds
+        } ?: 0.seconds
     }
 
     private fun consultStaff(flowFiber: FlowFiber,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -95,7 +95,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
         val time = Instant.now()
         log.info("Flow ${flowFiber.id} admitted to hospital in state $currentState")
 
-        val (event, backOffForChronicalConditions) = mutex.locked {
+        val (event, backOffForChronicCondition) = mutex.locked {
             val medicalHistory = flowPatients.computeIfAbsent(flowFiber.id) { FlowMedicalHistory() }
 
             val report = consultStaff(flowFiber, currentState, errors, medicalHistory)
@@ -125,14 +125,14 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
         }
 
         if (event != null) {
-            if (backOffForChronicalConditions.isZero) {
+            if (backOffForChronicCondition.isZero) {
                 flowFiber.scheduleEvent(event)
             } else {
                 delayedDischargeTimer.schedule(object : TimerTask() {
                     override fun run() {
                         flowFiber.scheduleEvent(event)
                     }
-                }, backOffForChronicalConditions.toMillis())
+                }, backOffForChronicCondition.toMillis())
             }
         }
     }


### PR DESCRIPTION
If flows get retried for DB deadlocks, add exponential back off to avoid the retries increasing the DB deadlock probability.