### PR TITLE
CORDA-2318 resolve nested type params

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
@@ -223,15 +223,8 @@ sealed class TypeIdentifier {
  */
 internal fun Type.resolveAgainst(context: Type): Type = when (this) {
     is WildcardType -> this.upperBound
-    // Ignore types that we have created ourselves
     is ReconstitutedParameterizedType -> this
-    is ParameterizedType -> {
-        val resolved = ReconstitutedParameterizedType(
-                rawType,
-                ownerType,
-                actualTypeArguments.map { it.resolveAgainst(context) }.toTypedArray())
-        TypeToken.of(context).resolveType(resolved).type.upperBound
-    }
+    is ParameterizedType,
     is TypeVariable<*> -> TypeToken.of(context).resolveType(this).type.upperBound
     else -> this
 }
@@ -246,6 +239,12 @@ private val Type.upperBound: Type
             this.upperBounds.isEmpty() || this.upperBounds.size > 1 -> this
             else -> this.upperBounds[0]
         }
+        // Ignore types that we have created ourselves
+        is ReconstitutedParameterizedType -> this
+        is ParameterizedType -> ReconstitutedParameterizedType(
+                rawType,
+                ownerType,
+                actualTypeArguments.map { it.upperBound }.toTypedArray())
         else -> this
     }
 

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
@@ -1,15 +1,28 @@
 package net.corda.serialization.internal.amqp
 
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.TransactionState
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.entropyToKeyPair
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
 import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.core.serialization.SerializableCalculatedProperty
+import net.corda.serialization.internal.amqp.custom.PublicKeySerializer
 import net.corda.serialization.internal.amqp.testutils.deserialize
 import net.corda.serialization.internal.amqp.testutils.serialize
 import net.corda.serialization.internal.amqp.testutils.testDefaultFactoryNoEvolution
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import java.math.BigInteger
+import kotlin.test.assertEquals
 
 class RoundTripTests {
+
     @Test
     fun mutableBecomesImmutable() {
         data class C(val l: MutableList<String>)
@@ -119,5 +132,35 @@ class RoundTripTests {
         val bytes = SerializationOutput(factory).serialize(instance)
         val deserialized = DeserializationInput(factory).deserialize(bytes) as I
         assertThat(deserialized.squared).isEqualTo(2)
+    }
+
+    data class MembershipState<out T: Any>(val metadata: T): ContractState {
+        override val participants: List<AbstractParty>
+            get() = emptyList()
+    }
+
+    data class OnMembershipChanged(val changedMembership : StateAndRef<MembershipState<Any>>)
+
+    @Test
+    fun canSerializeClassesWithUntypedProperties() {
+        val data = MembershipState<Any>(mapOf("foo" to "bar"))
+        val party = Party(
+                CordaX500Name(organisation = "Test Corp", locality = "Madrid", country = "ES"),
+                entropyToKeyPair(BigInteger.valueOf(83)).public)
+        val transactionState = TransactionState(
+                data,
+                "foo",
+                party
+        )
+        val ref = StateRef(SecureHash.zeroHash, 0)
+        val instance = OnMembershipChanged(StateAndRef(
+                transactionState,
+                ref
+        ))
+
+        val factory = testDefaultFactoryNoEvolution().apply { register(PublicKeySerializer) }
+        val bytes = SerializationOutput(factory).serialize(instance)
+        val deserialized = DeserializationInput(factory).deserialize(bytes)
+        assertEquals(mapOf("foo" to "bar"), deserialized.changedMembership.state.data.metadata)
     }
 }


### PR DESCRIPTION
When resolving a parameterised type against another type which may hold information about its type variables, we need to take wildcard type parameters to their upper bounds recursively (i.e. converting `Foo<? extends Bar<? extends Baz>>` to `Foo<Bar<Baz>>`, otherwise nested generics will not be handled correctly.

The reason we need to do this in v4, and didn't in v3, is that in v3 the order of traversal of types when constructing a serialiser was different, and things got resolved naturally along the way. Now that we traverse the entire graph of related types up-front via the `LocalTypeInformationBuilder`, we need to fix up type parameters at each stage before proceeding further into the graph traversal.

As all of this is cached, the performance impact should be minimal.

This PR addresses [CORDA-2318](https://r3-cev.atlassian.net/browse/CORDA-2318).