### PR TITLE
Corda 2426 resolve pointers for regular states

### DIFF
--- a/core/src/test/kotlin/net/corda/core/internal/StatePointerSearchTests.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/StatePointerSearchTests.kt
@@ -1,0 +1,77 @@
+package net.corda.core.internal
+
+import net.corda.core.contracts.*
+import net.corda.core.crypto.NullKeys
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.utilities.OpaqueBytes
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class StatePointerSearchTests {
+
+    private val partyAndRef = PartyAndReference(AnonymousParty(NullKeys.NullPublicKey), OpaqueBytes.of(0))
+
+    private data class StateWithGeneric(val amount: Amount<Issued<LinearPointer<LinearState>>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithList(val pointerList: List<LinearPointer<LinearState>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithMap(val pointerMap: Map<Any, Any>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithSet(val pointerSet: Set<LinearPointer<LinearState>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithListOfList(val pointerSet: List<List<LinearPointer<LinearState>>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    @Test
+    fun `find pointer in state with generic type`() {
+        val linearPointer = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithGeneric(Amount(100L, Issued(partyAndRef, linearPointer)))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointer))
+    }
+
+    @Test
+    fun `find pointers which are inside a list`() {
+        val linearPointerOne = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val linearPointerTwo = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithList(listOf(linearPointerOne, linearPointerTwo))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointerOne, linearPointerTwo))
+    }
+
+    @Test
+    fun `find pointers which are inside a map`() {
+        val linearPointerOne = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val linearPointerTwo = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithMap(mapOf(linearPointerOne to 1, 2 to linearPointerTwo))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointerOne, linearPointerTwo))
+    }
+
+    @Test
+    fun `find pointers which are inside a set`() {
+        val linearPointer = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithSet(setOf(linearPointer))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointer))
+    }
+
+    @Test
+    fun `find pointers which are inside nested iterables`() {
+        val linearPointer = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithListOfList(listOf(listOf(linearPointer)))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointer))
+    }
+
+}

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
@@ -87,7 +87,7 @@ class ResolveStatePointersTest {
     @Test
     fun `resolving nested pointers is possible`() {
         // Create barOne.
-        createPointedToState(barOne)
+        val barOneStateAndRef = createPointedToState(barOne)
 
         // Create another Bar - barTwo - which points to barOne.
         val barTwoStateAndRef = createPointedToState(barTwo)
@@ -105,6 +105,7 @@ class ResolveStatePointersTest {
 
         // Check both Bar StateRefs have been added to the transaction.
         assertEquals(2, tx.referenceStates().size)
+        assertEquals(setOf(barOneStateAndRef.ref, barTwoStateAndRef.ref), tx.referenceStates().toSet())
     }
 
     @Test

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ComposableTypePropertySerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ComposableTypePropertySerializer.kt
@@ -4,8 +4,6 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.serialization.internal.model.*
 import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.codec.Data
-import java.lang.reflect.Method
-import java.lang.reflect.Field
 import java.lang.reflect.Type
 
 /**
@@ -124,53 +122,6 @@ class ComposableTypePropertySerializer(
                         isCalculated,
                         PropertyReadStrategy.make(name, typeIdentifier, type),
                         EvolutionPropertyWriteStrategy)
-    }
-}
-
-/**
- * Obtains the value of a property from an instance of the type to which that property belongs, either by calling a getter method
- * or by reading the value of a private backing field.
- */
-sealed class PropertyReader {
-
-    companion object {
-        /**
-         * Make a [PropertyReader] based on the provided [LocalPropertyInformation].
-         */
-        fun make(propertyInformation: LocalPropertyInformation) = when(propertyInformation) {
-            is LocalPropertyInformation.GetterSetterProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.ConstructorPairedProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.ReadOnlyProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.CalculatedProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.PrivateConstructorPairedProperty -> FieldReader(propertyInformation.observedField)
-        }
-    }
-
-    /**
-     * Get the value of the property from the supplied instance, or null if the instance is itself null.
-     */
-    abstract fun read(obj: Any?): Any?
-
-    /**
-     * Reads a property using a getter [Method].
-     */
-    class GetterReader(private val getter: Method): PropertyReader() {
-        init {
-            getter.isAccessible = true
-        }
-
-        override fun read(obj: Any?): Any? = if (obj == null) null else getter.invoke(obj)
-    }
-
-    /**
-     * Reads a property using a backing [Field].
-     */
-    class FieldReader(private val field: Field): PropertyReader() {
-        init {
-            field.isAccessible = true
-        }
-
-        override fun read(obj: Any?): Any? = if (obj == null) null else field.get(obj)
     }
 }
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/custom/ThrowableSerializer.kt
@@ -8,6 +8,7 @@ import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.amqp.*
 import net.corda.serialization.internal.model.LocalConstructorInformation
 import net.corda.serialization.internal.model.LocalTypeInformation
+import net.corda.serialization.internal.model.PropertyReader
 import java.io.NotSerializableException
 
 @KeepForDJVM

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/PropertyEnumerator.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/PropertyEnumerator.kt
@@ -1,0 +1,38 @@
+package net.corda.serialization.internal.model
+
+import net.corda.serialization.internal.amqp.LocalSerializerFactory
+import java.lang.reflect.Type
+
+data class PropertyEnumerator(private val readers: Map<String, PropertyReader>): (Any) -> Sequence<Pair<String, Any?>> {
+
+    companion object {
+        fun forType(typeInformation: LocalTypeInformation) =
+                PropertyEnumerator(typeInformation.propertiesOrEmptyMap.mapValues { (_, property) ->
+                    PropertyReader.make(property)
+                })
+    }
+
+    override fun invoke(value: Any): Sequence<Pair<String, Any?>> =
+            readers.asSequence().map { (name, reader) -> name to reader.read(value) }
+}
+
+class ObjectGraphTraverser(private val typeInformationProvider: (Type) -> LocalTypeInformation) {
+
+    constructor(factory: LocalSerializerFactory) : this(factory::getTypeInformation)
+
+    private val propertyEnumeratorCache = DefaultCacheProvider.createCache<TypeIdentifier, PropertyEnumerator>()
+    private val alreadySeen: MutableSet<Any> = mutableSetOf()
+
+    fun traverseGraph(value: Any?): Sequence<Any> {
+        if (value == null || value in alreadySeen) return emptySequence()
+
+        alreadySeen += value
+        val typeInformation = typeInformationProvider(value::class.java)
+
+        val converter = propertyEnumeratorCache.getOrPut(typeInformation.typeIdentifier) {
+            PropertyEnumerator.forType(typeInformation)
+        }
+
+        return converter(value).flatMap { (_, propertyValue) -> traverseGraph(propertyValue) } + sequenceOf(value)
+    }
+}

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/model/PropertyReader.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/model/PropertyReader.kt
@@ -1,0 +1,51 @@
+package net.corda.serialization.internal.model
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+/**
+ * Obtains the value of a property from an instance of the type to which that property belongs, either by calling a getter method
+ * or by reading the value of a private backing field.
+ */
+sealed class PropertyReader {
+
+    companion object {
+        /**
+         * Make a [PropertyReader] based on the provided [LocalPropertyInformation].
+         */
+        fun make(propertyInformation: LocalPropertyInformation) = when(propertyInformation) {
+            is LocalPropertyInformation.GetterSetterProperty -> GetterReader(propertyInformation.observedGetter)
+            is LocalPropertyInformation.ConstructorPairedProperty -> GetterReader(propertyInformation.observedGetter)
+            is LocalPropertyInformation.ReadOnlyProperty -> GetterReader(propertyInformation.observedGetter)
+            is LocalPropertyInformation.CalculatedProperty -> GetterReader(propertyInformation.observedGetter)
+            is LocalPropertyInformation.PrivateConstructorPairedProperty -> FieldReader(propertyInformation.observedField)
+        }
+    }
+
+    /**
+     * Get the value of the property from the supplied instance, or null if the instance is itself null.
+     */
+    abstract fun read(obj: Any?): Any?
+
+    /**
+     * Reads a property using a getter [Method].
+     */
+    class GetterReader(private val getter: Method): PropertyReader() {
+        init {
+            getter.isAccessible = true
+        }
+
+        override fun read(obj: Any?): Any? = if (obj == null) null else getter.invoke(obj)
+    }
+
+    /**
+     * Reads a property using a backing [Field].
+     */
+    class FieldReader(private val field: Field): PropertyReader() {
+        init {
+            field.isAccessible = true
+        }
+
+        override fun read(obj: Any?): Any? = if (obj == null) null else field.get(obj)
+    }
+}

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/PropertyEnumeratorTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/PropertyEnumeratorTests.kt
@@ -1,0 +1,50 @@
+package net.corda.serialization.internal.model
+
+import org.junit.Test
+import java.lang.reflect.Type
+import kotlin.test.assertEquals
+
+class PropertyEnumeratorTests {
+
+    private val configuration = object : LocalTypeModelConfiguration {
+        override fun isOpaque(type: Type): Boolean = false
+        override fun isExcluded(type: Type): Boolean = false
+    }
+
+    private val typeModel = ConfigurableLocalTypeModel(configuration)
+
+    @Test
+    fun traversesObjectGraphDepthFirst() {
+        data class Bottom(var value: Any?) {
+            override fun hashCode(): Int = when(value) {
+                is String -> value!!.hashCode()
+                else -> 0
+            }
+
+            override fun toString(): String = when(value) {
+                is String -> "Bottom($value)"
+                else -> "cycle"
+            }
+        }
+
+        data class Middle(val value: String, val bottomA: Bottom, val bottomB: Bottom)
+        data class Top(val value: String, val middleA: Middle, val middleB: Middle)
+
+        val bottomAA = Bottom("aa")
+        val bottomAB = Bottom("ab")
+        val bottomBA = Bottom("ba")
+        val bottomBB = Bottom(null)
+        val middleA = Middle("middle a", bottomAA, bottomAB)
+        val middleB = Middle("middle b", bottomBA, bottomBB)
+        val top = Top("top", middleA, middleB)
+
+        // create a cycle
+        bottomBB.value = top
+
+        val objectsInGraph = ObjectGraphTraverser(typeModel::inspect).traverseGraph(top).toList()
+        val expected = listOf(
+                "aa", bottomAA, "ab", bottomAB, "middle a", middleA, "ba", bottomBA, bottomBB, "middle b", middleB, "top", top)
+
+        assertEquals(expected, objectsInGraph)
+    }
+}


### PR DESCRIPTION
This fixes some of the bugs in state pointer search, see JIRA: https://r3-cev.atlassian.net/browse/CORDA-2426

Pointers are now searched for inside iterables and maps but this fix still doesn't search for state pointers inside computed properties.