### PR TITLE
CORDA-4498 - Incorrect description of `ServiceHub.jdbcSession`

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
+++ b/core/src/main/kotlin/net/corda/core/node/ServiceHub.kt
@@ -359,7 +359,7 @@ interface ServiceHub : ServicesForResolution {
      * and thus queryable data will include everything committed as of the last checkpoint.
      *
      * @throws IllegalStateException if called outside of a transaction.
-     * @return A new [Connection]
+     * @return A [Connection]
      */
     fun jdbcSession(): Connection
 


### PR DESCRIPTION
As requested in https://github.com/corda/corda/issues/4498 I created a pull request with the new description