### PR TITLE
Update Corda gradle plugins to 4.0.38

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.37
+gradlePluginsVersion=4.0.39-SNAPSHOT
 kotlinVersion=1.2.71
 # ***************************************************************#
 # When incrementing platformVersion make sure to update          #

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.39-SNAPSHOT
+gradlePluginsVersion=4.0.38
 kotlinVersion=1.2.71
 # ***************************************************************#
 # When incrementing platformVersion make sure to update          #

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -28,7 +28,7 @@ Alter the versions you depend on in your Gradle file like so:
 .. sourcecode:: groovy
 
     ext.corda_release_version = '4.0'
-    ext.corda_gradle_plugins_version = '4.0.37'
+    ext.corda_gradle_plugins_version = '4.0.38'
     ext.kotlin_version = '1.2.71'
     ext.quasar_version = '0.7.10'
 

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -140,13 +140,18 @@ To copy the same file to all nodes `ext.drivers` can be defined in the top level
 
 Signing Cordapp JARs
 ^^^^^^^^^^^^^^^^^^^^
-Cordform entry ``signing`` configures the signing of CorDapp JARs.
+The default behaviour of Cordform is to deploy CorDapp JARs "as built":
+
+ - prior to Corda 4 all CorDapp JARs were unsigned.
+ - as of Corda 4, CorDapp JARs are signed by a Corda development certificate by default.
+
+The Cordform ``signing`` entry can be used to override and customise the signing of CorDapp JARs.
 Signing the CorDapp enables its contract classes to use signature constraints instead of other types of the constraints :doc:`api-contract-constraints`.
-By default all CorDapp JARs are signed by Corda development certificate.
+
 The sign task may use an external keystore, or create a new one.
 The ``signing`` entry may contain the following parameters:
 
-* ``enabled`` the control flag to enable signing process, by default is set to ``true``, set to ``false`` to disable signing
+* ``enabled`` the control flag to enable signing process, by default is set to ``false``, set to ``true`` to enable signing
 * ``all`` if set to ``true`` (by default) all CorDapps inside *cordapp* subdirectory will be signed, otherwise if ``false`` then only the generated Cordapp will be signed
 * ``options`` any relevant parameters of `SignJar ANT task <https://ant.apache.org/manual/Tasks/signjar.html>`_ and `GenKey ANT task <https://ant.apache.org/manual/Tasks/genkey.html>`_,
   by default the JAR file is signed by Corda development key, the external keystore can be specified,

--- a/docs/source/generating-a-node.rst
+++ b/docs/source/generating-a-node.rst
@@ -143,7 +143,7 @@ Signing Cordapp JARs
 The default behaviour of Cordform is to deploy CorDapp JARs "as built":
 
  - prior to Corda 4 all CorDapp JARs were unsigned.
- - as of Corda 4, CorDapp JARs are signed by a Corda development certificate by default.
+ - as of Corda 4, CorDapp JARs created by the Gradle *cordapp* plugin are signed by a Corda development certificate by default.
 
 The Cordform ``signing`` entry can be used to override and customise the signing of CorDapp JARs.
 Signing the CorDapp enables its contract classes to use signature constraints instead of other types of the constraints :doc:`api-contract-constraints`.


### PR DESCRIPTION
Includes following changes:

* `cordformation`: deployNodes does not attempt to sign any JARs unless explicitly configured to do so using `signing.enabled = true`
* `cordapp`: enforce CorDapp `workflow` and `contract` version identifier metadata to be an integer.
* `cordapp`: relax cordapp metadata checking (warn on missing metadata rather than failing-fast).
   This allows multi-module structured CorDapps to only define metadata for flows and/or contracts modules.