### PR TITLE
CORDA-2280 migration from whitelist constraint to signature constraint

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -420,7 +420,9 @@ open class TransactionBuilder(
         // Sanity check.
         constraints.isEmpty() -> throw IllegalArgumentException("Cannot transition from no constraints.")
 
-        // When all input states have the same constraint.
+        attachmentToUse.signerKeys.isNotEmpty() && constraints.all { it is WhitelistedByZoneAttachmentConstraint } -> makeSignatureAttachmentConstraint(attachmentToUse.signerKeys)
+
+        // When all input states have the same constraint except the above case
         constraints.size == 1 -> constraints.single()
 
         // Fail when combining the insecure AlwaysAcceptAttachmentConstraint with something else. The size must be at least 2 at this point.

--- a/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
@@ -38,8 +38,8 @@ import kotlin.test.assertNotNull
 class SignatureConstraintVersioningTests {
 
     private val baseUnsinded = cordappWithPackages(MessageState::class.packageName, DummyMessageContract::class.packageName)
-    private val oldUnsigedCordapp = baseUnsinded.copy(versionId = 2)
     private val base = baseUnsinded.signed()
+    private val oldUnsigedCordapp = baseUnsinded.copy(versionId = 2)
     private val oldCordapp = base.copy(versionId = 2)
     private val newCordapp = base.copy(versionId = 3)
     private val user = User("mark", "dadada", setOf(startFlow<CreateMessage>(), startFlow<ConsumeMessage>(), invokeRpc("vaultQuery")))
@@ -138,6 +138,7 @@ class SignatureConstraintVersioningTests {
         assertEquals(message, stateAndRef!!.state.data.message)
     }
 
+    //TODO this test doesn't actually verifies that signature constrint was used for the second transaction
     @Test
     fun `auto migration from WhitelistConstraint to SignatureConstraint`() {
         assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.


### PR DESCRIPTION
If all constrains are ZoneConstraints and the selected Attachment is signed then use SignatureConstraint.

There are two test the positive one, and the negative.
Negative tests when the Signed Jar is not whitelisted yet. Note this setup would fail before and after the change but at different places:

After the change the Constraint will be SignatureConstraint however it fails 
during verification:
```net.corda.core.contracts.TransactionVerificationException$ContractConstraintRejection: Contract constraints failed for net.corda.contracts.DummyMessageContract, transaction: 0EBD577E5EB20F2F800478159B2417A04F179231433FCD1EB1853B633FDACBA7```

Before this change it would select ZoneConstraint and then fail in handleContract :
``` java.lang.IllegalArgumentException: Selected output constraint: net.corda.core.contracts.WhitelistedByZoneAttachmentConstraint@100c23bf not satisfying 685946826AC230AB922DEA5092D704F55171C249F5B982C484625040C097FE91```