### PR TITLE
CORDA-1942: Renamed NetworkParametersStorage to NetworkParametersService to match its public usage

### DIFF
--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/JacksonSupportTest.kt
@@ -25,7 +25,7 @@ import net.corda.core.internal.DigitalSignatureWithCert
 import net.corda.core.node.NodeInfo
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.AttachmentStorage
-import net.corda.core.node.services.NetworkParametersStorage
+import net.corda.core.node.services.NetworkParametersService
 import net.corda.core.node.services.TransactionStorage
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializedBytes
@@ -96,10 +96,10 @@ class JacksonSupportTest(@Suppress("unused") private val name: String, factory: 
         services = rigorousMock()
         cordappProvider = rigorousMock()
         val networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
-        val networkParametersStorage = rigorousMock<NetworkParametersStorage>().also {
+        val networkParametersService = rigorousMock<NetworkParametersService>().also {
             doReturn(networkParameters.serialize().hash).whenever(it).currentHash
         }
-        doReturn(networkParametersStorage).whenever(services).networkParametersStorage
+        doReturn(networkParametersService).whenever(services).networkParametersService
         doReturn(cordappProvider).whenever(services).cordappProvider
         doReturn(networkParameters).whenever(services).networkParameters
         doReturn(attachments).whenever(services).attachments

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryChangeFlow.kt
@@ -34,7 +34,7 @@ class NotaryChangeFlow<out T : ContractState>(
                 inputs.map { it.ref },
                 originalState.state.notary,
                 modification,
-                serviceHub.networkParametersStorage.currentHash
+                serviceHub.networkParametersService.currentHash
         ).build()
 
         val participantKeys = inputs.flatMap { it.state.data.participants }.map { it.owningKey }.toSet()

--- a/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
+++ b/core/src/main/kotlin/net/corda/core/flows/NotaryFlow.kt
@@ -10,7 +10,7 @@ import net.corda.core.crypto.TransactionSignature
 import net.corda.core.identity.Party
 import net.corda.core.internal.BackpressureAwareTimedFlow
 import net.corda.core.internal.FetchDataFlow
-import net.corda.core.internal.notary.HistoricNetworkParameterStorage
+import net.corda.core.internal.NetworkParametersServiceInternal
 import net.corda.core.internal.notary.generateSignature
 import net.corda.core.internal.notary.validateSignatures
 import net.corda.core.internal.pushToLoggingContext
@@ -107,7 +107,7 @@ class NotaryFlow {
                 check(stx.coreTransaction is NotaryChangeWireTransaction) {
                     "Notary $notaryParty is not on the network parameter whitelist. A non-whitelisted notary can only be used for notary change transactions"
                 }
-                val historicNotary = (serviceHub.networkParametersStorage as HistoricNetworkParameterStorage).getHistoricNotary(notaryParty)
+                val historicNotary = (serviceHub.networkParametersService as NetworkParametersServiceInternal).getHistoricNotary(notaryParty)
                         ?: throw IllegalStateException("The notary party $notaryParty specified by transaction ${stx.id}, is not recognised as a current or historic notary.")
                 historicNotary.validating
 

--- a/core/src/main/kotlin/net/corda/core/internal/ContractUpgradeUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ContractUpgradeUtils.kt
@@ -21,7 +21,7 @@ object ContractUpgradeUtils {
             else -> getContractAttachmentId(stateAndRef.state.contract, services)
         }
         val upgradedContractAttachmentId = getContractAttachmentId(upgradedContractClass.name, services)
-        val networkParametersHash = services.networkParametersStorage.currentHash
+        val networkParametersHash = services.networkParametersService.currentHash
 
         val inputs = listOf(stateAndRef.ref)
         return ContractUpgradeTransactionBuilder(

--- a/core/src/main/kotlin/net/corda/core/internal/NetworkParametersServiceInternal.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/NetworkParametersServiceInternal.kt
@@ -1,9 +1,10 @@
-package net.corda.core.internal.notary
+package net.corda.core.internal
 
 import net.corda.core.identity.Party
 import net.corda.core.node.NotaryInfo
+import net.corda.core.node.services.NetworkParametersService
 
-interface HistoricNetworkParameterStorage {
+interface NetworkParametersServiceInternal : NetworkParametersService {
     /**
      * Returns the [NotaryInfo] for a notary [party] in the current or any historic network parameter whitelist, or null if not found.
      */

--- a/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/TransactionUtils.kt
@@ -166,7 +166,7 @@ fun FlowLogic<*>.checkParameterHash(networkParametersHash: SecureHash?) {
         if (serviceHub.networkParameters.minimumPlatformVersion < 4) return
         else throw IllegalArgumentException("Transaction for notarisation doesn't contain network parameters hash.")
     } else {
-        serviceHub.networkParametersStorage.lookup(networkParametersHash) ?: throw IllegalArgumentException("Transaction for notarisation contains unknown parameters hash: $networkParametersHash")
+        serviceHub.networkParametersService.lookup(networkParametersHash) ?: throw IllegalArgumentException("Transaction for notarisation contains unknown parameters hash: $networkParametersHash")
     }
 
     // TODO: [ENT-2666] Implement network parameters fuzzy checking. By design in Corda network we have propagation time delay.

--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -38,8 +38,8 @@ interface ServicesForResolution {
     /** Provides access to anything relating to cordapps including contract attachment resolution and app context */
     val cordappProvider: CordappProvider
 
-    /** Provides access to storage of historical network parameters that are used in transaction resolution */
-    val networkParametersStorage: NetworkParametersStorage
+    /** Provides access to historical network parameters that are used in transaction resolution. */
+    val networkParametersService: NetworkParametersService
 
     /** Returns the network parameters the node is operating under. */
     val networkParameters: NetworkParameters

--- a/core/src/main/kotlin/net/corda/core/node/services/NetworkParametersService.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/NetworkParametersService.kt
@@ -2,16 +2,14 @@ package net.corda.core.node.services
 
 import net.corda.core.DoNotImplement
 import net.corda.core.crypto.SecureHash
-import net.corda.core.identity.Party
 import net.corda.core.node.NetworkParameters
-import net.corda.core.node.NotaryInfo
 
 /**
- * Interface for handling network parameters storage used for resolving transactions according to parameters that were
+ * Service for retrieving network parameters used for resolving transactions according to parameters that were
  * historically in force in the network.
  */
 @DoNotImplement
-interface NetworkParametersStorage {
+interface NetworkParametersService {
     /**
      * Hash of the current parameters for the network.
      */
@@ -23,8 +21,7 @@ interface NetworkParametersStorage {
     val defaultHash: SecureHash
 
     /**
-     * Return network parameters for the given hash. Null if there are no parameters for this hash in the storage and we are unable to
-     * get them from network map.
+     * Return the network parameters with the given hash, or null if it doesn't exist.
      */
     fun lookup(hash: SecureHash): NetworkParameters?
 }

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -111,8 +111,8 @@ data class ContractUpgradeWireTransaction(
                 ?: throw AttachmentResolutionException(legacyContractAttachmentId)
         val upgradedContractAttachment = services.attachments.openAttachment(upgradedContractAttachmentId)
                 ?: throw AttachmentResolutionException(upgradedContractAttachmentId)
-        val hashToResolve = networkParametersHash ?: services.networkParametersStorage.defaultHash
-        val resolvedNetworkParameters = services.networkParametersStorage.lookup(hashToResolve) ?: throw TransactionResolutionException(id)
+        val hashToResolve = networkParametersHash ?: services.networkParametersService.defaultHash
+        val resolvedNetworkParameters = services.networkParametersService.lookup(hashToResolve) ?: throw TransactionResolutionException(id)
         return ContractUpgradeLedgerTransaction(
                 resolvedInputs,
                 notary,

--- a/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/NotaryChangeTransactions.kt
@@ -78,8 +78,8 @@ data class NotaryChangeWireTransaction(
     @DeleteForDJVM
     fun resolve(services: ServicesForResolution, sigs: List<TransactionSignature>): NotaryChangeLedgerTransaction {
         val resolvedInputs = services.loadStates(inputs.toSet()).toList()
-        val hashToResolve = networkParametersHash ?: services.networkParametersStorage.defaultHash
-        val resolvedNetworkParameters = services.networkParametersStorage.lookup(hashToResolve)
+        val hashToResolve = networkParametersHash ?: services.networkParametersService.defaultHash
+        val resolvedNetworkParameters = services.networkParametersService.lookup(hashToResolve)
                 ?: throw TransactionResolutionException(id)
         return NotaryChangeLedgerTransaction.create(resolvedInputs, notary, newNotary, id, sigs, resolvedNetworkParameters)
     }

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -156,7 +156,7 @@ open class TransactionBuilder @JvmOverloads constructor(
                             notary,
                             window,
                             referenceStates,
-                            services.networkParametersStorage.currentHash),
+                            services.networkParametersService.currentHash),
                     privacySalt
             )
         }

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -105,8 +105,8 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
                 resolveAttachment = { services.attachments.openAttachment(it) },
                 resolveStateRefAsSerialized = { resolveStateRefBinaryComponent(it, services) },
                 resolveParameters = {
-                    val hashToResolve = it ?: services.networkParametersStorage.defaultHash
-                    services.networkParametersStorage.lookup(hashToResolve)
+                    val hashToResolve = it ?: services.networkParametersService.defaultHash
+                    services.networkParametersService.lookup(hashToResolve)
                 },
                 resolveContractAttachment = { services.loadContractAttachment(it) }
         )

--- a/core/src/test/kotlin/net/corda/core/transactions/TransactionBuilderTest.kt
+++ b/core/src/test/kotlin/net/corda/core/transactions/TransactionBuilderTest.kt
@@ -10,12 +10,11 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.Party
 import net.corda.core.internal.AbstractAttachment
 import net.corda.core.internal.PLATFORM_VERSION
-import net.corda.core.internal.RPC_UPLOADER
 import net.corda.core.internal.cordapp.CordappImpl.Companion.DEFAULT_CORDAPP_VERSION
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.ZoneVersionTooLowException
 import net.corda.core.node.services.AttachmentStorage
-import net.corda.core.node.services.NetworkParametersStorage
+import net.corda.core.node.services.NetworkParametersService
 import net.corda.core.serialization.serialize
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
@@ -40,14 +39,14 @@ class TransactionBuilderTest {
     private val services = rigorousMock<ServicesForResolution>()
     private val contractAttachmentId = SecureHash.randomSHA256()
     private val attachments = rigorousMock<AttachmentStorage>()
-    private val networkParametersStorage = mock<NetworkParametersStorage>()
+    private val networkParametersService = mock<NetworkParametersService>()
 
     @Before
     fun setup() {
         val cordappProvider = rigorousMock<CordappProvider>()
         val networkParameters = testNetworkParameters(minimumPlatformVersion = PLATFORM_VERSION)
-        doReturn(networkParametersStorage).whenever(services).networkParametersStorage
-        doReturn(networkParameters.serialize().hash).whenever(networkParametersStorage).currentHash
+        doReturn(networkParametersService).whenever(services).networkParametersService
+        doReturn(networkParameters.serialize().hash).whenever(networkParametersService).currentHash
         doReturn(cordappProvider).whenever(services).cordappProvider
         doReturn(contractAttachmentId).whenever(cordappProvider).getContractAttachmentID(DummyContract.PROGRAM_ID)
         doReturn(networkParameters).whenever(services).networkParameters
@@ -78,7 +77,7 @@ class TransactionBuilderTest {
         val wtx = builder.toWireTransaction(services)
         assertThat(wtx.outputs).containsOnly(outputState)
         assertThat(wtx.commands).containsOnly(Command(DummyCommandData, notary.owningKey))
-        assertThat(wtx.networkParametersHash).isEqualTo(networkParametersStorage.currentHash)
+        assertThat(wtx.networkParametersHash).isEqualTo(networkParametersService.currentHash)
     }
 
     @Test

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
@@ -12,7 +12,7 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.cordapp.CordappImpl.Companion.DEFAULT_CORDAPP_VERSION
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.services.AttachmentStorage
-import net.corda.core.node.services.NetworkParametersStorage
+import net.corda.core.node.services.NetworkParametersService
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
 import net.corda.core.transactions.LedgerTransaction
@@ -71,7 +71,7 @@ class AttachmentsClassLoaderStaticContractTests {
 
     private val networkParameters = testNetworkParameters()
 
-    private val networkParametersStorage get() = mock<NetworkParametersStorage>().also {
+    private val networkParametersService get() = mock<NetworkParametersService>().also {
         doReturn(networkParameters.serialize().hash).whenever(it).currentHash
     }
 
@@ -79,7 +79,7 @@ class AttachmentsClassLoaderStaticContractTests {
         val cordappProviderImpl = CordappProviderImpl(cordappLoaderForPackages(listOf("net.corda.nodeapi.internal")), MockCordappConfigProvider(), MockAttachmentStorage())
         cordappProviderImpl.start(testNetworkParameters().whitelistedContractImplementations)
         doReturn(cordappProviderImpl).whenever(it).cordappProvider
-        doReturn(networkParametersStorage).whenever(it).networkParametersStorage
+        doReturn(networkParametersService).whenever(it).networkParametersService
         doReturn(networkParameters).whenever(it).networkParameters
         val attachmentStorage = rigorousMock<AttachmentStorage>()
         doReturn(attachmentStorage).whenever(it).attachments

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -171,7 +171,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     val attachments = NodeAttachmentService(metricRegistry, cacheFactory, database).tokenize()
     val cryptoService = configuration.makeCryptoService()
     @Suppress("LeakingThis")
-    val networkParametersStorage = makeParametersStorage()
+    val networkParametersStorage = makeNetworkParametersStorage()
     val cordappProvider = CordappProviderImpl(cordappLoader, CordappConfigFileProvider(configuration.cordappDirectories), attachments).tokenize()
     @Suppress("LeakingThis")
     val keyManagementService = makeKeyManagementService(identityService).tokenize()
@@ -712,7 +712,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         return DBTransactionStorage(database, cacheFactory)
     }
 
-    protected open fun makeParametersStorage(): NetworkParametersStorageInternal {
+    protected open fun makeNetworkParametersStorage(): NetworkParametersStorage {
         return DBNetworkParametersStorage(cacheFactory, database, networkMapClient).tokenize()
     }
 
@@ -1012,7 +1012,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         override val configuration: NodeConfiguration get() = this@AbstractNode.configuration
         override val networkMapUpdater: NetworkMapUpdater get() = this@AbstractNode.networkMapUpdater
         override val cacheFactory: NamedCacheFactory get() = this@AbstractNode.cacheFactory
-        override val networkParametersStorage: NetworkParametersStorage get() = this@AbstractNode.networkParametersStorage
+        override val networkParametersService: NetworkParametersStorage get() = this@AbstractNode.networkParametersStorage
 
         private lateinit var _myInfo: NodeInfo
         override val myInfo: NodeInfo get() = _myInfo

--- a/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/DBNetworkParametersStorage.kt
@@ -5,10 +5,9 @@ import net.corda.core.identity.Party
 import net.corda.core.internal.DigitalSignatureWithCert
 import net.corda.core.internal.NamedCacheFactory
 import net.corda.core.internal.SignedDataWithCert
-import net.corda.core.internal.notary.HistoricNetworkParameterStorage
+import net.corda.core.internal.NetworkParametersServiceInternal
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
-import net.corda.core.node.services.NetworkParametersStorage
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.serialization.deserialize
@@ -27,7 +26,7 @@ import org.apache.commons.lang.ArrayUtils
 import java.security.cert.X509Certificate
 import javax.persistence.*
 
-interface NetworkParametersStorageInternal : NetworkParametersStorage {
+interface NetworkParametersStorage : NetworkParametersServiceInternal {
     /**
      * Return parameters epoch for the given parameters hash. Null if there are no parameters for this hash in the storage and we are unable to
      * get them from network map.
@@ -50,7 +49,7 @@ class DBNetworkParametersStorage(
         // TODO It's very inefficient solution (at least at the beginning when node joins without historical data)
         // We could have historic parameters endpoint or always add parameters as an attachment to the transaction.
         private val networkMapClient: NetworkMapClient?
-) : NetworkParametersStorageInternal, HistoricNetworkParameterStorage, SingletonSerializeAsToken() {
+) : NetworkParametersStorage, SingletonSerializeAsToken() {
     private lateinit var trustRoot: X509Certificate
 
     companion object {

--- a/node/src/main/kotlin/net/corda/node/internal/ServicesForResolutionImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/ServicesForResolutionImpl.kt
@@ -6,8 +6,8 @@ import net.corda.core.internal.SerializedStateAndRef
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.services.AttachmentStorage
-import net.corda.core.node.services.NetworkParametersStorage
 import net.corda.core.node.services.IdentityService
+import net.corda.core.node.services.NetworkParametersService
 import net.corda.core.node.services.TransactionStorage
 import net.corda.core.transactions.ContractUpgradeWireTransaction
 import net.corda.core.transactions.NotaryChangeWireTransaction
@@ -18,10 +18,10 @@ data class ServicesForResolutionImpl(
         override val identityService: IdentityService,
         override val attachments: AttachmentStorage,
         override val cordappProvider: CordappProvider,
-        override val networkParametersStorage: NetworkParametersStorage,
+        override val networkParametersService: NetworkParametersService,
         private val validatedTransactions: TransactionStorage
 ) : ServicesForResolution {
-    override val networkParameters: NetworkParameters get() = networkParametersStorage.lookup(networkParametersStorage.currentHash) ?:
+    override val networkParameters: NetworkParameters get() = networkParametersService.lookup(networkParametersService.currentHash) ?:
             throw IllegalArgumentException("No current parameters in network parameters storage")
 
     @Throws(TransactionResolutionException::class)

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapUpdater.kt
@@ -13,7 +13,7 @@ import net.corda.core.node.services.KeyManagementService
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.minutes
-import net.corda.node.internal.NetworkParametersStorageInternal
+import net.corda.node.internal.NetworkParametersStorage
 import net.corda.node.services.api.NetworkMapCacheInternal
 import net.corda.node.services.config.NetworkParameterAcceptanceSettings
 import net.corda.node.utilities.NamedThreadFactory
@@ -41,7 +41,7 @@ class NetworkMapUpdater(private val networkMapCache: NetworkMapCacheInternal,
                         private val networkMapClient: NetworkMapClient?,
                         private val baseDirectory: Path,
                         private val extraNetworkMapKeys: List<UUID>,
-                        private val networkParametersStorage: NetworkParametersStorageInternal
+                        private val networkParametersStorage: NetworkParametersStorage
 ) : AutoCloseable {
     companion object {
         private val logger = contextLogger()

--- a/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
+++ b/node/src/main/kotlin/net/corda/node/services/transactions/NonValidatingNotaryFlow.kt
@@ -72,13 +72,13 @@ class NonValidatingNotaryFlow(otherSideSession: FlowSession, service: SinglePart
             if (attachedParameterHash == null) {
                 throw IllegalArgumentException("Transaction must contain network parameters.")
             }
-            val attachedParameters = serviceHub.networkParametersStorage.lookup(attachedParameterHash)
+            val attachedParameters = serviceHub.networkParametersService.lookup(attachedParameterHash)
                     ?: throw IllegalStateException("Unable to resolve network parameters from hash: $attachedParameterHash")
 
             checkInWhitelist(attachedParameters, notary)
         } else {
             // Using current network parameters for platform versions 3 or earlier.
-            val defaultParams = with(serviceHub.networkParametersStorage) {
+            val defaultParams = with(serviceHub.networkParametersService) {
                 lookup(currentHash)
                         ?: throw IllegalStateException("Unable to verify whether the notary $notary is whitelisted: current network parameters not set.")
             }

--- a/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/network/NetworkMapUpdaterTest.kt
@@ -18,7 +18,7 @@ import net.corda.core.node.services.AttachmentId
 import net.corda.core.serialization.serialize
 import net.corda.core.utilities.millis
 import net.corda.node.VersionInfo
-import net.corda.node.internal.NetworkParametersStorageInternal
+import net.corda.node.internal.NetworkParametersStorage
 import net.corda.node.services.api.NetworkMapCacheInternal
 import net.corda.node.services.config.NetworkParameterAcceptanceSettings
 import net.corda.nodeapi.internal.NodeInfoAndSigned
@@ -71,7 +71,7 @@ class NetworkMapUpdaterTest {
     private val networkMapCache = createMockNetworkMapCache()
     private lateinit var ourKeyPair: KeyPair
     private lateinit var ourNodeInfo: SignedNodeInfo
-    private val networkParametersStorage: NetworkParametersStorageInternal = mock()
+    private val networkParametersStorage: NetworkParametersStorage = mock()
     private lateinit var server: NetworkMapServer
     private lateinit var networkMapClient: NetworkMapClient
     private var updater: NetworkMapUpdater? = null

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateColumnConverterTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateColumnConverterTests.kt
@@ -2,24 +2,21 @@ package net.corda.node.services.persistence
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
-import net.corda.core.node.NotaryInfo
-import net.corda.core.serialization.CordaSerializable
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
-import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.getOrThrow
 import net.corda.finance.DOLLARS
 import net.corda.finance.`issued by`
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.AbstractCashFlow
-import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.issuedBy
-import net.corda.node.internal.NetworkParametersStorageInternal
 import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.keys.E2ETestKeyManagementService
-import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.core.BOC_NAME
+import net.corda.testing.internal.TestingNamedCacheFactory
 import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.StartedMockNode
@@ -48,7 +45,7 @@ class HibernateColumnConverterTests {
             return Result(tx, ourIdentity)
         }
     }
-
+    
     @Before
     fun start() {
         mockNet = MockNetwork(

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -22,7 +22,6 @@ import net.corda.testing.node.internal.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
@@ -89,7 +88,7 @@ class NotaryServiceTests {
 
         private fun generateTransaction(node: TestStartedNode,
                                         party: Party, notary: Party,
-                                        paramsHash: SecureHash? = node.services.networkParametersStorage.currentHash,
+                                        paramsHash: SecureHash? = node.services.networkParametersService.currentHash,
                                         numberOfInputs: Int = 10_005): SignedTransaction {
             val txHash = SecureHash.randomSHA256()
             val inputs = (1..numberOfInputs).map { StateRef(txHash, it) }

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
@@ -222,7 +222,7 @@ class NotaryWhitelistTests(
                 listOf(inputState.ref),
                 fakeNotaryParty,
                 oldNotary,
-                aliceNode.services.networkParametersStorage.currentHash
+                aliceNode.services.networkParametersService.currentHash
         ).build()
 
         val notaryChangeAliceSig = getAliceSig(notaryChangeTx)

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -646,7 +646,7 @@ class NodeVaultServiceTest {
         // Change notary
         services.identityService.verifyAndRegisterIdentity(DUMMY_NOTARY_IDENTITY)
         val newNotary = DUMMY_NOTARY
-        val changeNotaryTx = NotaryChangeTransactionBuilder(listOf(initialCashState.ref), issueStx.notary!!, newNotary, services.networkParametersStorage.currentHash).build()
+        val changeNotaryTx = NotaryChangeTransactionBuilder(listOf(initialCashState.ref), issueStx.notary!!, newNotary, services.networkParametersService.currentHash).build()
         val cashStateWithNewNotary = StateAndRef(initialCashState.state.copy(notary = newNotary), StateRef(changeNotaryTx.id, 0))
 
         database.transaction {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/NodeTestUtils.kt
@@ -23,14 +23,14 @@ fun ServiceHub.ledger(
         notary: Party = TestIdentity.fresh("ledger notary").party,
         script: LedgerDSL<TestTransactionDSLInterpreter, TestLedgerDSLInterpreter>.() -> Unit
 ): LedgerDSL<TestTransactionDSLInterpreter, TestLedgerDSLInterpreter> {
-    val currentParameters = networkParametersStorage.run {
+    val currentParameters = networkParametersService.run {
         lookup(currentHash) ?: throw IllegalStateException("Current network parameters not found, $currentHash")
 
     }
     if (currentParameters.notaries.none { it.identity == notary }) {
         // Add the notary to the whitelist. Otherwise no constructed transactions will verify.
         val newParameters = currentParameters.addNotary(notary)
-        (networkParametersStorage as MockNetworkParametersStorage).setCurrentParametersUnverified(newParameters)
+        (networkParametersService as MockNetworkParametersStorage).setCurrentParametersUnverified(newParameters)
     }
 
     return withTestSerializationEnvIfNotSet {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -30,7 +30,7 @@ import net.corda.core.utilities.seconds
 import net.corda.node.VersionInfo
 import net.corda.node.internal.AbstractNode
 import net.corda.node.internal.InitiatedFlowFactory
-import net.corda.node.internal.NetworkParametersStorageInternal
+import net.corda.node.internal.NetworkParametersStorage
 import net.corda.node.internal.NodeFlowManager
 import net.corda.node.services.api.FlowStarter
 import net.corda.node.services.api.ServiceHubInternal
@@ -437,9 +437,7 @@ open class InternalMockNetwork(cordappPackages: List<String> = emptyList(),
             }
         }
 
-        override fun makeParametersStorage(): NetworkParametersStorageInternal {
-            return MockNetworkParametersStorage()
-        }
+        override fun makeNetworkParametersStorage(): NetworkParametersStorage = MockNetworkParametersStorage()
     }
 
     fun createUnstartedNode(parameters: InternalMockNodeParameters = InternalMockNodeParameters()): MockNode {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersService.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/MockNetworkParametersService.kt
@@ -3,18 +3,17 @@ package net.corda.testing.node.internal
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.Party
 import net.corda.core.internal.SignedDataWithCert
-import net.corda.core.internal.notary.HistoricNetworkParameterStorage
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.NotaryInfo
 import net.corda.core.serialization.serialize
-import net.corda.node.internal.NetworkParametersStorageInternal
+import net.corda.node.internal.NetworkParametersStorage
 import net.corda.nodeapi.internal.network.verifiedNetworkMapCert
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.internal.withTestSerializationEnvIfNotSet
 import java.security.cert.X509Certificate
 import java.time.Instant
 
-class MockNetworkParametersStorage(private var currentParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN)) : NetworkParametersStorageInternal, HistoricNetworkParameterStorage {
+class MockNetworkParametersStorage(private var currentParameters: NetworkParameters = testNetworkParameters(modifiedTime = Instant.MIN)) : NetworkParametersStorage {
     private val hashToParametersMap: HashMap<SecureHash, NetworkParameters> = HashMap()
 
     init {


### PR DESCRIPTION
As a public API it's not a true storage - CorDapps can't add network parameters.

