### PR TITLE
Trival change to improve search hits for log4j2

### DIFF
--- a/docs/source/node-administration.rst
+++ b/docs/source/node-administration.rst
@@ -11,9 +11,9 @@ option will affect all modules.
 
 It may be the case that you require to amend the log level of a particular subset of modules (e.g., if you'd like to take a
 closer look at hibernate activity). So, for more bespoke logging configuration, the logger settings can be completely overridden
-with a `Log4j 2 <https://logging.apache.org/log4j/2.x>`_ configuration file assigned to the ``log4j.configurationFile`` system property.
+with a `Log4j2 <https://logging.apache.org/log4j/2.x>`_ configuration file assigned to the ``log4j.configurationFile`` system property.
 
-The node is using log4j asynchronous logging by default (configured via log4j2 properties file in its resources)
+The node is using log4j2 asynchronous logging by default (configured via log4j2 properties file in its resources)
 to ensure that log message flushing is not slowing down the actual processing.
 If you need to switch to synchronous logging (e.g. for debugging/testing purposes), you can override this behaviour
 by adding ``-DLog4jContextSelector=org.apache.logging.log4j.core.selector.ClassLoaderContextSelector`` to the node's

--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -130,7 +130,7 @@ The example CorDapp has the following structure:
 The key files and directories are as follows:
 
 * The **root directory** contains some gradle files, a README and a LICENSE
-* **config** contains log4j configs
+* **config** contains log4j2 configs
 * **gradle** contains the gradle wrapper, which allows the use of Gradle without installing it yourself and worrying
   about which version is required
 * **lib** contains the Quasar jar which rewrites our CorDapp's flows to be checkpointable


### PR DESCRIPTION
Make log4j2 consistence - to make docs search easier (log4j 2) wasn't
catch by 'log4j2' search.

This is trivial docs change. Currently docs search won't return pages where there was a space between  'log4j' and '2'. I've changed it to make wider search results.


