### PR TITLE
CORDA-2450 Creating attachment version from whitelisted JARs fails for node upgrade

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
@@ -29,7 +29,7 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
 
             if (System.getProperty(NODE_BASE_DIR_KEY).isNotEmpty()) {
                 val path = Paths.get(System.getProperty(NODE_BASE_DIR_KEY)) / NETWORK_PARAMS_FILE_NAME
-                val networkParameters = getNetworkParametersFromFile(path)
+                networkParameters = getNetworkParametersFromFile(path)
                 if (networkParameters != null) {
                     logger.info("Network parameters from $path, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
                 } else {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
@@ -23,6 +23,8 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
 
     override fun execute(database: Database?) {
         val connection = database?.connection as JdbcConnection
+        val msg = "Attachment version creation from whitelisted JARs"
+
         try {
             logger.info("Start executing...")
             var networkParameters: NetworkParameters? = null
@@ -31,30 +33,30 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
                 val path = Paths.get(System.getProperty(NODE_BASE_DIR_KEY)) / NETWORK_PARAMS_FILE_NAME
                 networkParameters = getNetworkParametersFromFile(path)
                 if (networkParameters != null) {
-                    logger.info("Network parameters from $path, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
+                    logger.info("$msg using network parameters from $path, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
                 } else {
-                    logger.warn("Network parameters not found in $path.")
+                    logger.warn("$msg, network parameters not found in $path.")
                 }
             } else {
-                logger.error("Network parameters not retried, could not determine node base directory due to system property $NODE_BASE_DIR_KEY being not set.")
+                logger.error("$msg, network parameters not retrieved, could not determine node base directory due to system property $NODE_BASE_DIR_KEY being not set.")
             }
 
             if (networkParameters == null) {
                 networkParameters = getNetworkParametersFromDb(connection)
                 if (networkParameters != null) {
-                    logger.info("Network parameters from database, epoch: ${networkParameters.epoch}, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
+                    logger.info("$msg using network parameters from database, epoch: ${networkParameters.epoch}, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
                 } else {
-                    logger.warn("Network parameters not found in database.")
+                    logger.warn("$msg skipped, network parameters not found in database.")
                     return
                 }
             }
 
             val availableAttachments = getAttachmentsWithDefaultVersion(connection)
             if (availableAttachments.isEmpty()) {
-                logger.info("Attachments not found.")
+                logger.info("$msg skipped, no attachments not found.")
                 return
             } else {
-                logger.info("Attachments with version '1': $availableAttachments")
+                logger.info("$msg, candidate attachments with version '1': $availableAttachments")
             }
 
             availableAttachments.forEach { attachmentId ->
@@ -71,7 +73,7 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
                 }
             }
         } catch (e: Exception) {
-            logger.error("Exception while retrieving network parameters ${e.message}", e)
+            logger.error("$msg exception ${e.message}", e)
         }
     }
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -13,6 +13,7 @@ import net.corda.core.schemas.MappedSchema
 import net.corda.core.utilities.contextLogger
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.nio.file.Path
 import java.sql.Statement
 import javax.sql.DataSource
 
@@ -20,10 +21,12 @@ class SchemaMigration(
         val schemas: Set<MappedSchema>,
         val dataSource: DataSource,
         private val databaseConfig: DatabaseConfig,
-        private val classLoader: ClassLoader = Thread.currentThread().contextClassLoader) {
+        private val classLoader: ClassLoader = Thread.currentThread().contextClassLoader,
+        private val currentDirectory: Path?) {
 
     companion object {
         private val logger = contextLogger()
+        const val NODE_BASE_DIR_KEY = "liquibase.nodeDaseDir"
     }
 
     /**
@@ -85,6 +88,8 @@ class SchemaMigration(
                     else -> throw MissingMigrationException(mappedSchema)
                 }
             }
+
+            System.setProperty(NODE_BASE_DIR_KEY, currentDirectory.toString()) // base dir for any custom change set which may need to load a file (currently AttachmentVersionNumberMigration)
 
             val customResourceAccessor = CustomResourceAccessor(dynamicInclude, changelogList, classLoader)
 


### PR DESCRIPTION
Upgrade from node 3.0 to 4.0 fails to create versions of whitelisted JARs from networkParameters - read parameters from file at first as in Corda 3.0 there no relevant table, then try from the table.

Tested using https://r3-cev.atlassian.net/browse/R3T-1549

As this is migration, the code will run only once on each node, she increased log level to info for messages.