### PR TITLE
CORDA-2388 Deprecate `CommandWithParties.signingParties`

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -237,7 +237,7 @@ interface MoveCommand : CommandData {
 data class CommandWithParties<out T : CommandData>(
         val signers: List<PublicKey>,
         /** If any public keys were recognised, the looked up institutions are available here */
-        @Deprecated("Should not be used in contract verification code as it is non-deterministic, will be disabled in the future Corda release.")
+        @Deprecated("Should not be used in contract verification code as it is non-deterministic, will be disabled for some future target platform version onwards and will take effect only for CorDapps targeting those versions.")
         val signingParties: List<Party>,
         val value: T
 )

--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -237,6 +237,7 @@ interface MoveCommand : CommandData {
 data class CommandWithParties<out T : CommandData>(
         val signers: List<PublicKey>,
         /** If any public keys were recognised, the looked up institutions are available here */
+        @Deprecated("Should not be used in contract verification code as it is non-deterministic, will be disabled in the future Corda release.")
         val signingParties: List<Party>,
         val value: T
 )

--- a/finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt
+++ b/finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/Obligation.kt
@@ -315,7 +315,7 @@ class Obligation<P : Any> : Contract {
         val outputAmount = outputs.sumObligations<P>()
         val issueCommands = tx.commands.select<Commands.Issue>()
         requireThat {
-            "output states are issued by a command signer" using (issuer.party in issueCommand.signingParties)
+            "output states are issued by a command signer" using (issuer.party.owningKey in issueCommand.signers)
             "output values sum to more than the inputs" using (outputAmount > inputAmount)
             "there is only a single issue command" using (issueCommands.count() == 1)
         }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-2388
`CommandWithParties.signingParties` should not be used in contract verification code as it is non-deterministic.
 Replaced one remaining usage of ``signingParties`` with ``signers`` in Obligation following other examples (e.g. around https://github.com/corda/corda/blob/4aaefb4fe9dcb3eb2fe55f0fb7cf2b3216cd8f31/finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt#L197).
 No other contracts use ``signingParties`` in their logic.