### PR TITLE
Docs: improve upgrade notes and versioning page

### DIFF
--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -208,31 +208,27 @@ a flow:
 
 Contract attachment non-downgrade rule
 --------------------------------------
-Contract code is versioned and deployed as an independent jar that gets imported into a nodes database as a contract attachment (either explicitly
-loaded via `rpc` or automatically loaded upon node startup for a given corDapp). When constructing new transactions it is paramount to ensure
-that the contract version of code associated with new output states is the same or newer than the highest version of any existing inputs states.
-This is to prevent the possibility of nodes from selecting older, potentially malicious or buggy, contract code when creating new states from existing consumed states.
+Contract code is versioned and deployed as an independent JAR that gets imported into a node's database as a contract attachment (either explicitly
+uploaded via RPC or automatically loaded from disk). When constructing new transaction it is paramount to ensure
+that the contract version of code associated with new output states is the same or newer than the highest version of any existing input states.
+This is to prevent the possibility of nodes selecting older, potentially malicious or buggy contract code when creating new states from
+existing consumed states.
 
 Transactions contain an attachment for each contract. The version of the output states is the version of this contract attachment.
-This can be seen as the version of code that instantiated and serialised those classes.
+See :doc:`versioning` for more details on how these versions are set. These can be seen as the version of the code that instantiated and
+serialised those classes.
 
-The non-downgrade rule specifies that the version of the code used in the transaction that spends a state needs to be >= highest version of the
-input states (eg. spending_version >= creation_version)
+The non-downgrade rule specifies that the version of the code used in the transaction that spends a state needs to be greater than or equal to
+the highest version of the input states (i.e. spending_version >= creation_version)
 
-The Contract attachment non-downgrade rule is enforced in two locations:
+The contract attachment non-downgrade rule is enforced in two locations:
 
-    - Transaction building, upon creation of new output states. During this step, the node also selects the latest available attachment
-    (eg. the contract code with the latest contract class version).
-    - Transaction verification, upon resolution of existing transaction chains
+1. Transaction building, upon creation of new output states. During this step, the node also selects the latest available attachment
+   (i.e. the contract code with the latest contract class version).
+2. Transaction verification, upon resolution of existing transaction chains.
 
-A Contracts version identifier is stored in the manifest information of the enclosing jar file. This version identifier should be a whole number starting from 1.
-
-.. sourcecode:: groovy
-
-    'Cordapp-Contract-Name': "My contract name"
-    'Cordapp-Contract-Version': 1
-
-This information should be set using the Gradle cordapp plugin or manually as described in :ref:`CorDapp separation <cordapp_separation_ref>`.
+A version number is stored in the manifest information of the enclosing JAR file. This version identifier should be a whole number starting
+from 1. This information should be set using the Gradle cordapp plugin, or manually, as described in :doc:`versioning`.
 
 Issues when using the HashAttachmentConstraint
 ----------------------------------------------

--- a/docs/source/api-identity.rst
+++ b/docs/source/api-identity.rst
@@ -1,11 +1,6 @@
 API: Identity
 =============
 
-.. note:: Before reading this page, you should be familiar with the key concepts of :doc:`key-concepts-identity`.
-
-.. warning:: The ``confidential-identities`` module is still not stabilised, so this API may change in future releases.
-   See :doc:`corda-api`.
-
 .. contents::
 
 Party
@@ -37,8 +32,14 @@ basis.
 The ``PartyAndCertificate`` class is also used by the network map service to represent well-known identities, with the
 certificate path proving the certificate was issued by the doorman service.
 
+.. _confidential_identities_ref:
+
 Confidential identities
 -----------------------
+
+.. warning:: The ``confidential-identities`` module is still not stabilised, so this API may change in future releases.
+   See :doc:`corda-api`.
+
 Confidential identities are key pairs where the corresponding X.509 certificate (and path) are not made public, so that
 parties who are not involved in the transaction cannot identify the owner. They are owned by a well-known identity,
 which must sign the X.509 certificate. Before constructing a new transaction the involved parties must generate and

--- a/docs/source/api-states.rst
+++ b/docs/source/api-states.rst
@@ -103,7 +103,7 @@ another transaction.
 FungibleState
 ~~~~~~~~~~~~~
 
-`FungibleState<T>` is an interface to represent things which are fungible, this means that there is an expectation that
+``FungibleState<T>`` is an interface to represent things which are fungible, this means that there is an expectation that
 these things can be split and merged. That's the only assumption made by this interface. This interface should be
 implemented if you want to represent fractional ownership in a thing, or if you have many things. Examples:
 
@@ -120,16 +120,17 @@ The interface is defined as follows:
         :start-after: DOCSTART 1
         :end-before: DOCEND 1
 
-As seen, the interface takes a type parameter `T` that represents the fungible thing in question. This should describe
+As seen, the interface takes a type parameter ``T`` that represents the fungible thing in question. This should describe
 the basic type of the asset e.g. GBP, USD, oil, shares in company <X>, etc. and any additional metadata (issuer, grade,
-class, etc.). An upper-bound is not specified for `T` to ensure flexibility. Typically, a class would be provided that
-implements `TokenizableAssetInfo` so the thing can be easily added and subtracted using the `Amount` class.
+class, etc.). An upper-bound is not specified for ``T`` to ensure flexibility. Typically, a class would be provided that
+implements `TokenizableAssetInfo` so the thing can be easily added and subtracted using the ``Amount`` class.
 
-This interface has been added in addition to `FungibleAsset` to provide some additional flexibility which
-`FungibleAsset` lacks, in particular:
-* `FungibleAsset` defines an amount property of type Amount<Issued<T>>, therefore there is an assumption that all
+This interface has been added in addition to ``FungibleAsset`` to provide some additional flexibility which
+``FungibleAsset`` lacks, in particular:
+
+* ``FungibleAsset`` defines an amount property of type ``Amount<Issued<T>>``, therefore there is an assumption that all
   fungible things are issued by a single well known party but this is not always the case.
-* `FungibleAsset` implements `OwnableState`, as such there is an assumption that all fungible things are ownable.
+* ``FungibleAsset`` implements ``OwnableState``, as such there is an assumption that all fungible things are ownable.
 
 Other interfaces
 ^^^^^^^^^^^^^^^^
@@ -170,10 +171,10 @@ When a ``ContractState`` is added to a ``TransactionBuilder``, it is wrapped in 
 
 .. container:: codeset
 
-    .. literalinclude:: ../../core/src/main/kotlin/net/corda/core/contracts/TransactionState.kt
-        :language: kotlin
-        :start-after: DOCSTART 1
-        :end-before: DOCEND 1
+   .. literalinclude:: ../../core/src/main/kotlin/net/corda/core/contracts/TransactionState.kt
+      :language: kotlin
+      :start-after: DOCSTART 1
+      :end-before: DOCEND 1
 
 Where:
 
@@ -183,6 +184,8 @@ Where:
 * ``encumbrance`` points to another state that must also appear as an input to any transaction consuming this
   state
 * ``constraint`` is a constraint on which contract-code attachments can be used with this state
+
+.. _reference_states:
 
 Reference States
 ----------------
@@ -220,11 +223,13 @@ reference states with two different notaries cannot be committed to the ledger.
 As such, if reference states assigned to multiple different notaries are added to a transaction builder
 then the check below will fail.
 
-        .. warning:: Currently, encumbrances should not be used with reference states. In the case where a state is
-                     encumbered by an encumbrance state, the encumbrance state should also be referenced in the same
-                     transaction that references the encumbered state. This is because the data contained within the
-                     encumbered state may take on a different meaning, and likely would do, once the encumbrance state
-                     is taken into account.
+.. warning:: Currently, encumbrances should not be used with reference states. In the case where a state is
+   encumbered by an encumbrance state, the encumbrance state should also be referenced in the same
+   transaction that references the encumbered state. This is because the data contained within the
+   encumbered state may take on a different meaning, and likely would do, once the encumbrance state
+   is taken into account.
+
+.. _state_pointers:
 
 State Pointers
 --------------
@@ -235,12 +240,12 @@ a look-up. There are two types of pointers; linear and static.
 
 1. ``StaticPointer`` s are for use with any type of ``ContractState``. The ``StaticPointer`` does as it suggests, it always
    points to the same ``ContractState``.
