### PR TITLE
Remove safe cast at initial registration attempt

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -83,7 +83,7 @@ class InitialRegistration(val baseDirectory: Path, private val networkRootTrustS
 
     private fun initialRegistration(config: NodeConfiguration) {
         // Null checks for [compatibilityZoneURL], [rootTruststorePath] and [rootTruststorePassword] has been done in [CmdLineOptions.loadConfig]
-        attempt { registerWithNetwork(config) }.doOnException(this::handleRegistrationError) as? Try.Success
+        attempt { registerWithNetwork(config) }.doOnException(this::handleRegistrationError) as Try.Success
         // At this point the node registration was successful. We can delete the marker file.
         deleteNodeRegistrationMarker(baseDirectory)
     }


### PR DESCRIPTION
The node should exit with an error when the initial registration fails.