### PR TITLE
CORDA-1839 - Remove race condition between trackBy and notifyAll

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ release, see :doc:`upgrade-notes`.
 
 Unreleased
 ----------
+* Fixed race condition between ``NodeVaultService.trackBy`` and ``NodeVaultService.notifyAll``, where there could be states that were not reflected
+  in the data feed returned from ``trackBy`` (either in the query's result snapshot or the observable).
 
 * TimedFlows (only used by the notary client flow) will never give up trying to reach the notary, as this would leave the states
   in the notarisation request in an undefined state (unknown whether the spend has been notarised, i.e. has happened, or not). Also,

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -607,7 +607,10 @@ class NodeVaultService(
      *       the snapshot or in the observable).
      */
     private fun <T: ContractState> containsDuplicates(update: Vault.Update<T>, page: Vault.Page<T>): Boolean {
-        return page.states.toSet().containsAll(update.produced)
+        val pageStatesRefs = page.states.map { it.ref }.toSet()
+        val updateProducedStatesRefs = update.produced.map { it.ref }.toSet()
+
+        return pageStatesRefs.containsAll(updateProducedStatesRefs)
     }
 
     private fun getSession() = database.currentOrNew().session

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -579,7 +579,7 @@ class NodeVaultService(
     override fun <T : ContractState> _trackBy(criteria: QueryCriteria, paging: PageSpecification, sorting: Sort, contractStateType: Class<out T>): DataFeed<Vault.Page<T>, Vault.Update<T>> {
         return mutex.locked {
             val updates: Observable<Vault.Update<T>> = uncheckedCast(_updatesPublisher.bufferUntilSubscribed())
-            if (contextDatabaseOrNull == null) {
+            if (contextDatabaseOrNull != null) {
                 log.warn("trackBy is called with an already existing, open DB transaction. As a result, there might be states missing from both the snapshot and observable, included in the returned data feed, because of race conditions.")
             }
             val snapshotResults = _queryBy(criteria, paging, sorting, contractStateType)


### PR DESCRIPTION
## Changes
This change removes a race condition between `trackBy` and `notifyAll`, which could lead to states missing from both the snapshot and the observable, included in the returned `DataFeed` from `trackBy`.  For more details, check the JIRA ticket, it has extremely elaborate explanation.

Notes:
- I also added a missing test for `bufferUntilSubscribed`
- There was a test in `CashFlowPaymentTest`, executing both `trackBy` and `notifyAll` in a single transaction. I unwrapped the test from this transaction, since as discussed `trackBy` should not be invoked with an open transaction to avoid race conditions and thus I think it's better to demonstrate good practices in the tests, as well.

## Testing
- To simulate the race condition, I've instrumented a test, triggering the expected race condition (documented in the ticket, as well).
- Run `./gradlew :node:test` locally

Note: I can't see an easy way to deterministically test there's no race condition now, open to any suggestions.