### PR TITLE
CORDA-2391: Revert behaviour of Try.on to V3

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/subcommands/InitialRegistrationCli.kt
@@ -16,6 +16,7 @@ import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 import java.io.File
 import java.nio.file.Path
+import java.util.function.Consumer
 
 class InitialRegistrationCli(val startup: NodeStartup): CliWrapperBase("initial-registration", "Start initial node registration with Corda network to obtain certificate from the permissioning server.") {
     @Option(names = ["-t", "--network-root-truststore"], description = ["Network root trust store obtained from network operator."])
@@ -83,7 +84,7 @@ class InitialRegistration(val baseDirectory: Path, private val networkRootTrustS
 
     private fun initialRegistration(config: NodeConfiguration) {
         // Null checks for [compatibilityZoneURL], [rootTruststorePath] and [rootTruststorePassword] has been done in [CmdLineOptions.loadConfig]
-        attempt { registerWithNetwork(config) }.doOnException(this::handleRegistrationError) as Try.Success
+        attempt { registerWithNetwork(config) }.doOnFailure(Consumer(this::handleRegistrationError)) as Try.Success
         // At this point the node registration was successful. We can delete the marker file.
         deleteNodeRegistrationMarker(baseDirectory)
     }


### PR DESCRIPTION
Apps may depend on the previous behaviour of catching Throwable rather than just Exception. Better to not risk this break and instead provide a helper to throw Errors.

Also using Consumer to avoid ugly usage in Java for doOnSuccess and doOnFailure.

