### PR TITLE
CORDA-2304 Never give up on notarisations

### DIFF
--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -49,9 +49,10 @@ class NotaryFlow {
         }
 
         override val canBeRestarted: Boolean
-            get() = _canBeRestarted
-
-        private var _canBeRestarted = false
+            get() {
+                val notaryParty = stx.notary ?: throw IllegalStateException("Transaction does not specify a Notary")
+                return serviceHub.networkMapCache.getNodesByLegalIdentityKey(notaryParty.owningKey).size > 1
+            }
 
         @Suspendable
         @Throws(NotaryException::class)
@@ -73,7 +74,6 @@ class NotaryFlow {
         // TODO: [CORDA-2274] Perform full transaction verification once verification caching is enabled.
         protected fun checkTransaction(): Party {
             val notaryParty = stx.notary ?: throw IllegalStateException("Transaction does not specify a Notary")
-            _canBeRestarted = serviceHub.networkMapCache.getNodesByLegalIdentityKey(notaryParty.owningKey).size > 1
             check(serviceHub.networkMapCache.isNotary(notaryParty)) { "$notaryParty is not a notary on the network" }
             check(serviceHub.loadStates(stx.inputs.toSet() + stx.references.toSet()).all { it.state.notary == notaryParty }) {
                 "Input states and reference input states must have the same Notary"

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -48,7 +48,7 @@ class NotaryFlow {
             fun tracker() = ProgressTracker(REQUESTING, VALIDATING)
         }
 
-        override val canBeRestarted: Boolean
+        override val isTimeoutEnabled: Boolean
             get() {
                 val notaryParty = stx.notary ?: throw IllegalStateException("Transaction does not specify a Notary")
                 return serviceHub.networkMapCache.getNodesByLegalIdentityKey(notaryParty.owningKey).size > 1

--- a/core/src/main/kotlin/net/corda/core/internal/IdempotentFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/IdempotentFlow.kt
@@ -21,5 +21,5 @@ interface IdempotentFlow
  */
 // TODO: allow specifying retry settings per flow
 interface TimedFlow : IdempotentFlow {
-    val canBeRestarted: Boolean
+    val isTimeoutEnabled: Boolean
 }

--- a/core/src/main/kotlin/net/corda/core/internal/IdempotentFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/IdempotentFlow.kt
@@ -20,4 +20,6 @@ interface IdempotentFlow
  * persisted. Otherwise, it wouldn't be possible to correctly reset the [TimedFlow].
  */
 // TODO: allow specifying retry settings per flow
-interface TimedFlow : IdempotentFlow
+interface TimedFlow : IdempotentFlow {
+    val canBeRestarted: Boolean
+}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,9 +7,10 @@ release, see :doc:`upgrade-notes`.
 Unreleased
 ----------
 
-* TimedFlows (used for notarisations) will never give up trying to reach the notary, as this would leave the states in the
-  notarisation request in an undefined state (unknown whether the spent has been notarised, i.e. has happened, or not). Also,
-  retries have been disabled for single node notaries.
+* TimedFlows (only used by the notary client flow) will never give up trying to reach the notary, as this would leave the states
+  in the notarisation request in an undefined state (unknown whether the spend has been notarised, i.e. has happened, or not). Also,
+  retries have been disabled for single node notaries since in this case they offer no potential benefits, unlike for a notary cluster with
+  several members who might have different availability.
 
 * New configuration property `database.initialiseAppSchema` with values `UPDATE`, `VALIDATE` and `NONE`.
   The property controls the behavior of the Hibernate DDL generation. `UPDATE` performs an update of CorDapp schemas, while

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,10 @@ release, see :doc:`upgrade-notes`.
 Unreleased
 ----------
 
+* TimedFlows (used for notarisations) will never give up trying to reach the notary, as this would leave the states in the
+  notarisation request in an undefined state (unknown whether the spent has been notarised, i.e. has happened, or not). Also,
+  retries have been disabled for single node notaries.
+
 * New configuration property `database.initialiseAppSchema` with values `UPDATE`, `VALIDATE` and `NONE`.
   The property controls the behavior of the Hibernate DDL generation. `UPDATE` performs an update of CorDapp schemas, while
   `VALID` only verifies their integrity.  The property does not affect the node-specific DDL handling and

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -111,14 +111,15 @@ The available config fields are listed below.
 :additionalP2PAddresses: An array of additional host:port values, which will be included in the advertised NodeInfo in the network map in addition to the ``p2pAddress``.
     Nodes can use this configuration option to advertise HA endpoints and aliases to external parties. If not specified the default value is an empty list.
 
-:flowTimeout: When a flow implementing the ``TimedFlow`` interface and setting the ``isTimeoutEnabled`` flag does not complete in time,
-    it is restarted from the initial checkpoint. Currently only used for notarisation requests with clustered notaries: if a notary
-    replica dies while processing a notarisation request, the client flow eventually times out and gets restarted. On restart the request is
-    resent to a different notary replica in a round-robin fashion (assuming the notary is clustered). Note that the flow will keep
-    retrying forever.
+:flowTimeout: When a flow implementing the ``TimedFlow`` interface and setting the ``isTimeoutEnabled`` flag does not complete within a
+    defined elapsed time, it is restarted from the initial checkpoint. Currently only used for notarisation requests with clustered
+    notaries: if a notary cluster member dies while processing a notarisation request, the client flow eventually times out and gets
+    restarted. On restart the request is resent to a different notary cluster member in a round-robin fashion. Note that the flow will
+    keep retrying forever.
 
         :timeout: The initial flow timeout period, e.g. `30 seconds`.
-        :maxRestartCount: The number of retries the back-off time keeps growing for. Afterwards, it will stay at the latest value.
+        :maxRestartCount: The number of retries the back-off time keeps growing for. For subsequent retries, the timeout value will remain
+                 constant.
         :backoffBase: The base of the exponential backoff, `t_{wait} = timeout * backoffBase^{retryCount}`.
 
 :rpcAddress: (Deprecated) The address of the RPC system on which RPC requests can be made to the node. If not provided then the node will run without RPC. This is now deprecated in favour of the ``rpcSettings`` block.

--- a/docs/source/corda-configuration-file.rst
+++ b/docs/source/corda-configuration-file.rst
@@ -111,13 +111,14 @@ The available config fields are listed below.
 :additionalP2PAddresses: An array of additional host:port values, which will be included in the advertised NodeInfo in the network map in addition to the ``p2pAddress``.
     Nodes can use this configuration option to advertise HA endpoints and aliases to external parties. If not specified the default value is an empty list.
 
-:flowTimeout: When a flow implementing the ``TimedFlow`` interface does not complete in time, it is restarted from the
-    initial checkpoint. Currently only used for notarisation requests: if a notary replica dies while processing a notarisation request,
-    the client flow eventually times out and gets restarted. On restart the request is resent to a different notary replica
-    in a round-robin fashion (assuming the notary is clustered).
+:flowTimeout: When a flow implementing the ``TimedFlow`` interface and setting the ``isTimeoutEnabled`` flag does not complete in time,
+    it is restarted from the initial checkpoint. Currently only used for notarisation requests with clustered notaries: if a notary
+    replica dies while processing a notarisation request, the client flow eventually times out and gets restarted. On restart the request is
+    resent to a different notary replica in a round-robin fashion (assuming the notary is clustered). Note that the flow will keep
+    retrying forever.
 
         :timeout: The initial flow timeout period, e.g. `30 seconds`.
-        :maxRestartCount: Maximum number of times the flow will restart before resulting in an error.
+        :maxRestartCount: The number of retries the back-off time keeps growing for. Afterwards, it will stay at the latest value.
         :backoffBase: The base of the exponential backoff, `t_{wait} = timeout * backoffBase^{retryCount}`.
 
 :rpcAddress: (Deprecated) The address of the RPC system on which RPC requests can be made to the node. If not provided then the node will run without RPC. This is now deprecated in favour of the ``rpcSettings`` block.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
@@ -80,7 +80,7 @@ sealed class Event {
      *
      * @param subFlowClass the [Class] of the subflow, to be used to determine whether it's Initiating or inlined.
      */
-    data class EnterSubFlow(val subFlowClass: Class<FlowLogic<*>>, val subFlowVersion: SubFlowVersion ) : Event()
+    data class EnterSubFlow(val subFlowClass: Class<FlowLogic<*>>, val subFlowVersion: SubFlowVersion, val retryableTimedFlow: Boolean) : Event()
 
     /**
      * Signal the leaving of a subflow.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/Event.kt
@@ -80,7 +80,7 @@ sealed class Event {
      *
      * @param subFlowClass the [Class] of the subflow, to be used to determine whether it's Initiating or inlined.
      */
-    data class EnterSubFlow(val subFlowClass: Class<FlowLogic<*>>, val subFlowVersion: SubFlowVersion, val retryableTimedFlow: Boolean) : Event()
+    data class EnterSubFlow(val subFlowClass: Class<FlowLogic<*>>, val subFlowVersion: SubFlowVersion, val isEnabledTimedFlow: Boolean) : Event()
 
     /**
      * Signal the leaving of a subflow.

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -273,7 +273,8 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                 Event.EnterSubFlow(subFlow.javaClass,
                         createSubFlowVersion(
                                 serviceHub.cordappProvider.getCordappForFlow(subFlow), serviceHub.myInfo.platformVersion
-                        )
+                        ),
+                        (subFlow as? TimedFlow)?.canBeRestarted ?: false
                 ),
                 isDbTransactionOpenOnEntry = true,
                 isDbTransactionOpenOnExit = true

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -24,6 +24,7 @@ import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.logging.pushToLoggingContext
 import net.corda.node.services.statemachine.transitions.FlowContinuation
 import net.corda.node.services.statemachine.transitions.StateMachine
+import net.corda.node.utilities.isRestartableTimedFlow
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseTransaction
 import net.corda.nodeapi.internal.persistence.contextTransaction
@@ -274,7 +275,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                         createSubFlowVersion(
                                 serviceHub.cordappProvider.getCordappForFlow(subFlow), serviceHub.myInfo.platformVersion
                         ),
-                        (subFlow as? TimedFlow)?.canBeRestarted ?: false
+                        subFlow.isRestartableTimedFlow()
                 ),
                 isDbTransactionOpenOnEntry = true,
                 isDbTransactionOpenOnExit = true

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowStateMachineImpl.kt
@@ -24,7 +24,7 @@ import net.corda.node.services.api.ServiceHubInternal
 import net.corda.node.services.logging.pushToLoggingContext
 import net.corda.node.services.statemachine.transitions.FlowContinuation
 import net.corda.node.services.statemachine.transitions.StateMachine
-import net.corda.node.utilities.isRestartableTimedFlow
+import net.corda.node.utilities.isEnabledTimedFlow
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseTransaction
 import net.corda.nodeapi.internal.persistence.contextTransaction
@@ -275,7 +275,7 @@ class FlowStateMachineImpl<R>(override val id: StateMachineRunId,
                         createSubFlowVersion(
                                 serviceHub.cordappProvider.getCordappForFlow(subFlow), serviceHub.myInfo.platformVersion
                         ),
-                        subFlow.isRestartableTimedFlow()
+                        subFlow.isEnabledTimedFlow()
                 ),
                 isDbTransactionOpenOnEntry = true,
                 isDbTransactionOpenOnExit = true

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/FlowTimeoutException.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/FlowTimeoutException.kt
@@ -6,4 +6,4 @@ import net.corda.core.CordaException
  * This exception is fired once the retry timeout of a [TimedFlow] expires.
  * It will indicate to the flow hospital to restart the flow.
  */
-data class FlowTimeoutException(val maxRetries: Int) : CordaException("replaying flow from the last checkpoint")
+class FlowTimeoutException : CordaException("replaying flow from the last checkpoint")

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -46,6 +46,7 @@ import net.corda.node.services.statemachine.interceptors.PrintingInterceptor
 import net.corda.node.services.statemachine.transitions.StateMachine
 import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.injectOldProgressTracker
+import net.corda.node.utilities.isRestartableTimedFlow
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.wrapWithDatabaseTransaction
 import net.corda.serialization.internal.CheckpointSerializeAsTokenContextImpl
@@ -552,7 +553,7 @@ class SingleThreadedStateMachineManager(
                 frozenFlowLogic,
                 ourIdentity,
                 flowCorDappVersion,
-                (flowLogic as? TimedFlow)?.canBeRestarted ?: false
+                flowLogic.isRestartableTimedFlow()
         ).getOrThrow()
         val startedFuture = openFuture<Unit>()
         val initialState = StateMachineState(
@@ -770,7 +771,7 @@ class SingleThreadedStateMachineManager(
                     oldFlow.resultFuture.captureLater(flow.resultFuture)
                 }
                 val flowLogic = flow.fiber.logic
-                if ((flowLogic as? TimedFlow)?.canBeRestarted ?: false) scheduleTimeout(id)
+                if (flowLogic.isRestartableTimedFlow()) scheduleTimeout(id)
                 flow.fiber.scheduleEvent(Event.DoRemainingWork)
                 when (checkpoint.flowState) {
                     is FlowState.Unstarted -> {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -762,7 +762,7 @@ class SingleThreadedStateMachineManager(
                     oldFlow.resultFuture.captureLater(flow.resultFuture)
                 }
                 val flowLogic = flow.fiber.logic
-                if (flowLogic is TimedFlow) scheduleTimeout(id)
+                if ((flowLogic as? TimedFlow)?.canBeRestarted ?: false) scheduleTimeout(id)
                 flow.fiber.scheduleEvent(Event.DoRemainingWork)
                 when (checkpoint.flowState) {
                     is FlowState.Unstarted -> {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -545,7 +545,15 @@ class SingleThreadedStateMachineManager(
 
         val flowCorDappVersion = createSubFlowVersion(serviceHub.cordappProvider.getCordappForFlow(flowLogic), serviceHub.myInfo.platformVersion)
 
-        val initialCheckpoint = Checkpoint.create(invocationContext, flowStart, flowLogic.javaClass, frozenFlowLogic, ourIdentity, flowCorDappVersion).getOrThrow()
+        val initialCheckpoint = Checkpoint.create(
+                invocationContext,
+                flowStart,
+                flowLogic.javaClass,
+                frozenFlowLogic,
+                ourIdentity,
+                flowCorDappVersion,
+                (flowLogic as? TimedFlow)?.canBeRestarted ?: false
+        ).getOrThrow()
         val startedFuture = openFuture<Unit>()
         val initialState = StateMachineState(
                 checkpoint = initialCheckpoint,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -15,7 +15,6 @@ import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
 import net.corda.core.internal.FlowStateMachine
 import net.corda.core.internal.ThreadBox
-import net.corda.core.internal.TimedFlow
 import net.corda.core.internal.bufferUntilSubscribed
 import net.corda.core.internal.castIfPossible
 import net.corda.core.internal.concurrent.OpenFuture
@@ -46,7 +45,7 @@ import net.corda.node.services.statemachine.interceptors.PrintingInterceptor
 import net.corda.node.services.statemachine.transitions.StateMachine
 import net.corda.node.utilities.AffinityExecutor
 import net.corda.node.utilities.injectOldProgressTracker
-import net.corda.node.utilities.isRestartableTimedFlow
+import net.corda.node.utilities.isEnabledTimedFlow
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.wrapWithDatabaseTransaction
 import net.corda.serialization.internal.CheckpointSerializeAsTokenContextImpl
@@ -553,7 +552,7 @@ class SingleThreadedStateMachineManager(
                 frozenFlowLogic,
                 ourIdentity,
                 flowCorDappVersion,
-                flowLogic.isRestartableTimedFlow()
+                flowLogic.isEnabledTimedFlow()
         ).getOrThrow()
         val startedFuture = openFuture<Unit>()
         val initialState = StateMachineState(
@@ -771,7 +770,7 @@ class SingleThreadedStateMachineManager(
                     oldFlow.resultFuture.captureLater(flow.resultFuture)
                 }
                 val flowLogic = flow.fiber.logic
-                if (flowLogic.isRestartableTimedFlow()) scheduleTimeout(id)
+                if (flowLogic.isEnabledTimedFlow()) scheduleTimeout(id)
                 flow.fiber.scheduleEvent(Event.DoRemainingWork)
                 when (checkpoint.flowState) {
                     is FlowState.Unstarted -> {

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -292,15 +292,7 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
     object DoctorTimeout : Staff {
         override fun consult(flowFiber: FlowFiber, currentState: StateMachineState, newError: Throwable, history: FlowMedicalHistory): Diagnosis {
             if (newError is FlowTimeoutException) {
-                if (history.notDischargedForTheSameThingMoreThan(newError.maxRetries, this, currentState)) {
-                    return Diagnosis.DISCHARGE
-                } else {
-                    val errorMsg = "Maximum number of retries reached for flow ${flowFiber.snapshot().flowLogic.javaClass}. " +
-                            "If the flow involves notarising a transaction, it means that no response was received from the notary." +
-                            "This could be either due to the the notary being overloaded or unable to reach this node."
-                    newError.setMessage(errorMsg)
-                    log.warn(errorMsg)
-                }
+                return Diagnosis.DISCHARGE
             }
             return Diagnosis.NOT_MY_SPECIALTY
         }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -70,9 +70,9 @@ data class Checkpoint(
                 frozenFlowLogic: SerializedBytes<FlowLogic<*>>,
                 ourIdentity: Party,
                 subFlowVersion: SubFlowVersion,
-                retryableTimedFlow: Boolean
+                isEnabledTimedFlow: Boolean
         ): Try<Checkpoint> {
-            return SubFlow.create(flowLogicClass, subFlowVersion, retryableTimedFlow).map { topLevelSubFlow ->
+            return SubFlow.create(flowLogicClass, subFlowVersion, isEnabledTimedFlow).map { topLevelSubFlow ->
                 Checkpoint(
                         invocationContext = invocationContext,
                         ourIdentity = ourIdentity,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StateMachineState.kt
@@ -69,9 +69,10 @@ data class Checkpoint(
                 flowLogicClass: Class<FlowLogic<*>>,
                 frozenFlowLogic: SerializedBytes<FlowLogic<*>>,
                 ourIdentity: Party,
-                subFlowVersion: SubFlowVersion
+                subFlowVersion: SubFlowVersion,
+                retryableTimedFlow: Boolean
         ): Try<Checkpoint> {
-            return SubFlow.create(flowLogicClass, subFlowVersion).map { topLevelSubFlow ->
+            return SubFlow.create(flowLogicClass, subFlowVersion, retryableTimedFlow).map { topLevelSubFlow ->
                 Checkpoint(
                         invocationContext = invocationContext,
                         ourIdentity = ourIdentity,

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SubFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SubFlow.kt
@@ -16,12 +16,12 @@ sealed class SubFlow {
     // Version of the code.
     abstract val subFlowVersion: SubFlowVersion
 
-    abstract val retryableTimedFlow: Boolean
+    abstract val isEnabledTimedFlow: Boolean
 
     /**
      * An inlined subflow.
      */
-    data class Inlined(override val flowClass: Class<FlowLogic<*>>, override val subFlowVersion: SubFlowVersion, override val retryableTimedFlow: Boolean) : SubFlow()
+    data class Inlined(override val flowClass: Class<FlowLogic<*>>, override val subFlowVersion: SubFlowVersion, override val isEnabledTimedFlow: Boolean) : SubFlow()
 
     /**
      * An initiating subflow.
@@ -35,21 +35,21 @@ sealed class SubFlow {
             val classToInitiateWith: Class<in FlowLogic<*>>,
             val flowInfo: FlowInfo,
             override val subFlowVersion: SubFlowVersion,
-            override val retryableTimedFlow: Boolean
+            override val isEnabledTimedFlow: Boolean
     ) : SubFlow()
 
     companion object {
-        fun create(flowClass: Class<FlowLogic<*>>, subFlowVersion: SubFlowVersion, retryableTimedFlow: Boolean): Try<SubFlow> {
+        fun create(flowClass: Class<FlowLogic<*>>, subFlowVersion: SubFlowVersion, isEnabledTimedFlow: Boolean): Try<SubFlow> {
             // Are we an InitiatingFlow?
             val initiatingAnnotations = getInitiatingFlowAnnotations(flowClass)
             return when (initiatingAnnotations.size) {
                 0 -> {
-                    Try.Success(Inlined(flowClass, subFlowVersion, retryableTimedFlow))
+                    Try.Success(Inlined(flowClass, subFlowVersion, isEnabledTimedFlow))
                 }
                 1 -> {
                     val initiatingAnnotation = initiatingAnnotations[0]
                     val flowContext = FlowInfo(initiatingAnnotation.second.version, flowClass.appName)
-                    Try.Success(Initiating(flowClass, initiatingAnnotation.first, flowContext, subFlowVersion, retryableTimedFlow))
+                    Try.Success(Initiating(flowClass, initiatingAnnotation.first, flowContext, subFlowVersion, isEnabledTimedFlow))
                 }
                 else -> {
                     Try.Failure(IllegalArgumentException("${InitiatingFlow::class.java.name} can only be annotated " +

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SubFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SubFlow.kt
@@ -21,9 +21,7 @@ sealed class SubFlow {
     /**
      * An inlined subflow.
      */
-    data class Inlined(override val flowClass: Class<FlowLogic<*>>, override val subFlowVersion: SubFlowVersion) : SubFlow() {
-        override val retryableTimedFlow: Boolean = false
-    }
+    data class Inlined(override val flowClass: Class<FlowLogic<*>>, override val subFlowVersion: SubFlowVersion, override val retryableTimedFlow: Boolean) : SubFlow()
 
     /**
      * An initiating subflow.
@@ -46,7 +44,7 @@ sealed class SubFlow {
             val initiatingAnnotations = getInitiatingFlowAnnotations(flowClass)
             return when (initiatingAnnotations.size) {
                 0 -> {
-                    Try.Success(Inlined(flowClass, subFlowVersion))
+                    Try.Success(Inlined(flowClass, subFlowVersion, retryableTimedFlow))
                 }
                 1 -> {
                     val initiatingAnnotation = initiatingAnnotations[0]

--- a/node/src/main/kotlin/net/corda/node/utilities/TimedFlowUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/TimedFlowUtils.kt
@@ -7,6 +7,6 @@ import net.corda.core.internal.TimedFlow
  * Check if a flow logic is a [TimedFlow] and if yes whether it actually can be restarted. Only flows that match both criteria should time
  * out and get restarted.
  */
-internal fun FlowLogic<*>.isRestartableTimedFlow(): Boolean {
-    return (this as? TimedFlow)?.canBeRestarted ?: false
+internal fun FlowLogic<*>.isEnabledTimedFlow(): Boolean {
+    return (this as? TimedFlow)?.isTimeoutEnabled ?: false
 }

--- a/node/src/main/kotlin/net/corda/node/utilities/TimedFlowUtils.kt
+++ b/node/src/main/kotlin/net/corda/node/utilities/TimedFlowUtils.kt
@@ -1,0 +1,12 @@
+package net.corda.node.utilities
+
+import net.corda.core.flows.FlowLogic
+import net.corda.core.internal.TimedFlow
+
+/**
+ * Check if a flow logic is a [TimedFlow] and if yes whether it actually can be restarted. Only flows that match both criteria should time
+ * out and get restarted.
+ */
+internal fun FlowLogic<*>.isRestartableTimedFlow(): Boolean {
+    return (this as? TimedFlow)?.canBeRestarted ?: false
+}

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -155,7 +155,9 @@ class TimedFlowTests {
                 setTimeWindow(services.clock.instant(), 30.seconds)
                 addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
             }
-            val flow = NotaryFlow.Client(issueTx)
+            val flow = object : NotaryFlow.Client(issueTx) {
+                override val canBeRestarted: Boolean = true
+            }
             val progressTracker = flow.progressTracker
             assertNotEquals(ProgressTracker.DONE, progressTracker.currentStep)
             val progressTrackerDone = getDoneFuture(progressTracker)
@@ -193,7 +195,9 @@ class TimedFlowTests {
                     setTimeWindow(services.clock.instant(), 30.seconds)
                     addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
                 }
-                val flow = NotaryFlow.Client(issueTx)
+                val flow = object : NotaryFlow.Client(issueTx) {
+                    override val canBeRestarted: Boolean = true
+                }
                 val progressTracker = flow.progressTracker
                 assertNotEquals(ProgressTracker.DONE, progressTracker.currentStep)
                 val progressTrackerDone = getDoneFuture(progressTracker)
@@ -225,7 +229,9 @@ class TimedFlowTests {
                     setTimeWindow(services.clock.instant(), 30.seconds)
                     addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
                 }
-                val flow = NotaryFlow.Client(issueTx)
+                val flow = object : NotaryFlow.Client(issueTx) {
+                    override val canBeRestarted: Boolean = true
+                }
                 val progressTracker = flow.progressTracker
                 assertNotEquals(ProgressTracker.DONE, progressTracker.currentStep)
                 val progressTrackerDone = getDoneFuture(progressTracker)

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -155,9 +155,7 @@ class TimedFlowTests {
                 setTimeWindow(services.clock.instant(), 30.seconds)
                 addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
             }
-            val flow = object : NotaryFlow.Client(issueTx) {
-                override val canBeRestarted: Boolean = true
-            }
+            val flow = NotaryFlow.Client(issueTx)
             val progressTracker = flow.progressTracker
             assertNotEquals(ProgressTracker.DONE, progressTracker.currentStep)
             val progressTrackerDone = getDoneFuture(progressTracker)
@@ -195,9 +193,7 @@ class TimedFlowTests {
                     setTimeWindow(services.clock.instant(), 30.seconds)
                     addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
                 }
-                val flow = object : NotaryFlow.Client(issueTx) {
-                    override val canBeRestarted: Boolean = true
-                }
+                val flow = NotaryFlow.Client(issueTx)
                 val progressTracker = flow.progressTracker
                 assertNotEquals(ProgressTracker.DONE, progressTracker.currentStep)
                 val progressTrackerDone = getDoneFuture(progressTracker)
@@ -229,9 +225,7 @@ class TimedFlowTests {
                     setTimeWindow(services.clock.instant(), 30.seconds)
                     addOutputState(DummyContract.SingleOwnerState(owner = info.singleIdentity()), DummyContract.PROGRAM_ID, AlwaysAcceptAttachmentConstraint)
                 }
-                val flow = object : NotaryFlow.Client(issueTx) {
-                    override val canBeRestarted: Boolean = true
-                }
+                val flow = NotaryFlow.Client(issueTx)
                 val progressTracker = flow.progressTracker
                 assertNotEquals(ProgressTracker.DONE, progressTracker.currentStep)
                 val progressTrackerDone = getDoneFuture(progressTracker)

--- a/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/DBCheckpointStorageTests.kt
@@ -190,7 +190,8 @@ class DBCheckpointStorageTests {
             override fun call() {}
         }
         val frozenLogic = logic.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
-        val checkpoint = Checkpoint.create(InvocationContext.shell(), FlowStart.Explicit, logic.javaClass, frozenLogic, ALICE, SubFlowVersion.CoreFlow(version)).getOrThrow()
+        val checkpoint = Checkpoint.create(InvocationContext.shell(), FlowStart.Explicit, logic.javaClass, frozenLogic, ALICE, SubFlowVersion.CoreFlow(version), false)
+                .getOrThrow()
         return id to checkpoint.checkpointSerialize(context = CheckpointSerializationDefaults.CHECKPOINT_CONTEXT)
     }
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/IdempotentFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/IdempotentFlowTests.kt
@@ -66,7 +66,7 @@ class IdempotentFlowTests {
     }
 
     private class TimedSubflow : FlowLogic<Unit>(), TimedFlow {
-        override val canBeRestarted: Boolean = true
+        override val isTimeoutEnabled: Boolean = true
 
         @Suspendable
         override fun call() {

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/IdempotentFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/IdempotentFlowTests.kt
@@ -66,6 +66,8 @@ class IdempotentFlowTests {
     }
 
     private class TimedSubflow : FlowLogic<Unit>(), TimedFlow {
+        override val canBeRestarted: Boolean = true
+
         @Suspendable
         override fun call() {
             subFlowExecutionCounter.incrementAndGet() // No checkpoint should be taken before invoking IdempotentSubFlow,


### PR DESCRIPTION
Timed flows would give up after a configurable number of tries. However, this can cause problems when a node gives up on a notarisation, as the notary might receive the request and mark states as spent, but the answer doesn't come back, so the node gives up and releases the states as unspent. Now the node and the notary don't agree any longer on the state of the world, and future flows trying to use these states will error.
A node therefore should never give up on trying to notarise a transaction.
Also, if the notary is a single node notary, don't even retry a notarisation - if the node comes back up, the message will eventually go through (or if the node gets restarted, it will be resent), but there is no alternative node that could answer any quicker.