### PR TITLE
ENT-2589: Suppress core.server.lambda$channelActive$0 - AMQ224088 errors

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/ArtemisTcpTransport.kt
@@ -6,8 +6,8 @@ import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.nodeapi.BrokerRpcSslOptions
 import net.corda.nodeapi.internal.config.CertificateStore
 import net.corda.nodeapi.internal.config.FileBasedCertificateStoreSupplier
-import net.corda.nodeapi.internal.config.SslConfiguration
 import net.corda.nodeapi.internal.config.MutualSslConfiguration
+import net.corda.nodeapi.internal.config.SslConfiguration
 import org.apache.activemq.artemis.api.core.TransportConfiguration
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants
@@ -115,6 +115,7 @@ class ArtemisTcpTransport {
                 options.putAll(defaultSSLOptions)
                 (keyStore to trustStore).addToTransportOptions(options)
             }
+            options[TransportConstants.HANDSHAKE_TIMEOUT] = 0 // Suppress core.server.lambda$channelActive$0 - AMQ224088 error from load balancer type connections
             return TransportConfiguration(acceptorFactoryClassName, options)
         }
 
@@ -136,6 +137,7 @@ class ArtemisTcpTransport {
                 options.putAll(config.toTransportOptions())
                 options.putAll(defaultSSLOptions)
             }
+            options[TransportConstants.HANDSHAKE_TIMEOUT] = 0 // Suppress core.server.lambda$channelActive$0 - AMQ224088 error from load balancer type connections
             return TransportConfiguration(acceptorFactoryClassName, options)
         }
 
@@ -159,7 +161,7 @@ class ArtemisTcpTransport {
         }
 
         fun rpcInternalAcceptorTcpTransport(hostAndPort: NetworkHostAndPort, config: SslConfiguration): TransportConfiguration {
-            return TransportConfiguration(acceptorFactoryClassName, defaultArtemisOptions(hostAndPort) + defaultSSLOptions + config.toTransportOptions())
+            return TransportConfiguration(acceptorFactoryClassName, defaultArtemisOptions(hostAndPort) + defaultSSLOptions + config.toTransportOptions() + (TransportConstants.HANDSHAKE_TIMEOUT to 0))
         }
     }
 }


### PR DESCRIPTION
Connections from load balancers and other health checks can last for a long time without sending any bytes. This logs messages like:
[ERROR] 2018-12-18T11:00:05,509Z [Thread-4 (ActiveMQ-scheduled-threads)] core.server.lambda$channelActive$0 - AMQ224088: Timeout (10 seconds) while handshaking has occurred.
that fill the logs up and make monitoring of errors difficult.
This change suppresses this artemis logic, although the normal TLS timers will still apply, but silently. The RPC plan socket will allow an indefinite connection without disconnect, but that should be fine with a load balancer and the complexity of adding yet more confusing config is not worth it.
