### PR TITLE
Reducing the size of the CorDapp jars used in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ buildscript {
     ext.commons_cli_version = '1.4'
     ext.protonj_version = '0.27.1' // This is now aligned with the Artemis version, but retaining in case we ever need to diverge again for a bug fix.
     ext.snappy_version = '0.4'
-    ext.class_graph_version = '4.2.12'
+    ext.class_graph_version = '4.6.12'
     ext.jcabi_manifests_version = '1.1'
     ext.picocli_version = '3.8.0'
     ext.commons_io_version = '2.6'

--- a/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
+++ b/core/src/test/java/net/corda/core/flows/FlowsInJavaTest.java
@@ -14,14 +14,15 @@ import org.junit.Test;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static java.util.Collections.singletonList;
 import static net.corda.testing.core.TestUtils.singleIdentity;
-import static net.corda.testing.node.internal.InternalTestUtilsKt.cordappsForPackages;
+import static net.corda.testing.node.internal.InternalTestUtilsKt.enclosedCordapp;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.fail;
 
 public class FlowsInJavaTest {
     private final MockNetwork mockNet = new MockNetwork(
-            new MockNetworkParameters().withCordappsForAllNodes(cordappsForPackages("net.corda.core.flows"))
+            new MockNetworkParameters().withCordappsForAllNodes(singletonList(enclosedCordapp(this)))
     );
     private StartedMockNode aliceNode;
     private StartedMockNode bobNode;

--- a/core/src/test/kotlin/net/corda/core/contracts/ContractHierarchyTest.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/ContractHierarchyTest.kt
@@ -13,7 +13,7 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startFlow
 import org.junit.After
 import org.junit.Before
@@ -25,7 +25,7 @@ class ContractHierarchyTest {
     @Before
     fun before() {
         // We run this in parallel threads to help catch any race conditions that may exist.
-        mockNet = InternalMockNetwork(networkSendManuallyPumped = false, threadPerNode = true, cordappsForAllNodes = cordappsForPackages("net.corda.core.contracts"))
+        mockNet = InternalMockNetwork(networkSendManuallyPumped = false, threadPerNode = true, cordappsForAllNodes = listOf(enclosedCordapp()))
     }
 
     @After

--- a/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/CollectSignaturesFlowTests.kt
@@ -19,9 +19,10 @@ import net.corda.testing.internal.matchers.flow.willReturn
 import net.corda.testing.internal.matchers.flow.willThrow
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.node.MockServices
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.TestStartedNode
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.AfterClass
 import org.junit.Test
 
@@ -29,7 +30,7 @@ class CollectSignaturesFlowTests : WithContracts {
     companion object {
         private val miniCorp = TestIdentity(CordaX500Name("MiniCorp", "London", "GB"))
         private val miniCorpServices = MockServices(listOf("net.corda.testing.contracts"), miniCorp, rigorousMock<IdentityService>())
-        private val classMockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", "net.corda.core.flows"))
+        private val classMockNet = InternalMockNetwork(cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()))
 
         private const val MAGIC_NUMBER = 1337
 

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowRPCTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowRPCTest.kt
@@ -8,8 +8,6 @@ import com.natpryce.hamkrest.isA
 import net.corda.core.CordaRuntimeException
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
-import net.corda.testing.internal.matchers.rpc.willReturn
-import net.corda.testing.internal.matchers.rpc.willThrow
 import net.corda.core.flows.mixins.WithContracts
 import net.corda.core.flows.mixins.WithFinality
 import net.corda.core.messaging.CordaRPCOps
@@ -21,6 +19,8 @@ import net.corda.testing.contracts.DummyContractV2
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
+import net.corda.testing.internal.matchers.rpc.willReturn
+import net.corda.testing.internal.matchers.rpc.willThrow
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.*
 import org.junit.AfterClass
@@ -28,7 +28,7 @@ import org.junit.Test
 
 class ContractUpgradeFlowRPCTest : WithContracts, WithFinality {
     companion object {
-        private val classMockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", "net.corda.finance.contracts.asset", "net.corda.core.flows"))
+        private val classMockNet = InternalMockNetwork(cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()))
 
         @JvmStatic
         @AfterClass

--- a/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ContractUpgradeFlowTest.kt
@@ -23,17 +23,15 @@ import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.internal.matchers.flow.willReturn
 import net.corda.testing.internal.matchers.flow.willThrow
-import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.TestStartedNode
-import net.corda.testing.node.internal.cordappsForPackages
-import net.corda.testing.node.internal.startFlow
+import net.corda.testing.node.internal.*
 import org.junit.AfterClass
 import org.junit.Test
 import java.util.*
 
 class ContractUpgradeFlowTest : WithContracts, WithFinality {
+
     companion object {
-        private val classMockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", "net.corda.finance.contracts.asset", "net.corda.core.flows", "net.corda.finance.schemas"))
+        private val classMockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP, DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()))
 
         @JvmStatic
         @AfterClass

--- a/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/FinalityFlowTests.kt
@@ -26,11 +26,7 @@ class FinalityFlowTests : WithFinality {
         private val CHARLIE = TestIdentity(CHARLIE_NAME, 90).party
     }
 
-    override val mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(
-            "net.corda.finance.contracts.asset",
-            "net.corda.finance.schemas",
-            "net.corda.core.flows.mixins"
-    ))
+    override val mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP, enclosedCordapp()))
 
     private val aliceNode = makeNode(ALICE_NAME)
 

--- a/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/WithReferencedStatesFlowTests.kt
@@ -14,111 +14,16 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.VersionInfo
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.InternalMockNodeParameters
-import net.corda.testing.node.internal.cordappsForPackages
-import net.corda.testing.node.internal.startFlow
+import net.corda.testing.node.internal.*
 import org.junit.After
 import org.junit.Test
 import kotlin.test.assertEquals
-
-// A dummy reference state contract.
-internal class RefState : Contract {
-    companion object {
-        const val CONTRACT_ID = "net.corda.core.flows.RefState"
-    }
-
-    override fun verify(tx: LedgerTransaction) = Unit
-
-    data class State(val owner: Party, val version: Int = 0, override val linearId: UniqueIdentifier = UniqueIdentifier()) : LinearState {
-        override val participants: List<AbstractParty> get() = listOf(owner)
-        fun update() = copy(version = version + 1)
-    }
-
-    class Create : CommandData
-    class Update : CommandData
-}
-
-// A flow to create a reference state.
-internal class CreateRefState : FlowLogic<SignedTransaction>() {
-    @Suspendable
-    override fun call(): SignedTransaction {
-        val notary = serviceHub.networkMapCache.notaryIdentities.first()
-        val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
-            addOutputState(RefState.State(ourIdentity), RefState.CONTRACT_ID)
-            addCommand(RefState.Create(), listOf(ourIdentity.owningKey))
-        })
-        return subFlow(FinalityFlow(stx, emptyList()))
-    }
-}
-
-// A flow to update a specific reference state.
-internal class UpdateRefState(private val stateAndRef: StateAndRef<RefState.State>) : FlowLogic<SignedTransaction>() {
-    @Suspendable
-    override fun call(): SignedTransaction {
-        val notary = serviceHub.networkMapCache.notaryIdentities.first()
-        val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
-            addInputState(stateAndRef)
-            addOutputState(stateAndRef.state.data.update(), RefState.CONTRACT_ID)
-            addCommand(RefState.Update(), listOf(ourIdentity.owningKey))
-        })
-        return subFlow(FinalityFlow(stx, emptyList()))
-    }
-}
-
-// A set of flows to share a stateref with all other nodes in the mock network.
-internal object ShareRefState {
-    @InitiatingFlow
-    class Initiator(private val stateAndRef: StateAndRef<ContractState>) : FlowLogic<Unit>() {
-        @Suspendable
-        override fun call() {
-            val sessions = serviceHub.networkMapCache.allNodes.flatMap { it.legalIdentities }.map { initiateFlow(it) }
-            val transactionId = stateAndRef.ref.txhash
-            val transaction = serviceHub.validatedTransactions.getTransaction(transactionId)
-                    ?: throw FlowException("Cannot find $transactionId.")
-            sessions.forEach { subFlow(SendTransactionFlow(it, transaction)) }
-        }
-    }
-
-    @InitiatedBy(ShareRefState.Initiator::class)
-    class Responder(private val otherSession: FlowSession) : FlowLogic<Unit>() {
-        @Suspendable
-        override fun call() {
-            logger.info("Receiving dependencies.")
-            subFlow(ReceiveTransactionFlow(
-                    otherSideSession = otherSession,
-                    checkSufficientSignatures = true,
-                    statesToRecord = StatesToRecord.ALL_VISIBLE
-            ))
-        }
-    }
-}
-
-// A flow to use a reference state in another transaction.
-internal class UseRefState(private val linearId: UniqueIdentifier) : FlowLogic<SignedTransaction>() {
-    @Suspendable
-    override fun call(): SignedTransaction {
-        val notary = serviceHub.networkMapCache.notaryIdentities.first()
-        val query = QueryCriteria.LinearStateQueryCriteria(
-                linearId = listOf(linearId),
-                relevancyStatus = Vault.RelevancyStatus.ALL
-        )
-        val referenceState = serviceHub.vaultService.queryBy<ContractState>(query).states.single()
-
-        val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
-            addReferenceState(referenceState.referenced())
-            addOutputState(RefState.State(ourIdentity), RefState.CONTRACT_ID)
-            addCommand(RefState.Create(), listOf(ourIdentity.owningKey))
-        })
-        return subFlow(FinalityFlow(stx, emptyList()))
-    }
-}
 
 class WithReferencedStatesFlowTests {
     companion object {
         @JvmStatic
         private val mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.core.flows", "net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
                 threadPerNode = true,
                 initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
         )
@@ -142,7 +47,7 @@ class WithReferencedStatesFlowTests {
         val newRefState = newRefTx.tx.outRefsOfType<RefState.State>().single()
 
         // 2. Share it with others.
-        nodes[0].services.startFlow(ShareRefState.Initiator(newRefState)).resultFuture.getOrThrow()
+        nodes[0].services.startFlow(Initiator(newRefState)).resultFuture.getOrThrow()
 
         // 3. Update the reference state but don't share the update.
         val updatedRefTx = nodes[0].services.startFlow(UpdateRefState(newRefState)).resultFuture.getOrThrow()
@@ -152,10 +57,100 @@ class WithReferencedStatesFlowTests {
         val useRefTx = nodes[1].services.startFlow(WithReferencedStatesFlow { UseRefState(newRefState.state.data.linearId) }).resultFuture
 
         // 5. Share the update reference state.
-        nodes[0].services.startFlow(ShareRefState.Initiator(updatedRefState)).resultFuture.getOrThrow()
+        nodes[0].services.startFlow(Initiator(updatedRefState)).resultFuture.getOrThrow()
 
         // 6. Check that we have a valid signed transaction with the updated reference state.
         val result = useRefTx.getOrThrow()
         assertEquals(updatedRefState.ref, result.tx.references.single())
+    }
+
+    // A dummy reference state contract.
+    class RefState : Contract {
+        companion object {
+            val CONTRACT_ID: String = RefState::class.java.name
+        }
+
+        override fun verify(tx: LedgerTransaction) = Unit
+
+        data class State(val owner: Party, val version: Int = 0, override val linearId: UniqueIdentifier = UniqueIdentifier()) : LinearState {
+            override val participants: List<AbstractParty> get() = listOf(owner)
+            fun update() = copy(version = version + 1)
+        }
+
+        class Create : CommandData
+        class Update : CommandData
+    }
+
+    // A flow to create a reference state.
+    class CreateRefState : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val notary = serviceHub.networkMapCache.notaryIdentities.first()
+            val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
+                addOutputState(RefState.State(ourIdentity), RefState.CONTRACT_ID)
+                addCommand(RefState.Create(), listOf(ourIdentity.owningKey))
+            })
+            return subFlow(FinalityFlow(stx, emptyList()))
+        }
+    }
+
+    // A flow to update a specific reference state.
+    class UpdateRefState(private val stateAndRef: StateAndRef<RefState.State>) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val notary = serviceHub.networkMapCache.notaryIdentities.first()
+            val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
+                addInputState(stateAndRef)
+                addOutputState(stateAndRef.state.data.update(), RefState.CONTRACT_ID)
+                addCommand(RefState.Update(), listOf(ourIdentity.owningKey))
+            })
+            return subFlow(FinalityFlow(stx, emptyList()))
+        }
+    }
+
+    // A set of flows to share a stateref with all other nodes in the mock network.
+    @InitiatingFlow
+    class Initiator(private val stateAndRef: StateAndRef<ContractState>) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val sessions = serviceHub.networkMapCache.allNodes.flatMap { it.legalIdentities }.map { initiateFlow(it) }
+            val transactionId = stateAndRef.ref.txhash
+            val transaction = serviceHub.validatedTransactions.getTransaction(transactionId)
+                    ?: throw FlowException("Cannot find $transactionId.")
+            sessions.forEach { subFlow(SendTransactionFlow(it, transaction)) }
+        }
+    }
+
+    @InitiatedBy(Initiator::class)
+    class Responder(private val otherSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            logger.info("Receiving dependencies.")
+            subFlow(ReceiveTransactionFlow(
+                    otherSideSession = otherSession,
+                    checkSufficientSignatures = true,
+                    statesToRecord = StatesToRecord.ALL_VISIBLE
+            ))
+        }
+    }
+
+    // A flow to use a reference state in another transaction.
+    class UseRefState(private val linearId: UniqueIdentifier) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        override fun call(): SignedTransaction {
+            val notary = serviceHub.networkMapCache.notaryIdentities.first()
+            val query = QueryCriteria.LinearStateQueryCriteria(
+                    linearId = listOf(linearId),
+                    relevancyStatus = Vault.RelevancyStatus.ALL
+            )
+            val referenceState = serviceHub.vaultService.queryBy<ContractState>(query).states.single()
+
+            val stx = serviceHub.signInitialTransaction(TransactionBuilder(notary = notary).apply {
+                addReferenceState(referenceState.referenced())
+                addOutputState(RefState.State(ourIdentity), RefState.CONTRACT_ID)
+                addCommand(RefState.Create(), listOf(ourIdentity.owningKey))
+            })
+            return subFlow(FinalityFlow(stx, emptyList()))
+        }
     }
 }