-2. The ``LinearPointer`` is for use with ``LinearState`` s. They are particularly useful because due to the way ``LinearState`` s
-   work, the pointer will automatically point you to the latest version of a ``LinearState`` that the node performing ``resolve``
-   is aware of. In effect, the pointer "moves" as the ``LinearState`` is updated.
+2. The ``LinearPointer`` is for use with LinearStates. They are particularly useful because due to the way LinearStates
+   work, the pointer will automatically point you to the latest version of a LinearState that the node performing ``resolve``
+   is aware of. In effect, the pointer "moves" as the LinearState is updated.
 
- ``StatePointer`` s do not enable a feature in Corda which was unavailable before. Rather, they help to formalise a pattern
- which was already possible. In that light it is worth nothing some issues which you may encounter with `StatePointer` s:
+StatePointers do not enable a feature in Corda which was unavailable before. Rather, they help to formalise a pattern which was
+already possible. In that light it is worth nothing some issues which you may encounter with it:
 
 * If the node calling ``resolve`` has not seen any transactions containing a ``ContractState`` which the ``StatePointer``
   points to, then ``resolve`` will throw an exception. Here, the node calling ``resolve`` might be missing some crucial data.
@@ -248,7 +253,7 @@ a look-up. There are two types of pointers; linear and static.
   the specified ``linearId``. However, there is no guarantee the ``StateAndRef<T>`` returned by ``resolve`` is the most recent
   version of the ``LinearState``. The node only returns the most recent version that _it_ is aware of.
 
-**Resolving state pointers in `TransactionBuilder`**
+**Resolving state pointers in TransactionBuilder**
 
 When building transactions, any ``StatePointer`` s contained within inputs or outputs added to a ``TransactionBuilder`` can
 be optionally resolved to reference states using the ``resolveStatePointers`` method. The effect is that the pointed to

--- a/docs/source/building-a-cordapp-index.rst
+++ b/docs/source/building-a-cordapp-index.rst
@@ -12,6 +12,7 @@ CorDapps
    cordapp-build-systems
    building-against-master
    debugging-a-cordapp
+   versioning
    upgrade-notes
    upgrading-cordapps
    secure-coding-guidelines

--- a/docs/source/corda-networks-index.rst
+++ b/docs/source/corda-networks-index.rst
@@ -7,7 +7,6 @@ Networks
    compatibility-zones
    permissioning
    network-map
-   versioning
    cipher-suites
    joining-a-compatibility-zone
    corda-testnet-intro

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,6 +84,7 @@ We look forward to seeing what you can do with Corda!
    design/threat-model/corda-threat-model.md
    design/data-model-upgrades/signature-constraints.md
    design/data-model-upgrades/package-namespace-ownership.md
+   design/targetversion/design.md
 
 .. conditional-toctree::
    :caption: Participate

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -160,7 +160,7 @@ This is no longer necessary with ``ReceiveFinalityFlow`` and the call to ``waitF
 Step 4. Upgrade your use of SwapIdentitiesFlow
 ----------------------------------------------
 
-The ``confidential-identities`` module is experimental in Corda 3 and remains so in Corda 4. In this release, the ``SwapIdentitiesFlow``
+The :ref:`confidential_identities_ref` API is experimental in Corda 3 and remains so in Corda 4. In this release, the ``SwapIdentitiesFlow``
 has been adjusted in the same way as ``FinalityFlow`` above, to close problems with confidential identities being injectable into a node
 outside of other flow context. Old code will still work, but it is recommended to adjust your call sites so a session is passed into
 the ``SwapIdentitiesFlow``.
@@ -172,6 +172,24 @@ Step 5. Possibly, adjust unit test code
 Use a ``MockNetworkConfigOverrides`` object instead. This is an API change we regret, but unfortunately in Corda 3 we accidentally exposed
 large amounts of the node internal code through this one API entry point. We have now insulated the test API from node internals and
 reduced the exposure.
+
+If you are constructing a MockServices for testing contracts, and your contract uses the Cash contract from the finance app, you
+now need to explicitly add ``net.corda.finance.contracts`` to the list of ``cordappPackages``. This is a part of the work to disentangle
+the finance app (which is really a demo app) from the Corda internals. Example::
+
+    val ledgerServices = MockServices(
+        listOf("net.corda.examples.obligation", "net.corda.testing.contracts"),
+        identityService = makeTestIdentityService(),
+        initialIdentity = TestIdentity(CordaX500Name("TestIdentity", "", "GB"))
+    )
+
+becomes::
+
+    val ledgerServices = MockServices(
+        listOf("net.corda.examples.obligation", "net.corda.testing.contracts", "net.corda.finance.contracts"),
+        identityService = makeTestIdentityService(),
+        initialIdentity = TestIdentity(CordaX500Name("TestIdentity", "", "GB"))
+    )
 
 Step 6. Security: refactor to avoid violating sealed packages
 -------------------------------------------------------------
@@ -229,3 +247,12 @@ that causes transaction details to be converted to a PDF and sent to a particula
 into shared business logic, but it makes perfect sense to put into a user-specific app they developed themselves.
 
 If your flows could benefit from being extended in this way, read ":doc:`flow-overriding`" to learn more.
+
+Step 10. Explore other new features that may be useful
+------------------------------------------------------
+
+Corda 4 adds several new APIs that help you build applications. Why not explore:
+
+* The `new withEntityManager API <api/javadoc/net/corda/core/node/ServiceHub.html#withEntityManager-block->`_ for using JPA inside your flows and services.
+* :ref:`reference_states`, that let you use an input state without consuming it.
+* :ref:`state_pointers`, that make it easier to 'point' to one state from another and follow the latest version of a linear state.

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -40,11 +40,13 @@ Step 2. Add a "cordapp" section to your Gradle build file
 This is used by the Corda Gradle build plugin to populate your app JAR with useful information. It should look like this::
 
     cordapp {
-        info {
+        targetPlatformVersion 4
+        minimumPlatformVersion 4
+        contract {
             name "MegaApp"
             vendor "MegaCorp"
-            targetPlatformVersion 4
-            minimumPlatformVersion 4
+            license "A really expensive license"
+            versionId 1
         }
     }
 
@@ -169,24 +171,11 @@ Step 5. Security: refactor to avoid violating sealed packages
 Hardly any apps will need to do anything in this step.
 
 App isolation has been improved. Version 4 of the finance CorDapp (*corda-finance.jar*) is now built as a sealed and signed JAR file.
-This means classes in your own CorDapps cannot be placed under the following packages:
+This means classes in your own CorDapps cannot be placed under the following package namespace:  ``net.corda.finance``
 
-  .. sourcecode:: java
-
-     net.corda.finance
-     net.corda.finance.contracts
-     net.corda.finance.contracts.asset.cash.selection
-     net.corda.finance.contracts.asset
-     net.corda.finance.contracts.math
-     net.corda.finance.flows
-     net.corda.finance.internal
-     net.corda.finance.plugin
-     net.corda.finance.schemas
-     net.corda.finance.utils
-
-In the unlikely event that you were injecting code into ``net.corda.*`` package namespaces from your own apps, you will need to move them
-into a new package, e.g. *net/corda/finance/flows.MyClass.java* can be moved to *net/corda/finance/flows/company/MyClass.java*.
-Also your classes are no longer able to access non-public members of finance CorDapp classes.
+In the unlikely event that you were injecting code into ``net.corda.finance.*`` package namespaces from your own apps, you will need to move them
+into a new package, e.g. ``net/corda/finance/flows/MyClass.java`` can be moved to ``com/company/corda/finance/flows/MyClass.java``.
+As a consequence your classes are no longer able to access non-public members of finance CorDapp classes.
 
 When recompiling your JARs for Corda 4, your own apps will also become sealed, meaning other JARs cannot place classes into your own packages.
 This is a security upgrade that ensures package-private visibility in Java code works correctly.

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -43,10 +43,15 @@ This is used by the Corda Gradle build plugin to populate your app JAR with usef
         targetPlatformVersion 4
         minimumPlatformVersion 4
         contract {
-            name "MegaApp"
+            name "MegaApp Contracts"
             vendor "MegaCorp"
-            license "A really expensive license"
+            license "A liberal, open source license"
             versionId 1
+        }
+        workflow {
+            name "MegaApp flows"
+            vendor "MegaCorp"
+            license "A really expensive proprietary license"
         }
     }
 
