### PR TITLE
CORDA-2398 - Include private network ID in node info publish request [MERGE POST C4 CUT]

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -63,7 +63,6 @@ import net.corda.node.services.network.NetworkMapUpdater
 import net.corda.node.services.network.NodeInfoWatcher
 import net.corda.node.services.network.PersistentNetworkMapCache
 import net.corda.node.services.persistence.*
-import net.corda.node.services.persistence.AttachmentStorageInternal
 import net.corda.node.services.schema.NodeSchemaService
 import net.corda.node.services.statemachine.*
 import net.corda.node.services.transactions.InMemoryTransactionVerifierService
@@ -507,11 +506,12 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
         } else {
             1.days
         }
+        val privateNetworkUUID = configuration.networkServices?.pnm
         val executor = Executors.newSingleThreadScheduledExecutor(NamedThreadFactory("Network Map Updater"))
         executor.submit(object : Runnable {
             override fun run() {
                 val republishInterval = try {
-                    networkMapClient.publish(signedNodeInfo)
+                    networkMapClient.publish(signedNodeInfo, privateNetworkUUID)
                     heartbeatInterval
                 } catch (e: Exception) {
                     log.warn("Error encountered while publishing node info, will retry again", e)

--- a/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
+++ b/node/src/main/kotlin/net/corda/node/services/network/NetworkMapClient.kt
@@ -36,12 +36,13 @@ class NetworkMapClient(compatibilityZoneURL: URL, private val versionInfo: Versi
         this.trustRoot = trustRoot
     }
 
-    fun publish(signedNodeInfo: SignedNodeInfo) {
+    fun publish(signedNodeInfo: SignedNodeInfo, privateNetworkUUID: UUID? = null) {
         val publishURL = URL("$networkMapUrl/publish")
         logger.trace { "Publishing NodeInfo to $publishURL." }
         publishURL.post(signedNodeInfo.serialize(),
                 "Platform-Version" to "${versionInfo.platformVersion}",
-                "Client-Version" to versionInfo.releaseVersion)
+                "Client-Version" to versionInfo.releaseVersion,
+                "Private-Network-Map" to (privateNetworkUUID?.toString() ?: ""))
         logger.trace { "Published NodeInfo to $publishURL successfully." }
     }
 


### PR DESCRIPTION
This PR includes a small change to add in a node's private network UUID (if exists) via a header during the node info publish request to the Network Map service.