--- a/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/ResolveTransactionsFlowTest.kt
@@ -15,7 +15,8 @@ import net.corda.testing.core.singleIdentity
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.StartedMockNode
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -40,7 +41,7 @@ class ResolveTransactionsFlowTest {
 
     @Before
     fun setup() {
-        mockNet = MockNetwork(MockNetworkParameters(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", javaClass.packageName)))
+        mockNet = MockNetwork(MockNetworkParameters(cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp())))
         notaryNode = mockNet.defaultNotaryNode
         megaCorpNode = mockNet.createPartyNode(CordaX500Name("MegaCorp", "London", "GB"))
         miniCorpNode = mockNet.createPartyNode(CordaX500Name("MiniCorp", "London", "GB"))

--- a/finance/workflows/src/test/kotlin/net/corda/finance/contracts/asset/selection/CashSelectionH2ImplTest.kt
+++ b/finance/workflows/src/test/kotlin/net/corda/finance/contracts/asset/selection/CashSelectionH2ImplTest.kt
@@ -9,8 +9,10 @@ import net.corda.finance.flows.CashException
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
 import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.MockNodeConfigOverrides
 import net.corda.testing.node.MockNodeParameters
+import net.corda.testing.node.internal.FINANCE_CORDAPPS
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Test
@@ -18,7 +20,7 @@ import java.util.Collections.nCopies
 import kotlin.test.assertNotNull
 
 class CashSelectionH2ImplTest {
-    private val mockNet = MockNetwork(threadPerNode = true, cordappPackages = listOf("net.corda.finance"))
+    private val mockNet = MockNetwork(MockNetworkParameters(threadPerNode = true, cordappsForAllNodes = FINANCE_CORDAPPS))
 
     @After
     fun cleanUp() {

--- a/finance/workflows/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
+++ b/finance/workflows/src/test/kotlin/net/corda/finance/flows/CashExitFlowTests.kt
@@ -9,7 +9,9 @@ import net.corda.finance.contracts.asset.Cash
 import net.corda.testing.core.BOC_NAME
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.internal.FINANCE_CORDAPPS
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -26,8 +28,7 @@ class CashExitFlowTests {
 
     @Before
     fun start() {
-        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(),
-                cordappPackages = listOf("net.corda.finance.contracts.asset", "net.corda.finance.schemas"))
+        mockNet = MockNetwork(MockNetworkParameters(servicePeerAllocationStrategy = RoundRobin(), cordappsForAllNodes = FINANCE_CORDAPPS))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda = bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         notary = mockNet.defaultNotaryIdentity

--- a/finance/workflows/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt
+++ b/finance/workflows/src/test/kotlin/net/corda/finance/flows/CashIssueFlowTests.kt
@@ -9,7 +9,9 @@ import net.corda.finance.contracts.asset.Cash
 import net.corda.testing.core.BOC_NAME
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.internal.FINANCE_CORDAPPS
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -24,9 +26,7 @@ class CashIssueFlowTests {
 
     @Before
     fun start() {
-        mockNet = MockNetwork(
-                servicePeerAllocationStrategy = RoundRobin(),
-                cordappPackages = listOf("net.corda.finance.contracts", "net.corda.finance.schemas"))
+        mockNet = MockNetwork(MockNetworkParameters(servicePeerAllocationStrategy = RoundRobin(), cordappsForAllNodes = FINANCE_CORDAPPS))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda = bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         notary = mockNet.defaultNotaryIdentity

--- a/finance/workflows/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
+++ b/finance/workflows/src/test/kotlin/net/corda/finance/flows/CashPaymentFlowTests.kt
@@ -12,7 +12,9 @@ import net.corda.finance.contracts.asset.Cash
 import net.corda.testing.core.*
 import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.internal.FINANCE_CORDAPPS
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -30,7 +32,7 @@ class CashPaymentFlowTests {
 
     @Before
     fun start() {
-        mockNet = MockNetwork(servicePeerAllocationStrategy = RoundRobin(), cordappPackages = listOf("net.corda.finance"))
+        mockNet = MockNetwork(MockNetworkParameters(servicePeerAllocationStrategy = RoundRobin(), cordappsForAllNodes = FINANCE_CORDAPPS))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda = bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         aliceNode = mockNet.createPartyNode(ALICE_NAME)

--- a/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/AttachmentLoadingTests.kt
@@ -23,7 +23,7 @@ import net.corda.testing.driver.DriverDSL
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.enclosedCordapp
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import java.net.URL
@@ -50,7 +50,7 @@ class AttachmentLoadingTests {
         driver(DriverParameters(
                 startNodesInProcess = false,
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = false)),
-                cordappsForAllNodes = cordappsForPackages(javaClass.packageName)
+                cordappsForAllNodes = listOf(enclosedCordapp())
         )) {
             installIsolatedCordapp(ALICE_NAME)
 
@@ -73,7 +73,7 @@ class AttachmentLoadingTests {
         driver(DriverParameters(
                 startNodesInProcess = false,
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = false)),
-                cordappsForAllNodes = cordappsForPackages(javaClass.packageName)
+                cordappsForAllNodes = listOf(enclosedCordapp())
         )) {
             installIsolatedCordapp(ALICE_NAME)
             installIsolatedCordapp(BOB_NAME)

--- a/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/distributed/DistributedServiceTests.kt
@@ -23,6 +23,7 @@ import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.DummyClusterSpec
 import net.corda.testing.node.internal.FINANCE_CORDAPPS
+import net.corda.testing.node.internal.cordappWithPackages
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import rx.Observable
@@ -43,8 +44,7 @@ class DistributedServiceTests {
                 invokeRpc(CordaRPCOps::stateMachinesFeed))
         )
         driver(DriverParameters(
-                extraCordappPackagesToScan = listOf("net.corda.notary.raft"),
-                cordappsForAllNodes = FINANCE_CORDAPPS,
+                cordappsForAllNodes = FINANCE_CORDAPPS + cordappWithPackages("net.corda.notary.raft"),
                 notarySpecs = listOf(NotarySpec(
                         DUMMY_NOTARY_NAME,
                         rpcUsers = listOf(testUser),

--- a/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/events/ScheduledFlowIntegrationTests.kt
@@ -23,6 +23,9 @@ import net.corda.testing.core.dummyCommand
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.cordappWithPackages
+import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.Test
 import java.time.Instant
 import java.util.*
@@ -97,7 +100,7 @@ class ScheduledFlowIntegrationTests {
     fun `test that when states are being spent at the same time that schedules trigger everything is processed`() {
         driver(DriverParameters(
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.testing.contracts", "net.corda.testMessage")
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, cordappWithPackages("net.corda.testMessage"), enclosedCordapp())
         )) {
             val N = 23
             val rpcUser = User("admin", "admin", setOf("ALL"))

--- a/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/services/statemachine/LargeTransactionsTest.kt
@@ -20,6 +20,8 @@ import net.corda.testing.core.dummyCommand
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
+import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -76,9 +78,10 @@ class LargeTransactionsTest {
         val bigFile2 = InputStreamAndHash.createInMemoryTestZip(3.MB.toInt(), 1, "b")
         val bigFile3 = InputStreamAndHash.createInMemoryTestZip(3.MB.toInt(), 2, "c")
         val bigFile4 = InputStreamAndHash.createInMemoryTestZip(3.MB.toInt(), 3, "d")
+
         driver(DriverParameters(
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
                 networkParameters = testNetworkParameters(maxMessageSize = 15.MB.toInt(), maxTransactionSize = 13.MB.toInt())
         )) {
             val rpcUser = User("admin", "admin", setOf("ALL"))

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -47,10 +47,10 @@ import net.corda.testing.core.expect
 import net.corda.testing.core.expectEvents
 import net.corda.testing.core.sequence
 import net.corda.testing.internal.fromUserList
+import net.corda.testing.node.internal.FINANCE_CORDAPPS
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.TestStartedNode
-import net.corda.testing.node.internal.cordappsForPackages
 import net.corda.testing.node.testActor
 import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.*
@@ -94,7 +94,7 @@ class CordaRPCOpsImplTest {
 
     @Before
     fun setup() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.finance"))
+        mockNet = InternalMockNetwork(cordappsForAllNodes = FINANCE_CORDAPPS)
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         rpc = aliceNode.rpcOps
         CURRENT_RPC_CONTEXT.set(RpcAuthContext(InvocationContext.rpc(testActor()), buildSubject("TEST_USER", emptySet())))

--- a/node/src/test/kotlin/net/corda/node/internal/NodeUnloadHandlerTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/NodeUnloadHandlerTests.kt
@@ -1,12 +1,11 @@
 package net.corda.node.internal
 
-import net.corda.core.internal.packageName
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.core.utilities.contextLogger
 import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.enclosedCordapp
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -19,7 +18,7 @@ class NodeUnloadHandlerTests {
         val shutdownLatch = CountDownLatch(1)
     }
 
-    private val mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(javaClass.packageName), notarySpecs = emptyList())
+    private val mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(enclosedCordapp()), notarySpecs = emptyList())
 
     @After
     fun cleanUp() {

--- a/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/messaging/TwoPartyTradeFlowTests.kt
@@ -70,13 +70,11 @@ import kotlin.test.assertTrue
 @RunWith(Parameterized::class)
 class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
     companion object {
-        private val cordappPackages = listOf("net.corda.finance.contracts", "net.corda.finance.schemas")
         @JvmStatic
         @Parameterized.Parameters(name = "Anonymous = {0}")
         fun data(): Collection<Boolean> = listOf(true, false)
 
         private val dummyNotary = TestIdentity(DUMMY_NOTARY_NAME, 20)
-        private val DUMMY_NOTARY get() = dummyNotary.party
     }
 
     private lateinit var mockNet: InternalMockNetwork
@@ -99,7 +97,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
         // We run this in parallel threads to help catch any race conditions that may exist. The other tests
         // we run in the unit test thread exclusively to speed things up, ensure deterministic results and
         // allow interruption half way through.
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages), threadPerNode = true)
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP), threadPerNode = true)
         val notaryNode = mockNet.defaultNotaryNode
         val notary = mockNet.defaultNotaryIdentity
         notaryNode.services.ledger(notary) {
@@ -149,7 +147,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
 
     @Test(expected = InsufficientBalanceException::class)
     fun `trade cash for commercial paper fails using soft locking`() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages), threadPerNode = true)
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP), threadPerNode = true)
         val notaryNode = mockNet.defaultNotaryNode
         notaryNode.services.ledger(notaryNode.info.singleIdentity()) {
             val aliceNode = mockNet.createPartyNode(ALICE_NAME)
@@ -205,7 +203,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
 
     @Test
     fun `shutdown and restore`() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages))
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP))
         val notaryNode = mockNet.defaultNotaryNode
         val notary = mockNet.defaultNotaryIdentity
         notaryNode.services.ledger(notary) {
@@ -314,7 +312,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
 
     @Test
     fun `check dependencies of sale asset are resolved`() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages))
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP))
         val notaryNode = mockNet.defaultNotaryNode
         val aliceNode = makeNodeWithTracking(ALICE_NAME)
         val bobNode = makeNodeWithTracking(BOB_NAME)
@@ -417,7 +415,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
 
     @Test
     fun `track works`() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages))
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP))
         val notaryNode = mockNet.defaultNotaryNode
         val aliceNode = makeNodeWithTracking(ALICE_NAME)
         val bobNode = makeNodeWithTracking(BOB_NAME)
