### PR TITLE
[CORDA-2349] - Upgrade API scanner to include Kotlin-synthesized mehtods

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.38
+gradlePluginsVersion=4.0.39
 kotlinVersion=1.2.71
 # ***************************************************************#
 # When incrementing platformVersion make sure to update          #

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -55,3 +55,15 @@ jar {
 publish {
     name jar.baseName
 }
+
+scanApi {
+    //Constructors that are synthesized by Kotlin unexpectedly
+    excludeMethods = [
+        "net.corda.testing.node.MockServices": [
+            "<init>(Lnet/corda/node/cordapp/CordappLoader;Lnet/corda/core/node/services/IdentityService;Lnet/corda/core/node/NetworkParameters;Lnet/corda/testing/core/TestIdentity;[Ljava/security/KeyPair;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+        ],
+        "net.corda.testing.node.InMemoryMessagingNetwork\$MessageTransfer": [
+            "<init>(Lnet/corda/testing/node/InMemoryMessagingNetwork\$PeerHandle;Lnet/corda/node/services/messaging/Message;Lnet/corda/core/messaging/MessageRecipients;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+        ]
+    ]
+}


### PR DESCRIPTION
### Changes
This change enables reporting of methods synthesized by Kotlin, so that Kotlin-only ABI breakages are prevented.

The reason to backport this to the RC is so that we can have a point-in-time, where we know that any subsequent fix introduced in the RC does not cause any such breakage (since things can slip under the current version of api-scanning) & use this point to compare with 3.0 version, ensuring we eliminated all the breakages that were introduced (without being reported) during this period.

Link to original PR in master: https://github.com/corda/corda/pull/4595