### PR TITLE
finance-workflows jar contains confidential identities

### DIFF
--- a/client/rpc/build.gradle
+++ b/client/rpc/build.gradle
@@ -62,9 +62,6 @@ processSmokeTestResources {
     from(project(':finance:contracts').tasks['jar']) {
         rename '.*finance-contracts-.*', 'cordapp-finance-contracts.jar'
     }
-    from(project(':confidential-identities').tasks['jar']) {
-        rename '.*confidential-identities-.*', 'cordapp-confidential-identities.jar'
-    }
 }
 
 // To find potential version conflicts, run "gradle htmlDependencyReport" and then look in

--- a/finance/contracts/build.gradle
+++ b/finance/contracts/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     // cordapp project(':finance:workflows')
     // cordapp project(':finance:contracts')
     cordapp project(':core')
-    cordapp project(':confidential-identities')
 
     // For JSON
     compile "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"


### PR DESCRIPTION
As highlighted in https://github.com/corda/corda/pull/4296, confidential-identities should now be bundled in with the CorDapp. For some reason this was lost when finance was split.

