### PR TITLE
CORDA-2418: Fixed inability to use TestCordapp under gradle in Windows if referring to self cordapp

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/PathUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/PathUtils.kt
@@ -75,6 +75,9 @@ inline val Path.isReadable: Boolean get() = Files.isReadable(this)
 /** @see Files.size */
 inline val Path.size: Long get() = Files.size(this)
 
+/** @see Files.readAttributes */
+fun Path.attributes(vararg options: LinkOption): BasicFileAttributes = Files.readAttributes(this, BasicFileAttributes::class.java, *options)
+
 /** @see Files.getLastModifiedTime */
 fun Path.lastModifiedTime(vararg options: LinkOption): FileTime = Files.getLastModifiedTime(this, *options)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
@@ -78,13 +78,12 @@ data class TestCordappImpl(val scanPackage: String, override val config: Map<Str
         private fun buildCordappJar(projectRoot: Path): Path {
             return projectRootToBuiltJar.computeIfAbsent(projectRoot) {
                 val gradlew = findGradlewDir(projectRoot) / (if (SystemUtils.IS_OS_WINDOWS) "gradlew.bat" else "gradlew")
-                val libs = projectRoot / "build" / "libs"
-                libs.deleteRecursively()
                 log.info("Generating CorDapp jar from local project in $projectRoot ...")
                 val exitCode = ProcessBuilder(gradlew.toString(), "jar").directory(projectRoot.toFile()).inheritIO().start().waitFor()
-                check(exitCode == 0) { "Unable to generate CorDapp jar from local project in $projectRoot ($exitCode)" }
-                val jars = libs.list { it.filter { it.toString().endsWith(".jar") }.toList() }
-                checkNotNull(jars.singleOrNull()) { "Expecting a single built jar in $libs, but instead got $jars" }
+                check(exitCode == 0) { "Unable to generate CorDapp jar from local project in $projectRoot (exit=$exitCode)" }
+                val libs = projectRoot / "build" / "libs"
+                val jars = libs.list { it.filter { it.toString().endsWith(".jar") }.toList() }.sortedBy { it.attributes().creationTime() }
+                checkNotNull(jars.lastOrNull()) { "No jars were built in $libs" }
             }
         }
 


### PR DESCRIPTION
The gradle process that runs the tests keeps an exclusive hold on built jars in Windows, which means if a test wants to get hold of the CorDapp, and it's requested from the same module, it will fail. Now instead of deleting the "libs" dir we just use the latest created jar.
