### PR TITLE
3267 - Node names that contain commas don't work - use RFC1779 for CordaX500Name to verify principles

### DIFF
--- a/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
@@ -171,7 +171,7 @@ class CordaX500NameTest {
     @Test
     fun `validate special format for quoted , `() {
         val cordaX500Name = CordaX500Name.parse("O=\"Sue, Grabbit and Runn\", L=VALID, C=CH")
-        assertSame(cordaX500Name.organisation, "Sue\\, Grabbit and Runn", "Quoted string with , replaced with quoted \\,")
+        assertEquals(cordaX500Name.organisation, "Sue\\, Grabbit and Runn", "Quoted string with , replaced with quoted \\,")
     }
 
 

--- a/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
+++ b/core/src/test/kotlin/net/corda/core/identity/CordaX500NameTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 import java.lang.Character.MIN_VALUE as NULLCHAR
 
@@ -153,6 +154,26 @@ class CordaX500NameTest {
         }
         checkLocalityAndOrganisationalUnitAndCommonNameReject("IN\\VALID")
     }
+
+    // checkout quote tests from https://tools.ietf.org/html/rfc1779#page-4
+    @Test
+    fun `accepts names with quoted , (comma) `() {
+        CordaX500Name.parse("O=Sue\\, Grabbit and Runn, L=VALID, C=CH")
+        validateLocalityAndOrganisationalUnitAndCommonName("\"Sue, Grabbit and Runn\"")
+    }
+    // checkout quote tests from https://tools.ietf.org/html/rfc1779#page-4
+    @Test
+    fun `accepts names with double quotes`() {
+        CordaX500Name.parse("O=\"Sue, Grabbit and Runn\", L=VALID, C=CH")
+        validateLocalityAndOrganisationalUnitAndCommonName("\"Sue, Grabbit and Runn\"")
+    }
+
+    @Test
+    fun `validate special format for quoted , `() {
+        val cordaX500Name = CordaX500Name.parse("O=\"Sue, Grabbit and Runn\", L=VALID, C=CH")
+        assertSame(cordaX500Name.organisation, "Sue\\, Grabbit and Runn", "Quoted string with , replaced with quoted \\,")
+    }
+
 
     @Test
     fun `rejects double spacing only in the organisation attribute`() {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OptionalSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/OptionalSerializer.kt
@@ -7,7 +7,7 @@ import java.time.OffsetTime
 import java.util.*
 
 /**
- * A serializer for [OffsetTime] that uses a proxy object to write out the time and zone offset.
+ * A serializer for [Optional] that uses a proxy object to write out the value stored in the optional or [Optional.EMPTY].
  */
 class OptionalSerializer(factory: SerializerFactory) : CustomSerializer.Proxy<Optional<*>, OptionalSerializer.OptionalProxy>(Optional::class.java, OptionalProxy::class.java, factory) {
 


### PR DESCRIPTION
from bug https://github.com/corda/corda/issues/3267
 
special characters in X500Name are supported but today CordaX500Name does not supports it while validating the minimal requirements of a X500name for corda.
Using the RFC1779 and the representation of an attribute (e.g. O) we are able represent the x500name in corda own class as it is in the standard X500Name of our security library

# PR Checklist:
- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)? only "unit" tests
- [x] If you added public APIs, did you write the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [x] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
