### PR TITLE
[CORDA-2460] Add note to documentation warning about state relevancy update

### DIFF
--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -350,3 +350,9 @@ Corda 4 adds several new APIs that help you build applications. Why not explore:
 * The `new withEntityManager API <api/javadoc/net/corda/core/node/ServiceHub.html#withEntityManager-block->`_ for using JPA inside your flows and services.
 * :ref:`reference_states`, that let you use an input state without consuming it.
 * :ref:`state_pointers`, that make it easier to 'point' to one state from another and follow the latest version of a linear state.
+
+.. note:: When upgrading a node from Corda 3 to Corda 4, the states in the vault of the node are modified to be usable with Corda 4 features.
+          As part of this, all states in the vault created while the node was running Corda 3 will be marked as relevant. This could be incorrect
+          if the node was using Observer node functionality in Corda 3. The effects of this will only be visible if an app running on the node
+          is upgraded to target Corda 4 and starts using new features in Corda 4 (for example filtering vault queries by state relevancy).
+          This is tracked by https://r3-cev.atlassian.net/projects/CORDA/issues/CORDA-2435.


### PR DESCRIPTION
[CORDA-2435](https://r3-cev.atlassian.net/projects/CORDA/issues/CORDA-2435) tracks an issue whereby the database upgrade process from V3 to V4 introduces a new column and a new table that are not appropriately backfilled by the migration process. This results in all states created in a V3 node in the vault being marked as relevant, which is incorrect. This may result in unexpected issues for an app that upgrades to V4, and starts running on an upgraded node, in the event that the app starts using V4 features.

The aim is to fix this issue in a patch release, but in the meantime a warning should be placed highlighting the problem to any party upgrading their app. This PR adds that warning.

Changes:
 * Add a note to the app upgrade notes indicating that unexpected results may occur if both an app and the node it runs on are upgraded to V4 and the app starts working with states created in V3 using V4 features.