@@ -54,6 +59,12 @@ Name and vendor can be set to any string you like, they don't have to be Corda i
 introduced in Corda 4. Learn more by reading :doc:`versioning`. Setting a target version of 4 disables workarounds for various
 bugs that may exist in your app, so by doing this you are promising that you have thoroughly tested your app on the new version.
 Using a high target version is a good idea because some features and improvements are only available to apps that opt in.
+
+The duplication between ``contract`` and ``workflow`` blocks exists because you should split your app into two separate JARs/modules,
+one that contains on-ledger validation code like states and contracts, and one for the rest (called by convention the "workflows"
+module although it can contain a lot more than just flows: services would also go here, for instance). For simplicity, here we
+use one JAR for both, but this is in general an anti-pattern and can result in your flow logic code being sent over the network to
+arbitrary third party peers, even though they don't need it.
 
 Step 3. Upgrade your use of FinalityFlow
 ----------------------------------------

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -4,48 +4,66 @@
    <script type="text/javascript" src="_static/jquery.js"></script>
    <script type="text/javascript" src="_static/codesets.js"></script>
 
-Upgrading a CorDapp to a new platform version
-=============================================
+Upgrading apps to Corda 4
+=========================
 
-These notes provide instructions for upgrading your CorDapps from previous versions, starting with the upgrade from our
-first public Beta (:ref:`Milestone 12 <changelog_m12>`), to :ref:`V1.0 <changelog_v1>`.
+These notes provide instructions for upgrading your CorDapps from previous versions. Corda provides backwards compatibility for public,
+non-experimental APIs that have been committed to. A list can be found in the :doc:`corda-api` page.
+
+This means that you can upgrade your node across versions *without recompiling or adjusting your CorDapps*. You just have to upgrade
+your node and restart.
+
+However, there are usually new features and other opt-in changes that may improve the security, performance or usability of your
+application that are worth considering for any actively maintained software. This guide shows you how to upgrade your app to benefit
+from the new features in the latest release.
 
 .. contents::
    :depth: 3
 
-General rules
--------------
-Always remember to update the version identifiers in your project's gradle file:
+Step 1. Adjust the version numbers in your Gradle build files
+-------------------------------------------------------------
 
-.. sourcecode:: shell
+.. sourcecode:: groovy
 
-    ext.corda_release_version = 'x.y.0'
-    ext.corda_gradle_plugins_version = 'x.y.0'
+    ext.corda_release_version = '4.0'
+    ext.corda_gradle_plugins_version = '4.0.36'
+    ext.kotlin_version = '1.2.71'
+    ext.quasar_version = '0.7.10'
 
-It may also be necessary to update the version of major dependencies:
+.. important:: Apps targeting Corda 4 may not at this time use Kotlin 1.3, as it was released too late in the development cycle
+   for us to risk an upgrade. Sorry! Future work on app isolation will make it easier for apps to use newer Kotlin versions than
+   the node itself uses.
 
-.. sourcecode:: shell
+Step 2. Add a "cordapp" section to your Gradle build file
+---------------------------------------------------------
 
-    ext.kotlin_version = 'x.y.z'
-    ext.quasar_version = 'x.y.z'
+This is used by the Corda Gradle build plugin to populate your app JAR with useful information. It should look like this::
 
-Please consult the relevant release notes of the release in question. If not specified, you may assume the
-versions you are currently using are still in force.
+    cordapp {
+        info {
+            name "MegaApp"
+            vendor "MegaCorp"
+            targetPlatformVersion 4
+            minimumPlatformVersion 4
+        }
+    }
 
-We also strongly recommend cross referencing with the :doc:`changelog` to confirm changes
+Name and vendor can be set to any string you like, they don't have to be Corda identities. Target versioning is a new concept
+introduced in Corda 4. Learn more by reading :doc:`versioning`. Setting a target version of 4 disables workarounds for various
+bugs that may exist in your app, so by doing this you are promising that you have thoroughly tested your app on the new version.
+Using a high target version is a good idea because some features and improvements are only available to apps that opt in.
 
-To run database upgrades against H2, you'll need to connect to the node's database without starting the node. You can
-do this by connecting directly to the node's ``persistence.mv.db`` file. See :ref:`h2_relative_path`
+Step 3. Upgrade your use of FinalityFlow
+----------------------------------------
 
-UNRELEASED
-----------
-
-FinalityFlow
-^^^^^^^^^^^^
-
-The previous ``FinalityFlow`` API is insecure. It requires a handler flow in the counterparty node which accepts any and
+The previous ``FinalityFlow`` API is insecure. It doesn't have a receive flow, so requires counterparty nodes to accept any and
 all signed transactions that are sent to it, without checks. It is **highly** recommended that existing CorDapps migrate
-away to the new API.
+away to the new API, as otherwise things like business network membership checks won't be reliably enforced.
+
+This is a two step process:
+
+1. Change the flow that calls ``FinalityFlow``
+2. Change or create the flow that will receive the finalised transaction.
 
 As an example, let's take a very simple flow that finalises a transaction without the involvement of a counterpart flow:
 
@@ -137,63 +155,21 @@ finalised transaction. If the initiator is written in a backwards compatible way
 The responder flow may be waiting for the finalised transaction to appear in the local node's vault using ``waitForLedgerCommit``.
 This is no longer necessary with ``ReceiveFinalityFlow`` and the call to ``waitForLedgerCommit`` can be removed.
 
-Database schema changes
-^^^^^^^^^^^^^^^^^^^^^^^
+Step 4. Possibly, adjust unit test code
+---------------------------------------
 
-The type of the ``checkpoint_value`` column has changed. This will address the issue that the `vacuum` function is unable
-to clean up deleted checkpoints as they are still referenced from the ``pg_shdepend`` table.
+``MockNodeParameters`` and functions creating it no longer use a lambda expecting a ``NodeConfiguration`` object.
+Use a ``MockNetworkConfigOverrides`` object instead. This is an API change we regret, but unfortunately in Corda 3 we accidentally exposed
+large amounts of the node internal code through this one API entry point. We have now insulated the test API from node internals and
+reduced the exposure.
 
-For Postgres:
+Step 5. Security: refactor to avoid violating sealed packages
+-------------------------------------------------------------
 
-.. sourcecode:: sql
+Hardly any apps will need to do anything in this step.
 
-    ALTER TABLE node_checkpoints ALTER COLUMN checkpoint_value set data type bytea;
-
-For H2:
-
-.. sourcecode:: sql
-
-    ALTER TABLE node_checkpoints ALTER COLUMN checkpoint_value set data type VARBINARY(33554432);
-
-* API change: ``net.corda.core.schemas.PersistentStateRef`` fields (``index`` and ``txId``) incorrectly marked as nullable are now non-nullable,
-  :doc:`changelog` contains the explanation.
-
-  H2 database upgrade action:
-
-  For Cordapps persisting custom entities with ``PersistentStateRef`` used as non Primary Key column, the backing table needs to be updated,
-  In SQL replace ``your_transaction_id``/``your_output_index`` column names with your custom names, if entity didn't used JPA ``@AttributeOverrides``
-  then default names are ``transaction_id`` and ``output_index``.
-
-  .. sourcecode:: sql
-
-       SELECT count(*) FROM [YOUR_PersistentState_TABLE_NAME] WHERE your_transaction_id IS NULL OR your_output_index IS NULL;
-
-  In case your table already contains rows with NULL columns, and the logic doesn't distinguish between NULL and an empty string,
-  all NULL column occurrences can be changed to an empty string:
-
-  .. sourcecode:: sql
-
-       UPDATE [YOUR_PersistentState_TABLE_NAME] SET your_transaction_id="" WHERE your_transaction_id IS NULL;
-       UPDATE [YOUR_PersistentState_TABLE_NAME] SET your_output_index="" WHERE your_output_index IS NULL;
-
-  If all rows have NON NULL ``transaction_ids`` and ``output_idx`` or you have assigned empty string values, then it's safe to update the table:
-
-  .. sourcecode:: sql
-
-       ALTER TABLE [YOUR_PersistentState_TABLE_NAME] ALTER COLUMN your_transaction_id SET NOT NULL;
-       ALTER TABLE [YOUR_PersistentState_TABLE_NAME] ALTER COLUMN your_output_index SET NOT NULL;
-
-  If the table already contains rows with NULL values, and the logic caters differently between NULL and an empty string,
-  and the logic has to be preserved you would need to create copy of ``PersistentStateRef`` class with different name and use the new class in your entity.
-
-  No action is needed for default node tables as ``PersistentStateRef`` is used as Primary Key only and the backing columns are automatically not nullable
-  or custom Cordapp entities using ``PersistentStateRef`` as Primary Key.
-
-* MockNetwork: ``MockNodeParameters`` and functions creating it no longer use a lambda expecting a ``NodeConfiguration``
-  object. Use a ``MockNetworkConfigOverrides`` object instead.
-
-* Finance CorDapp (*corda-finance-XXX.jar*) is now build as a sealed and signed JAR file.
-  This means classes in your CorDapps cannot be placed under the following packages:
+App isolation has been improved. Version 4 of the finance CorDapp (*corda-finance.jar*) is now built as a sealed and signed JAR file.
+This means classes in your own CorDapps cannot be placed under the following packages:
 
   .. sourcecode:: java
 
