### PR TITLE
ENT-2785 Create clearer separation between RPC and P2P classes to mak…

### DIFF
--- a/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
+++ b/client/rpc/src/integration-test/kotlin/net/corda/client/rpc/RPCStabilityTests.kt
@@ -9,7 +9,7 @@ import net.corda.core.messaging.RPCOps
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.*
-import net.corda.node.services.messaging.RPCServerConfiguration
+import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.eventually
 import net.corda.testing.core.SerializationEnvironmentRule

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/AbstractRPCTest.kt
@@ -4,7 +4,7 @@ import net.corda.core.internal.concurrent.flatMap
 import net.corda.core.internal.concurrent.map
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.seconds
-import net.corda.node.services.messaging.RPCServerConfiguration
+import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.testing.core.SerializationEnvironmentRule
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.RPCDriverDSL

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/ClientRPCInfrastructureTests.kt
@@ -7,7 +7,7 @@ import net.corda.core.internal.concurrent.openFuture
 import net.corda.core.internal.concurrent.thenMatch
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.getOrThrow
-import net.corda.node.services.messaging.rpcContext
+import net.corda.node.services.rpc.rpcContext
 import net.corda.testing.node.internal.RPCDriverDSL
 import net.corda.testing.node.internal.rpcDriver
 import net.corda.testing.node.internal.rpcTestUser

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCConcurrencyTests.kt
@@ -7,7 +7,7 @@ import net.corda.core.messaging.RPCOps
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
-import net.corda.node.services.messaging.RPCServerConfiguration
+import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.testing.internal.testThreadFactory
 import net.corda.testing.node.internal.RPCDriverDSL
 import net.corda.testing.node.internal.rpcDriver

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPerformanceTests.kt
@@ -4,7 +4,7 @@ import com.google.common.base.Stopwatch
 import net.corda.core.messaging.RPCOps
 import net.corda.core.utilities.minutes
 import net.corda.core.utilities.seconds
-import net.corda.node.services.messaging.RPCServerConfiguration
+import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.testing.internal.performance.div
 import net.corda.testing.node.internal.RPCDriverDSL
 import net.corda.testing.node.internal.performance.startPublishingFixedRateInjector

--- a/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt
+++ b/client/rpc/src/test/kotlin/net/corda/client/rpc/RPCPermissionsTests.kt
@@ -1,7 +1,7 @@
 package net.corda.client.rpc
 
 import net.corda.core.messaging.RPCOps
-import net.corda.node.services.messaging.rpcContext
+import net.corda.node.services.rpc.rpcContext
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.RPCDriverDSL
 import net.corda.testing.node.internal.rpcDriver

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -330,6 +330,8 @@ Unreleased
 
 * The ``node_transaction_mapping`` database table has been folded into the ``node_transactions`` database table as an additional column.
 
+* Logging for P2P and RPC has been separated, to make it easier to enable all P2P or RPC logging without hand-picking loggers for individual classes.
+
 Version 3.3
 -----------
 

--- a/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/rpc/ArtemisRpcTests.kt
@@ -12,8 +12,6 @@ import net.corda.node.internal.artemis.ArtemisBroker
 import net.corda.node.internal.security.RPCSecurityManager
 import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.Permissions.Companion.all
-import net.corda.node.services.messaging.InternalRPCMessagingClient
-import net.corda.node.services.messaging.RPCServerConfiguration
 import net.corda.node.utilities.createKeyPairAndSelfSignedTLSCertificate
 import net.corda.node.utilities.saveToKeyStore
 import net.corda.node.utilities.saveToTrustStore

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -31,7 +31,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
 import net.corda.node.services.api.FlowStarter
 import net.corda.node.services.api.ServiceHubInternal
-import net.corda.node.services.messaging.context
+import net.corda.node.services.rpc.context
 import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.nodeapi.exceptions.NonRpcFlowException
 import net.corda.nodeapi.exceptions.RejectedCommandException

--- a/node/src/main/kotlin/net/corda/node/internal/Node.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/Node.kt
@@ -45,6 +45,8 @@ import net.corda.node.services.api.StartedNodeServices
 import net.corda.node.services.config.*
 import net.corda.node.services.messaging.*
 import net.corda.node.services.rpc.ArtemisRpcBroker
+import net.corda.node.services.rpc.InternalRPCMessagingClient
+import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.node.services.statemachine.StateMachineManager
 import net.corda.node.utilities.*
 import net.corda.nodeapi.internal.ArtemisMessagingComponent.Companion.INTERNAL_SHELL_USER

--- a/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt
@@ -4,8 +4,8 @@ import net.corda.client.rpc.PermissionException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.node.internal.InvocationHandlerTemplate
-import net.corda.node.services.messaging.RpcAuthContext
-import net.corda.node.services.messaging.rpcContext
+import net.corda.node.services.rpc.RpcAuthContext
+import net.corda.node.services.rpc.rpcContext
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 

