### PR TITLE
CORDA-2404: SwapIdentitiesHandler is a proper responder to SwapIdentitiesFlow

### DIFF
--- a/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
+++ b/confidential-identities/src/main/kotlin/net/corda/confidential/SwapIdentitiesHandler.kt
@@ -3,6 +3,7 @@ package net.corda.confidential
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
 import net.corda.core.identity.PartyAndCertificate
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
@@ -10,6 +11,7 @@ import net.corda.core.serialization.serialize
 import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
 
+@InitiatedBy(SwapIdentitiesFlow::class)
 class SwapIdentitiesHandler(val otherSideSession: FlowSession, val revocationEnabled: Boolean) : FlowLogic<Unit>() {
     constructor(otherSideSession: FlowSession) : this(otherSideSession, false)
 


### PR DESCRIPTION
This enables V4 nodes to run V3 CorDapps that use confidential identities by installing the new V3 confidential-identities jar as a CorDapp.

