### PR TITLE
CORDA-2352 Be more lenient with setter property signature validation

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/PropertyDescriptor.kt
@@ -207,7 +207,9 @@ private data class PropertyNamedMethod(val fieldName: String, val classifier: Me
     fun hasValidSignature(): Boolean = method.run {
         when (classifier) {
             GET -> parameterCount == 0 && returnType != Void.TYPE
-            SET -> parameterCount == 1 && returnType == Void.TYPE
+            // We don't check the return type, because some Java frameworks (such as Lombok) generate setters
+            // with non-void returns for method chaining.
+            SET -> parameterCount == 1
             IS -> parameterCount == 0 &&
                     (returnType == Boolean::class.java ||
                             returnType == Boolean::class.javaObjectType)

--- a/serialization/src/test/java/net/corda/serialization/internal/amqp/SetterConstructorTests.java
+++ b/serialization/src/test/java/net/corda/serialization/internal/amqp/SetterConstructorTests.java
@@ -25,7 +25,12 @@ public class SetterConstructorTests {
 
         public void setA(int a) { this.a = a; }
         public void setB(int b) { this.b = b; }
-        public void setC(int c) { this.c = c; }
+
+        // See https://r3-cev.atlassian.net/browse/CORDA-2352
+        public C setC(int c) {
+            this.c = c;
+            return this;
+        }
     }
 
     static class C2 {


### PR DESCRIPTION
Correcting a regression introduced by serialisation code refactoring, we relax the rule that "setter" methods must have a void return method, so that serialisation will continue to work with Java frameworks such as Lombok which generate setter methods with non-void returns for method-chaining purposes. See [CORDA-2352](https://r3-cev.atlassian.net/browse/CORDA-2352).