--- a/node/src/main/kotlin/net/corda/node/serialization/amqp/RpcServerObservableSerializer.kt
+++ b/node/src/main/kotlin/net/corda/node/serialization/amqp/RpcServerObservableSerializer.kt
@@ -4,8 +4,8 @@ import net.corda.core.context.Trace
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.loggerFor
-import net.corda.node.services.messaging.ObservableContextInterface
-import net.corda.node.services.messaging.ObservableSubscription
+import net.corda.node.services.rpc.ObservableContextInterface
+import net.corda.node.services.rpc.ObservableSubscription
 import net.corda.nodeapi.RPCApi
 import net.corda.serialization.internal.amqp.*
 import org.apache.qpid.proton.codec.Data

--- a/node/src/main/kotlin/net/corda/node/services/rpc/InternalRPCMessagingClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/InternalRPCMessagingClient.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.messaging
+package net.corda.node.services.rpc
 
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.NamedCacheFactory

--- a/node/src/main/kotlin/net/corda/node/services/rpc/ObservableContextInterface.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/ObservableContextInterface.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.messaging
+package net.corda.node.services.rpc
 
 import com.github.benmanes.caffeine.cache.Cache
 import net.corda.core.context.Trace

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.messaging
+package net.corda.node.services.rpc
 
 import co.paralleluniverse.common.util.SameThreadExecutor
 import com.github.benmanes.caffeine.cache.Cache

--- a/node/src/main/kotlin/net/corda/node/services/rpc/RpcAuthContext.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RpcAuthContext.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.messaging
+package net.corda.node.services.rpc
 
 import net.corda.core.context.InvocationContext
 import net.corda.node.internal.security.AuthorizingSubject

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -38,8 +38,8 @@ import net.corda.node.internal.security.RPCSecurityManagerImpl
 import net.corda.node.services.Permissions.Companion.all
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
-import net.corda.node.services.messaging.CURRENT_RPC_CONTEXT
-import net.corda.node.services.messaging.RpcAuthContext
+import net.corda.node.services.rpc.CURRENT_RPC_CONTEXT
+import net.corda.node.services.rpc.RpcAuthContext
 import net.corda.nodeapi.exceptions.NonRpcFlowException
 import net.corda.nodeapi.internal.config.User
 import net.corda.testing.core.ALICE_NAME

--- a/node/src/test/kotlin/net/corda/node/internal/serialization/RoundTripObservableSerializerTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/serialization/RoundTripObservableSerializerTests.kt
@@ -12,7 +12,7 @@ import net.corda.core.internal.toSynchronised
 import net.corda.node.internal.serialization.testutils.AMQPRoundTripRPCSerializationScheme
 import net.corda.node.internal.serialization.testutils.serializationContext
 import net.corda.node.serialization.amqp.RpcServerObservableSerializer
-import net.corda.node.services.messaging.ObservableSubscription
+import net.corda.node.services.rpc.ObservableSubscription
 import net.corda.nodeapi.RPCApi
 import net.corda.serialization.internal.amqp.*
 import org.apache.activemq.artemis.api.core.SimpleString

--- a/node/src/test/kotlin/net/corda/node/internal/serialization/RpcServerObservableSerializerTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/serialization/RpcServerObservableSerializerTests.kt
@@ -7,7 +7,7 @@ import net.corda.core.context.Trace
 import net.corda.node.internal.serialization.testutils.TestObservableContext
 import net.corda.node.internal.serialization.testutils.serializationContext
 import net.corda.node.serialization.amqp.RpcServerObservableSerializer
-import net.corda.node.services.messaging.ObservableSubscription
+import net.corda.node.services.rpc.ObservableSubscription
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.SerializationOutput
 import net.corda.serialization.internal.amqp.SerializerFactoryBuilder

--- a/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestObservableContext.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/serialization/testutils/TestObservableContext.kt
@@ -2,8 +2,8 @@ package net.corda.node.internal.serialization.testutils
 
 import com.github.benmanes.caffeine.cache.Cache
 import net.corda.core.context.Trace
-import net.corda.node.services.messaging.ObservableContextInterface
-import net.corda.node.services.messaging.ObservableSubscription
+import net.corda.node.services.rpc.ObservableContextInterface
+import net.corda.node.services.rpc.ObservableSubscription
 import net.corda.nodeapi.RPCApi
 import org.apache.activemq.artemis.api.core.SimpleString
 import java.util.concurrent.ConcurrentHashMap

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/RPCDriver.kt
@@ -19,8 +19,8 @@ import net.corda.core.node.NetworkParameters
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.seconds
 import net.corda.node.internal.security.RPCSecurityManagerImpl
-import net.corda.node.services.messaging.RPCServer
-import net.corda.node.services.messaging.RPCServerConfiguration
+import net.corda.node.services.rpc.RPCServer
+import net.corda.node.services.rpc.RPCServerConfiguration
 import net.corda.nodeapi.RPCApi
 import net.corda.nodeapi.internal.ArtemisTcpTransport
 import net.corda.serialization.internal.AMQP_RPC_CLIENT_CONTEXT


### PR DESCRIPTION
…e it easier to adjust logging levels independently.  (P2P remained as is, some internal node RPC classes moved to existing node RPC package from generic messaging package, which is now just for P2P).

net.corda.node.services.messaging Will be for P2P only
net.corda.node.services.rpc Will be for RPC only