### PR TITLE
Moves Contrib and Network sections up in index. Makes requesting a contribution more prominent.

### DIFF
--- a/docs/source/contributing-philosophy.rst
+++ b/docs/source/contributing-philosophy.rst
@@ -44,8 +44,12 @@ Community maintainers
 ^^^^^^^^^^^^^^^^^^^^^
 Current community maintainers:
 
-* `Joel Dudley <https://github.com/joeldudleyr3>`_ - Contact via the `Corda Slack team <http://slack.corda.net/>`_, either in the
-  ``#community`` channel or via direct message using the handle ``@joel``
+* `Joel Dudley <https://github.com/joeldudleyr3>`_ - Contact me:
+
+    * On the `Corda Slack team <http://slack.corda.net/>`_, either in the ``#community`` channel or by direct message using the handle
+      ``@joel``
+
+    * By email: joel.dudley at r3.com
 
 We anticipate additional maintainers joining the project in the future from across the community.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -7,10 +7,10 @@ Identifying an area to contribute
 ---------------------------------
 There are several ways to identify an area where you can contribute to Corda:
 
-* The easiest is just to drop a message to one of the :ref:`Community Maintainers <community-maintainers>` in Slack saying "I want to
-  help!". We'll work together to find a place for you to contribute
+* The easiest is just to message one of the :ref:`Community Maintainers <community-maintainers>` saying "I want to help!". They'll work
+  with you to find an area for you to contribute
 
-* If you have a specific contribution you would like to make, confirm whether the contribution is appropriate first by reaching out in the
+* If you have a specific contribution in mind, confirm whether the contribution is appropriate first by reaching out in the
   ``#contributing`` channel of the `Corda Slack <http://slack.corda.net/>`_ or contacting one of the
   :ref:`Community Maintainers <community-maintainers>` directly
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -3,6 +3,22 @@ How to contribute
 
 .. contents::
 
+Identifying an area to contribute
+---------------------------------
+There are several ways to identify an area where you can contribute to Corda:
+
+* The easiest is just to drop a message to one of the :ref:`Community Maintainers <community-maintainers>` in Slack saying "I want to
+  help!". We'll work together to find a place for you to contribute
+
+* If you have a specific contribution you would like to make, confirm whether the contribution is appropriate first by reaching out in the
+  ``#contributing`` channel of the `Corda Slack <http://slack.corda.net/>`_ or contacting one of the
+  :ref:`Community Maintainers <community-maintainers>` directly
+
+* If you do not have a specific contribution in mind, you can also browse the issues labelled as ``help wanted`` on the
+  `Corda GitHub issues <https://github.com/corda/corda/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_ page
+
+  * Issues that additionally have the ``good first issue`` label are considered ideal for first-timers
+
 Contribution guidelines
 -----------------------
 We believe one of the things that makes Corda special is its coherent design and we seek to retain this defining characteristic. From the
@@ -26,19 +42,6 @@ outset we defined some guidelines to ensure new contributions only ever enhance 
   features at any given time. To avoid surprises and foster transparency,
   `our Jira work tracking system is public <https://r3-cev.atlassian.net/projects/CORDA/summary>`_. If in doubt, reach out to one of the
   :ref:`Community Maintainers <community-maintainers>`
-
-Identifying an area to contribute
----------------------------------
-There are two ways to identify an area where you can contribute to Corda:
-
-* If there is a specific contribution you would like to make, you should first confirm whether the contribution is appropriate by reaching
-  out in the ``#contributing`` channel of the `Corda Slack <http://slack.corda.net/>`_ or contacting one of the
-  :ref:`Community Maintainers <community-maintainers>` directly
-
-* If you do not have a specific contribution in mind, you can browse issues labelled as ``help wanted`` in the
-  `Corda GitHub Issues <https://github.com/corda/corda/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_
-
-  * Issues that additionally have the ``good first issue`` label are considered ideal for first-timers
 
 Making the required changes
 ---------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,23 @@ We look forward to seeing what you can do with Corda!
    changelog.rst
 
 .. conditional-toctree::
+   :caption: Participate
+   :maxdepth: 2
+   :if_tag: htmlmode
+
+   contributing-index.rst
+   corda-repo-layout.rst
+   deterministic-modules.rst
+   changelog
+
+.. conditional-toctree::
+   :caption: Corda Network
+   :maxdepth: 2
+   :if_tag: htmlmode
+
+   corda-network/index.md
+
+.. conditional-toctree::
    :caption: Design docs
    :maxdepth: 2
    :if_tag: htmlmode
@@ -90,20 +107,3 @@ We look forward to seeing what you can do with Corda!
    design/data-model-upgrades/signature-constraints.md
    design/data-model-upgrades/package-namespace-ownership.md
    design/targetversion/design.md
-
-.. conditional-toctree::
-   :caption: Participate
-   :maxdepth: 2
-   :if_tag: htmlmode
-   
-   contributing-index.rst
-   corda-repo-layout.rst
-   deterministic-modules.rst
-   changelog
-
-.. conditional-toctree::
-   :caption: Corda Network
-   :maxdepth: 2
-   :if_tag: htmlmode
-
-   corda-network/index.md


### PR DESCRIPTION
The contributing section of the docs is buried currently. It also wasn't clear from the section about finding an area to contribute that you could just reach out to a maintainer.