### PR TITLE
[CORDA-2431] - Small refactorings following-up on PR-4551

### DIFF
--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -253,8 +253,8 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
  *  HA mode, the client will round-robin from the beginning of the list and try all servers.
 >>>>>>> Small refactorings following-up on PR-4551
  * @param classLoader a classloader, which will be used (if provided) to discover available [SerializationCustomSerializer]s and [SerializationWhitelist]s
- *  If the created RPC client is intended to use types with custom serializers / whitelists, a classloader will need to be provided that
- *  contains all these classes (i.e. a [URLClassLoader], containing the associated Cordapp jar)
+ *  If the created RPC client is intended to use types with custom serializers / whitelists,
+ *  a classloader will need to be provided that contains the associated CorDapp jars.
  */
 class CordaRPCClient private constructor(
         private val hostAndPort: NetworkHostAndPort?,

--- a/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
+++ b/client/rpc/src/main/kotlin/net/corda/client/rpc/CordaRPCClient.kt
@@ -245,13 +245,8 @@ open class CordaRPCClientConfiguration @JvmOverloads constructor(
  * @param configuration An optional configuration used to tweak client behaviour.
  * @param sslConfiguration An optional [ClientRpcSslOptions] used to enable secure communication with the server.
  * @param haAddressPool A list of [NetworkHostAndPort] representing the addresses of servers in HA mode.
-<<<<<<< HEAD
- * The client will attempt to connect to a live server by trying each address in the list. If the servers are not in
- * HA mode, the client will round-robin from the beginning of the list and try all servers.
-=======
  *  The client will attempt to connect to a live server by trying each address in the list. If the servers are not in
  *  HA mode, the client will round-robin from the beginning of the list and try all servers.
->>>>>>> Small refactorings following-up on PR-4551
  * @param classLoader a classloader, which will be used (if provided) to discover available [SerializationCustomSerializer]s and [SerializationWhitelist]s
  *  If the created RPC client is intended to use types with custom serializers / whitelists,
  *  a classloader will need to be provided that contains the associated CorDapp jars.

--- a/core-deterministic/testing/src/test/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
+++ b/core-deterministic/testing/src/test/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
@@ -3,6 +3,6 @@ package net.corda.core.internal
 /**
  * Stubbing out non-deterministic method.
  */
-fun <T: Any> loadClassesImplementing(classloader: ClassLoader, clazz: Class<T>): Set<T> {
+fun <T: Any> createInstancesOfClassesImplementing(classloader: ClassLoader, clazz: Class<T>): Set<T> {
     return emptySet()
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
@@ -2,7 +2,6 @@ package net.corda.core.internal
 
 import io.github.classgraph.ClassGraph
 import net.corda.core.StubOutForDJVM
-import kotlin.reflect.full.createInstance
 
 /**
  * Creates instances of all the classes in the classpath of the provided classloader, which implement the interface of the provided class.
@@ -17,15 +16,15 @@ import kotlin.reflect.full.createInstance
  * - either be a Kotlin object or have a constructor with no parameters (or only optional ones)
  */
 @StubOutForDJVM
-fun <T: Any> loadClassesImplementing(classloader: ClassLoader, clazz: Class<T>): Set<T> {
+fun <T: Any> createInstancesOfClassesImplementing(classloader: ClassLoader, clazz: Class<T>): Set<T> {
     return ClassGraph().addClassLoader(classloader)
             .enableClassInfo()
             .scan()
             .use {
                 it.getClassesImplementing(clazz.name)
                         .filterNot { it.isAbstract }
-                        .mapNotNull { classloader.loadClass(it.name).asSubclass(clazz) }
-                        .map { it.kotlin.objectInstance ?: it.kotlin.createInstance() }
+                        .map { classloader.loadClass(it.name).asSubclass(clazz) }
+                        .map { it.kotlin.objectOrNewInstance() }
                         .toSet()
             }
 }

--- a/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
@@ -28,3 +28,11 @@ fun <T: Any> createInstancesOfClassesImplementing(classloader: ClassLoader, claz
                         .toSet()
             }
 }
+
+fun <T: Any?> executeWithThreadContextClassLoader(classloader: ClassLoader, fn: () -> T): T {
+    val threadClassLoader = Thread.currentThread().contextClassLoader
+    Thread.currentThread().contextClassLoader = classloader
+    val result = fn()
+    Thread.currentThread().contextClassLoader = threadClassLoader
+    return result
+}

--- a/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
@@ -31,8 +31,11 @@ fun <T: Any> createInstancesOfClassesImplementing(classloader: ClassLoader, claz
 
 fun <T: Any?> executeWithThreadContextClassLoader(classloader: ClassLoader, fn: () -> T): T {
     val threadClassLoader = Thread.currentThread().contextClassLoader
-    Thread.currentThread().contextClassLoader = classloader
-    val result = fn()
-    Thread.currentThread().contextClassLoader = threadClassLoader
-    return result
+    try {
+        Thread.currentThread().contextClassLoader = classloader
+        return fn()
+    } finally {
+        Thread.currentThread().contextClassLoader = threadClassLoader
+    }
+
 }

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -2,7 +2,7 @@ package net.corda.core.serialization.internal
 
 import net.corda.core.CordaException
 import net.corda.core.KeepForDJVM
-import net.corda.core.internal.loadClassesImplementing
+import net.corda.core.internal.createInstancesOfClassesImplementing
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.TransactionVerificationException.OverlappingAttachmentsException
@@ -11,7 +11,6 @@ import net.corda.core.crypto.sha256
 import net.corda.core.internal.*
 import net.corda.core.internal.cordapp.targetPlatformVersion
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.serialization.MissingAttachmentsException
 import net.corda.core.serialization.SerializationCustomSerializer
 import net.corda.core.serialization.SerializationFactory
 import net.corda.core.serialization.SerializationWhitelist
@@ -196,7 +195,7 @@ internal object AttachmentsClassLoaderBuilder {
         val serializationContext = cache.computeIfAbsent(attachmentIds) {
             // Create classloader and load serializers, whitelisted classes
             val transactionClassLoader = AttachmentsClassLoader(attachments)
-            val serializers = loadClassesImplementing(transactionClassLoader, SerializationCustomSerializer::class.java)
+            val serializers = createInstancesOfClassesImplementing(transactionClassLoader, SerializationCustomSerializer::class.java)
             val whitelistedClasses = ServiceLoader.load(SerializationWhitelist::class.java, transactionClassLoader)
                     .flatMap { it.whitelist }
                     .toList()

--- a/core/src/test/kotlin/net/corda/core/internal/ClassLoadingUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ClassLoadingUtilsTest.kt
@@ -18,7 +18,7 @@ class ClassLoadingUtilsTest {
 
     @Test
     fun predicateClassAreLoadedSuccessfully() {
-        val classes = loadClassesImplementing(BaseInterface::class.java.classLoader, BaseInterface::class.java)
+        val classes = createInstancesOfClassesImplementing(BaseInterface::class.java.classLoader, BaseInterface::class.java)
 
         val classNames = classes.map { it.javaClass.name }
 
@@ -28,7 +28,7 @@ class ClassLoadingUtilsTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun throwsExceptionWhenClassDoesNotContainProperConstructors() {
-        val classes = loadClassesImplementing(BaseInterface::class.java.classLoader, BaseInterface2::class.java)
+        val classes = createInstancesOfClassesImplementing(BaseInterface::class.java.classLoader, BaseInterface2::class.java)
     }
 
 }

--- a/core/src/test/kotlin/net/corda/core/internal/ClassLoadingUtilsTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ClassLoadingUtilsTest.kt
@@ -1,10 +1,15 @@
 package net.corda.core.internal
 
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import java.lang.IllegalArgumentException
+import java.lang.RuntimeException
 
 class ClassLoadingUtilsTest {
+
+    private val temporaryClassLoader = mock<ClassLoader>()
 
     interface BaseInterface {}
 
@@ -29,6 +34,26 @@ class ClassLoadingUtilsTest {
     @Test(expected = IllegalArgumentException::class)
     fun throwsExceptionWhenClassDoesNotContainProperConstructors() {
         val classes = createInstancesOfClassesImplementing(BaseInterface::class.java.classLoader, BaseInterface2::class.java)
+    }
+
+    @Test
+    fun `thread context class loader is adjusted, during the function execution`() {
+        val result = executeWithThreadContextClassLoader(temporaryClassLoader) {
+            assertThat(Thread.currentThread().contextClassLoader).isEqualTo(temporaryClassLoader)
+            true
+        }
+
+        assertThat(result).isTrue()
+        assertThat(Thread.currentThread().contextClassLoader).isNotEqualTo(temporaryClassLoader)
+    }
+
+    @Test
+    fun `thread context class loader is set to the initial, even in case of a failure`() {
+        assertThatThrownBy { executeWithThreadContextClassLoader(temporaryClassLoader) {
+            throw RuntimeException()
+        } }.isInstanceOf(RuntimeException::class.java)
+
+        assertThat(Thread.currentThread().contextClassLoader).isNotEqualTo(temporaryClassLoader)
     }
 
 }

--- a/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ThreadContextAdjustingRpcOpsProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/ThreadContextAdjustingRpcOpsProxy.kt
@@ -1,0 +1,29 @@
+package net.corda.node.internal.rpc.proxies
+
+import net.corda.core.internal.executeWithThreadContextClassLoader
+import net.corda.core.messaging.CordaRPCOps
+import net.corda.node.internal.InvocationHandlerTemplate
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+/**
+ * A [CordaRPCOps] proxy that adjusts the thread context's class loader temporarily on every invocation with the provided classloader.
+ * As an example, this can be used to work-around cases, where 3rd party libraries prioritise the thread context's class loader over the current one,
+ * without sensible fallbacks to the classloader of the current instance.
+ * If clients' CorDapps use one of these libraries, this temporary adjustment can ensure that any provided classes from these libraries will be available during RPC calls.
+ */
+internal class ThreadContextAdjustingRpcOpsProxy(private val delegate: CordaRPCOps, private val classLoader: ClassLoader): CordaRPCOps by proxy(delegate, classLoader) {
+    private companion object {
+        private fun proxy(delegate: CordaRPCOps, classLoader: ClassLoader): CordaRPCOps {
+            val handler = ThreadContextAdjustingRpcOpsProxy.ThreadContextAdjustingInvocationHandler(delegate, classLoader)
+            return Proxy.newProxyInstance(delegate::class.java.classLoader, arrayOf(CordaRPCOps::class.java), handler) as CordaRPCOps
+        }
+    }
+
+    private class ThreadContextAdjustingInvocationHandler(override val delegate: CordaRPCOps, private val classLoader: ClassLoader) : InvocationHandlerTemplate {
+        override fun invoke(proxy: Any, method: Method, arguments: Array<out Any?>?): Any? {
+            return executeWithThreadContextClassLoader(this.classLoader) { super.invoke(proxy, method, arguments) }
+        }
+    }
+
+}

--- a/node/src/test/kotlin/net/corda/node/internal/rpc/proxies/ThreadContextAdjustingRpcOpsProxyTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/rpc/proxies/ThreadContextAdjustingRpcOpsProxyTest.kt
@@ -1,0 +1,32 @@
+package net.corda.node.internal.rpc.proxies
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.messaging.CordaRPCOps
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.Mockito.`when`
+
+class ThreadContextAdjustingRpcOpsProxyTest {
+
+    private val coreOps = mock<InstrumentedCordaRPCOps>()
+    private val mockClassloader = mock<ClassLoader>()
+    private val proxy = ThreadContextAdjustingRpcOpsProxy(coreOps, mockClassloader)
+
+
+    private interface InstrumentedCordaRPCOps: CordaRPCOps {
+        fun getThreadContextClassLoader(): ClassLoader = Thread.currentThread().contextClassLoader
+    }
+
+    @Test
+    fun verifyThreadContextIsAdjustedTemporarily() {
+        `when`(coreOps.killFlow(any())).thenAnswer {
+            assertThat(Thread.currentThread().contextClassLoader).isEqualTo(mockClassloader)
+            true
+        }
+
+        val result = proxy.killFlow(StateMachineRunId.createRandom())
+        assertThat(Thread.currentThread().contextClassLoader).isNotEqualTo(mockClassloader)
+    }
+}

--- a/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencySerializer.kt
+++ b/samples/simm-valuation-demo/contracts-states/src/main/kotlin/net/corda/vega/plugin/customserializers/CurrencySerializer.kt
@@ -7,24 +7,6 @@ import net.corda.core.serialization.SerializationCustomSerializer
 class CurrencySerializer : SerializationCustomSerializer<Currency, CurrencySerializer.Proxy> {
     data class Proxy(val currency: String)
 
-    override fun fromProxy(proxy: Proxy): Currency {
-        return withCurrentClassLoader { Currency.parse(proxy.currency) }
-    }
+    override fun fromProxy(proxy: Proxy): Currency = Currency.parse(proxy.currency)
     override fun toProxy(obj: Currency) = Proxy(obj.toString())
-
-    /**
-     * The initialization of [Currency] uses the classpath to identify needed resources.
-     * However, it gives priority to the classloader in the thread context over the one this class was loaded with.
-     * See: [com.opengamma.strata.collect.io.ResourceLocator.classLoader]
-     *
-     * This is the reason we temporarily override the class loader in the thread context here, with the classloader of this
-     * class, which is guaranteed to contain everything in the 3rd party library's classpath.
-     */
-    private fun withCurrentClassLoader(serializationFunction: () -> Currency): Currency {
-        val threadClassLoader = Thread.currentThread().contextClassLoader
-        Thread.currentThread().contextClassLoader = this.javaClass.classLoader
-        val result =serializationFunction()
-        Thread.currentThread().contextClassLoader = threadClassLoader
-        return result
-    }
 }


### PR DESCRIPTION
## Changes
This addresses the remaining comments from https://github.com/corda/corda/pull/4551, which was merged to expedite RC testing. It's mainly refactorings + a fix of a Kotlin-only ABI breakage.

## Testing
For the API breakage, I run `./gradlew generateApi`, using the enhanced version of api-scanner, making sure that the breakage was reported and removed after the fix.
