### PR TITLE
CORDA-2395 Add cordapp code signing dev key to production blacklist.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
@@ -9,7 +9,9 @@ import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.internal.hash
 import net.corda.core.internal.toX500Name
 import net.corda.nodeapi.internal.config.CertificateStore
-import net.corda.nodeapi.internal.crypto.*
+import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
+import net.corda.nodeapi.internal.crypto.CertificateType
+import net.corda.nodeapi.internal.crypto.X509Utilities
 import org.bouncycastle.asn1.x509.GeneralName
 import org.bouncycastle.asn1.x509.GeneralSubtree
 import org.bouncycastle.asn1.x509.NameConstraints
@@ -102,7 +104,12 @@ const val DEV_CA_TRUST_STORE_FILE: String = "cordatruststore.jks"
 const val DEV_CA_TRUST_STORE_PASS: String = "trustpass"
 const val DEV_CA_TRUST_STORE_PRIVATE_KEY_PASS: String = "trustpasskeypass"
 
-val DEV_PUB_KEY_HASHES: List<SecureHash.SHA256> get() = listOf(DEV_INTERMEDIATE_CA.certificate, DEV_ROOT_CA.certificate).map { it.publicKey.hash.sha256() }
+// A code signing policy is currently under discussion (https://r3-cev.atlassian.net/wiki/spaces/SEC/pages/859996195/Code+Signing+Certificates+-+options+for+discussion)
+// The following interim key represents a self-signed certificate produced using the Java keytool and located in the gradle cordapp plugins resources key store:
+// https://github.com/corda/corda-gradle-plugins/blob/master/cordapp/src/main/resources/certificates/cordadevcodesign.jks
+const val DEV_CORDAPP_CODE_SIGNING_STR = "AA59D829F2CA8FDDF5ABEA40D815F937E3E54E572B65B93B5C216AE6594E7D6B"
+
+val DEV_PUB_KEY_HASHES: List<SecureHash.SHA256> get() = listOf(DEV_INTERMEDIATE_CA.certificate, DEV_ROOT_CA.certificate).map { it.publicKey.hash.sha256() } + SecureHash.parse(DEV_CORDAPP_CODE_SIGNING_STR).sha256()
 
 // We need a class so that we can get hold of the class loader
 internal object DevCaHelper {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/KeyStoreConfigHelpers.kt
@@ -104,7 +104,7 @@ const val DEV_CA_TRUST_STORE_FILE: String = "cordatruststore.jks"
 const val DEV_CA_TRUST_STORE_PASS: String = "trustpass"
 const val DEV_CA_TRUST_STORE_PRIVATE_KEY_PASS: String = "trustpasskeypass"
 
-// A code signing policy is currently under discussion (https://r3-cev.atlassian.net/wiki/spaces/SEC/pages/859996195/Code+Signing+Certificates+-+options+for+discussion)
+// A code signing policy is currently under design.
 // The following interim key represents a self-signed certificate produced using the Java keytool and located in the gradle cordapp plugins resources key store:
 // https://github.com/corda/corda-gradle-plugins/blob/master/cordapp/src/main/resources/certificates/cordadevcodesign.jks
 const val DEV_CORDAPP_CODE_SIGNING_STR = "AA59D829F2CA8FDDF5ABEA40D815F937E3E54E572B65B93B5C216AE6594E7D6B"

--- a/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/utilities/registration/NodeRegistrationTest.kt
@@ -100,17 +100,6 @@ class NodeRegistrationTest {
                     aliceName.organisation,
                     genevieveName.organisation,
                     notaryName.organisation)
-
-            // Check the nodes can communicate among themselves (and the notary).
-            val anonymous = false
-            genevieve.rpc.startFlow(
-                    ::CashIssueAndPaymentFlow,
-                    1000.DOLLARS,
-                    OpaqueBytes.of(12),
-                    alice.nodeInfo.singleIdentity(),
-                    anonymous,
-                    defaultNotaryIdentity
-            ).returnValue.getOrThrow()
         }
     }
 }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
@@ -1,9 +1,11 @@
 package net.corda.testing.core.internal
 
+import net.corda.core.crypto.sha256
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.JarSignatureCollector
 import net.corda.core.internal.deleteRecursively
 import net.corda.core.internal.div
+import net.corda.core.internal.hash
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import java.io.Closeable
 import java.io.FileInputStream
@@ -67,10 +69,12 @@ object JarSignatureTestUtils {
         return ks.getCertificate(alias).publicKey
     }
 
