### PR TITLE
[CORDA-2441] Fix Stdout progress renderer to swap out correct appender

### DIFF
--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -250,7 +250,12 @@ object StdoutANSIProgressRenderer : ANSIProgressRenderer() {
             // than doing things the official way with a dedicated plugin, etc, as it avoids mucking around with all
             // the config XML and lifecycle goop.
             val manager = LogManager.getContext(false) as LoggerContext
-            val consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().single { it.name == "Console-Selector" }
+            val consoleAppender: ConsoleAppender
+            try {
+                consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().single { it.name == "Console-Selector" }
+            } catch (e: java.util.NoSuchElementException) {
+                throw AppenderNotFoundException("Failed to find Console-Selector appender - cannot display flow progress", e)
+            }
             val scrollingAppender = object : AbstractOutputStreamAppender<OutputStreamManager>(
                     consoleAppender.name, consoleAppender.layout, consoleAppender.filter,
                     consoleAppender.ignoreExceptions(), true, consoleAppender.manager) {
@@ -296,3 +301,5 @@ object StdoutANSIProgressRenderer : ANSIProgressRenderer() {
         System.out.flush()
     }
 }
+
+class AppenderNotFoundException(override val message: String?, override val cause: Throwable? = null): Exception()

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -2,6 +2,8 @@ package net.corda.tools.shell.utlities
 
 import net.corda.core.internal.Emoji
 import net.corda.core.messaging.FlowProgressHandle
+import net.corda.core.utilities.contextLogger
+import net.corda.core.utilities.loggerFor
 import org.apache.commons.lang.SystemUtils
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LogEvent
@@ -14,6 +16,7 @@ import org.fusesource.jansi.Ansi
 import org.fusesource.jansi.Ansi.Attribute
 import org.fusesource.jansi.AnsiConsole
 import org.fusesource.jansi.AnsiOutputStream
+import org.slf4j.LoggerFactory
 import rx.Subscription
 
 abstract class ANSIProgressRenderer {
@@ -250,11 +253,11 @@ object StdoutANSIProgressRenderer : ANSIProgressRenderer() {
             // than doing things the official way with a dedicated plugin, etc, as it avoids mucking around with all
             // the config XML and lifecycle goop.
             val manager = LogManager.getContext(false) as LoggerContext
-            val consoleAppender: ConsoleAppender
-            try {
-                consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().single { it.name == "Console-Selector" }
-            } catch (e: java.util.NoSuchElementException) {
-                throw AppenderNotFoundException("Failed to find Console-Selector appender - cannot display flow progress", e)
+            val consoleAppender: ConsoleAppender?
+            consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().singleOrNull { it.name == "Console-Selector" }
+            if (consoleAppender == null) {
+                loggerFor<StdoutANSIProgressRenderer>().warn("Cannot find console appender - progress tracking may not work as expected")
+                return
             }
             val scrollingAppender = object : AbstractOutputStreamAppender<OutputStreamManager>(
                     consoleAppender.name, consoleAppender.layout, consoleAppender.filter,
@@ -301,5 +304,3 @@ object StdoutANSIProgressRenderer : ANSIProgressRenderer() {
         System.out.flush()
     }
 }
-
-class AppenderNotFoundException(override val message: String?, override val cause: Throwable? = null): Exception()

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -253,8 +253,7 @@ object StdoutANSIProgressRenderer : ANSIProgressRenderer() {
             // than doing things the official way with a dedicated plugin, etc, as it avoids mucking around with all
             // the config XML and lifecycle goop.
             val manager = LogManager.getContext(false) as LoggerContext
-            val consoleAppender: ConsoleAppender?
-            consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().singleOrNull { it.name == "Console-Selector" }
+            val consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().singleOrNull { it.name == "Console-Selector" }
             if (consoleAppender == null) {
                 loggerFor<StdoutANSIProgressRenderer>().warn("Cannot find console appender - progress tracking may not work as expected")
                 return

--- a/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
+++ b/tools/shell/src/main/kotlin/net/corda/tools/shell/utlities/ANSIProgressRenderer.kt
@@ -187,7 +187,7 @@ abstract class ANSIProgressRenderer {
         }
     }
 
-    private fun renderInBold(payload: String, ansi: Ansi): Unit {
+    private fun renderInBold(payload: String, ansi: Ansi) {
         with(ansi) {
             a(Attribute.INTENSITY_BOLD)
             a(payload)
@@ -195,7 +195,7 @@ abstract class ANSIProgressRenderer {
         }
     }
 
-    private fun renderInFaint(payload: String, ansi: Ansi): Unit {
+    private fun renderInFaint(payload: String, ansi: Ansi) {
         with(ansi) {
             a(Attribute.INTENSITY_FAINT)
             a(payload)
@@ -250,7 +250,7 @@ object StdoutANSIProgressRenderer : ANSIProgressRenderer() {
             // than doing things the official way with a dedicated plugin, etc, as it avoids mucking around with all
             // the config XML and lifecycle goop.
             val manager = LogManager.getContext(false) as LoggerContext
-            val consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().single { it.name == "Console-Appender" }
+            val consoleAppender = manager.configuration.appenders.values.filterIsInstance<ConsoleAppender>().single { it.name == "Console-Selector" }
             val scrollingAppender = object : AbstractOutputStreamAppender<OutputStreamManager>(
                     consoleAppender.name, consoleAppender.layout, consoleAppender.filter,
                     consoleAppender.ignoreExceptions(), true, consoleAppender.manager) {


### PR DESCRIPTION
The StdoutANSIProgressRenderer uses a bit of a hack to ensure the progress tracker information is printed at the bottom of the console - it looks for the console appender in the current log4j configuration and swaps this out for its own. To do this it looks for the name of this appender in the log4j config. This was changed in a previous fix ([CORDA-1897](https://r3-cev.atlassian.net/browse/CORDA-1897)), but the corresponding name the renderer was looking up was not changed.

This fix has been tested manually, by deploying the Bank of Corda demo and running a CashIssueFlow.

Changes:
 - Update the name of the appender the renderer looks for to swap out
 - Remove two superfluous return types the compiler was warning about
