### PR TITLE
CORDA-2262 Align ID -> pubKey mapping between BasicHSMKeyManagementService and PersistentKeyManagementService

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/BasicHSMKeyManagementService.kt
@@ -14,13 +14,12 @@ import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
 import org.apache.commons.lang.ArrayUtils.EMPTY_BYTE_ARRAY
 import org.bouncycastle.operator.ContentSigner
+import org.hibernate.annotations.Type
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.Id
-import javax.persistence.Lob
+import java.util.*
+import javax.persistence.*
 
 /**
  * A persistent re-implementation of [E2ETestKeyManagementService] to support CryptoService for initial keys and
@@ -33,9 +32,8 @@ import javax.persistence.Lob
 class BasicHSMKeyManagementService(cacheFactory: NamedCacheFactory, val identityService: PersistentIdentityService,
                                    private val database: CordaPersistence, private val cryptoService: CryptoService) : SingletonSerializeAsToken(), KeyManagementServiceInternal {
     @Entity
-    @javax.persistence.Table(name = "${NODE_DATABASE_PREFIX}our_key_pairs")
+    @Table(name = "${NODE_DATABASE_PREFIX}our_key_pairs")
     class PersistentKey(
-
             @Id
             @Column(name = "public_key_hash", length = MAX_HASH_HEX_SIZE, nullable = false)
             var publicKeyHash: String,
@@ -49,6 +47,25 @@ class BasicHSMKeyManagementService(cacheFactory: NamedCacheFactory, val identity
     ) {
         constructor(publicKey: PublicKey, privateKey: PrivateKey)
             : this(publicKey.toStringShort(), publicKey.encoded, privateKey.encoded)
+    }
+
+    @Entity
+    @Table(name = "pk_hash_to_ext_id_map", indexes = [Index(name = "pk_hash_to_xid_idx", columnList = "public_key_hash")])
+    class PublicKeyHashToExternalId(
+            @Id
+            @GeneratedValue
+            @Column(name = "id", unique = true, nullable = false)
+            val key: Long?,
+
+            @Column(name = "external_id", nullable = false)
+            @Type(type = "uuid-char")
+            val externalId: UUID,
+
+            @Column(name = "public_key_hash", nullable = false)
+            val publicKeyHash: String
+    ) {
+        constructor(accountId: UUID, publicKey: PublicKey)
+                : this(null, accountId, publicKey.toStringShort())
     }
 
     private companion object {

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -23,6 +23,7 @@ import javax.persistence.*
  *
  * This class needs database transactions to be in-flight during method calls and init.
  */
+@Deprecated("Superseded by net.corda.node.services.keys.BasicHSMKeyManagementService")
 class PersistentKeyManagementService(cacheFactory: NamedCacheFactory, val identityService: PersistentIdentityService,
                                      private val database: CordaPersistence) : SingletonSerializeAsToken(), KeyManagementServiceInternal {
     @Entity

--- a/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/keys/PersistentKeyManagementService.kt
@@ -11,11 +11,9 @@ import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.NODE_DATABASE_PREFIX
 import org.apache.commons.lang.ArrayUtils.EMPTY_BYTE_ARRAY
 import org.bouncycastle.operator.ContentSigner
-import org.hibernate.annotations.Type
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
-import java.util.*
 import javax.persistence.*
 
 /**
@@ -43,25 +41,6 @@ class PersistentKeyManagementService(cacheFactory: NamedCacheFactory, val identi
     ) {
         constructor(publicKey: PublicKey, privateKey: PrivateKey)
             : this(publicKey.toStringShort(), publicKey.encoded, privateKey.encoded)
-    }
-
-    @Entity
-    @Table(name = "pk_hash_to_ext_id_map", indexes = [Index(name = "pk_hash_to_xid_idx", columnList = "public_key_hash")])
-    class PublicKeyHashToExternalId(
-            @Id
-            @GeneratedValue
-            @Column(name = "id", unique = true, nullable = false)
-            val key: Long?,
-
-            @Column(name = "external_id", nullable = false)
-            @Type(type = "uuid-char")
-            val externalId: UUID,
-
-            @Column(name = "public_key_hash", nullable = false)
-            val publicKeyHash: String
-    ) {
-        constructor(accountId: UUID, publicKey: PublicKey)
-                : this(null, accountId, publicKey.toStringShort())
     }
 
     private companion object {

--- a/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
@@ -45,7 +45,7 @@ class NodeSchemaService(private val extraSchemas: Set<MappedSchema> = emptySet()
                     PersistentIdentityService.PersistentIdentityNames::class.java,
                     ContractUpgradeServiceImpl.DBContractUpgrade::class.java,
                     DBNetworkParametersStorage.PersistentNetworkParameters::class.java,
-                    PersistentKeyManagementService.PublicKeyHashToExternalId::class.java
+                    BasicHSMKeyManagementService.PublicKeyHashToExternalId::class.java
             )) {
         override val migrationResource = "node-core.changelog-master"
     }

--- a/node/src/test/kotlin/net/corda/node/services/vault/ExternalIdMappingTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/ExternalIdMappingTest.kt
@@ -10,7 +10,7 @@ import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.builder
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.node.services.api.IdentityServiceInternal
-import net.corda.node.services.keys.PersistentKeyManagementService
+import net.corda.node.services.keys.BasicHSMKeyManagementService
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
@@ -62,7 +62,7 @@ class ExternalIdMappingTest {
         val anonymousParty = freshKey()
         database.transaction {
             services.withEntityManager {
-                val mapping = PersistentKeyManagementService.PublicKeyHashToExternalId(externalId, anonymousParty.owningKey)
+                val mapping = BasicHSMKeyManagementService.PublicKeyHashToExternalId(externalId, anonymousParty.owningKey)
                 persist(mapping)
                 flush()
             }


### PR DESCRIPTION
There was a parallel work done on `PersistentKeyManagementService` (added new table) while this service has been superseded by `BasicHSMKeyManagementService`.
Move this change for the former class to the later one and did some minor cleanup. 

The general question `PersistentKeyManagementService` is not used anymore, should in  introduction https://github.com/corda/corda/pull/4099, or is there a reason to keep it?

There are still some references to `PersistentKeyManagementService` in docs.