-    fun Path.getPublicKey(alias: String, storePassword: String) : PublicKey {
-        val ks = loadKeyStore(this.resolve("_teststore"), storePassword)
+    fun Path.getPublicKey(alias: String, storeName: String, storePassword: String) : PublicKey {
+        val ks = loadKeyStore(this.resolve(storeName), storePassword)
         return ks.getCertificate(alias).publicKey
     }
+
+    fun Path.getPublicKey(alias: String, storePassword: String) = getPublicKey(alias, "_teststore", storePassword)
 
     fun Path.getJarSigners(fileName: String) =
             JarInputStream(FileInputStream((this / fileName).toFile())).use(JarSignatureCollector::collectSigners)
@@ -97,4 +101,29 @@ object JarSignatureTestUtils {
             output.close()
         }
     }
+
+    fun printCodeSigningDetails() {
+        // See signing options: https://github.com/corda/corda-gradle-plugins/blob/master/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
+        // Using Java keytool to display the PK:
+        // -keystore /Users/josecoll/IdeaProjects/corda-gradle-plugins/cordapp/src/main/resources/certificates/cordadevcodesign.jks -storepass cordacadevpass
+        val keyStoreDir = Paths.get("/Users/josecoll/IdeaProjects/corda-gradle-plugins/cordapp/src/main/resources/certificates/")
+        val codeSigningPk = keyStoreDir.getPublicKey("cordacodesign", "cordadevcodesign.jks", "cordacadevpass")
+        println("Public Key: $codeSigningPk")
+        val pkHash = codeSigningPk.hash
+        println("SecureHash: $pkHash")
+        val sha256Hash = pkHash.sha256()
+        println("SHA256    : $sha256Hash")
+
+        // Output:
+//        Public Key: Sun EC public key, 256 bits
+//        public x coord: 1606301601488985262456987828510069198490398827685577289418991162593641911319
+//        public y coord: 39305038020852387120148508817752828470229346772241518574141632445003972282481
+//        parameters: secp256r1 [NIST P-256, X9.62 prime256v1] (1.2.840.10045.3.1.7)
+//        SecureHash: AA59D829F2CA8FDDF5ABEA40D815F937E3E54E572B65B93B5C216AE6594E7D6B
+//        SHA256    : 6F6696296C3F58B55FB6CA865A025A3A6CC27AD17C4AFABA1E8EF062E0A82739
+    }
+}
+
+fun main(args: Array<String>) {
+    JarSignatureTestUtils.printCodeSigningDetails()
 }

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/internal/JarSignatureTestUtils.kt
@@ -1,11 +1,9 @@
 package net.corda.testing.core.internal
 
-import net.corda.core.crypto.sha256
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.JarSignatureCollector
 import net.corda.core.internal.deleteRecursively
 import net.corda.core.internal.div
-import net.corda.core.internal.hash
 import net.corda.nodeapi.internal.crypto.loadKeyStore
 import java.io.Closeable
 import java.io.FileInputStream
@@ -101,29 +99,4 @@ object JarSignatureTestUtils {
             output.close()
         }
     }
-
-    fun printCodeSigningDetails() {
-        // See signing options: https://github.com/corda/corda-gradle-plugins/blob/master/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
-        // Using Java keytool to display the PK:
-        // -keystore /Users/josecoll/IdeaProjects/corda-gradle-plugins/cordapp/src/main/resources/certificates/cordadevcodesign.jks -storepass cordacadevpass
-        val keyStoreDir = Paths.get("/Users/josecoll/IdeaProjects/corda-gradle-plugins/cordapp/src/main/resources/certificates/")
-        val codeSigningPk = keyStoreDir.getPublicKey("cordacodesign", "cordadevcodesign.jks", "cordacadevpass")
-        println("Public Key: $codeSigningPk")
-        val pkHash = codeSigningPk.hash
-        println("SecureHash: $pkHash")
-        val sha256Hash = pkHash.sha256()
-        println("SHA256    : $sha256Hash")
-
-        // Output:
-//        Public Key: Sun EC public key, 256 bits
-//        public x coord: 1606301601488985262456987828510069198490398827685577289418991162593641911319
-//        public y coord: 39305038020852387120148508817752828470229346772241518574141632445003972282481
-//        parameters: secp256r1 [NIST P-256, X9.62 prime256v1] (1.2.840.10045.3.1.7)
-//        SecureHash: AA59D829F2CA8FDDF5ABEA40D815F937E3E54E572B65B93B5C216AE6594E7D6B
-//        SHA256    : 6F6696296C3F58B55FB6CA865A025A3A6CC27AD17C4AFABA1E8EF062E0A82739
-    }
-}
-
-fun main(args: Array<String>) {
-    JarSignatureTestUtils.printCodeSigningDetails()
 }


### PR DESCRIPTION
Add the DEV Code Signing key to the node fingerprint blacklist such that a Node cannot use artifacts signed by this key in a production environment (eg. devMode = false).