### PR TITLE
[CORDA-1992] Better document requirements for Node Explorer

### DIFF
--- a/docs/source/node-explorer.rst
+++ b/docs/source/node-explorer.rst
@@ -14,9 +14,9 @@ Running the UI
 
     ./gradlew tools:explorer:run
 
-.. note:: In order to connect to a given node, the node explorer must have access to all CorDapps loaded on that particular node. By default,
-it only has access to the finance CorDapp. All other CorDapps present on the node must be copied to a ``cordapps`` directory located within
-the directory from which the node explorer is run.
+.. note:: In order to connect to a given node, the node explorer must have access to all CorDapps loaded on that particular node.
+          By default, it only has access to the finance CorDapp.
+          All other CorDapps present on the node must be copied to a ``cordapps`` directory located within the directory from which the node explorer is run.
 
 Running demo nodes
 ------------------

--- a/docs/source/node-explorer.rst
+++ b/docs/source/node-explorer.rst
@@ -13,7 +13,10 @@ Running the UI
 **Other**::
 
     ./gradlew tools:explorer:run
-    
+
+.. note:: In order to connect to a given node, the node explorer must have access to all CorDapps loaded on that particular node. By default,
+it only has access to the finance CorDapp. All other CorDapps present on the node must be copied to a ``cordapps`` directory located within
+the directory from which the node explorer is run.
 
 Running demo nodes
 ------------------


### PR DESCRIPTION
This PR adds a note to the Node Explorer documentation setting out the requirement that all CorDapps on a node must be available to the Node Explorer in order for it to run. These are made available by putting them in a cordapps directory within the directory from which the Node Explorer is run. Note that the finance CorDapp is always available.

Failing to do this leads to the exceptions seen in [CORDA-1992](https://r3-cev.atlassian.net/browse/CORDA-1992) when the Node Explorer connects.
