### PR TITLE
Flagged API issues between 4.0 and 3.3.

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -251,6 +251,8 @@ class CordaRPCClient private constructor(
         private val haAddressPool: List<NetworkHostAndPort> = emptyList()
 ) {
     @JvmOverloads
+    // TODO sollecitom default constructor used to be `public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.nodeapi.internal.config.SSLConfiguration, kotlin.jvm.internal.DefaultConstructorMarker)`.
+    // TODO sollecitom hopefully unlikely CorDapps are using CordaRPCClient from flows / contracts.
     constructor(hostAndPort: NetworkHostAndPort,
                 configuration: CordaRPCClientConfiguration = CordaRPCClientConfiguration.DEFAULT)
             : this(hostAndPort, configuration, null)

--- a/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Attachment.kt
@@ -67,6 +67,7 @@ interface Attachment : NamedByHash {
      * The keys that have correctly signed the whole attachment.
      * Can be empty, for example non-contract attachments won't be necessarily be signed.
      */
+    // TODO sollecitom this would break any type implementing Attachment. @DoNotImplement was added as part of 4, and it wasn't there in 3.3. Probably unlikely CorDapps implement Attachment.
     val signerKeys: List<PublicKey>
 
     /**

--- a/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/ContractAttachment.kt
@@ -14,6 +14,7 @@ import java.security.PublicKey
  */
 @KeepForDJVM
 @CordaSerializable
+// TODO sollecitom use to be `constructor(val attachment: Attachment, val contract: ContractClassName, val additionalContracts: Set<ContractClassName> = emptySet(), val uploader: String? = null)`, not ABI compatible, but I don't think CorDapps construct this manually.
 class ContractAttachment @JvmOverloads constructor(
         val attachment: Attachment,
         val contract: ContractClassName,

--- a/core/src/main/kotlin/net/corda/core/cordapp/CordappContext.kt
+++ b/core/src/main/kotlin/net/corda/core/cordapp/CordappContext.kt
@@ -17,6 +17,7 @@ import net.corda.core.crypto.SecureHash
  * @property config Configuration for this CorDapp
  */
 @DeleteForDJVM
+// TODO sollecitom used to be public `constructor(val cordapp: Cordapp, val attachmentId: SecureHash?, val classLoader: ClassLoader)`. Unlikely CorDapps construct this manually.
 class CordappContext internal constructor(
         val cordapp: Cordapp,
         val attachmentId: SecureHash?,

--- a/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt
@@ -162,6 +162,8 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
     /**
      * LinearStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultLinearState]
      */
+    // TODO sollecitom used to be `public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)`.
+    // TODO sollecitom this needs fixing.
     data class LinearStateQueryCriteria @JvmOverloads constructor(
             override val participants: List<AbstractParty>? = null,
             val uuid: List<UUID>? = null,
@@ -226,6 +228,8 @@ sealed class QueryCriteria : GenericQueryCriteria<QueryCriteria, IQueryCriteriaP
     /**
      * FungibleStateQueryCriteria: provides query by attributes defined in [VaultSchema.VaultFungibleStates]
      */
+    // TODO sollecitom used to be `public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)`.
+    // TODO sollecitom this needs fixing.
     data class FungibleAssetQueryCriteria @JvmOverloads constructor(
             override val participants: List<AbstractParty>? = null,
             val owner: List<AbstractParty>? = null,
@@ -326,6 +330,8 @@ sealed class AttachmentQueryCriteria : GenericQueryCriteria<AttachmentQueryCrite
     /**
      * AttachmentsQueryCriteria:
      */
+    // TODO sollecitom used to be `public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)`.
+    // TODO sollecitom this needs fixing.
     data class AttachmentsQueryCriteria @JvmOverloads constructor(val uploaderCondition: ColumnPredicate<String>? = null,
                                                                   val filenameCondition: ColumnPredicate<String>? = null,
                                                                   val uploadDateCondition: ColumnPredicate<Instant>? = null,

--- a/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt
+++ b/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt
@@ -90,6 +90,7 @@ class PersistentState(@EmbeddedId override var stateRef: PersistentStateRef? = n
 @KeepForDJVM
 @Embeddable
 @Immutable
+// TODO sollecitom both `txId` and `index` used to be nullable, with `null` default value. Maybe unlikely created by CorDapps code?
 data class PersistentStateRef(
         @Column(name = "transaction_id", length = 64, nullable = false)
         var txId: String,
@@ -104,6 +105,7 @@ data class PersistentStateRef(
  * Marker interface to denote a persistable Corda state entity that will always have a transaction id and index
  */
 @KeepForDJVM
+// TODO sollecitom used to be @Serializable. Do we care?
 interface StatePersistable
 
 /**

--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -243,6 +243,7 @@ enum class ContextPropertyKeys {
  */
 @KeepForDJVM
 object SerializationDefaults {
+    // TODO sollecito val CHECKPOINT_CONTEXT: SerializationContext get() = ... is gone. Hope no CorDapp should ever deal with this object explicitly.
     val SERIALIZATION_FACTORY get() = effectiveSerializationEnv.serializationFactory
     val P2P_CONTEXT get() = effectiveSerializationEnv.p2pContext
     @DeleteForDJVM val RPC_SERVER_CONTEXT get() = effectiveSerializationEnv.rpcServerContext

--- a/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/LedgerTransaction.kt
@@ -31,6 +31,8 @@ import java.util.function.Predicate
 class LedgerTransaction
 @ConstructorForDeserialization
 // LedgerTransaction is not meant to be created directly from client code, but rather via WireTransaction.toLedgerTransaction
+// TODO sollecitom constructor used to be public, and `public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)`.
+// TODO sollecitom hopefully not a problem.
 private constructor(
         // DOCSTART 1
         /** The resolved input states which will be consumed/invalidated by the execution of this transaction. */

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -54,6 +54,8 @@ class WireTransaction(componentGroups: List<ComponentGroup>, val privacySalt: Pr
 
     @Deprecated("Required only in some unit-tests and for backwards compatibility purposes.",
             ReplaceWith("WireTransaction(val componentGroups: List<ComponentGroup>, override val privacySalt: PrivacySalt)"), DeprecationLevel.WARNING)
+    // TODO sollecitom default constructor used to be `public <init>(java.util.List, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)`.
+    // TODO sollecitom hopefully not a problem because CorDapps are supposed to be using TransactionBuilder.
     @DeleteForDJVM
     @JvmOverloads
     constructor(

--- a/samples/3.3.txt
+++ b/samples/3.3.txt
@@ -1,0 +1,7536 @@
+@CordaSerializable
+public class net.corda.core.CordaException extends java.lang.Exception implements net.corda.core.CordaThrowable
+  public <init>()
+  public <init>(String)
+  public <init>(String, String, Throwable)
+  public <init>(String, String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(String, Throwable)
+  public void addSuppressed(Throwable[])
+  public boolean equals(Object)
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
+  public int hashCode()
+  public void setCause(Throwable)
+  public void setMessage(String)
+  public void setOriginalExceptionClassName(String)
+##
+public final class net.corda.core.CordaOID extends java.lang.Object
+  @NotNull
+  public static final String CORDA_PLATFORM = "1.3.6.1.4.1.50530.1"
+  public static final net.corda.core.CordaOID INSTANCE
+  @NotNull
+  public static final String R3_ROOT = "1.3.6.1.4.1.50530"
+  @NotNull
+  public static final String X509_EXTENSION_CORDA_ROLE = "1.3.6.1.4.1.50530.1.1"
+##
+@CordaSerializable
+public class net.corda.core.CordaRuntimeException extends java.lang.RuntimeException implements net.corda.core.CordaThrowable
+  public <init>(String)
+  public <init>(String, String, Throwable)
+  public <init>(String, Throwable)
+  public void addSuppressed(Throwable[])
+  public boolean equals(Object)
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
+  public int hashCode()
+  public void setCause(Throwable)
+  public void setMessage(String)
+  public void setOriginalExceptionClassName(String)
+##
+@CordaSerializable
+public interface net.corda.core.CordaThrowable
+  public abstract void addSuppressed(Throwable[])
+  @Nullable
+  public abstract String getOriginalExceptionClassName()
+  @Nullable
+  public abstract String getOriginalMessage()
+  public abstract void setCause(Throwable)
+  public abstract void setMessage(String)
+  public abstract void setOriginalExceptionClassName(String)
+##
+public @interface net.corda.core.DoNotImplement
+##
+public final class net.corda.core.Utils extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<T> toFuture(rx.Observable<T>)
+  @NotNull
+  public static final rx.Observable<A> toObservable(net.corda.core.concurrent.CordaFuture<? extends A>)
+##
+public final class net.corda.core.concurrent.ConcurrencyUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<W> firstOf(net.corda.core.concurrent.CordaFuture<? extends V>[], kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<? extends V>, ? extends W>)
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<W> firstOf(net.corda.core.concurrent.CordaFuture<? extends V>[], org.slf4j.Logger, kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<? extends V>, ? extends W>)
+  public static final W match(java.util.concurrent.Future<V>, kotlin.jvm.functions.Function1<? super V, ? extends W>, kotlin.jvm.functions.Function1<? super Throwable, ? extends W>)
+  @NotNull
+  public static final String shortCircuitedTaskFailedMessage = "Short-circuited task failed:"
+##
+public interface net.corda.core.concurrent.CordaFuture extends java.util.concurrent.Future
+  public abstract void then(kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<V>, ? extends W>)
+  @NotNull
+  public abstract java.util.concurrent.CompletableFuture<V> toCompletableFuture()
+##
+@CordaSerializable
+public final class net.corda.core.context.Actor extends java.lang.Object
+  public <init>(net.corda.core.context.Actor$Id, net.corda.core.context.AuthServiceId, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.context.Actor$Id component1()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId component2()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component3()
+  @NotNull
+  public final net.corda.core.context.Actor copy(net.corda.core.context.Actor$Id, net.corda.core.context.AuthServiceId, net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.context.Actor$Id getId()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId getServiceId()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
+  public String toString()
+  public static final net.corda.core.context.Actor$Companion Companion
+##
+public static final class net.corda.core.context.Actor$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
+##
+@CordaSerializable
+public static final class net.corda.core.context.Actor$Id extends java.lang.Object
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.context.Actor$Id copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getValue()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.context.AuthServiceId extends java.lang.Object
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getValue()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.context.InvocationContext extends java.lang.Object
+  public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin component1()
+  @NotNull
+  public final net.corda.core.context.Trace component2()
+  @Nullable
+  public final net.corda.core.context.Actor component3()
+  @Nullable
+  public final net.corda.core.context.Trace component4()
+  @Nullable
+  public final net.corda.core.context.Actor component5()
+  @NotNull
+  public final net.corda.core.context.InvocationContext copy(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.core.context.Actor getActor()
+  @Nullable
+  public final net.corda.core.context.Trace getExternalTrace()
+  @Nullable
+  public final net.corda.core.context.Actor getImpersonatedActor()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin getOrigin()
+  @NotNull
+  public final net.corda.core.context.Trace getTrace()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final java.security.Principal principal()
+  @NotNull
+  public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
+  public String toString()
+  public static final net.corda.core.context.InvocationContext$Companion Companion
+##
+public static final class net.corda.core.context.InvocationContext$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
+##
+@CordaSerializable
+public abstract class net.corda.core.context.InvocationOrigin extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract java.security.Principal principal()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Peer extends net.corda.core.context.InvocationOrigin
+  public <init>(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Peer copy(net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getParty()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$RPC extends net.corda.core.context.InvocationOrigin
+  public <init>(net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.Actor component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$RPC copy(net.corda.core.context.Actor)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.context.Actor getActor()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Scheduled extends net.corda.core.context.InvocationOrigin
+  public <init>(net.corda.core.contracts.ScheduledStateRef)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Service extends net.corda.core.context.InvocationOrigin
+  public <init>(String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Service copy(String, net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
+  @NotNull
+  public final String getServiceClassName()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Shell extends net.corda.core.context.InvocationOrigin
+  @NotNull
+  public java.security.Principal principal()
+  public static final net.corda.core.context.InvocationOrigin$Shell INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.context.Trace extends java.lang.Object
+  public <init>(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId component1()
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId component2()
+  @NotNull
+  public final net.corda.core.context.Trace copy(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId getInvocationId()
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId getSessionId()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  public String toString()
+  public static final net.corda.core.context.Trace$Companion Companion
+##
+public static final class net.corda.core.context.Trace$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+##
+@CordaSerializable
+public static final class net.corda.core.context.Trace$InvocationId extends net.corda.core.utilities.Id
+  public <init>(String, java.time.Instant)
+  @NotNull
+  public static final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
+  public static final net.corda.core.context.Trace$InvocationId$Companion Companion
+##
+public static final class net.corda.core.context.Trace$InvocationId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
+##
+@CordaSerializable
+public static final class net.corda.core.context.Trace$SessionId extends net.corda.core.utilities.Id
+  public <init>(String, java.time.Instant)
+  @NotNull
+  public static final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
+  public static final net.corda.core.context.Trace$SessionId$Companion Companion
+##
+public static final class net.corda.core.context.Trace$SessionId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AlwaysAcceptAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.AlwaysAcceptAttachmentConstraint INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.contracts.Amount extends java.lang.Object implements java.lang.Comparable
+  public <init>(long, T)
+  public <init>(long, java.math.BigDecimal, T)
+  public int compareTo(net.corda.core.contracts.Amount<T>)
+  public final long component1()
+  @NotNull
+  public final java.math.BigDecimal component2()
+  @NotNull
+  public final T component3()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> copy(long, java.math.BigDecimal, T)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T, java.math.RoundingMode)
+  @NotNull
+  public final java.math.BigDecimal getDisplayTokenSize()
+  @NotNull
+  public static final java.math.BigDecimal getDisplayTokenSize(Object)
+  public final long getQuantity()
+  @NotNull
+  public final T getToken()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> minus(net.corda.core.contracts.Amount<T>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<java.util.Currency> parseCurrency(String)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> plus(net.corda.core.contracts.Amount<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Amount<T>> splitEvenly(int)
+  @Nullable
+  public static final net.corda.core.contracts.Amount<T> sumOrNull(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> sumOrThrow(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> sumOrZero(Iterable<net.corda.core.contracts.Amount<T>>, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> times(int)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> times(long)
+  @NotNull
+  public final java.math.BigDecimal toDecimal()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> zero(T)
+  public static final net.corda.core.contracts.Amount$Companion Companion
+##
+public static final class net.corda.core.contracts.Amount$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T, java.math.RoundingMode)
+  @NotNull
+  public final java.math.BigDecimal getDisplayTokenSize(Object)
+  @NotNull
+  public final net.corda.core.contracts.Amount<java.util.Currency> parseCurrency(String)
+  @Nullable
+  public final net.corda.core.contracts.Amount<T> sumOrNull(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> sumOrThrow(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> sumOrZero(Iterable<net.corda.core.contracts.Amount<T>>, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> zero(T)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.AmountTransfer extends java.lang.Object
+  public <init>(long, T, P, P)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.SourceAndAmount<T, P>> apply(java.util.List<? extends net.corda.core.contracts.SourceAndAmount<T, ? extends P>>, Object)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> copy(long, T, P, P)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P)
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P, java.math.RoundingMode)
+  @NotNull
+  public final P getDestination()
+  public final long getQuantityDelta()
+  @NotNull
+  public final P getSource()
+  @NotNull
+  public final T getToken()
+  public int hashCode()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.AmountTransfer<T, P>> novate(P)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> plus(net.corda.core.contracts.AmountTransfer<T, P>)
+  @NotNull
+  public final java.math.BigDecimal toDecimal()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> zero(T, P, P)
+  public static final net.corda.core.contracts.AmountTransfer$Companion Companion
+##
+public static final class net.corda.core.contracts.AmountTransfer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P, java.math.RoundingMode)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> zero(T, P, P)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.Attachment extends net.corda.core.contracts.NamedByHash
+  public abstract void extractFile(String, java.io.OutputStream)
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> getSigners()
+  public abstract int getSize()
+  @NotNull
+  public abstract java.io.InputStream open()
+  @NotNull
+  public abstract java.util.jar.JarInputStream openAsJAR()
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.contracts.AttachmentConstraint
+  public abstract boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AutomaticHashConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.AutomaticHashConstraint INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.contracts.Command extends java.lang.Object
+  public <init>(T, java.security.PublicKey)
+  public <init>(T, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> component2()
+  @NotNull
+  public final net.corda.core.contracts.Command<T> copy(T, java.util.List<? extends java.security.PublicKey>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigners()
+  @NotNull
+  public final T getValue()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.contracts.CommandAndState extends java.lang.Object
+  public <init>(net.corda.core.contracts.CommandData, net.corda.core.contracts.OwnableState)
+  @NotNull
+  public final net.corda.core.contracts.CommandData component1()
+  @NotNull
+  public final net.corda.core.contracts.OwnableState component2()
+  @NotNull
+  public final net.corda.core.contracts.CommandAndState copy(net.corda.core.contracts.CommandData, net.corda.core.contracts.OwnableState)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.CommandData getCommand()
+  @NotNull
+  public final net.corda.core.contracts.OwnableState getOwnableState()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.CommandData
+##
+@CordaSerializable
+public final class net.corda.core.contracts.CommandWithParties extends java.lang.Object
+  public <init>(java.util.List<? extends java.security.PublicKey>, java.util.List<net.corda.core.identity.Party>, T)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> component2()
+  @NotNull
+  public final T component3()
+  @NotNull
+  public final net.corda.core.contracts.CommandWithParties<T> copy(java.util.List<? extends java.security.PublicKey>, java.util.List<net.corda.core.identity.Party>, T)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigners()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> getSigningParties()
+  @NotNull
+  public final T getValue()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.core.contracts.ComponentGroupEnum extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.contracts.ComponentGroupEnum valueOf(String)
+  public static net.corda.core.contracts.ComponentGroupEnum[] values()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.Contract
+  public abstract void verify(net.corda.core.transactions.LedgerTransaction)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.ContractAttachment extends java.lang.Object implements net.corda.core.contracts.Attachment
+  public <init>(net.corda.core.contracts.Attachment, String)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>, String)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public void extractFile(String, java.io.OutputStream)
+  @NotNull
+  public final java.util.Set<String> getAdditionalContracts()
+  @NotNull
+  public final java.util.Set<String> getAllContracts()
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment()
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.identity.Party> getSigners()
+  public int getSize()
+  @Nullable
+  public final String getUploader()
+  @NotNull
+  public java.io.InputStream open()
+  @NotNull
+  public java.util.jar.JarInputStream openAsJAR()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+##
+public final class net.corda.core.contracts.ContractsDSL extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.contracts.CommandWithParties<C> requireSingleCommand(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>)
+  public static final R requireThat(kotlin.jvm.functions.Function1<? super net.corda.core.contracts.Requirements, ? extends R>)
+  @NotNull
+  public static final java.util.List<net.corda.core.contracts.CommandWithParties<C>> select(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>, java.security.PublicKey, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final java.util.List<net.corda.core.contracts.CommandWithParties<C>> select(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>, java.util.Collection<? extends java.security.PublicKey>, java.util.Collection<net.corda.core.identity.Party>)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.FungibleAsset extends net.corda.core.contracts.OwnableState
+  @NotNull
+  public abstract net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>> getAmount()
+  @NotNull
+  public abstract java.util.Collection<java.security.PublicKey> getExitKeys()
+  @NotNull
+  public abstract net.corda.core.contracts.FungibleAsset<T> withNewOwnerAndAmount(net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>>, net.corda.core.identity.AbstractParty)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.HashAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.contracts.HashAttachmentConstraint copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
+  public int hashCode()
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.InsufficientBalanceException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.contracts.Amount<?>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<?> getAmountMissing()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.Issued extends java.lang.Object
+  public <init>(net.corda.core.contracts.PartyAndReference, P)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference component1()
+  @NotNull
+  public final P component2()
+  @NotNull
+  public final net.corda.core.contracts.Issued<P> copy(net.corda.core.contracts.PartyAndReference, P)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference getIssuer()
+  @NotNull
+  public final P getProduct()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public @interface net.corda.core.contracts.LegalProseReference
+  public abstract String uri()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.LinearState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.contracts.UniqueIdentifier getLinearId()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.MoveCommand extends net.corda.core.contracts.CommandData
+  @Nullable
+  public abstract Class<? extends net.corda.core.contracts.Contract> getContract()
+##
+public interface net.corda.core.contracts.NamedByHash
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getId()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.OwnableState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.identity.AbstractParty getOwner()
+  @NotNull
+  public abstract net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.PartyAndReference extends java.lang.Object
+  public <init>(net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public final net.corda.core.identity.AbstractParty component1()
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes component2()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference copy(net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.AbstractParty getParty()
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes getReference()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.PrivacySalt extends net.corda.core.utilities.OpaqueBytes
+  public <init>()
+  public <init>(byte[])
+##
+public final class net.corda.core.contracts.Requirements extends java.lang.Object
+  public final void using(String, boolean)
+  public static final net.corda.core.contracts.Requirements INSTANCE
+##
+@CordaSerializable
+public interface net.corda.core.contracts.SchedulableState extends net.corda.core.contracts.ContractState
+  @Nullable
+  public abstract net.corda.core.contracts.ScheduledActivity nextScheduledActivity(net.corda.core.contracts.StateRef, net.corda.core.flows.FlowLogicRefFactory)
+##
+public interface net.corda.core.contracts.Scheduled
+  @NotNull
+  public abstract java.time.Instant getScheduledAt()
+##
+public final class net.corda.core.contracts.ScheduledActivity extends java.lang.Object implements net.corda.core.contracts.Scheduled
+  public <init>(net.corda.core.flows.FlowLogicRef, java.time.Instant)
+  @NotNull
+  public final net.corda.core.flows.FlowLogicRef component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledActivity copy(net.corda.core.flows.FlowLogicRef, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.flows.FlowLogicRef getLogicRef()
+  @NotNull
+  public java.time.Instant getScheduledAt()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.ScheduledStateRef extends java.lang.Object implements net.corda.core.contracts.Scheduled
+  public <init>(net.corda.core.contracts.StateRef, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef copy(net.corda.core.contracts.StateRef, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public java.time.Instant getScheduledAt()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.core.contracts.SourceAndAmount extends java.lang.Object
+  public <init>(P, net.corda.core.contracts.Amount<T>, Object)
+  public <init>(Object, net.corda.core.contracts.Amount, Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final P component1()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> component2()
+  @Nullable
+  public final Object component3()
+  @NotNull
+  public final net.corda.core.contracts.SourceAndAmount<T, P> copy(P, net.corda.core.contracts.Amount<T>, Object)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> getAmount()
+  @Nullable
+  public final Object getRef()
+  @NotNull
+  public final P getSource()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.core.contracts.StateAndContract extends java.lang.Object
+  public <init>(net.corda.core.contracts.ContractState, String)
+  @NotNull
+  public final net.corda.core.contracts.ContractState component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.contracts.StateAndContract copy(net.corda.core.contracts.ContractState, String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getState()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.StateAndRef extends java.lang.Object
+  public <init>(net.corda.core.contracts.TransactionState<? extends T>, net.corda.core.contracts.StateRef)
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> component1()
+  @NotNull
+  public final net.corda.core.contracts.StateRef component2()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> copy(net.corda.core.contracts.TransactionState<? extends T>, net.corda.core.contracts.StateRef)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> getState()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.StateRef extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, int)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.contracts.StateRef copy(net.corda.core.crypto.SecureHash, int)
+  public boolean equals(Object)
+  public final int getIndex()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxhash()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.contracts.Structures extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash hash(net.corda.core.contracts.ContractState)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> withoutIssuer(net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>>)
+  public static final int MAX_ISSUER_REF_SIZE = 512
+##
+@CordaSerializable
+public abstract class net.corda.core.contracts.TimeWindow extends java.lang.Object
+  public <init>()
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
+  public abstract boolean contains(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
+  @Nullable
+  public abstract java.time.Instant getFromTime()
+  @Nullable
+  public final java.time.Duration getLength()
+  @Nullable
+  public abstract java.time.Instant getMidpoint()
+  @Nullable
+  public abstract java.time.Instant getUntilTime()
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
+  public static final net.corda.core.contracts.TimeWindow$Companion Companion
+##
+public static final class net.corda.core.contracts.TimeWindow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
+##
+public interface net.corda.core.contracts.TokenizableAssetInfo
+  @NotNull
+  public abstract java.math.BigDecimal getDisplayTokenSize()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.TransactionResolutionException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.TransactionState extends java.lang.Object
+  public <init>(T, String, net.corda.core.identity.Party)
+  public <init>(T, String, net.corda.core.identity.Party, Integer)
+  public <init>(T, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  public <init>(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @Nullable
+  public final Integer component4()
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint component5()
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> copy(T, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint getConstraint()
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public final T getData()
+  @Nullable
+  public final Integer getEncumbrance()
+  @NotNull
+  public final net.corda.core.identity.Party getNotary()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.core.contracts.TransactionStateKt extends java.lang.Object
+##
+@CordaSerializable
+public abstract class net.corda.core.contracts.TransactionVerificationException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ConflictingAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractConstraintRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractCreationError extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.Contract, Throwable)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$Direction extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.contracts.TransactionVerificationException$Direction valueOf(String)
+  public static net.corda.core.contracts.TransactionVerificationException$Direction[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateInputStates extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef> getDuplicates()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$InvalidNotaryChange extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MissingAttachmentRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MoreThanOneNotary extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$NotaryChangeInWrongTransactionType extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party getOutputNotary()
+  @NotNull
+  public final net.corda.core.identity.Party getTxNotary()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$SignersMissing extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getMissing()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionMissingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, int, net.corda.core.contracts.TransactionVerificationException$Direction)
+  @NotNull
+  public final net.corda.core.contracts.TransactionVerificationException$Direction getInOut()
+  public final int getMissing()
+##
+@CordaSerializable
+public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.lang.Object implements net.corda.core.contracts.CommandData
+  public <init>()
+  public boolean equals(Object)
+  public int hashCode()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.UniqueIdentifier extends java.lang.Object implements java.lang.Comparable
+  public <init>()
+  public <init>(String, java.util.UUID)
+  public <init>(String, java.util.UUID, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public int compareTo(net.corda.core.contracts.UniqueIdentifier)
+  @Nullable
+  public final String component1()
+  @NotNull
+  public final java.util.UUID component2()
+  @NotNull
+  public final net.corda.core.contracts.UniqueIdentifier copy(String, java.util.UUID)
+  public boolean equals(Object)
+  @Nullable
+  public final String getExternalId()
+  @NotNull
+  public final java.util.UUID getId()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.contracts.UniqueIdentifier$Companion Companion
+##
+public static final class net.corda.core.contracts.UniqueIdentifier$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.UniqueIdentifier fromString(String)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.UpgradedContract extends net.corda.core.contracts.Contract
+  @NotNull
+  public abstract String getLegacyContract()
+  @NotNull
+  public abstract NewState upgrade(OldState)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.UpgradedContractWithLegacyConstraint extends net.corda.core.contracts.UpgradedContract
+  @NotNull
+  public abstract net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint INSTANCE
+##
+@DoNotImplement
+public interface net.corda.core.cordapp.Cordapp
+  @NotNull
+  public abstract java.util.List<String> getContractClassNames()
+  @NotNull
+  public abstract java.util.List<String> getCordappClasses()
+  @NotNull
+  public abstract java.util.Set<net.corda.core.schemas.MappedSchema> getCustomSchemas()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getInitiatedFlows()
+  @NotNull
+  public abstract java.net.URL getJarPath()
+  @NotNull
+  public abstract String getName()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getRpcFlows()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getSchedulableFlows()
+  @NotNull
+  public abstract java.util.List<net.corda.core.serialization.SerializationCustomSerializer<?, ?>> getSerializationCustomSerializers()
+  @NotNull
+  public abstract java.util.List<net.corda.core.serialization.SerializationWhitelist> getSerializationWhitelists()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getServiceFlows()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.serialization.SerializeAsToken>> getServices()
+##
+public final class net.corda.core.cordapp.CordappContext extends java.lang.Object
+  public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader)
+  @Nullable
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
+  @NotNull
+  public final ClassLoader getClassLoader()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp getCordapp()
+##
+@DoNotImplement
+public interface net.corda.core.cordapp.CordappProvider
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappContext getAppContext()
+  @Nullable
+  public abstract net.corda.core.crypto.SecureHash getContractAttachmentID(String)
+##
+public class net.corda.core.crypto.AddressFormatException extends java.lang.IllegalArgumentException
+  public <init>()
+  public <init>(String)
+##
+public class net.corda.core.crypto.Base58 extends java.lang.Object
+  public <init>()
+  public static byte[] decode(String)
+  public static byte[] decodeChecked(String)
+  public static java.math.BigInteger decodeToBigInteger(String)
+  public static String encode(byte[])
+##
+@CordaSerializable
+public final class net.corda.core.crypto.CompositeKey extends java.lang.Object implements java.security.PublicKey
+  public <init>(int, java.util.List, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final void checkValidity()
+  public boolean equals(Object)
+  @NotNull
+  public String getAlgorithm()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.CompositeKey$NodeAndWeight> getChildren()
+  @NotNull
+  public byte[] getEncoded()
+  @NotNull
+  public String getFormat()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getLeafKeys()
+  public final int getThreshold()
+  public int hashCode()
+  public final boolean isFulfilledBy(Iterable<? extends java.security.PublicKey>)
+  public final boolean isFulfilledBy(java.security.PublicKey)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.crypto.CompositeKey$Companion Companion
+  @NotNull
+  public static final String KEY_ALGORITHM = "COMPOSITE"
+##
+public static final class net.corda.core.crypto.CompositeKey$Builder extends java.lang.Object
+  public <init>()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKey(java.security.PublicKey, int)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.security.PublicKey...)
+  @NotNull
+  public final java.security.PublicKey build(Integer)
+##
+public static final class net.corda.core.crypto.CompositeKey$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.security.PublicKey getInstance(org.bouncycastle.asn1.ASN1Primitive)
+  @NotNull
+  public final java.security.PublicKey getInstance(byte[])
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.CompositeKey$NodeAndWeight extends org.bouncycastle.asn1.ASN1Object implements java.lang.Comparable
+  public <init>(java.security.PublicKey, int)
+  public int compareTo(net.corda.core.crypto.CompositeKey$NodeAndWeight)
+  @NotNull
+  public final java.security.PublicKey component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$NodeAndWeight copy(java.security.PublicKey, int)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getNode()
+  public final int getWeight()
+  public int hashCode()
+  @NotNull
+  public org.bouncycastle.asn1.ASN1Primitive toASN1Primitive()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.crypto.CompositeKeyFactory extends java.security.KeyFactorySpi
+  public <init>()
+  @NotNull
+  protected java.security.PrivateKey engineGeneratePrivate(java.security.spec.KeySpec)
+  @Nullable
+  protected java.security.PublicKey engineGeneratePublic(java.security.spec.KeySpec)
+  @NotNull
+  protected T engineGetKeySpec(java.security.Key, Class<T>)
+  @NotNull
+  protected java.security.Key engineTranslateKey(java.security.Key)
+##
+public final class net.corda.core.crypto.CompositeSignature extends java.security.Signature
+  public <init>()
+  @NotNull
+  protected Object engineGetParameter(String)
+  protected void engineInitSign(java.security.PrivateKey)
+  protected void engineInitVerify(java.security.PublicKey)
+  protected void engineSetParameter(String, Object)
+  protected void engineSetParameter(java.security.spec.AlgorithmParameterSpec)
+  @NotNull
+  protected byte[] engineSign()
+  protected void engineUpdate(byte)
+  protected void engineUpdate(byte[], int, int)
+  protected boolean engineVerify(byte[])
+  @NotNull
+  public static final java.security.Provider$Service getService(java.security.Provider)
+  public static final net.corda.core.crypto.CompositeSignature$Companion Companion
+  @NotNull
+  public static final String SIGNATURE_ALGORITHM = "COMPOSITESIG"
+##
+public static final class net.corda.core.crypto.CompositeSignature$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.security.Provider$Service getService(java.security.Provider)
+##
+public static final class net.corda.core.crypto.CompositeSignature$State extends java.lang.Object
+  public <init>(java.io.ByteArrayOutputStream, net.corda.core.crypto.CompositeKey)
+  @NotNull
+  public final java.io.ByteArrayOutputStream component1()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey component2()
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignature$State copy(java.io.ByteArrayOutputStream, net.corda.core.crypto.CompositeKey)
+  public final boolean engineVerify(byte[])
+  public boolean equals(Object)
+  @NotNull
+  public final java.io.ByteArrayOutputStream getBuffer()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey getVerifyKey()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.crypto.CompositeSignaturesWithKeys extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component1()
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignaturesWithKeys copy(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  public int hashCode()
+  public String toString()
+  public static final net.corda.core.crypto.CompositeSignaturesWithKeys$Companion Companion
+##
+public static final class net.corda.core.crypto.CompositeSignaturesWithKeys$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignaturesWithKeys getEMPTY()
+##
+public final class net.corda.core.crypto.CordaObjectIdentifier extends java.lang.Object
+  @NotNull
+  public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_KEY
+  @NotNull
+  public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_SIGNATURE
+  public static final net.corda.core.crypto.CordaObjectIdentifier INSTANCE
+##
+public final class net.corda.core.crypto.CordaSecurityProvider extends java.security.Provider
+  public <init>()
+  public static final net.corda.core.crypto.CordaSecurityProvider$Companion Companion
+  @NotNull
+  public static final String PROVIDER_NAME = "Corda"
+##
+public static final class net.corda.core.crypto.CordaSecurityProvider$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.core.crypto.Crypto extends java.lang.Object
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(String, byte[])
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(net.corda.core.crypto.SignatureScheme, byte[])
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(String, byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(net.corda.core.crypto.SignatureScheme, byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPair(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPair(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPairFromEntropy(java.math.BigInteger)
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPairFromEntropy(net.corda.core.crypto.SignatureScheme, java.math.BigInteger)
+  @NotNull
+  public static final byte[] doSign(String, java.security.PrivateKey, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.TransactionSignature doSign(java.security.KeyPair, net.corda.core.crypto.SignableData)
+  @NotNull
+  public static final byte[] doSign(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final byte[] doSign(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
+  public static final boolean doVerify(String, java.security.PublicKey, byte[], byte[])
+  public static final boolean doVerify(java.security.PublicKey, byte[], byte[])
+  public static final boolean doVerify(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
+  public static final boolean doVerify(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
+  @NotNull
+  public static final java.security.Provider findProvider(String)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(String)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PrivateKey)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(org.bouncycastle.asn1.x509.AlgorithmIdentifier)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair()
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair(String)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair(net.corda.core.crypto.SignatureScheme)
+  public static final boolean isSupportedSignatureScheme(net.corda.core.crypto.SignatureScheme)
+  public static final boolean isValid(java.security.PublicKey, byte[], byte[])
+  public static final boolean isValid(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
+  public static final boolean isValid(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
+  public static final boolean publicKeyOnCurve(net.corda.core.crypto.SignatureScheme, java.security.PublicKey)
+  @NotNull
+  public static final java.util.List<net.corda.core.crypto.SignatureScheme> supportedSignatureSchemes()
+  @NotNull
+  public static final java.security.PrivateKey toSupportedPrivateKey(java.security.PrivateKey)
+  @NotNull
+  public static final java.security.PublicKey toSupportedPublicKey(java.security.PublicKey)
+  @NotNull
+  public static final java.security.PublicKey toSupportedPublicKey(org.bouncycastle.asn1.x509.SubjectPublicKeyInfo)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme DEFAULT_SIGNATURE_SCHEME
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256K1_SHA256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256R1_SHA256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme EDDSA_ED25519_SHA512
+  public static final net.corda.core.crypto.Crypto INSTANCE
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme RSA_SHA256
+  @NotNull
+  public static final org.bouncycastle.asn1.DLSequence SHA512_256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme SPHINCS256_SHA256
+##
+public final class net.corda.core.crypto.CryptoUtils extends java.lang.Object
+  @NotNull
+  public static final java.util.Set<java.security.PublicKey> byKeys(Iterable<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public static final java.security.PrivateKey component1(java.security.KeyPair)
+  @NotNull
+  public static final java.security.PublicKey component2(java.security.KeyPair)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.crypto.SecureHash, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.utilities.OpaqueBytes, net.corda.core.contracts.PrivacySalt, int, int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 computeNonce(net.corda.core.contracts.PrivacySalt, int, int)
+  public static final boolean containsAny(java.security.PublicKey, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public static final java.security.KeyPair entropyToKeyPair(java.math.BigInteger)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair()
+  @NotNull
+  public static final java.util.Set<java.security.PublicKey> getKeys(java.security.PublicKey)
+  public static final boolean isFulfilledBy(java.security.PublicKey, Iterable<? extends java.security.PublicKey>)
+  public static final boolean isFulfilledBy(java.security.PublicKey, java.security.PublicKey)
+  public static final boolean isValid(java.security.PublicKey, byte[], net.corda.core.crypto.DigitalSignature)
+  @NotNull
+  public static final java.security.SecureRandom newSecureRandom()
+  public static final long random63BitValue()
+  @NotNull
+  public static final byte[] secureRandomBytes(int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash serializedHash(T)
+  @NotNull
+  public static final net.corda.core.crypto.TransactionSignature sign(java.security.KeyPair, net.corda.core.crypto.SignableData)
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature sign(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.PrivateKey, byte[], java.security.PublicKey)
+  @NotNull
+  public static final String toStringShort(java.security.PublicKey)
+  public static final boolean verify(java.security.KeyPair, byte[], byte[])
+  public static final boolean verify(java.security.PublicKey, byte[], net.corda.core.crypto.DigitalSignature)
+  public static final boolean verify(java.security.PublicKey, byte[], byte[])
+##
+@CordaSerializable
+public class net.corda.core.crypto.DigitalSignature extends net.corda.core.utilities.OpaqueBytes
+  public <init>(byte[])
+##
+@CordaSerializable
+public static class net.corda.core.crypto.DigitalSignature$WithKey extends net.corda.core.crypto.DigitalSignature
+  public <init>(java.security.PublicKey, byte[])
+  @NotNull
+  public final java.security.PublicKey getBy()
+  public final boolean isValid(byte[])
+  public final boolean verify(net.corda.core.utilities.OpaqueBytes)
+  public final boolean verify(byte[])
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature withoutKey()
+##
+public abstract class net.corda.core.crypto.MerkleTree extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getHash()
+  public static final net.corda.core.crypto.MerkleTree$Companion Companion
+##
+public static final class net.corda.core.crypto.MerkleTree$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getMerkleTree(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+##
+public static final class net.corda.core.crypto.MerkleTree$Leaf extends net.corda.core.crypto.MerkleTree
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree$Leaf copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  public String toString()
+##
+public static final class net.corda.core.crypto.MerkleTree$Node extends net.corda.core.crypto.MerkleTree
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.MerkleTree, net.corda.core.crypto.MerkleTree)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree component2()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree component3()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree$Node copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.MerkleTree, net.corda.core.crypto.MerkleTree)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getLeft()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getRight()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.crypto.MerkleTreeException extends net.corda.core.CordaException
+  public <init>(String)
+  @NotNull
+  public final String getReason()
+##
+public final class net.corda.core.crypto.NullKeys extends java.lang.Object
+  @NotNull
+  public final net.corda.core.identity.AnonymousParty getNULL_PARTY()
+  @NotNull
+  public final net.corda.core.crypto.TransactionSignature getNULL_SIGNATURE()
+  public static final net.corda.core.crypto.NullKeys INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.NullKeys$NullPublicKey extends java.lang.Object implements java.security.PublicKey, java.lang.Comparable
+  public int compareTo(java.security.PublicKey)
+  @NotNull
+  public String getAlgorithm()
+  @NotNull
+  public byte[] getEncoded()
+  @NotNull
+  public String getFormat()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.crypto.NullKeys$NullPublicKey INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.crypto.PartialMerkleTree extends java.lang.Object
+  public <init>(net.corda.core.crypto.PartialMerkleTree$PartialTree)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRoot()
+  public final boolean verify(net.corda.core.crypto.SecureHash, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  public static final net.corda.core.crypto.PartialMerkleTree$Companion Companion
+##
+public static final class net.corda.core.crypto.PartialMerkleTree$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree build(net.corda.core.crypto.MerkleTree, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash rootAndUsedHashes(net.corda.core.crypto.PartialMerkleTree$PartialTree, java.util.List<net.corda.core.crypto.SecureHash>)
+##
+@CordaSerializable
+public abstract static class net.corda.core.crypto.PartialMerkleTree$PartialTree extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Node extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+  public <init>(net.corda.core.crypto.PartialMerkleTree$PartialTree, net.corda.core.crypto.PartialMerkleTree$PartialTree)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree component2()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Node copy(net.corda.core.crypto.PartialMerkleTree$PartialTree, net.corda.core.crypto.PartialMerkleTree$PartialTree)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getLeft()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRight()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.crypto.SecureHash extends net.corda.core.utilities.OpaqueBytes
+  public <init>(byte[], kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 hashConcat(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 parse(String)
+  @NotNull
+  public final String prefixChars(int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
+  @NotNull
+  public String toString()
+  public static final net.corda.core.crypto.SecureHash$Companion Companion
+##
+public static final class net.corda.core.crypto.SecureHash$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getAllOnesHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getZeroHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 parse(String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.SecureHash$SHA256 extends net.corda.core.crypto.SecureHash
+  public <init>(byte[])
+##
+public final class net.corda.core.crypto.SecureHashKt extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+##
+@CordaSerializable
+public final class net.corda.core.crypto.SignableData extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignatureMetadata)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata component2()
+  @NotNull
+  public final net.corda.core.crypto.SignableData copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignatureMetadata)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.crypto.SignatureMetadata extends java.lang.Object
+  public <init>(int, int)
+  public final int component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata copy(int, int)
+  public boolean equals(Object)
+  public final int getPlatformVersion()
+  public final int getSchemeNumberID()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.core.crypto.SignatureScheme extends java.lang.Object
+  public <init>(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, java.util.List<? extends org.bouncycastle.asn1.x509.AlgorithmIdentifier>, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
+  public final int component1()
+  @NotNull
+  public final String component10()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final org.bouncycastle.asn1.x509.AlgorithmIdentifier component3()
+  @NotNull
+  public final java.util.List<org.bouncycastle.asn1.x509.AlgorithmIdentifier> component4()
+  @NotNull
+  public final String component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final String component7()
+  @Nullable
+  public final java.security.spec.AlgorithmParameterSpec component8()
+  @Nullable
+  public final Integer component9()
+  @NotNull
+  public final net.corda.core.crypto.SignatureScheme copy(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, java.util.List<? extends org.bouncycastle.asn1.x509.AlgorithmIdentifier>, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
+  public boolean equals(Object)
+  @Nullable
+  public final java.security.spec.AlgorithmParameterSpec getAlgSpec()
+  @NotNull
+  public final String getAlgorithmName()
+  @NotNull
+  public final java.util.List<org.bouncycastle.asn1.x509.AlgorithmIdentifier> getAlternativeOIDs()
+  @NotNull
+  public final String getDesc()
+  @Nullable
+  public final Integer getKeySize()
+  @NotNull
+  public final String getProviderName()
+  @NotNull
+  public final String getSchemeCodeName()
+  public final int getSchemeNumberID()
+  @NotNull
+  public final String getSignatureName()
+  @NotNull
+  public final org.bouncycastle.asn1.x509.AlgorithmIdentifier getSignatureOID()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public class net.corda.core.crypto.SignedData extends java.lang.Object
+  public <init>(net.corda.core.serialization.SerializedBytes<T>, net.corda.core.crypto.DigitalSignature$WithKey)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> getRaw()
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey getSig()
+  @NotNull
+  public final T verified()
+  protected void verifyData(T)
+##
+@CordaSerializable
+public final class net.corda.core.crypto.TransactionSignature extends net.corda.core.crypto.DigitalSignature
+  public <init>(byte[], java.security.PublicKey, net.corda.core.crypto.SignatureMetadata)
+  public <init>(byte[], java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.crypto.PartialMerkleTree)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getBy()
+  @Nullable
+  public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
+  public int hashCode()
+  public final boolean isValid(net.corda.core.crypto.SecureHash)
+  public final boolean verify(net.corda.core.crypto.SecureHash)
+##
+public abstract class net.corda.core.flows.AbstractStateReplacementFlow extends java.lang.Object
+  public <init>()
+##
+public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getInitiatingSession()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  protected abstract void verifyProposal(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.AbstractStateReplacementFlow$Proposal<? extends T>)
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion Companion
+##
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$APPROVING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$APPROVING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$VERIFYING INSTANCE
+##
+public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Instigator extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.contracts.StateAndRef<? extends S>, M, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.contracts.StateAndRef, Object, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  protected abstract net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+  @Suspendable
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> call()
+  public final M getModification()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<S> getOriginalState()
+  @NotNull
+  public java.util.List<kotlin.Pair<net.corda.core.flows.FlowSession, java.util.List<net.corda.core.identity.AbstractParty>>> getParticipantSessions()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion Companion
+##
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$NOTARY extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$NOTARY INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$SIGNING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Proposal extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateRef, M)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  public final M component2()
+  @NotNull
+  public final net.corda.core.flows.AbstractStateReplacementFlow$Proposal<M> copy(net.corda.core.contracts.StateRef, M)
+  public boolean equals(Object)
+  public final M getModification()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
+  public int hashCode()
+  public String toString()
+##
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx extends java.lang.Object
+  public <init>(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction component1()
+  @NotNull
+  public final net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx copy(net.corda.core.transactions.SignedTransaction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getStx()
+  public int hashCode()
+  public String toString()
+##
+@Suspendable
+public final class net.corda.core.flows.CollectSignatureFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, java.util.List<? extends java.security.PublicKey>)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, java.security.PublicKey...)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> call()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getSession()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigningKeys()
+##
+public final class net.corda.core.flows.CollectSignaturesFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, Iterable, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @Nullable
+  public final Iterable<java.security.PublicKey> getMyOptionalKeys()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final java.util.Collection<net.corda.core.flows.FlowSession> getSessionsToCollectFrom()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.CollectSignaturesFlow$Companion Companion
+##
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$COLLECTING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.CollectSignaturesFlow$Companion$COLLECTING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.CollectSignaturesFlow$Companion$VERIFYING INSTANCE
+##
+public final class net.corda.core.flows.ContractUpgradeFlow extends java.lang.Object
+  public static final net.corda.core.flows.ContractUpgradeFlow INSTANCE
+##
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Authorise extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.contracts.StateAndRef<?>, Class<? extends net.corda.core.contracts.UpgradedContract<?, ?>>)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<?> getStateAndRef()
+##
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Deauthorise extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.contracts.StateRef)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
+##
+@InitiatingFlow
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Initiate extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
+  public <init>(net.corda.core.contracts.StateAndRef<? extends OldState>, Class<? extends net.corda.core.contracts.UpgradedContract<? super OldState, ? extends NewState>>)
+  @Suspendable
+  @NotNull
+  protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+##
+public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession, Object)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public final Object getPayload()
+  @Suspendable
+  @NotNull
+  protected net.corda.core.utilities.UntrustworthyData<net.corda.core.internal.FetchDataFlow$Request> sendPayloadAndReceiveDataRequest(net.corda.core.flows.FlowSession, Object)
+  @Suspendable
+  protected void verifyDataRequest(net.corda.core.internal.FetchDataFlow$Request$Data)
+##
+@InitiatingFlow
+public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getTransaction()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.FinalityFlow$Companion Companion
+##
+public static final class net.corda.core.flows.FinalityFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING extends net.corda.core.utilities.ProgressTracker$Step
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker childProgressTracker()
+  public static final net.corda.core.flows.FinalityFlow$Companion$NOTARISING INSTANCE
+##
+@CordaSerializable
+public class net.corda.core.flows.FlowException extends net.corda.core.CordaException
+  public <init>()
+  public <init>(String)
+  public <init>(String, Throwable)
+  public <init>(Throwable)
+##
+@CordaSerializable
+public final class net.corda.core.flows.FlowInfo extends java.lang.Object
+  public <init>(int, String)
+  public final int component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.FlowInfo copy(int, String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getAppName()
+  public final int getFlowVersion()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.flows.FlowInitiator extends java.lang.Object implements java.security.Principal
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.InvocationContext getInvocationContext()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Peer extends net.corda.core.flows.FlowInitiator
+  public <init>(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Peer copy(net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$RPC extends net.corda.core.flows.FlowInitiator
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$RPC copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final String getUsername()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Scheduled extends net.corda.core.flows.FlowInitiator
+  public <init>(net.corda.core.contracts.ScheduledStateRef)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Service extends net.corda.core.flows.FlowInitiator
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Service copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final String getServiceClassName()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Shell extends net.corda.core.flows.FlowInitiator
+  @NotNull
+  public String getName()
+  public static final net.corda.core.flows.FlowInitiator$Shell INSTANCE
+##
+public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
+  public <init>()
+  @Suspendable
+  public abstract T call()
+  public final void checkFlowPermission(String, java.util.Map<String, String>)
+  @Suspendable
+  @Nullable
+  public final net.corda.core.flows.FlowStackSnapshot flowStackSnapshot()
+  @Nullable
+  public static final net.corda.core.flows.FlowLogic<?> getCurrentTopLevel()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.flows.FlowInfo getFlowInfo(net.corda.core.identity.Party)
+  @NotNull
+  public final org.slf4j.Logger getLogger()
+  @NotNull
+  public final net.corda.core.identity.Party getOurIdentity()
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate getOurIdentityAndCert()
+  @Nullable
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getRunId()
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServiceHub()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.identity.Party)
+  @Suspendable
+  public final void persistFlowStackSnapshot()
+  @Suspendable
+  @NotNull
+  public net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>, net.corda.core.identity.Party)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(Class<R>, java.util.List<? extends net.corda.core.flows.FlowSession>)
+  @Suspendable
+  @NotNull
+  public java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAllMap(java.util.Map<net.corda.core.flows.FlowSession, ? extends Class<?>>)
+  public final void recordAuditEvent(String, String, java.util.Map<String, String>)
+  @Suspendable
+  public void send(net.corda.core.identity.Party, Object)
+  @Suspendable
+  @NotNull
+  public net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, net.corda.core.identity.Party, Object)
+  @Suspendable
+  public static final void sleep(java.time.Duration)
+  @Suspendable
+  public R subFlow(net.corda.core.flows.FlowLogic<? extends R>)
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> track()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> trackStepsTree()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<Integer, Integer> trackStepsTreeIndex()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash)
+  @Suspendable
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash, boolean)
+  public static final net.corda.core.flows.FlowLogic$Companion Companion
+##
+public static final class net.corda.core.flows.FlowLogic$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.flows.FlowLogic<?> getCurrentTopLevel()
+  @Suspendable
+  public final void sleep(java.time.Duration)
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.flows.FlowLogicRef
+##
+@DoNotImplement
+public interface net.corda.core.flows.FlowLogicRefFactory
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogicRef create(Class<? extends net.corda.core.flows.FlowLogic<?>>, Object...)
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogicRef create(String, Object...)
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogic<?> toFlowLogic(net.corda.core.flows.FlowLogicRef)
+##
+@DoNotImplement
+public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
+  public <init>()
+  @NotNull
+  public abstract net.corda.core.identity.Party getCounterparty()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo(boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>, boolean)
+  @Suspendable
+  public abstract void send(Object)
+  @Suspendable
+  public abstract void send(Object, boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, Object)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, Object, boolean)
+##
+public final class net.corda.core.flows.FlowStackSnapshot extends java.lang.Object
+  public <init>(java.time.Instant, String, java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame>)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame> component3()
+  @NotNull
+  public final net.corda.core.flows.FlowStackSnapshot copy(java.time.Instant, String, java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame>)
+  public boolean equals(Object)
+  @NotNull
+  public final String getFlowClass()
+  @NotNull
+  public final java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame> getStackFrames()
+  @NotNull
+  public final java.time.Instant getTime()
+  public int hashCode()
+  public String toString()
+##
+public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends java.lang.Object
+  public <init>(StackTraceElement, java.util.List<?>)
+  @NotNull
+  public final StackTraceElement component1()
+  @NotNull
+  public final java.util.List<Object> component2()
+  @NotNull
+  public final net.corda.core.flows.FlowStackSnapshot$Frame copy(StackTraceElement, java.util.List<?>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<Object> getStackObjects()
+  @NotNull
+  public final StackTraceElement getStackTraceElement()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.IllegalFlowLogicException extends java.lang.IllegalArgumentException
+  public <init>(Class<?>, String)
+  public <init>(String, String)
+  @NotNull
+  public final String getType()
+##
+public @interface net.corda.core.flows.InitiatedBy
+  public abstract Class<? extends net.corda.core.flows.FlowLogic<?>> value()
+##
+public @interface net.corda.core.flows.InitiatingFlow
+  public abstract int version()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationPayload extends java.lang.Object
+  public <init>(Object, net.corda.core.flows.NotarisationRequestSignature)
+  @NotNull
+  public final Object component1()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature component2()
+  @NotNull
+  public final net.corda.core.flows.NotarisationPayload copy(Object, net.corda.core.flows.NotarisationRequestSignature)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature getRequestSignature()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getSignedTransaction()
+  @NotNull
+  public final Object getTransaction()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationRequest extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getStatesToConsume()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTransactionId()
+  public final void verifySignature(net.corda.core.flows.NotarisationRequestSignature, net.corda.core.identity.Party)
+  public static final net.corda.core.flows.NotarisationRequest$Companion Companion
+##
+public static final class net.corda.core.flows.NotarisationRequest$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationRequestSignature extends java.lang.Object
+  public <init>(net.corda.core.crypto.DigitalSignature$WithKey, int)
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature copy(net.corda.core.crypto.DigitalSignature$WithKey, int)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey getDigitalSignature()
+  public final int getPlatformVersion()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationResponse extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component1()
+  @NotNull
+  public final net.corda.core.flows.NotarisationResponse copy(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> getSignatures()
+  public int hashCode()
+  public String toString()
+##
+@InitiatingFlow
+public final class net.corda.core.flows.NotaryChangeFlow extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
+  public <init>(net.corda.core.contracts.StateAndRef<? extends T>, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.contracts.StateAndRef, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+##
+@CordaSerializable
+public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$Conflict extends net.corda.core.flows.NotaryError
+  public <init>(net.corda.core.crypto.SecureHash, java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails>)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails> component2()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$Conflict copy(net.corda.core.crypto.SecureHash, java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails> getConsumedStates()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$General extends net.corda.core.flows.NotaryError
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$General copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getCause()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$RequestSignatureInvalid extends net.corda.core.flows.NotaryError
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$RequestSignatureInvalid copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getCause()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid extends net.corda.core.flows.NotaryError
+  public <init>(java.time.Instant, net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow component2()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$TimeWindowInvalid copy(java.time.Instant, net.corda.core.contracts.TimeWindow)
+  public boolean equals(Object)
+  @NotNull
+  public final java.time.Instant getCurrentTime()
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow getTxTimeWindow()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion Companion
+  @NotNull
+  public static final net.corda.core.flows.NotaryError$TimeWindowInvalid INSTANCE
+##
+public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$TransactionInvalid extends net.corda.core.flows.NotaryError
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$TransactionInvalid copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getCause()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$WrongNotary extends net.corda.core.flows.NotaryError
+  public static final net.corda.core.flows.NotaryError$WrongNotary INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotaryException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash)
+  public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.NotaryError getError()
+  @Nullable
+  public final net.corda.core.crypto.SecureHash getTxId()
+##
+public final class net.corda.core.flows.NotaryFlow extends java.lang.Object
+  public <init>()
+##
+@DoNotImplement
+@InitiatingFlow
+public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> call()
+  @NotNull
+  protected final net.corda.core.identity.Party checkTransaction()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @Suspendable
+  @NotNull
+  protected final net.corda.core.utilities.UntrustworthyData<net.corda.core.flows.NotarisationResponse> notarise(net.corda.core.identity.Party)
+  @NotNull
+  protected final java.util.List<net.corda.core.crypto.TransactionSignature> validateResponse(net.corda.core.utilities.UntrustworthyData<net.corda.core.flows.NotarisationResponse>, net.corda.core.identity.Party)
+  public static final net.corda.core.flows.NotaryFlow$Client$Companion Companion
+##
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUESTING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.NotaryFlow$Client$Companion$REQUESTING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
+##
+public abstract static class net.corda.core.flows.NotaryFlow$Service extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.node.services.TrustedAuthorityNotaryService)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @Suspendable
+  protected final void checkNotary(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public final net.corda.core.node.services.TrustedAuthorityNotaryService getService()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.TransactionParts receiveAndVerifyTx()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotaryInternalException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.flows.NotaryError)
+  @NotNull
+  public final net.corda.core.flows.NotaryError getError()
+##
+public final class net.corda.core.flows.ReceiveStateAndRefFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<T>> call()
+##
+public final class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  public <init>(net.corda.core.flows.FlowSession, boolean)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+##
+public @interface net.corda.core.flows.SchedulableFlow
+##
+public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flows.DataVendingFlow
+  public <init>(net.corda.core.flows.FlowSession, java.util.List<? extends net.corda.core.contracts.StateAndRef<?>>)
+##
+public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
+##
+public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @Suspendable
+  protected abstract void checkTransaction(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.SignTransactionFlow$Companion Companion
+##
+public static final class net.corda.core.flows.SignTransactionFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$RECEIVING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.SignTransactionFlow$Companion$RECEIVING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.SignTransactionFlow$Companion$SIGNING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING INSTANCE
+##
+public final class net.corda.core.flows.StackFrameDataToken extends java.lang.Object
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.StackFrameDataToken copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getClassName()
+  public int hashCode()
+  public String toString()
+##
+public @interface net.corda.core.flows.StartableByRPC
+##
+public @interface net.corda.core.flows.StartableByService
+##
+@CordaSerializable
+public final class net.corda.core.flows.StateConsumptionDetails extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHashOfTransactionId()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.StateMachineRunId extends java.lang.Object
+  public <init>(java.util.UUID)
+  @NotNull
+  public final java.util.UUID component1()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId copy(java.util.UUID)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.UUID getUuid()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.flows.StateMachineRunId$Companion Companion
+##
+public static final class net.corda.core.flows.StateMachineRunId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId createRandom()
+##
+@CordaSerializable
+public class net.corda.core.flows.StateReplacementException extends net.corda.core.flows.FlowException
+  public <init>()
+  public <init>(String)
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.core.flows.TransactionParts extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.contracts.TimeWindow, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> component2()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow component3()
+  @Nullable
+  public final net.corda.core.identity.Party component4()
+  @NotNull
+  public final net.corda.core.flows.TransactionParts copy(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.contracts.TimeWindow, net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimestamp()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException
+  public <init>(String)
+  public <init>(String, Throwable)
+##
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.identity.AbstractParty extends java.lang.Object
+  public <init>(java.security.PublicKey)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getOwningKey()
+  public int hashCode()
+  @Nullable
+  public abstract net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public abstract net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference ref(byte...)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.identity.AnonymousParty extends net.corda.core.identity.AbstractParty
+  public <init>(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.identity.CordaX500Name extends java.lang.Object
+  public <init>(String, String, String)
+  public <init>(String, String, String, String)
+  public <init>(String, String, String, String, String, String)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
+  @Nullable
+  public final String component1()
+  @Nullable
+  public final String component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final String component4()
+  @Nullable
+  public final String component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name copy(String, String, String, String, String, String)
+  public boolean equals(Object)
+  @Nullable
+  public final String getCommonName()
+  @NotNull
+  public final String getCountry()
+  @NotNull
+  public final String getLocality()
+  @NotNull
+  public final String getOrganisation()
+  @Nullable
+  public final String getOrganisationUnit()
+  @Nullable
+  public final String getState()
+  @NotNull
+  public final javax.security.auth.x500.X500Principal getX500Principal()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name parse(String)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.identity.CordaX500Name$Companion Companion
+  public static final int LENGTH_COUNTRY = 2
+  public static final int MAX_LENGTH_COMMON_NAME = 64
+  public static final int MAX_LENGTH_LOCALITY = 64
+  public static final int MAX_LENGTH_ORGANISATION = 128
+  public static final int MAX_LENGTH_ORGANISATION_UNIT = 64
+  public static final int MAX_LENGTH_STATE = 64
+##
+public static final class net.corda.core.identity.CordaX500Name$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name parse(String)
+##
+public final class net.corda.core.identity.IdentityUtils extends java.lang.Object
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, T> excludeHostNode(net.corda.core.node.ServiceHub, java.util.Map<net.corda.core.identity.Party, ? extends T>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, T> excludeNotary(java.util.Map<net.corda.core.identity.Party, ? extends T>, net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<net.corda.core.identity.AbstractParty>> groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<net.corda.core.identity.AbstractParty>> groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends net.corda.core.identity.AbstractParty>, boolean)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>, boolean)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.identity.Party extends net.corda.core.identity.AbstractParty
+  public <init>(java.security.cert.X509Certificate)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
+  @NotNull
+  public final net.corda.core.identity.AnonymousParty anonymise()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.identity.PartyAndCertificate extends java.lang.Object
+  public <init>(java.security.cert.CertPath)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final java.security.cert.X509Certificate component2()
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.cert.CertPath getCertPath()
+  @NotNull
+  public final java.security.cert.X509Certificate getCertificate()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final java.security.PublicKey getOwningKey()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final java.security.cert.PKIXCertPathValidatorResult verify(java.security.cert.TrustAnchor)
+##
+@CordaSerializable
+public interface net.corda.core.messaging.AllPossibleRecipients extends net.corda.core.messaging.MessageRecipients
+##
+@DoNotImplement
+public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.messaging.RPCOps
+  public abstract void acceptNewNetworkParameters(net.corda.core.crypto.SecureHash)
+  public abstract void addVaultTransactionNote(net.corda.core.crypto.SecureHash, String)
+  public abstract boolean attachmentExists(net.corda.core.crypto.SecureHash)
+  public abstract void clearNetworkMapCache()
+  @NotNull
+  public abstract java.time.Instant currentNodeTime()
+  public abstract int getProtocolVersion()
+  @NotNull
+  public abstract Iterable<String> getVaultTransactionNotes(net.corda.core.crypto.SecureHash)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction> internalVerifiedTransactionsFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.transactions.SignedTransaction> internalVerifiedTransactionsSnapshot()
+  public abstract boolean isFlowsDrainingModeEnabled()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> networkMapFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> networkMapSnapshot()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.messaging.ParametersUpdateInfo, net.corda.core.messaging.ParametersUpdateInfo> networkParametersFeed()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo nodeInfo()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> notaryIdentities()
+  @Nullable
+  public abstract net.corda.core.identity.Party notaryPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract java.io.InputStream openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String, boolean)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+  @NotNull
+  public abstract java.util.List<String> registeredFlows()
+  public abstract void setFlowsDrainingModeEnabled(boolean)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.FlowHandle<T> startFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.messaging.StateMachineTransactionMapping>, net.corda.core.messaging.StateMachineTransactionMapping> stateMachineRecordedTransactionMappingFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.messaging.StateMachineTransactionMapping> stateMachineRecordedTransactionMappingSnapshot()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.messaging.StateMachineInfo>, net.corda.core.messaging.StateMachineUpdate> stateMachinesFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.messaging.StateMachineInfo> stateMachinesSnapshot()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash uploadAttachment(java.io.InputStream)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash uploadAttachmentWithMetadata(java.io.InputStream, String, String)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQuery(Class<? extends T>)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByCriteria(net.corda.core.node.services.vault.QueryCriteria, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByWithPagingSpec(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByWithSorting(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrack(Class<? extends T>)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByCriteria(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByWithPagingSpec(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByWithSorting(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<Void> waitUntilNetworkReady()
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public final class net.corda.core.messaging.CordaRPCOpsKt extends java.lang.Object
+##
+@CordaSerializable
+public final class net.corda.core.messaging.DataFeed extends java.lang.Object
+  public <init>(A, rx.Observable<B>)
+  public final A component1()
+  @NotNull
+  public final rx.Observable<B> component2()
+  @NotNull
+  public final net.corda.core.messaging.DataFeed<A, B> copy(A, rx.Observable<B>)
+  public boolean equals(Object)
+  public final A getSnapshot()
+  @NotNull
+  public final rx.Observable<B> getUpdates()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.messaging.FlowHandle extends java.lang.AutoCloseable
+  public abstract void close()
+  @NotNull
+  public abstract net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowHandle
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>)
+  public void close()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<A> component2()
+  @NotNull
+  public final net.corda.core.messaging.FlowHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.messaging.FlowProgressHandle extends net.corda.core.messaging.FlowHandle
+  public abstract void close()
+  @NotNull
+  public abstract rx.Observable<String> getProgress()
+  @Nullable
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeFeed()
+  @Nullable
+  public abstract net.corda.core.messaging.DataFeed<Integer, Integer> getStepsTreeIndexFeed()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowProgressHandle
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>, net.corda.core.messaging.DataFeed<? extends java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed, net.corda.core.messaging.DataFeed, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public void close()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<A> component2()
+  @NotNull
+  public final rx.Observable<String> component3()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<Integer, Integer> component4()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> component5()
+  @NotNull
+  public final net.corda.core.messaging.FlowProgressHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>)
+  @NotNull
+  public final net.corda.core.messaging.FlowProgressHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>, net.corda.core.messaging.DataFeed<? extends java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public rx.Observable<String> getProgress()
+  @NotNull
+  public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+  @Nullable
+  public net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeFeed()
+  @Nullable
+  public net.corda.core.messaging.DataFeed<Integer, Integer> getStepsTreeIndexFeed()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.messaging.MessageRecipientGroup extends net.corda.core.messaging.MessageRecipients
+##
+@CordaSerializable
+public interface net.corda.core.messaging.MessageRecipients
+##
+@CordaSerializable
+public final class net.corda.core.messaging.ParametersUpdateInfo extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.node.NetworkParameters, String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final java.time.Instant component4()
+  @NotNull
+  public final net.corda.core.messaging.ParametersUpdateInfo copy(net.corda.core.crypto.SecureHash, net.corda.core.node.NetworkParameters, String, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public final String getDescription()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getParameters()
+  @NotNull
+  public final java.time.Instant getUpdateDeadline()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.messaging.RPCOps
+  public abstract int getProtocolVersion()
+##
+public @interface net.corda.core.messaging.RPCReturnsObservables
+##
+@CordaSerializable
+public interface net.corda.core.messaging.SingleMessageRecipient extends net.corda.core.messaging.MessageRecipients
+##
+@CordaSerializable
+public final class net.corda.core.messaging.StateMachineInfo extends java.lang.Object
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>)
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>, net.corda.core.context.InvocationContext)
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed, net.corda.core.context.InvocationContext, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator component3()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> component4()
+  @NotNull
+  public final net.corda.core.context.InvocationContext component5()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>)
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>, net.corda.core.context.InvocationContext)
+  public boolean equals(Object)
+  @NotNull
+  public final String getFlowLogicClassName()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator getInitiator()
+  @NotNull
+  public final net.corda.core.context.InvocationContext getInvocationContext()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> getProgressTrackerStepAndUpdates()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.messaging.StateMachineTransactionMapping extends java.lang.Object
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component2()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineTransactionMapping copy(net.corda.core.flows.StateMachineRunId, net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getStateMachineRunId()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTransactionId()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.messaging.StateMachineUpdate extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.flows.StateMachineRunId getId()
+##
+@CordaSerializable
+public static final class net.corda.core.messaging.StateMachineUpdate$Added extends net.corda.core.messaging.StateMachineUpdate
+  public <init>(net.corda.core.messaging.StateMachineInfo)
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo component1()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineUpdate$Added copy(net.corda.core.messaging.StateMachineInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo getStateMachineInfo()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.messaging.StateMachineUpdate$Removed extends net.corda.core.messaging.StateMachineUpdate
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try<?>)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.utilities.Try<?> component2()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineUpdate$Removed copy(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try<?>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.utilities.Try<?> getResult()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.ServiceHub
+  @NotNull
+  public abstract net.corda.core.messaging.FlowHandle<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlow(net.corda.core.flows.FlowLogic<? extends T>)
+##
+@CordaSerializable
+public final class net.corda.core.node.NetworkParameters extends java.lang.Object
+  @DeprecatedConstructorForDeserialization
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.node.NotaryInfo> component2()
+  public final int component3()
+  public final int component4()
+  @NotNull
+  public final java.time.Instant component5()
+  public final int component6()
+  @NotNull
+  public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> component7()
+  @NotNull
+  public final java.time.Duration component8()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration)
+  public boolean equals(Object)
+  public final int getEpoch()
+  @NotNull
+  public final java.time.Duration getEventHorizon()
+  public final int getMaxMessageSize()
+  public final int getMaxTransactionSize()
+  public final int getMinimumPlatformVersion()
+  @NotNull
+  public final java.time.Instant getModifiedTime()
+  @NotNull
+  public final java.util.List<net.corda.core.node.NotaryInfo> getNotaries()
+  @NotNull
+  public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> getWhitelistedContractImplementations()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.NodeInfo extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.PartyAndCertificate> component2()
+  public final int component3()
+  public final long component4()
+  @NotNull
+  public final net.corda.core.node.NodeInfo copy(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getAddresses()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> getLegalIdentities()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.PartyAndCertificate> getLegalIdentitiesAndCerts()
+  public final int getPlatformVersion()
+  public final long getSerial()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate identityAndCertFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.Party identityFromX500Name(net.corda.core.identity.CordaX500Name)
+  public final boolean isLegalIdentity(net.corda.core.identity.Party)
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.NotaryInfo extends java.lang.Object
+  public <init>(net.corda.core.identity.Party, boolean)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.core.node.NotaryInfo copy(net.corda.core.identity.Party, boolean)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getIdentity()
+  public final boolean getValidating()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.node.ServiceHub extends net.corda.core.node.ServicesForResolution
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract T cordaService(Class<T>)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract java.time.Clock getClock()
+  @NotNull
+  public abstract net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public abstract net.corda.core.node.services.KeyManagementService getKeyManagementService()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getMyInfo()
+  @NotNull
+  public abstract net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
+  @NotNull
+  public abstract net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
+  @NotNull
+  public abstract net.corda.core.node.services.TransactionStorage getValidatedTransactions()
+  @NotNull
+  public abstract net.corda.core.node.services.VaultService getVaultService()
+  @NotNull
+  public abstract java.sql.Connection jdbcSession()
+  public abstract void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public abstract void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public abstract void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  public abstract void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public abstract void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  public abstract void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
+##
+@DoNotImplement
+public interface net.corda.core.node.ServicesForResolution
+  @NotNull
+  public abstract net.corda.core.node.services.AttachmentStorage getAttachments()
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public abstract net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public abstract net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+##
+public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.StatesToRecord valueOf(String)
+  public static net.corda.core.node.StatesToRecord[] values()
+##
+@DoNotImplement
+public interface net.corda.core.node.services.AttachmentStorage
+  public abstract boolean hasAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
+  @Nullable
+  public abstract net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+##
+public final class net.corda.core.node.services.AttachmentStorageKt extends java.lang.Object
+##
+@DoNotImplement
+public interface net.corda.core.node.services.ContractUpgradeService
+  @Nullable
+  public abstract String getAuthorisedContractUpgrade(net.corda.core.contracts.StateRef)
+  public abstract void removeAuthorisedContractUpgrade(net.corda.core.contracts.StateRef)
+  public abstract void storeAuthorisedContractUpgrade(net.corda.core.contracts.StateRef, Class<? extends net.corda.core.contracts.UpgradedContract<?, ?>>)
+##
+public @interface net.corda.core.node.services.CordaService
+##
+@DoNotImplement
+public interface net.corda.core.node.services.IdentityService
+  public abstract void assertOwnership(net.corda.core.identity.Party, net.corda.core.identity.AnonymousParty)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract Iterable<net.corda.core.identity.PartyAndCertificate> getAllIdentities()
+  @NotNull
+  public abstract java.security.cert.CertStore getCaCertStore()
+  @NotNull
+  public abstract java.security.cert.TrustAnchor getTrustAnchor()
+  @NotNull
+  public abstract java.security.cert.X509Certificate getTrustRoot()
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String, boolean)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.identity.Party requireWellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate verifyAndRegisterIdentity(net.corda.core.identity.PartyAndCertificate)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.contracts.PartyAndReference)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.KeyManagementService
+  @NotNull
+  public abstract Iterable<java.security.PublicKey> filterMyKeys(Iterable<? extends java.security.PublicKey>)
+  @Suspendable
+  @NotNull
+  public abstract java.security.PublicKey freshKey()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean)
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getKeys()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature sign(net.corda.core.crypto.SignableData, java.security.PublicKey)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.crypto.DigitalSignature$WithKey sign(byte[], java.security.PublicKey)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkMapCache extends net.corda.core.node.services.NetworkMapCacheBase
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByLegalIdentity(net.corda.core.identity.AbstractParty)
+##
+@CordaSerializable
+public abstract static class net.corda.core.node.services.NetworkMapCache$MapChange extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getNode()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Added extends net.corda.core.node.services.NetworkMapCache$MapChange
+  public <init>(net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Added copy(net.corda.core.node.NodeInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Modified extends net.corda.core.node.services.NetworkMapCache$MapChange
+  public <init>(net.corda.core.node.NodeInfo, net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.NodeInfo component2()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Modified copy(net.corda.core.node.NodeInfo, net.corda.core.node.NodeInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
+  @NotNull
+  public final net.corda.core.node.NodeInfo getPreviousNode()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Removed extends net.corda.core.node.services.NetworkMapCache$MapChange
+  public <init>(net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Removed copy(net.corda.core.node.NodeInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkMapCacheBase
+  public abstract void clearNetworkMapCache()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getAllNodes()
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.NetworkMapCache$MapChange> getChanged()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByAddress(net.corda.core.utilities.NetworkHostAndPort)
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByLegalName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<Void> getNodeReady()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getNodesByLegalIdentityKey(java.security.PublicKey)
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getNodesByLegalName(net.corda.core.identity.CordaX500Name)
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> getNotaryIdentities()
+  @Nullable
+  public abstract net.corda.core.node.services.PartyInfo getPartyInfo(net.corda.core.identity.Party)
+  @Nullable
+  public abstract net.corda.core.identity.Party getPeerByLegalName(net.corda.core.identity.CordaX500Name)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate getPeerCertificateByLegalName(net.corda.core.identity.CordaX500Name)
+  public abstract boolean isNotary(net.corda.core.identity.Party)
+  public abstract boolean isValidatingNotary(net.corda.core.identity.Party)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> track()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.NotaryService extends net.corda.core.serialization.SingletonSerializeAsToken
+  public <init>()
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogic<Void> createServiceFlow(net.corda.core.flows.FlowSession)
+  @NotNull
+  public abstract java.security.PublicKey getNotaryIdentityKey()
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServices()
+  public abstract void start()
+  public abstract void stop()
+  public static final void validateTimeWindow(java.time.Clock, net.corda.core.contracts.TimeWindow)
+  public static final net.corda.core.node.services.NotaryService$Companion Companion
+  @NotNull
+  public static final String ID_PREFIX = "corda.notary."
+##
+public static final class net.corda.core.node.services.NotaryService$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final String constructId(boolean, boolean, boolean, boolean)
+  public final void validateTimeWindow(java.time.Clock, net.corda.core.contracts.TimeWindow)
+##
+public abstract class net.corda.core.node.services.PartyInfo extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.identity.Party getParty()
+##
+public static final class net.corda.core.node.services.PartyInfo$DistributedNode extends net.corda.core.node.services.PartyInfo
+  public <init>(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.core.node.services.PartyInfo$DistributedNode copy(net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.identity.Party getParty()
+  public int hashCode()
+  public String toString()
+##
+public static final class net.corda.core.node.services.PartyInfo$SingleNode extends net.corda.core.node.services.PartyInfo
+  public <init>(net.corda.core.identity.Party, java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> component2()
+  @NotNull
+  public final net.corda.core.node.services.PartyInfo$SingleNode copy(net.corda.core.identity.Party, java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getAddresses()
+  @NotNull
+  public net.corda.core.identity.Party getParty()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.StatesNotAvailableException extends net.corda.core.flows.FlowException
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.node.services.TimeWindowChecker extends java.lang.Object
+  public <init>()
+  public <init>(java.time.Clock)
+  public <init>(java.time.Clock, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.time.Clock getClock()
+  public final boolean isValid(net.corda.core.contracts.TimeWindow)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.TransactionStorage
+  @Nullable
+  public abstract net.corda.core.transactions.SignedTransaction getTransaction(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.transactions.SignedTransaction> getUpdates()
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction> track()
+##
+@DoNotImplement
+public interface net.corda.core.node.services.TransactionVerifierService
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<?> verify(net.corda.core.transactions.LedgerTransaction)
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.TrustedAuthorityNotaryService extends net.corda.core.node.services.NotaryService
+  public <init>()
+  public final void commitInputStates(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party)
+  @NotNull
+  protected org.slf4j.Logger getLog()
+  @NotNull
+  protected net.corda.core.node.services.TimeWindowChecker getTimeWindowChecker()
+  @NotNull
+  protected abstract net.corda.core.node.services.UniquenessProvider getUniquenessProvider()
+  @NotNull
+  public final net.corda.core.crypto.TransactionSignature sign(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey sign(byte[])
+  public final void validateTimeWindow(net.corda.core.contracts.TimeWindow)
+  public static final net.corda.core.node.services.TrustedAuthorityNotaryService$Companion Companion
+##
+public static final class net.corda.core.node.services.TrustedAuthorityNotaryService$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public final class net.corda.core.node.services.UniquenessException extends net.corda.core.CordaException
+  public <init>(net.corda.core.node.services.UniquenessProvider$Conflict)
+  @NotNull
+  public final net.corda.core.node.services.UniquenessProvider$Conflict getError()
+##
+public interface net.corda.core.node.services.UniquenessProvider
+  public abstract void commit(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.UniquenessProvider$Conflict extends java.lang.Object
+  public <init>(java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx>)
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx> component1()
+  @NotNull
+  public final net.corda.core.node.services.UniquenessProvider$Conflict copy(java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.node.services.UniquenessProvider$ConsumingTx> getStateHistory()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.UniquenessProvider$ConsumingTx extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, int, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @NotNull
+  public final net.corda.core.node.services.UniquenessProvider$ConsumingTx copy(net.corda.core.crypto.SecureHash, int, net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  public final int getInputIndex()
+  @NotNull
+  public final net.corda.core.identity.Party getRequestingParty()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.UnknownAnonymousPartyException extends net.corda.core.CordaException
+  public <init>(String)
+##
+@CordaSerializable
+public final class net.corda.core.node.services.Vault extends java.lang.Object
+  public <init>(Iterable<? extends net.corda.core.contracts.StateAndRef<? extends T>>)
+  @NotNull
+  public final Iterable<net.corda.core.contracts.StateAndRef<T>> getStates()
+  public static final net.corda.core.node.services.Vault$Companion Companion
+##
+public static final class net.corda.core.node.services.Vault$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoNotaryUpdate()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoUpdate()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.node.services.Vault$StateMetadata> component2()
+  public final long component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component4()
+  @NotNull
+  public final java.util.List<Object> component5()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<Object> getOtherResults()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus getStateTypes()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> getStates()
+  @NotNull
+  public final java.util.List<net.corda.core.node.services.Vault$StateMetadata> getStatesMetadata()
+  public final long getTotalStatesAvailable()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$StateMetadata extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.time.Instant component3()
+  @Nullable
+  public final java.time.Instant component4()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component5()
+  @Nullable
+  public final net.corda.core.identity.AbstractParty component6()
+  @Nullable
+  public final String component7()
+  @Nullable
+  public final java.time.Instant component8()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateMetadata copy(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
+  public boolean equals(Object)
+  @Nullable
+  public final java.time.Instant getConsumedTime()
+  @NotNull
+  public final String getContractStateClassName()
+  @Nullable
+  public final String getLockId()
+  @Nullable
+  public final java.time.Instant getLockUpdateTime()
+  @Nullable
+  public final net.corda.core.identity.AbstractParty getNotary()
+  @NotNull
+  public final java.time.Instant getRecordedTime()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$StateStatus extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$StateStatus valueOf(String)
+  public static net.corda.core.node.services.Vault$StateStatus[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$Update extends java.lang.Object
+  public <init>(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
+  public <init>(java.util.Set, java.util.Set, java.util.UUID, net.corda.core.node.services.Vault$UpdateType, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component1()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component2()
+  @Nullable
+  public final java.util.UUID component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$UpdateType component4()
+  public final boolean containsType(Class<T>, net.corda.core.node.services.Vault$StateStatus)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<U> copy(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getConsumed()
+  @Nullable
+  public final java.util.UUID getFlowId()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getProduced()
+  @NotNull
+  public final net.corda.core.node.services.Vault$UpdateType getType()
+  public int hashCode()
+  public final boolean isEmpty()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<U> plus(net.corda.core.node.services.Vault$Update<U>)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$UpdateType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$UpdateType valueOf(String)
+  public static net.corda.core.node.services.Vault$UpdateType[] values()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.VaultQueryException extends net.corda.core.flows.FlowException
+  public <init>(String)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.VaultService
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> _queryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> _trackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  public abstract void addNoteToTransaction(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> getRawUpdates()
+  @NotNull
+  public abstract Iterable<String> getTransactionNotes(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> getUpdates()
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  public abstract void softLockRelease(java.util.UUID, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  public abstract void softLockReserve(java.util.UUID, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @Suspendable
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<T>> tryLockFungibleStatesForSpending(java.util.UUID, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.contracts.Amount<U>, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> whenConsumed(net.corda.core.contracts.StateRef)
+##
+public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.AggregateFunctionType valueOf(String)
+  public static net.corda.core.node.services.vault.AggregateFunctionType[] values()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.AttachmentQueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria and(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria or(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AndComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
+  public <init>(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria extends net.corda.core.node.services.vault.AttachmentQueryCriteria
+  public <init>()
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> component1()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> component2()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria copy(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> getFilenameCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> getUploadDateCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> getUploaderCondition()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$OrComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
+  public <init>(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.AttachmentSort extends net.corda.core.node.services.vault.BaseSort
+  public <init>(java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn>)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort copy(java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn> getColumns()
+  public int hashCode()
+  public String toString()
+##
+public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute extends java.lang.Enum
+  protected <init>(String)
+  @NotNull
+  public final String getColumnName()
+  public static net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public <init>(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn copy(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction getDirection()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute getSortAttribute()
+  public int hashCode()
+  public String toString()
+##
+public interface net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria)
+##
+public interface net.corda.core.node.services.vault.BaseQueryCriteriaParser
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parse(Q, S)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseAnd(Q, Q)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseOr(Q, Q)
+##
+public abstract class net.corda.core.node.services.vault.BaseSort extends java.lang.Object
+  public <init>()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.BinaryComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.BinaryComparisonOperator valueOf(String)
+  public static net.corda.core.node.services.vault.BinaryComparisonOperator[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.BinaryLogicalOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.BinaryLogicalOperator valueOf(String)
+  public static net.corda.core.node.services.vault.BinaryLogicalOperator[] values()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Builder extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> avg(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Between<R> between(R, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> between(reflect.Field, R, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> between(kotlin.reflect.KProperty1<O, ? extends R>, R, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> between(net.corda.core.node.services.vault.FieldInfo, R, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> compare(net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> comparePredicate(reflect.Field, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> comparePredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> comparePredicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, Object> count(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> count(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, Object> count(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> equal(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> equal(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> functionPredicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<Object, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> functionPredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> functionPredicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<Object, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThan(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThan(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThan(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThanOrEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThanOrEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThanOrEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(reflect.Field, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> in(java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> in(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<R> isNotNull()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<R> isNull()
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> isNull(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> isNull(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> isNull(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThan(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThan(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThan(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThanOrEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThanOrEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThanOrEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness like(String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(reflect.Field, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> like(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(net.corda.core.node.services.vault.FieldInfo, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> max(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> min(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> notEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(reflect.Field, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> notIn(java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notIn(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness notLike(String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(reflect.Field, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> notLike(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(net.corda.core.node.services.vault.FieldInfo, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> notNull(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notNull(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> notNull(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> predicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> predicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> predicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> sum(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  public static final net.corda.core.node.services.vault.Builder INSTANCE
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.CollectionOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.CollectionOperator valueOf(String)
+  public static net.corda.core.node.services.vault.CollectionOperator[] values()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Column extends java.lang.Object
+  public <init>(String, Class<?>)
+  public <init>(reflect.Field)
+  public <init>(kotlin.reflect.KProperty1<O, ? extends C>)
+  public <init>(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final Class<?> getDeclaringClass()
+  @NotNull
+  public final String getName()
+  public static final net.corda.core.node.services.vault.Column$Companion Companion
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.ColumnPredicate extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.AggregateFunctionType)
+  @NotNull
+  public final net.corda.core.node.services.vault.AggregateFunctionType component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction<C> copy(net.corda.core.node.services.vault.AggregateFunctionType)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.AggregateFunctionType getType()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$Between extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(C, C)
+  @NotNull
+  public final C component1()
+  @NotNull
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Between<C> copy(C, C)
+  public boolean equals(Object)
+  @NotNull
+  public final C getRightFromLiteral()
+  @NotNull
+  public final C getRightToLiteral()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.BinaryComparisonOperator, C)
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryComparisonOperator component1()
+  @NotNull
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<C> copy(net.corda.core.node.services.vault.BinaryComparisonOperator, C)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryComparisonOperator getOperator()
+  @NotNull
+  public final C getRightLiteral()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.CollectionOperator, java.util.Collection<? extends C>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CollectionOperator component1()
+  @NotNull
+  public final java.util.Collection<C> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<C> copy(net.corda.core.node.services.vault.CollectionOperator, java.util.Collection<? extends C>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.CollectionOperator getOperator()
+  @NotNull
+  public final java.util.Collection<C> getRightLiteral()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.EqualityComparisonOperator, C)
+  @NotNull
+  public final net.corda.core.node.services.vault.EqualityComparisonOperator component1()
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<C> copy(net.corda.core.node.services.vault.EqualityComparisonOperator, C)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.EqualityComparisonOperator getOperator()
+  public final C getRightLiteral()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$Likeness extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.LikenessOperator, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.LikenessOperator component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness copy(net.corda.core.node.services.vault.LikenessOperator, String)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.LikenessOperator getOperator()
+  @NotNull
+  public final String getRightLiteral()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$NullExpression extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.NullOperator)
+  @NotNull
+  public final net.corda.core.node.services.vault.NullOperator component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<C> copy(net.corda.core.node.services.vault.NullOperator)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.NullOperator getOperator()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.CriteriaExpression extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends C>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> component2()
+  @Nullable
+  public final java.util.List<net.corda.core.node.services.vault.Column<O, C>> component3()
+  @Nullable
+  public final net.corda.core.node.services.vault.Sort$Direction component4()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, C> copy(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends C>>, net.corda.core.node.services.vault.Sort$Direction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> getColumn()
+  @Nullable
+  public final java.util.List<net.corda.core.node.services.vault.Column<O, C>> getGroupByColumns()
+  @Nullable
+  public final net.corda.core.node.services.vault.Sort$Direction getOrderBy()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.BinaryLogicalOperator)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryLogicalOperator component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical<O> copy(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.BinaryLogicalOperator)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getLeft()
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryLogicalOperator getOperator()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getRight()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, C> copy(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> getColumn()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$Not extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$Not<O> copy(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getExpression()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.EqualityComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.EqualityComparisonOperator valueOf(String)
+  public static net.corda.core.node.services.vault.EqualityComparisonOperator[] values()
+##
+public final class net.corda.core.node.services.vault.FieldInfo extends java.lang.Object
+  public <init>(String, Class<?>)
+  @NotNull
+  public final Class<?> getEntityClass()
+  @NotNull
+  public final String getName()
+##
+public interface net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
+##
+public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria
+  @NotNull
+  public abstract Q and(Q)
+  @NotNull
+  public abstract Q or(Q)
+##
+public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor extends net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public abstract Q getA()
+  @NotNull
+  public abstract Q getB()
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
+##
+public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor extends net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public abstract Q getA()
+  @NotNull
+  public abstract Q getB()
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.vault.IQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L>)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.LikenessOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.LikenessOperator valueOf(String)
+  public static net.corda.core.node.services.vault.LikenessOperator[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.NullOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.NullOperator valueOf(String)
+  public static net.corda.core.node.services.vault.NullOperator[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.node.services.vault.Operator
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.PageSpecification extends java.lang.Object
+  public <init>()
+  public <init>(int, int)
+  public <init>(int, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.PageSpecification copy(int, int)
+  public boolean equals(Object)
+  public final int getPageNumber()
+  public final int getPageSize()
+  public int hashCode()
+  public final boolean isDefault()
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.QueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria and(net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria or(net.corda.core.node.services.vault.QueryCriteria)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$AndComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
+  public <init>(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public abstract static class net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria
+  public <init>()
+  @Nullable
+  public abstract java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$StateStatus getStatus()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> component3()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component4()
+  @Nullable
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component5()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component6()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component7()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getIssuer()
+  @Nullable
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getIssuerRef()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwner()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> getQuantity()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final java.util.List<java.util.UUID> component2()
+  @Nullable
+  public final java.util.List<String> component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component4()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component5()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<String> getExternalId()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public final java.util.List<java.util.UUID> getUuid()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$OrComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
+  public <init>(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List<java.util.UUID>)
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType component1()
+  @NotNull
+  public final java.util.List<java.util.UUID> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition copy(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List<java.util.UUID>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<java.util.UUID> getLockIds()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType getType()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.QueryCriteria$SoftLockingType valueOf(String)
+  public static net.corda.core.node.services.vault.QueryCriteria$SoftLockingType[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$TimeCondition extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition copy(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> getPredicate()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType getType()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$TimeInstantType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.QueryCriteria$TimeInstantType valueOf(String)
+  public static net.corda.core.node.services.vault.QueryCriteria$TimeInstantType[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component2()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> copy(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> getExpression()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(net.corda.core.node.services.Vault$StateStatus)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component1()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component2()
+  @Nullable
+  public final java.util.List<net.corda.core.contracts.StateRef> component3()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component4()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition component5()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition component6()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getNotary()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition getSoftLockingCondition()
+  @Nullable
+  public final java.util.List<net.corda.core.contracts.StateRef> getStateRefs()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition getTimeCondition()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends java.lang.Object
+  public static final A builder(kotlin.jvm.functions.Function1<? super net.corda.core.node.services.vault.Builder, ? extends A>)
+  @NotNull
+  public static final String getColumnName(net.corda.core.node.services.vault.Column<O, ? extends C>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.FieldInfo getField(String, Class<?>)
+  @NotNull
+  public static final Class<O> resolveEnclosingObjectFromColumn(net.corda.core.node.services.vault.Column<O, ? extends C>)
+  @NotNull
+  public static final Class<O> resolveEnclosingObjectFromExpression(net.corda.core.node.services.vault.CriteriaExpression<O, ? extends R>)
+  public static final int DEFAULT_PAGE_NUM = 1
+  public static final int DEFAULT_PAGE_SIZE = 200
+  public static final int MAX_PAGE_SIZE = 2147483647
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Sort extends net.corda.core.node.services.vault.BaseSort
+  public <init>(java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn>)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort copy(java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn> getColumns()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public static interface net.corda.core.node.services.vault.Sort$Attribute
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$CommonStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String, String)
+  @Nullable
+  public final String getAttributeChild()
+  @NotNull
+  public final String getAttributeParent()
+  public static net.corda.core.node.services.vault.Sort$CommonStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$CommonStateAttribute[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$Direction extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.Sort$Direction valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$Direction[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$FungibleStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
+  public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$LinearStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
+  public static net.corda.core.node.services.vault.Sort$LinearStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$LinearStateAttribute[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$SortColumn extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public <init>(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$SortColumn copy(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction getDirection()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute getSortAttribute()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$VaultStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
+  public static net.corda.core.node.services.vault.Sort$VaultStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$VaultStateAttribute[] values()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.SortAttribute extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.SortAttribute$Custom extends net.corda.core.node.services.vault.SortAttribute
+  public <init>(Class<? extends net.corda.core.schemas.PersistentState>, String)
+  @NotNull
+  public final Class<? extends net.corda.core.schemas.PersistentState> component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute$Custom copy(Class<? extends net.corda.core.schemas.PersistentState>, String)
+  public boolean equals(Object)
+  @NotNull
+  public final Class<? extends net.corda.core.schemas.PersistentState> getEntityStateClass()
+  @NotNull
+  public final String getEntityStateColumnName()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.SortAttribute$Standard extends net.corda.core.node.services.vault.SortAttribute
+  public <init>(net.corda.core.node.services.vault.Sort$Attribute)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Attribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute$Standard copy(net.corda.core.node.services.vault.Sort$Attribute)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Attribute getAttribute()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.core.schemas.CommonSchema extends java.lang.Object
+  public static final net.corda.core.schemas.CommonSchema INSTANCE
+##
+public final class net.corda.core.schemas.CommonSchemaV1 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.core.schemas.CommonSchemaV1 INSTANCE
+##
+@MappedSuperclass
+@CordaSerializable
+public static class net.corda.core.schemas.CommonSchemaV1$FungibleState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[])
+  public <init>(java.util.Set, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.identity.AbstractParty getIssuer()
+  @NotNull
+  public byte[] getIssuerRef()
+  @NotNull
+  public net.corda.core.identity.AbstractParty getOwner()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public long getQuantity()
+  public void setIssuer(net.corda.core.identity.AbstractParty)
+  public void setIssuerRef(byte[])
+  public void setOwner(net.corda.core.identity.AbstractParty)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setQuantity(long)
+##
+@MappedSuperclass
+@CordaSerializable
+public static class net.corda.core.schemas.CommonSchemaV1$LinearState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, String, java.util.UUID)
+  public <init>(java.util.Set, String, java.util.UUID, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.contracts.UniqueIdentifier, java.util.Set<? extends net.corda.core.identity.AbstractParty>)
+  @Nullable
+  public String getExternalId()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public java.util.UUID getUuid()
+  public void setExternalId(String)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setUuid(java.util.UUID)
+##
+public class net.corda.core.schemas.MappedSchema extends java.lang.Object
+  public <init>(Class<?>, int, Iterable<? extends Class<?>>)
+  @NotNull
+  public final Iterable<Class<?>> getMappedTypes()
+  @NotNull
+  public final String getName()
+  public final int getVersion()
+  @NotNull
+  public String toString()
+##
+@MappedSuperclass
+@CordaSerializable
+public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.StatePersistable
+  public <init>()
+  public <init>(net.corda.core.schemas.PersistentStateRef)
+  public <init>(net.corda.core.schemas.PersistentStateRef, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public net.corda.core.schemas.PersistentStateRef getStateRef()
+  public void setStateRef(net.corda.core.schemas.PersistentStateRef)
+##
+@Embeddable
+public class net.corda.core.schemas.PersistentStateRef extends java.lang.Object implements java.io.Serializable
+  public <init>()
+  public <init>(String, Integer)
+  public <init>(String, Integer, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.contracts.StateRef)
+  @Nullable
+  public final String component1()
+  @Nullable
+  public final Integer component2()
+  @NotNull
+  public final net.corda.core.schemas.PersistentStateRef copy(String, Integer)
+  public boolean equals(Object)
+  @Nullable
+  public Integer getIndex()
+  @Nullable
+  public String getTxId()
+  public int hashCode()
+  public void setIndex(Integer)
+  public void setTxId(String)
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.schemas.QueryableState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.schemas.PersistentState generateMappedObject(net.corda.core.schemas.MappedSchema)
+  @NotNull
+  public abstract Iterable<net.corda.core.schemas.MappedSchema> supportedSchemas()
+##
+public interface net.corda.core.schemas.StatePersistable extends java.io.Serializable
+##
+public interface net.corda.core.serialization.ClassWhitelist
+  public abstract boolean hasListed(Class<?>)
+##
+public @interface net.corda.core.serialization.ConstructorForDeserialization
+##
+public @interface net.corda.core.serialization.CordaSerializable
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformEnumDefault
+  public abstract String new()
+  public abstract String old()
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformEnumDefaults
+  public abstract net.corda.core.serialization.CordaSerializationTransformEnumDefault[] value()
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformRename
+  public abstract String from()
+  public abstract String to()
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformRenames
+  public abstract net.corda.core.serialization.CordaSerializationTransformRename[] value()
+##
+public @interface net.corda.core.serialization.DeprecatedConstructorForDeserialization
+  public abstract int version()
+##
+@CordaSerializable
+public final class net.corda.core.serialization.MissingAttachmentsException extends net.corda.core.CordaException
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
+##
+public final class net.corda.core.serialization.ObjectWithCompatibleContext extends java.lang.Object
+  public <init>(T, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext component2()
+  @NotNull
+  public final net.corda.core.serialization.ObjectWithCompatibleContext<T> copy(T, net.corda.core.serialization.SerializationContext)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getContext()
+  @NotNull
+  public final T getObj()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.core.serialization.SerializationAPIKt extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> serialize(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
+##
+public interface net.corda.core.serialization.SerializationContext
+  @NotNull
+  public abstract ClassLoader getDeserializationClassLoader()
+  public abstract boolean getObjectReferencesEnabled()
+  @NotNull
+  public abstract net.corda.core.utilities.ByteSequence getPreferredSerializationVersion()
+  @NotNull
+  public abstract java.util.Map<Object, Object> getProperties()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext$UseCase getUseCase()
+  @NotNull
+  public abstract net.corda.core.serialization.ClassWhitelist getWhitelist()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withAttachmentsClassLoader(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withClassLoader(ClassLoader)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withPreferredSerializationVersion(net.corda.core.utilities.ByteSequence)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withProperty(Object, Object)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withWhitelisted(Class<?>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withoutReferences()
+##
+public static final class net.corda.core.serialization.SerializationContext$UseCase extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.serialization.SerializationContext$UseCase valueOf(String)
+  public static net.corda.core.serialization.SerializationContext$UseCase[] values()
+##
+public interface net.corda.core.serialization.SerializationCustomSerializer
+  public abstract OBJ fromProxy(PROXY)
+  public abstract PROXY toProxy(OBJ)
+##
+public final class net.corda.core.serialization.SerializationDefaults extends java.lang.Object
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getCHECKPOINT_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getP2P_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getRPC_CLIENT_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getRPC_SERVER_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getSERIALIZATION_FACTORY()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getSTORAGE_CONTEXT()
+  public static final net.corda.core.serialization.SerializationDefaults INSTANCE
+##
+public abstract class net.corda.core.serialization.SerializationFactory extends java.lang.Object
+  public <init>()
+  public final T asCurrent(kotlin.jvm.functions.Function1<? super net.corda.core.serialization.SerializationFactory, ? extends T>)
+  @NotNull
+  public abstract T deserialize(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public abstract net.corda.core.serialization.ObjectWithCompatibleContext<T> deserializeWithCompatibleContext(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.SerializationContext)
+  @Nullable
+  public final net.corda.core.serialization.SerializationContext getCurrentContext()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getDefaultContext()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializedBytes<T> serialize(T, net.corda.core.serialization.SerializationContext)
+  public final T withCurrentContext(net.corda.core.serialization.SerializationContext, kotlin.jvm.functions.Function0<? extends T>)
+  public static final net.corda.core.serialization.SerializationFactory$Companion Companion
+##
+public static final class net.corda.core.serialization.SerializationFactory$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.serialization.SerializationFactory getCurrentFactory()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getDefaultFactory()
+##
+public interface net.corda.core.serialization.SerializationToken
+  @NotNull
+  public abstract Object fromToken(net.corda.core.serialization.SerializeAsTokenContext)
+##
+public interface net.corda.core.serialization.SerializationWhitelist
+  @NotNull
+  public abstract java.util.List<Class<?>> getWhitelist()
+##
+@CordaSerializable
+public interface net.corda.core.serialization.SerializeAsToken
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
+##
+public interface net.corda.core.serialization.SerializeAsTokenContext
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServiceHub()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializeAsToken getSingleton(String)
+  public abstract void putSingleton(net.corda.core.serialization.SerializeAsToken)
+##
+@CordaSerializable
+public final class net.corda.core.serialization.SerializedBytes extends net.corda.core.utilities.OpaqueBytes
+  public <init>(byte[])
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+##
+public final class net.corda.core.serialization.SingletonSerializationToken extends java.lang.Object implements net.corda.core.serialization.SerializationToken
+  public <init>(String, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.serialization.SerializeAsToken fromToken(net.corda.core.serialization.SerializeAsTokenContext)
+  @NotNull
+  public final net.corda.core.serialization.SingletonSerializationToken registerWithContext(net.corda.core.serialization.SerializeAsTokenContext, net.corda.core.serialization.SerializeAsToken)
+  public static final net.corda.core.serialization.SingletonSerializationToken$Companion Companion
+##
+public static final class net.corda.core.serialization.SingletonSerializationToken$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.serialization.SingletonSerializationToken singletonSerializationToken(Class<T>)
+##
+@CordaSerializable
+public abstract class net.corda.core.serialization.SingletonSerializeAsToken extends java.lang.Object implements net.corda.core.serialization.SerializeAsToken
+  public <init>()
+  @NotNull
+  public net.corda.core.serialization.SingletonSerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
+##
+@DoNotImplement
+public abstract class net.corda.core.transactions.BaseTransaction extends java.lang.Object implements net.corda.core.contracts.NamedByHash
+  public <init>()
+  protected void checkBaseInvariants()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterOutRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterOutputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findOutRef(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findOutput(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public abstract java.util.List<?> getInputs()
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getOutput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> outRef(int)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> outRef(net.corda.core.contracts.ContractState)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> outRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> outputsOfType(Class<T>)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public class net.corda.core.transactions.ComponentGroup extends java.lang.Object
+  public <init>(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  @NotNull
+  public java.util.List<net.corda.core.utilities.OpaqueBytes> getComponents()
+  public int getGroupIndex()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.ComponentVisibilityException extends net.corda.core.CordaException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final String getReason()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.ContractUpgradeFilteredTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent>, java.util.Map<Integer, ? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent> component1()
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.crypto.SecureHash> component2()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeFilteredTransaction copy(java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent>, java.util.Map<Integer, ? extends net.corda.core.crypto.SecureHash>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.crypto.SecureHash> getHiddenComponents()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent> getVisibleComponents()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent extends java.lang.Object
+  public <init>(net.corda.core.utilities.OpaqueBytes, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes getComponent()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getNonce()
+##
+@DoNotImplement
+public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
+  public void checkSignaturesAreValid()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final net.corda.core.identity.Party component2()
+  @NotNull
+  public final net.corda.core.contracts.Attachment component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.contracts.Attachment component5()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component6()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component7()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component8()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @NotNull
+  public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getLegacyContractAttachment()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @NotNull
+  public final net.corda.core.contracts.Attachment getUpgradedContractAttachment()
+  @NotNull
+  public final String getUpgradedContractClassName()
+  public int hashCode()
+  public String toString()
+  public void verifyRequiredSignatures()
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
+  public void verifySignaturesExcept(java.security.PublicKey...)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.ContractUpgradeWireTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeFilteredTransaction buildFilteredTransaction()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component1()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component2()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeWireTransaction copy(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.contracts.PrivacySalt)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getLegacyContractAttachmentId()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getUpgradedContractAttachmentId()
+  @NotNull
+  public final String getUpgradedContractClassName()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public String toString()
+##
+public static final class net.corda.core.transactions.ContractUpgradeWireTransaction$Component extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.transactions.ContractUpgradeWireTransaction$Component valueOf(String)
+  public static net.corda.core.transactions.ContractUpgradeWireTransaction$Component[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.transactions.CoreTransaction extends net.corda.core.transactions.BaseTransaction
+  public <init>()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredComponentGroup extends net.corda.core.transactions.ComponentGroup
+  public <init>(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.crypto.PartialMerkleTree)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component2()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> component3()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree component4()
+  @NotNull
+  public final net.corda.core.transactions.FilteredComponentGroup copy(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.crypto.PartialMerkleTree)
+  public boolean equals(Object)
+  @NotNull
+  public java.util.List<net.corda.core.utilities.OpaqueBytes> getComponents()
+  public int getGroupIndex()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getNonces()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredTransaction extends net.corda.core.transactions.TraversableTransaction
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.transactions.FilteredComponentGroup>, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public static final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, java.util.function.Predicate<Object>)
+  public final void checkAllComponentsVisible(net.corda.core.contracts.ComponentGroupEnum)
+  public final void checkCommandVisibility(java.security.PublicKey)
+  public final boolean checkWithFun(kotlin.jvm.functions.Function1<Object, Boolean>)
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.FilteredComponentGroup> getFilteredComponentGroups()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getGroupHashes()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  public final void verify()
+  public static final net.corda.core.transactions.FilteredTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.FilteredTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, java.util.function.Predicate<Object>)
+##
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredTransactionVerificationException extends net.corda.core.CordaException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final String getReason()
+##
+@DoNotImplement
+public abstract class net.corda.core.transactions.FullTransaction extends net.corda.core.transactions.BaseTransaction
+  public <init>()
+  protected void checkBaseInvariants()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<T>> commandsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> component2()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.CommandWithParties<net.corda.core.contracts.CommandData>> component3()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Attachment> component4()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component5()
+  @Nullable
+  public final net.corda.core.identity.Party component6()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow component7()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component8()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<T>> filterCommands(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterInRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterInputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.Command<T> findCommand(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findInRef(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findInput(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment(int)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Attachment> getAttachments()
+  @NotNull
+  public final net.corda.core.contracts.Command<T> getCommand(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.CommandWithParties<net.corda.core.contracts.CommandData>> getCommands()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getInput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getInputStates()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @Nullable
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimeWindow()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.LedgerTransaction$InOutGroup<T, K>> groupStates(Class<T>, kotlin.jvm.functions.Function1<? super T, ? extends K>)
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> inRef(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> inRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> inputsOfType(Class<T>)
+  public String toString()
+  public final void verify()
+  public static final net.corda.core.transactions.LedgerTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.LedgerTransaction$InOutGroup extends java.lang.Object
+  public <init>(java.util.List<? extends T>, java.util.List<? extends T>, K)
+  @NotNull
+  public final java.util.List<T> component1()
+  @NotNull
+  public final java.util.List<T> component2()
+  @NotNull
+  public final K component3()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction$InOutGroup<T, K> copy(java.util.List<? extends T>, java.util.List<? extends T>, K)
+  public boolean equals(Object)
+  @NotNull
+  public final K getGroupingKey()
+  @NotNull
+  public final java.util.List<T> getInputs()
+  @NotNull
+  public final java.util.List<T> getOutputs()
+  public int hashCode()
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.MissingContractAttachments extends net.corda.core.flows.FlowException
+  public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getStates()
+##
+@DoNotImplement
+public final class net.corda.core.transactions.NotaryChangeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public void checkSignaturesAreValid()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final net.corda.core.identity.Party component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component4()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component5()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @NotNull
+  public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
+  @NotNull
+  public final net.corda.core.identity.Party getNewNotary()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  public int hashCode()
+  public String toString()
+  public void verifyRequiredSignatures()
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
+  public void verifySignaturesExcept(java.security.PublicKey...)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.NotaryChangeWireTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.identity.Party, net.corda.core.identity.Party)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component1()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeWireTransaction copy(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final net.corda.core.identity.Party getNewNotary()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServiceHub, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public String toString()
+##
+public static final class net.corda.core.transactions.NotaryChangeWireTransaction$Component extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.transactions.NotaryChangeWireTransaction$Component valueOf(String)
+  public static net.corda.core.transactions.NotaryChangeWireTransaction$Component[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.SignedTransaction extends java.lang.Object implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction>, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public <init>(net.corda.core.transactions.CoreTransaction, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
+  public void checkSignaturesAreValid()
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component2()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction copy(net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction>, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public java.util.ArrayList<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction getTx()
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
+  public int hashCode()
+  public final boolean isNotaryChangeTransaction()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction plus(java.util.Collection<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction plus(net.corda.core.crypto.TransactionSignature)
+  @NotNull
+  public final net.corda.core.transactions.BaseTransaction resolveBaseTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolveContractUpgradeTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.TransactionWithSignatures resolveTransactionWithSignatures(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub, boolean)
+  @NotNull
+  public String toString()
+  public final void verify(net.corda.core.node.ServiceHub)
+  public final void verify(net.corda.core.node.ServiceHub, boolean)
+  public void verifyRequiredSignatures()
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
+  public void verifySignaturesExcept(java.security.PublicKey...)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(java.security.KeyPair, net.corda.core.crypto.SignatureMetadata)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(net.corda.core.crypto.TransactionSignature)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable<net.corda.core.crypto.TransactionSignature>)
+  public static final net.corda.core.transactions.SignedTransaction$Companion Companion
+##
+@CordaSerializable
+public static final class net.corda.core.transactions.SignedTransaction$SignaturesMissingException extends java.security.SignatureException implements net.corda.core.CordaThrowable, net.corda.core.contracts.NamedByHash
+  public <init>(java.util.Set<? extends java.security.PublicKey>, java.util.List<String>, net.corda.core.crypto.SecureHash)
+  public void addSuppressed(Throwable[])
+  @NotNull
+  public final java.util.List<String> getDescriptions()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getMissing()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
+  public void setCause(Throwable)
+  public void setMessage(String)
+  public void setOriginalExceptionClassName(String)
+##
+public class net.corda.core.transactions.TransactionBuilder extends java.lang.Object
+  public <init>()
+  public <init>(net.corda.core.identity.Party)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.Command<?>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.security.PublicKey...)
+  @NotNull
+  public net.corda.core.transactions.TransactionBuilder addInputState(net.corda.core.contracts.StateAndRef<?>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.TransactionState<?>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> attachments()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<?>> commands()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder copy()
+  @NotNull
+  protected final java.util.List<net.corda.core.crypto.SecureHash> getAttachments()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.Command<?>> getCommands()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final java.util.UUID getLockId()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  protected final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @Nullable
+  protected final net.corda.core.contracts.TimeWindow getWindow()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> inputStates()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<?>> outputStates()
+  public final void setLockId(java.util.UUID)
+  public final void setNotary(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setPrivacySalt(net.corda.core.contracts.PrivacySalt)
+  protected final void setPrivacySalt(net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setTimeWindow(java.time.Instant, java.time.Duration)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setTimeWindow(net.corda.core.contracts.TimeWindow)
+  protected final void setWindow(net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction toSignedTransaction(net.corda.core.node.services.KeyManagementService, java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction toWireTransaction(net.corda.core.node.ServicesForResolution)
+  public final void verify(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder withItems(Object...)
+##
+@DoNotImplement
+public interface net.corda.core.transactions.TransactionWithSignatures extends net.corda.core.contracts.NamedByHash
+  public abstract void checkSignaturesAreValid()
+  @NotNull
+  public abstract java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getMissingSigners()
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  public abstract void verifyRequiredSignatures()
+  public abstract void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
+  public abstract void verifySignaturesExcept(java.security.PublicKey...)
+##
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.transactions.TraversableTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getAttachments()
+  @NotNull
+  public final java.util.List<java.util.List<Object>> getAvailableComponentGroups()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<?>> getCommands()
+  @NotNull
+  public java.util.List<net.corda.core.transactions.ComponentGroup> getComponentGroups()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimeWindow()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.WireTransaction extends net.corda.core.transactions.TraversableTransaction
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.crypto.SecureHash>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
+  public final void checkSignature(net.corda.core.crypto.TransactionSignature)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getMerkleTree()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(kotlin.jvm.functions.Function1<? super java.security.PublicKey, net.corda.core.identity.Party>, kotlin.jvm.functions.Function1<? super net.corda.core.crypto.SecureHash, ? extends net.corda.core.contracts.Attachment>, kotlin.jvm.functions.Function1<? super net.corda.core.contracts.StateRef, ? extends net.corda.core.contracts.TransactionState<?>>, kotlin.jvm.functions.Function1<? super net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>, ? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.transactions.WireTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.WireTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.ComponentGroup> createComponentGroups(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow)
+##
+public final class net.corda.core.utilities.ByteArrays extends java.lang.Object
+  @NotNull
+  public static final byte[] parseAsHex(String)
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence sequence(byte[], int, int)
+  @NotNull
+  public static final String toHexString(byte[])
+##
+@CordaSerializable
+public abstract class net.corda.core.utilities.ByteSequence extends java.lang.Object implements java.lang.Comparable
+  public <init>(byte[], kotlin.jvm.internal.DefaultConstructorMarker)
+  public int compareTo(net.corda.core.utilities.ByteSequence)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence copy()
+  public boolean equals(Object)
+  @NotNull
+  public abstract byte[] getBytes()
+  public abstract int getOffset()
+  public abstract int getSize()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[])
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[], int)
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[], int, int)
+  @NotNull
+  public final java.io.ByteArrayInputStream open()
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence subSequence(int, int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence take(int)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.utilities.ByteSequence$Companion Companion
+##
+public static final class net.corda.core.utilities.ByteSequence$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[])
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[], int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[], int, int)
+##
+public final class net.corda.core.utilities.EncodingUtils extends java.lang.Object
+  @NotNull
+  public static final byte[] base58ToByteArray(String)
+  @NotNull
+  public static final String base58ToRealString(String)
+  @NotNull
+  public static final String base58toBase64(String)
+  @NotNull
+  public static final String base58toHex(String)
+  @NotNull
+  public static final byte[] base64ToByteArray(String)
+  @NotNull
+  public static final String base64ToRealString(String)
+  @NotNull
+  public static final String base64toBase58(String)
+  @NotNull
+  public static final String base64toHex(String)
+  @NotNull
+  public static final String hexToBase58(String)
+  @NotNull
+  public static final String hexToBase64(String)
+  @NotNull
+  public static final byte[] hexToByteArray(String)
+  @NotNull
+  public static final String hexToRealString(String)
+  @NotNull
+  public static final java.security.PublicKey parsePublicKeyBase58(String)
+  @NotNull
+  public static final String toBase58(byte[])
+  @NotNull
+  public static final String toBase58String(java.security.PublicKey)
+  @NotNull
+  public static final String toBase64(byte[])
+  @NotNull
+  public static final String toHex(byte[])
+  @NotNull
+  public static final byte[] toSHA256Bytes(java.security.PublicKey)
+  public static final int MAX_HASH_HEX_SIZE = 130
+##
+public class net.corda.core.utilities.Id extends java.lang.Object
+  public <init>(VALUE, String, java.time.Instant)
+  public final boolean equals(Object)
+  @Nullable
+  public final String getEntityType()
+  @NotNull
+  public final java.time.Instant getTimestamp()
+  @NotNull
+  public final VALUE getValue()
+  public final int hashCode()
+  @NotNull
+  public static final net.corda.core.utilities.Id<V> newInstance(V, String, java.time.Instant)
+  @NotNull
+  public final String toString()
+  public static final net.corda.core.utilities.Id$Companion Companion
+##
+public static final class net.corda.core.utilities.Id$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.Id<V> newInstance(V, String, java.time.Instant)
+##
+public final class net.corda.core.utilities.KotlinUtilsKt extends java.lang.Object
+  @NotNull
+  public static final org.slf4j.Logger contextLogger(Object)
+  public static final void debug(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
+  public static final int exactAdd(int, int)
+  public static final long exactAdd(long, long)
+  @NotNull
+  public static final java.time.Duration getDays(int)
+  @NotNull
+  public static final java.time.Duration getHours(int)
+  @NotNull
+  public static final java.time.Duration getMillis(int)
+  @NotNull
+  public static final java.time.Duration getMinutes(int)
+  public static final V getOrThrow(java.util.concurrent.Future<V>, java.time.Duration)
+  @NotNull
+  public static final java.time.Duration getSeconds(int)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> toNonEmptySet(java.util.Collection<? extends T>)
+  public static final void trace(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
+  @NotNull
+  public static final net.corda.core.utilities.PropertyDelegate<T> transient(kotlin.jvm.functions.Function0<? extends T>)
+##
+@CordaSerializable
+public final class net.corda.core.utilities.NetworkHostAndPort extends java.lang.Object
+  public <init>(String, int)
+  @NotNull
+  public final String component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort copy(String, int)
+  public boolean equals(Object)
+  @NotNull
+  public final String getHost()
+  public final int getPort()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.utilities.NetworkHostAndPort parse(String)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.utilities.NetworkHostAndPort$Companion Companion
+  @NotNull
+  public static final String INVALID_PORT_FORMAT = "Invalid port: %s"
+  @NotNull
+  public static final String MISSING_PORT_FORMAT = "Missing port: %s"
+  @NotNull
+  public static final String UNPARSEABLE_ADDRESS_FORMAT = "Unparseable address: %s"
+##
+public static final class net.corda.core.utilities.NetworkHostAndPort$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort parse(String)
+##
+public final class net.corda.core.utilities.NonEmptySet extends java.lang.Object implements kotlin.jvm.internal.markers.KMappedMarker, java.util.Set
+  public <init>(java.util.Set, kotlin.jvm.internal.DefaultConstructorMarker)
+  public boolean add(T)
+  public boolean addAll(java.util.Collection<? extends T>)
+  public void clear()
+  public boolean contains(Object)
+  public boolean containsAll(java.util.Collection<?>)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> copyOf(java.util.Collection<? extends T>)
+  public boolean equals(Object)
+  public void forEach(java.util.function.Consumer<? super T>)
+  public int getSize()
+  public int hashCode()
+  public final T head()
+  public boolean isEmpty()
+  @NotNull
+  public java.util.Iterator<T> iterator()
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> of(T)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> of(T, T, T...)
+  @NotNull
+  public java.util.stream.Stream<T> parallelStream()
+  public boolean remove(Object)
+  public boolean removeAll(java.util.Collection<?>)
+  public boolean retainAll(java.util.Collection<?>)
+  @NotNull
+  public java.util.Spliterator<T> spliterator()
+  @NotNull
+  public java.util.stream.Stream<T> stream()
+  public Object[] toArray()
+  public T[] toArray(T[])
+  @NotNull
+  public String toString()
+  public static final net.corda.core.utilities.NonEmptySet$Companion Companion
+##
+public static final class net.corda.core.utilities.NonEmptySet$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> copyOf(java.util.Collection<? extends T>)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> of(T)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> of(T, T, T...)
+##
+@CordaSerializable
+public class net.corda.core.utilities.OpaqueBytes extends net.corda.core.utilities.ByteSequence
+  public <init>(byte[])
+  @NotNull
+  public final byte[] getBytes()
+  public int getOffset()
+  public int getSize()
+  @NotNull
+  public static final net.corda.core.utilities.OpaqueBytes of(byte...)
+  public static final net.corda.core.utilities.OpaqueBytes$Companion Companion
+##
+public static final class net.corda.core.utilities.OpaqueBytes$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes of(byte...)
+##
+@CordaSerializable
+public final class net.corda.core.utilities.OpaqueBytesSubSequence extends net.corda.core.utilities.ByteSequence
+  public <init>(byte[], int, int)
+  @NotNull
+  public byte[] getBytes()
+  public int getOffset()
+  public int getSize()
+##
+@CordaSerializable
+public final class net.corda.core.utilities.ProgressTracker extends java.lang.Object
+  public <init>(net.corda.core.utilities.ProgressTracker$Step...)
+  public final void endWithError(Throwable)
+  @NotNull
+  public final java.util.List<kotlin.Pair<Integer, net.corda.core.utilities.ProgressTracker$Step>> getAllSteps()
+  @NotNull
+  public final java.util.List<kotlin.Pair<Integer, String>> getAllStepsLabels()
+  @NotNull
+  public final rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
+  @Nullable
+  public final net.corda.core.utilities.ProgressTracker getChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getCurrentStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getCurrentStepRecursive()
+  public final boolean getHasEnded()
+  @Nullable
+  public final net.corda.core.utilities.ProgressTracker getParent()
+  public final int getStepIndex()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step[] getSteps()
+  @NotNull
+  public final rx.Observable<java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeChanges()
+  public final int getStepsTreeIndex()
+  @NotNull
+  public final rx.Observable<Integer> getStepsTreeIndexChanges()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTopLevelTracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step nextStep()
+  public final void setChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step, net.corda.core.utilities.ProgressTracker)
+  public final void setCurrentStep(net.corda.core.utilities.ProgressTracker$Step)
+##
+@CordaSerializable
+public abstract static class net.corda.core.utilities.ProgressTracker$Change extends java.lang.Object
+  public <init>(net.corda.core.utilities.ProgressTracker, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getProgressTracker()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Position extends net.corda.core.utilities.ProgressTracker$Change
+  public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Position copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getNewStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Rendering extends net.corda.core.utilities.ProgressTracker$Change
+  public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Rendering copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getOfStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Structural extends net.corda.core.utilities.ProgressTracker$Change
+  public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Structural copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getParent()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$DONE extends net.corda.core.utilities.ProgressTracker$Step
+  public boolean equals(Object)
+  public static final net.corda.core.utilities.ProgressTracker$DONE INSTANCE
+##
+@CordaSerializable
+public static class net.corda.core.utilities.ProgressTracker$Step extends java.lang.Object
+  public <init>(String)
+  @Nullable
+  public net.corda.core.utilities.ProgressTracker childProgressTracker()
+  @NotNull
+  public rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
+  @NotNull
+  public java.util.Map<String, String> getExtraAuditData()
+  @NotNull
+  public String getLabel()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED extends net.corda.core.utilities.ProgressTracker$Step
+  public boolean equals(Object)
+  public static final net.corda.core.utilities.ProgressTracker$UNSTARTED INSTANCE
+##
+public interface net.corda.core.utilities.PropertyDelegate
+  public abstract T getValue(Object, kotlin.reflect.KProperty<?>)
+##
+@CordaSerializable
+public abstract class net.corda.core.utilities.Try extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.Try<C> combine(net.corda.core.utilities.Try<? extends B>, kotlin.jvm.functions.Function2<? super A, ? super B, ? extends C>)
+  @NotNull
+  public final net.corda.core.utilities.Try<B> flatMap(kotlin.jvm.functions.Function1<? super A, ? extends net.corda.core.utilities.Try<? extends B>>)
+  public abstract A getOrThrow()
+  public abstract boolean isFailure()
+  public abstract boolean isSuccess()
+  @NotNull
+  public final net.corda.core.utilities.Try<B> map(kotlin.jvm.functions.Function1<? super A, ? extends B>)
+  @NotNull
+  public static final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
+  public static final net.corda.core.utilities.Try$Companion Companion
+##
+public static final class net.corda.core.utilities.Try$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.Try$Failure extends net.corda.core.utilities.Try
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.utilities.Try$Failure<A> copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getException()
+  public A getOrThrow()
+  public int hashCode()
+  public boolean isFailure()
+  public boolean isSuccess()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.Try$Success extends net.corda.core.utilities.Try
+  public <init>(A)
+  public final A component1()
+  @NotNull
+  public final net.corda.core.utilities.Try$Success<A> copy(A)
+  public boolean equals(Object)
+  public A getOrThrow()
+  public final A getValue()
+  public int hashCode()
+  public boolean isFailure()
+  public boolean isSuccess()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.utilities.UntrustworthyData extends java.lang.Object
+  public <init>(T)
+  public final T getFromUntrustedWorld()
+  @Suspendable
+  public final R unwrap(net.corda.core.utilities.UntrustworthyData$Validator<? super T, ? extends R>)
+##
+public static interface net.corda.core.utilities.UntrustworthyData$Validator extends java.io.Serializable
+  @Suspendable
+  public abstract R validate(T)
+##
+public final class net.corda.core.utilities.UntrustworthyDataKt extends java.lang.Object
+  public static final R unwrap(net.corda.core.utilities.UntrustworthyData<? extends T>, kotlin.jvm.functions.Function1<? super T, ? extends R>)
+##
+public final class net.corda.core.utilities.UuidGenerator extends java.lang.Object
+  public <init>()
+  public static final net.corda.core.utilities.UuidGenerator$Companion Companion
+##
+public static final class net.corda.core.utilities.UuidGenerator$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.UUID next()
+##
+public interface net.corda.core.utilities.VariablePropertyDelegate extends net.corda.core.utilities.PropertyDelegate
+  public abstract void setValue(Object, kotlin.reflect.KProperty<?>, T)
+##
+public final class net.corda.client.jackson.JacksonSupport extends java.lang.Object
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper()
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public final com.fasterxml.jackson.databind.Module getCordaModule()
+  public static final net.corda.client.jackson.JacksonSupport INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AmountDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.contracts.Amount<?> deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$AmountDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AmountSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.contracts.Amount<?>, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$AmountSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.AnonymousParty deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.AnonymousParty, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.CordaX500Name deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.CordaX500Name, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer INSTANCE
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$IdentityObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getFuzzyIdentityMatch()
+  @NotNull
+  public final net.corda.core.node.services.IdentityService getIdentityService()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(com.fasterxml.jackson.core.JsonFactory)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.node.NodeInfo deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$NodeInfoSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.node.NodeInfo, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$NodeInfoSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.utilities.OpaqueBytes deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.utilities.OpaqueBytes, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.Party deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$PartyDeserializer INSTANCE
+##
+@DoNotImplement
+public static interface net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public abstract boolean isFullParties()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$PartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.Party, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$PartySerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public java.security.PublicKey deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PublicKeySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(java.security.PublicKey, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$PublicKeySerializer INSTANCE
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$RpcObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getFuzzyIdentityMatch()
+  @NotNull
+  public final net.corda.core.messaging.CordaRPCOps getRpc()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$SecureHashDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  public <init>()
+  @NotNull
+  public T deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+##
+public static final class net.corda.client.jackson.JacksonSupport$SecureHashSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.crypto.SecureHash, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$SecureHashSerializer INSTANCE
+##
+public abstract static class net.corda.client.jackson.JacksonSupport$SignedTransactionMixin extends java.lang.Object
+  public <init>()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getId()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @JsonIgnore
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @JsonProperty
+  @NotNull
+  protected abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @JsonProperty
+  @NotNull
+  protected abstract net.corda.core.transactions.CoreTransaction getTransaction()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction getTx()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
+##
+public static final class net.corda.client.jackson.JacksonSupport$ToStringSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$ToStringSerializer INSTANCE
+##
+public abstract static class net.corda.client.jackson.JacksonSupport$WireTransactionMixin extends java.lang.Object
+  public <init>()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> getAvailableComponentHashes()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<Object> getAvailableComponents()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.MerkleTree getMerkleTree()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
+##
+@ThreadSafe
+public class net.corda.client.jackson.StringToMethodCallParser extends java.lang.Object
+  public <init>(Class<? extends T>)
+  public <init>(Class<? extends T>, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(Class, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(kotlin.reflect.KClass<? extends T>)
+  @NotNull
+  public final java.util.Map<String, String> getAvailableCommands()
+  @NotNull
+  protected final com.google.common.collect.Multimap<String, reflect.Method> getMethodMap()
+  @NotNull
+  public final java.util.Map<String, java.util.List<String>> getMethodParamNames()
+  @NotNull
+  public java.util.List<String> paramNamesFromConstructor(reflect.Constructor<?>)
+  @NotNull
+  public java.util.List<String> paramNamesFromMethod(reflect.Method)
+  @NotNull
+  public final net.corda.client.jackson.StringToMethodCallParser<T>$ParsedMethodCall parse(T, String)
+  @NotNull
+  public final Object[] parseArguments(String, java.util.List<? extends kotlin.Pair<String, ? extends reflect.Type>>, String)
+  public static final net.corda.client.jackson.StringToMethodCallParser$Companion Companion
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.jackson.StringToMethodCallParser$ParsedMethodCall extends java.lang.Object implements java.util.concurrent.Callable
+  public <init>(T, reflect.Method, Object[])
+  @Nullable
+  public Object call()
+  @NotNull
+  public final Object[] getArgs()
+  @NotNull
+  public final reflect.Method getMethod()
+  @Nullable
+  public final Object invoke()
+##
+public static class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException extends net.corda.core.CordaException
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$FailedParse extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(Exception)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$MissingParameter extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, String, String)
+  @NotNull
+  public final String getParamName()
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$ReflectionDataMissing extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, int)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$TooManyParameters extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, String)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$UnknownMethod extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String)
+  @NotNull
+  public final String getMethodName()
+##
+public final class net.corda.testing.driver.Driver extends java.lang.Object
+  public static final A driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1<? super net.corda.testing.driver.DriverDSL, ? extends A>)
+##
+@DoNotImplement
+public interface net.corda.testing.driver.DriverDSL
+  @NotNull
+  public abstract java.nio.file.Path baseDirectory(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract net.corda.testing.driver.NotaryHandle getDefaultNotaryHandle()
+  @NotNull
+  public abstract net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> getDefaultNotaryNode()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.driver.NotaryHandle> getNotaryHandles()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle, String)
+##
+public final class net.corda.testing.driver.DriverParameters extends java.lang.Object
+  public <init>()
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean component1()
+  @NotNull
+  public final java.util.List<String> component10()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy component11()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component12()
+  @NotNull
+  public final java.nio.file.Path component2()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component3()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component4()
+  @NotNull
+  public final java.util.Map<String, String> component5()
+  public final boolean component6()
+  public final boolean component7()
+  public final boolean component8()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> component9()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
+  @NotNull
+  public final java.nio.file.Path getDriverDirectory()
+  @NotNull
+  public final java.util.List<String> getExtraCordappPackagesToScan()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy getJmxPolicy()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getPortAllocation()
+  public final boolean getStartNodesInProcess()
+  @NotNull
+  public final java.util.Map<String, String> getSystemProperties()
+  public final boolean getUseTestClock()
+  public final boolean getWaitForAllNodesToFinish()
+  public int hashCode()
+  public final boolean isDebug()
+  public String toString()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(java.util.List<String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withIsDebug(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withJmxPolicy(net.corda.testing.driver.JmxPolicy)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withStartNodesInProcess(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withSystemProperties(java.util.Map<String, String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withUseTestClock(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withWaitForAllNodesToFinish(boolean)
+##
+@DoNotImplement
+public interface net.corda.testing.driver.InProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServices()
+  @NotNull
+  public abstract rx.Observable<T> registerInitiatedFlow(Class<T>)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+##
+public final class net.corda.testing.driver.JmxPolicy extends java.lang.Object
+  public <init>()
+  public <init>(boolean, net.corda.testing.driver.PortAllocation)
+  public <init>(boolean, net.corda.testing.driver.PortAllocation, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean component1()
+  @Nullable
+  public final net.corda.testing.driver.PortAllocation component2()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy copy(boolean, net.corda.testing.driver.PortAllocation)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.testing.driver.PortAllocation getJmxHttpServerPortAllocation()
+  public final boolean getStartJmxHttpServer()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoCloseable
+  @NotNull
+  public abstract java.nio.file.Path getBaseDirectory()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getNodeInfo()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getP2pAddress()
+  @NotNull
+  public abstract net.corda.core.messaging.CordaRPCOps getRpc()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAddress()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.node.User> getRpcUsers()
+  public abstract void stop()
+##
+public final class net.corda.testing.driver.NodeParameters extends java.lang.Object
+  public <init>()
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component2()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component3()
+  @NotNull
+  public final java.util.Map<String, Object> component4()
+  @Nullable
+  public final Boolean component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<String, Object> getCustomOverrides()
+  @NotNull
+  public final String getMaximumHeapSize()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getProvidedName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  @Nullable
+  public final Boolean getStartInSameProcess()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withProvidedName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withRpcUsers(java.util.List<net.corda.testing.node.User>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withStartInSameProcess(Boolean)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withVerifierType(net.corda.testing.driver.VerifierType)
+##
+public final class net.corda.testing.driver.NotaryHandle extends java.lang.Object
+  public <init>(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> component3()
+  @NotNull
+  public final net.corda.testing.driver.NotaryHandle copy(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getIdentity()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> getNodeHandles()
+  public final boolean getValidating()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.testing.driver.OutOfProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract Process getProcess()
+##
+@DoNotImplement
+public abstract class net.corda.testing.driver.PortAllocation extends java.lang.Object
+  public <init>()
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort nextHostAndPort()
+  public abstract int nextPort()
+##
+@DoNotImplement
+public static final class net.corda.testing.driver.PortAllocation$Incremental extends net.corda.testing.driver.PortAllocation
+  public <init>(int)
+  @NotNull
+  public final java.util.concurrent.atomic.AtomicInteger getPortCounter()
+  public int nextPort()
+##
+public final class net.corda.testing.driver.VerifierType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.testing.driver.VerifierType valueOf(String)
+  public static net.corda.testing.driver.VerifierType[] values()
+##
+public final class net.corda.testing.driver.WebserverHandle extends java.lang.Object
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Process)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort component1()
+  @NotNull
+  public final Process component2()
+  @NotNull
+  public final net.corda.testing.driver.WebserverHandle copy(net.corda.core.utilities.NetworkHostAndPort, Process)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort getListenAddress()
+  @NotNull
+  public final Process getProcess()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
+  public <init>()
+  public abstract int getClusterSize()
+##
+@DoNotImplement
+public static final class net.corda.testing.node.ClusterSpec$Raft extends net.corda.testing.node.ClusterSpec
+  public <init>(int)
+  public final int component1()
+  @NotNull
+  public final net.corda.testing.node.ClusterSpec$Raft copy(int)
+  public boolean equals(Object)
+  public int getClusterSize()
+  public int hashCode()
+  public String toString()
+##
+@ThreadSafe
+public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.corda.core.serialization.SingletonSerializeAsToken
+  public <init>(boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, org.apache.activemq.artemis.utils.ReusableLatch, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final synchronized java.util.List<net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService> getEndpointsExternal()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getReceivedMessages()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getSentMessages()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpSend(boolean)
+  public final void stop()
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle extends java.lang.Object implements net.corda.core.messaging.MessageRecipientGroup
+  public <init>(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle copy(net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static interface net.corda.testing.node.InMemoryMessagingNetwork$LatencyCalculator
+  @NotNull
+  public abstract java.time.Duration between(net.corda.core.messaging.SingleMessageRecipient, net.corda.core.messaging.SingleMessageRecipient)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer extends java.lang.Object
+  public <init>(net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle, net.corda.node.services.messaging.Message, net.corda.core.messaging.MessageRecipients, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence getMessageData()
+  @NotNull
+  public final net.corda.core.messaging.MessageRecipients getRecipients()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle getSender()
+  @NotNull
+  public String toString()
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.InternalMockMessagingService, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle extends java.lang.Object implements net.corda.core.messaging.SingleMessageRecipient
+  public <init>(int, net.corda.core.identity.CordaX500Name)
+  public final int component1()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle copy(int, net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  public final int getId()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public abstract static class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public abstract A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$Random extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+  public <init>()
+  public <init>(java.util.SplittableRandom)
+  public <init>(java.util.SplittableRandom, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.SplittableRandom getRandom()
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+  public <init>()
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+public class net.corda.testing.node.MockNetwork extends java.lang.Object
+  public <init>(java.util.List<String>)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.nio.file.Path baseDirectory(int)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode()
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final java.util.List<String> getCordappPackages()
+  @NotNull
+  public final net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode getDefaultNotaryNode()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters getDefaultParameters()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public final boolean getNetworkSendManuallyPumped()
+  public final int getNextNodeId()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.StartedMockNode> getNotaryNodes()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  public final boolean getThreadPerNode()
+  public final void runNetwork()
+  public final void runNetwork(int)
+  public final void startNodes()
+  public final void stopNodes()
+  public final void waitQuiescent()
+##
+public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkNotarySpec copy(net.corda.core.identity.CordaX500Name, boolean)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  public final boolean getValidating()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.testing.node.MockNetworkParameters extends java.lang.Object
+  public <init>()
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy component3()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> component4()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component5()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public final boolean getNetworkSendManuallyPumped()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  public final boolean getThreadPerNode()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkSendManuallyPumped(boolean)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNotarySpecs(java.util.List<net.corda.testing.node.MockNetworkNotarySpec>)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withServicePeerAllocationStrategy(net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withThreadPerNode(boolean)
+##
+public final class net.corda.testing.node.MockNodeParameters extends java.lang.Object
+  public <init>()
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final Integer component1()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final java.math.BigInteger component3()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<net.corda.node.services.config.NodeConfiguration, Object> component4()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  public boolean equals(Object)
+  @NotNull
+  public final kotlin.jvm.functions.Function1<net.corda.node.services.config.NodeConfiguration, Object> getConfigOverrides()
+  @NotNull
+  public final java.math.BigInteger getEntropyRoot()
+  @Nullable
+  public final Integer getForcedID()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getLegalName()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withConfigOverrides(kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withEntropyRoot(java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withForcedID(Integer)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withLegalName(net.corda.core.identity.CordaX500Name)
+##
+public class net.corda.testing.node.MockServices extends java.lang.Object implements net.corda.core.node.ServiceHub
+  public <init>()
+  public <init>(java.util.List<String>)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(java.util.List, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(java.util.List, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
+  public <init>(java.util.List, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.node.internal.cordapp.CordappLoader, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity, java.security.KeyPair[], kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
+  public final void addMockCordapp(String)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public T cordaService(Class<T>)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public final net.corda.testing.services.MockAttachmentStorage getAttachments()
+  @NotNull
+  public java.time.Clock getClock()
+  @NotNull
+  public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public net.corda.core.node.services.KeyManagementService getKeyManagementService()
+  @NotNull
+  public net.corda.core.node.NodeInfo getMyInfo()
+  @NotNull
+  public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
+  @NotNull
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
+  @NotNull
+  public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
+  @NotNull
+  public net.corda.core.node.services.TransactionStorage getValidatedTransactions()
+  @NotNull
+  public net.corda.core.node.services.VaultService getVaultService()
+  @NotNull
+  public java.sql.Connection jdbcSession()
+  @NotNull
+  public net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
+  @NotNull
+  public java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public static final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  @NotNull
+  public Void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
+  public static final net.corda.testing.node.MockServices$Companion Companion
+##
+public static final class net.corda.testing.node.MockServices$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+##
+public final class net.corda.testing.node.MockServicesKt extends java.lang.Object
+  @NotNull
+  public static final T createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1<? super net.corda.core.node.AppServiceHub, ? extends T>)
+  @NotNull
+  public static final net.corda.node.services.identity.InMemoryIdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
+##
+public final class net.corda.testing.node.NodeTestUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.core.context.Actor testActor(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext testContext(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+##
+public final class net.corda.testing.node.NotarySpec extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  public final boolean component2()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component3()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component4()
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec component5()
+  @NotNull
+  public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec getCluster()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  public final boolean getValidating()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.testing.node.StartedMockNode extends java.lang.Object
+  public <init>(net.corda.node.internal.StartedNode, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<kotlin.Pair<F, net.corda.core.concurrent.CordaFuture<?>>> findStateMachines(Class<F>)
+  public final int getId()
+  @NotNull
+  public final net.corda.core.node.NodeInfo getInfo()
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServices()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  @NotNull
+  public final rx.Observable<F> registerInitiatedFlow(Class<F>)
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  public final void stop()
+  public final T transaction(kotlin.jvm.functions.Function0<? extends T>)
+  public static final net.corda.testing.node.StartedMockNode$Companion Companion
+##
+public static final class net.corda.testing.node.StartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@ThreadSafe
+public final class net.corda.testing.node.TestClock extends net.corda.node.MutableClock
+  public <init>(java.time.Clock)
+  public final synchronized void advanceBy(java.time.Duration)
+  public final synchronized void setTo(java.time.Instant)
+##
+public final class net.corda.testing.node.UnstartedMockNode extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.InternalMockNetwork$MockNode, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int getId()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode start()
+  public static final net.corda.testing.node.UnstartedMockNode$Companion Companion
+##
+public static final class net.corda.testing.node.UnstartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.testing.node.User extends java.lang.Object
+  public <init>(String, String, java.util.Set<String>)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.util.Set<String> component3()
+  @NotNull
+  public final net.corda.testing.node.User copy(String, String, java.util.Set<String>)
+  public boolean equals(Object)
+  @NotNull
+  public final String getPassword()
+  @NotNull
+  public final java.util.Set<String> getPermissions()
+  @NotNull
+  public final String getUsername()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
+  public <init>(net.corda.core.utilities.NetworkHostAndPort)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.nodeapi.internal.config.SSLConfiguration, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public final A use(String, String, kotlin.jvm.functions.Function1<? super net.corda.client.rpc.CordaRPCConnection, ? extends A>)
+  public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
+##
+public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
+  public <init>(java.time.Duration)
+  @NotNull
+  public final java.time.Duration component1()
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration)
+  public boolean equals(Object)
+  @NotNull
+  public final java.time.Duration getConnectionMaxRetryInterval()
+  public int hashCode()
+  public String toString()
+  public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
+  @NotNull
+  public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
+##
+public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
+  public <init>(net.corda.client.rpc.RPCConnection<? extends net.corda.core.messaging.CordaRPCOps>)
+  public void close()
+  public void forceClose()
+  @NotNull
+  public net.corda.core.messaging.CordaRPCOps getProxy()
+  public int getServerProtocolVersion()
+  public void notifyServerAndClose()
+##
+public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException
+  public <init>(String)
+##
+@DoNotImplement
+public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
+  public abstract void forceClose()
+  @NotNull
+  public abstract I getProxy()
+  public abstract int getServerProtocolVersion()
+  public abstract void notifyServerAndClose()
+##
+public class net.corda.client.rpc.RPCException extends net.corda.core.CordaRuntimeException
+  public <init>(String)
+  public <init>(String, Throwable)
+##
+public @interface net.corda.client.rpc.RPCSinceVersion
+  public abstract int version()
+##
+public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
+  public static final void notUsed(rx.Observable<T>)
+##
+public final class net.corda.testing.contracts.DummyContract extends java.lang.Object implements net.corda.core.contracts.Contract
+  public <init>()
+  public <init>(Object)
+  public <init>(Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final Object component1()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract copy(Object)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @Nullable
+  public final Object getBlank()
+  @NotNull
+  public final String getPROGRAM_ID()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
+  public String toString()
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContract$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContract"
+##
+public static interface net.corda.testing.contracts.DummyContract$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContract$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContract$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContract$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
+##
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$MultiOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$MultiOwnerState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$SingleOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State, net.corda.core.contracts.OwnableState
+  public <init>(int, net.corda.core.identity.AbstractParty)
+  public <init>(int, net.corda.core.identity.AbstractParty, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final net.corda.core.identity.AbstractParty component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$SingleOwnerState copy(int, net.corda.core.identity.AbstractParty)
+  public boolean equals(Object)
+  public int getMagicNumber()
+  @NotNull
+  public net.corda.core.identity.AbstractParty getOwner()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  public String toString()
+  @NotNull
+  public net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
+##
+@DoNotImplement
+public static interface net.corda.testing.contracts.DummyContract$State extends net.corda.core.contracts.ContractState
+  public abstract int getMagicNumber()
+##
+public final class net.corda.testing.contracts.DummyContractV2 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
+  public <init>()
+  @NotNull
+  public String getLegacyContract()
+  @NotNull
+  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+  @NotNull
+  public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContractV2$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV2"
+##
+public static interface net.corda.testing.contracts.DummyContractV2$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContractV2$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.testing.contracts.DummyState extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>()
+  public <init>(int)
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int)
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  public String toString()
+##
+public final class net.corda.testing.core.DummyCommandData extends net.corda.core.contracts.TypeOnlyCommandData
+  public static final net.corda.testing.core.DummyCommandData INSTANCE
+##
+public final class net.corda.testing.core.Expect extends java.lang.Object
+  public <init>(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  @NotNull
+  public final Class<T> component1()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> component2()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> component3()
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> copy(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  public boolean equals(Object)
+  @NotNull
+  public final Class<T> getClazz()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> getExpectClosure()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> getMatch()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public abstract class net.corda.testing.core.ExpectCompose extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Parallel extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getParallel()
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Sequential extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getSequence()
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Single extends net.corda.testing.core.ExpectCompose
+  public <init>(net.corda.testing.core.Expect<? extends E, T>)
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> getExpect()
+##
+public static final class net.corda.testing.core.ExpectComposeState$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> fromExpectCompose(net.corda.testing.core.ExpectCompose<? extends E>)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Finished extends net.corda.testing.core.ExpectComposeState
+  public <init>()
+  @NotNull
+  public java.util.List<Class<E>> getExpectedEvents()
+  @Nullable
+  public Void nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Parallel extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Parallel<? extends E>, java.util.List<? extends net.corda.testing.core.ExpectComposeState<E>>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Parallel<E> getParallel()
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectComposeState<E>> getStates()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Sequential extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Sequential<? extends E>, int, net.corda.testing.core.ExpectComposeState<E>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
+  public final int getIndex()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Sequential<E> getSequential()
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> getState()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Single extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Single<? extends E, T>)
+  @NotNull
+  public java.util.List<Class<T>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Single<E, T> getSingle()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public final class net.corda.testing.core.ExpectKt extends java.lang.Object
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> expect(Class<E>, kotlin.jvm.functions.Function1<? super E, Boolean>, kotlin.jvm.functions.Function1<? super E, kotlin.Unit>)
+  public static final void expectEvents(Iterable<? extends E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void expectEvents(rx.Observable<E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void genericExpectEvents(S, boolean, kotlin.jvm.functions.Function2<? super S, ? super kotlin.jvm.functions.Function1<? super E, kotlin.Unit>, kotlin.Unit>, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(net.corda.testing.core.ExpectCompose<? extends E>...)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> replicate(int, kotlin.jvm.functions.Function1<? super Integer, ? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(net.corda.testing.core.ExpectCompose<? extends E>...)
+##
+public final class net.corda.testing.core.SerializationEnvironmentRule extends java.lang.Object implements org.junit.rules.TestRule
+  public <init>()
+  public <init>(boolean)
+  public <init>(boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement, org.junit.runner.Description)
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getCheckpointContext()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getSerializationFactory()
+  public static final net.corda.testing.core.SerializationEnvironmentRule$Companion Companion
+##
+public static final class net.corda.testing.core.SerializationEnvironmentRule$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public final T run(String, kotlin.jvm.functions.Function1<? super net.corda.core.serialization.internal.SerializationEnvironment, ? extends T>)
+##
+public final class net.corda.testing.core.TestConstants extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.contracts.Command<net.corda.core.contracts.TypeOnlyCommandData> dummyCommand(java.security.PublicKey...)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name ALICE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOB_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOC_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
+  public static final int MAX_MESSAGE_SIZE = 10485760
+##
+public final class net.corda.testing.core.TestIdentity extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, long)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair)
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate getIdentity()
+  @NotNull
+  public final java.security.KeyPair getKeyPair()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  @NotNull
+  public final java.security.PublicKey getPublicKey()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference ref(byte...)
+  public static final net.corda.testing.core.TestIdentity$Companion Companion
+##
+public static final class net.corda.testing.core.TestIdentity$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.core.TestIdentity fresh(String)
+##
+public final class net.corda.testing.core.TestUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.utilities.NetworkHostAndPort freeLocalHostAndPort()
+  public static final int freePort()
+  @NotNull
+  public static final net.corda.core.contracts.StateRef generateStateRef()
+  @NotNull
+  public static final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getFreeLocalPorts(String, int)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.Party)
+  @NotNull
+  public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate singleIdentityAndCert(net.corda.core.node.NodeInfo)
+##
+public final class net.corda.testing.dsl.AttachmentResolutionException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash)
+##
+public final class net.corda.testing.dsl.DoubleSpentInputs extends net.corda.core.flows.FlowException
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+##
+public final class net.corda.testing.dsl.DuplicateOutputLabel extends net.corda.core.flows.FlowException
+  public <init>(String)
+##
+@DoNotImplement
+public abstract class net.corda.testing.dsl.EnforceVerifyOrFail extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public static final class net.corda.testing.dsl.EnforceVerifyOrFail$Token extends net.corda.testing.dsl.EnforceVerifyOrFail
+  public static final net.corda.testing.dsl.EnforceVerifyOrFail$Token INSTANCE
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.LedgerDSL extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
+  public <init>(L, net.corda.core.identity.Party)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public final L getInterpreter()
+  @NotNull
+  public final S retrieveOutput(Class<S>, String)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(String, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public final void tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<? extends T, ? extends L>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.LedgerDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super T, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public abstract void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<? extends T>, kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.OutputStateLookup
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.TestLedgerDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
+  public <init>(net.corda.core.node.ServiceHub)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TestTransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TestTransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TestTransactionDSLInterpreter, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+  @NotNull
+  public final net.corda.core.node.ServiceHub component1()
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter copy(net.corda.core.node.ServiceHub, java.util.HashMap<String, net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>>, java.util.HashMap<net.corda.core.crypto.SecureHash, net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation>, java.util.HashMap<net.corda.core.crypto.SecureHash, net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServices()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getTransactionsToVerify()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getTransactionsUnverified()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getWireTransactions()
+  public int hashCode()
+  @Nullable
+  public final String outputToLabel(net.corda.core.contracts.ContractState)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  public String toString()
+  @Nullable
+  public final String transactionName(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+  public static final net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion Companion
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$TypeMismatch extends java.lang.Exception
+  public <init>(Class<?>, Class<?>)
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$VerifiesFailed extends java.lang.Exception
+  public <init>(String, Throwable)
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation extends java.lang.Object
+  public <init>(String, net.corda.core.transactions.WireTransaction, String)
+  @Nullable
+  public final String component1()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction component2()
+  @Nullable
+  public final String component3()
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation copy(String, net.corda.core.transactions.WireTransaction, String)
+  public boolean equals(Object)
+  @Nullable
+  public final String getLabel()
+  @Nullable
+  public final String getLocation()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction getTransaction()
+  public int hashCode()
+  public String toString()
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.TestTransactionDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter, net.corda.testing.dsl.OutputStateLookup
+  public <init>(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder)
+  public void _attachment(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void attachment(net.corda.core.crypto.SecureHash)
+  public void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter component1()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder component2()
+  @NotNull
+  public final net.corda.testing.dsl.TestTransactionDSLInterpreter copy(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder, java.util.HashMap<String, Integer>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public net.corda.testing.dsl.TestLedgerDSLInterpreter getLedgerInterpreter()
+  @NotNull
+  public final net.corda.core.node.ServicesForResolution getServices()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder getTransactionBuilder()
+  public int hashCode()
+  public void input(net.corda.core.contracts.StateRef)
+  public void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  public void timeWindow(net.corda.core.contracts.TimeWindow)
+  public String toString()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter
+  public <init>(T, net.corda.core.identity.Party)
+  public void _attachment(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public final void attachment(String)
+  public void attachment(net.corda.core.crypto.SecureHash)
+  public final void attachments(String...)
+  public final void command(java.security.PublicKey, net.corda.core.contracts.CommandData)
+  public void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
+  public final void input(String)
+  public final void input(String, net.corda.core.contracts.ContractState)
+  public void input(net.corda.core.contracts.StateRef)
+  public final void output(String, int, net.corda.core.contracts.ContractState)
+  public final void output(String, String, int, net.corda.core.contracts.ContractState)
+  public final void output(String, String, net.corda.core.contracts.ContractState)
+  public void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  public final void output(String, String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
+  public final void output(String, net.corda.core.contracts.ContractState)
+  public final void output(String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  public final void timeWindow(java.time.Instant)
+  public final void timeWindow(java.time.Instant, java.time.Duration)
+  public void timeWindow(net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final net.corda.testing.dsl.EnforceVerifyOrFail tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.TransactionDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
+  public abstract void _attachment(String)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public abstract void attachment(net.corda.core.crypto.SecureHash)
+  public abstract void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public abstract net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
+  public abstract void input(net.corda.core.contracts.StateRef)
+  public abstract void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  public abstract void timeWindow(net.corda.core.contracts.TimeWindow)
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.Verifies
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+public final class net.corda.testing.http.HttpApi extends java.lang.Object
+  public <init>(java.net.URL, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(java.net.URL, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final com.fasterxml.jackson.databind.ObjectMapper getMapper()
+  @NotNull
+  public final java.net.URL getRoot()
+  public final void postJson(String, Object)
+  public final void postPlain(String, String)
+  public final void putJson(String, Object)
+  public static final net.corda.testing.http.HttpApi$Companion Companion
+##
+public static final class net.corda.testing.http.HttpApi$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.http.HttpApi fromHostAndPort(net.corda.core.utilities.NetworkHostAndPort, String, String, com.fasterxml.jackson.databind.ObjectMapper)
+##
+public final class net.corda.testing.http.HttpUtils extends java.lang.Object
+  @NotNull
+  public final com.fasterxml.jackson.databind.ObjectMapper getDefaultMapper()
+  public final void postJson(java.net.URL, String)
+  public final void postPlain(java.net.URL, String)
+  public final void putJson(java.net.URL, String)
+  public static final net.corda.testing.http.HttpUtils INSTANCE
+##
+public final class net.corda.testing.services.MockAttachmentStorage extends net.corda.core.serialization.SingletonSerializeAsToken implements net.corda.core.node.services.AttachmentStorage
+  public <init>()
+  @NotNull
+  public final kotlin.Pair<net.corda.core.crypto.SecureHash, byte[]> getAttachmentIdAndBytes(java.io.InputStream)
+  @NotNull
+  public final java.util.Map<net.corda.core.crypto.SecureHash, kotlin.Pair<net.corda.core.contracts.Attachment, byte[]>> getFiles()
+  public boolean hasAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
+  @Nullable
+  public net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+##

--- a/samples/4.0-09_01.txt
+++ b/samples/4.0-09_01.txt
@@ -1,0 +1,8765 @@
+@CordaSerializable
+public interface net.corda.core.ClientRelevantError
+##
+@CordaSerializable
+public class net.corda.core.CordaException extends java.lang.Exception implements net.corda.core.CordaThrowable
+  public <init>()
+  public <init>(String)
+  public <init>(String, String, Throwable)
+  public <init>(String, String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(String, Throwable)
+  public void addSuppressed(Throwable[])
+  public boolean equals(Object)
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
+  public int hashCode()
+  public void setCause(Throwable)
+  public void setMessage(String)
+  public void setOriginalExceptionClassName(String)
+##
+public final class net.corda.core.CordaOID extends java.lang.Object
+  @NotNull
+  public static final String ALIAS_PRIVATE_KEY = "1.3.6.1.4.1.50530.1.2"
+  @NotNull
+  public static final String CORDA_PLATFORM = "1.3.6.1.4.1.50530.1"
+  public static final net.corda.core.CordaOID INSTANCE
+  @NotNull
+  public static final String R3_ROOT = "1.3.6.1.4.1.50530"
+  @NotNull
+  public static final String X509_EXTENSION_CORDA_ROLE = "1.3.6.1.4.1.50530.1.1"
+##
+@CordaSerializable
+public class net.corda.core.CordaRuntimeException extends java.lang.RuntimeException implements net.corda.core.CordaThrowable
+  public <init>(String)
+  public <init>(String, String, Throwable)
+  public <init>(String, Throwable)
+  public void addSuppressed(Throwable[])
+  public boolean equals(Object)
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
+  public int hashCode()
+  public void setCause(Throwable)
+  public void setMessage(String)
+  public void setOriginalExceptionClassName(String)
+##
+@CordaSerializable
+public interface net.corda.core.CordaThrowable
+  public abstract void addSuppressed(Throwable[])
+  @Nullable
+  public abstract String getOriginalExceptionClassName()
+  @Nullable
+  public abstract String getOriginalMessage()
+  public abstract void setCause(Throwable)
+  public abstract void setMessage(String)
+  public abstract void setOriginalExceptionClassName(String)
+##
+public @interface net.corda.core.DoNotImplement
+##
+public final class net.corda.core.Utils extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.messaging.DataFeed<SNAPSHOT, ELEMENT> doOnError(net.corda.core.messaging.DataFeed<? extends SNAPSHOT, ELEMENT>, kotlin.jvm.functions.Function1<? super Throwable, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.core.messaging.DataFeed<SNAPSHOT, ELEMENT> mapErrors(net.corda.core.messaging.DataFeed<? extends SNAPSHOT, ELEMENT>, kotlin.jvm.functions.Function1<? super Throwable, ? extends Throwable>)
+  @NotNull
+  public static final rx.Observable<ELEMENT> mapErrors(rx.Observable<ELEMENT>, kotlin.jvm.functions.Function1<? super Throwable, ? extends Throwable>)
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<T> toFuture(rx.Observable<T>)
+  @NotNull
+  public static final rx.Observable<A> toObservable(net.corda.core.concurrent.CordaFuture<? extends A>)
+##
+public final class net.corda.core.concurrent.ConcurrencyUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<W> firstOf(net.corda.core.concurrent.CordaFuture<? extends V>[], kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<? extends V>, ? extends W>)
+  @NotNull
+  public static final net.corda.core.concurrent.CordaFuture<W> firstOf(net.corda.core.concurrent.CordaFuture<? extends V>[], org.slf4j.Logger, kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<? extends V>, ? extends W>)
+  public static final W match(java.util.concurrent.Future<V>, kotlin.jvm.functions.Function1<? super V, ? extends W>, kotlin.jvm.functions.Function1<? super Throwable, ? extends W>)
+  @NotNull
+  public static final String shortCircuitedTaskFailedMessage = "Short-circuited task failed:"
+##
+@CordaSerializable
+public interface net.corda.core.concurrent.CordaFuture extends java.util.concurrent.Future
+  public abstract void then(kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<V>, ? extends W>)
+  @NotNull
+  public abstract java.util.concurrent.CompletableFuture<V> toCompletableFuture()
+##
+@CordaSerializable
+public final class net.corda.core.context.Actor extends java.lang.Object
+  public <init>(net.corda.core.context.Actor$Id, net.corda.core.context.AuthServiceId, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.context.Actor$Id component1()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId component2()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component3()
+  @NotNull
+  public final net.corda.core.context.Actor copy(net.corda.core.context.Actor$Id, net.corda.core.context.AuthServiceId, net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.context.Actor$Id getId()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId getServiceId()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.context.Actor$Companion Companion
+##
+public static final class net.corda.core.context.Actor$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
+##
+@CordaSerializable
+public static final class net.corda.core.context.Actor$Id extends java.lang.Object
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.context.Actor$Id copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getValue()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.context.AuthServiceId extends java.lang.Object
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.context.AuthServiceId copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getValue()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.context.InvocationContext extends java.lang.Object
+  public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin component1()
+  @NotNull
+  public final net.corda.core.context.Trace component2()
+  @Nullable
+  public final net.corda.core.context.Actor component3()
+  @Nullable
+  public final net.corda.core.context.Trace component4()
+  @Nullable
+  public final net.corda.core.context.Actor component5()
+  @NotNull
+  public final net.corda.core.context.InvocationContext copy(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.core.context.Actor getActor()
+  @Nullable
+  public final net.corda.core.context.Trace getExternalTrace()
+  @Nullable
+  public final net.corda.core.context.Actor getImpersonatedActor()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin getOrigin()
+  @NotNull
+  public final net.corda.core.context.Trace getTrace()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final java.security.Principal principal()
+  @NotNull
+  public static final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.context.InvocationContext$Companion Companion
+##
+public static final class net.corda.core.context.InvocationContext$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext peer(net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext rpc(net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.InvocationContext scheduled(net.corda.core.contracts.ScheduledStateRef, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
+  public final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
+##
+@CordaSerializable
+public abstract class net.corda.core.context.InvocationOrigin extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract java.security.Principal principal()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Peer extends net.corda.core.context.InvocationOrigin
+  public <init>(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Peer copy(net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getParty()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$RPC extends net.corda.core.context.InvocationOrigin
+  public <init>(net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.core.context.Actor component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$RPC copy(net.corda.core.context.Actor)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.context.Actor getActor()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Scheduled extends net.corda.core.context.InvocationOrigin
+  public <init>(net.corda.core.contracts.ScheduledStateRef)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef component1()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Service extends net.corda.core.context.InvocationOrigin
+  public <init>(String, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final net.corda.core.context.InvocationOrigin$Service copy(String, net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getOwningLegalIdentity()
+  @NotNull
+  public final String getServiceClassName()
+  public int hashCode()
+  @NotNull
+  public java.security.Principal principal()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.context.InvocationOrigin$Shell extends net.corda.core.context.InvocationOrigin
+  @NotNull
+  public java.security.Principal principal()
+  public static final net.corda.core.context.InvocationOrigin$Shell INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.context.Trace extends java.lang.Object
+  public <init>(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId component1()
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId component2()
+  @NotNull
+  public final net.corda.core.context.Trace copy(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId getInvocationId()
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId getSessionId()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.context.Trace$Companion Companion
+##
+public static final class net.corda.core.context.Trace$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+##
+@CordaSerializable
+public static final class net.corda.core.context.Trace$InvocationId extends net.corda.core.utilities.Id
+  public <init>(String, java.time.Instant)
+  @NotNull
+  public static final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
+  public static final net.corda.core.context.Trace$InvocationId$Companion Companion
+##
+public static final class net.corda.core.context.Trace$InvocationId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
+##
+@CordaSerializable
+public static final class net.corda.core.context.Trace$SessionId extends net.corda.core.utilities.Id
+  public <init>(String, java.time.Instant)
+  @NotNull
+  public static final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
+  public static final net.corda.core.context.Trace$SessionId$Companion Companion
+##
+public static final class net.corda.core.context.Trace$SessionId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AlwaysAcceptAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.AlwaysAcceptAttachmentConstraint INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.contracts.Amount extends java.lang.Object implements java.lang.Comparable
+  public <init>(long, T)
+  public <init>(long, java.math.BigDecimal, T)
+  public int compareTo(net.corda.core.contracts.Amount<T>)
+  public final long component1()
+  @NotNull
+  public final java.math.BigDecimal component2()
+  @NotNull
+  public final T component3()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> copy(long, java.math.BigDecimal, T)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T, java.math.RoundingMode)
+  @NotNull
+  public final java.math.BigDecimal getDisplayTokenSize()
+  @NotNull
+  public static final java.math.BigDecimal getDisplayTokenSize(Object)
+  public final long getQuantity()
+  @NotNull
+  public final T getToken()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> minus(net.corda.core.contracts.Amount<T>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<java.util.Currency> parseCurrency(String)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> plus(net.corda.core.contracts.Amount<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Amount<T>> splitEvenly(int)
+  @Nullable
+  public static final net.corda.core.contracts.Amount<T> sumOrNull(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> sumOrThrow(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> sumOrZero(Iterable<net.corda.core.contracts.Amount<T>>, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> times(int)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> times(long)
+  @NotNull
+  public final java.math.BigDecimal toDecimal()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> zero(T)
+  public static final net.corda.core.contracts.Amount$Companion Companion
+##
+public static final class net.corda.core.contracts.Amount$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T, java.math.RoundingMode)
+  @NotNull
+  public final java.math.BigDecimal getDisplayTokenSize(Object)
+  @NotNull
+  public final net.corda.core.contracts.Amount<java.util.Currency> parseCurrency(String)
+  @Nullable
+  public final net.corda.core.contracts.Amount<T> sumOrNull(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> sumOrThrow(Iterable<net.corda.core.contracts.Amount<T>>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> sumOrZero(Iterable<net.corda.core.contracts.Amount<T>>, T)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> zero(T)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.AmountTransfer extends java.lang.Object
+  public <init>(long, T, P, P)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.SourceAndAmount<T, P>> apply(java.util.List<? extends net.corda.core.contracts.SourceAndAmount<T, ? extends P>>, Object)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> copy(long, T, P, P)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P)
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P, java.math.RoundingMode)
+  @NotNull
+  public final P getDestination()
+  public final long getQuantityDelta()
+  @NotNull
+  public final P getSource()
+  @NotNull
+  public final T getToken()
+  public int hashCode()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.AmountTransfer<T, P>> novate(P)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> plus(net.corda.core.contracts.AmountTransfer<T, P>)
+  @NotNull
+  public final java.math.BigDecimal toDecimal()
+  @NotNull
+  public String toString()
+  @NotNull
+  public static final net.corda.core.contracts.AmountTransfer<T, P> zero(T, P, P)
+  public static final net.corda.core.contracts.AmountTransfer$Companion Companion
+##
+public static final class net.corda.core.contracts.AmountTransfer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P, java.math.RoundingMode)
+  @NotNull
+  public final net.corda.core.contracts.AmountTransfer<T, P> zero(T, P, P)
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.contracts.Attachment extends net.corda.core.contracts.NamedByHash
+  public void extractFile(String, java.io.OutputStream)
+  @NotNull
+  public abstract java.util.List<java.security.PublicKey> getSignerKeys()
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> getSigners()
+  public abstract int getSize()
+  @NotNull
+  public abstract java.io.InputStream open()
+  @NotNull
+  public java.util.jar.JarInputStream openAsJAR()
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.contracts.AttachmentConstraint
+  public abstract boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.AttachmentResolutionException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AutomaticHashConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.AutomaticHashConstraint INSTANCE
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AutomaticPlaceholderConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.AutomaticPlaceholderConstraint INSTANCE
+##
+public @interface net.corda.core.contracts.BelongsToContract
+  public abstract Class<? extends net.corda.core.contracts.Contract> value()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.Command extends java.lang.Object
+  public <init>(T, java.security.PublicKey)
+  public <init>(T, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> component2()
+  @NotNull
+  public final net.corda.core.contracts.Command<T> copy(T, java.util.List<? extends java.security.PublicKey>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigners()
+  @NotNull
+  public final T getValue()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.contracts.CommandAndState extends java.lang.Object
+  public <init>(net.corda.core.contracts.CommandData, net.corda.core.contracts.OwnableState)
+  @NotNull
+  public final net.corda.core.contracts.CommandData component1()
+  @NotNull
+  public final net.corda.core.contracts.OwnableState component2()
+  @NotNull
+  public final net.corda.core.contracts.CommandAndState copy(net.corda.core.contracts.CommandData, net.corda.core.contracts.OwnableState)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.CommandData getCommand()
+  @NotNull
+  public final net.corda.core.contracts.OwnableState getOwnableState()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.CommandData
+##
+@CordaSerializable
+public final class net.corda.core.contracts.CommandWithParties extends java.lang.Object
+  public <init>(java.util.List<? extends java.security.PublicKey>, java.util.List<net.corda.core.identity.Party>, T)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> component2()
+  @NotNull
+  public final T component3()
+  @NotNull
+  public final net.corda.core.contracts.CommandWithParties<T> copy(java.util.List<? extends java.security.PublicKey>, java.util.List<net.corda.core.identity.Party>, T)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigners()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> getSigningParties()
+  @NotNull
+  public final T getValue()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.contracts.ComponentGroupEnum extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.contracts.ComponentGroupEnum valueOf(String)
+  public static net.corda.core.contracts.ComponentGroupEnum[] values()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.Contract
+  public abstract void verify(net.corda.core.transactions.LedgerTransaction)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.ContractAttachment extends java.lang.Object implements net.corda.core.contracts.Attachment
+  public <init>(net.corda.core.contracts.Attachment, String)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>, String)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>, String, java.util.List<? extends java.security.PublicKey>)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>, String, java.util.List<? extends java.security.PublicKey>, int)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set, String, java.util.List, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.Set<String> getAdditionalContracts()
+  @NotNull
+  public final java.util.Set<String> getAllContracts()
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment()
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<java.security.PublicKey> getSignerKeys()
+  @NotNull
+  public java.util.List<net.corda.core.identity.Party> getSigners()
+  public int getSize()
+  @Nullable
+  public final String getUploader()
+  public final int getVersion()
+  public final boolean isSigned()
+  @NotNull
+  public java.io.InputStream open()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+##
+public final class net.corda.core.contracts.ContractsDSL extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.contracts.CommandWithParties<C> requireSingleCommand(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>)
+  public static final R requireThat(kotlin.jvm.functions.Function1<? super net.corda.core.contracts.Requirements, ? extends R>)
+  @NotNull
+  public static final java.util.List<net.corda.core.contracts.CommandWithParties<C>> select(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>, java.security.PublicKey, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final java.util.List<net.corda.core.contracts.CommandWithParties<C>> select(java.util.Collection<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, Class<C>, java.util.Collection<? extends java.security.PublicKey>, java.util.Collection<net.corda.core.identity.Party>)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.FungibleAsset extends net.corda.core.contracts.FungibleState, net.corda.core.contracts.OwnableState
+  @NotNull
+  public abstract net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>> getAmount()
+  @SerializableCalculatedProperty
+  @NotNull
+  public abstract java.util.Collection<java.security.PublicKey> getExitKeys()
+  @NotNull
+  public abstract net.corda.core.contracts.FungibleAsset<T> withNewOwnerAndAmount(net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>>, net.corda.core.identity.AbstractParty)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.FungibleState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.contracts.Amount<T> getAmount()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.HashAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.contracts.HashAttachmentConstraint copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
+  public int hashCode()
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.InsufficientBalanceException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.contracts.Amount<?>)
+  @NotNull
+  public final net.corda.core.contracts.Amount<?> getAmountMissing()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.Issued extends java.lang.Object
+  public <init>(net.corda.core.contracts.PartyAndReference, P)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference component1()
+  @NotNull
+  public final P component2()
+  @NotNull
+  public final net.corda.core.contracts.Issued<P> copy(net.corda.core.contracts.PartyAndReference, P)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference getIssuer()
+  @NotNull
+  public final P getProduct()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public @interface net.corda.core.contracts.LegalProseReference
+  public abstract String uri()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.LinearPointer extends net.corda.core.contracts.StatePointer
+  public <init>(net.corda.core.contracts.UniqueIdentifier, Class<T>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.contracts.UniqueIdentifier getPointer()
+  @NotNull
+  public Class<T> getType()
+  public int hashCode()
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.transactions.LedgerTransaction)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.LinearState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.contracts.UniqueIdentifier getLinearId()
+##
+@CordaSerializable
+public interface net.corda.core.contracts.MoveCommand extends net.corda.core.contracts.CommandData
+  @Nullable
+  public abstract Class<? extends net.corda.core.contracts.Contract> getContract()
+##
+public interface net.corda.core.contracts.NamedByHash
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getId()
+##
+public @interface net.corda.core.contracts.NoConstraintPropagation
+##
+@CordaSerializable
+public interface net.corda.core.contracts.OwnableState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.identity.AbstractParty getOwner()
+  @NotNull
+  public abstract net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.PartyAndReference extends java.lang.Object
+  public <init>(net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public final net.corda.core.identity.AbstractParty component1()
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes component2()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference copy(net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.AbstractParty getParty()
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes getReference()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.PrivacySalt extends net.corda.core.utilities.OpaqueBytes
+  public <init>()
+  public <init>(byte[])
+##
+public final class net.corda.core.contracts.ReferencedStateAndRef extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateAndRef<? extends T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> component1()
+  @NotNull
+  public final net.corda.core.contracts.ReferencedStateAndRef<T> copy(net.corda.core.contracts.StateAndRef<? extends T>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> getStateAndRef()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.contracts.Requirements extends java.lang.Object
+  public final void using(String, boolean)
+  public static final net.corda.core.contracts.Requirements INSTANCE
+##
+@CordaSerializable
+public interface net.corda.core.contracts.SchedulableState extends net.corda.core.contracts.ContractState
+  @Nullable
+  public abstract net.corda.core.contracts.ScheduledActivity nextScheduledActivity(net.corda.core.contracts.StateRef, net.corda.core.flows.FlowLogicRefFactory)
+##
+public interface net.corda.core.contracts.Scheduled
+  @NotNull
+  public abstract java.time.Instant getScheduledAt()
+##
+public final class net.corda.core.contracts.ScheduledActivity extends java.lang.Object implements net.corda.core.contracts.Scheduled
+  public <init>(net.corda.core.flows.FlowLogicRef, java.time.Instant)
+  @NotNull
+  public final net.corda.core.flows.FlowLogicRef component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledActivity copy(net.corda.core.flows.FlowLogicRef, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.flows.FlowLogicRef getLogicRef()
+  @NotNull
+  public java.time.Instant getScheduledAt()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.ScheduledStateRef extends java.lang.Object implements net.corda.core.contracts.Scheduled
+  public <init>(net.corda.core.contracts.StateRef, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @NotNull
+  public final java.time.Instant component2()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef copy(net.corda.core.contracts.StateRef, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public java.time.Instant getScheduledAt()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.SignatureAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public <init>(java.security.PublicKey)
+  @NotNull
+  public final java.security.PublicKey component1()
+  @NotNull
+  public final net.corda.core.contracts.SignatureAttachmentConstraint copy(java.security.PublicKey)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getKey()
+  public int hashCode()
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.contracts.SourceAndAmount extends java.lang.Object
+  public <init>(P, net.corda.core.contracts.Amount<T>, Object)
+  public <init>(Object, net.corda.core.contracts.Amount, Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final P component1()
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> component2()
+  @Nullable
+  public final Object component3()
+  @NotNull
+  public final net.corda.core.contracts.SourceAndAmount<T, P> copy(P, net.corda.core.contracts.Amount<T>, Object)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.Amount<T> getAmount()
+  @Nullable
+  public final Object getRef()
+  @NotNull
+  public final P getSource()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.contracts.StateAndContract extends java.lang.Object
+  public <init>(net.corda.core.contracts.ContractState, String)
+  @NotNull
+  public final net.corda.core.contracts.ContractState component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.contracts.StateAndContract copy(net.corda.core.contracts.ContractState, String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getState()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.StateAndRef extends java.lang.Object
+  public <init>(net.corda.core.contracts.TransactionState<? extends T>, net.corda.core.contracts.StateRef)
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> component1()
+  @NotNull
+  public final net.corda.core.contracts.StateRef component2()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> copy(net.corda.core.contracts.TransactionState<? extends T>, net.corda.core.contracts.StateRef)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> getState()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.contracts.ReferencedStateAndRef<T> referenced()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.contracts.StatePointer extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract Object getPointer()
+  @NotNull
+  public abstract Class<T> getType()
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.transactions.LedgerTransaction)
+##
+@CordaSerializable
+public final class net.corda.core.contracts.StateRef extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, int)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.contracts.StateRef copy(net.corda.core.crypto.SecureHash, int)
+  public boolean equals(Object)
+  public final int getIndex()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxhash()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.StaticPointer extends net.corda.core.contracts.StatePointer
+  public <init>(net.corda.core.contracts.StateRef, Class<T>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.contracts.StateRef getPointer()
+  @NotNull
+  public Class<T> getType()
+  public int hashCode()
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.transactions.LedgerTransaction)
+##
+public final class net.corda.core.contracts.Structures extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash hash(net.corda.core.contracts.ContractState)
+  @NotNull
+  public static final net.corda.core.contracts.Amount<T> withoutIssuer(net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>>)
+  public static final int MAX_ISSUER_REF_SIZE = 512
+##
+@CordaSerializable
+public abstract class net.corda.core.contracts.TimeWindow extends java.lang.Object
+  public <init>()
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
+  public abstract boolean contains(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
+  @Nullable
+  public abstract java.time.Instant getFromTime()
+  @Nullable
+  public final java.time.Duration getLength()
+  @Nullable
+  public abstract java.time.Instant getMidpoint()
+  @Nullable
+  public abstract java.time.Instant getUntilTime()
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
+  @NotNull
+  public static final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
+  public static final net.corda.core.contracts.TimeWindow$Companion Companion
+##
+public static final class net.corda.core.contracts.TimeWindow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow fromOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow fromStartAndDuration(java.time.Instant, java.time.Duration)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow untilOnly(java.time.Instant)
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow withTolerance(java.time.Instant, java.time.Duration)
+##
+public interface net.corda.core.contracts.TokenizableAssetInfo
+  @NotNull
+  public abstract java.math.BigDecimal getDisplayTokenSize()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.TransactionResolutionException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.TransactionState extends java.lang.Object
+  public <init>(T, String, net.corda.core.identity.Party)
+  public <init>(T, String, net.corda.core.identity.Party, Integer)
+  public <init>(T, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  public <init>(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(T, net.corda.core.identity.Party)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @Nullable
+  public final Integer component4()
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint component5()
+  @NotNull
+  public final net.corda.core.contracts.TransactionState<T> copy(T, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint getConstraint()
+  @NotNull
+  public final String getContract()
+  @NotNull
+  public final T getData()
+  @Nullable
+  public final Integer getEncumbrance()
+  @NotNull
+  public final net.corda.core.identity.Party getNotary()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.contracts.TransactionState$Companion Companion
+##
+public final class net.corda.core.contracts.TransactionStateKt extends java.lang.Object
+##
+@CordaSerializable
+public abstract class net.corda.core.contracts.TransactionVerificationException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ConflictingAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ConstraintPropagationRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractAttachmentNotSignedByPackageOwnerException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentHash()
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractConstraintRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractCreationError extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.Contract, Throwable)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$Direction extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.contracts.TransactionVerificationException$Direction valueOf(String)
+  public static net.corda.core.contracts.TransactionVerificationException$Direction[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$DuplicateInputStates extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef> getDuplicates()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$InvalidNotaryChange extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MissingAttachmentRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$MoreThanOneNotary extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$NotaryChangeInWrongTransactionType extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party getOutputNotary()
+  @NotNull
+  public final net.corda.core.identity.Party getTxNotary()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$OverlappingAttachmentsException extends java.lang.Exception
+  public <init>(String)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$SignersMissing extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getMissing()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionContractConflictException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>, String)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionDuplicateEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, int)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionMissingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, int, net.corda.core.contracts.TransactionVerificationException$Direction)
+  @NotNull
+  public final net.corda.core.contracts.TransactionVerificationException$Direction getInOut()
+  public final int getMissing()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNonMatchingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, java.util.Collection<Integer>)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNotaryMismatchEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, int, int, net.corda.core.identity.Party, net.corda.core.identity.Party)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionRequiredContractUnspecifiedException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionVerificationVersionException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, String, String)
+##
+@CordaSerializable
+public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.lang.Object implements net.corda.core.contracts.CommandData
+  public <init>()
+  public boolean equals(Object)
+  public int hashCode()
+##
+@CordaSerializable
+public final class net.corda.core.contracts.UniqueIdentifier extends java.lang.Object implements java.lang.Comparable
+  public <init>()
+  public <init>(String)
+  public <init>(String, java.util.UUID)
+  public <init>(String, java.util.UUID, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public int compareTo(net.corda.core.contracts.UniqueIdentifier)
+  @Nullable
+  public final String component1()
+  @NotNull
+  public final java.util.UUID component2()
+  @NotNull
+  public final net.corda.core.contracts.UniqueIdentifier copy(String, java.util.UUID)
+  public boolean equals(Object)
+  @Nullable
+  public final String getExternalId()
+  @NotNull
+  public final java.util.UUID getId()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.contracts.UniqueIdentifier$Companion Companion
+##
+public static final class net.corda.core.contracts.UniqueIdentifier$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.UniqueIdentifier fromString(String)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.UpgradedContract extends net.corda.core.contracts.Contract
+  @NotNull
+  public abstract String getLegacyContract()
+  @NotNull
+  public abstract NewState upgrade(OldState)
+##
+@CordaSerializable
+public interface net.corda.core.contracts.UpgradedContractWithLegacyConstraint extends net.corda.core.contracts.UpgradedContract
+  @NotNull
+  public abstract net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint INSTANCE
+##
+@DoNotImplement
+public interface net.corda.core.cordapp.Cordapp
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getAllFlows()
+  @NotNull
+  public abstract java.util.List<String> getContractClassNames()
+  @NotNull
+  public abstract java.util.List<String> getCordappClasses()
+  @NotNull
+  public abstract java.util.Set<net.corda.core.schemas.MappedSchema> getCustomSchemas()
+  @NotNull
+  public abstract net.corda.core.cordapp.Cordapp$Info getInfo()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getInitiatedFlows()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash$SHA256 getJarHash()
+  @NotNull
+  public abstract java.net.URL getJarPath()
+  public abstract int getMinimumPlatformVersion()
+  @NotNull
+  public abstract String getName()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getRpcFlows()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getSchedulableFlows()
+  @NotNull
+  public abstract java.util.List<net.corda.core.serialization.SerializationCustomSerializer<?, ?>> getSerializationCustomSerializers()
+  @NotNull
+  public abstract java.util.List<net.corda.core.serialization.SerializationWhitelist> getSerializationWhitelists()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getServiceFlows()
+  @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.serialization.SerializeAsToken>> getServices()
+  public abstract int getTargetPlatformVersion()
+##
+@DoNotImplement
+public static interface net.corda.core.cordapp.Cordapp$Info
+  @NotNull
+  public abstract String getLicence()
+  @NotNull
+  public abstract String getShortName()
+  @NotNull
+  public abstract String getVendor()
+  @NotNull
+  public abstract String getVersion()
+  public abstract boolean hasUnknownFields()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$Contract extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(String, String, int, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Contract copy(String, String, int, String)
+  public boolean equals(Object)
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  public final int getVersionId()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$ContractAndWorkflow extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(net.corda.core.cordapp.Cordapp$Info$Contract, net.corda.core.cordapp.Cordapp$Info$Workflow)
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Contract component1()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Workflow component2()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$ContractAndWorkflow copy(net.corda.core.cordapp.Cordapp$Info$Contract, net.corda.core.cordapp.Cordapp$Info$Workflow)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Contract getContract()
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Workflow getWorkflow()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$Default extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(String, String, String, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Default copy(String, String, String, String)
+  public boolean equals(Object)
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$Workflow extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(String, String, int, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Workflow copy(String, String, int, String)
+  public boolean equals(Object)
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  public final int getVersionId()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.cordapp.CordappConfig
+  public abstract boolean exists(String)
+  @NotNull
+  public abstract Object get(String)
+  public abstract boolean getBoolean(String)
+  public abstract double getDouble(String)
+  public abstract float getFloat(String)
+  public abstract int getInt(String)
+  public abstract long getLong(String)
+  @NotNull
+  public abstract Number getNumber(String)
+  @NotNull
+  public abstract String getString(String)
+##
+public final class net.corda.core.cordapp.CordappConfigException extends java.lang.Exception
+  public <init>(String, Throwable)
+##
+public final class net.corda.core.cordapp.CordappContext extends java.lang.Object
+  public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader, net.corda.core.cordapp.CordappConfig)
+  @Nullable
+  public final net.corda.core.crypto.SecureHash getAttachmentId()
+  @NotNull
+  public final ClassLoader getClassLoader()
+  @NotNull
+  public final net.corda.core.cordapp.CordappConfig getConfig()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp getCordapp()
+##
+@DoNotImplement
+public interface net.corda.core.cordapp.CordappProvider
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappContext getAppContext()
+  @Nullable
+  public abstract net.corda.core.crypto.SecureHash getContractAttachmentID(String)
+##
+public class net.corda.core.crypto.AddressFormatException extends java.lang.IllegalArgumentException
+  public <init>()
+  public <init>(String)
+##
+public class net.corda.core.crypto.Base58 extends java.lang.Object
+  public <init>()
+  public static byte[] decode(String)
+  public static byte[] decodeChecked(String)
+  public static java.math.BigInteger decodeToBigInteger(String)
+  public static String encode(byte[])
+##
+@CordaSerializable
+public final class net.corda.core.crypto.CompositeKey extends java.lang.Object implements java.security.PublicKey
+  public <init>(int, java.util.List, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final void checkValidity()
+  public boolean equals(Object)
+  @NotNull
+  public String getAlgorithm()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.CompositeKey$NodeAndWeight> getChildren()
+  @NotNull
+  public byte[] getEncoded()
+  @NotNull
+  public String getFormat()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getLeafKeys()
+  public final int getThreshold()
+  public int hashCode()
+  public final boolean isFulfilledBy(Iterable<? extends java.security.PublicKey>)
+  public final boolean isFulfilledBy(java.security.PublicKey)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.crypto.CompositeKey$Companion Companion
+  @NotNull
+  public static final String KEY_ALGORITHM = "COMPOSITE"
+##
+public static final class net.corda.core.crypto.CompositeKey$Builder extends java.lang.Object
+  public <init>()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKey(java.security.PublicKey, int)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$Builder addKeys(java.security.PublicKey...)
+  @NotNull
+  public final java.security.PublicKey build(Integer)
+##
+public static final class net.corda.core.crypto.CompositeKey$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.security.PublicKey getInstance(org.bouncycastle.asn1.ASN1Primitive)
+  @NotNull
+  public final java.security.PublicKey getInstance(byte[])
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.CompositeKey$NodeAndWeight extends org.bouncycastle.asn1.ASN1Object implements java.lang.Comparable
+  public <init>(java.security.PublicKey, int)
+  public int compareTo(net.corda.core.crypto.CompositeKey$NodeAndWeight)
+  @NotNull
+  public final java.security.PublicKey component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey$NodeAndWeight copy(java.security.PublicKey, int)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getNode()
+  public final int getWeight()
+  public int hashCode()
+  @NotNull
+  public org.bouncycastle.asn1.ASN1Primitive toASN1Primitive()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.crypto.CompositeKeyFactory extends java.security.KeyFactorySpi
+  public <init>()
+  @NotNull
+  protected java.security.PrivateKey engineGeneratePrivate(java.security.spec.KeySpec)
+  @Nullable
+  protected java.security.PublicKey engineGeneratePublic(java.security.spec.KeySpec)
+  @NotNull
+  protected T engineGetKeySpec(java.security.Key, Class<T>)
+  @NotNull
+  protected java.security.Key engineTranslateKey(java.security.Key)
+##
+public final class net.corda.core.crypto.CompositeSignature extends java.security.Signature
+  public <init>()
+  @NotNull
+  protected Object engineGetParameter(String)
+  protected void engineInitSign(java.security.PrivateKey)
+  protected void engineInitVerify(java.security.PublicKey)
+  protected void engineSetParameter(String, Object)
+  protected void engineSetParameter(java.security.spec.AlgorithmParameterSpec)
+  @NotNull
+  protected byte[] engineSign()
+  protected void engineUpdate(byte)
+  protected void engineUpdate(byte[], int, int)
+  protected boolean engineVerify(byte[])
+  @NotNull
+  public static final java.security.Provider$Service getService(java.security.Provider)
+  public static final net.corda.core.crypto.CompositeSignature$Companion Companion
+  @NotNull
+  public static final String SIGNATURE_ALGORITHM = "COMPOSITESIG"
+##
+public static final class net.corda.core.crypto.CompositeSignature$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.security.Provider$Service getService(java.security.Provider)
+##
+public static final class net.corda.core.crypto.CompositeSignature$State extends java.lang.Object
+  public <init>(java.io.ByteArrayOutputStream, net.corda.core.crypto.CompositeKey)
+  @NotNull
+  public final java.io.ByteArrayOutputStream component1()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey component2()
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignature$State copy(java.io.ByteArrayOutputStream, net.corda.core.crypto.CompositeKey)
+  public final boolean engineVerify(byte[])
+  public boolean equals(Object)
+  @NotNull
+  public final java.io.ByteArrayOutputStream getBuffer()
+  @NotNull
+  public final net.corda.core.crypto.CompositeKey getVerifyKey()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.crypto.CompositeSignaturesWithKeys extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component1()
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignaturesWithKeys copy(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.crypto.CompositeSignaturesWithKeys$Companion Companion
+##
+public static final class net.corda.core.crypto.CompositeSignaturesWithKeys$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.CompositeSignaturesWithKeys getEMPTY()
+##
+public final class net.corda.core.crypto.CordaObjectIdentifier extends java.lang.Object
+  @NotNull
+  public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_KEY
+  @NotNull
+  public static final org.bouncycastle.asn1.ASN1ObjectIdentifier COMPOSITE_SIGNATURE
+  public static final net.corda.core.crypto.CordaObjectIdentifier INSTANCE
+##
+public final class net.corda.core.crypto.CordaSecurityProvider extends java.security.Provider
+  public <init>()
+  public static final net.corda.core.crypto.CordaSecurityProvider$Companion Companion
+  @NotNull
+  public static final String PROVIDER_NAME = "Corda"
+##
+public static final class net.corda.core.crypto.CordaSecurityProvider$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.core.crypto.CordaSecurityProviderKt extends java.lang.Object
+##
+public final class net.corda.core.crypto.Crypto extends java.lang.Object
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(String, byte[])
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(net.corda.core.crypto.SignatureScheme, byte[])
+  @NotNull
+  public static final java.security.PrivateKey decodePrivateKey(byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(String, byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(net.corda.core.crypto.SignatureScheme, byte[])
+  @NotNull
+  public static final java.security.PublicKey decodePublicKey(byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPair(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPair(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPairFromEntropy(java.math.BigInteger)
+  @NotNull
+  public static final java.security.KeyPair deriveKeyPairFromEntropy(net.corda.core.crypto.SignatureScheme, java.math.BigInteger)
+  @NotNull
+  public static final byte[] doSign(String, java.security.PrivateKey, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.TransactionSignature doSign(java.security.KeyPair, net.corda.core.crypto.SignableData)
+  @NotNull
+  public static final byte[] doSign(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final byte[] doSign(net.corda.core.crypto.SignatureScheme, java.security.PrivateKey, byte[])
+  public static final boolean doVerify(String, java.security.PublicKey, byte[], byte[])
+  public static final boolean doVerify(java.security.PublicKey, byte[], byte[])
+  public static final boolean doVerify(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
+  public static final boolean doVerify(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
+  @NotNull
+  public static final java.security.Provider findProvider(String)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(int)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(String)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PrivateKey)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme findSignatureScheme(org.bouncycastle.asn1.x509.AlgorithmIdentifier)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair()
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair(String)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair(net.corda.core.crypto.SignatureScheme)
+  public static final boolean isSupportedSignatureScheme(net.corda.core.crypto.SignatureScheme)
+  public static final boolean isValid(java.security.PublicKey, byte[], byte[])
+  public static final boolean isValid(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
+  public static final boolean isValid(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
+  public static final boolean publicKeyOnCurve(net.corda.core.crypto.SignatureScheme, java.security.PublicKey)
+  public static final void registerProviders()
+  @NotNull
+  public static final java.util.List<net.corda.core.crypto.SignatureScheme> supportedSignatureSchemes()
+  @NotNull
+  public static final java.security.PrivateKey toSupportedPrivateKey(java.security.PrivateKey)
+  @NotNull
+  public static final java.security.PublicKey toSupportedPublicKey(java.security.PublicKey)
+  @NotNull
+  public static final java.security.PublicKey toSupportedPublicKey(org.bouncycastle.asn1.x509.SubjectPublicKeyInfo)
+  public static final boolean validatePublicKey(java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme DEFAULT_SIGNATURE_SCHEME
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256K1_SHA256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme ECDSA_SECP256R1_SHA256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme EDDSA_ED25519_SHA512
+  public static final net.corda.core.crypto.Crypto INSTANCE
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme RSA_SHA256
+  @NotNull
+  public static final org.bouncycastle.asn1.DLSequence SHA512_256
+  @NotNull
+  public static final net.corda.core.crypto.SignatureScheme SPHINCS256_SHA256
+##
+public final class net.corda.core.crypto.CryptoUtils extends java.lang.Object
+  @NotNull
+  public static final java.util.Set<java.security.PublicKey> byKeys(Iterable<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public static final java.security.PrivateKey component1(java.security.KeyPair)
+  @NotNull
+  public static final java.security.PublicKey component2(java.security.KeyPair)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.crypto.SecureHash, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash componentHash(net.corda.core.utilities.OpaqueBytes, net.corda.core.contracts.PrivacySalt, int, int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 computeNonce(net.corda.core.contracts.PrivacySalt, int, int)
+  public static final boolean containsAny(java.security.PublicKey, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public static final java.security.KeyPair entropyToKeyPair(java.math.BigInteger)
+  @NotNull
+  public static final java.security.KeyPair generateKeyPair()
+  @NotNull
+  public static final java.util.Set<java.security.PublicKey> getKeys(java.security.PublicKey)
+  public static final boolean isFulfilledBy(java.security.PublicKey, Iterable<? extends java.security.PublicKey>)
+  public static final boolean isFulfilledBy(java.security.PublicKey, java.security.PublicKey)
+  public static final boolean isValid(java.security.PublicKey, byte[], net.corda.core.crypto.DigitalSignature)
+  @NotNull
+  public static final java.security.SecureRandom newSecureRandom()
+  public static final long random63BitValue()
+  @NotNull
+  public static final byte[] secureRandomBytes(int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash serializedHash(T)
+  @NotNull
+  public static final net.corda.core.crypto.TransactionSignature sign(java.security.KeyPair, net.corda.core.crypto.SignableData)
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.KeyPair, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature sign(java.security.PrivateKey, byte[])
+  @NotNull
+  public static final net.corda.core.crypto.DigitalSignature$WithKey sign(java.security.PrivateKey, byte[], java.security.PublicKey)
+  @NotNull
+  public static final String toStringShort(java.security.PublicKey)
+  public static final boolean verify(java.security.KeyPair, byte[], byte[])
+  public static final boolean verify(java.security.PublicKey, byte[], net.corda.core.crypto.DigitalSignature)
+  public static final boolean verify(java.security.PublicKey, byte[], byte[])
+##
+@CordaSerializable
+public class net.corda.core.crypto.DigitalSignature extends net.corda.core.utilities.OpaqueBytes
+  public <init>(byte[])
+##
+@CordaSerializable
+public static class net.corda.core.crypto.DigitalSignature$WithKey extends net.corda.core.crypto.DigitalSignature
+  public <init>(java.security.PublicKey, byte[])
+  @NotNull
+  public final java.security.PublicKey getBy()
+  public final boolean isValid(byte[])
+  public final boolean verify(net.corda.core.utilities.OpaqueBytes)
+  public final boolean verify(byte[])
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature withoutKey()
+##
+public abstract class net.corda.core.crypto.MerkleTree extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getHash()
+  public static final net.corda.core.crypto.MerkleTree$Companion Companion
+##
+public static final class net.corda.core.crypto.MerkleTree$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getMerkleTree(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+##
+public static final class net.corda.core.crypto.MerkleTree$Leaf extends net.corda.core.crypto.MerkleTree
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree$Leaf copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static final class net.corda.core.crypto.MerkleTree$Node extends net.corda.core.crypto.MerkleTree
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.MerkleTree, net.corda.core.crypto.MerkleTree)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree component2()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree component3()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree$Node copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.MerkleTree, net.corda.core.crypto.MerkleTree)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getLeft()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getRight()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.crypto.MerkleTreeException extends net.corda.core.CordaException
+  public <init>(String)
+  @NotNull
+  public final String getReason()
+##
+public final class net.corda.core.crypto.NullKeys extends java.lang.Object
+  @NotNull
+  public final net.corda.core.identity.AnonymousParty getNULL_PARTY()
+  @NotNull
+  public final net.corda.core.crypto.TransactionSignature getNULL_SIGNATURE()
+  public static final net.corda.core.crypto.NullKeys INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.NullKeys$NullPublicKey extends java.lang.Object implements java.security.PublicKey, java.lang.Comparable
+  public int compareTo(java.security.PublicKey)
+  @NotNull
+  public String getAlgorithm()
+  @NotNull
+  public byte[] getEncoded()
+  @NotNull
+  public String getFormat()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.crypto.NullKeys$NullPublicKey INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.crypto.PartialMerkleTree extends java.lang.Object
+  public <init>(net.corda.core.crypto.PartialMerkleTree$PartialTree)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRoot()
+  public final boolean verify(net.corda.core.crypto.SecureHash, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  public static final net.corda.core.crypto.PartialMerkleTree$Companion Companion
+##
+public static final class net.corda.core.crypto.PartialMerkleTree$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree build(net.corda.core.crypto.MerkleTree, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash rootAndUsedHashes(net.corda.core.crypto.PartialMerkleTree$PartialTree, java.util.List<net.corda.core.crypto.SecureHash>)
+##
+@CordaSerializable
+public abstract static class net.corda.core.crypto.PartialMerkleTree$PartialTree extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Leaf copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Node extends net.corda.core.crypto.PartialMerkleTree$PartialTree
+  public <init>(net.corda.core.crypto.PartialMerkleTree$PartialTree, net.corda.core.crypto.PartialMerkleTree$PartialTree)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree component1()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree component2()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree$Node copy(net.corda.core.crypto.PartialMerkleTree$PartialTree, net.corda.core.crypto.PartialMerkleTree$PartialTree)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getLeft()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRight()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.crypto.SecureHash extends net.corda.core.utilities.OpaqueBytes
+  public <init>(byte[], kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 hashConcat(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 parse(String)
+  @NotNull
+  public final String prefixChars(int)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
+  @NotNull
+  public String toString()
+  public static final net.corda.core.crypto.SecureHash$Companion Companion
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 allOnesHash
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 zeroHash
+##
+public static final class net.corda.core.crypto.SecureHash$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getAllOnesHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 getZeroHash()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 parse(String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 randomSHA256()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256(String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+  @NotNull
+  public final net.corda.core.crypto.SecureHash$SHA256 sha256Twice(byte[])
+##
+@CordaSerializable
+public static final class net.corda.core.crypto.SecureHash$SHA256 extends net.corda.core.crypto.SecureHash
+  public <init>(byte[])
+##
+public final class net.corda.core.crypto.SecureHashKt extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 sha256(byte[])
+##
+@CordaSerializable
+public final class net.corda.core.crypto.SignableData extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignatureMetadata)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata component2()
+  @NotNull
+  public final net.corda.core.crypto.SignableData copy(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SignatureMetadata)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.crypto.SignatureMetadata extends java.lang.Object
+  public <init>(int, int)
+  public final int component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata copy(int, int)
+  public boolean equals(Object)
+  public final int getPlatformVersion()
+  public final int getSchemeNumberID()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.crypto.SignatureScheme extends java.lang.Object
+  public <init>(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, java.util.List<? extends org.bouncycastle.asn1.x509.AlgorithmIdentifier>, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
+  public final int component1()
+  @NotNull
+  public final String component10()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final org.bouncycastle.asn1.x509.AlgorithmIdentifier component3()
+  @NotNull
+  public final java.util.List<org.bouncycastle.asn1.x509.AlgorithmIdentifier> component4()
+  @NotNull
+  public final String component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final String component7()
+  @Nullable
+  public final java.security.spec.AlgorithmParameterSpec component8()
+  @Nullable
+  public final Integer component9()
+  @NotNull
+  public final net.corda.core.crypto.SignatureScheme copy(int, String, org.bouncycastle.asn1.x509.AlgorithmIdentifier, java.util.List<? extends org.bouncycastle.asn1.x509.AlgorithmIdentifier>, String, String, String, java.security.spec.AlgorithmParameterSpec, Integer, String)
+  public boolean equals(Object)
+  @Nullable
+  public final java.security.spec.AlgorithmParameterSpec getAlgSpec()
+  @NotNull
+  public final String getAlgorithmName()
+  @NotNull
+  public final java.util.List<org.bouncycastle.asn1.x509.AlgorithmIdentifier> getAlternativeOIDs()
+  @NotNull
+  public final String getDesc()
+  @Nullable
+  public final Integer getKeySize()
+  @NotNull
+  public final String getProviderName()
+  @NotNull
+  public final String getSchemeCodeName()
+  public final int getSchemeNumberID()
+  @NotNull
+  public final String getSignatureName()
+  @NotNull
+  public final org.bouncycastle.asn1.x509.AlgorithmIdentifier getSignatureOID()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public class net.corda.core.crypto.SignedData extends java.lang.Object
+  public <init>(net.corda.core.serialization.SerializedBytes<T>, net.corda.core.crypto.DigitalSignature$WithKey)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> getRaw()
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey getSig()
+  @NotNull
+  public final T verified()
+  protected void verifyData(T)
+##
+@CordaSerializable
+public final class net.corda.core.crypto.TransactionSignature extends net.corda.core.crypto.DigitalSignature
+  public <init>(byte[], java.security.PublicKey, net.corda.core.crypto.SignatureMetadata)
+  public <init>(byte[], java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.crypto.PartialMerkleTree)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getBy()
+  @Nullable
+  public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
+  @NotNull
+  public final net.corda.core.crypto.SignatureMetadata getSignatureMetadata()
+  public int hashCode()
+  public final boolean isValid(net.corda.core.crypto.SecureHash)
+  public final boolean verify(net.corda.core.crypto.SecureHash)
+##
+public abstract class net.corda.core.flows.AbstractStateReplacementFlow extends java.lang.Object
+  public <init>()
+##
+public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getInitiatingSession()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  protected abstract void verifyProposal(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.AbstractStateReplacementFlow$Proposal<? extends T>)
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion Companion
+##
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$APPROVING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$APPROVING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion$VERIFYING INSTANCE
+##
+public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Instigator extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.contracts.StateAndRef<? extends S>, M, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.contracts.StateAndRef, Object, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  protected abstract net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+  @Suspendable
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> call()
+  public final M getModification()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<S> getOriginalState()
+  @NotNull
+  public java.util.List<kotlin.Pair<net.corda.core.flows.FlowSession, java.util.List<net.corda.core.identity.AbstractParty>>> getParticipantSessions()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion Companion
+##
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$NOTARY extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$NOTARY INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion$SIGNING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$Proposal extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateRef, M)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  public final M component2()
+  @NotNull
+  public final net.corda.core.flows.AbstractStateReplacementFlow$Proposal<M> copy(net.corda.core.contracts.StateRef, M)
+  public boolean equals(Object)
+  public final M getModification()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static final class net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx extends java.lang.Object
+  public <init>(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction component1()
+  @NotNull
+  public final net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx copy(net.corda.core.transactions.SignedTransaction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getStx()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@Suspendable
+public final class net.corda.core.flows.CollectSignatureFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, java.util.List<? extends java.security.PublicKey>)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, java.security.PublicKey...)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> call()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getSession()
+  @NotNull
+  public final java.util.List<java.security.PublicKey> getSigningKeys()
+##
+public final class net.corda.core.flows.CollectSignaturesFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, Iterable, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @Nullable
+  public final Iterable<java.security.PublicKey> getMyOptionalKeys()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getPartiallySignedTx()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final java.util.Collection<net.corda.core.flows.FlowSession> getSessionsToCollectFrom()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.CollectSignaturesFlow$Companion Companion
+##
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$COLLECTING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.CollectSignaturesFlow$Companion$COLLECTING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.CollectSignaturesFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.CollectSignaturesFlow$Companion$VERIFYING INSTANCE
+##
+public final class net.corda.core.flows.ContractUpgradeFlow extends java.lang.Object
+  public static final net.corda.core.flows.ContractUpgradeFlow INSTANCE
+##
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Authorise extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.contracts.StateAndRef<?>, Class<? extends net.corda.core.contracts.UpgradedContract<?, ?>>)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<?> getStateAndRef()
+##
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Deauthorise extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.contracts.StateRef)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
+##
+@InitiatingFlow
+@StartableByRPC
+public static final class net.corda.core.flows.ContractUpgradeFlow$Initiate extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
+  public <init>(net.corda.core.contracts.StateAndRef<? extends OldState>, Class<? extends net.corda.core.contracts.UpgradedContract<? super OldState, ? extends NewState>>)
+  @Suspendable
+  @NotNull
+  protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+##
+public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession, Object)
+  @Suspendable
+  @Nullable
+  public Void call()
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public final Object getPayload()
+  @Suspendable
+  @NotNull
+  protected net.corda.core.utilities.UntrustworthyData<net.corda.core.internal.FetchDataFlow$Request> sendPayloadAndReceiveDataRequest(net.corda.core.flows.FlowSession, Object)
+  @Suspendable
+  protected void verifyDataRequest(net.corda.core.internal.FetchDataFlow$Request$Data)
+##
+@InitiatingFlow
+public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.transactions.SignedTransaction)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, net.corda.core.flows.FlowSession...)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getTransaction()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.FinalityFlow$Companion Companion
+##
+public static final class net.corda.core.flows.FinalityFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$BROADCASTING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.FinalityFlow$Companion$BROADCASTING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FinalityFlow$Companion$NOTARISING extends net.corda.core.utilities.ProgressTracker$Step
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker childProgressTracker()
+  public static final net.corda.core.flows.FinalityFlow$Companion$NOTARISING INSTANCE
+##
+@CordaSerializable
+public class net.corda.core.flows.FlowException extends net.corda.core.CordaException implements net.corda.core.flows.IdentifiableException
+  public <init>()
+  public <init>(String)
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, Long)
+  public <init>(String, Throwable, Long, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Throwable)
+  @Nullable
+  public Long getErrorId()
+  @Nullable
+  public final Long getOriginalErrorId()
+  public final void setOriginalErrorId(Long)
+##
+@CordaSerializable
+public final class net.corda.core.flows.FlowInfo extends java.lang.Object
+  public <init>(int, String)
+  public final int component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.FlowInfo copy(int, String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getAppName()
+  public final int getFlowVersion()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.flows.FlowInitiator extends java.lang.Object implements java.security.Principal
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.context.InvocationContext getInvocationContext()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Peer extends net.corda.core.flows.FlowInitiator
+  public <init>(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Peer copy(net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$RPC extends net.corda.core.flows.FlowInitiator
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$RPC copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final String getUsername()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Scheduled extends net.corda.core.flows.FlowInitiator
+  public <init>(net.corda.core.contracts.ScheduledStateRef)
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Scheduled copy(net.corda.core.contracts.ScheduledStateRef)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Service extends net.corda.core.flows.FlowInitiator
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator$Service copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public String getName()
+  @NotNull
+  public final String getServiceClassName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.FlowInitiator$Shell extends net.corda.core.flows.FlowInitiator
+  @NotNull
+  public String getName()
+  public static final net.corda.core.flows.FlowInitiator$Shell INSTANCE
+##
+public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
+  public <init>()
+  @Suspendable
+  public abstract T call()
+  public final void checkFlowPermission(String, java.util.Map<String, String>)
+  @Suspendable
+  @Nullable
+  public final net.corda.core.flows.FlowStackSnapshot flowStackSnapshot()
+  @Nullable
+  public static final net.corda.core.flows.FlowLogic<?> getCurrentTopLevel()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.flows.FlowInfo getFlowInfo(net.corda.core.identity.Party)
+  @NotNull
+  public final org.slf4j.Logger getLogger()
+  @NotNull
+  public final net.corda.core.identity.Party getOurIdentity()
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate getOurIdentityAndCert()
+  @Nullable
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getRunId()
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServiceHub()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.flows.FlowSession initiateFlow(net.corda.core.identity.Party)
+  @Suspendable
+  public final void persistFlowStackSnapshot()
+  @Suspendable
+  @NotNull
+  public net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>, net.corda.core.identity.Party)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(Class<R>, java.util.List<? extends net.corda.core.flows.FlowSession>)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(Class<R>, java.util.List<? extends net.corda.core.flows.FlowSession>, boolean)
+  @Suspendable
+  @NotNull
+  public java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAllMap(java.util.Map<net.corda.core.flows.FlowSession, ? extends Class<?>>)
+  @Suspendable
+  @NotNull
+  public java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAllMap(java.util.Map<net.corda.core.flows.FlowSession, ? extends Class<?>>, boolean)
+  public final void recordAuditEvent(String, String, java.util.Map<String, String>)
+  @Suspendable
+  public void send(net.corda.core.identity.Party, Object)
+  @Suspendable
+  @NotNull
+  public net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, net.corda.core.identity.Party, Object)
+  @Suspendable
+  public static final void sleep(java.time.Duration)
+  @Suspendable
+  public static final void sleep(java.time.Duration, boolean)
+  @Suspendable
+  public R subFlow(net.corda.core.flows.FlowLogic<? extends R>)
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> track()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> trackStepsTree()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<Integer, Integer> trackStepsTreeIndex()
+  @Suspendable
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash)
+  @Suspendable
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash, boolean)
+  @Suspendable
+  public final void waitForStateConsumption(java.util.Set<net.corda.core.contracts.StateRef>)
+  public static final net.corda.core.flows.FlowLogic$Companion Companion
+##
+public static final class net.corda.core.flows.FlowLogic$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.flows.FlowLogic<?> getCurrentTopLevel()
+  @Suspendable
+  public final void sleep(java.time.Duration)
+  @Suspendable
+  public final void sleep(java.time.Duration, boolean)
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.flows.FlowLogicRef
+##
+@DoNotImplement
+public interface net.corda.core.flows.FlowLogicRefFactory
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogicRef create(Class<? extends net.corda.core.flows.FlowLogic<?>>, Object...)
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogicRef create(String, Object...)
+  @NotNull
+  public abstract net.corda.core.flows.FlowLogic<?> toFlowLogic(net.corda.core.flows.FlowLogicRef)
+##
+@DoNotImplement
+public abstract class net.corda.core.flows.FlowSession extends java.lang.Object
+  public <init>()
+  @NotNull
+  public abstract net.corda.core.identity.Party getCounterparty()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.flows.FlowInfo getCounterpartyFlowInfo(boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> receive(Class<R>, boolean)
+  @Suspendable
+  public abstract void send(Object)
+  @Suspendable
+  public abstract void send(Object, boolean)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, Object)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, Object, boolean)
+##
+public final class net.corda.core.flows.FlowStackSnapshot extends java.lang.Object
+  public <init>(java.time.Instant, String, java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame>)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame> component3()
+  @NotNull
+  public final net.corda.core.flows.FlowStackSnapshot copy(java.time.Instant, String, java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame>)
+  public boolean equals(Object)
+  @NotNull
+  public final String getFlowClass()
+  @NotNull
+  public final java.util.List<net.corda.core.flows.FlowStackSnapshot$Frame> getStackFrames()
+  @NotNull
+  public final java.time.Instant getTime()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends java.lang.Object
+  public <init>(StackTraceElement, java.util.List<?>)
+  @NotNull
+  public final StackTraceElement component1()
+  @NotNull
+  public final java.util.List<Object> component2()
+  @NotNull
+  public final net.corda.core.flows.FlowStackSnapshot$Frame copy(StackTraceElement, java.util.List<?>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<Object> getStackObjects()
+  @NotNull
+  public final StackTraceElement getStackTraceElement()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public interface net.corda.core.flows.IdentifiableException
+  @Nullable
+  public Long getErrorId()
+##
+@CordaSerializable
+public final class net.corda.core.flows.IllegalFlowLogicException extends java.lang.IllegalArgumentException
+  public <init>(Class<?>, String)
+  public <init>(String, String)
+  @NotNull
+  public final String getType()
+##
+public @interface net.corda.core.flows.InitiatedBy
+  public abstract Class<? extends net.corda.core.flows.FlowLogic<?>> value()
+##
+public @interface net.corda.core.flows.InitiatingFlow
+  public abstract int version()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationPayload extends java.lang.Object
+  public <init>(Object, net.corda.core.flows.NotarisationRequestSignature)
+  @NotNull
+  public final Object component1()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature component2()
+  @NotNull
+  public final net.corda.core.flows.NotarisationPayload copy(Object, net.corda.core.flows.NotarisationRequestSignature)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature getRequestSignature()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction getSignedTransaction()
+  @NotNull
+  public final Object getTransaction()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationRequest extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getStatesToConsume()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTransactionId()
+  public static final net.corda.core.flows.NotarisationRequest$Companion Companion
+##
+public static final class net.corda.core.flows.NotarisationRequest$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationRequestSignature extends java.lang.Object
+  public <init>(net.corda.core.crypto.DigitalSignature$WithKey, int)
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.flows.NotarisationRequestSignature copy(net.corda.core.crypto.DigitalSignature$WithKey, int)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.DigitalSignature$WithKey getDigitalSignature()
+  public final int getPlatformVersion()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotarisationResponse extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component1()
+  @NotNull
+  public final net.corda.core.flows.NotarisationResponse copy(java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> getSignatures()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@InitiatingFlow
+public final class net.corda.core.flows.NotaryChangeFlow extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
+  public <init>(net.corda.core.contracts.StateAndRef<? extends T>, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.contracts.StateAndRef, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
+##
+@CordaSerializable
+public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$Conflict extends net.corda.core.flows.NotaryError
+  public <init>(net.corda.core.crypto.SecureHash, java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails>)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails> component2()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$Conflict copy(net.corda.core.crypto.SecureHash, java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<net.corda.core.contracts.StateRef, net.corda.core.flows.StateConsumptionDetails> getConsumedStates()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTxId()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$General extends net.corda.core.flows.NotaryError
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$General copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getCause()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$RequestSignatureInvalid extends net.corda.core.flows.NotaryError
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$RequestSignatureInvalid copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getCause()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid extends net.corda.core.flows.NotaryError
+  public <init>(java.time.Instant, net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final java.time.Instant component1()
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow component2()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$TimeWindowInvalid copy(java.time.Instant, net.corda.core.contracts.TimeWindow)
+  public boolean equals(Object)
+  @NotNull
+  public final java.time.Instant getCurrentTime()
+  @NotNull
+  public final net.corda.core.contracts.TimeWindow getTxTimeWindow()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion Companion
+  @NotNull
+  public static final net.corda.core.flows.NotaryError$TimeWindowInvalid INSTANCE
+##
+public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$TransactionInvalid extends net.corda.core.flows.NotaryError
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.flows.NotaryError$TransactionInvalid copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getCause()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryError$WrongNotary extends net.corda.core.flows.NotaryError
+  public static final net.corda.core.flows.NotaryError$WrongNotary INSTANCE
+##
+@CordaSerializable
+public final class net.corda.core.flows.NotaryException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash)
+  public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.NotaryError getError()
+  @Nullable
+  public final net.corda.core.crypto.SecureHash getTxId()
+##
+public final class net.corda.core.flows.NotaryFlow extends java.lang.Object
+  public <init>()
+##
+@DoNotImplement
+@InitiatingFlow
+public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.core.internal.BackpressureAwareTimedFlow
+  public <init>(net.corda.core.transactions.SignedTransaction)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> call()
+  @NotNull
+  protected final net.corda.core.identity.Party checkTransaction()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @Suspendable
+  @NotNull
+  protected final net.corda.core.utilities.UntrustworthyData<net.corda.core.flows.NotarisationResponse> notarise(net.corda.core.identity.Party)
+  @NotNull
+  protected final java.util.List<net.corda.core.crypto.TransactionSignature> validateResponse(net.corda.core.utilities.UntrustworthyData<net.corda.core.flows.NotarisationResponse>, net.corda.core.identity.Party)
+  public static final net.corda.core.flows.NotaryFlow$Client$Companion Companion
+##
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUESTING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.NotaryFlow$Client$Companion$REQUESTING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
+##
+public final class net.corda.core.flows.ReceiveFinalityFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+##
+public final class net.corda.core.flows.ReceiveStateAndRefFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  @Suspendable
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<T>> call()
+##
+public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  public <init>(net.corda.core.flows.FlowSession, boolean)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @Suspendable
+  protected void checkBeforeRecording(net.corda.core.transactions.SignedTransaction)
+##
+public @interface net.corda.core.flows.SchedulableFlow
+##
+public class net.corda.core.flows.SendStateAndRefFlow extends net.corda.core.flows.DataVendingFlow
+  public <init>(net.corda.core.flows.FlowSession, java.util.List<? extends net.corda.core.contracts.StateAndRef<?>>)
+##
+public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flows.DataVendingFlow
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
+##
+public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+  @Suspendable
+  protected abstract void checkTransaction(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public final net.corda.core.flows.FlowSession getOtherSideSession()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.SignTransactionFlow$Companion Companion
+##
+public static final class net.corda.core.flows.SignTransactionFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$RECEIVING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.SignTransactionFlow$Companion$RECEIVING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$SIGNING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.SignTransactionFlow$Companion$SIGNING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.SignTransactionFlow$Companion$VERIFYING INSTANCE
+##
+public final class net.corda.core.flows.StackFrameDataToken extends java.lang.Object
+  public <init>(String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final net.corda.core.flows.StackFrameDataToken copy(String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getClassName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public @interface net.corda.core.flows.StartableByRPC
+##
+public @interface net.corda.core.flows.StartableByService
+##
+@CordaSerializable
+public final class net.corda.core.flows.StateConsumptionDetails extends java.lang.Object
+  @DeprecatedConstructorForDeserialization
+  public <init>(net.corda.core.crypto.SecureHash)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.flows.StateConsumptionDetails$ConsumedStateType)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails$ConsumedStateType component2()
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails copy(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails copy(net.corda.core.crypto.SecureHash, net.corda.core.flows.StateConsumptionDetails$ConsumedStateType)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHashOfTransactionId()
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails$ConsumedStateType getType()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.StateConsumptionDetails$ConsumedStateType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.flows.StateConsumptionDetails$ConsumedStateType valueOf(String)
+  public static net.corda.core.flows.StateConsumptionDetails$ConsumedStateType[] values()
+##
+@CordaSerializable
+public final class net.corda.core.flows.StateMachineRunId extends java.lang.Object
+  public <init>(java.util.UUID)
+  @NotNull
+  public final java.util.UUID component1()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId copy(java.util.UUID)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.UUID getUuid()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.flows.StateMachineRunId$Companion Companion
+##
+public static final class net.corda.core.flows.StateMachineRunId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId createRandom()
+##
+@CordaSerializable
+public class net.corda.core.flows.StateReplacementException extends net.corda.core.flows.FlowException
+  public <init>()
+  public <init>(String)
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
+  public <init>(String)
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, Long)
+  @Nullable
+  public Long getErrorId()
+  @Nullable
+  public final Long getOriginalErrorId()
+##
+@CordaSerializable
+public final class net.corda.core.flows.WaitTimeUpdate extends java.lang.Object
+  public <init>(java.time.Duration)
+  @NotNull
+  public final java.time.Duration component1()
+  @NotNull
+  public final net.corda.core.flows.WaitTimeUpdate copy(java.time.Duration)
+  public boolean equals(Object)
+  @NotNull
+  public final java.time.Duration getWaitTime()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.flows.WithReferencedStatesFlow extends net.corda.core.flows.FlowLogic
+  public <init>(kotlin.jvm.functions.Function0<? extends net.corda.core.flows.FlowLogic<? extends T>>)
+  public <init>(net.corda.core.utilities.ProgressTracker, kotlin.jvm.functions.Function0<? extends net.corda.core.flows.FlowLogic<? extends T>>)
+  public <init>(net.corda.core.utilities.ProgressTracker, kotlin.jvm.functions.Function0, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public T call()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion Companion
+##
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion$ATTEMPT extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion$ATTEMPT INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion$RETRYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion$RETRYING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion$SUCCESS extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion$SUCCESS INSTANCE
+##
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.identity.AbstractParty extends java.lang.Object
+  public <init>(java.security.PublicKey)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getOwningKey()
+  public int hashCode()
+  @Nullable
+  public abstract net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public abstract net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference ref(byte...)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.identity.AnonymousParty extends net.corda.core.identity.AbstractParty
+  public <init>(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.identity.CordaX500Name extends java.lang.Object
+  public <init>(String, String, String)
+  public <init>(String, String, String, String)
+  public <init>(String, String, String, String, String, String)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
+  @Nullable
+  public final String component1()
+  @Nullable
+  public final String component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final String component4()
+  @Nullable
+  public final String component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name copy(String, String, String, String, String, String)
+  public boolean equals(Object)
+  @Nullable
+  public final String getCommonName()
+  @NotNull
+  public final String getCountry()
+  @NotNull
+  public final String getLocality()
+  @NotNull
+  public final String getOrganisation()
+  @Nullable
+  public final String getOrganisationUnit()
+  @Nullable
+  public final String getState()
+  @NotNull
+  public final javax.security.auth.x500.X500Principal getX500Principal()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name parse(String)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.identity.CordaX500Name$Companion Companion
+  public static final int LENGTH_COUNTRY = 2
+  public static final int MAX_LENGTH_COMMON_NAME = 64
+  public static final int MAX_LENGTH_LOCALITY = 64
+  public static final int MAX_LENGTH_ORGANISATION = 128
+  public static final int MAX_LENGTH_ORGANISATION_UNIT = 64
+  public static final int MAX_LENGTH_STATE = 64
+##
+public static final class net.corda.core.identity.CordaX500Name$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name parse(String)
+##
+public final class net.corda.core.identity.IdentityUtils extends java.lang.Object
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, T> excludeHostNode(net.corda.core.node.ServiceHub, java.util.Map<net.corda.core.identity.Party, ? extends T>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, T> excludeNotary(java.util.Map<net.corda.core.identity.Party, ? extends T>, net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<net.corda.core.identity.AbstractParty>> groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<net.corda.core.identity.AbstractParty>> groupAbstractPartyByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends net.corda.core.identity.AbstractParty>, boolean)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>)
+  @NotNull
+  public static final java.util.Map<net.corda.core.identity.Party, java.util.List<java.security.PublicKey>> groupPublicKeysByWellKnownParty(net.corda.core.node.ServiceHub, java.util.Collection<? extends java.security.PublicKey>, boolean)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.identity.Party extends net.corda.core.identity.AbstractParty
+  public <init>(java.security.cert.X509Certificate)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
+  @NotNull
+  public final net.corda.core.identity.AnonymousParty anonymise()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public net.corda.core.identity.CordaX500Name nameOrNull()
+  @NotNull
+  public net.corda.core.contracts.PartyAndReference ref(net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.identity.PartyAndCertificate extends java.lang.Object
+  public <init>(java.security.cert.CertPath)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final java.security.cert.X509Certificate component2()
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.cert.CertPath getCertPath()
+  @NotNull
+  public final java.security.cert.X509Certificate getCertificate()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final java.security.PublicKey getOwningKey()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final java.security.cert.PKIXCertPathValidatorResult verify(java.security.cert.TrustAnchor)
+##
+@CordaSerializable
+public interface net.corda.core.messaging.AllPossibleRecipients extends net.corda.core.messaging.MessageRecipients
+##
+public final class net.corda.core.messaging.ClientRpcSslOptions extends java.lang.Object
+  public <init>(java.nio.file.Path, String, String)
+  public <init>(java.nio.file.Path, String, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.nio.file.Path component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final net.corda.core.messaging.ClientRpcSslOptions copy(java.nio.file.Path, String, String)
+  public boolean equals(Object)
+  @NotNull
+  public final String getTrustStorePassword()
+  @NotNull
+  public final java.nio.file.Path getTrustStorePath()
+  @NotNull
+  public final String getTrustStoreProvider()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.messaging.RPCOps
+  public abstract void acceptNewNetworkParameters(net.corda.core.crypto.SecureHash)
+  public abstract void addVaultTransactionNote(net.corda.core.crypto.SecureHash, String)
+  public abstract boolean attachmentExists(net.corda.core.crypto.SecureHash)
+  public abstract void clearNetworkMapCache()
+  @NotNull
+  public abstract java.time.Instant currentNodeTime()
+  @NotNull
+  public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public abstract Iterable<String> getVaultTransactionNotes(net.corda.core.crypto.SecureHash)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction> internalVerifiedTransactionsFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.transactions.SignedTransaction> internalVerifiedTransactionsSnapshot()
+  public abstract boolean isFlowsDrainingModeEnabled()
+  public abstract boolean isWaitingForShutdown()
+  public abstract boolean killFlow(net.corda.core.flows.StateMachineRunId)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> networkMapFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> networkMapSnapshot()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.messaging.ParametersUpdateInfo, net.corda.core.messaging.ParametersUpdateInfo> networkParametersFeed()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo nodeInfo()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> notaryIdentities()
+  @Nullable
+  public abstract net.corda.core.identity.Party notaryPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract java.io.InputStream openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String, boolean)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+  public abstract void refreshNetworkMapCache()
+  @NotNull
+  public abstract java.util.List<String> registeredFlows()
+  public abstract void setFlowsDrainingModeEnabled(boolean)
+  public abstract void shutdown()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.FlowHandle<T> startFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.messaging.StateMachineTransactionMapping>, net.corda.core.messaging.StateMachineTransactionMapping> stateMachineRecordedTransactionMappingFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.messaging.StateMachineTransactionMapping> stateMachineRecordedTransactionMappingSnapshot()
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.messaging.StateMachineInfo>, net.corda.core.messaging.StateMachineUpdate> stateMachinesFeed()
+  @NotNull
+  public abstract java.util.List<net.corda.core.messaging.StateMachineInfo> stateMachinesSnapshot()
+  public abstract void terminate(boolean)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash uploadAttachment(java.io.InputStream)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash uploadAttachmentWithMetadata(java.io.InputStream, String, String)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQuery(Class<? extends T>)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByCriteria(net.corda.core.node.services.vault.QueryCriteria, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByWithPagingSpec(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> vaultQueryByWithSorting(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrack(Class<? extends T>)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByCriteria(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByWithPagingSpec(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> vaultTrackByWithSorting(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @RPCReturnsObservables
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<Void> waitUntilNetworkReady()
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public final class net.corda.core.messaging.CordaRPCOpsKt extends java.lang.Object
+##
+@CordaSerializable
+public final class net.corda.core.messaging.DataFeed extends java.lang.Object
+  public <init>(A, rx.Observable<B>)
+  public final A component1()
+  @NotNull
+  public final rx.Observable<B> component2()
+  @NotNull
+  public final net.corda.core.messaging.DataFeed<A, B> copy(A, rx.Observable<B>)
+  public boolean equals(Object)
+  public final A getSnapshot()
+  @NotNull
+  public final rx.Observable<B> getUpdates()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.messaging.FlowHandle extends java.lang.AutoCloseable
+  public abstract void close()
+  @NotNull
+  public abstract net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowHandle
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>)
+  public void close()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<A> component2()
+  @NotNull
+  public final net.corda.core.messaging.FlowHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.messaging.FlowProgressHandle extends net.corda.core.messaging.FlowHandle
+  public abstract void close()
+  @NotNull
+  public abstract rx.Observable<String> getProgress()
+  @Nullable
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeFeed()
+  @Nullable
+  public abstract net.corda.core.messaging.DataFeed<Integer, Integer> getStepsTreeIndexFeed()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.lang.Object implements net.corda.core.messaging.FlowProgressHandle
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>, net.corda.core.messaging.DataFeed<? extends java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed, net.corda.core.messaging.DataFeed, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public void close()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<A> component2()
+  @NotNull
+  public final rx.Observable<String> component3()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<Integer, Integer> component4()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> component5()
+  @NotNull
+  public final net.corda.core.messaging.FlowProgressHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>)
+  @NotNull
+  public final net.corda.core.messaging.FlowProgressHandleImpl<A> copy(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>, net.corda.core.messaging.DataFeed<? extends java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public rx.Observable<String> getProgress()
+  @NotNull
+  public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
+  @Nullable
+  public net.corda.core.messaging.DataFeed<java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeFeed()
+  @Nullable
+  public net.corda.core.messaging.DataFeed<Integer, Integer> getStepsTreeIndexFeed()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.messaging.MessageRecipientGroup extends net.corda.core.messaging.MessageRecipients
+##
+@CordaSerializable
+public interface net.corda.core.messaging.MessageRecipients
+##
+@CordaSerializable
+public final class net.corda.core.messaging.ParametersUpdateInfo extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.node.NetworkParameters, String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final java.time.Instant component4()
+  @NotNull
+  public final net.corda.core.messaging.ParametersUpdateInfo copy(net.corda.core.crypto.SecureHash, net.corda.core.node.NetworkParameters, String, java.time.Instant)
+  public boolean equals(Object)
+  @NotNull
+  public final String getDescription()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getParameters()
+  @NotNull
+  public final java.time.Instant getUpdateDeadline()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.messaging.RPCOps
+  public abstract int getProtocolVersion()
+##
+public @interface net.corda.core.messaging.RPCReturnsObservables
+##
+@CordaSerializable
+public interface net.corda.core.messaging.SingleMessageRecipient extends net.corda.core.messaging.MessageRecipients
+##
+@CordaSerializable
+public final class net.corda.core.messaging.StateMachineInfo extends java.lang.Object
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>)
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>, net.corda.core.context.InvocationContext)
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed, net.corda.core.context.InvocationContext, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator component3()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> component4()
+  @NotNull
+  public final net.corda.core.context.InvocationContext component5()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>)
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo copy(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>, net.corda.core.context.InvocationContext)
+  public boolean equals(Object)
+  @NotNull
+  public final String getFlowLogicClassName()
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.flows.FlowInitiator getInitiator()
+  @NotNull
+  public final net.corda.core.context.InvocationContext getInvocationContext()
+  @Nullable
+  public final net.corda.core.messaging.DataFeed<String, String> getProgressTrackerStepAndUpdates()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.messaging.StateMachineTransactionMapping extends java.lang.Object
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component2()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineTransactionMapping copy(net.corda.core.flows.StateMachineRunId, net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId getStateMachineRunId()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getTransactionId()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.messaging.StateMachineUpdate extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.flows.StateMachineRunId getId()
+##
+@CordaSerializable
+public static final class net.corda.core.messaging.StateMachineUpdate$Added extends net.corda.core.messaging.StateMachineUpdate
+  public <init>(net.corda.core.messaging.StateMachineInfo)
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo component1()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineUpdate$Added copy(net.corda.core.messaging.StateMachineInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineInfo getStateMachineInfo()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.messaging.StateMachineUpdate$Removed extends net.corda.core.messaging.StateMachineUpdate
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try<?>)
+  @NotNull
+  public final net.corda.core.flows.StateMachineRunId component1()
+  @NotNull
+  public final net.corda.core.utilities.Try<?> component2()
+  @NotNull
+  public final net.corda.core.messaging.StateMachineUpdate$Removed copy(net.corda.core.flows.StateMachineRunId, net.corda.core.utilities.Try<?>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.flows.StateMachineRunId getId()
+  @NotNull
+  public final net.corda.core.utilities.Try<?> getResult()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.ServiceHub
+  @NotNull
+  public abstract net.corda.core.messaging.FlowHandle<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlow(net.corda.core.flows.FlowLogic<? extends T>)
+##
+public @interface net.corda.core.node.AutoAcceptable
+##
+@CordaSerializable
+public final class net.corda.core.node.NetworkParameters extends java.lang.Object
+  @DeprecatedConstructorForDeserialization
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
+  @DeprecatedConstructorForDeserialization
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration)
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration, java.util.Map<String, ? extends java.security.PublicKey>)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.node.NotaryInfo> component2()
+  public final int component3()
+  public final int component4()
+  @NotNull
+  public final java.time.Instant component5()
+  public final int component6()
+  @NotNull
+  public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> component7()
+  @NotNull
+  public final java.time.Duration component8()
+  @NotNull
+  public final java.util.Map<String, java.security.PublicKey> component9()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration)
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration, java.util.Map<String, ? extends java.security.PublicKey>)
+  public boolean equals(Object)
+  public final int getEpoch()
+  @NotNull
+  public final java.time.Duration getEventHorizon()
+  public final int getMaxMessageSize()
+  public final int getMaxTransactionSize()
+  public final int getMinimumPlatformVersion()
+  @NotNull
+  public final java.time.Instant getModifiedTime()
+  @NotNull
+  public final java.util.List<net.corda.core.node.NotaryInfo> getNotaries()
+  @NotNull
+  public final java.util.Map<String, java.security.PublicKey> getPackageOwnership()
+  @NotNull
+  public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> getWhitelistedContractImplementations()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.NodeInfo extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.PartyAndCertificate> component2()
+  public final int component3()
+  public final long component4()
+  @NotNull
+  public final net.corda.core.node.NodeInfo copy(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, java.util.List<net.corda.core.identity.PartyAndCertificate>, int, long)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getAddresses()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.Party> getLegalIdentities()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.PartyAndCertificate> getLegalIdentitiesAndCerts()
+  public final int getPlatformVersion()
+  public final long getSerial()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate identityAndCertFromX500Name(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.core.identity.Party identityFromX500Name(net.corda.core.identity.CordaX500Name)
+  public final boolean isLegalIdentity(net.corda.core.identity.Party)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.NotaryInfo extends java.lang.Object
+  public <init>(net.corda.core.identity.Party, boolean)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.core.node.NotaryInfo copy(net.corda.core.identity.Party, boolean)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getIdentity()
+  public final boolean getValidating()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.node.ServiceHub extends net.corda.core.node.ServicesForResolution
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract T cordaService(Class<T>)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappContext getAppContext()
+  @NotNull
+  public abstract java.time.Clock getClock()
+  @NotNull
+  public abstract net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public abstract net.corda.core.node.services.KeyManagementService getKeyManagementService()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getMyInfo()
+  @NotNull
+  public abstract net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
+  @NotNull
+  public abstract net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
+  @NotNull
+  public abstract net.corda.core.node.services.TransactionStorage getValidatedTransactions()
+  @NotNull
+  public abstract net.corda.core.node.services.VaultService getVaultService()
+  @NotNull
+  public abstract java.sql.Connection jdbcSession()
+  public abstract void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public abstract void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public abstract void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  public abstract void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public abstract void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  public abstract void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
+  public abstract void withEntityManager(java.util.function.Consumer<javax.persistence.EntityManager>)
+  @NotNull
+  public abstract T withEntityManager(kotlin.jvm.functions.Function1<? super javax.persistence.EntityManager, ? extends T>)
+##
+@DoNotImplement
+public interface net.corda.core.node.ServicesForResolution
+  @NotNull
+  public abstract net.corda.core.node.services.AttachmentStorage getAttachments()
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public abstract net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public abstract net.corda.core.node.services.NetworkParametersService getNetworkParametersService()
+  @NotNull
+  public abstract net.corda.core.contracts.Attachment loadContractAttachment(net.corda.core.contracts.StateRef, String)
+  @NotNull
+  public abstract net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+##
+public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.StatesToRecord valueOf(String)
+  public static net.corda.core.node.StatesToRecord[] values()
+##
+@CordaSerializable
+public final class net.corda.core.node.ZoneVersionTooLowException extends net.corda.core.CordaRuntimeException
+  public <init>(String)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.AttachmentStorage
+  @Nullable
+  public abstract net.corda.core.crypto.SecureHash getContractAttachmentWithHighestContractVersion(String, int)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.crypto.SecureHash> getContractAttachments(String)
+  public abstract boolean hasAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
+  @Nullable
+  public abstract net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+##
+public final class net.corda.core.node.services.AttachmentStorageKt extends java.lang.Object
+##
+@DoNotImplement
+public interface net.corda.core.node.services.ContractUpgradeService
+  @Nullable
+  public abstract String getAuthorisedContractUpgrade(net.corda.core.contracts.StateRef)
+  public abstract void removeAuthorisedContractUpgrade(net.corda.core.contracts.StateRef)
+  public abstract void storeAuthorisedContractUpgrade(net.corda.core.contracts.StateRef, Class<? extends net.corda.core.contracts.UpgradedContract<?, ?>>)
+##
+public @interface net.corda.core.node.services.CordaService
+##
+@DoNotImplement
+public interface net.corda.core.node.services.IdentityService
+  public abstract void assertOwnership(net.corda.core.identity.Party, net.corda.core.identity.AnonymousParty)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate certificateFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract Iterable<net.corda.core.identity.PartyAndCertificate> getAllIdentities()
+  @NotNull
+  public abstract java.security.cert.CertStore getCaCertStore()
+  @NotNull
+  public abstract java.security.cert.TrustAnchor getTrustAnchor()
+  @NotNull
+  public abstract java.security.cert.X509Certificate getTrustRoot()
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String, boolean)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.identity.Party requireWellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate verifyAndRegisterIdentity(net.corda.core.identity.PartyAndCertificate)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.contracts.PartyAndReference)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromAnonymous(net.corda.core.identity.AbstractParty)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.KeyManagementService
+  @NotNull
+  public abstract Iterable<java.security.PublicKey> filterMyKeys(Iterable<? extends java.security.PublicKey>)
+  @Suspendable
+  @NotNull
+  public abstract java.security.PublicKey freshKey()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.identity.PartyAndCertificate freshKeyAndCert(net.corda.core.identity.PartyAndCertificate, boolean)
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getKeys()
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.crypto.TransactionSignature sign(net.corda.core.crypto.SignableData, java.security.PublicKey)
+  @Suspendable
+  @NotNull
+  public abstract net.corda.core.crypto.DigitalSignature$WithKey sign(byte[], java.security.PublicKey)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkMapCache extends net.corda.core.node.services.NetworkMapCacheBase
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByLegalIdentity(net.corda.core.identity.AbstractParty)
+##
+@CordaSerializable
+public abstract static class net.corda.core.node.services.NetworkMapCache$MapChange extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getNode()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Added extends net.corda.core.node.services.NetworkMapCache$MapChange
+  public <init>(net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Added copy(net.corda.core.node.NodeInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Modified extends net.corda.core.node.services.NetworkMapCache$MapChange
+  public <init>(net.corda.core.node.NodeInfo, net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.NodeInfo component2()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Modified copy(net.corda.core.node.NodeInfo, net.corda.core.node.NodeInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
+  @NotNull
+  public final net.corda.core.node.NodeInfo getPreviousNode()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.NetworkMapCache$MapChange$Removed extends net.corda.core.node.services.NetworkMapCache$MapChange
+  public <init>(net.corda.core.node.NodeInfo)
+  @NotNull
+  public final net.corda.core.node.NodeInfo component1()
+  @NotNull
+  public final net.corda.core.node.services.NetworkMapCache$MapChange$Removed copy(net.corda.core.node.NodeInfo)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.node.NodeInfo getNode()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkMapCacheBase
+  public abstract void clearNetworkMapCache()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getAllNodes()
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.NetworkMapCache$MapChange> getChanged()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByAddress(net.corda.core.utilities.NetworkHostAndPort)
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo getNodeByLegalName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<Void> getNodeReady()
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getNodesByLegalIdentityKey(java.security.PublicKey)
+  @NotNull
+  public abstract java.util.List<net.corda.core.node.NodeInfo> getNodesByLegalName(net.corda.core.identity.CordaX500Name)
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract java.util.List<net.corda.core.identity.Party> getNotaryIdentities()
+  @Nullable
+  public abstract net.corda.core.node.services.PartyInfo getPartyInfo(net.corda.core.identity.Party)
+  @Nullable
+  public abstract net.corda.core.identity.Party getPeerByLegalName(net.corda.core.identity.CordaX500Name)
+  @Nullable
+  public abstract net.corda.core.identity.PartyAndCertificate getPeerCertificateByLegalName(net.corda.core.identity.CordaX500Name)
+  public abstract boolean isNotary(net.corda.core.identity.Party)
+  public abstract boolean isValidatingNotary(net.corda.core.identity.Party)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> track()
+##
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkParametersService
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getCurrentHash()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getDefaultHash()
+  @Nullable
+  public abstract net.corda.core.node.NetworkParameters lookup(net.corda.core.crypto.SecureHash)
+##
+public abstract class net.corda.core.node.services.PartyInfo extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public abstract net.corda.core.identity.Party getParty()
+##
+public static final class net.corda.core.node.services.PartyInfo$DistributedNode extends net.corda.core.node.services.PartyInfo
+  public <init>(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.core.node.services.PartyInfo$DistributedNode copy(net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static final class net.corda.core.node.services.PartyInfo$SingleNode extends net.corda.core.node.services.PartyInfo
+  public <init>(net.corda.core.identity.Party, java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> component2()
+  @NotNull
+  public final net.corda.core.node.services.PartyInfo$SingleNode copy(net.corda.core.identity.Party, java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getAddresses()
+  @NotNull
+  public net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.StatesNotAvailableException extends net.corda.core.flows.FlowException
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public Throwable getCause()
+  @Nullable
+  public String getMessage()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.node.services.TimeWindowChecker extends java.lang.Object
+  public <init>()
+  public <init>(java.time.Clock)
+  public <init>(java.time.Clock, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.time.Clock getClock()
+  public final boolean isValid(net.corda.core.contracts.TimeWindow)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.TransactionStorage
+  @Nullable
+  public abstract net.corda.core.transactions.SignedTransaction getTransaction(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.transactions.SignedTransaction> getUpdates()
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction> track()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.transactions.SignedTransaction> trackTransaction(net.corda.core.crypto.SecureHash)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.TransactionVerifierService
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<?> verify(net.corda.core.transactions.LedgerTransaction)
+##
+@CordaSerializable
+public final class net.corda.core.node.services.UnknownAnonymousPartyException extends net.corda.core.CordaException
+  public <init>(String)
+##
+@CordaSerializable
+public final class net.corda.core.node.services.Vault extends java.lang.Object
+  public <init>(Iterable<? extends net.corda.core.contracts.StateAndRef<? extends T>>)
+  @NotNull
+  public final Iterable<net.corda.core.contracts.StateAndRef<T>> getStates()
+  public static final net.corda.core.node.services.Vault$Companion Companion
+##
+public static final class net.corda.core.node.services.Vault$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoNotaryUpdate()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoUpdate()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$ConstraintInfo extends java.lang.Object
+  public <init>(net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint component1()
+  @NotNull
+  public final net.corda.core.node.services.Vault$ConstraintInfo copy(net.corda.core.contracts.AttachmentConstraint)
+  @Nullable
+  public final byte[] data()
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint getConstraint()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.core.node.services.Vault$ConstraintInfo$Type type()
+  public static final net.corda.core.node.services.Vault$ConstraintInfo$Companion Companion
+##
+public static final class net.corda.core.node.services.Vault$ConstraintInfo$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.Vault$ConstraintInfo constraintInfo(net.corda.core.node.services.Vault$ConstraintInfo$Type, byte[])
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$ConstraintInfo$Type extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$ConstraintInfo$Type valueOf(String)
+  public static net.corda.core.node.services.Vault$ConstraintInfo$Type[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.node.services.Vault$StateMetadata> component2()
+  public final long component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component4()
+  @NotNull
+  public final java.util.List<Object> component5()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Page<T> copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends T>>, java.util.List<net.corda.core.node.services.Vault$StateMetadata>, long, net.corda.core.node.services.Vault$StateStatus, java.util.List<?>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<Object> getOtherResults()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus getStateTypes()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> getStates()
+  @NotNull
+  public final java.util.List<net.corda.core.node.services.Vault$StateMetadata> getStatesMetadata()
+  public final long getTotalStatesAvailable()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$RelevancyStatus extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$RelevancyStatus valueOf(String)
+  public static net.corda.core.node.services.Vault$RelevancyStatus[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$StateMetadata extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
+  public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus, net.corda.core.node.services.Vault$ConstraintInfo)
+  public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus, net.corda.core.node.services.Vault$ConstraintInfo, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @Nullable
+  public final net.corda.core.node.services.Vault$ConstraintInfo component10()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.time.Instant component3()
+  @Nullable
+  public final java.time.Instant component4()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component5()
+  @Nullable
+  public final net.corda.core.identity.AbstractParty component6()
+  @Nullable
+  public final String component7()
+  @Nullable
+  public final java.time.Instant component8()
+  @Nullable
+  public final net.corda.core.node.services.Vault$RelevancyStatus component9()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateMetadata copy(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateMetadata copy(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateMetadata copy(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus, net.corda.core.node.services.Vault$ConstraintInfo)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.core.node.services.Vault$ConstraintInfo getConstraintInfo()
+  @Nullable
+  public final java.time.Instant getConsumedTime()
+  @NotNull
+  public final String getContractStateClassName()
+  @Nullable
+  public final String getLockId()
+  @Nullable
+  public final java.time.Instant getLockUpdateTime()
+  @Nullable
+  public final net.corda.core.identity.AbstractParty getNotary()
+  @NotNull
+  public final java.time.Instant getRecordedTime()
+  @NotNull
+  public final net.corda.core.contracts.StateRef getRef()
+  @Nullable
+  public final net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$StateStatus extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$StateStatus valueOf(String)
+  public static net.corda.core.node.services.Vault$StateStatus[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$Update extends java.lang.Object
+  public <init>(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
+  public <init>(java.util.Set, java.util.Set, java.util.UUID, net.corda.core.node.services.Vault$UpdateType, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component1()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component2()
+  @Nullable
+  public final java.util.UUID component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$UpdateType component4()
+  public final boolean containsType(Class<T>, net.corda.core.node.services.Vault$StateStatus)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<U> copy(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getConsumed()
+  @Nullable
+  public final java.util.UUID getFlowId()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getProduced()
+  @NotNull
+  public final net.corda.core.node.services.Vault$UpdateType getType()
+  public int hashCode()
+  public final boolean isEmpty()
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<U> plus(net.corda.core.node.services.Vault$Update<U>)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$UpdateType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$UpdateType valueOf(String)
+  public static net.corda.core.node.services.Vault$UpdateType[] values()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.VaultQueryException extends net.corda.core.flows.FlowException
+  public <init>(String)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.VaultService
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> _queryBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> _trackBy(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort, Class<? extends T>)
+  public abstract void addNoteToTransaction(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> getRawUpdates()
+  @NotNull
+  public abstract Iterable<String> getTransactionNotes(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract rx.Observable<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> getUpdates()
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  public abstract void softLockRelease(java.util.UUID, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  public abstract void softLockReserve(java.util.UUID, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification, net.corda.core.node.services.vault.Sort)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.Sort)
+  @Suspendable
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<T>> tryLockFungibleStatesForSpending(java.util.UUID, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.contracts.Amount<?>, Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> whenConsumed(net.corda.core.contracts.StateRef)
+##
+public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
+  public static final int MAX_CONSTRAINT_DATA_SIZE = 563
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.AggregateFunctionType valueOf(String)
+  public static net.corda.core.node.services.vault.AggregateFunctionType[] values()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.AttachmentQueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria and(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria or(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AndComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
+  public <init>(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria extends net.corda.core.node.services.vault.AttachmentQueryCriteria
+  public <init>()
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>, net.corda.core.node.services.vault.ColumnPredicate<Integer>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> component1()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> component2()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> component3()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>> component4()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>> component5()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Boolean> component6()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Integer> component7()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria copy(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria copy(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>, net.corda.core.node.services.vault.ColumnPredicate<Integer>)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>> getContractClassNamesCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> getFilenameCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>> getSignersCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> getUploadDateCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<String> getUploaderCondition()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Integer> getVersionCondition()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria isSigned(net.corda.core.node.services.vault.ColumnPredicate<Boolean>)
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Boolean> isSignedCondition()
+  @NotNull
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withContractClassNames(net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withFilename(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withSigners(net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withUploadDate(net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withUploader(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withVersion(net.corda.core.node.services.vault.ColumnPredicate<Integer>)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$OrComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
+  public <init>(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.AttachmentQueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.AttachmentSort extends net.corda.core.node.services.vault.BaseSort
+  public <init>(java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn>)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort copy(java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn> getColumns()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute extends java.lang.Enum
+  protected <init>(String)
+  @NotNull
+  public final String getColumnName()
+  public static net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public <init>(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn copy(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction getDirection()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute getSortAttribute()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public interface net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria)
+##
+public interface net.corda.core.node.services.vault.BaseQueryCriteriaParser
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parse(Q, S)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseAnd(Q, Q)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseOr(Q, Q)
+##
+public abstract class net.corda.core.node.services.vault.BaseSort extends java.lang.Object
+  public <init>()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.BinaryComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.BinaryComparisonOperator valueOf(String)
+  public static net.corda.core.node.services.vault.BinaryComparisonOperator[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.BinaryLogicalOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.BinaryLogicalOperator valueOf(String)
+  public static net.corda.core.node.services.vault.BinaryLogicalOperator[] values()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Builder extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> avg(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Between<R> between(R, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> between(reflect.Field, R, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> between(kotlin.reflect.KProperty1<O, ? extends R>, R, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> between(net.corda.core.node.services.vault.FieldInfo, R, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> compare(net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> comparePredicate(reflect.Field, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> comparePredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> comparePredicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, Object> count(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> count(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, Object> count(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> equal(R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> equal(R, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(reflect.Field, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(reflect.Field, R, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> equal(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> equal(kotlin.reflect.KProperty1<O, ? extends R>, R, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(net.corda.core.node.services.vault.FieldInfo, R, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> functionPredicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<Object, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> functionPredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> functionPredicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<Object, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThan(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThan(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThan(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThanOrEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThanOrEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThanOrEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(reflect.Field, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(reflect.Field, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> in(java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> in(java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> in(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> in(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<R> isNotNull()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<R> isNull()
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> isNull(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> isNull(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> isNull(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThan(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThan(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThan(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThanOrEqual(R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThanOrEqual(reflect.Field, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThanOrEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness like(String)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness like(String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(reflect.Field, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(reflect.Field, String, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> like(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> like(kotlin.reflect.KProperty1<O, String>, String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(net.corda.core.node.services.vault.FieldInfo, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(net.corda.core.node.services.vault.FieldInfo, String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> max(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> min(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> notEqual(R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> notEqual(R, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(reflect.Field, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(reflect.Field, R, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notEqual(kotlin.reflect.KProperty1<O, ? extends R>, R, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(net.corda.core.node.services.vault.FieldInfo, R, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(reflect.Field, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(reflect.Field, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> notIn(java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> notIn(java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notIn(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notIn(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness notLike(String)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness notLike(String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(reflect.Field, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(reflect.Field, String, boolean)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> notLike(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> notLike(kotlin.reflect.KProperty1<O, String>, String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(net.corda.core.node.services.vault.FieldInfo, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(net.corda.core.node.services.vault.FieldInfo, String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> notNull(reflect.Field)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notNull(kotlin.reflect.KProperty1<O, ? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> notNull(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> predicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> predicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> predicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field, java.util.List<reflect.Field>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> sum(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  public static final net.corda.core.node.services.vault.Builder INSTANCE
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.CollectionOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.CollectionOperator valueOf(String)
+  public static net.corda.core.node.services.vault.CollectionOperator[] values()
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Column extends java.lang.Object
+  public <init>(String, Class<?>)
+  public <init>(reflect.Field)
+  public <init>(kotlin.reflect.KProperty1<O, ? extends C>)
+  public <init>(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public final Class<?> getDeclaringClass()
+  @NotNull
+  public final String getName()
+  public static final net.corda.core.node.services.vault.Column$Companion Companion
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.ColumnPredicate extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.AggregateFunctionType)
+  @NotNull
+  public final net.corda.core.node.services.vault.AggregateFunctionType component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction<C> copy(net.corda.core.node.services.vault.AggregateFunctionType)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.AggregateFunctionType getType()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$Between extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(C, C)
+  @NotNull
+  public final C component1()
+  @NotNull
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Between<C> copy(C, C)
+  public boolean equals(Object)
+  @NotNull
+  public final C getRightFromLiteral()
+  @NotNull
+  public final C getRightToLiteral()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.BinaryComparisonOperator, C)
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryComparisonOperator component1()
+  @NotNull
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<C> copy(net.corda.core.node.services.vault.BinaryComparisonOperator, C)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryComparisonOperator getOperator()
+  @NotNull
+  public final C getRightLiteral()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.CollectionOperator, java.util.Collection<? extends C>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CollectionOperator component1()
+  @NotNull
+  public final java.util.Collection<C> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<C> copy(net.corda.core.node.services.vault.CollectionOperator, java.util.Collection<? extends C>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.CollectionOperator getOperator()
+  @NotNull
+  public final java.util.Collection<C> getRightLiteral()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.EqualityComparisonOperator, C)
+  @NotNull
+  public final net.corda.core.node.services.vault.EqualityComparisonOperator component1()
+  public final C component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<C> copy(net.corda.core.node.services.vault.EqualityComparisonOperator, C)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.EqualityComparisonOperator getOperator()
+  public final C getRightLiteral()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$Likeness extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.LikenessOperator, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.LikenessOperator component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness copy(net.corda.core.node.services.vault.LikenessOperator, String)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.LikenessOperator getOperator()
+  @NotNull
+  public final String getRightLiteral()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.ColumnPredicate$NullExpression extends net.corda.core.node.services.vault.ColumnPredicate
+  public <init>(net.corda.core.node.services.vault.NullOperator)
+  @NotNull
+  public final net.corda.core.node.services.vault.NullOperator component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<C> copy(net.corda.core.node.services.vault.NullOperator)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.NullOperator getOperator()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.CriteriaExpression extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends C>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> component2()
+  @Nullable
+  public final java.util.List<net.corda.core.node.services.vault.Column<O, C>> component3()
+  @Nullable
+  public final net.corda.core.node.services.vault.Sort$Direction component4()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, C> copy(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends C>>, net.corda.core.node.services.vault.Sort$Direction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> getColumn()
+  @Nullable
+  public final java.util.List<net.corda.core.node.services.vault.Column<O, C>> getGroupByColumns()
+  @Nullable
+  public final net.corda.core.node.services.vault.Sort$Direction getOrderBy()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.BinaryLogicalOperator)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryLogicalOperator component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$BinaryLogical<O> copy(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>, net.corda.core.node.services.vault.BinaryLogicalOperator)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getLeft()
+  @NotNull
+  public final net.corda.core.node.services.vault.BinaryLogicalOperator getOperator()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getRight()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, C> copy(net.corda.core.node.services.vault.Column<O, ? extends C>, net.corda.core.node.services.vault.ColumnPredicate<C>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Column<O, C> getColumn()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.CriteriaExpression$Not extends net.corda.core.node.services.vault.CriteriaExpression
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$Not<O> copy(net.corda.core.node.services.vault.CriteriaExpression<O, Boolean>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getExpression()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.EqualityComparisonOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.EqualityComparisonOperator valueOf(String)
+  public static net.corda.core.node.services.vault.EqualityComparisonOperator[] values()
+##
+public final class net.corda.core.node.services.vault.FieldInfo extends java.lang.Object
+  public <init>(String, Class<?>)
+  @NotNull
+  public final Class<?> getEntityClass()
+  @NotNull
+  public final String getName()
+##
+public interface net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
+##
+public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria
+  @NotNull
+  public abstract Q and(Q)
+  @NotNull
+  public abstract Q or(Q)
+##
+public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor extends net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public abstract Q getA()
+  @NotNull
+  public abstract Q getB()
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
+##
+public static interface net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor extends net.corda.core.node.services.vault.GenericQueryCriteria
+  @NotNull
+  public abstract Q getA()
+  @NotNull
+  public abstract Q getB()
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> visit(P)
+##
+@DoNotImplement
+public interface net.corda.core.node.services.vault.IQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L>)
+  @NotNull
+  public abstract java.util.Collection<javax.persistence.criteria.Predicate> parseCriteria(net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.LikenessOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.LikenessOperator valueOf(String)
+  public static net.corda.core.node.services.vault.LikenessOperator[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.node.services.vault.NullOperator extends java.lang.Enum implements net.corda.core.node.services.vault.Operator
+  protected <init>()
+  public static net.corda.core.node.services.vault.NullOperator valueOf(String)
+  public static net.corda.core.node.services.vault.NullOperator[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public interface net.corda.core.node.services.vault.Operator
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.PageSpecification extends java.lang.Object
+  public <init>()
+  public <init>(int, int)
+  public <init>(int, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.PageSpecification copy(int, int)
+  public boolean equals(Object)
+  public final int getPageNumber()
+  public final int getPageSize()
+  public int hashCode()
+  public final boolean isDefault()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.QueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria and(net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria or(net.corda.core.node.services.vault.QueryCriteria)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$AndComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$AndVisitor
+  public <init>(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public abstract static class net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria
+  public <init>()
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo$Type> getConstraintTypes()
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo> getConstraints()
+  @Nullable
+  public abstract java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
+  public abstract net.corda.core.node.services.Vault$StateStatus getStatus()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> component3()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component4()
+  @Nullable
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component5()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component6()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component7()
+  @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component8()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getIssuer()
+  @Nullable
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getIssuerRef()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwner()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> getQuantity()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> component2()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component3()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component4()
+  @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component5()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> getQuantity()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final java.util.List<java.util.UUID> component2()
+  @Nullable
+  public final java.util.List<String> component3()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component4()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component5()
+  @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component6()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<String> getExternalId()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public final java.util.List<java.util.UUID> getUuid()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$OrComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
+  public <init>(net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.QueryCriteria)
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getA()
+  @NotNull
+  public net.corda.core.node.services.vault.QueryCriteria getB()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List<java.util.UUID>)
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType component1()
+  @NotNull
+  public final java.util.List<java.util.UUID> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition copy(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List<java.util.UUID>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<java.util.UUID> getLockIds()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType getType()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.QueryCriteria$SoftLockingType valueOf(String)
+  public static net.corda.core.node.services.vault.QueryCriteria$SoftLockingType[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$TimeCondition extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition copy(net.corda.core.node.services.vault.QueryCriteria$TimeInstantType, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant> getPredicate()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType getType()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$TimeInstantType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.QueryCriteria$TimeInstantType valueOf(String)
+  public static net.corda.core.node.services.vault.QueryCriteria$TimeInstantType[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> component1()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component2()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component3()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> copy(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> copy(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> getExpression()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(net.corda.core.node.services.Vault$StateStatus)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component1()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component2()
+  @Nullable
+  public final java.util.List<net.corda.core.contracts.StateRef> component3()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component4()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition component5()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition component6()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo$Type> getConstraintTypes()
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo> getConstraints()
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> getNotary()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition getSoftLockingCondition()
+  @Nullable
+  public final java.util.List<net.corda.core.contracts.StateRef> getStateRefs()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  @Nullable
+  public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition getTimeCondition()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+##
+public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends java.lang.Object
+  public static final A builder(kotlin.jvm.functions.Function1<? super net.corda.core.node.services.vault.Builder, ? extends A>)
+  @NotNull
+  public static final String getColumnName(net.corda.core.node.services.vault.Column<O, ? extends C>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.FieldInfo getField(String, Class<?>)
+  @NotNull
+  public static final Class<O> resolveEnclosingObjectFromColumn(net.corda.core.node.services.vault.Column<O, ? extends C>)
+  @NotNull
+  public static final Class<O> resolveEnclosingObjectFromExpression(net.corda.core.node.services.vault.CriteriaExpression<O, ? extends R>)
+  public static final int DEFAULT_PAGE_NUM = 1
+  public static final int DEFAULT_PAGE_SIZE = 200
+  public static final int MAX_PAGE_SIZE = 2147483646
+##
+@CordaSerializable
+public final class net.corda.core.node.services.vault.Sort extends net.corda.core.node.services.vault.BaseSort
+  public <init>(java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn>)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn> component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort copy(java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn> getColumns()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public static interface net.corda.core.node.services.vault.Sort$Attribute
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$CommonStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String, String)
+  @Nullable
+  public final String getAttributeChild()
+  @NotNull
+  public final String getAttributeParent()
+  public static net.corda.core.node.services.vault.Sort$CommonStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$CommonStateAttribute[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$Direction extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.vault.Sort$Direction valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$Direction[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$FungibleStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
+  public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$FungibleStateAttribute[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$LinearStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
+  public static net.corda.core.node.services.vault.Sort$LinearStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$LinearStateAttribute[] values()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$SortColumn extends java.lang.Object
+  public <init>(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public <init>(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$SortColumn copy(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Direction getDirection()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute getSortAttribute()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.Sort$VaultStateAttribute extends java.lang.Enum implements net.corda.core.node.services.vault.Sort$Attribute
+  protected <init>(String)
+  @NotNull
+  public final String getAttributeName()
+  public static net.corda.core.node.services.vault.Sort$VaultStateAttribute valueOf(String)
+  public static net.corda.core.node.services.vault.Sort$VaultStateAttribute[] values()
+##
+@CordaSerializable
+public abstract class net.corda.core.node.services.vault.SortAttribute extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.SortAttribute$Custom extends net.corda.core.node.services.vault.SortAttribute
+  public <init>(Class<? extends net.corda.core.schemas.StatePersistable>, String)
+  @NotNull
+  public final Class<? extends net.corda.core.schemas.StatePersistable> component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute$Custom copy(Class<? extends net.corda.core.schemas.StatePersistable>, String)
+  public boolean equals(Object)
+  @NotNull
+  public final Class<? extends net.corda.core.schemas.StatePersistable> getEntityStateClass()
+  @NotNull
+  public final String getEntityStateColumnName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.SortAttribute$Standard extends net.corda.core.node.services.vault.SortAttribute
+  public <init>(net.corda.core.node.services.vault.Sort$Attribute)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Attribute component1()
+  @NotNull
+  public final net.corda.core.node.services.vault.SortAttribute$Standard copy(net.corda.core.node.services.vault.Sort$Attribute)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.node.services.vault.Sort$Attribute getAttribute()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.schemas.CommonSchema extends java.lang.Object
+  public static final net.corda.core.schemas.CommonSchema INSTANCE
+##
+public final class net.corda.core.schemas.CommonSchemaV1 extends net.corda.core.schemas.MappedSchema
+  @NotNull
+  public String getMigrationResource()
+  public static final net.corda.core.schemas.CommonSchemaV1 INSTANCE
+##
+@MappedSuperclass
+@CordaSerializable
+public static class net.corda.core.schemas.CommonSchemaV1$FungibleState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[])
+  public <init>(java.util.Set, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.identity.AbstractParty getIssuer()
+  @NotNull
+  public byte[] getIssuerRef()
+  @NotNull
+  public net.corda.core.identity.AbstractParty getOwner()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public long getQuantity()
+  public void setIssuer(net.corda.core.identity.AbstractParty)
+  public void setIssuerRef(byte[])
+  public void setOwner(net.corda.core.identity.AbstractParty)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setQuantity(long)
+##
+@MappedSuperclass
+@CordaSerializable
+public static class net.corda.core.schemas.CommonSchemaV1$LinearState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, String, java.util.UUID)
+  public <init>(java.util.Set, String, java.util.UUID, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.contracts.UniqueIdentifier, java.util.Set<? extends net.corda.core.identity.AbstractParty>)
+  @Nullable
+  public String getExternalId()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public java.util.UUID getUuid()
+  public void setExternalId(String)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setUuid(java.util.UUID)
+##
+public interface net.corda.core.schemas.DirectStatePersistable extends net.corda.core.schemas.StatePersistable
+  @Nullable
+  public abstract net.corda.core.schemas.PersistentStateRef getStateRef()
+##
+public interface net.corda.core.schemas.IndirectStatePersistable extends net.corda.core.schemas.StatePersistable
+  @NotNull
+  public abstract T getCompositeKey()
+##
+public class net.corda.core.schemas.MappedSchema extends java.lang.Object
+  public <init>(Class<?>, int, Iterable<? extends Class<?>>)
+  public boolean equals(Object)
+  @NotNull
+  public final Iterable<Class<?>> getMappedTypes()
+  @Nullable
+  public String getMigrationResource()
+  @NotNull
+  public final String getName()
+  public final int getVersion()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.schemas.MappedSchemaValidator extends java.lang.Object
+  @NotNull
+  public final java.util.List<net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport> crossReferencesToOtherMappedSchema(net.corda.core.schemas.MappedSchema)
+  @NotNull
+  public final java.util.List<net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport> fieldsFromOtherMappedSchema(net.corda.core.schemas.MappedSchema)
+  @NotNull
+  public final java.util.List<net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport> methodsFromOtherMappedSchema(net.corda.core.schemas.MappedSchema)
+  public static final net.corda.core.schemas.MappedSchemaValidator INSTANCE
+##
+public static final class net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport extends java.lang.Object
+  public <init>(String, String, String, String, String)
+  @NotNull
+  public String toString()
+  @NotNull
+  public final String toWarning()
+##
+@MappedSuperclass
+@CordaSerializable
+public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.DirectStatePersistable
+  public <init>()
+  public <init>(net.corda.core.schemas.PersistentStateRef)
+  public <init>(net.corda.core.schemas.PersistentStateRef, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public net.corda.core.schemas.PersistentStateRef getStateRef()
+  public void setStateRef(net.corda.core.schemas.PersistentStateRef)
+##
+@Embeddable
+@Immutable
+public class net.corda.core.schemas.PersistentStateRef extends java.lang.Object implements java.io.Serializable
+  public <init>()
+  public <init>(String, int)
+  public <init>(net.corda.core.contracts.StateRef)
+  @NotNull
+  public final String component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.schemas.PersistentStateRef copy(String, int)
+  public boolean equals(Object)
+  public int getIndex()
+  @NotNull
+  public String getTxId()
+  public int hashCode()
+  public void setIndex(int)
+  public void setTxId(String)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public interface net.corda.core.schemas.QueryableState extends net.corda.core.contracts.ContractState
+  @NotNull
+  public abstract net.corda.core.schemas.PersistentState generateMappedObject(net.corda.core.schemas.MappedSchema)
+  @NotNull
+  public abstract Iterable<net.corda.core.schemas.MappedSchema> supportedSchemas()
+##
+public interface net.corda.core.schemas.StatePersistable
+##
+public interface net.corda.core.serialization.ClassWhitelist
+  public abstract boolean hasListed(Class<?>)
+##
+public @interface net.corda.core.serialization.ConstructorForDeserialization
+##
+public final class net.corda.core.serialization.ContextPropertyKeys extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.serialization.ContextPropertyKeys valueOf(String)
+  public static net.corda.core.serialization.ContextPropertyKeys[] values()
+##
+public @interface net.corda.core.serialization.CordaSerializable
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformEnumDefault
+  public abstract String new()
+  public abstract String old()
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformEnumDefaults
+  public abstract net.corda.core.serialization.CordaSerializationTransformEnumDefault[] value()
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformRename
+  public abstract String from()
+  public abstract String to()
+##
+public @interface net.corda.core.serialization.CordaSerializationTransformRenames
+  public abstract net.corda.core.serialization.CordaSerializationTransformRename[] value()
+##
+public @interface net.corda.core.serialization.DeprecatedConstructorForDeserialization
+  public abstract int version()
+##
+@DoNotImplement
+public interface net.corda.core.serialization.EncodingWhitelist
+  public abstract boolean acceptEncoding(net.corda.core.serialization.SerializationEncoding)
+##
+@CordaSerializable
+public final class net.corda.core.serialization.MissingAttachmentsException extends net.corda.core.CordaException
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>, String)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
+##
+public final class net.corda.core.serialization.ObjectWithCompatibleContext extends java.lang.Object
+  public <init>(T, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public final T component1()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext component2()
+  @NotNull
+  public final net.corda.core.serialization.ObjectWithCompatibleContext<T> copy(T, net.corda.core.serialization.SerializationContext)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getContext()
+  @NotNull
+  public final T getObj()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public @interface net.corda.core.serialization.SerializableCalculatedProperty
+##
+public final class net.corda.core.serialization.SerializationAPIKt extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> serialize(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
+##
+@DoNotImplement
+public interface net.corda.core.serialization.SerializationContext
+  @NotNull
+  public abstract ClassLoader getDeserializationClassLoader()
+  @Nullable
+  public abstract net.corda.core.serialization.SerializationEncoding getEncoding()
+  @NotNull
+  public abstract net.corda.core.serialization.EncodingWhitelist getEncodingWhitelist()
+  public abstract boolean getLenientCarpenterEnabled()
+  public abstract boolean getObjectReferencesEnabled()
+  @NotNull
+  public abstract net.corda.core.utilities.ByteSequence getPreferredSerializationVersion()
+  public abstract boolean getPreventDataLoss()
+  @NotNull
+  public abstract java.util.Map<Object, Object> getProperties()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext$UseCase getUseCase()
+  @NotNull
+  public abstract net.corda.core.serialization.ClassWhitelist getWhitelist()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withAttachmentsClassLoader(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withClassLoader(ClassLoader)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withEncoding(net.corda.core.serialization.SerializationEncoding)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withEncodingWhitelist(net.corda.core.serialization.EncodingWhitelist)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withLenientCarpenter()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withPreferredSerializationVersion(net.corda.core.utilities.ByteSequence)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withPreventDataLoss()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withProperty(Object, Object)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withWhitelisted(Class<?>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withoutReferences()
+##
+public static final class net.corda.core.serialization.SerializationContext$UseCase extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.serialization.SerializationContext$UseCase valueOf(String)
+  public static net.corda.core.serialization.SerializationContext$UseCase[] values()
+##
+public interface net.corda.core.serialization.SerializationCustomSerializer
+  public abstract OBJ fromProxy(PROXY)
+  public abstract PROXY toProxy(OBJ)
+##
+public final class net.corda.core.serialization.SerializationDefaults extends java.lang.Object
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getP2P_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getRPC_CLIENT_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getRPC_SERVER_CONTEXT()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getSERIALIZATION_FACTORY()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getSTORAGE_CONTEXT()
+  public static final net.corda.core.serialization.SerializationDefaults INSTANCE
+##
+@DoNotImplement
+public interface net.corda.core.serialization.SerializationEncoding
+##
+public abstract class net.corda.core.serialization.SerializationFactory extends java.lang.Object
+  public <init>()
+  public final T asCurrent(kotlin.jvm.functions.Function1<? super net.corda.core.serialization.SerializationFactory, ? extends T>)
+  @NotNull
+  public abstract T deserialize(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public abstract net.corda.core.serialization.ObjectWithCompatibleContext<T> deserializeWithCompatibleContext(net.corda.core.utilities.ByteSequence, Class<T>, net.corda.core.serialization.SerializationContext)
+  @Nullable
+  public final net.corda.core.serialization.SerializationContext getCurrentContext()
+  @NotNull
+  public final net.corda.core.serialization.SerializationContext getDefaultContext()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializedBytes<T> serialize(T, net.corda.core.serialization.SerializationContext)
+  public final T withCurrentContext(net.corda.core.serialization.SerializationContext, kotlin.jvm.functions.Function0<? extends T>)
+  public static final net.corda.core.serialization.SerializationFactory$Companion Companion
+##
+public static final class net.corda.core.serialization.SerializationFactory$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.serialization.SerializationFactory getCurrentFactory()
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getDefaultFactory()
+##
+public interface net.corda.core.serialization.SerializationToken
+  @NotNull
+  public abstract Object fromToken(net.corda.core.serialization.SerializeAsTokenContext)
+##
+public interface net.corda.core.serialization.SerializationWhitelist
+  @NotNull
+  public abstract java.util.List<Class<?>> getWhitelist()
+##
+@CordaSerializable
+public interface net.corda.core.serialization.SerializeAsToken
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
+##
+public interface net.corda.core.serialization.SerializeAsTokenContext
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServiceHub()
+  @NotNull
+  public abstract net.corda.core.serialization.SerializeAsToken getSingleton(String)
+  public abstract void putSingleton(net.corda.core.serialization.SerializeAsToken)
+##
+@CordaSerializable
+public final class net.corda.core.serialization.SerializedBytes extends net.corda.core.utilities.OpaqueBytes
+  public <init>(byte[])
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> from(T)
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory)
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  public static final net.corda.core.serialization.SerializedBytes$Companion Companion
+##
+public static final class net.corda.core.serialization.SerializedBytes$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> from(T)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
+##
+public final class net.corda.core.serialization.SingletonSerializationToken extends java.lang.Object implements net.corda.core.serialization.SerializationToken
+  public <init>(String, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public net.corda.core.serialization.SerializeAsToken fromToken(net.corda.core.serialization.SerializeAsTokenContext)
+  @NotNull
+  public final net.corda.core.serialization.SingletonSerializationToken registerWithContext(net.corda.core.serialization.SerializeAsTokenContext, net.corda.core.serialization.SerializeAsToken)
+  public static final net.corda.core.serialization.SingletonSerializationToken$Companion Companion
+##
+public static final class net.corda.core.serialization.SingletonSerializationToken$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.serialization.SingletonSerializationToken singletonSerializationToken(Class<T>)
+##
+@CordaSerializable
+public abstract class net.corda.core.serialization.SingletonSerializeAsToken extends java.lang.Object implements net.corda.core.serialization.SerializeAsToken
+  public <init>()
+  @NotNull
+  public net.corda.core.serialization.SingletonSerializationToken toToken(net.corda.core.serialization.SerializeAsTokenContext)
+##
+@DoNotImplement
+public abstract class net.corda.core.transactions.BaseTransaction extends java.lang.Object implements net.corda.core.contracts.NamedByHash
+  public <init>()
+  protected void checkBaseInvariants()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterOutRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterOutputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findOutRef(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findOutput(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public abstract java.util.List<?> getInputs()
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getOutput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public abstract java.util.List<?> getReferences()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> outRef(int)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> outRef(net.corda.core.contracts.ContractState)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> outRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> outputsOfType(Class<T>)
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public class net.corda.core.transactions.ComponentGroup extends java.lang.Object
+  public <init>(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  @NotNull
+  public java.util.List<net.corda.core.utilities.OpaqueBytes> getComponents()
+  public int getGroupIndex()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.ComponentVisibilityException extends net.corda.core.CordaException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final String getReason()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.ContractUpgradeFilteredTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent>, java.util.Map<Integer, ? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent> component1()
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.crypto.SecureHash> component2()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeFilteredTransaction copy(java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent>, java.util.Map<Integer, ? extends net.corda.core.crypto.SecureHash>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.crypto.SecureHash> getHiddenComponents()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @NotNull
+  public final java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent> getVisibleComponents()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent extends java.lang.Object
+  public <init>(net.corda.core.utilities.OpaqueBytes, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes getComponent()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getNonce()
+##
+@DoNotImplement
+public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final net.corda.core.identity.Party component2()
+  @NotNull
+  public final net.corda.core.contracts.Attachment component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.contracts.Attachment component5()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component6()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component7()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component8()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component9()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @NotNull
+  public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getLegacyContractAttachment()
+  @NotNull
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @NotNull
+  public final net.corda.core.contracts.Attachment getUpgradedContractAttachment()
+  @NotNull
+  public final String getUpgradedContractClassName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.ContractUpgradeWireTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeFilteredTransaction buildFilteredTransaction()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component1()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component2()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeWireTransaction copy(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.contracts.PrivacySalt)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getLegacyContractAttachmentId()
+  @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getUpgradedContractAttachmentId()
+  @NotNull
+  public final String getUpgradedContractClassName()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.transactions.ContractUpgradeWireTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.ContractUpgradeWireTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.core.transactions.ContractUpgradeWireTransaction$Component extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.transactions.ContractUpgradeWireTransaction$Component valueOf(String)
+  public static net.corda.core.transactions.ContractUpgradeWireTransaction$Component[] values()
+##
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.transactions.CoreTransaction extends net.corda.core.transactions.BaseTransaction
+  public <init>()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public abstract net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getReferences()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredComponentGroup extends net.corda.core.transactions.ComponentGroup
+  public <init>(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.crypto.PartialMerkleTree)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component2()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> component3()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree component4()
+  @NotNull
+  public final net.corda.core.transactions.FilteredComponentGroup copy(int, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, java.util.List<? extends net.corda.core.crypto.SecureHash>, net.corda.core.crypto.PartialMerkleTree)
+  public boolean equals(Object)
+  @NotNull
+  public java.util.List<net.corda.core.utilities.OpaqueBytes> getComponents()
+  public int getGroupIndex()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getNonces()
+  @NotNull
+  public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredTransaction extends net.corda.core.transactions.TraversableTransaction
+  public <init>(net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.transactions.FilteredComponentGroup>, java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public static final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, java.util.function.Predicate<Object>)
+  public final void checkAllComponentsVisible(net.corda.core.contracts.ComponentGroupEnum)
+  public final void checkCommandVisibility(java.security.PublicKey)
+  public final boolean checkWithFun(kotlin.jvm.functions.Function1<Object, Boolean>)
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.FilteredComponentGroup> getFilteredComponentGroups()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getGroupHashes()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  public final void verify()
+  public static final net.corda.core.transactions.FilteredTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.FilteredTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, java.util.function.Predicate<Object>)
+##
+@CordaSerializable
+public final class net.corda.core.transactions.FilteredTransactionVerificationException extends net.corda.core.CordaException
+  public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final String getReason()
+##
+@DoNotImplement
+public abstract class net.corda.core.transactions.FullTransaction extends net.corda.core.transactions.BaseTransaction
+  public <init>()
+  protected void checkBaseInvariants()
+  protected final void checkNotaryWhitelisted()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @Nullable
+  public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  @DeprecatedConstructorForDeserialization
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters, java.util.List, java.util.Map, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<T>> commandsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component10()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> component2()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.CommandWithParties<net.corda.core.contracts.CommandData>> component3()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Attachment> component4()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component5()
+  @Nullable
+  public final net.corda.core.identity.Party component6()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow component7()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt component8()
+  @Nullable
+  public final net.corda.core.node.NetworkParameters component9()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<T>> filterCommands(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterInRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterInputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterReferenceInputRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterReferenceInputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.Command<T> findCommand(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findInRef(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findInput(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findReference(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findReferenceInputRef(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment(int)
+  @NotNull
+  public final net.corda.core.contracts.Attachment getAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Attachment> getAttachments()
+  @NotNull
+  public final net.corda.core.contracts.Command<T> getCommand(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.CommandWithParties<net.corda.core.contracts.CommandData>> getCommands()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getInput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getInputStates()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @Nullable
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @Nullable
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getReferenceInput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getReferenceStates()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimeWindow()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.LedgerTransaction$InOutGroup<T, K>> groupStates(Class<T>, kotlin.jvm.functions.Function1<? super T, ? extends K>)
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> inRef(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> inRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> inputsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> referenceInputRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> referenceInputsOfType(Class<T>)
+  @NotNull
+  public String toString()
+  public final void verify()
+  public static final net.corda.core.transactions.LedgerTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.LedgerTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.core.transactions.LedgerTransaction$InOutGroup extends java.lang.Object
+  public <init>(java.util.List<? extends T>, java.util.List<? extends T>, K)
+  @NotNull
+  public final java.util.List<T> component1()
+  @NotNull
+  public final java.util.List<T> component2()
+  @NotNull
+  public final K component3()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction$InOutGroup<T, K> copy(java.util.List<? extends T>, java.util.List<? extends T>, K)
+  public boolean equals(Object)
+  @NotNull
+  public final K getGroupingKey()
+  @NotNull
+  public final java.util.List<T> getInputs()
+  @NotNull
+  public final java.util.List<T> getOutputs()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.MissingContractAttachments extends net.corda.core.flows.FlowException
+  public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, Integer)
+  public <init>(java.util.List, Integer, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getStates()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.NetworkParametersHash extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.transactions.NetworkParametersHash copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public final class net.corda.core.transactions.NotaryChangeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public <init>(java.util.List, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List, net.corda.core.node.NetworkParameters, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final net.corda.core.identity.Party component2()
+  @NotNull
+  public final net.corda.core.identity.Party component3()
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component4()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component5()
+  @Nullable
+  public final net.corda.core.node.NetworkParameters component6()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @NotNull
+  public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @Nullable
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public final net.corda.core.identity.Party getNewNotary()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.core.transactions.NotaryChangeLedgerTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.NotaryChangeLedgerTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.NotaryChangeWireTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.identity.Party, net.corda.core.identity.Party)
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> component1()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeWireTransaction copy(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @NotNull
+  public final net.corda.core.identity.Party getNewNotary()
+  @NotNull
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @NotNull
+  public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServiceHub, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public String toString()
+##
+public static final class net.corda.core.transactions.NotaryChangeWireTransaction$Component extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.transactions.NotaryChangeWireTransaction$Component valueOf(String)
+  public static net.corda.core.transactions.NotaryChangeWireTransaction$Component[] values()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.ReferenceStateRef extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateRef)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @NotNull
+  public final net.corda.core.transactions.ReferenceStateRef copy(net.corda.core.contracts.StateRef)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.SignedTransaction extends java.lang.Object implements net.corda.core.transactions.TransactionWithSignatures
+  public <init>(net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction>, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public <init>(net.corda.core.transactions.CoreTransaction, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.TransactionSignature> component2()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction copy(net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction>, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.transactions.CoreTransaction getCoreTransaction()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public java.util.ArrayList<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @Nullable
+  public final net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction getTx()
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
+  public int hashCode()
+  public final boolean isNotaryChangeTransaction()
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction plus(java.util.Collection<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction plus(net.corda.core.crypto.TransactionSignature)
+  @NotNull
+  public final net.corda.core.transactions.BaseTransaction resolveBaseTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolveContractUpgradeTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolveNotaryChangeTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.TransactionWithSignatures resolveTransactionWithSignatures(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub, boolean)
+  @NotNull
+  public String toString()
+  public final void verify(net.corda.core.node.ServiceHub)
+  public final void verify(net.corda.core.node.ServiceHub, boolean)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(java.security.KeyPair, net.corda.core.crypto.SignatureMetadata)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignature(net.corda.core.crypto.TransactionSignature)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction withAdditionalSignatures(Iterable<net.corda.core.crypto.TransactionSignature>)
+  public static final net.corda.core.transactions.SignedTransaction$Companion Companion
+##
+@CordaSerializable
+public static final class net.corda.core.transactions.SignedTransaction$SignaturesMissingException extends java.security.SignatureException implements net.corda.core.CordaThrowable, net.corda.core.contracts.NamedByHash
+  public <init>(java.util.Set<? extends java.security.PublicKey>, java.util.List<String>, net.corda.core.crypto.SecureHash)
+  public void addSuppressed(Throwable[])
+  @NotNull
+  public final java.util.List<String> getDescriptions()
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getMissing()
+  @Nullable
+  public String getOriginalExceptionClassName()
+  @Nullable
+  public String getOriginalMessage()
+  public void setCause(Throwable)
+  public void setMessage(String)
+  public void setOriginalExceptionClassName(String)
+##
+public class net.corda.core.transactions.TransactionBuilder extends java.lang.Object
+  public <init>()
+  public <init>(net.corda.core.identity.Party)
+  public <init>(net.corda.core.identity.Party, java.util.UUID)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>, net.corda.core.contracts.TimeWindow)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.node.ServiceHub)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, java.util.List, net.corda.core.node.ServiceHub, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.Command<?>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.util.List<? extends java.security.PublicKey>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addCommand(net.corda.core.contracts.CommandData, java.security.PublicKey...)
+  @NotNull
+  public net.corda.core.transactions.TransactionBuilder addInputState(net.corda.core.contracts.StateAndRef<?>)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.TransactionState<?>)
+  @NotNull
+  public net.corda.core.transactions.TransactionBuilder addReferenceState(net.corda.core.contracts.ReferencedStateAndRef<?>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> attachments()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<?>> commands()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder copy()
+  @NotNull
+  protected final java.util.List<net.corda.core.crypto.SecureHash> getAttachments()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.Command<?>> getCommands()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @NotNull
+  public final java.util.UUID getLockId()
+  @Nullable
+  public final net.corda.core.identity.Party getNotary()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  protected final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @Nullable
+  protected final net.corda.core.node.ServiceHub getServiceHub()
+  @Nullable
+  protected final net.corda.core.contracts.TimeWindow getWindow()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> inputStates()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.TransactionState<?>> outputStates()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> referenceStates()
+  public final void setLockId(java.util.UUID)
+  public final void setNotary(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setPrivacySalt(net.corda.core.contracts.PrivacySalt)
+  protected final void setPrivacySalt(net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setTimeWindow(java.time.Instant, java.time.Duration)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder setTimeWindow(net.corda.core.contracts.TimeWindow)
+  protected final void setWindow(net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.SignedTransaction toSignedTransaction(net.corda.core.node.services.KeyManagementService, java.security.PublicKey, net.corda.core.crypto.SignatureMetadata, net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction toWireTransaction(net.corda.core.node.ServicesForResolution)
+  public final void verify(net.corda.core.node.ServiceHub)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder withItems(Object...)
+  public static final net.corda.core.transactions.TransactionBuilder$Companion Companion
+##
+@DoNotImplement
+public interface net.corda.core.transactions.TransactionWithSignatures extends net.corda.core.contracts.NamedByHash
+  public void checkSignaturesAreValid()
+  @NotNull
+  public abstract java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @NotNull
+  public java.util.Set<java.security.PublicKey> getMissingSigners()
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  public void verifyRequiredSignatures()
+  public void verifySignaturesExcept(java.util.Collection<? extends java.security.PublicKey>)
+  public void verifySignaturesExcept(java.security.PublicKey...)
+##
+@DoNotImplement
+@CordaSerializable
+public abstract class net.corda.core.transactions.TraversableTransaction extends net.corda.core.transactions.CoreTransaction
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>)
+  @NotNull
+  public final java.util.List<net.corda.core.crypto.SecureHash> getAttachments()
+  @NotNull
+  public final java.util.List<java.util.List<Object>> getAvailableComponentGroups()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.Command<?>> getCommands()
+  @NotNull
+  public java.util.List<net.corda.core.transactions.ComponentGroup> getComponentGroups()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @Nullable
+  public net.corda.core.identity.Party getNotary()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @Nullable
+  public final net.corda.core.contracts.TimeWindow getTimeWindow()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.transactions.WireTransaction extends net.corda.core.transactions.TraversableTransaction
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>)
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.crypto.SecureHash>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow)
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.crypto.SecureHash>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>, net.corda.core.contracts.PrivacySalt)
+  @NotNull
+  public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
+  public final void checkSignature(net.corda.core.crypto.TransactionSignature)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.core.crypto.SecureHash getId()
+  @NotNull
+  public final net.corda.core.crypto.MerkleTree getMerkleTree()
+  @NotNull
+  public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public final java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  public int hashCode()
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(kotlin.jvm.functions.Function1<? super java.security.PublicKey, net.corda.core.identity.Party>, kotlin.jvm.functions.Function1<? super net.corda.core.crypto.SecureHash, ? extends net.corda.core.contracts.Attachment>, kotlin.jvm.functions.Function1<? super net.corda.core.contracts.StateRef, ? extends net.corda.core.contracts.TransactionState<?>>, kotlin.jvm.functions.Function1<? super net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>, ? extends net.corda.core.crypto.SecureHash>)
+  @NotNull
+  public final net.corda.core.transactions.LedgerTransaction toLedgerTransaction(net.corda.core.node.ServicesForResolution)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.transactions.WireTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.WireTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.core.utilities.ByteArrays extends java.lang.Object
+  @NotNull
+  public static final byte[] parseAsHex(String)
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence sequence(byte[], int, int)
+  @NotNull
+  public static final String toHexString(byte[])
+##
+@CordaSerializable
+public abstract class net.corda.core.utilities.ByteSequence extends java.lang.Object implements java.lang.Comparable
+  public <init>(byte[], int, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public int compareTo(net.corda.core.utilities.ByteSequence)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence copy()
+  @NotNull
+  public final byte[] copyBytes()
+  public boolean equals(Object)
+  @NotNull
+  public abstract byte[] getBytes()
+  public final int getOffset()
+  public final int getSize()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[])
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[], int)
+  @NotNull
+  public static final net.corda.core.utilities.ByteSequence of(byte[], int, int)
+  @NotNull
+  public final java.io.ByteArrayInputStream open()
+  @NotNull
+  public final java.nio.ByteBuffer putTo(java.nio.ByteBuffer)
+  @NotNull
+  public final java.nio.ByteBuffer slice(int, int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence subSequence(int, int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence take(int)
+  @NotNull
+  public String toString()
+  public final void writeTo(java.io.OutputStream)
+  public static final net.corda.core.utilities.ByteSequence$Companion Companion
+##
+public static final class net.corda.core.utilities.ByteSequence$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[])
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[], int)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence of(byte[], int, int)
+##
+public final class net.corda.core.utilities.EncodingUtils extends java.lang.Object
+  @NotNull
+  public static final byte[] base58ToByteArray(String)
+  @NotNull
+  public static final String base58ToRealString(String)
+  @NotNull
+  public static final String base58toBase64(String)
+  @NotNull
+  public static final String base58toHex(String)
+  @NotNull
+  public static final byte[] base64ToByteArray(String)
+  @NotNull
+  public static final String base64ToRealString(String)
+  @NotNull
+  public static final String base64toBase58(String)
+  @NotNull
+  public static final String base64toHex(String)
+  @NotNull
+  public static final String hexToBase58(String)
+  @NotNull
+  public static final String hexToBase64(String)
+  @NotNull
+  public static final byte[] hexToByteArray(String)
+  @NotNull
+  public static final String hexToRealString(String)
+  @NotNull
+  public static final java.security.PublicKey parsePublicKeyBase58(String)
+  @NotNull
+  public static final String toBase58(byte[])
+  @NotNull
+  public static final String toBase58String(java.security.PublicKey)
+  @NotNull
+  public static final String toBase64(byte[])
+  @NotNull
+  public static final String toHex(byte[])
+  @NotNull
+  public static final byte[] toSHA256Bytes(java.security.PublicKey)
+  public static final int MAX_HASH_HEX_SIZE = 130
+##
+public class net.corda.core.utilities.Id extends java.lang.Object
+  public <init>(VALUE, String, java.time.Instant)
+  public final boolean equals(Object)
+  @Nullable
+  public final String getEntityType()
+  @NotNull
+  public final java.time.Instant getTimestamp()
+  @NotNull
+  public final VALUE getValue()
+  public final int hashCode()
+  @NotNull
+  public static final net.corda.core.utilities.Id<V> newInstance(V, String, java.time.Instant)
+  @NotNull
+  public final String toString()
+  public static final net.corda.core.utilities.Id$Companion Companion
+##
+public static final class net.corda.core.utilities.Id$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.Id<V> newInstance(V, String, java.time.Instant)
+##
+public final class net.corda.core.utilities.KotlinUtilsKt extends java.lang.Object
+  @NotNull
+  public static final org.slf4j.Logger contextLogger(Object)
+  public static final void debug(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
+  public static final int exactAdd(int, int)
+  public static final long exactAdd(long, long)
+  @NotNull
+  public static final java.time.Duration getDays(int)
+  @NotNull
+  public static final java.time.Duration getHours(int)
+  @NotNull
+  public static final java.time.Duration getMillis(int)
+  @NotNull
+  public static final java.time.Duration getMinutes(int)
+  public static final V getOrThrow(java.util.concurrent.Future<V>, java.time.Duration)
+  @NotNull
+  public static final java.time.Duration getSeconds(int)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> toNonEmptySet(java.util.Collection<? extends T>)
+  public static final void trace(org.slf4j.Logger, kotlin.jvm.functions.Function0<String>)
+  @NotNull
+  public static final net.corda.core.utilities.PropertyDelegate<T> transient(kotlin.jvm.functions.Function0<? extends T>)
+##
+@CordaSerializable
+public final class net.corda.core.utilities.NetworkHostAndPort extends java.lang.Object
+  public <init>(String, int)
+  @NotNull
+  public final String component1()
+  public final int component2()
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort copy(String, int)
+  public boolean equals(Object)
+  @NotNull
+  public final String getHost()
+  public final int getPort()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.utilities.NetworkHostAndPort parse(String)
+  @NotNull
+  public String toString()
+  public static final net.corda.core.utilities.NetworkHostAndPort$Companion Companion
+  @NotNull
+  public static final String INVALID_PORT_FORMAT = "Invalid port: %s"
+  @NotNull
+  public static final String MISSING_PORT_FORMAT = "Missing port: %s"
+  @NotNull
+  public static final String UNPARSEABLE_ADDRESS_FORMAT = "Unparseable address: %s"
+##
+public static final class net.corda.core.utilities.NetworkHostAndPort$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort parse(String)
+##
+public final class net.corda.core.utilities.NonEmptySet extends java.lang.Object implements kotlin.jvm.internal.markers.KMappedMarker, java.util.Set
+  public <init>(java.util.Set, kotlin.jvm.internal.DefaultConstructorMarker)
+  public boolean add(T)
+  public boolean addAll(java.util.Collection<? extends T>)
+  public void clear()
+  public boolean contains(Object)
+  public boolean containsAll(java.util.Collection<?>)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> copyOf(java.util.Collection<? extends T>)
+  public boolean equals(Object)
+  public void forEach(java.util.function.Consumer<? super T>)
+  public int getSize()
+  public int hashCode()
+  public final T head()
+  public boolean isEmpty()
+  @NotNull
+  public java.util.Iterator<T> iterator()
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> of(T)
+  @NotNull
+  public static final net.corda.core.utilities.NonEmptySet<T> of(T, T, T...)
+  @NotNull
+  public java.util.stream.Stream<T> parallelStream()
+  public boolean remove(Object)
+  public boolean removeAll(java.util.Collection<?>)
+  public boolean retainAll(java.util.Collection<?>)
+  @NotNull
+  public java.util.Spliterator<T> spliterator()
+  @NotNull
+  public java.util.stream.Stream<T> stream()
+  public Object[] toArray()
+  public T[] toArray(T[])
+  @NotNull
+  public String toString()
+  public static final net.corda.core.utilities.NonEmptySet$Companion Companion
+##
+public static final class net.corda.core.utilities.NonEmptySet$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> copyOf(java.util.Collection<? extends T>)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> of(T)
+  @NotNull
+  public final net.corda.core.utilities.NonEmptySet<T> of(T, T, T...)
+##
+@CordaSerializable
+public class net.corda.core.utilities.OpaqueBytes extends net.corda.core.utilities.ByteSequence
+  public <init>(byte[])
+  @NotNull
+  public final byte[] getBytes()
+  @NotNull
+  public static final net.corda.core.utilities.OpaqueBytes of(byte...)
+  public static final net.corda.core.utilities.OpaqueBytes$Companion Companion
+##
+public static final class net.corda.core.utilities.OpaqueBytes$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.OpaqueBytes of(byte...)
+##
+@CordaSerializable
+public final class net.corda.core.utilities.OpaqueBytesSubSequence extends net.corda.core.utilities.ByteSequence
+  public <init>(byte[], int, int)
+  @NotNull
+  public byte[] getBytes()
+##
+@CordaSerializable
+public final class net.corda.core.utilities.ProgressTracker extends java.lang.Object
+  public <init>(net.corda.core.utilities.ProgressTracker$Step...)
+  public final void endWithError(Throwable)
+  @NotNull
+  public final java.util.List<kotlin.Pair<Integer, net.corda.core.utilities.ProgressTracker$Step>> getAllSteps()
+  @NotNull
+  public final java.util.List<kotlin.Pair<Integer, String>> getAllStepsLabels()
+  @NotNull
+  public final rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
+  @Nullable
+  public final net.corda.core.utilities.ProgressTracker getChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getCurrentStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getCurrentStepRecursive()
+  public final boolean getHasEnded()
+  @Nullable
+  public final net.corda.core.utilities.ProgressTracker getParent()
+  public final int getStepIndex()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step[] getSteps()
+  @NotNull
+  public final rx.Observable<java.util.List<kotlin.Pair<Integer, String>>> getStepsTreeChanges()
+  public final int getStepsTreeIndex()
+  @NotNull
+  public final rx.Observable<Integer> getStepsTreeIndexChanges()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTopLevelTracker()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step nextStep()
+  public final void setChildProgressTracker(net.corda.core.utilities.ProgressTracker$Step, net.corda.core.utilities.ProgressTracker)
+  public final void setCurrentStep(net.corda.core.utilities.ProgressTracker$Step)
+##
+@CordaSerializable
+public abstract static class net.corda.core.utilities.ProgressTracker$Change extends java.lang.Object
+  public <init>(net.corda.core.utilities.ProgressTracker, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getProgressTracker()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Position extends net.corda.core.utilities.ProgressTracker$Change
+  public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Position copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getNewStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Rendering extends net.corda.core.utilities.ProgressTracker$Change
+  public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Rendering copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getOfStep()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$Change$Structural extends net.corda.core.utilities.ProgressTracker$Change
+  public <init>(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker component1()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step component2()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Change$Structural copy(net.corda.core.utilities.ProgressTracker, net.corda.core.utilities.ProgressTracker$Step)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker$Step getParent()
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker getTracker()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$DONE extends net.corda.core.utilities.ProgressTracker$Step
+  public boolean equals(Object)
+  public static final net.corda.core.utilities.ProgressTracker$DONE INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$STARTING extends net.corda.core.utilities.ProgressTracker$Step
+  public boolean equals(Object)
+  public static final net.corda.core.utilities.ProgressTracker$STARTING INSTANCE
+##
+@CordaSerializable
+public static class net.corda.core.utilities.ProgressTracker$Step extends java.lang.Object
+  public <init>(String)
+  @Nullable
+  public net.corda.core.utilities.ProgressTracker childProgressTracker()
+  @NotNull
+  public rx.Observable<net.corda.core.utilities.ProgressTracker$Change> getChanges()
+  @NotNull
+  public java.util.Map<String, String> getExtraAuditData()
+  @NotNull
+  public String getLabel()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$UNSTARTED extends net.corda.core.utilities.ProgressTracker$Step
+  public boolean equals(Object)
+  public static final net.corda.core.utilities.ProgressTracker$UNSTARTED INSTANCE
+##
+public interface net.corda.core.utilities.PropertyDelegate
+  public abstract T getValue(Object, kotlin.reflect.KProperty<?>)
+##
+@CordaSerializable
+public abstract class net.corda.core.utilities.Try extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.Try<C> combine(net.corda.core.utilities.Try<? extends B>, kotlin.jvm.functions.Function2<? super A, ? super B, ? extends C>)
+  @NotNull
+  public final net.corda.core.utilities.Try<A> doOnFailure(java.util.function.Consumer<Throwable>)
+  @NotNull
+  public final net.corda.core.utilities.Try<A> doOnSuccess(java.util.function.Consumer<? super A>)
+  @NotNull
+  public final net.corda.core.utilities.Try<B> flatMap(kotlin.jvm.functions.Function1<? super A, ? extends net.corda.core.utilities.Try<? extends B>>)
+  public abstract A getOrThrow()
+  public abstract boolean isFailure()
+  public abstract boolean isSuccess()
+  @NotNull
+  public final net.corda.core.utilities.Try<B> map(kotlin.jvm.functions.Function1<? super A, ? extends B>)
+  @NotNull
+  public static final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
+  @NotNull
+  public final net.corda.core.utilities.Try<A> throwError()
+  public static final net.corda.core.utilities.Try$Companion Companion
+##
+public static final class net.corda.core.utilities.Try$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.Try$Failure extends net.corda.core.utilities.Try
+  public <init>(Throwable)
+  @NotNull
+  public final Throwable component1()
+  @NotNull
+  public final net.corda.core.utilities.Try$Failure<A> copy(Throwable)
+  public boolean equals(Object)
+  @NotNull
+  public final Throwable getException()
+  public A getOrThrow()
+  public int hashCode()
+  public boolean isFailure()
+  public boolean isSuccess()
+  @NotNull
+  public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.utilities.Try$Success extends net.corda.core.utilities.Try
+  public <init>(A)
+  public final A component1()
+  @NotNull
+  public final net.corda.core.utilities.Try$Success<A> copy(A)
+  public boolean equals(Object)
+  public A getOrThrow()
+  public final A getValue()
+  public int hashCode()
+  public boolean isFailure()
+  public boolean isSuccess()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.utilities.UntrustworthyData extends java.lang.Object
+  public <init>(T)
+  public final T getFromUntrustedWorld()
+  @Suspendable
+  public final R unwrap(net.corda.core.utilities.UntrustworthyData$Validator<? super T, ? extends R>)
+##
+public static interface net.corda.core.utilities.UntrustworthyData$Validator extends java.io.Serializable
+  @Suspendable
+  public abstract R validate(T)
+##
+public final class net.corda.core.utilities.UntrustworthyDataKt extends java.lang.Object
+  public static final R unwrap(net.corda.core.utilities.UntrustworthyData<? extends T>, kotlin.jvm.functions.Function1<? super T, ? extends R>)
+##
+public final class net.corda.core.utilities.UuidGenerator extends java.lang.Object
+  public <init>()
+  public static final net.corda.core.utilities.UuidGenerator$Companion Companion
+##
+public static final class net.corda.core.utilities.UuidGenerator$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.UUID next()
+##
+public interface net.corda.core.utilities.VariablePropertyDelegate extends net.corda.core.utilities.PropertyDelegate
+  public abstract void setValue(Object, kotlin.reflect.KProperty<?>, T)
+##
+public final class net.corda.client.jackson.JacksonSupport extends java.lang.Object
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper()
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory, boolean)
+  @NotNull
+  public final com.fasterxml.jackson.databind.Module getCordaModule()
+  public static final net.corda.client.jackson.JacksonSupport INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AmountDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.contracts.Amount<?> deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$AmountDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AmountSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.contracts.Amount<?>, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$AmountSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.AnonymousParty deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartyDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.AnonymousParty, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$AnonymousPartySerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.CordaX500Name deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.CordaX500Name, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer INSTANCE
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$IdentityObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getFuzzyIdentityMatch()
+  @NotNull
+  public final net.corda.core.node.services.IdentityService getIdentityService()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(com.fasterxml.jackson.core.JsonFactory)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.node.NodeInfo deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$NodeInfoDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$NodeInfoSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.node.NodeInfo, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$NodeInfoSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.utilities.OpaqueBytes deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.utilities.OpaqueBytes, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$OpaqueBytesSerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PartyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public net.corda.core.identity.Party deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$PartyDeserializer INSTANCE
+##
+@DoNotImplement
+public static interface net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public abstract boolean isFullParties()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public abstract net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$PartySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.identity.Party, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$PartySerializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  @NotNull
+  public java.security.PublicKey deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+  public static final net.corda.client.jackson.JacksonSupport$PublicKeyDeserializer INSTANCE
+##
+public static final class net.corda.client.jackson.JacksonSupport$PublicKeySerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(java.security.PublicKey, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$PublicKeySerializer INSTANCE
+##
+@DoNotImplement
+public static final class net.corda.client.jackson.JacksonSupport$RpcObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean getFuzzyIdentityMatch()
+  @NotNull
+  public final net.corda.core.messaging.CordaRPCOps getRpc()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
+  @NotNull
+  public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
+  @Nullable
+  public net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
+  @Nullable
+  public net.corda.core.identity.Party wellKnownPartyFromX500Name(net.corda.core.identity.CordaX500Name)
+##
+public static final class net.corda.client.jackson.JacksonSupport$SecureHashDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer
+  public <init>()
+  @NotNull
+  public T deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
+##
+public static final class net.corda.client.jackson.JacksonSupport$SecureHashSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(net.corda.core.crypto.SecureHash, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$SecureHashSerializer INSTANCE
+##
+public abstract static class net.corda.client.jackson.JacksonSupport$SignedTransactionMixin extends java.lang.Object
+  public <init>()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getId()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @JsonIgnore
+  @Nullable
+  public abstract net.corda.core.identity.Party getNotary()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
+  @JsonProperty
+  @NotNull
+  protected abstract java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
+  @JsonProperty
+  @NotNull
+  protected abstract net.corda.core.transactions.CoreTransaction getTransaction()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction getTx()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.serialization.SerializedBytes<net.corda.core.transactions.CoreTransaction> getTxBits()
+##
+public static final class net.corda.client.jackson.JacksonSupport$ToStringSerializer extends com.fasterxml.jackson.databind.JsonSerializer
+  public void serialize(Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
+  public static final net.corda.client.jackson.JacksonSupport$ToStringSerializer INSTANCE
+##
+public abstract static class net.corda.client.jackson.JacksonSupport$WireTransactionMixin extends java.lang.Object
+  public <init>()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> getAvailableComponentHashes()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<Object> getAvailableComponents()
+  @JsonIgnore
+  @NotNull
+  public abstract net.corda.core.crypto.MerkleTree getMerkleTree()
+  @JsonIgnore
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
+##
+@ThreadSafe
+public class net.corda.client.jackson.StringToMethodCallParser extends java.lang.Object
+  public <init>(Class<? extends T>)
+  public <init>(Class<? extends T>, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(Class, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(kotlin.reflect.KClass<? extends T>)
+  @NotNull
+  public final java.util.Map<String, String> getAvailableCommands()
+  @NotNull
+  protected final com.google.common.collect.Multimap<String, reflect.Method> getMethodMap()
+  @NotNull
+  public final java.util.Map<String, java.util.List<String>> getMethodParamNames()
+  @NotNull
+  public java.util.List<String> paramNamesFromConstructor(reflect.Constructor<?>)
+  @NotNull
+  public java.util.List<String> paramNamesFromMethod(reflect.Method)
+  @NotNull
+  public final net.corda.client.jackson.StringToMethodCallParser<T>$ParsedMethodCall parse(T, String)
+  @NotNull
+  public final Object[] parseArguments(String, java.util.List<? extends kotlin.Pair<String, ? extends reflect.Type>>, String)
+  public static final net.corda.client.jackson.StringToMethodCallParser$Companion Companion
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.jackson.StringToMethodCallParser$ParsedMethodCall extends java.lang.Object implements java.util.concurrent.Callable
+  public <init>(T, reflect.Method, Object[])
+  @Nullable
+  public Object call()
+  @NotNull
+  public final Object[] getArgs()
+  @NotNull
+  public final reflect.Method getMethod()
+  @Nullable
+  public final Object invoke()
+##
+public static class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException extends net.corda.core.CordaException
+  public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$FailedParse extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(Exception)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$MissingParameter extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, String, String)
+  @NotNull
+  public final String getParamName()
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$ReflectionDataMissing extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, int)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$TooManyParameters extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String, String)
+##
+public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$UnknownMethod extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
+  public <init>(String)
+  @NotNull
+  public final String getMethodName()
+##
+public final class net.corda.testing.driver.Driver extends java.lang.Object
+  public static final A driver(net.corda.testing.driver.DriverParameters, kotlin.jvm.functions.Function1<? super net.corda.testing.driver.DriverDSL, ? extends A>)
+##
+@DoNotImplement
+public interface net.corda.testing.driver.DriverDSL
+  @NotNull
+  public abstract java.nio.file.Path baseDirectory(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public abstract net.corda.testing.driver.NotaryHandle getDefaultNotaryHandle()
+  @NotNull
+  public abstract net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> getDefaultNotaryNode()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.driver.NotaryHandle> getNotaryHandles()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.WebserverHandle> startWebserver(net.corda.testing.driver.NodeHandle, String)
+##
+public final class net.corda.testing.driver.DriverParameters extends java.lang.Object
+  public <init>()
+  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
+  public final boolean component1()
+  @NotNull
+  public final java.util.List<String> component10()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy component11()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component12()
+  @NotNull
+  public final java.util.Map<String, Object> component13()
+  public final boolean component14()
+  @Nullable
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component15()
+  @NotNull
+  public final java.nio.file.Path component2()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component3()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component4()
+  @NotNull
+  public final java.util.Map<String, String> component5()
+  public final boolean component6()
+  public final boolean component7()
+  public final boolean component8()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> component9()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
+  public boolean equals(Object)
+  @Nullable
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
+  @NotNull
+  public final java.nio.file.Path getDriverDirectory()
+  @NotNull
+  public final java.util.List<String> getExtraCordappPackagesToScan()
+  public final boolean getInMemoryDB()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy getJmxPolicy()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public final java.util.Map<String, Object> getNotaryCustomOverrides()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getPortAllocation()
+  public final boolean getStartNodesInProcess()
+  @NotNull
+  public final java.util.Map<String, String> getSystemProperties()
+  public final boolean getUseTestClock()
+  public final boolean getWaitForAllNodesToFinish()
+  public int hashCode()
+  public final boolean isDebug()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withDriverDirectory(java.nio.file.Path)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(java.util.List<String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withInMemoryDB(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withIsDebug(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withJmxPolicy(net.corda.testing.driver.JmxPolicy)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotaryCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withPortAllocation(net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withStartNodesInProcess(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withSystemProperties(java.util.Map<String, String>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withUseTestClock(boolean)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withWaitForAllNodesToFinish(boolean)
+##
+@DoNotImplement
+public interface net.corda.testing.driver.InProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract net.corda.core.node.ServiceHub getServices()
+  @NotNull
+  public abstract rx.Observable<T> registerInitiatedFlow(Class<T>)
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+##
+public final class net.corda.testing.driver.JmxPolicy extends java.lang.Object
+  public <init>()
+  public <init>(net.corda.testing.driver.PortAllocation)
+  public <init>(boolean, net.corda.testing.driver.PortAllocation)
+  public <init>(boolean, net.corda.testing.driver.PortAllocation, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean component1()
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation component2()
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy copy(boolean, net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public static final net.corda.testing.driver.JmxPolicy defaultEnabled()
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.testing.driver.PortAllocation getJmxHttpServerPortAllocation()
+  public final boolean getStartJmxHttpServer()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.testing.driver.JmxPolicy$Companion Companion
+##
+public static final class net.corda.testing.driver.JmxPolicy$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy defaultEnabled()
+##
+@DoNotImplement
+public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoCloseable
+  @NotNull
+  public abstract java.nio.file.Path getBaseDirectory()
+  @Nullable
+  public abstract net.corda.core.utilities.NetworkHostAndPort getJmxAddress()
+  @NotNull
+  public abstract net.corda.core.node.NodeInfo getNodeInfo()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getP2pAddress()
+  @NotNull
+  public abstract net.corda.core.messaging.CordaRPCOps getRpc()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAddress()
+  @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAdminAddress()
+  @NotNull
+  public abstract java.util.List<net.corda.testing.node.User> getRpcUsers()
+  public abstract void stop()
+##
+public final class net.corda.testing.driver.NodeParameters extends java.lang.Object
+  public <init>()
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component1()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component2()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component3()
+  @NotNull
+  public final java.util.Map<String, Object> component4()
+  @Nullable
+  public final Boolean component5()
+  @NotNull
+  public final String component6()
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component7()
+  @NotNull
+  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> component8()
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
+  @NotNull
+  public final java.util.Map<String, Object> getCustomOverrides()
+  @NotNull
+  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> getFlowOverrides()
+  @NotNull
+  public final String getMaximumHeapSize()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getProvidedName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  @Nullable
+  public final Boolean getStartInSameProcess()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withAdditionalCordapps(java.util.Set<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withFlowOverrides(java.util.Map<Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withProvidedName(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withRpcUsers(java.util.List<net.corda.testing.node.User>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withStartInSameProcess(Boolean)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withVerifierType(net.corda.testing.driver.VerifierType)
+##
+public final class net.corda.testing.driver.NotaryHandle extends java.lang.Object
+  public <init>(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> component3()
+  @NotNull
+  public final net.corda.testing.driver.NotaryHandle copy(net.corda.core.identity.Party, boolean, net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getIdentity()
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> getNodeHandles()
+  public final boolean getValidating()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.testing.driver.OutOfProcess extends net.corda.testing.driver.NodeHandle
+  @NotNull
+  public abstract Process getProcess()
+##
+@DoNotImplement
+public abstract class net.corda.testing.driver.PortAllocation extends java.lang.Object
+  public <init>()
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort nextHostAndPort()
+  public abstract int nextPort()
+##
+@DoNotImplement
+public static class net.corda.testing.driver.PortAllocation$Incremental extends net.corda.testing.driver.PortAllocation
+  public <init>(int)
+  @NotNull
+  public final java.util.concurrent.atomic.AtomicInteger getPortCounter()
+  public int nextPort()
+##
+public final class net.corda.testing.driver.VerifierType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.testing.driver.VerifierType valueOf(String)
+  public static net.corda.testing.driver.VerifierType[] values()
+##
+public final class net.corda.testing.driver.WebserverHandle extends java.lang.Object
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, Process)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort component1()
+  @NotNull
+  public final Process component2()
+  @NotNull
+  public final net.corda.testing.driver.WebserverHandle copy(net.corda.core.utilities.NetworkHostAndPort, Process)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.utilities.NetworkHostAndPort getListenAddress()
+  @NotNull
+  public final Process getProcess()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public abstract class net.corda.testing.node.ClusterSpec extends java.lang.Object
+  public <init>()
+  public abstract int getClusterSize()
+##
+@DoNotImplement
+public static final class net.corda.testing.node.ClusterSpec$Raft extends net.corda.testing.node.ClusterSpec
+  public <init>(int)
+  public final int component1()
+  @NotNull
+  public final net.corda.testing.node.ClusterSpec$Raft copy(int)
+  public boolean equals(Object)
+  public int getClusterSize()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@ThreadSafe
+public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.corda.core.serialization.SingletonSerializeAsToken
+  public <init>(boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, org.apache.activemq.artemis.utils.ReusableLatch, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final synchronized java.util.List<net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService> getEndpointsExternal()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getReceivedMessages()
+  @NotNull
+  public final rx.Observable<net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer> getSentMessages()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpSend(boolean)
+  public final void stop()
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle extends java.lang.Object implements net.corda.core.messaging.MessageRecipientGroup
+  public <init>(net.corda.core.identity.Party)
+  @NotNull
+  public final net.corda.core.identity.Party component1()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle copy(net.corda.core.identity.Party)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public static interface net.corda.testing.node.InMemoryMessagingNetwork$LatencyCalculator
+  @NotNull
+  public abstract java.time.Duration between(net.corda.core.messaging.SingleMessageRecipient, net.corda.core.messaging.SingleMessageRecipient)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer extends java.lang.Object
+  public <init>(net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle, net.corda.node.services.messaging.Message, net.corda.core.messaging.MessageRecipients, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ByteSequence getMessageData()
+  @NotNull
+  public final net.corda.core.messaging.MessageRecipients getRecipients()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle getSender()
+  @NotNull
+  public String toString()
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.MockNodeMessagingService, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  public static final net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion Companion
+##
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@CordaSerializable
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle extends java.lang.Object implements net.corda.core.messaging.SingleMessageRecipient
+  public <init>(int, net.corda.core.identity.CordaX500Name)
+  public final int component1()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle copy(int, net.corda.core.identity.CordaX500Name)
+  public boolean equals(Object)
+  public final int getId()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public abstract static class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  public abstract A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$Random extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+  public <init>()
+  public <init>(java.util.SplittableRandom)
+  public <init>(java.util.SplittableRandom, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.SplittableRandom getRandom()
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+@DoNotImplement
+public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$RoundRobin extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
+  public <init>()
+  public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
+##
+public final class net.corda.testing.node.MockNetFlowTimeOut extends java.lang.Object
+  public <init>(java.time.Duration, int, double)
+  public final double getBackoffBase()
+  public final int getMaxRestartCount()
+  @NotNull
+  public final java.time.Duration getTimeout()
+##
+public final class net.corda.testing.node.MockNetNotaryConfig extends java.lang.Object
+  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name)
+  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final String getClassName()
+  @Nullable
+  public final com.typesafe.config.Config getExtraConfig()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getServiceLegalName()
+  public final boolean getValidating()
+##
+public class net.corda.testing.node.MockNetwork extends java.lang.Object
+  public <init>(java.util.List<String>)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.testing.node.MockNetworkParameters)
+  @NotNull
+  public final java.nio.file.Path baseDirectory(int)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createPartyNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode()
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
+  @NotNull
+  public final java.util.List<String> getCordappPackages()
+  @NotNull
+  public final net.corda.core.identity.Party getDefaultNotaryIdentity()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode getDefaultNotaryNode()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters getDefaultParameters()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public final boolean getNetworkSendManuallyPumped()
+  public final int getNextNodeId()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.StartedMockNode> getNotaryNodes()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  public final boolean getThreadPerNode()
+  public final void runNetwork()
+  public final void runNetwork(int)
+  public final void startNodes()
+  public final void stopNodes()
+  public final void waitQuiescent()
+##
+public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkNotarySpec copy(net.corda.core.identity.CordaX500Name, boolean)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  public final boolean getValidating()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.node.MockNetworkParameters extends java.lang.Object
+  public <init>()
+  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final boolean component1()
+  public final boolean component2()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy component3()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> component4()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters component5()
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component6()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
+  @NotNull
+  public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  public final boolean getNetworkSendManuallyPumped()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.MockNetworkNotarySpec> getNotarySpecs()
+  @NotNull
+  public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
+  public final boolean getThreadPerNode()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNetworkSendManuallyPumped(boolean)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withNotarySpecs(java.util.List<net.corda.testing.node.MockNetworkNotarySpec>)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withServicePeerAllocationStrategy(net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withThreadPerNode(boolean)
+##
+public final class net.corda.testing.node.MockNodeConfigOverrides extends java.lang.Object
+  public <init>()
+  public <init>(java.util.Map<String, String>, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut)
+  public <init>(java.util.Map, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.Map<String, String> getExtraDataSourceProperties()
+  @Nullable
+  public final net.corda.testing.node.MockNetFlowTimeOut getFlowTimeout()
+  @Nullable
+  public final net.corda.testing.node.MockNetNotaryConfig getNotary()
+##
+public final class net.corda.testing.node.MockNodeParameters extends java.lang.Object
+  public <init>()
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final Integer component1()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name component2()
+  @NotNull
+  public final java.math.BigInteger component3()
+  @Nullable
+  public final net.corda.testing.node.MockNodeConfigOverrides component4()
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component5()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
+  @Nullable
+  public final net.corda.testing.node.MockNodeConfigOverrides getConfigOverrides()
+  @NotNull
+  public final java.math.BigInteger getEntropyRoot()
+  @Nullable
+  public final Integer getForcedID()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getLegalName()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withAdditionalCordapps(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withConfigOverrides(net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withEntropyRoot(java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withForcedID(Integer)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withLegalName(net.corda.core.identity.CordaX500Name)
+##
+public class net.corda.testing.node.MockServices extends java.lang.Object implements net.corda.core.node.ServiceHub
+  public <init>()
+  public <init>(Iterable<String>)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
+  public <init>(Iterable, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.node.cordapp.CordappLoader, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity, java.security.KeyPair[], kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
+  public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
+  public final void addMockCordapp(String)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction addSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public T cordaService(Class<T>)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.FilteredTransaction, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
+  @NotNull
+  public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.cordapp.CordappContext getAppContext()
+  @NotNull
+  public final net.corda.testing.services.MockAttachmentStorage getAttachments()
+  @NotNull
+  public net.corda.testing.node.TestClock getClock()
+  @NotNull
+  public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public final ClassLoader getCordappClassloader()
+  @NotNull
+  public net.corda.core.cordapp.CordappProvider getCordappProvider()
+  @NotNull
+  public net.corda.core.node.services.IdentityService getIdentityService()
+  @NotNull
+  public net.corda.core.node.services.KeyManagementService getKeyManagementService()
+  @NotNull
+  public net.corda.core.node.NodeInfo getMyInfo()
+  @NotNull
+  public net.corda.core.node.services.NetworkMapCache getNetworkMapCache()
+  @NotNull
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public net.corda.core.node.services.NetworkParametersService getNetworkParametersService()
+  @NotNull
+  protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
+  @NotNull
+  public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
+  @NotNull
+  public net.corda.core.node.services.TransactionStorage getValidatedTransactions()
+  @NotNull
+  public net.corda.core.node.services.VaultService getVaultService()
+  @NotNull
+  public java.sql.Connection jdbcSession()
+  @NotNull
+  public net.corda.core.contracts.Attachment loadContractAttachment(net.corda.core.contracts.StateRef, String)
+  @NotNull
+  public net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
+  @NotNull
+  public java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public static final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public static final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public void recordTransactions(Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(net.corda.core.node.StatesToRecord, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  public void recordTransactions(boolean, Iterable<net.corda.core.transactions.SignedTransaction>)
+  public void recordTransactions(boolean, net.corda.core.transactions.SignedTransaction, net.corda.core.transactions.SignedTransaction...)
+  @NotNull
+  public Void registerUnloadHandler(kotlin.jvm.functions.Function0<kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, Iterable<? extends java.security.PublicKey>)
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
+  public void withEntityManager(java.util.function.Consumer<javax.persistence.EntityManager>)
+  @NotNull
+  public T withEntityManager(kotlin.jvm.functions.Function1<? super javax.persistence.EntityManager, ? extends T>)
+  public static final net.corda.testing.node.MockServices$Companion Companion
+##
+public static final class net.corda.testing.node.MockServices$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.Properties makeTestDataSourceProperties(String)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
+  @NotNull
+  public final kotlin.Pair<net.corda.nodeapi.internal.persistence.CordaPersistence, net.corda.testing.node.MockServices> makeTestDatabaseAndMockServices(java.util.List<String>, net.corda.core.node.services.IdentityService, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+##
+public final class net.corda.testing.node.MockServicesKt extends java.lang.Object
+  @NotNull
+  public static final T createMockCordaService(net.corda.testing.node.MockServices, kotlin.jvm.functions.Function1<? super net.corda.core.node.AppServiceHub, ? extends T>)
+  @NotNull
+  public static final net.corda.core.node.services.IdentityService makeTestIdentityService(net.corda.core.identity.PartyAndCertificate...)
+##
+public final class net.corda.testing.node.NodeTestUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> ledger(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.core.context.Actor testActor(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.core.context.InvocationContext testContext(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public static final net.corda.testing.dsl.LedgerDSL<net.corda.testing.dsl.TestTransactionDSLInterpreter, net.corda.testing.dsl.TestLedgerDSLInterpreter> transaction(net.corda.core.node.ServiceHub, net.corda.core.identity.Party, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+##
+public final class net.corda.testing.node.NotarySpec extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name component1()
+  public final boolean component2()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> component3()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType component4()
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec component5()
+  @NotNull
+  public final net.corda.testing.node.NotarySpec copy(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  public boolean equals(Object)
+  @Nullable
+  public final net.corda.testing.node.ClusterSpec getCluster()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final java.util.List<net.corda.testing.node.User> getRpcUsers()
+  public final boolean getValidating()
+  @NotNull
+  public final net.corda.testing.driver.VerifierType getVerifierType()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.node.StartedMockNode extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.TestStartedNode, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.util.List<kotlin.Pair<F, net.corda.core.concurrent.CordaFuture<?>>> findStateMachines(Class<F>)
+  public final int getId()
+  @NotNull
+  public final net.corda.core.node.NodeInfo getInfo()
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServices()
+  @Nullable
+  public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
+  @NotNull
+  public final rx.Observable<F> registerInitiatedFlow(Class<F>)
+  @NotNull
+  public final rx.Observable<F> registerInitiatedFlow(Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<F>)
+  @NotNull
+  public final net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
+  public final void stop()
+  public final T transaction(kotlin.jvm.functions.Function0<? extends T>)
+  public static final net.corda.testing.node.StartedMockNode$Companion Companion
+##
+public static final class net.corda.testing.node.StartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@ThreadSafe
+public final class net.corda.testing.node.TestClock extends net.corda.node.MutableClock
+  public <init>(java.time.Clock)
+  public final synchronized void advanceBy(java.time.Duration)
+  public final synchronized void setTo(java.time.Instant)
+##
+@DoNotImplement
+public abstract class net.corda.testing.node.TestCordapp extends java.lang.Object
+  public <init>()
+  @NotNull
+  public static final net.corda.testing.node.TestCordapp findCordapp(String)
+  @NotNull
+  public abstract java.util.Map<String, Object> getConfig()
+  @NotNull
+  public abstract net.corda.testing.node.TestCordapp withConfig(java.util.Map<String, ?>)
+  public static final net.corda.testing.node.TestCordapp$Companion Companion
+##
+public static final class net.corda.testing.node.TestCordapp$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.node.TestCordapp findCordapp(String)
+##
+public final class net.corda.testing.node.UnstartedMockNode extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.InternalMockNetwork$MockNode, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int getId()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode getStarted()
+  public final boolean isStarted()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode start()
+  public static final net.corda.testing.node.UnstartedMockNode$Companion Companion
+##
+public static final class net.corda.testing.node.UnstartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.testing.node.User extends java.lang.Object
+  public <init>(String, String, java.util.Set<String>)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final java.util.Set<String> component3()
+  @NotNull
+  public final net.corda.testing.node.User copy(String, String, java.util.Set<String>)
+  public boolean equals(Object)
+  @NotNull
+  public final String getPassword()
+  @NotNull
+  public final java.util.Set<String> getPermissions()
+  @NotNull
+  public final String getUsername()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public class net.corda.client.rpc.ConnectionFailureException extends net.corda.client.rpc.RPCException
+  public <init>()
+  public <init>(Throwable)
+  public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(java.util.List, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.identity.CordaX500Name)
+  public final A use(String, String, kotlin.jvm.functions.Function1<? super net.corda.client.rpc.CordaRPCConnection, ? extends A>)
+  public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
+##
+public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClient createWithSsl(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.core.messaging.ClientRpcSslOptions, net.corda.client.rpc.CordaRPCClientConfiguration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClient createWithSsl(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, net.corda.client.rpc.CordaRPCClientConfiguration)
+##
+public class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
+  public <init>()
+  public <init>(java.time.Duration)
+  public <init>(java.time.Duration, int)
+  public <init>(java.time.Duration, int, boolean)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final java.time.Duration component1()
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy()
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
+  public boolean equals(Object)
+  public int getCacheConcurrencyLevel()
+  @NotNull
+  public java.time.Duration getConnectionMaxRetryInterval()
+  @NotNull
+  public java.time.Duration getConnectionRetryInterval()
+  public double getConnectionRetryIntervalMultiplier()
+  @NotNull
+  public java.time.Duration getDeduplicationCacheExpiry()
+  public int getMaxFileSize()
+  public int getMaxReconnectAttempts()
+  public int getMinimumServerProtocolVersion()
+  public int getObservationExecutorPoolSize()
+  @NotNull
+  public java.time.Duration getReapInterval()
+  public boolean getTrackRpcCallSites()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
+  @NotNull
+  public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
+##
+public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
+  public <init>(net.corda.client.rpc.RPCConnection<? extends net.corda.core.messaging.CordaRPCOps>)
+  public void close()
+  public void forceClose()
+  @NotNull
+  public net.corda.core.messaging.CordaRPCOps getProxy()
+  public int getServerProtocolVersion()
+  public void notifyServerAndClose()
+##
+public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException implements net.corda.nodeapi.exceptions.RpcSerializableError, net.corda.core.ClientRelevantError
+  public <init>(String)
+##
+@DoNotImplement
+public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
+  public abstract void forceClose()
+  @NotNull
+  public abstract I getProxy()
+  public abstract int getServerProtocolVersion()
+  public abstract void notifyServerAndClose()
+##
+public class net.corda.client.rpc.RPCException extends net.corda.core.CordaRuntimeException
+  public <init>(String)
+  public <init>(String, Throwable)
+##
+public @interface net.corda.client.rpc.RPCSinceVersion
+  public abstract int version()
+##
+public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
+  public static final void notUsed(rx.Observable<T>)
+##
+public final class net.corda.finance.test.CashSchema extends java.lang.Object
+  public static final net.corda.finance.test.CashSchema INSTANCE
+##
+public final class net.corda.finance.test.SampleCashSchemaV1 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV1 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV1$PersistentCashState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(String, long, String, String, byte[])
+  @NotNull
+  public String getCurrency()
+  @NotNull
+  public String getIssuerPartyHash()
+  @NotNull
+  public byte[] getIssuerRef()
+  @NotNull
+  public String getOwnerHash()
+  public long getPennies()
+  public void setCurrency(String)
+  public void setIssuerPartyHash(String)
+  public void setIssuerRef(byte[])
+  public void setOwnerHash(String)
+  public void setPennies(long)
+##
+public final class net.corda.finance.test.SampleCashSchemaV2 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV2 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV2$PersistentCashState extends net.corda.core.schemas.CommonSchemaV1$FungibleState
+  public <init>()
+  public <init>(String, java.util.Set<? extends net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String getCurrency()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public void setCurrency(String)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+##
+public final class net.corda.finance.test.SampleCashSchemaV3 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV3 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV3$PersistentCashState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[])
+  public <init>(java.util.Set, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public String getCurrency()
+  @Nullable
+  public net.corda.core.identity.AbstractParty getIssuer()
+  @NotNull
+  public byte[] getIssuerRef()
+  @Nullable
+  public net.corda.core.identity.AbstractParty getOwner()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public long getPennies()
+  public void setCurrency(String)
+  public void setIssuer(net.corda.core.identity.AbstractParty)
+  public void setIssuerRef(byte[])
+  public void setOwner(net.corda.core.identity.AbstractParty)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setPennies(long)
+##
+public final class net.corda.testing.contracts.DummyContract extends java.lang.Object implements net.corda.core.contracts.Contract
+  public <init>()
+  public <init>(Object)
+  public <init>(Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final Object component1()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract copy(Object)
+  public boolean equals(Object)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @Nullable
+  public final Object getBlank()
+  @NotNull
+  public final String getPROGRAM_ID()
+  public int hashCode()
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public String toString()
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContract$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContract"
+##
+public static interface net.corda.testing.contracts.DummyContract$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContract$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContract$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContract$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContract$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
+##
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$MultiOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$MultiOwnerState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.testing.contracts.DummyContract$SingleOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State, net.corda.core.contracts.OwnableState
+  public <init>(int, net.corda.core.identity.AbstractParty)
+  public <init>(int, net.corda.core.identity.AbstractParty, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final net.corda.core.identity.AbstractParty component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContract$SingleOwnerState copy(int, net.corda.core.identity.AbstractParty)
+  public boolean equals(Object)
+  public int getMagicNumber()
+  @NotNull
+  public net.corda.core.identity.AbstractParty getOwner()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
+##
+@DoNotImplement
+public static interface net.corda.testing.contracts.DummyContract$State extends net.corda.core.contracts.ContractState
+  public abstract int getMagicNumber()
+##
+public final class net.corda.testing.contracts.DummyContractV2 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
+  public <init>()
+  @NotNull
+  public String getLegacyContract()
+  @NotNull
+  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+  @NotNull
+  public net.corda.testing.contracts.DummyContractV2$State upgrade(net.corda.testing.contracts.DummyContract$State)
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContractV2$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV2"
+##
+public static interface net.corda.testing.contracts.DummyContractV2$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV2$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContractV2$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.contracts.DummyContractV3 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
+  public <init>()
+  @NotNull
+  public String getLegacyContract()
+  @NotNull
+  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+  @NotNull
+  public net.corda.testing.contracts.DummyContractV3$State upgrade(net.corda.testing.contracts.DummyContractV2$State)
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContractV3$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV3"
+##
+public static interface net.corda.testing.contracts.DummyContractV3$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.contracts.DummyContractV3$State extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContractV3$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@BelongsToContract
+public final class net.corda.testing.contracts.DummyState extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>()
+  public <init>(int)
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int)
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.testing.core.DummyCommandData extends net.corda.core.contracts.TypeOnlyCommandData
+  public static final net.corda.testing.core.DummyCommandData INSTANCE
+##
+public final class net.corda.testing.core.Expect extends java.lang.Object
+  public <init>(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  @NotNull
+  public final Class<T> component1()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> component2()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> component3()
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> copy(Class<T>, kotlin.jvm.functions.Function1<? super T, Boolean>, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  public boolean equals(Object)
+  @NotNull
+  public final Class<T> getClazz()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, kotlin.Unit> getExpectClosure()
+  @NotNull
+  public final kotlin.jvm.functions.Function1<T, Boolean> getMatch()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public abstract class net.corda.testing.core.ExpectCompose extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Parallel extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getParallel()
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Sequential extends net.corda.testing.core.ExpectCompose
+  public <init>(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectCompose<E>> getSequence()
+##
+@DoNotImplement
+public static final class net.corda.testing.core.ExpectCompose$Single extends net.corda.testing.core.ExpectCompose
+  public <init>(net.corda.testing.core.Expect<? extends E, T>)
+  @NotNull
+  public final net.corda.testing.core.Expect<E, T> getExpect()
+##
+public static final class net.corda.testing.core.ExpectComposeState$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> fromExpectCompose(net.corda.testing.core.ExpectCompose<? extends E>)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Finished extends net.corda.testing.core.ExpectComposeState
+  public <init>()
+  @NotNull
+  public java.util.List<Class<E>> getExpectedEvents()
+  @Nullable
+  public Void nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Parallel extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Parallel<? extends E>, java.util.List<? extends net.corda.testing.core.ExpectComposeState<E>>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Parallel<E> getParallel()
+  @NotNull
+  public final java.util.List<net.corda.testing.core.ExpectComposeState<E>> getStates()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Sequential extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Sequential<? extends E>, int, net.corda.testing.core.ExpectComposeState<E>)
+  @NotNull
+  public java.util.List<Class<? extends E>> getExpectedEvents()
+  public final int getIndex()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Sequential<E> getSequential()
+  @NotNull
+  public final net.corda.testing.core.ExpectComposeState<E> getState()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public static final class net.corda.testing.core.ExpectComposeState$Single extends net.corda.testing.core.ExpectComposeState
+  public <init>(net.corda.testing.core.ExpectCompose$Single<? extends E, T>)
+  @NotNull
+  public java.util.List<Class<T>> getExpectedEvents()
+  @NotNull
+  public final net.corda.testing.core.ExpectCompose$Single<E, T> getSingle()
+  @Nullable
+  public kotlin.Pair<kotlin.jvm.functions.Function0<kotlin.Unit>, net.corda.testing.core.ExpectComposeState<E>> nextState(E)
+##
+public final class net.corda.testing.core.ExpectKt extends java.lang.Object
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> expect(Class<E>, kotlin.jvm.functions.Function1<? super E, Boolean>, kotlin.jvm.functions.Function1<? super E, kotlin.Unit>)
+  public static final void expectEvents(Iterable<? extends E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void expectEvents(rx.Observable<E>, boolean, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  public static final void genericExpectEvents(S, boolean, kotlin.jvm.functions.Function2<? super S, ? super kotlin.jvm.functions.Function1<? super E, kotlin.Unit>, kotlin.Unit>, kotlin.jvm.functions.Function0<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> parallel(net.corda.testing.core.ExpectCompose<? extends E>...)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> replicate(int, kotlin.jvm.functions.Function1<? super Integer, ? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(java.util.List<? extends net.corda.testing.core.ExpectCompose<? extends E>>)
+  @NotNull
+  public static final net.corda.testing.core.ExpectCompose<E> sequence(net.corda.testing.core.ExpectCompose<? extends E>...)
+##
+public final class net.corda.testing.core.SerializationEnvironmentRule extends java.lang.Object implements org.junit.rules.TestRule
+  public <init>()
+  public <init>(boolean)
+  public <init>(boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement, org.junit.runner.Description)
+  @NotNull
+  public final net.corda.core.serialization.SerializationFactory getSerializationFactory()
+  public static final net.corda.testing.core.SerializationEnvironmentRule$Companion Companion
+##
+public static final class net.corda.testing.core.SerializationEnvironmentRule$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.testing.core.TestConstants extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.contracts.Command<net.corda.core.contracts.TypeOnlyCommandData> dummyCommand(java.security.PublicKey...)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name ALICE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOB_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name BOC_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name CHARLIE_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_A_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_B_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_BANK_C_NAME
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name DUMMY_NOTARY_NAME
+  public static final int MAX_MESSAGE_SIZE = 10485760
+##
+public final class net.corda.testing.core.TestIdentity extends java.lang.Object
+  public <init>(net.corda.core.identity.CordaX500Name)
+  public <init>(net.corda.core.identity.CordaX500Name, long)
+  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme)
+  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public static final net.corda.testing.core.TestIdentity fresh(String)
+  @NotNull
+  public static final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
+  @NotNull
+  public final net.corda.core.identity.PartyAndCertificate getIdentity()
+  @NotNull
+  public final java.security.KeyPair getKeyPair()
+  @NotNull
+  public final net.corda.core.identity.CordaX500Name getName()
+  @NotNull
+  public final net.corda.core.identity.Party getParty()
+  @NotNull
+  public final java.security.PublicKey getPublicKey()
+  @NotNull
+  public final net.corda.core.contracts.PartyAndReference ref(byte...)
+  public static final net.corda.testing.core.TestIdentity$Companion Companion
+##
+public static final class net.corda.testing.core.TestIdentity$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.core.TestIdentity fresh(String)
+  @NotNull
+  public final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
+##
+public final class net.corda.testing.core.TestUtils extends java.lang.Object
+  @NotNull
+  public static final net.corda.core.utilities.NetworkHostAndPort freeLocalHostAndPort()
+  public static final int freePort()
+  @NotNull
+  public static final net.corda.core.contracts.StateRef generateStateRef()
+  @NotNull
+  public static final java.util.List<net.corda.core.utilities.NetworkHostAndPort> getFreeLocalPorts(String, int)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.Party)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name makeUnique(net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
+  @NotNull
+  public static final net.corda.core.identity.PartyAndCertificate singleIdentityAndCert(net.corda.core.node.NodeInfo)
+##
+public final class net.corda.testing.dsl.AttachmentResolutionException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash)
+##
+public final class net.corda.testing.dsl.DoubleSpentInputs extends net.corda.core.flows.FlowException
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+##
+public final class net.corda.testing.dsl.DuplicateOutputLabel extends net.corda.core.flows.FlowException
+  public <init>(String)
+##
+@DoNotImplement
+public abstract class net.corda.testing.dsl.EnforceVerifyOrFail extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+@DoNotImplement
+public static final class net.corda.testing.dsl.EnforceVerifyOrFail$Token extends net.corda.testing.dsl.EnforceVerifyOrFail
+  public static final net.corda.testing.dsl.EnforceVerifyOrFail$Token INSTANCE
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.LedgerDSL extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
+  public <init>(L, net.corda.core.identity.Party)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public final L getInterpreter()
+  @NotNull
+  public final S retrieveOutput(Class<S>, String)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(String, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction transaction(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public final void tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSL<? extends T, ? extends L>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction unverifiedTransaction(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.LedgerDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super T, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public abstract void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<? extends T>, kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super T, kotlin.Unit>)
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.OutputStateLookup
+  @NotNull
+  public abstract net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.TestLedgerDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.LedgerDSLInterpreter
+  public <init>(net.corda.core.node.ServiceHub)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _transaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TestTransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TestTransactionDSLInterpreter>, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.transactions.WireTransaction _unverifiedTransaction(String, net.corda.core.transactions.TransactionBuilder, kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TestTransactionDSLInterpreter, kotlin.Unit>)
+  @NotNull
+  public net.corda.core.crypto.SecureHash attachment(java.io.InputStream)
+  @NotNull
+  public final net.corda.core.node.ServiceHub component1()
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter copy(net.corda.core.node.ServiceHub, java.util.HashMap<String, net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>>, java.util.HashMap<net.corda.core.crypto.SecureHash, net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation>, java.util.HashMap<net.corda.core.crypto.SecureHash, net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public final net.corda.core.node.ServiceHub getServices()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getTransactionsToVerify()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getTransactionsUnverified()
+  @NotNull
+  public final java.util.List<net.corda.core.transactions.WireTransaction> getWireTransactions()
+  public int hashCode()
+  @Nullable
+  public final String outputToLabel(net.corda.core.contracts.ContractState)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  @NotNull
+  public String toString()
+  @Nullable
+  public final String transactionName(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+  public static final net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion Companion
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$TypeMismatch extends java.lang.Exception
+  public <init>(Class<?>, Class<?>)
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$VerifiesFailed extends java.lang.Exception
+  public <init>(String, Throwable)
+##
+public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation extends java.lang.Object
+  public <init>(String, net.corda.core.transactions.WireTransaction, String)
+  @Nullable
+  public final String component1()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction component2()
+  @Nullable
+  public final String component3()
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTransactionWithLocation copy(String, net.corda.core.transactions.WireTransaction, String)
+  public boolean equals(Object)
+  @Nullable
+  public final String getLabel()
+  @Nullable
+  public final String getLocation()
+  @NotNull
+  public final net.corda.core.transactions.WireTransaction getTransaction()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.TestTransactionDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter, net.corda.testing.dsl.OutputStateLookup
+  public <init>(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder)
+  public void _attachment(String)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public void attachment(net.corda.core.crypto.SecureHash)
+  public void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public final net.corda.testing.dsl.TestLedgerDSLInterpreter component1()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder component2()
+  @NotNull
+  public final net.corda.testing.dsl.TestTransactionDSLInterpreter copy(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder, java.util.HashMap<String, Integer>)
+  public boolean equals(Object)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public net.corda.testing.dsl.TestLedgerDSLInterpreter getLedgerInterpreter()
+  @NotNull
+  public final net.corda.core.node.ServicesForResolution getServices()
+  @NotNull
+  public final net.corda.core.transactions.TransactionBuilder getTransactionBuilder()
+  public int hashCode()
+  public void input(net.corda.core.contracts.StateRef)
+  public void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  public void reference(net.corda.core.contracts.StateRef)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  public void timeWindow(net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public String toString()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+@DoNotImplement
+public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter
+  public <init>(T, net.corda.core.identity.Party)
+  public void _attachment(String)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public final void attachment(String)
+  public final void attachment(String, net.corda.core.crypto.SecureHash)
+  public final void attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
+  public void attachment(net.corda.core.crypto.SecureHash)
+  public final void attachments(String...)
+  public final void command(java.security.PublicKey, net.corda.core.contracts.CommandData)
+  public void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
+  public final void input(String)
+  public final void input(String, String)
+  public final void input(String, net.corda.core.contracts.ContractState)
+  public void input(net.corda.core.contracts.StateRef)
+  public final void output(String, int, net.corda.core.contracts.ContractState)
+  public final void output(String, String, int, net.corda.core.contracts.ContractState)
+  public final void output(String, String, net.corda.core.contracts.ContractState)
+  public void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  public final void output(String, String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
+  public final void output(String, net.corda.core.contracts.ContractState)
+  public final void output(String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
+  public final void reference(String)
+  public final void reference(String, net.corda.core.contracts.ContractState)
+  public void reference(net.corda.core.contracts.StateRef)
+  @NotNull
+  public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  public final void timeWindow(java.time.Instant)
+  public final void timeWindow(java.time.Instant, java.time.Duration)
+  public void timeWindow(net.corda.core.contracts.TimeWindow)
+  @NotNull
+  public final net.corda.testing.dsl.EnforceVerifyOrFail tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSL<? extends net.corda.testing.dsl.TransactionDSLInterpreter>, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  @NotNull
+  public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.TransactionDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
+  public abstract void _attachment(String)
+  public abstract void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public abstract void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
+  public abstract void attachment(net.corda.core.crypto.SecureHash)
+  public abstract void command(java.util.List<? extends java.security.PublicKey>, net.corda.core.contracts.CommandData)
+  @NotNull
+  public abstract net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
+  public abstract void input(net.corda.core.contracts.StateRef)
+  public abstract void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  public abstract void reference(net.corda.core.contracts.StateRef)
+  public abstract void timeWindow(net.corda.core.contracts.TimeWindow)
+##
+@DoNotImplement
+public interface net.corda.testing.dsl.Verifies
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails()
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail fails with(String)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail failsWith(String)
+  @NotNull
+  public abstract net.corda.testing.dsl.EnforceVerifyOrFail verifies()
+##
+public final class net.corda.testing.http.HttpApi extends java.lang.Object
+  public <init>(java.net.URL, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(java.net.URL, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final com.fasterxml.jackson.databind.ObjectMapper getMapper()
+  @NotNull
+  public final java.net.URL getRoot()
+  public final void postJson(String, Object)
+  public final void postPlain(String, String)
+  public final void putJson(String, Object)
+  public static final net.corda.testing.http.HttpApi$Companion Companion
+##
+public static final class net.corda.testing.http.HttpApi$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.http.HttpApi fromHostAndPort(net.corda.core.utilities.NetworkHostAndPort, String, String, com.fasterxml.jackson.databind.ObjectMapper)
+##
+public final class net.corda.testing.http.HttpUtils extends java.lang.Object
+  @NotNull
+  public final com.fasterxml.jackson.databind.ObjectMapper getDefaultMapper()
+  public final void postJson(java.net.URL, String)
+  public final void postPlain(java.net.URL, String)
+  public final void putJson(java.net.URL, String)
+  public static final net.corda.testing.http.HttpUtils INSTANCE
+##
+public final class net.corda.testing.services.MockAttachmentStorage extends net.corda.core.serialization.SingletonSerializeAsToken implements net.corda.core.node.services.AttachmentStorage
+  public <init>()
+  @NotNull
+  public final kotlin.Pair<net.corda.core.crypto.SecureHash, byte[]> getAttachmentIdAndBytes(java.io.InputStream)
+  @Nullable
+  public net.corda.core.crypto.SecureHash getContractAttachmentWithHighestContractVersion(String, int)
+  @NotNull
+  public java.util.Set<net.corda.core.crypto.SecureHash> getContractAttachments(String)
+  @NotNull
+  public final java.util.Map<net.corda.core.crypto.SecureHash, kotlin.Pair<net.corda.core.contracts.Attachment, byte[]>> getFiles()
+  public boolean hasAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream, String, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public final void importContractAttachment(net.corda.core.crypto.SecureHash, net.corda.core.contracts.ContractAttachment)
+  @NotNull
+  public net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
+  @Nullable
+  public net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria)
+  @NotNull
+  public java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+##

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockNetwork.kt
@@ -37,6 +37,9 @@ import java.nio.file.Path
  * @property additionalCordapps [TestCordapp]s that will be added to this node in addition to the ones shared by all nodes, which get specified at [MockNetwork] level.
  */
 @Suppress("unused")
+// TODO sollecitom constructor `public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)` is gone.
+// TODO sollecitom constructor `public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, kotlin.jvm.functions.Function1, int, kotlin.jvm.internal.DefaultConstructorMarker)` is gone.
+// TODO sollecitom these are public API breaking changes.
 data class MockNodeParameters(
         val forcedID: Int? = null,
         val legalName: CordaX500Name? = null,
@@ -79,6 +82,8 @@ data class MockNodeParameters(
  * @property cordappsForAllNodes [TestCordapp]s added to all nodes.
  */
 @Suppress("unused")
+// TODO sollecitom constructor `public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)` is gone.
+// TODO sollecitom this is a public API breaking change.
 data class MockNetworkParameters(
         val networkSendManuallyPumped: Boolean = false,
         val threadPerNode: Boolean = false,
@@ -332,6 +337,8 @@ open class MockNetwork(
      * @param configOverrides Add/override the default configuration/behaviour of the node
      */
     @JvmOverloads
+    // TODO sollecitom used to be `net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)`.
+    // TODO sollecitom this is an API breaking change.
     fun createNode(legalName: CordaX500Name? = null,
                    forcedID: Int? = null,
                    entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),
@@ -354,6 +361,8 @@ open class MockNetwork(
      * @param configOverrides Add/override behaviour of the [NodeConfiguration] mock object.
      */
     @JvmOverloads
+    // TODO sollecitom used to be `public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, kotlin.jvm.functions.Function1<? super net.corda.node.services.config.NodeConfiguration, ?>)`.
+    // TODO sollecitom this is an API breaking change.
     fun createUnstartedNode(legalName: CordaX500Name? = null,
                             forcedID: Int? = null,
                             entropyRoot: BigInteger = BigInteger.valueOf(random63BitValue()),

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentRule.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/core/SerializationEnvironmentRule.kt
@@ -32,9 +32,13 @@ class SerializationEnvironmentRule(private val inheritable: Boolean = false) : T
                 }.whenever(it).execute(any())
             }
         }
+
+        // TODO sollecitom `public final T run(String, kotlin.jvm.functions.Function1<? super net.corda.core.serialization.internal.SerializationEnvironment, ? extends T>)` is gone. Do we care?
     }
 
     private lateinit var env: SerializationEnvironment
+
+    // TODO sollecitom `val checkpointContext: SerializationContext get() = ...`. Do we care?
 
     val serializationFactory: SerializationFactory get() = env.serializationFactory
 


### PR DESCRIPTION
For now, just flagging up issues with API and ABI between 4.0 SNAPSHOT as for the 09/01 and 3.3.
We should discuss and fix/ignore issues.

**Notes**:

- In StartedMockNode, constructor `public <init>(net.corda.node.internal.StartedNode)` is replaced by `public <init>(net.corda.testing.node.internal.TestStartedNode)` (incompatible, check). Private constructor and internal factory function -> OK.

- net.corda.core.node.services.vault.Builder, function `in`. Not sure why the API/ABI checker flags it up, seems legit.

- In ByteSequence, default constructor `public <init>(byte[], kotlin.jvm.internal.DefaultConstructorMarker)` is replaced by `public <init>(byte[], int, int, kotlin.jvm.internal.DefaultConstructorMarker)` (there's no other compatible constructor either). Also, functions `int getOffset()` and `int getSize()` were abstract and are now final. It's a sealed class, and it used to be as well, so this is a problem with the checker.

- In InMemoryMessagingNetwork$MockMessagingService, constructor `<init>(net.corda.testing.node.internal.InternalMockMessagingService)` is replaced by `<init>(net.corda.testing.node.internal.MockNodeMessagingService)` (the type was renamed). Private constructor and internal factory function -> OK.

**Test code ABI problems**: 

These are used by test source in CorDapps, meaning ABI is not an issue because tests are not ran against the Corda JAR.

- In `DriverParameters`, default constructor `public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)` is replaced by `public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)` (shouldn't be a problem because tests are not run through the JAR, check that the old constructor still exists).

- In `NodeParameters`, default constructor `public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, int, kotlin.jvm.internal.DefaultConstructorMarker)` is replaced by `public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)`(shouldn't be a problem because tests are not run through the JAR, check that the old constructor still exists).

**Notaries** (we whitelisted the breaking changes):

- In NotarisationRequest, function `void verifySignature(net.corda.core.flows.NotarisationRequestSignature, net.corda.core.identity.Party)` does not exist anymore.
- In NotaryFlow$Client, version 4.0 extends the internal type `BackpressureAwareTimedFlow`.
- NotaryFlow$Service is gone.
- NotaryInternalException is gone.
- TransactionParts is gone.
- NotaryService is gone.
- TrustedAuthorityNotaryService is gone.
- UniquenessException is gone.
- UniquenessProvider is gone.
