### PR TITLE
CORDA-2375 Ensure node has unique attachment contract classname/version from signed JARs

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteriaUtils.kt
@@ -212,7 +212,7 @@ data class Sort(val columns: Collection<SortColumn>) : BaseSort() {
 data class AttachmentSort(val columns: Collection<AttachmentSortColumn>) : BaseSort() {
 
     enum class AttachmentSortAttribute(val columnName: String) {
-        INSERTION_DATE("insertion_date"),
+        INSERTION_DATE("insertionDate"),
         UPLOADER("uploader"),
         FILENAME("filename"),
         VERSION ("version")

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -230,6 +230,23 @@ The contract attachment non-downgrade rule is enforced in two locations:
 A version number is stored in the manifest information of the enclosing JAR file. This version identifier should be a whole number starting
 from 1. This information should be set using the Gradle cordapp plugin, or manually, as described in :doc:`versioning`.
 
+
+Uniqueness requirement Contract and Version for Signature Constraint
+--------------------------------------------------------------------
+
+Corda Node ensures a given contract class and version can be sourced from a single signed Contract JAR (attachment) only.
+When building a transaction with a signature constraints the node can safely select the unique attachment containing the contract code of the exact version.
+For transactions with Hash Constraint or Zone Constraint there's no requirement for a unique version number per contract class,
+because a contract is denoted by the AttachmentID (hash).
+However it is a good practice to add version to Contract JAR. The node will logs warning if the version or duplicated attachment is found.
+
+At runtime an attempt to load a signed Contract JAR with a contract class and version which is already present in the attachment store
+will raise ``DuplicateContractClassException`` exception.
+Additional check is done to prevent misconfiguration due to adding an attachment directly to the database (e.g. manual SQL which skips runtime import code).
+When Transaction Builder selects an attachment (for a transaction with Signature Constraint),
+any duplication of the signed attachment for a given contract and version will raise an exception ``DuplicateContractClassIllegalState``.
+
+
 Issues when using the HashAttachmentConstraint
 ----------------------------------------------
 

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -234,18 +234,13 @@ from 1. This information should be set using the Gradle cordapp plugin, or manua
 Uniqueness requirement Contract and Version for Signature Constraint
 --------------------------------------------------------------------
 
-Corda Node ensures a given contract class and version can be sourced from a single signed Contract JAR (attachment) only.
-When building a transaction with a signature constraints the node can safely select the unique attachment containing the contract code of the exact version.
-For transactions with Hash Constraint or Zone Constraint there's no requirement for a unique version number per contract class,
-because a contract is denoted by the AttachmentID (hash).
+From Corda 4 a node ensures a given contract class and version can be sourced from a single signed Contract JAR (attachment) only.
+When building a transaction with a signature constraints the node can can safely select this unique, signed and versioned attachment.
+Prior to Corda 4 all attachments were unsigned, un-versioned and explicitly stored by hash in the attachment store.
 However it is a good practice to add version to Contract JAR. The node will logs warning if the version or duplicated attachment is found.
 
 At runtime an attempt to load a signed Contract JAR with a contract class and version which is already present in the attachment store
 will raise ``DuplicateContractClassException`` exception.
-Additional check is done to prevent misconfiguration due to adding an attachment directly to the database (e.g. manual SQL which skips runtime import code).
-When Transaction Builder selects an attachment (for a transaction with Signature Constraint),
-any duplication of the signed attachment for a given contract and version will raise an exception ``DuplicateContractClassIllegalState``.
-
 
 Issues when using the HashAttachmentConstraint
 ----------------------------------------------

--- a/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
@@ -12,6 +12,12 @@ import net.corda.core.serialization.CordaSerializable
 class DuplicateAttachmentException(attachmentHash: String) : java.nio.file.FileAlreadyExistsException(attachmentHash), ClientRelevantError
 
 /**
+ * Thrown to indicate that an contract class name of the same version was already uploaded to a Corda node.
+ */
+class DuplicateContractClass(attachmentHash: String, otherAttachmentHash: String, contractClassName: String, version: Int, isSigned: Boolean) : java.nio.file.FileAlreadyExistsException(
+        attachmentHash, otherAttachmentHash, "Contract $contractClassName version '$version' of ${if (isSigned) "signed" else "unsigned"} JAR is already present in the attachment $otherAttachmentHash"), ClientRelevantError
+
+/**
  * Thrown to indicate that a flow was not designed for RPC and should be started from an RPC client.
  */
 class NonRpcFlowException(logicType: Class<*>) : IllegalArgumentException("${logicType.name} was not designed for RPC"), ClientRelevantError

--- a/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/exceptions/RpcExceptions.kt
@@ -12,10 +12,10 @@ import net.corda.core.serialization.CordaSerializable
 class DuplicateAttachmentException(attachmentHash: String) : java.nio.file.FileAlreadyExistsException(attachmentHash), ClientRelevantError
 
 /**
- * Thrown to indicate that an contract class name of the same version was already uploaded to a Corda node.
+ * Thrown to indicate that a contract class name of the same version was already uploaded to a Corda node.
  */
-class DuplicateContractClass(attachmentHash: String, otherAttachmentHash: String, contractClassName: String, version: Int, isSigned: Boolean) : java.nio.file.FileAlreadyExistsException(
-        attachmentHash, otherAttachmentHash, "Contract $contractClassName version '$version' of ${if (isSigned) "signed" else "unsigned"} JAR is already present in the attachment $otherAttachmentHash"), ClientRelevantError
+class DuplicateContractClassException(contractClassName: String, version: Int, attachmentHashes: List<String>) :
+        Exception("Contract $contractClassName version '$version' already present in the attachments $attachmentHashes"), ClientRelevantError
 
 /**
  * Thrown to indicate that a flow was not designed for RPC and should be started from an RPC client.

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -231,11 +231,15 @@ class HibernateAttachmentQueryCriteriaParser(override val criteriaBuilder: Crite
         }
 
         criteria.isSignedCondition?.let { isSigned ->
-            val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers")
-            if (isSigned == Builder.equal(true))
+            if (isSigned == Builder.equal(true)) {
+                val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers")
                 predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNotNull))
-            else
+            } else {
+                val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers", JoinType.LEFT)
                 predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNull))
+                // TODO Something like the line below would be better solution than left join:
+                // predicateSet.add(criteriaBuilder.isEmpty(root.get<List<PublicKey>?>("signers")))
+            }
         }
 
         criteria.versionCondition?.let {

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -235,10 +235,11 @@ class HibernateAttachmentQueryCriteriaParser(override val criteriaBuilder: Crite
                 val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers")
                 predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNotNull))
             } else {
-                val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers", JoinType.LEFT)
-                predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNull))
+                //val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers", JoinType.LEFT)
+                //predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNull))
                 // TODO Something like the line below would be better solution than left join:
-                // predicateSet.add(criteriaBuilder.isEmpty(root.get<List<PublicKey>?>("signers")))
+                 //predicateSet.add(criteriaBuilder.isEmpty(root.get<List<PublicKey>?>("signers")))
+                predicateSet.add(criteriaBuilder.equal(criteriaBuilder.size(root.get<List<PublicKey>?>("signers")),0))
             }
         }
 

--- a/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/HibernateQueryCriteriaParser.kt
@@ -235,10 +235,6 @@ class HibernateAttachmentQueryCriteriaParser(override val criteriaBuilder: Crite
                 val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers")
                 predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNotNull))
             } else {
-                //val joinDBAttachmentToSigners = root.joinList<NodeAttachmentService.DBAttachment, PublicKey>("signers", JoinType.LEFT)
-                //predicateSet.add(criteriaBuilder.and(joinDBAttachmentToSigners.isNull))
-                // TODO Something like the line below would be better solution than left join:
-                 //predicateSet.add(criteriaBuilder.isEmpty(root.get<List<PublicKey>?>("signers")))
                 predicateSet.add(criteriaBuilder.equal(criteriaBuilder.size(root.get<List<PublicKey>?>("signers")),0))
             }
         }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -18,7 +18,7 @@ import net.corda.core.node.services.vault.Sort
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.services.transactions.PersistentUniquenessProvider
 import net.corda.nodeapi.exceptions.DuplicateAttachmentException
-import net.corda.nodeapi.exceptions.DuplicateContractClass
+import net.corda.nodeapi.exceptions.DuplicateContractClassException
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.testing.core.internal.ContractJarTestUtils.makeTestContractJar
@@ -332,7 +332,7 @@ class NodeAttachmentServiceTest {
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), generateManifest = false)
             contractJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
 
-            assertThatExceptionOfType(DuplicateContractClass::class.java).isThrownBy {
+            assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
                 anotherContractJar.read { storage.importAttachment(it, "uploaderA", "another-sample.jar") }
             }
         }
@@ -345,7 +345,7 @@ class NodeAttachmentServiceTest {
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), generateManifest = false)
             contractJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
 
-            assertThatExceptionOfType(DuplicateContractClass::class.java).isThrownBy {
+            assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
                 anotherContractJar.read { storage.importAttachment(it, "uploaderB", "another-sample.jar") }
             }
         }

--- a/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/NodeAttachmentServiceTest.kt
@@ -326,27 +326,63 @@ class NodeAttachmentServiceTest {
     }
 
     @Test
-    fun `cannot import jar with duplicated contract class, version and signers`() {
+    fun `cannot import jar with duplicated contract class, version and signers for trusted uploader`() {
         SelfCleaningDir().use { file ->
             val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
-            contractJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
+            contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
 
             assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
-                anotherContractJar.read { storage.importAttachment(it, "uploaderA", "another-sample.jar") }
+                anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
             }
         }
     }
 
     @Test
-    fun `cannot import jar with duplicated contract class, version and signers - uploader doesnt matter`() {
+    fun `can import jar with duplicated contract class, version and signers - when one uploader is trusted and other isnt`() {
         SelfCleaningDir().use { file ->
             val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
+            val attachmentId =  contractJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
+            val anotherAttachmentId = anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
+            assertNotEquals(attachmentId, anotherAttachmentId)
+        }
+    }
+
+    @Test
+    fun `can promote to trusted uploader for the same attachment`() {
+        SelfCleaningDir().use { file ->
+            val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
+            val attachmentId = contractJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
+            val reimporteddAttachmentId = contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
+            assertEquals(attachmentId, reimporteddAttachmentId)
+        }
+    }
+
+    @Test
+    fun `cannot promote to trusted uploader if other trusted attachment already has duplicated contract class, version and signers`() {
+        SelfCleaningDir().use { file ->
+            val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
             contractJar.read { storage.importAttachment(it, "uploaderA", "sample.jar") }
+            val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
+            anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
 
             assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
-                anotherContractJar.read { storage.importAttachment(it, "uploaderB", "another-sample.jar") }
+                val reimporteddAttachmentId = contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
+            }
+
+        }
+    }
+
+    @Test
+    fun `cannot  promote to trusted uploder the same jar if other trusted uplodaer `() {
+        SelfCleaningDir().use { file ->
+            val (contractJar, _) = makeTestSignedContractJar(file.path, "com.example.MyContract")
+            val anotherContractJar = makeTestContractJar(file.path, listOf( "com.example.MyContract", "com.example.AnotherContract"), true, generateManifest = false, jarFileName = "another-sample.jar")
+            contractJar.read { storage.privilegedImportAttachment(it, "app", "sample.jar") }
+
+            assertThatExceptionOfType(DuplicateContractClassException::class.java).isThrownBy {
+                anotherContractJar.read { storage.privilegedImportAttachment(it, "app", "another-sample.jar") }
             }
         }
     }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/ContractJarTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/ContractJarTestUtils.kt
@@ -67,6 +67,22 @@ object ContractJarTestUtils {
         return workingDir.resolve(jarName)
     }
 
+    @JvmOverloads
+    fun makeTestContractJar(workingDir: Path, contractNames: List<String>, signed: Boolean = false, version: Int = 1, generateManifest: Boolean = true): Path {
+        contractNames.forEach {
+            val packages = it.split(".")
+            val className = packages.last()
+            createTestClass(workingDir, className, packages.subList(0, packages.size - 1))
+        }
+
+        val packages = contractNames.first().split(".")
+        val jarName = "attachment-${packages.last()}-$version${(if (signed) "-signed" else "")}.jar"
+        workingDir.createJar(jarName, *contractNames.map{ "${it.replace(".", "/")}.class" }.toTypedArray() )
+        if (generateManifest)
+            workingDir.addManifest(jarName, Pair(Attributes.Name(CORDAPP_CONTRACT_VERSION), version.toString()))
+        return workingDir.resolve(jarName)
+    }
+
     private fun createTestClass(workingDir: Path, className: String, packages: List<String>): Path {
         val newClass = """package ${packages.joinToString(".")};
                 import net.corda.core.contracts.*;

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/ContractJarTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/ContractJarTestUtils.kt
@@ -44,7 +44,7 @@ object ContractJarTestUtils {
         }
     }
 
-    private fun Path.singWithDummyKey(jarName: Path): PublicKey{
+    private fun Path.signWithDummyKey(jarName: Path): PublicKey{
         val alias = "testAlias"
         val pwd = "testPassword"
         this.generateKey(alias, pwd, ALICE_NAME.toString())
@@ -57,7 +57,7 @@ object ContractJarTestUtils {
     @JvmOverloads
     fun makeTestSignedContractJar(workingDir: Path, contractName: String, version: Int = 1): Pair<Path, PublicKey> {
         val jarName = makeTestContractJar(workingDir, contractName, true, version)
-        val signer = workingDir.singWithDummyKey(jarName)
+        val signer = workingDir.signWithDummyKey(jarName)
         return workingDir.resolve(jarName) to signer
     }
 
@@ -85,7 +85,7 @@ object ContractJarTestUtils {
         if (generateManifest)
             workingDir.addManifest(jarName, Pair(Attributes.Name(CORDAPP_CONTRACT_VERSION), version.toString()))
         if (signed)
-            workingDir.singWithDummyKey(workingDir.resolve(jarName))
+            workingDir.signWithDummyKey(workingDir.resolve(jarName))
         return workingDir.resolve(jarName)
     }
 

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
@@ -82,7 +82,7 @@ object JarSignatureTestUtils {
                 manifest.mainAttributes[attributeName] = value
             }
             val output = JarOutputStream(FileOutputStream((this / fileName).toFile()), manifest)
-            var entry= input.nextEntry
+            var entry = input.nextEntry
             val buffer = ByteArray(1 shl 14)
             while (true) {
                 output.putNextEntry(entry)


### PR DESCRIPTION
* Corda Node ensures a given contract class and version can be sourced from only one signed and trusted Attachment (JAR).
 An attempt to import a signed JAR as a trusted uploader  (or promote to be  trusted) with a class and version already present in the other trusted Attachment will raise ``DuplicateContractClassException``.

* Minor fixes to Hibernate Attachment Query parser (original query to select attachment without signers would always return no attachments)