### PR TITLE
Enable methods synthesized by Kotlin in api scanning

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.38
+gradlePluginsVersion=4.0.39
 kotlinVersion=1.2.71
 # ***************************************************************#
 # When incrementing platformVersion make sure to update          #

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -63,7 +63,7 @@ scanApi {
             "<init>(Lnet/corda/node/cordapp/CordappLoader;Lnet/corda/core/node/services/IdentityService;Lnet/corda/core/node/NetworkParameters;Lnet/corda/testing/core/TestIdentity;[Ljava/security/KeyPair;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
         ],
         "net.corda.testing.node.InMemoryMessagingNetwork\$MessageTransfer": [
-                "<init>(Lnet/corda/testing/node/InMemoryMessagingNetwork\$PeerHandle;Lnet/corda/node/services/messaging/Message;Lnet/corda/core/messaging/MessageRecipients;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+            "<init>(Lnet/corda/testing/node/InMemoryMessagingNetwork\$PeerHandle;Lnet/corda/node/services/messaging/Message;Lnet/corda/core/messaging/MessageRecipients;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
         ]
     ]
 }

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -55,3 +55,15 @@ jar {
 publish {
     name jar.baseName
 }
+
+scanApi {
+    //Constructors that are synthesized by Kotlin unexpectedly
+    excludeMethods = [
+        "net.corda.testing.node.MockServices": [
+            "<init>(Lnet/corda/node/cordapp/CordappLoader;Lnet/corda/core/node/services/IdentityService;Lnet/corda/core/node/NetworkParameters;Lnet/corda/testing/core/TestIdentity;[Ljava/security/KeyPair;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+        ],
+        "net.corda.testing.node.InMemoryMessagingNetwork\$MessageTransfer": [
+                "<init>(Lnet/corda/testing/node/InMemoryMessagingNetwork\$PeerHandle;Lnet/corda/node/services/messaging/Message;Lnet/corda/core/messaging/MessageRecipients;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+        ]
+    ]
+}


### PR DESCRIPTION
## Changes
* Bump gradle-plugins to 4.0.39 to enable synthetic methods in API scanning (I've already published it)
* Disable non-effective constructors that are synthesized by Kotlin

## Testing
```
$ ./gradlew generateApi && .ci/check-api-changes.sh
Number of API removals/changes:  0
Number of new internal class exposures:  0
Number of new abstract APIs:  0
Exiting with exit code 0
```