@@ -208,616 +184,51 @@ For H2:
      net.corda.finance.schemas
      net.corda.finance.utils
 
-  Refactor any classes by moving them into a new package, e.g. *net/corda/finance/flows.MyClass.java* can be moved to *net/corda/finance/flows/company/MyClass.java*.
-  Also your classes are no longer able to access non-public members of Finance CorDapp classes.
+In the unlikely event that you were injecting code into ``net.corda.*`` package namespaces from your own apps, you will need to move them
+into a new package, e.g. *net/corda/finance/flows.MyClass.java* can be moved to *net/corda/finance/flows/company/MyClass.java*.
+Also your classes are no longer able to access non-public members of finance CorDapp classes.
 
-V3.2 to v3.3
-------------
+When recompiling your JARs for Corda 4, your own apps will also become sealed, meaning other JARs cannot place classes into your own packages.
+This is a security upgrade that ensures package-private visibility in Java code works correctly.
 
-* Update the Corda Release version
+Step 6. Security: Add BelongsToContract annotations
+---------------------------------------------------
 
-  The ``corda_release_version`` identifier in your projects gradle file will need changing as follows:
+In versions of the platform prior to v4, it was the responsibility of contract and flow logic to ensure that ``TransactionState`` objects
+contained the correct class name of the expected contract class. If these checks were omitted, it would be possible for a malicious counterparty
+to construct a transaction containing e.g. a cash state governed by a commercial paper contract. The contract would see that there were no
+commercial paper states in a transaction and do nothing, i.e. accept.
 
-  .. sourcecode:: shell
+In Corda 4 the platform takes over this responsibility from the app, if the app has a target version of 4 or higher. A state is expected
+to be governed by a contract that is either:
 
-    ext.corda_release_version = '3.3-corda'
+1. The outer class of the state class, if the state is an inner class of a contract. This is a common design pattern.
+2. Annotated with ``@BelongsToContract`` which specifies the contract class explicitly.
 
-v3.1 to v3.2
-------------
+Learn more by reading ":ref:`implicit_constraint_types`". If an app targets Corda 3 or lower (i.e. does not specify a target version),
+states that point to contracts outside their package will trigger a log warning but validation will proceed.
 
-Gradle Plugin Version
-^^^^^^^^^^^^^^^^^^^^^
+Step 7. Consider adopting signature constraints
+-----------------------------------------------
 
-You will need to update the ``corda_release_version`` identifier in your project gradle file.
+:doc:`design/data-model-upgrades/signature-constraints` are a new data model feature introduced in Corda 4. They make it much easier to
+deploy application upgrades smoothly and in a decentralised manner. We strongly recommend all apps move to using signature constraints
+as soon as feasible, as they represent the best tradeoff between the different upgrade control models.
 
-.. sourcecode:: shell
+.. important:: You will be able to use this feature if the compatibility zone you plan to deploy on has raised its minimum platform version
+   to 4. Otherwise attempting to use signature constraints will throw an exception, because other nodes would not understand it or be able
+   to check the correctness of the transaction. Please take this into account for your own schedule planning.
 
-  ext.corda_release_version = '3.2-corda'
+You can read more about signature constraints and what they do in :doc:`api-contract-constraints`. The ``TransactionBuilder`` class will
+automatically use them if your application JAR is signed. We recommend all JARs are signed. To start signing your JAR files, read
+:ref:`cordapp_build_system_signing_cordapp_jar_ref`.
 
-Database schema changes
-^^^^^^^^^^^^^^^^^^^^^^^
+Step 8. Consider adding extension points to your flows
+------------------------------------------------------
 
-* Database upgrade - a typo has been corrected in the ``NODE_ATTACHMENTS_CONTRACTS`` table name.
-  When upgrading from versions 3.0 or 3.1, run the following command:
+In Corda 4 it is possible for flows in one app to subclass and take over flows from another. This allows you to create generic, shared
+flow logic that individual users can customise at pre-agreed points (protected methods). For example, a site-specific app could be developed
+that causes transaction details to be converted to a PDF and sent to a particular printer. This would be an inappropriate feature to put
+into shared business logic, but it makes perfect sense to put into a user-specific app they developed themselves.
 
