### PR TITLE
CORDA-2426 Fixed bug in state pointer search.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/StatePointerSearch.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/StatePointerSearch.kt
@@ -26,9 +26,9 @@ class StatePointerSearch(val state: ContractState) {
     // Queue of fields to search.
     private val fieldQueue = ArrayDeque<FieldWithObject>().apply { addAllFields(state) }
 
-    private fun getAllFields(clazz: Class<*>, fields: List<Field> = emptyList()): List<Field> {
+    private fun getAllFields(clazz: Class<*>, fields: List<Field>): List<Field> {
         return if (clazz.superclass != null) {
-            getAllFields(clazz.superclass, fields + clazz.declaredFields)
+            getAllFields(clazz.superclass, fields + clazz.declaredFields.asList())
         } else {
             fields
         }
@@ -36,7 +36,7 @@ class StatePointerSearch(val state: ContractState) {
 
     // Helper for adding all fields to the queue.
     private fun ArrayDeque<FieldWithObject>.addAllFields(obj: Any) {
-        val fields = getAllFields(obj::class.java)
+        val fields = getAllFields(obj::class.java, emptyList())
 
         val fieldsWithObjects = fields.mapNotNull { field ->
             // Ignore classes which have not been loaded.

--- a/core/src/main/kotlin/net/corda/core/internal/StatePointerSearch.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/StatePointerSearch.kt
@@ -66,6 +66,7 @@ class StatePointerSearch(val state: ContractState) {
 
     private fun handleObject(obj: Any?) {
         if (obj == null) return
+        seenObjects.add(obj)
         when (obj) {
             is Map<*, *> -> handleMap(obj)
             is StatePointer<*> -> statePointers.add(obj)
@@ -81,7 +82,6 @@ class StatePointerSearch(val state: ContractState) {
     private fun handleField(obj: Any, field: Field) {
         val newObj = field.get(obj) ?: return
         if (newObj in seenObjects) return
-        seenObjects.add(obj)
         handleObject(newObj)
     }
 

--- a/core/src/main/kotlin/net/corda/core/internal/StatePointerSearch.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/StatePointerSearch.kt
@@ -11,7 +11,7 @@ import java.util.*
  */
 class StatePointerSearch(val state: ContractState) {
     // Classes in these packages should not be part of a search.
-    private val blackListedPackages = setOf("java.", "javax.", "org.bouncycastle", "org.hibernate")
+    private val blackListedPackages = setOf("java.", "javax.", "org.bouncycastle", "net.i2p.crypto")
 
     // Type required for traversal.
     private data class FieldWithObject(val obj: Any, val field: Field)

--- a/core/src/test/kotlin/net/corda/core/internal/StatePointerSearchTests.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/StatePointerSearchTests.kt
@@ -1,0 +1,77 @@
+package net.corda.core.internal
+
+import net.corda.core.contracts.*
+import net.corda.core.crypto.NullKeys
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.utilities.OpaqueBytes
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class StatePointerSearchTests {
+
+    private val partyAndRef = PartyAndReference(AnonymousParty(NullKeys.NullPublicKey), OpaqueBytes.of(0))
+
+    private data class StateWithGeneric(val amount: Amount<Issued<LinearPointer<LinearState>>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithList(val pointerList: List<LinearPointer<LinearState>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithMap(val pointerMap: Map<Any, Any>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithSet(val pointerSet: Set<LinearPointer<LinearState>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    private data class StateWithListOfList(val pointerSet: List<List<LinearPointer<LinearState>>>) : ContractState {
+        override val participants: List<AbstractParty> get() = listOf()
+    }
+
+    @Test
+    fun `find pointer in state with generic type`() {
+        val linearPointer = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithGeneric(Amount(100L, Issued(partyAndRef, linearPointer)))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointer))
+    }
+
+    @Test
+    fun `find pointers which are inside a list`() {
+        val linearPointerOne = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val linearPointerTwo = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithList(listOf(linearPointerOne, linearPointerTwo))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointerOne, linearPointerTwo))
+    }
+
+    @Test
+    fun `find pointers which are inside a map`() {
+        val linearPointerOne = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val linearPointerTwo = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithMap(mapOf(linearPointerOne to 1, 2 to linearPointerTwo))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointerOne, linearPointerTwo))
+    }
+
+    @Test
+    fun `find pointers which are inside a set`() {
+        val linearPointer = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithSet(setOf(linearPointer))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointer))
+    }
+
+    @Test
+    fun `find pointers which are inside nested iterables`() {
+        val linearPointer = LinearPointer(UniqueIdentifier(), LinearState::class.java)
+        val testState = StateWithListOfList(listOf(listOf(linearPointer)))
+        val results = StatePointerSearch(testState).search()
+        assertEquals(results, setOf(linearPointer))
+    }
+
+}

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ResolveStatePointersTest.kt
@@ -87,7 +87,7 @@ class ResolveStatePointersTest {
     @Test
     fun `resolving nested pointers is possible`() {
         // Create barOne.
-        createPointedToState(barOne)
+        val barOneStateAndRef = createPointedToState(barOne)
 
         // Create another Bar - barTwo - which points to barOne.
         val barTwoStateAndRef = createPointedToState(barTwo)
@@ -105,6 +105,7 @@ class ResolveStatePointersTest {
 
         // Check both Bar StateRefs have been added to the transaction.
         assertEquals(2, tx.referenceStates().size)
+        assertEquals(setOf(barOneStateAndRef.ref, barTwoStateAndRef.ref), tx.referenceStates().toSet())
     }
 
     @Test


### PR DESCRIPTION
This fixes some of the bugs in state pointer search, see JIRA: https://r3-cev.atlassian.net/browse/CORDA-2426

Pointers are now searched for inside iterables and maps but this fix still doesn't search for state pointers inside computed properties.

This code will just be used temporarily until Dominic has split all the basic type model stuff from serialisation to core but that won't happen until next week.