### PR TITLE
Fix docs formatting for node-database

### DIFF
--- a/docs/source/node-database.rst
+++ b/docs/source/node-database.rst
@@ -31,6 +31,7 @@ configuration for PostgreSQL:
     }
 
 Note that:
+
 * Database schema name can be set in JDBC URL string e.g. currentSchema=myschema
 * Database schema name must either match the ``dataSource.user`` value to end up
   on the standard schema search path according to the


### PR DESCRIPTION
Added a new-line before the beginning of the list, because otherwise markdown is not recognised as list, leading to a broken format.