-  .. sourcecode:: sql
-
-     ALTER TABLE [schema].NODE_ATTCHMENTS_CONTRACTS RENAME TO NODE_ATTACHMENTS_CONTRACTS;
-
-  .. note::
-    Schema name is optional, run SQL when the node is not running.
-
-* Postgres database upgrade - Change the type of the ``checkpoint_value`` column to ``bytea``.
-  This will address the issue that the `vacuum` function is unable to clean up deleted checkpoints as they are still referenced from the ``pg_shdepend`` table.
-
-  .. sourcecode:: sql
-
-    ALTER TABLE node_checkpoints ALTER COLUMN checkpoint_value set data type bytea using null;
-
-  .. note::
-    This change will also need to be run when migrating from version 3.0.
-
-.. important::
-   The Corda node will fail on startup if the database was not updated with the above commands.
-
-v3.0 to v3.1
-------------
-
-Gradle Plugin Version
-^^^^^^^^^^^^^^^^^^^^^
-
-Corda 3.1 uses version 3.1.0 of the gradle plugins and your ``build.gradle`` file should be updated to reflect this.
-
-.. sourcecode:: shell
-
-    ext.corda_gradle_plugins_version = '3.1.0'
-
-You will also need to update the ``corda_release_version`` identifier in your project gradle file.
-
-.. sourcecode:: shell
-
-  ext.corda_release_version = '3.1-corda'
-
-V2.0 to V3.0
-------------
-
-Gradle Plugin Version
-^^^^^^^^^^^^^^^^^^^^^
-
-Corda 3.0 uses version 3.0.9 of the gradle plugins and your ``build.gradle`` file should be updated to reflect this.
-
-.. sourcecode:: shell
-
-    ext.corda_gradle_plugins_version = '3.0.9'
-
-You will also need to update the ``corda_release_version`` identifier in your project gradle file.
-
-.. sourcecode:: shell
-
-  ext.corda_release_version = 'corda-3.0'
-
-Network Map Service
-^^^^^^^^^^^^^^^^^^^
-
-With the re-designed network map service the following changes need to be made:
-
-* The network map is no longer provided by a node and thus the ``networkMapService`` config is ignored. Instead the
-  network map is either provided by the compatibility zone (CZ) operator (who operates the doorman) and available
-  using the ``compatibilityZoneURL`` config, or is provided using signed node info files which are copied locally.
-  See :doc:`network-map` for more details, and :doc:`network-bootstrapper` on how to use the network
-  bootstrapper for deploying a local network.
-
-* Configuration for a notary has been simplified. ``extraAdvertisedServiceIds``, ``notaryNodeAddress``, ``notaryClusterAddresses``
-  and ``bftSMaRt`` configs have been replaced by a single ``notary`` config object. See :doc:`corda-configuration-file`
-  for more details.
-
-* The advertisement of the notary to the rest of the network, and its validation type, is no longer determined by the
-  ``extraAdvertisedServiceIds`` config. Instead it has been moved to the control of the network operator via
-  the introduction of network parameters. The network bootstrapper automatically includes the configured notaries
-  when generating the network parameters file for a local deployment.
-
-* Any nodes defined in a ``deployNodes`` gradle task performing the function of the network map can be removed, or the
-  ``NetworkMap`` parameter can be removed for any "controller" node which is both the network map and a notary.
-
-* For registering a node with the doorman the ``certificateSigningService`` config has been replaced by ``compatibilityZoneURL``.
-
-Corda Plugins
-^^^^^^^^^^^^^
-
-* Corda plugins have been modularised further so the following additional gradle entries are necessary:
-  For example:
-
-    .. sourcecode:: groovy
-
-        dependencies {
-            classpath "net.corda.plugins:cordapp:$corda_gradle_plugins_version"
-        }
-
-        apply plugin: 'net.corda.plugins.cordapp'
-
-The plugin needs to be applied in all gradle build files where there is a dependency on Corda using any of:
-cordaCompile, cordaRuntime, cordapp
-
-* For existing contract ORM schemas that extend from ``CommonSchemaV1.LinearState`` or ``CommonSchemaV1.FungibleState``,
-  you will need to explicitly map the ``participants`` collection to a database table. Previously this mapping was done
-  in the superclass, but that makes it impossible to properly configure the table name. The required changes are to:
-
-  * Add the ``override var participants: MutableSet<AbstractParty>? = null`` field to your class, and
-  * Add JPA mappings
-
-  For example:
-
-    .. sourcecode:: kotlin
-
-        @Entity
-        @Table(name = "cash_states_v2",
-                indexes = arrayOf(Index(name = "ccy_code_idx2", columnList = "ccy_code")))
-        class PersistentCashState(
-
-                @ElementCollection
-                @Column(name = "participants")
-                @CollectionTable(name="cash_states_v2_participants", joinColumns = arrayOf(
-                        JoinColumn(name = "output_index", referencedColumnName = "output_index"),
-                        JoinColumn(name = "transaction_id", referencedColumnName = "transaction_id")))
-                override var participants: MutableSet<AbstractParty>? = null,
-
-AMQP
-^^^^
-
-Whilst the enablement of AMQP is a transparent change, as noted in the :doc:`serialization` documentation
-the way classes, and states in particular, should be written to work with this new library may require some
-alteration to your current implementation.
-
-  * With AMQP enabled Java classes must be compiled with the -parameter flag.
-
-    * If they aren't, then the error message will complain about ``arg<N>`` being an unknown parameter.
-    * If recompilation is not viable, a custom serializer can be written as per :doc:`cordapp-custom-serializers`
-    * It is important to bear in mind that with AMQP there must be an implicit mapping between constructor
-      parameters and properties you wish included in the serialized form of a class.
-
-      * See :doc:`serialization` for more information
-
-  * Error messages of the form
-
-    ``Constructor parameter - "<some parameter of a constructor>" - doesn't refer to a property of "class <some.class.being.serialized>"``
-
-    indicate that a class, in the above example ``some.class.being.serialized``, has a parameter on its primary constructor that
-    doesn't correlate to a property of the class. This is a problem because the Corda AMQP serialization library uses a class's
-    constructor (default, primary, or annotated) as the means by which instances of the serialized form are reconstituted.
-
-    See the section "Mismatched Class Properties / Constructor Parameters" in the :doc:`serialization` documentation
-
-Database schema changes
-^^^^^^^^^^^^^^^^^^^^^^^
-
-An H2 database instance (represented on the filesystem as a file called `persistence.mv.db`) used in Corda 1.0 or 2.0
-cannot be directly reused with Corda 3.0 due to minor improvements and additions to stabilise the underlying schemas.
-
-Configuration
-^^^^^^^^^^^^^
-
-Nodes that do not require SSL to be enabled for RPC clients now need an additional port to be specified as part of their configuration.
-To do this, add a block as follows to the nodes configuration::
-
-    rpcSettings {
-        adminAddress "localhost:10007"
-    }
-
-to `node.conf` files.
-
-Also, the property `rpcPort` is now deprecated, so it would be preferable to substitute properties specified that way e.g., `rpcPort=10006` with a block as follows::
-
-    rpcSettings {
-        address "localhost:10006"
-        adminAddress "localhost:10007"
-    }
-
-Equivalent changes should be performed on classes extending ``CordformDefinition``.
-
-* Certificate Revocation List (CRL) support:
-
-    The newly added feature of certificate revocation (see :doc:`certificate-revocation`) introduces few changes to the node configuration.
-    In the configuration file it is required to explicitly specify what mode of the CRL check the node should apply. For that purpose the `crlCheckSoftFail`
-    parameter is now expected to be set explicitly in the node's SSL configuration.
-    Setting the `crlCheckSoftFail` to true, relaxes the CRL checking policy. In this mode, the SSL communication
-    will fail only when the certificate revocation status can be checked and the certificate is revoked. Otherwise it will succeed.
-    If `crlCheckSoftFail` is false, then the SSL failure will occur also if the certificate revocation status cannot be checked (e.g. due to a network failure).
-
-    Older versions of Corda do not have CRL distribution points embedded in the SSL certificates.
-    As such, in order to be able to reuse node and SSL certificates generated in those versions of Corda, the `crlCheckSoftFail` needs
-    to be set to true. This is required due to the fact that node and SSL certificates produced in the older versions of Corda miss attributes
-    required for the CRL check process. In this mode, if the CRL is unavailable for whatever reason, the check will still pass and the SSL connection will be allowed.
-
-    .. note:: The support for the mitigating this issue and being able to use the `strict` mode (i.e. with `crlCheckSoftFail` = false)
-    of the CRL checking with the certificates generated in the previous versions of Corda is going to be added in the near future.
-
-Testing
-^^^^^^^
-
-* The registration mechanism for CorDapps in ``MockNetwork`` unit tests has changed:
-
-  * CorDapp registration is now done via the ``cordappPackages`` constructor parameter of MockNetwork. This parameter
-    is a list of ``String`` values which should be the package names of the CorDapps containing the contract
-    verification code you wish to load
-
-  * The ``unsetCordappPackages`` method is now redundant and has been removed
-
-* Many classes have been moved between packages, so you will need to update your imports
-
-  .. tip:: We have provided a several scripts (depending upon your operating system of choice) to smooth the upgrade
-     process for existing projects. This can be found at ``tools\scripts\update-test-packages.sh`` for the Bash shell and
-     ``tools/scripts/upgrade-test-packages.ps1`` for Windows Power Shell users in the source tree
-
-* setCordappPackages and unsetCordappPackages have been removed from the ledger/transaction DSL and the flow test framework,
-  and are now set via a constructor parameter or automatically when constructing the MockServices or MockNetwork object
-
-* Key constants e.g. ``ALICE_KEY`` have been removed; you can now use TestIdentity to make your own
-
-* The ledger/transaction DSL must now be provided with MockServices as it no longer makes its own
-  * In transaction blocks, input and output take their arguments as ContractStates rather than lambdas
-  * Also in transaction blocks, command takes its arguments as CommandDatas rather than lambdas
-
-* The MockServices API has changed; please refer to its API documentation
-
-* TestDependencyInjectionBase has been retired in favour of a JUnit Rule called SerializationEnvironmentRule
-  * This replaces the initialiseSerialization parameter of ledger/transaction and verifierDriver
-  * The withTestSerialization method is obsoleted by SerializationEnvironmentRule and has been retired
-
-* MockNetwork now takes a MockNetworkParameters builder to make it more Java-friendly, like driver's DriverParameters
-    * Similarly, the MockNetwork.createNode methods now take a MockNodeParameters builder
-
-* MockNode constructor parameters are now aggregated in MockNodeArgs for easier subclassing
-
-* MockNetwork.Factory has been retired as you can simply use a lambda
-
-* testNodeConfiguration has been retired, please use a mock object framework of your choice instead
-
-* MockNetwork.createSomeNodes and IntegrationTestCategory have been retired with no replacement
-
-* Starting a flow can now be done directly from a node object. Change calls of the form ``node.getServices().startFlow(...)``
-  to ``node.startFlow(...)``
-
-* Similarly a transaction can be executed directly from a node object. Change calls of the form ``node.getDatabase().transaction({ it -> ... })``
-  to ``node.transaction({() -> ... })``
-
-* ``startFlow`` now returns a ``CordaFuture``, there is no need to call ``startFlow(...).getResultantFuture()``
-
-
-V1.0 to V2.0
-------------
-
-* You need to update the ``corda_release_version`` identifier in your project gradle file. The
-  corda_gradle_plugins_version should remain at 1.0.0:
-
-    .. sourcecode:: shell
-
-        ext.corda_release_version = '2.0.0'
-        ext.corda_gradle_plugins_version = '1.0.0'
-
-Public Beta (M12) to V1.0
--------------------------
-
-:ref:`From Milestone 14 <changelog_m14>`
-
-Build
-^^^^^
-
-* MockNetwork has moved. To continue using ``MockNetwork`` for testing, you must add the following dependency to your
-  ``build.gradle`` file:
-
-    .. sourcecode:: shell
-
-      testCompile "net.corda:corda-node-driver:$corda_release_version"
-
-    .. note:: You may only need ``testCompile "net.corda:corda-test-utils:$corda_release_version"`` if not using the Driver
-       DSL
-
-Configuration
-^^^^^^^^^^^^^
-
-* ``CordaPluginRegistry`` has been removed:
-
-  * The one remaining configuration item ``customizeSerialisation``, which defined a optional whitelist of types for
-    use in object serialization, has been replaced with the ``SerializationWhitelist`` interface which should be
-    implemented to define a list of equivalent whitelisted classes
-
-  * You will need to rename your services resource file. 'resources/META-INF/services/net.corda.core.node.CordaPluginRegistry'
-    becomes 'resources/META-INF/services/net.corda.core.serialization.SerializationWhitelist'
-
-  * ``MockNode.testPluginRegistries`` was renamed to ``MockNode.testSerializationWhitelists``
-
-  * In general, the ``@CordaSerializable`` annotation is the preferred method for whitelisting, as described in
-    :doc:`serialization`
-
-Missing imports
-^^^^^^^^^^^^^^^
-
-Use IntelliJ's automatic imports feature to intelligently resolve the new imports:
-
-* Missing imports for contract types:
-
-  * CommercialPaper and Cash are now contained within the ``finance`` module, as are associated helpers functions. For
-    example:
-
-    * ``import net.corda.contracts.ICommercialPaperState`` becomes ``import net.corda.finance.contracts.ICommercialPaperState``
-
-    * ``import net.corda.contracts.asset.sumCashBy`` becomes ``import net.corda.finance.utils.sumCashBy``
-
-    * ``import net.corda.core.contracts.DOLLARS`` becomes ``import net.corda.finance.DOLLARS``
-
-    * ``import net.corda.core.contracts.issued by`` becomes ``import net.corda.finance.issued by``
-
-    * ``import net.corda.contracts.asset.Cash`` becomes ``import net.corda.finance.contracts.asset.Cash``
-
-* Missing imports for utility functions:
-
-  * Many common types and helper methods have been consolidated into ``net.corda.core.utilities`` package. For example:
-
-    * ``import net.corda.core.crypto.commonName`` becomes ``import net.corda.core.utilities.commonName``
-
-    * ``import net.corda.core.crypto.toBase58String`` becomes ``import net.corda.core.utilities.toBase58String``
-
-    * ``import net.corda.core.getOrThrow`` becomes ``import net.corda.core.utilities.getOrThrow``
-
-* Missing flow imports:
-
-  * In general, all reusable library flows are contained within the **core** API ``net.corda.core.flows`` package
-
-  * Financial domain library flows are contained within the **finance** module ``net.corda.finance.flows`` package
-
-  * Other flows that have moved include ``import net.corda.core.flows.ResolveTransactionsFlow``, which becomes
-    ``import net.corda.core.internal.ResolveTransactionsFlow``
-
-Core data structures
-^^^^^^^^^^^^^^^^^^^^
-
-* Missing ``Contract`` override:
-
-  * ``Contract.legalContractReference`` has been removed, and replaced by the optional annotation
-    ``@LegalProseReference(uri = "<URI>")``
-
-* Unresolved reference:
-
-  * ``AuthenticatedObject`` was renamed to ``CommandWithParties``
-
-* Overrides nothing:
-
-  * ``LinearState.isRelevant`` was removed. Whether a node stores a ``LinearState`` in its vault depends on whether the
-    node is one of the state's ``participants``
-
-  * ``txBuilder.toLedgerTransaction`` now requires a ``ServiceHub`` parameter. This is used by the new Contract
-    Constraints functionality to validate and resolve attachments
-
-Flow framework
-^^^^^^^^^^^^^^
-
-* ``FlowLogic`` communication has been upgraded to use explicit ``FlowSession`` instances to communicate between nodes:
-
-  * ``FlowLogic.send``/``FlowLogic.receive``/``FlowLogic.sendAndReceive`` has been replaced by ``FlowSession.send``/
-    ``FlowSession.receive``/``FlowSession.sendAndReceive``. The replacement functions do not take a destination
-    parameter, as this is defined implicitly by the session used
-
-  * Initiated flows now take in a ``FlowSession`` instead of ``Party`` in their constructor. If you need to access the
-    counterparty identity, it is in the ``counterparty`` property of the flow session
-
-* ``FinalityFlow`` now returns a single ``SignedTransaction``, instead of a ``List<SignedTransaction>``
-
-* ``TransactionKeyFlow`` was renamed to ``SwapIdentitiesFlow``
-
-* ``SwapIdentitiesFlow`` must be imported from the *confidential-identities* package ``net.corda.confidential``
-
-Node services (ServiceHub)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* Unresolved reference to ``vaultQueryService``:
-
-  * Replace all references to ``<services>.vaultQueryService`` with ``<services>.vaultService``
-
-  * Previously there were two vault APIs. Now there is a single unified API with the same functions: ``VaultService``.
-
-* ``FlowLogic.ourIdentity`` has been introduced as a shortcut for retrieving our identity in a flow
-
-* ``serviceHub.myInfo.legalIdentity`` no longer exists
-
-* ``getAnyNotary`` has been removed. Use ``serviceHub.networkMapCache.notaryIdentities[0]`` instead
-
-* ``ServiceHub.networkMapUpdates`` is replaced by ``ServiceHub.networkMapFeed``
-
-* ``ServiceHub.partyFromX500Name`` is replaced by ``ServiceHub.wellKnownPartyFromX500Name``
-
-  * A "well known" party is one that isn't anonymous. This change was motivated by the confidential identities work
-
-RPC Client
-^^^^^^^^^^
-
-* Missing API methods on the ``CordaRPCOps`` interface:
-
-  * ``verifiedTransactionsFeed`` has been replaced by ``internalVerifiedTransactionsFeed``
-
-  * ``verifiedTransactions`` has been replaced by ``internalVerifiedTransactionsSnapshot``
-
-  * These changes are in preparation for the planned integration of Intel SGX™, which will encrypt the transactions
-    feed. Apps that use this API will not work on encrypted ledgers. They should generally be modified to use the vault
-    query API instead
-
-  * Accessing the ``networkMapCache`` via ``services.nodeInfo().legalIdentities`` returns a list of identities
-
-    * This change is in preparation for allowing a node to host multiple separate identities in the future
-
-Testing
-^^^^^^^
-
-Please note that ``Clauses`` have been removed completely as of V1.0. We will be revisiting this capability in a future
-release.
-
-* CorDapps must be explicitly registered in ``MockNetwork`` unit tests:
-
-  * This is done by calling ``setCordappPackages``, an extension helper function in the ``net.corda.testing`` package,
-    on the first line of your ``@Before`` method. This takes a variable number of ``String`` arguments which should be
-    the package names of the CorDapps containing the contract verification code you wish to load
-  * You should unset CorDapp packages in your ``@After`` method by using ``unsetCordappPackages`` after
-    ``stopNodes``
-
-* CorDapps must be explicitly registered in ``DriverDSL`` and ``RPCDriverDSL`` integration tests:
-
-  * You must register package names of the CorDapps containing the contract verification code you wish to load using
-    the ``extraCordappPackagesToScan: List<String>`` constructor parameter of the driver DSL
-
-Finance
-^^^^^^^
-
-* ``FungibleAsset`` interface simplification:
-
-  * The ``Commands`` grouping interface that included the ``Move``, ``Issue`` and ``Exit`` interfaces has been removed
-  * The ``move`` function has been renamed to ``withNewOwnerAndAmount``
-    * This is for consistency with ``OwnableState.withNewOwner``
-
-Miscellaneous
-^^^^^^^^^^^^^
-
-* ``args[0].parseNetworkHostAndPort()`` becomes ``NetworkHostAndPort.parse(args[0])``
-
-* There is no longer a ``NodeInfo.advertisedServices`` property
-
-  * The concept of advertised services has been removed from Corda. This is because it was vaguely defined and
-    real-world apps would not typically select random, unknown counterparties from the network map based on
-    self-declared capabilities
-  * We will introduce a replacement for this functionality, business networks, in a future release
-  * For now, services should be retrieved by legal name using ``NetworkMapCache.getNodeByLegalName``
-
-Gotchas
-^^^^^^^
-
-* Be sure to use the correct identity when issuing cash:
-
-  * The third parameter to ``CashIssueFlow`` should be the *notary* (and not the *node identity*)
-
-
-:ref:`From Milestone 13 <changelog_m13>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Core data structures
-^^^^^^^^^^^^^^^^^^^^
-
-* ``TransactionBuilder`` changes:
-
-  * Use convenience class ``StateAndContract`` instead of ``TransactionBuilder.withItems`` for passing
-    around a state and its contract.
-
-* Transaction builder DSL changes:
-
-  * When adding inputs and outputs to a transaction builder, you must also specify ``ContractClassName``
-
-    * ``ContractClassName`` is the name of the ``Contract`` subclass used to verify the transaction
-
-* Contract verify method signature change:
-
-  * ``override fun verify(tx: TransactionForContract)`` becomes ``override fun verify(tx: LedgerTransaction)``
-
-* You no longer need to override ``ContractState.contract`` function
-
-Node services (ServiceHub)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* ServiceHub API method changes:
-
-  * ``services.networkMapUpdates().justSnapshot`` becomes ``services.networkMapSnapshot()``
-
-Configuration
-^^^^^^^^^^^^^
-
-* No longer need to define ``CordaPluginRegistry`` and configure ``requiredSchemas``:
-
-  * Custom contract schemas are automatically detected at startup time by class path scanning
-
-  * For testing purposes, use the ``SchemaService`` method to register new custom schemas (e.g.
-    ``services.schemaService.registerCustomSchemas(setOf(YoSchemaV1))``)
-
-Identity
-^^^^^^^^
-
-* Party names are now ``CordaX500Name``, not ``X500Name``:
-
-  * ``CordaX500Name`` specifies a predefined set of mandatory (organisation, locality, country) and optional fields
-    (common name, organisation unit, state) with validation checking
-  * Use new builder ``CordaX500Name.build(X500Name(target))`` or explicitly define the X500Name parameters using the
-    ``CordaX500Name`` constructors
-
-Testing
-^^^^^^^
-
-* MockNetwork testing:
-
-  * Mock nodes in node tests are now of type ``StartedNode<MockNode>``, rather than ``MockNode``
-
-  * ``MockNetwork`` now returns a ``BasketOf(<StartedNode<MockNode>>)``
-
-  * You must call internals on ``StartedNode`` to get ``MockNode`` (e.g. ``a = nodes.partyNodes[0].internals``)
-
-* Host and port changes:
-
-  * Use string helper function ``parseNetworkHostAndPort`` to parse a URL on startup (e.g.
-    ``val hostAndPort = args[0].parseNetworkHostAndPort()``)
-
-* Node driver parameter changes:
-
-  * The node driver parameters for starting a node have been reordered
-  * The node’s name needs to be given as an ``CordaX500Name``, instead of using ``getX509Name``
-
-:ref:`From Milestone 12 (First Public Beta) <changelog_m12>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Core data structures
-^^^^^^^^^^^^^^^^^^^^
-
-* Transaction building:
-
-  * You no longer need to specify the type of a ``TransactionBuilder`` as ``TransactionType.General``
-  * ``TransactionType.General.Builder(notary)`` becomes ``TransactionBuilder(notary)``
-
-Build 
-^^^^^
-
-* Gradle dependency reference changes:
-
-  * Module names have changed to include ``corda`` in the artifacts' JAR names:
-
-.. sourcecode:: shell
-
-    compile "net.corda:core:$corda_release_version" -> compile "net.corda:corda-core:$corda_release_version"
-    compile "net.corda:finance:$corda_release_version" -> compile "net.corda:corda-finance:$corda_release_version"
-    compile "net.corda:jackson:$corda_release_version" -> compile "net.corda:corda-jackson:$corda_release_version"
-    compile "net.corda:node:$corda_release_version" -> compile "net.corda:corda-node:$corda_release_version"
-    compile "net.corda:rpc:$corda_release_version" -> compile "net.corda:corda-rpc:$corda_release_version"
-
-Node services (ServiceHub)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* ``ServiceHub`` API changes:
-
-  * ``services.networkMapUpdates`` becomes ``services.networkMapFeed``
-
-  * ``services.getCashBalances`` becomes a helper method in the *finance* module contracts package
-    (``net.corda.finance.contracts.getCashBalances``)
-
-Finance
-^^^^^^^
-
-* Financial asset contracts (``Cash``, ``CommercialPaper``, ``Obligations``) are now a standalone CorDapp within the
-  ``finance`` module:
-
-  * You need to import them from their respective packages within the ``finance`` module (e.g.
-    ``net.corda.finance.contracts.asset.Cash``)
-
-  * You need to import the associated asset flows from their respective packages within ``finance`` module. For
-    example:
-
-    * ``net.corda.finance.flows.CashIssueFlow``
-    * ``net.corda.finance.flows.CashIssueAndPaymentFlow``
-    * ``net.corda.finance.flows.CashExitFlow``
-
-* The ``finance`` gradle project files have been moved into a ``net.corda.finance`` package namespace:
-
-  * Adjust imports of Cash flow references
-  * Adjust the ``StartFlow`` permission in ``gradle.build`` files
-  * Adjust imports of the associated flows (``Cash*Flow``, ``TwoPartyTradeFlow``, ``TwoPartyDealFlow``)
+If your flows could benefit from being extended in this way, read ":doc:`flow-overriding`" to learn more.

--- a/docs/source/upgrade-notes.rst
+++ b/docs/source/upgrade-notes.rst
@@ -157,7 +157,15 @@ finalised transaction. If the initiator is written in a backwards compatible way
 The responder flow may be waiting for the finalised transaction to appear in the local node's vault using ``waitForLedgerCommit``.
 This is no longer necessary with ``ReceiveFinalityFlow`` and the call to ``waitForLedgerCommit`` can be removed.
 
-Step 4. Possibly, adjust unit test code
+Step 4. Upgrade your use of SwapIdentitiesFlow
+----------------------------------------------
+
+The ``confidential-identities`` module is experimental in Corda 3 and remains so in Corda 4. In this release, the ``SwapIdentitiesFlow``
+has been adjusted in the same way as ``FinalityFlow`` above, to close problems with confidential identities being injectable into a node
+outside of other flow context. Old code will still work, but it is recommended to adjust your call sites so a session is passed into
+the ``SwapIdentitiesFlow``.
+
+Step 5. Possibly, adjust unit test code
 ---------------------------------------
 
 ``MockNodeParameters`` and functions creating it no longer use a lambda expecting a ``NodeConfiguration`` object.
@@ -165,7 +173,7 @@ Use a ``MockNetworkConfigOverrides`` object instead. This is an API change we re
 large amounts of the node internal code through this one API entry point. We have now insulated the test API from node internals and
 reduced the exposure.
 
-Step 5. Security: refactor to avoid violating sealed packages
+Step 6. Security: refactor to avoid violating sealed packages
 -------------------------------------------------------------
 
 Hardly any apps will need to do anything in this step.
@@ -180,7 +188,7 @@ As a consequence your classes are no longer able to access non-public members of
 When recompiling your JARs for Corda 4, your own apps will also become sealed, meaning other JARs cannot place classes into your own packages.
 This is a security upgrade that ensures package-private visibility in Java code works correctly.
 
-Step 6. Security: Add BelongsToContract annotations
+Step 7. Security: Add BelongsToContract annotations
 ---------------------------------------------------
 
 In versions of the platform prior to v4, it was the responsibility of contract and flow logic to ensure that ``TransactionState`` objects
@@ -197,7 +205,7 @@ to be governed by a contract that is either:
 Learn more by reading ":ref:`implicit_constraint_types`". If an app targets Corda 3 or lower (i.e. does not specify a target version),
 states that point to contracts outside their package will trigger a log warning but validation will proceed.
 
-Step 7. Consider adopting signature constraints
+Step 8. Consider adopting signature constraints
 -----------------------------------------------
 
 :doc:`design/data-model-upgrades/signature-constraints` are a new data model feature introduced in Corda 4. They make it much easier to
@@ -212,7 +220,7 @@ You can read more about signature constraints and what they do in :doc:`api-cont
 automatically use them if your application JAR is signed. We recommend all JARs are signed. To start signing your JAR files, read
 :ref:`cordapp_build_system_signing_cordapp_jar_ref`.
 
-Step 8. Consider adding extension points to your flows
+Step 9. Consider adding extension points to your flows
 ------------------------------------------------------
 
 In Corda 4 it is possible for flows in one app to subclass and take over flows from another. This allows you to create generic, shared

--- a/docs/source/upgrading-cordapps.rst
+++ b/docs/source/upgrading-cordapps.rst
@@ -4,8 +4,8 @@
    <script type="text/javascript" src="_static/jquery.js"></script>
    <script type="text/javascript" src="_static/codesets.js"></script>
 
-Upgrading a CorDapp (outside of platform version upgrades)
-==========================================================
+Release new CorDapp versions
+============================
 
 .. note:: This document only concerns the upgrading of CorDapps and not the Corda platform itself (wire format, node
    database schemas, etc.).

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -50,16 +50,26 @@ Target versioning is one of the mechanisms we have to keep the platform evolving
 being bug-for-bug compatible with old versions. When no apps are loaded that target old versions, any emulations of older bugs or problems
 can be disabled (in Corda 4, an example of this is the old FinalityFlow handler that would accept any transactions into the vault, context free).
 
-Publishing versions in your JAR manifest
-----------------------------------------
+Publishing versions in your JAR manifests
+-----------------------------------------
 
-In your ``build.gradle`` file, add a block like this::
+A well structured CorDapp should be split into two separate modules:
+
+1. A contracts jar, that contains your states and contract logic.
+2. A workflows jar, that contains your flows, services and other support libraries.
+
+The reason for this split is that the contract JAR will be attached to transactions and sent around the network, because this code is what
+defines the data structures and smart contract logic all nodes will validate. If the rest of your app is a part of that same JAR, it'll get
+sent around the network too even though it's not needed and will never be used. By splitting your app into a contracts JAR and a workflows
+JAR that depends on the contracts JAR, this problem is avoided.
+
+In the ``build.gradle`` file for your contract module, add a block like this::
 
     cordapp {
         targetPlatformVersion 5
         minimumPlatformVersion 4
         contract {
-            name "MegaApp"
+            name "MegaApp Contracts"
             vendor "MegaCorp"
             license "MegaLicense"
             versionId 1
@@ -68,5 +78,22 @@ In your ``build.gradle`` file, add a block like this::
 
 This will put the necessary entries into your JAR manifest to set both platform version numbers. If they aren't specified, both default to 1.
 Your app can itself has a version number, which should always increment and must also always be an integer.
+
+And in the ``build.gradle`` file for your workflows jar, add a block like this::
+
+    cordapp {
+        targetPlatformVersion 5
+        minimumPlatformVersion 4
+        workflow {
+            name "MegaApp"
+            vendor "MegaCorp"
+            license "MegaLicense"
+            versionId 1
+        }
+    }
+
+It's entirely expected and reasonable to have an open source contracts module and a proprietary workflow module - the latter may contain
+sophisticated or proprietary business logic, machine learning models, even user interface code. There's nothing that restricts it to just
+being Corda flows or services.
 
 .. note:: You can read the original design doc here: :doc:`design/targetversion/design`.

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -96,4 +96,9 @@ It's entirely expected and reasonable to have an open source contracts module an
 sophisticated or proprietary business logic, machine learning models, even user interface code. There's nothing that restricts it to just
 being Corda flows or services.
 
+.. important:: The ``versionId`` specified for the JAR manifest is checked by the platform. Downgrades are not allowed: you cannot take a state
+   that was created with version 5 of your app, and then create a state with version 4. This is to prevent attacks in which bugs
+   are fixed, but an adversary uses an old version of the app to continue exploiting them. Version tracking in states is handled for you
+   automatically as long as the information is provided in your Gradle file. See ":ref:`contract_non-downgrade_rule_ref`" for more information.
+
 .. note:: You can read the original design doc here: :doc:`design/targetversion/design`.

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -3,7 +3,7 @@ Versioning
 
 As the Corda platform evolves and new features are added it becomes important to have a versioning system which allows
 its users to easily compare versions and know what feature are available to them. Each Corda release uses the standard
-semantic versioning scheme of ``major.minor.patch``. This is useful when making releases in the public domain but is not
+semantic versioning scheme of ``major.minor``. This is useful when making releases in the public domain but is not
 friendly for a developer working on the platform. It first has to be parsed and then they have three separate segments on
 which to determine API differences. The release version is still useful and every MQ message the node sends attaches it
 to the ``release-version`` header property for debugging purposes.
@@ -17,7 +17,7 @@ It starts at 1 and will increment by exactly 1 for each release which changes an
 entire platform. This includes public APIs on the node itself, the RPC system, messaging, serialisation, etc. API backwards
 compatibility will always be maintained, with the use of deprecation to suggest migration away from old APIs. In very rare
 situations APIs may have to be changed, for example due to security issues. There is no relationship between the platform version
-and the release version - a change in the major, minor or patch values may or may not increase the platform version. However
+and the release version - a change in the major or minor values may or may not increase the platform version. However
 we do endeavour to keep them synchronised for now, as a convenience.
 
 The platform version is part of the node's ``NodeInfo`` object, which is available from the ``ServiceHub``. This enables
@@ -30,7 +30,7 @@ Minimum platform version
 Applications can advertise a *minimum platform version* they require. If your app uses new APIs that were added in (for example) Corda 5,
 you should specify a minimum version of 5. This will ensure the app won't be loaded by older nodes. If you can *optionally* use the new
 APIs, you can keep the minimum set to a lower number. Attempting to use new APIs on older nodes can cause ``NoSuchMethodError`` exceptions
-and similar problems, so it's best to advertise the correct requirements so problems are caught up front, instead of at runtime.
+and similar problems, so you'd want to check the node version using ``ServiceHub.myInfo``.
 
 Target version
 --------------
@@ -48,7 +48,7 @@ this, you promise that you understood all the changes in Corda 6 and have thorou
 
 Target versioning is one of the mechanisms we have to keep the platform evolving and improving, without being permanently constrained to
 being bug-for-bug compatible with old versions. When no apps are loaded that target old versions, any emulations of older bugs or problems
-can be disabled.
+can be disabled (in Corda 4, an example of this is the old FinalityFlow handler that would accept any transactions into the vault, context free).
 
 Publishing versions in your JAR manifest
 ----------------------------------------
@@ -56,14 +56,17 @@ Publishing versions in your JAR manifest
 In your ``build.gradle`` file, add a block like this::
 
     cordapp {
-        info {
+        targetPlatformVersion 5
+        minimumPlatformVersion 4
+        contract {
             name "MegaApp"
             vendor "MegaCorp"
-            targetPlatformVersion 5
-            minimumPlatformVersion 4
+            license "MegaLicense"
+            versionId 1
         }
     }
 
-This will put the necessary entries into your JAR manifest to set both version numbers. If they aren't specified, both default to 1.
+This will put the necessary entries into your JAR manifest to set both platform version numbers. If they aren't specified, both default to 1.
+Your app can itself has a version number, which should always increment and must also always be an integer.
 
 .. note:: You can read the original design doc here: :doc:`design/targetversion/design`.


### PR DESCRIPTION
* Adds some more information on target/min platform versioning (prior info was only the design doc)
* Add a missing design doc to the toctree
* Move the versioning page to the API section
* Add more info to the upgrade notes
* Delete old upgrade notes that are no longer relevant
