### PR TITLE
Fixed incorrect usages of assertFailsWith

### DIFF
--- a/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
+++ b/confidential-identities/src/test/kotlin/net/corda/confidential/SwapIdentitiesFlowTests.kt
@@ -23,10 +23,10 @@ import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.TestStartedNode
 import net.corda.testing.node.internal.cordappsForPackages
 import net.corda.testing.node.internal.startFlow
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.AfterClass
 import org.junit.Test
 import java.security.PublicKey
-import kotlin.test.assertFailsWith
 
 class SwapIdentitiesFlowTests {
     companion object {
@@ -77,10 +77,9 @@ class SwapIdentitiesFlowTests {
     fun `verifies identity name`() {
         val notBob = charlieNode.issueFreshKeyAndCert()
         val signature = charlieNode.signSwapIdentitiesFlowData(notBob, notBob.owningKey)
-        assertFailsWith<SwapIdentitiesException>(
-            "Certificate subject must match counterparty's well known identity.") {
-            aliceNode.validateSwapIdentitiesFlow(bob, notBob, signature)
-        }
+        assertThatThrownBy { aliceNode.validateSwapIdentitiesFlow(bob, notBob, signature) }
+                .isInstanceOf(SwapIdentitiesException::class.java)
+                .hasMessage("Certificate subject must match counterparty's well known identity.")
     }
 
     /**
@@ -93,10 +92,9 @@ class SwapIdentitiesFlowTests {
         val anonymousEvilBob = evilBobNode.issueFreshKeyAndCert()
         val signature = evilBobNode.signSwapIdentitiesFlowData(evilBob, anonymousEvilBob.owningKey)
 
-        assertFailsWith<SwapIdentitiesException>(
-                "Signature does not match the given identity and nonce") {
-            aliceNode.validateSwapIdentitiesFlow(bob, anonymousEvilBob, signature)
-        }
+        assertThatThrownBy { aliceNode.validateSwapIdentitiesFlow(bob, anonymousEvilBob, signature) }
+                .isInstanceOf(SwapIdentitiesException::class.java)
+                .hasMessage("Signature does not match the expected identity ownership assertion.")
     }
 
     @Test
@@ -105,10 +103,9 @@ class SwapIdentitiesFlowTests {
         val anonymousBob = bobNode.issueFreshKeyAndCert()
         val signature = bobNode.signSwapIdentitiesFlowData(anonymousAlice, anonymousBob.owningKey)
 
-        assertFailsWith<SwapIdentitiesException>(
-                "Signature does not match the given identity and nonce.") {
-                aliceNode.validateSwapIdentitiesFlow(bob, anonymousBob, signature)
-        }
+        assertThatThrownBy { aliceNode.validateSwapIdentitiesFlow(bob, anonymousBob, signature) }
+                .isInstanceOf(SwapIdentitiesException::class.java)
+                .hasMessage("Signature does not match the expected identity ownership assertion.")
     }
 
     //region Operations

--- a/core/src/test/kotlin/net/corda/core/transactions/ReferenceInputStateTests.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/ReferenceInputStateTests.kt
@@ -20,6 +20,8 @@ import net.corda.testing.core.TestIdentity
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.ledger
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertFailsWith
@@ -199,9 +201,8 @@ class ReferenceStateTests {
     fun `state ref cannot be a reference input and regular input in the same transaction`() {
         val state = ExampleState(ALICE_PARTY, "HELLO CORDA")
         val stateAndRef = StateAndRef(TransactionState(state, CONTRACT_ID, DUMMY_NOTARY, constraint = AlwaysAcceptAttachmentConstraint), StateRef(SecureHash.zeroHash, 0))
-        assertFailsWith(IllegalArgumentException::class, "A StateRef cannot be both an input and a reference input in the same transaction.") {
-            @Suppress("DEPRECATION") // To be removed when feature is finalised.
+        assertThatIllegalArgumentException().isThrownBy {
             TransactionBuilder(notary = DUMMY_NOTARY).addInputState(stateAndRef).addReferenceState(stateAndRef.referenced())
-        }
+        }.withMessage("A StateRef cannot be both an input and a reference input in the same transaction.")
     }
 }

--- a/finance/contracts/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
+++ b/finance/contracts/src/test/kotlin/net/corda/finance/contracts/asset/CashTests.kt
@@ -696,8 +696,7 @@ class CashTests {
     @Test
     fun generateSpendInsufficientBalance() {
         database.transaction {
-
-            val e: InsufficientBalanceException = assertFailsWith("balance") {
+            val e = assertFailsWith<InsufficientBalanceException> {
                 makeSpend(ourServices, 1000.DOLLARS, miniCorpAnonymised)
             }
             assertEquals((1000 - 580).DOLLARS, e.amountMissing)

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/AliasPrivateKeyTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/crypto/AliasPrivateKeyTest.kt
@@ -2,11 +2,11 @@ package net.corda.nodeapi.internal.crypto
 
 import net.corda.core.crypto.internal.AliasPrivateKey
 import net.corda.testing.internal.stubs.CertificateStoreStubs
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class AliasPrivateKeyTest {
@@ -27,8 +27,8 @@ class AliasPrivateKeyTest {
         // We can retrieve the certificate.
         assertEquals(NOT_YET_REGISTERED_MARKER_KEYS_AND_CERTS.ECDSAR1_CERT, signingCertStore[alias])
         // Although we can store an AliasPrivateKey, we cannot retrieve it. But, it's fine as we use certStore for storing/handling certs only.
-        assertFailsWith<IllegalArgumentException>("Unrecognised algorithm: 2.26.40086077608615255153862931087626791001") {
+        assertThatIllegalArgumentException().isThrownBy {
             signingCertStore.query { getPrivateKey(alias, "entrypassword") }
-        }
+        }.withMessage("Unrecognised algorithm: 1.3.6.1.4.1.50530.1.2")
     }
 }

--- a/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/amqp/CertificateRevocationListNodeTests.kt
@@ -29,6 +29,7 @@ import net.corda.testing.internal.DEV_INTERMEDIATE_CA
 import net.corda.testing.internal.DEV_ROOT_CA
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.internal.stubs.CertificateStoreStubs
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.*
 import org.bouncycastle.cert.jcajce.JcaX509CRLConverter
@@ -62,7 +63,6 @@ import javax.ws.rs.Path
 import javax.ws.rs.Produces
 import javax.ws.rs.core.Response
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 class CertificateRevocationListNodeTests {
     @Rule
@@ -577,14 +577,15 @@ class CertificateRevocationListNodeTests {
         crl.verify(ROOT_CA.keyPair.public)
 
         // Try changing the algorithm to EC will fail.
-        assertFailsWith<IllegalArgumentException>("Unknown signature type requested: EC") {
+        assertThatIllegalArgumentException().isThrownBy {
             createRevocationList(
-                server,
-                EC_ALGORITHM,
-                ROOT_CA.certificate,
-                ROOT_CA.keyPair.private,
-                EMPTY_CRL,
-                true)
-        }
+                    server,
+                    EC_ALGORITHM,
+                    ROOT_CA.certificate,
+                    ROOT_CA.keyPair.private,
+                    EMPTY_CRL,
+                    true
+            )
+        }.withMessage("Unknown signature type requested: EC")
     }
 }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -368,9 +368,9 @@ class NodeAttachmentServiceTest {
         val path = fs.getPath("notajar")
         path.writeLines(listOf("Hey", "there!"))
         path.read {
-            assertFailsWith<IllegalArgumentException>("either empty or not a JAR") {
+            assertThatIllegalArgumentException().isThrownBy {
                 storage.importAttachment(it, "test", null)
-            }
+            }.withMessageContaining("either empty or not a JAR")
         }
     }
 


### PR DESCRIPTION
The overload that takes in a String does NOT check that the exception thrown has that message, which is what these tests are assuming. Rather it's the assertion message when the test fails.

