### PR TITLE
CORDA-2349 - Exclude kotlin.jvm.internal from api scanning

### DIFF
--- a/.ci/check-api-changes.sh
+++ b/.ci/check-api-changes.sh
@@ -44,10 +44,12 @@ $newAbstracts
 EOF
 `
 
-#Get a list of any methods that expose classes in .internal. namespaces, and any classes which extend/implement
-#an internal class
+# Get a list of any methods that expose internal classes, which includes:
+# - classes in .internal. namespaces (excluding the kotlin.jvm.internal namespace)
+# - classes which extend/implement an internal class (see above)
+# - classes in the net.corda.node. namespace
 #TODO: check that only classes in a whitelist are part of the API rather than look for specific invalid cases going forward
-newInternalExposures=$(echo "$userDiffContents" | grep "^+" | grep "\.internal\." )
+newInternalExposures=$(echo "$userDiffContents" | grep "^+" | grep "(?<!kotlin\.jvm)\.internal\." )
 newNodeExposures=$(echo "$userDiffContents" | grep "^+" | grep "net\.corda\.node\.")
 
 internalCount=`grep -v "^$" <<EOF | wc -l


### PR DESCRIPTION
## Changes

This change is related to: https://github.com/corda/corda-gradle-plugins/pull/150
It excludes `jvm.kotlin.internal` from the internal classes that are scanned in the API compatibility checks.

## Testing
- Run the API compatibility tests (`./gradlew generateApi && .ci/check-api-changes.sh`) and verified no new changes, as expected
- Additional tests have been done in the linked PR