### PR TITLE
Updated docs on the need to load confidential-identities CorDapp separately

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -52,6 +52,9 @@ Version 4.0
 
 * Fixed a problem that was preventing `Cash.generateSpend` to be used more than once per transaction (https://github.com/corda/corda/issues/4110).
 
+* The experimental confidential-identities is now a separate CorDapp and must now be loaded onto the node alongside any CorDapp that needs it.
+  This also means your gradle dependency for it should be ``cordapp`` and not ``cordaCompile``.
+
 * ``SwapIdentitiesFlow``, from the experimental confidential-identities module, is now an inlined flow. Instead of passing in a ``Party`` with
   whom to exchange the anonymous identity, a ``FlowSession`` to that party is required instead. The flow running on the other side must
   also call ``SwapIdentitiesFlow``. This change was required as the previous API allowed any counterparty to generate anonoymous identities
@@ -62,8 +65,6 @@ Version 4.0
 
   .. note:: V3 and V4 of confidential-identities are not compatible and confidential-identities V3 will not work with a V4 Corda node. CorDapps
      in such scenarios using confidential-identities must be updated.
-
-  The ``confidential-identities`` dependency in your CorDapp must now be ``compile`` and not ``cordaCompile``.
 
 * Fixed a bug resulting in poor vault query performance and incorrect results when sorting.
 

--- a/docs/source/corda-api.rst
+++ b/docs/source/corda-api.rst
@@ -50,7 +50,7 @@ Corda incubating modules
 The following modules don't yet have a completely stable API, but we will do our best to minimise disruption to
 developers using them until we are able to graduate them into the public API:
 
-* **net.corda.confidential.identities**: experimental support for confidential identities on the ledger
+* **net.corda.confidential**: experimental support for confidential identities on the ledger
 * **net.corda.finance**: a range of elementary contracts (and associated schemas) and protocols, such as abstract fungible assets, cash, obligation and commercial paper
 * **net.corda.client.jfx**: support for Java FX UI
 * **net.corda.client.mock**: client mock utilities

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -287,7 +287,13 @@ The TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 family of ciphers is retired from the li
 as it is a legacy cipher family not supported by all native SSL/TLS implementations. We anticipate that this
 will have no impact on any deployed configurations.
 
-Miscelleneous changes
+Confidential identities
++++++++++++++++++++++++
+
+If any of your CorDapps use the experimental confidential-identities module then it also needs to be loaded as a separate CorDapp jar. This
+includes the demo finance CorDapp.
+
+Miscellaneous changes
 ~~~~~~~~~~~~~~~~~~~~~
 
 To learn more about smaller changes, please read the :doc:`changelog`.

--- a/samples/bank-of-corda-demo/build.gradle
+++ b/samples/bank-of-corda-demo/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     // The bank of corda CorDapp depends upon Cash CorDapp features
     cordapp project(':finance:contracts')
     cordapp project(':finance:workflows')
+    cordapp project(':confidential-identities')
 
     // Corda integration dependencies
     cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')
@@ -37,6 +38,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask, 
     nodeDefaults {
         cordapp project(':finance:workflows')
         cordapp project(':finance:contracts')
+        cordapp project(':confidential-identities')
     }
     node {
         name "O=Notary Service,L=Zurich,C=CH"

--- a/samples/trader-demo/build.gradle
+++ b/samples/trader-demo/build.gradle
@@ -25,14 +25,13 @@ dependencies {
     // The trader demo CorDapp depends upon Cash CorDapp features
     cordapp project(':finance:contracts')
     cordapp project(':finance:workflows')
+    cordapp project(':confidential-identities')
+    cordapp project(':samples:bank-of-corda-demo')
 
     // Corda integration dependencies
     cordaRuntime project(path: ":node:capsule", configuration: 'runtimeArtifacts')
     cordaRuntime project(path: ":webserver:webcapsule", configuration: 'runtimeArtifacts')
     cordaCompile project(':core')
-
-    // Corda Plugins: dependent flows and services
-    cordapp project(':samples:bank-of-corda-demo')
 
     testCompile project(':test-utils')
     testCompile "junit:junit:$junit_version"
@@ -43,9 +42,12 @@ def nodeTask = tasks.getByPath(':node:capsule:assemble')
 def webTask = tasks.getByPath(':webserver:webcapsule:assemble')
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask, webTask]) {
     ext.rpcUsers = [['username': "demo", 'password': "demo", 'permissions': ["ALL"]]]
-
+    nodeDefaults {
+        cordapp project(':finance:workflows')
+        cordapp project(':finance:contracts')
+        cordapp project(':confidential-identities')
+    }
     directory "./build/nodes"
-    // This name "Notary" is hard-coded into TraderDemoClientApi so if you change it here, change it there too.
     node {
         name "O=Notary Service,L=Zurich,C=CH"
         notary = [validating : true]
@@ -55,12 +57,10 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask, 
             adminAddress "localhost:10004"
         }
         extraConfig = ['h2Settings.address' : 'localhost:10014']
-        cordapps = ["$project.group:workflows:$corda_release_version", "$project.group:contracts:$corda_release_version"]
     }
     node {
         name "O=Bank A,L=London,C=GB"
         p2pPort 10005
-        cordapps = ["$project.group:workflows:$corda_release_version", "$project.group:contracts:$corda_release_version"]
         rpcUsers = ext.rpcUsers
         rpcSettings {
             address "localhost:10006"
@@ -71,7 +71,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask, 
     node {
         name "O=Bank B,L=New York,C=US"
         p2pPort 10008
-        cordapps = ["$project.group:workflows:$corda_release_version", "$project.group:contracts:$corda_release_version"]
         rpcUsers = ext.rpcUsers
         rpcSettings {
             address "localhost:10009"
@@ -82,7 +81,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask, 
     node {
         name "O=BankOfCorda,L=New York,C=US"
         p2pPort 10011
-        cordapps = ["$project.group:workflows:$corda_release_version", "$project.group:contracts:$corda_release_version"]
         rpcUsers = ext.rpcUsers
         rpcSettings {
             address "localhost:10012"
@@ -95,7 +93,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar', nodeTask, 
     node {
         name "O=LoggingBank,L=London,C=GB"
         p2pPort 10025
-        cordapps = ["$project.group:workflows:$corda_release_version", "$project.group:contracts:$corda_release_version"]
         rpcUsers = ext.rpcUsers
         rpcSettings {
             address "localhost:10026"


### PR DESCRIPTION
Also, updated the trader and BoC demos to include confidential-identities jar.


