### PR TITLE
CORDA-2318 resolve type variables recursively

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
@@ -225,7 +225,12 @@ internal fun Type.resolveAgainst(context: Type): Type = when (this) {
     is WildcardType -> this.upperBound
     is ReconstitutedParameterizedType -> this
     is ParameterizedType,
-    is TypeVariable<*> -> TypeToken.of(context).resolveType(this).type.upperBound
+    is TypeVariable<*> -> {
+        val resolved = TypeToken.of(context).resolveType(this).type.upperBound
+        // Given a class C<A, B : A> : I<B>, B will resolve to A and needs to be resolved again
+        // until it is no longer a type variable
+        if (resolved !is TypeVariable<*> || resolved == this) resolved else resolved.resolveAgainst(context)
+    }
     else -> this
 }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/TypeIdentifier.kt
@@ -227,8 +227,6 @@ internal fun Type.resolveAgainst(context: Type): Type = when (this) {
     is ParameterizedType,
     is TypeVariable<*> -> {
         val resolved = TypeToken.of(context).resolveType(this).type.upperBound
-        // Given a class C<A, B : A> : I<B>, B will resolve to A and needs to be resolved again
-        // until it is no longer a type variable
         if (resolved !is TypeVariable<*> || resolved == this) resolved else resolved.resolveAgainst(context)
     }
     else -> this

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
@@ -168,7 +168,7 @@ class RoundTripTests {
         val t: T
     }
 
-    data class C<A, B : A>(override val t: B): I2<B>
+    data class C<A, B : A>(override val t: B) : I2<B>
 
     @Test
     fun recursiveTypeVariableResolution() {

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
@@ -164,18 +164,25 @@ class RoundTripTests {
         assertEquals(mapOf("foo" to "bar"), deserialized.changedMembership.state.data.metadata)
     }
 
-    interface RecursiveI<T> {
+    interface I2<T> {
         val t: T
     }
 
-    data class C<A, B : A>(override val t: B): RecursiveI<B>
+    data class C<A, B : A>(override val t: B): I2<B>
 
     @Test
     fun recursiveTypeVariableResolution() {
         val factory = testDefaultFactoryNoEvolution()
-        val instance = C<List<String>, ArrayList<String>>(ArrayList())
+        val instance = C<Collection<String>, List<String>>(emptyList())
+
         val bytes = SerializationOutput(factory).serialize(instance)
-        val deserialized = DeserializationInput(factory).deserialize(bytes)
-        assertEquals(instance, deserialized)
+        DeserializationInput(factory).deserialize(bytes)
+
+        assertEquals(
+                """
+                C (erased)(t: *): I2<*>
+                  t: *
+                """.trimIndent(),
+                factory.getTypeInformation(instance::class.java).prettyPrint())
     }
 }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/RoundTripTests.kt
@@ -163,4 +163,19 @@ class RoundTripTests {
         val deserialized = DeserializationInput(factory).deserialize(bytes)
         assertEquals(mapOf("foo" to "bar"), deserialized.changedMembership.state.data.metadata)
     }
+
+    interface RecursiveI<T> {
+        val t: T
+    }
+
+    data class C<A, B : A>(override val t: B): RecursiveI<B>
+
+    @Test
+    fun recursiveTypeVariableResolution() {
+        val factory = testDefaultFactoryNoEvolution()
+        val instance = C<List<String>, ArrayList<String>>(ArrayList())
+        val bytes = SerializationOutput(factory).serialize(instance)
+        val deserialized = DeserializationInput(factory).deserialize(bytes)
+        assertEquals(instance, deserialized)
+    }
 }


### PR DESCRIPTION
Following [CORDA-2318](https://r3-cev.atlassian.net/browse/CORDA-2318), I did some investigatory poking around with generics to see if it could be broken in any other way. It turned out that it could:

```kotlin
    interface I<T> {
        val t: T
    }

    data class C<A, B : A>(override val t: B) : I<B>
```

If we try to serialize an erased instance of `C`, the type parameter `B` is resolved to `A` rather than `*`, and serialisation fails. We need to resolve from `A` to `*` after going from `B` to `A`.

This PR introduces a test for this edge case, and code to make it pass.