### PR TITLE
Fix irs-demo dependency issues

### DIFF
--- a/samples/irs-demo/README.md
+++ b/samples/irs-demo/README.md
@@ -13,7 +13,7 @@ To run from the command line in Unix:
 2. Run ``./gradlew samples:irs-demo:web:deployWebapps`` to install configs and tools for running webservers
 3. Move to the ``samples/irs-demo/`` directory
 4. Run ``./cordapp/build/nodes/runnodes`` to open up three new terminals with the three nodes (you may have to install xterm)
-5. On Linux, run ``./web/build/webapps/runwebapps`` to open three more terminals for associated webservers. On macOS,
+5. On Linux, run ``./web/build/webapps/runwebapps.sh`` to open three more terminals for associated webservers. On macOS,
    use the following command instead: ``osascript ./web/build/webapps/runwebapps.scpt``
 
 To run from the command line in Windows:

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -54,7 +54,6 @@ def rpcUsersList = [
          ]]
 ]
 
-
 def nodeTask = tasks.getByPath(':node:capsule:assemble')
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask]) {
 
@@ -170,6 +169,7 @@ jar {
 
 task testJar(type: Jar) {
     classifier "test"
+    from sourceSets.main.output
     from sourceSets.test.output
 }
 

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     // Corda integration dependencies
     cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')
     cordaCompile project(':core')
+    cordaRuntime project(':node-api')
 
     // Cordapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps

--- a/samples/irs-demo/cordapp/build.gradle
+++ b/samples/irs-demo/cordapp/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     // Specify your cordapp's dependencies below, including dependent cordapps
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
 
-    cordaCompile project(':node-driver')
+    testCompile project(':node-driver')
     testCompile "junit:junit:$junit_version"
     testCompile "org.assertj:assertj-core:${assertj_version}"
 }
@@ -53,6 +53,7 @@ def rpcUsersList = [
                  "InvokeRpc.wellKnownPartyFromX500Name"
          ]]
 ]
+
 
 def nodeTask = tasks.getByPath(':node:capsule:assemble')
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask]) {
@@ -163,12 +164,17 @@ idea {
 }
 
 jar {
-    from sourceSets.test.output
+    from sourceSets.main.output
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
+task testJar(type: Jar) {
+    classifier "test"
+    from sourceSets.test.output
+}
+
 artifacts {
-    demoArtifacts jar
+    demoArtifacts testJar
 }
 
 cordapp {

--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -17,7 +17,6 @@ buildscript {
 
 import org.yaml.snakeyaml.DumperOptions
 
-
 plugins {
 	id 'com.craigburke.client-dependencies' version '1.4.0'
 }
@@ -66,11 +65,14 @@ dependencies {
         exclude module: "spring-boot-starter-logging"
         exclude module: "logback-classic"
     }
+	compile('org.springframework.boot:spring-boot-starter-log4j2')
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
     compile project(":client:rpc")
     compile project(":client:jackson")
-    compile project(":test-utils")
-    compile project(path: ":samples:irs-demo:cordapp", configuration: "demoArtifacts")
+	compile project(":samples:irs-demo:cordapp")
+
+    testCompile project(":test-utils")
+    testCompile project(path: ":samples:irs-demo:cordapp", configuration: "demoArtifacts")
 
 	// JOpt: for command line flags.
     compile "net.sf.jopt-simple:jopt-simple:$jopt_simple_version"
@@ -82,7 +84,7 @@ dependencies {
 }
 
 jar {
-    from sourceSets.test.output
+    from sourceSets.main.output
     dependsOn clientInstall
 }
 

--- a/samples/irs-demo/web/build.gradle
+++ b/samples/irs-demo/web/build.gradle
@@ -66,6 +66,7 @@ dependencies {
         exclude module: "logback-classic"
     }
 	compile('org.springframework.boot:spring-boot-starter-log4j2')
+    runtime("org.apache.logging.log4j:log4j-web:$log4j_version")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
     compile project(":client:rpc")
     compile project(":client:jackson")

--- a/samples/irs-demo/web/src/main/resources/log4j2.xml
+++ b/samples/irs-demo/web/src/main/resources/log4j2.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+
+    <Properties>
+        <Property name="log-path">logs</Property>
+        <Property name="log-name">node-${hostName}</Property>
+        <Property name="archive">${log-path}/archive</Property>
+    </Properties>
+
+    <ThresholdFilter level="trace"/>
+
+    <Appenders>
+        <Console name="Console-Appender" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %date{HH:mm:ss,SSSZ} [%t] %c{2}.%method - %msg%n"/>
+        </Console>
+
+        <!-- Required for printBasicInfo -->
+        <Console name="Console-Appender-Println" target="SYSTEM_OUT">
+            <PatternLayout pattern="%msg%n" />
+        </Console>
+
+        <!-- Will generate up to 10 log files for a given day. During every rollover it will delete
+             those that are older than 60 days, but keep the most recent 10 GB -->
+        <RollingFile name="RollingFile-Appender"
+                     fileName="${log-path}/${log-name}.log"
+                     filePattern="${archive}/${log-name}.%date{yyyy-MM-dd}-%i.log.gz">
+
+            <PatternLayout pattern="[%-5level] %date{ISO8601}{UTC}Z [%t] %c{2} - %msg%n"/>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10MB"/>
+            </Policies>
+
+            <DefaultRolloverStrategy min="1" max="10">
+                <Delete basePath="${archive}" maxDepth="1">
+                    <IfFileName glob="${log-name}*.log.gz"/>
+                    <IfLastModified age="60d">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="10 GB"/>
+                        </IfAny>
+                    </IfLastModified>
+                </Delete>
+            </DefaultRolloverStrategy>
+
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Root level="trace">
+            <AppenderRef ref="Console-Appender" level="info"/>
+            <AppenderRef ref="RollingFile-Appender" level="debug"/>
+        </Root>
+        <Logger name="BasicInfo" additivity="false">
+            <AppenderRef ref="Console-Appender-Println"/>
+            <AppenderRef ref="RollingFile-Appender" />
+        </Logger>
+    </Loggers>
+
+</Configuration>

--- a/testing/test-common/build.gradle
+++ b/testing/test-common/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.jfrog.artifactory'
 dependencies {
     compile project(':core')
     compile project(':node-api')
+    compile project(':tools:cliutils')
 
     // Unit testing helpers.
     compile "junit:junit:$junit_version"

--- a/tools/cliutils/build.gradle
+++ b/tools/cliutils/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 jar {
-    baseName = "cliutils"
+    baseName = "corda-tools-cliutils"
 }
 
 publish {

--- a/tools/cliutils/build.gradle
+++ b/tools/cliutils/build.gradle
@@ -25,6 +25,6 @@ jar {
 }
 
 publish {
-    name 'corda-tools-cliutils'
+    name jar.baseName
 }
 


### PR DESCRIPTION
The irs-demo is throwing an error on startup because it has a log4j.xml which uses a custom plugin which is in cli utils. However, it turns out the log4j2.xml is in the classpath because the irs-demo webapp is depending on the test utils, as well as the full corda jar. I have reworked the dependencies so that these are test only and added it's own log4j2.xml file, along with the spring boot log4j2 plugin. 

Additionally, `test-utils` needs to depend on `cli-utils` anyway, which I've changed.