### PR TITLE
ENT-2848 remove need for generated IDs on some frequently used tables

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -4398,6 +4398,14 @@ public static class net.corda.core.schemas.CommonSchemaV1$LinearState extends ne
   public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
   public void setUuid(java.util.UUID)
 ##
+public interface net.corda.core.schemas.DirectStatePersistable extends net.corda.core.schemas.StatePersistable
+  @Nullable
+  public abstract net.corda.core.schemas.PersistentStateRef getStateRef()
+##
+public interface net.corda.core.schemas.IndirectStatePersistable extends net.corda.core.schemas.StatePersistable
+  @NotNull
+  public abstract T getCompositeKey()
+##
 public class net.corda.core.schemas.MappedSchema extends java.lang.Object
   public <init>(Class<?>, int, Iterable<? extends Class<?>>)
   @NotNull

--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -4410,7 +4410,7 @@ public class net.corda.core.schemas.MappedSchema extends java.lang.Object
 ##
 @MappedSuperclass
 @CordaSerializable
-public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.StatePersistable
+public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.DirectStatePersistable
   public <init>()
   public <init>(net.corda.core.schemas.PersistentStateRef)
   @Nullable

--- a/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt
@@ -82,7 +82,7 @@ open class MappedSchema(schemaFamily: Class<*>,
 @KeepForDJVM
 @MappedSuperclass
 @CordaSerializable
-class PersistentState(@EmbeddedId var stateRef: PersistentStateRef? = null) : StatePersistable
+class PersistentState(@EmbeddedId override var stateRef: PersistentStateRef? = null) : DirectStatePersistable
 
 /**
  * Embedded [StateRef] representation used in state mapping.
@@ -105,6 +105,21 @@ data class PersistentStateRef(
  */
 @KeepForDJVM
 interface StatePersistable
+
+/**
+ * Marker interface to denote a persistable Corda state entity that exposes the transaction id and index as composite key called [stateRef].
+ */
+interface DirectStatePersistable : StatePersistable {
+    val stateRef: PersistentStateRef?
+}
+
+/**
+ * Marker interface to denote a persistable Corda state entity that exposes the transaction id and index as a nested composite key called [compositeKey]
+ * that is itself a [DirectStatePersistable].  i.e. exposes a [stateRef].
+ */
+interface IndirectStatePersistable<T : DirectStatePersistable> : StatePersistable {
+    val compositeKey: T
+}
 
 object MappedSchemaValidator {
     fun fieldsFromOtherMappedSchema(schema: MappedSchema) : List<SchemaCrossReferenceReport> =

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -544,9 +544,9 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             }
             predicateSet.add(joinPredicate)
 
-                        // resolve general criteria expressions
-                        @Suppress("UNCHECKED_CAST")
-                        parseExpression(entityRoot as Root<L>, criteria.expression, predicateSet)
+            // resolve general criteria expressions
+            @Suppress("UNCHECKED_CAST")
+            parseExpression(entityRoot as Root<L>, criteria.expression, predicateSet)
         } catch (e: Exception) {
             e.message?.let { message ->
                 if (message.contains("Not an entity"))

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -16,6 +16,7 @@ import net.corda.core.node.services.vault.LikenessOperator.*
 import net.corda.core.node.services.vault.NullOperator.IS_NULL
 import net.corda.core.node.services.vault.NullOperator.NOT_NULL
 import net.corda.core.node.services.vault.QueryCriteria.CommonQueryCriteria
+import net.corda.core.schemas.IndirectStatePersistable
 import net.corda.core.schemas.PersistentState
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.schemas.StatePersistable
@@ -460,7 +461,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             }
 
             // Add the join and participants predicates.
-            val statePartyJoin = criteriaBuilder.equal(vaultStates.get<VaultSchemaV1.VaultStates>("stateRef"), entityRoot.get<VaultSchemaV1.PersistentParty>("stateRef"))
+            val statePartyJoin = criteriaBuilder.equal(vaultStates.get<VaultSchemaV1.VaultStates>("stateRef"), entityRoot.get<VaultSchemaV1.PersistentParty>("compositeKey").get<PersistentStateRef>("stateRef"))
             val participantsPredicate = criteriaBuilder.and(entityRoot.get<VaultSchemaV1.PersistentParty>("x500Name").`in`(participants))
             predicateSet.add(statePartyJoin)
             predicateSet.add(participantsPredicate)
@@ -512,7 +513,7 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
             }
 
             // Add the join and participants predicates.