@@ -498,7 +496,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
 
     @Test
     fun `dependency with error on buyer side`() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages))
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP))
         mockNet.defaultNotaryNode.services.ledger(mockNet.defaultNotaryIdentity) {
             runWithError(true, false, "at least one cash input")
         }
@@ -506,7 +504,7 @@ class TwoPartyTradeFlowTests(private val anonymous: Boolean) {
 
     @Test
     fun `dependency with error on seller side`() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(cordappPackages))
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP))
         mockNet.defaultNotaryNode.services.ledger(mockNet.defaultNotaryIdentity) {
             runWithError(false, true, "Issuances have a time-window")
         }

--- a/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt
+++ b/node/src/test/kotlin/net/corda/node/modes/draining/ScheduledFlowsDrainingModeTest.kt
@@ -4,7 +4,6 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.*
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.internal.packageName
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.contextLogger
 import net.corda.core.utilities.getOrThrow
@@ -42,7 +41,7 @@ class ScheduledFlowsDrainingModeTest {
     @Before
     fun setup() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", javaClass.packageName),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
                 threadPerNode = true
         )
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))

--- a/node/src/test/kotlin/net/corda/node/services/FinalityHandlerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/FinalityHandlerTest.kt
@@ -6,7 +6,6 @@ import net.corda.core.crypto.SecureHash
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.cordapp.CordappResolver
-import net.corda.core.internal.packageName
 import net.corda.core.toFuture
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -43,7 +42,7 @@ class FinalityHandlerTest {
                 legalName = BOB_NAME,
                 // The node disables the FinalityHandler completely if there are no old CorDapps loaded, so we need to add
                 // a token old CorDapp to keep the handler running.
-                additionalCordapps = setOf(cordappWithPackages(javaClass.packageName).copy(targetPlatformVersion = 3))
+                additionalCordapps = setOf(DUMMY_CONTRACTS_CORDAPP.copy(targetPlatformVersion = 3))
         ))
 
         val stx = alice.issueCashTo(bob)

