### PR TITLE
[CORDA-2431] - Reduce memory footprint of classpath scanning

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
@@ -1,8 +1,6 @@
 package net.corda.core.internal
 
 import io.github.classgraph.ClassGraph
-import net.corda.core.CordaInternal
-import net.corda.core.DeleteForDJVM
 import net.corda.core.StubOutForDJVM
 import kotlin.reflect.full.createInstance
 
@@ -21,7 +19,7 @@ import kotlin.reflect.full.createInstance
 @StubOutForDJVM
 fun <T: Any> loadClassesImplementing(classloader: ClassLoader, clazz: Class<T>): Set<T> {
     return ClassGraph().addClassLoader(classloader)
-            .enableAllInfo()
+            .enableClassInfo()
             .scan()
             .getClassesImplementing(clazz.name)
             .filterNot { it.isAbstract }

--- a/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ClassLoadingUtils.kt
@@ -21,9 +21,11 @@ fun <T: Any> loadClassesImplementing(classloader: ClassLoader, clazz: Class<T>):
     return ClassGraph().addClassLoader(classloader)
             .enableClassInfo()
             .scan()
-            .getClassesImplementing(clazz.name)
-            .filterNot { it.isAbstract }
-            .mapNotNull { classloader.loadClass(it.name).asSubclass(clazz) }
-            .map { it.kotlin.objectInstance ?: it.kotlin.createInstance() }
-            .toSet()
+            .use {
+                it.getClassesImplementing(clazz.name)
+                        .filterNot { it.isAbstract }
+                        .mapNotNull { classloader.loadClass(it.name).asSubclass(clazz) }
+                        .map { it.kotlin.objectInstance ?: it.kotlin.createInstance() }
+                        .toSet()
+            }
 }

--- a/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
+++ b/samples/attachment-demo/src/integration-test/kotlin/net/corda/attachmentdemo/AttachmentDemoTest.kt
@@ -23,7 +23,7 @@ class AttachmentDemoTest {
                     startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = demoUser, maximumHeapSize = "1g"),
                     startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = demoUser, maximumHeapSize = "1g")
             ).map { it.getOrThrow() }
-            val webserverHandle = startWebserver(nodeB, "1g").getOrThrow()
+            val webserverHandle = startWebserver(nodeB).getOrThrow()
 
             val senderThread = supplyAsync {
                 CordaRPCClient(nodeA.rpcAddress).start(demoUser[0].username, demoUser[0].password).use {

--- a/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
+++ b/samples/irs-demo/cordapp/src/main/kotlin/net/corda/irs/flows/FixingFlow.kt
@@ -63,7 +63,7 @@ object FixingFlow {
 
                     // We set the transaction's time-window: it may be that none of the contracts need this!
                     // But it can't hurt to have one.
-                    ptx.setTimeWindow(serviceHub.clock.instant(), 60.seconds)
+                    ptx.setTimeWindow(serviceHub.clock.instant(), 30.seconds)
                 }
 
                 @Suspendable

--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -54,14 +54,13 @@ class SimmValuationTest {
         assertThat(logConfigFile).isRegularFile()
         driver(DriverParameters(isDebug = true,
                 cordappsForAllNodes = listOf(findCordapp("net.corda.vega.flows"), findCordapp("net.corda.vega.contracts"), findCordapp("net.corda.confidential")) + FINANCE_CORDAPPS,
-                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()),
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, maximumHeapSize = "1g")))
+                systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()))
         ) {
-            val nodeAFuture = startNode(providedName = nodeALegalName, maximumHeapSize = "1g")
-            val nodeBFuture = startNode(providedName = nodeBLegalName, maximumHeapSize = "1g")
+            val nodeAFuture = startNode(providedName = nodeALegalName)
+            val nodeBFuture = startNode(providedName = nodeBLegalName)
             val (nodeA, nodeB) = listOf(nodeAFuture, nodeBFuture).map { it.getOrThrow() }
-            val nodeAWebServerFuture = startWebserver(nodeA, "1g")
-            val nodeBWebServerFuture = startWebserver(nodeB, "1g")
+            val nodeAWebServerFuture = startWebserver(nodeA)
+            val nodeBWebServerFuture = startWebserver(nodeB)
             val nodeAApi = HttpApi.fromHostAndPort(nodeAWebServerFuture.getOrThrow().listenAddress, "api/simmvaluationdemo")
             val nodeBApi = HttpApi.fromHostAndPort(nodeBWebServerFuture.getOrThrow().listenAddress, "api/simmvaluationdemo")
             val nodeBParty = getPartyWithName(nodeAApi, nodeBLegalName)

--- a/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
+++ b/samples/trader-demo/src/integration-test/kotlin/net/corda/traderdemo/TraderDemoTest.kt
@@ -37,13 +37,12 @@ class TraderDemoTest {
         driver(DriverParameters(
                 startNodesInProcess = true,
                 inMemoryDB = false,
-                cordappsForAllNodes = FINANCE_CORDAPPS + TestCordapp.findCordapp("net.corda.traderdemo"),
-                notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, maximumHeapSize = "1g"))
+                cordappsForAllNodes = FINANCE_CORDAPPS + TestCordapp.findCordapp("net.corda.traderdemo")
         )) {
             val (nodeA, nodeB, bankNode) = listOf(
-                    startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser), maximumHeapSize = "1g"),
-                    startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = listOf(demoUser), maximumHeapSize = "1g"),
-                    startNode(providedName = BOC_NAME, rpcUsers = listOf(bankUser), maximumHeapSize = "1g")
+                    startNode(providedName = DUMMY_BANK_A_NAME, rpcUsers = listOf(demoUser)),
+                    startNode(providedName = DUMMY_BANK_B_NAME, rpcUsers = listOf(demoUser)),
+                    startNode(providedName = BOC_NAME, rpcUsers = listOf(bankUser))
             ).map { (it.getOrThrow() as InProcess) }
 
             val (nodeARpc, nodeBRpc) = listOf(nodeA, nodeB).map {

--- a/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt
+++ b/webserver/src/integration-test/kotlin/net/corda/webserver/WebserverDriverTests.kt
@@ -31,7 +31,7 @@ class WebserverDriverTests {
     fun `starting a node and independent web server works`() {
         val addr = driver(DriverParameters(notarySpecs = emptyList())) {
             val node = startNode(providedName = DUMMY_BANK_A_NAME).getOrThrow()
-            val webserverHandle = startWebserver(node, "512m").getOrThrow()
+            val webserverHandle = startWebserver(node).getOrThrow()
             webserverMustBeUp(webserverHandle)
             webserverHandle.listenAddress
         }


### PR DESCRIPTION
### Changes
This change switches from enabling all info to only class info during class loading to reduce the memory footprint. 

### Testing
I also switched all the affected tests back to their previous defaults and run them locally, they all passed.