-            val statePartyJoin = criteriaBuilder.equal(vaultStates.get<VaultSchemaV1.VaultStates>("stateRef"), entityRoot.get<VaultSchemaV1.PersistentParty>("stateRef"))
+            val statePartyJoin = criteriaBuilder.equal(vaultStates.get<VaultSchemaV1.VaultStates>("stateRef"), entityRoot.get<VaultSchemaV1.PersistentParty>("compositeKey").get<PersistentStateRef>("stateRef"))
             val participantsPredicate = criteriaBuilder.and(entityRoot.get<VaultSchemaV1.PersistentParty>("x500Name").`in`(participants))
             predicateSet.add(statePartyJoin)
             predicateSet.add(participantsPredicate)
@@ -536,12 +537,16 @@ class HibernateQueryCriteriaParser(val contractStateType: Class<out ContractStat
                         entityRoot
                     }
 
-            val joinPredicate = criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
+            val joinPredicate = if(IndirectStatePersistable::class.java.isAssignableFrom(entityRoot.javaType)) {
+                        criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<IndirectStatePersistable<*>>("compositeKey").get<PersistentStateRef>("stateRef"))
+                    } else {
+                criteriaBuilder.equal(vaultStates.get<PersistentStateRef>("stateRef"), entityRoot.get<PersistentStateRef>("stateRef"))
+            }
             predicateSet.add(joinPredicate)
 
-            // resolve general criteria expressions
-            @Suppress("UNCHECKED_CAST")
-            parseExpression(entityRoot as Root<L>, criteria.expression, predicateSet)
+                        // resolve general criteria expressions
+                        @Suppress("UNCHECKED_CAST")
+                        parseExpression(entityRoot as Root<L>, criteria.expression, predicateSet)
         } catch (e: Exception) {
             e.message?.let { message ->
                 if (message.contains("Not an entity"))

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -136,8 +136,8 @@ class NodeVaultService(
                 val constraintInfo = Vault.ConstraintInfo(stateAndRef.value.state.constraint)
                 // Save a row for each party in the state_party table.
                 // TODO: Perhaps these can be stored in a batch?
-                stateOnly.participants.forEach { participant ->
-                    val persistentParty = VaultSchemaV1.PersistentParty(persistentStateRef, participant)
+                stateOnly.participants.groupBy { it.owningKey }.forEach { participants ->
+                    val persistentParty = VaultSchemaV1.PersistentParty(persistentStateRef, participants.value.first())
                     session.save(persistentParty)
                 }
                 val stateToAdd = VaultSchemaV1.VaultStates(

--- a/node/src/main/resources/migration/vault-schema.changelog-v8.xml
+++ b/node/src/main/resources/migration/vault-schema.changelog-v8.xml
@@ -6,9 +6,6 @@
         <createTable tableName="state_party">
             <column name="output_index" type="INT"/>
             <column name="transaction_id" type="NVARCHAR(64)"/>
-            <column name="id" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
             <column name="public_key_hash" type="NVARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -33,7 +30,6 @@
         </createIndex>
         <createView viewName="v_pkey_hash_ex_id_map">
             select
-                state_party.id,
                 state_party.public_key_hash,
                 state_party.transaction_id,
                 state_party.output_index,


### PR DESCRIPTION
The generated IDs slow things down, and shouldn't be necessary.  There's a natural primary key.
