### PR TITLE
CORDA-2227 Emit java.lang.Object, not *, in TypeNotation

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifiers.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifiers.kt
@@ -47,7 +47,7 @@ object AMQPTypeIdentifiers {
         is TypeIdentifier.Erased -> typeIdentifier.name
         is TypeIdentifier.Unparameterised -> primitiveTypeNamesByName[typeIdentifier] ?: typeIdentifier.name
         is TypeIdentifier.UnknownType -> "?"
-        is TypeIdentifier.TopType -> TypeIdentifier.TopType.name
+        is TypeIdentifier.TopType -> Any::class.java.name
         is TypeIdentifier.ArrayOf ->
             if (typeIdentifier == primitiveByteArrayType) "binary"
             else nameForType(typeIdentifier.componentType) +

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPRemoteTypeModelTests.kt
@@ -45,10 +45,10 @@ class AMQPRemoteTypeModelTests {
     @Test
     fun `round-trip some types through AMQP serialisations`() {
         arrayOf("").assertRemoteType("String[]")
-        listOf(1).assertRemoteType("List<*>")
+        listOf(1).assertRemoteType("List<Object>")
         arrayOf(listOf(1)).assertRemoteType("List[]")
         Enum.BAZ.assertRemoteType("Enum(FOO|BAR|BAZ)")
-        mapOf("string" to 1).assertRemoteType("Map<*, *>")
+        mapOf("string" to 1).assertRemoteType("Map<Object, Object>")
         arrayOf(byteArrayOf(1, 2, 3)).assertRemoteType("byte[][]")
 
         SimpleClass(1, 2.0, null, byteArrayOf(1, 2, 3), byteArrayOf(4, 5, 6))
@@ -63,11 +63,11 @@ class AMQPRemoteTypeModelTests {
 
         C(arrayOf("a", "b"), listOf(UUID.randomUUID()), mapOf(UUID.randomUUID() to intArrayOf(1, 2, 3)), Enum.BAZ)
                 .assertRemoteType("""
-            C: Interface<String, UUID, *>
+            C: Interface<String, UUID, Object>
               array: String[]
               enum: Enum(FOO|BAR|BAZ)
               list: List<UUID>
-              map: Map<UUID, *>
+              map: Map<UUID, Object>
         """)
     }
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifierParserTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/AMQPTypeIdentifierParserTests.kt
@@ -67,7 +67,7 @@ class AMQPTypeIdentifierParserTests {
         assertParsesCompatibly<IntArray>()
         assertParsesCompatibly<Array<Int>>()
         assertParsesCompatibly<List<Int>>()
-        assertParsesCompatibly<WithParameter<*>>()
+        assertParsesTo<WithParameter<*>>("WithParameter<Object>")
         assertParsesCompatibly<WithParameter<Int>>()
         assertParsesCompatibly<Array<out WithParameter<Int>>>()
         assertParsesCompatibly<WithParameters<IntArray, WithParameter<Array<WithParameters<Array<Array<Date>>, UUID>>>>>()


### PR DESCRIPTION
If a type parameter is `*`, we should write it as `java.lang.Object`, so that Corda V3 can interpret it correctly.