### PR TITLE
CORDA-2345: Do not re-install CorDapps if possible in MockNetwork

### DIFF
--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -268,7 +268,11 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
 
             // ... bring the node back up ... the act of constructing the SMM will re-register the message handlers
             // that Bob was waiting on before the reboot occurred.
-            bobNode = mockNet.createNode(InternalMockNodeParameters(bobAddr.id, BOB_NAME))
+            // NB: Since CorDapps directory is shared for all nodes - there is no need to re-install CorDapps upon
+            // Bob's restart.
+            // Moreover, on some OSes (Windows) this will fail as we will be trying to replace a file that is open for
+            // reading by Alice's class loader.
+            bobNode = mockNet.createNode(InternalMockNodeParameters(bobAddr.id, BOB_NAME, installCorDapps = false))
             // Find the future representing the result of this state machine again.
             val bobFuture = bobNode.smm.findStateMachines(BuyerAcceptor::class.java).single().second
 


### PR DESCRIPTION
Since CorDapps directory is shared for all nodes - there is no need to re-install CorDapps upon node's restart.
Moreover, on some OSes (Windows) this will fail as we will be trying to replace a file that is open for
reading by different node class loader.

This change should fix failing `master` Windows build:
https://ci-master.corda.r3cev.com/viewLog.html?buildId=134406&buildTypeId=Corda_BuildWindowsTest