--- a/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/NotaryChangeTests.kt
@@ -19,10 +19,8 @@ import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
 import net.corda.testing.core.dummyCommand
 import net.corda.testing.core.singleIdentity
-import net.corda.testing.node.MockNetwork
-import net.corda.testing.node.MockNetworkNotarySpec
-import net.corda.testing.node.MockNodeParameters
-import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.*
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.After
 import org.junit.Before
@@ -47,10 +45,10 @@ class NotaryChangeTests {
 
     @Before
     fun setUp() {
-        mockNet = MockNetwork(
+        mockNet = MockNetwork(MockNetworkParameters(
                 notarySpecs = listOf(MockNetworkNotarySpec(oldNotaryName), MockNetworkNotarySpec(newNotaryName)),
-                cordappPackages = listOf("net.corda.testing.contracts")
-        )
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP)
+        ))
         clientNodeA = mockNet.createNode(MockNodeParameters(legalName = ALICE_NAME))
         clientNodeB = mockNet.createNode(MockNodeParameters(legalName = BOB_NAME))
         clientA = clientNodeA.info.singleIdentity()

--- a/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/ServiceHubConcurrentUsageTest.kt
@@ -5,7 +5,6 @@ import net.corda.core.contracts.ContractState
 import net.corda.core.flows.FinalityFlow
 import net.corda.core.flows.FlowLogic
 import net.corda.core.identity.Party
-import net.corda.core.internal.packageName
 import net.corda.core.node.services.queryBy
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -14,7 +13,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.finance.DOLLARS
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.issuedBy
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.FINANCE_CONTRACTS_CORDAPP
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.startFlow
 import org.assertj.core.api.Assertions.assertThat
@@ -24,11 +23,7 @@ import rx.schedulers.Schedulers
 import java.util.concurrent.CountDownLatch
 
 class ServiceHubConcurrentUsageTest {
-    private val mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(
-            "net.corda.finance.schemas",
-            "net.corda.node.services.vault.VaultQueryExceptionsTests",
-            Cash::class.packageName
-    ))
+    private val mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(FINANCE_CONTRACTS_CORDAPP))
 
     @After
     fun stopNodes() {
@@ -42,7 +37,7 @@ class ServiceHubConcurrentUsageTest {
         val initiatingFlow = TestFlow(mockNet.defaultNotaryIdentity)
         val node = mockNet.createPartyNode()
 
-        node.services.validatedTransactions.updates.observeOn(Schedulers.io()).subscribe { _ ->
+        node.services.validatedTransactions.updates.observeOn(Schedulers.io()).subscribe {
             try {
                 node.services.vaultService.queryBy<ContractState>().states
                 successful = true

--- a/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/TimedFlowTests.kt
@@ -75,7 +75,7 @@ class TimedFlowTests {
         @JvmStatic
         fun setup() {
             mockNet = InternalMockNetwork(
-                    cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", "net.corda.node.services"),
+                    cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
                     defaultParameters = MockNetworkParameters().withServicePeerAllocationStrategy(InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin()),
                     threadPerNode = true
             )

--- a/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/events/ScheduledFlowTests.kt
@@ -6,7 +6,6 @@ import net.corda.core.context.InvocationOrigin
 import net.corda.core.contracts.*
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
-import net.corda.core.internal.packageName
 import net.corda.core.node.services.VaultService
 import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria.VaultQueryCriteria
@@ -112,7 +111,7 @@ class ScheduledFlowTests {
 
     @Before
     fun setup() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", javaClass.packageName), threadPerNode = true)
+        mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()), threadPerNode = true)
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         bobNode = mockNet.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
         notary = mockNet.defaultNotaryIdentity

--- a/node/src/test/kotlin/net/corda/node/services/persistence/ExposeJpaToFlowsTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/ExposeJpaToFlowsTests.kt
@@ -13,7 +13,7 @@ import net.corda.testing.core.TestIdentity
 import net.corda.testing.node.MockNetwork
 import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.MockServices
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.makeTestIdentityService
 import org.junit.After
 import org.junit.Before
@@ -43,7 +43,7 @@ class ExposeJpaToFlowsTests {
 
     @Before
     fun setUp() {
-        mockNet = MockNetwork(MockNetworkParameters(cordappsForAllNodes = cordappsForPackages(javaClass.packageName)))
+        mockNet = MockNetwork(MockNetworkParameters(cordappsForAllNodes = listOf(enclosedCordapp())))
         val (db, mockServices) = MockServices.makeTestDatabaseAndMockServices(
                 cordappPackages = listOf(javaClass.packageName),
                 identityService = makeTestIdentityService(myself.identity),

--- a/node/src/test/kotlin/net/corda/node/services/persistence/HibernateColumnConverterTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/persistence/HibernateColumnConverterTests.kt
@@ -2,8 +2,6 @@ package net.corda.node.services.persistence
 
 import co.paralleluniverse.fibers.Suspendable
 import net.corda.core.contracts.Amount
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.StartableByRPC
 import net.corda.core.identity.Party
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.OpaqueBytes
@@ -17,9 +15,11 @@ import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.keys.E2ETestKeyManagementService
 import net.corda.testing.core.BOC_NAME
 import net.corda.testing.internal.TestingNamedCacheFactory
-import net.corda.testing.node.InMemoryMessagingNetwork
+import net.corda.testing.node.InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin
 import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
 import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.internal.FINANCE_CORDAPPS
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -48,9 +48,7 @@ class HibernateColumnConverterTests {
     
     @Before
     fun start() {
-        mockNet = MockNetwork(
-                servicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin(),
-                cordappPackages = listOf("net.corda.finance.contracts.asset", "net.corda.finance.schemas"))
+        mockNet = MockNetwork(MockNetworkParameters(servicePeerAllocationStrategy = RoundRobin(), cordappsForAllNodes = FINANCE_CORDAPPS))
         bankOfCordaNode = mockNet.createPartyNode(BOC_NAME)
         bankOfCorda = bankOfCordaNode.info.identityFromX500Name(BOC_NAME)
         notary = mockNet.defaultNotaryIdentity

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowAsyncOperationTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowAsyncOperationTests.kt
@@ -11,10 +11,7 @@ import net.corda.core.internal.executeAsync
 import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
-import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.TestStartedNode
-import net.corda.testing.node.internal.cordappsForPackages
-import net.corda.testing.node.internal.startFlow
+import net.corda.testing.node.internal.*
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -28,7 +25,7 @@ class FlowAsyncOperationTests {
     @Before
     fun setup() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts", "net.corda.node.services.statemachine"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
                 notarySpecs = emptyList()
         )
         aliceNode = mockNet.createNode()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkPersistenceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkPersistenceTests.kt
@@ -43,7 +43,7 @@ class FlowFrameworkPersistenceTests {
     @Before
     fun start() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
                 servicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin()
         )
         aliceFlowManager = MockNodeFlowManager()

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTests.kt
@@ -66,7 +66,7 @@ class FlowFrameworkTests {
     @Before
     fun setUpMockNet() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts") + FINANCE_CORDAPPS,
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
                 servicePeerAllocationStrategy = RoundRobin()
         )
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTripartyTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/FlowFrameworkTripartyTests.kt
@@ -40,7 +40,7 @@ class FlowFrameworkTripartyTests {
     @Before
     fun setUpGlobalMockNet() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.finance.contracts", "net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
                 servicePeerAllocationStrategy = InMemoryMessagingNetwork.ServicePeerAllocationStrategy.RoundRobin()
         )
 

--- a/node/src/test/kotlin/net/corda/node/services/statemachine/IdempotentFlowTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/statemachine/IdempotentFlowTests.kt
@@ -9,7 +9,6 @@ import net.corda.core.flows.InitiatingFlow
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.IdempotentFlow
 import net.corda.core.internal.TimedFlow
-import net.corda.core.internal.packageName
 import net.corda.core.utilities.seconds
 import net.corda.node.services.config.FlowTimeoutConfiguration
 import net.corda.testing.node.internal.*
@@ -33,7 +32,7 @@ class IdempotentFlowTests {
 
     @Before
     fun start() {
-        mockNet = InternalMockNetwork(threadPerNode = true, cordappsForAllNodes = cordappsForPackages(this.javaClass.packageName))
+        mockNet = InternalMockNetwork(threadPerNode = true, cordappsForAllNodes = listOf(enclosedCordapp()))
         nodeA = mockNet.createNode(InternalMockNodeParameters(
                 legalName = CordaX500Name("Alice", "AliceCorp", "GB"),
                 configOverrides = {

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NonValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NonValidatingNotaryServiceTests.kt
@@ -46,8 +46,10 @@ class NonValidatingNotaryServiceTests {
 
     @Before
     fun setup() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"),
-                notarySpecs = listOf(MockNetworkNotarySpec(DUMMY_NOTARY_NAME, false)))
+        mockNet = InternalMockNetwork(
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
+                notarySpecs = listOf(MockNetworkNotarySpec(DUMMY_NOTARY_NAME, false))
+        )
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         notaryNode = mockNet.defaultNotaryNode
         notary = mockNet.defaultNotaryIdentity

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryServiceTests.kt
@@ -35,7 +35,7 @@ class NotaryServiceTests {
     @Before
     fun setup() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
                 notarySpecs = listOf(MockNetworkNotarySpec(DUMMY_NOTARY_NAME, validating = false)),
                 initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
         )

--- a/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/NotaryWhitelistTests.kt
@@ -60,7 +60,7 @@ class NotaryWhitelistTests(
     @Before
     fun setup() {
         mockNet = InternalMockNetwork(
-                cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
                 notarySpecs = listOf(MockNetworkNotarySpec(oldNotaryName, validating = isValidating), MockNetworkNotarySpec(newNotaryName, validating = isValidating)),
                 initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
         )

--- a/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/node/services/transactions/ValidatingNotaryServiceTests.kt
@@ -48,8 +48,10 @@ class ValidatingNotaryServiceTests {
 
     @Before
     fun setup() {
-        mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"),
-                initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4))
+        mockNet = InternalMockNetwork(
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
+                initialNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+        )
         aliceNode = mockNet.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
         notaryNode = mockNet.defaultNotaryNode
         notary = mockNet.defaultNotaryIdentity

--- a/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/VaultSoftLockManagerTest.kt
@@ -6,7 +6,6 @@ import net.corda.core.contracts.*
 import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.internal.FlowStateMachine
-import net.corda.core.internal.packageName
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.node.ServicesForResolution
 import net.corda.core.node.services.KeyManagementService
@@ -26,7 +25,7 @@ import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.internal.rigorousMock
 import net.corda.testing.node.internal.InternalMockNetwork
-import net.corda.testing.node.internal.cordappsForPackages
+import net.corda.testing.node.internal.enclosedCordapp
 import net.corda.testing.node.internal.startFlow
 import org.junit.After
 import org.junit.Test
@@ -79,7 +78,7 @@ class VaultSoftLockManagerTest {
         doNothing().whenever(it).softLockRelease(any(), anyOrNull())
     }
 
-    private val mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages(ContractImpl::class.packageName), defaultFactory = { args ->
+    private val mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(enclosedCordapp()), defaultFactory = { args ->
         object : InternalMockNetwork.MockNode(args) {
             override fun makeVaultService(keyManagementService: KeyManagementService,
                                           services: ServicesForResolution,

--- a/node/src/test/kotlin/net/corda/node/testing/MessageChainState.kt
+++ b/node/src/test/kotlin/net/corda/node/testing/MessageChainState.kt
@@ -1,4 +1,4 @@
-package net.corda.node.services.persistence
+package net.corda.node.testing
 
 import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
@@ -48,7 +48,7 @@ object MessageChainSchemaV1 : MappedSchema(
     ) : PersistentState()
 }
 
-const val MESSAGE_CHAIN_CONTRACT_PROGRAM_ID = "net.corda.node.services.persistence.MessageChainContract"
+const val MESSAGE_CHAIN_CONTRACT_PROGRAM_ID = "net.corda.node.testing.MessageChainContract"
 
 open class MessageChainContract : Contract {
     override fun verify(tx: LedgerTransaction) {
@@ -67,4 +67,3 @@ open class MessageChainContract : Contract {
         class Send : Commands
     }
 }
-

--- a/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/notary/experimental/bftsmart/BFTNotaryServiceTests.kt
@@ -24,9 +24,6 @@ import net.corda.core.utilities.seconds
 import net.corda.node.services.config.NotaryConfig
 import net.corda.nodeapi.internal.DevIdentityGenerator
 import net.corda.nodeapi.internal.network.NetworkParametersCopier
-import net.corda.notary.experimental.bftsmart.BFTSmartConfig
-import net.corda.notary.experimental.bftsmart.minClusterSize
-import net.corda.notary.experimental.bftsmart.minCorrectReplicas
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.dummyCommand
@@ -60,7 +57,7 @@ class BFTNotaryServiceTests {
         @BeforeClass
         @JvmStatic
         fun before() {
-            mockNet = InternalMockNetwork(cordappsForAllNodes = cordappsForPackages("net.corda.testing.contracts"))
+            mockNet = InternalMockNetwork(cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP))
             val clusterSize = minClusterSize(1)
             val started = startBftClusterAndNode(clusterSize, mockNet)
             notary = started.first

--- a/node/src/test/kotlin/net/corda/notary/experimental/raft/RaftNotaryServiceTests.kt
+++ b/node/src/test/kotlin/net/corda/notary/experimental/raft/RaftNotaryServiceTests.kt
@@ -20,6 +20,7 @@ import net.corda.testing.driver.InProcess
 import net.corda.testing.driver.driver
 import net.corda.testing.node.ClusterSpec
 import net.corda.testing.node.NotarySpec
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import org.junit.Test
 import java.util.*
 import kotlin.test.assertEquals
@@ -32,7 +33,7 @@ class RaftNotaryServiceTests {
     fun `detect double spend`() {
         driver(DriverParameters(
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
                 notarySpecs = listOf(NotarySpec(notaryName, cluster = ClusterSpec.Raft(clusterSize = 3)))
         )) {
             val bankA = startNode(providedName = DUMMY_BANK_A_NAME).map { (it as InProcess) }.getOrThrow()
@@ -65,7 +66,7 @@ class RaftNotaryServiceTests {
     fun `notarise issue tx with time-window`() {
         driver(DriverParameters(
                 startNodesInProcess = true,
-                extraCordappPackagesToScan = listOf("net.corda.testing.contracts"),
+                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP),
                 notarySpecs = listOf(NotarySpec(notaryName, cluster = ClusterSpec.Raft(clusterSize = 3)))
         )) {
             val bankA = startNode(providedName = DUMMY_BANK_A_NAME).map { (it as InProcess) }.getOrThrow()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/CustomCordapp.kt
@@ -25,7 +25,7 @@ import java.util.zip.ZipEntry
  * disparate classes. The CorDapp metadata that's present in the MANIFEST can also be tailored.
  */
 data class CustomCordapp(
-        val packages: Set<String>,
+        val packages: Set<String> = emptySet(),
         val name: String = "custom-cordapp",
         val versionId: Int = 1,
         val targetPlatformVersion: Int = PLATFORM_VERSION,

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalTestUtils.kt
@@ -28,6 +28,7 @@ import net.corda.testing.node.InMemoryMessagingNetwork
 import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.User
 import net.corda.testing.node.testContext
+import org.apache.commons.lang.ClassUtils
 import org.slf4j.LoggerFactory
 import rx.Observable
 import rx.subjects.AsyncSubject
@@ -65,6 +66,13 @@ val FINANCE_WORKFLOWS_CORDAPP: TestCordappImpl = findCordapp("net.corda.finance.
 @JvmField
 val FINANCE_CORDAPPS: Set<TestCordappInternal> = setOf(FINANCE_CONTRACTS_CORDAPP, FINANCE_WORKFLOWS_CORDAPP)
 
+/**
+ * *Custom* CorDapp containing the contents of the `net.corda.testing.contracts` package, i.e. the dummy contracts. This is not a real CorDapp
+ * in the way that [FINANCE_CONTRACTS_CORDAPP] and [FINANCE_WORKFLOWS_CORDAPP] are.
+ */
+@JvmField
+val DUMMY_CONTRACTS_CORDAPP: CustomCordapp = cordappWithPackages("net.corda.testing.contracts")
+
 fun cordappsForPackages(vararg packageNames: String): Set<CustomCordapp> = cordappsForPackages(packageNames.asList())
 
 fun cordappsForPackages(packageNames: Iterable<String>): Set<CustomCordapp> {
@@ -87,6 +95,25 @@ fun cordappForClasses(vararg classes: Class<*>): CustomCordapp = CustomCordapp(p
  * [TestCordapp.findCordapp] but returns the internal [TestCordappImpl].
  */
 fun findCordapp(scanPackage: String): TestCordappImpl = TestCordapp.findCordapp(scanPackage) as TestCordappImpl
+
+/** Create a *custom* CorDapp which just contains the enclosed classes of the receiver class. */
+fun Any.enclosedCordapp(): CustomCordapp {
+    val receiverClass = javaClass.enclosingClass ?: javaClass // In case this is called in the companion object
+    val classes = HashSet<Class<*>>()
+    receiverClass.collectEnclosedClasses(classes)
+    ClassUtils.getAllSuperclasses(receiverClass).forEach { (it as Class<*>).collectEnclosedClasses(classes) }
+    ClassUtils.getAllInterfaces(receiverClass).forEach { (it as Class<*>).collectEnclosedClasses(classes) }
+    require(classes.isNotEmpty()) { "${receiverClass.name} does not contain any enclosed classes to build a CorDapp out of" }
+    return CustomCordapp(name = receiverClass.name, classes = classes)
+}
+
+private fun Class<*>.collectEnclosedClasses(classes: MutableSet<Class<*>>) {
+    val enclosedClasses = declaredClasses
+    if (enclosedClasses.isNotEmpty() || enclosingClass != null) {
+        classes += this
+    }
+    enclosedClasses.forEach { it.collectEnclosedClasses(classes) }
+}
 
 private fun getCallerClass(directCallerClass: KClass<*>): Class<*>? {
     val stackTrace = Throwable().stackTrace

--- a/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/HashLookupCommandTest.kt
+++ b/tools/shell/src/integration-test/kotlin/net/corda/tools/shell/HashLookupCommandTest.kt
@@ -19,6 +19,7 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.NodeHandle
 import net.corda.testing.driver.driver
 import net.corda.testing.node.User
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import org.bouncycastle.util.io.Streams
 import org.junit.Ignore
 import org.junit.Test
@@ -30,7 +31,7 @@ class HashLookupCommandTest {
     fun `hash lookup command returns correct response`() {
         val user = User("u", "p", setOf(Permissions.all()))
 
-        driver(DriverParameters(notarySpecs = emptyList(), extraCordappPackagesToScan = listOf("net.corda.testing.contracts"))) {
+        driver(DriverParameters(notarySpecs = emptyList(), cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP))) {
             val nodeFuture = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user), startInSameProcess = true)
             val node = nodeFuture.getOrThrow()
             val txId = issueTransaction(node)


### PR DESCRIPTION
The helper method enclosedCordapp is a replacement to scanning the current package (which pulls in a lot more into the jar than intended) when all you need are the flows/contracts within the enclosed test class.

