### PR TITLE
Remove dependencies from classpath in SIMM valuation integ test

### DIFF
--- a/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
+++ b/samples/simm-valuation-demo/src/integration-test/kotlin/net/corda/vega/SimmValuationTest.kt
@@ -38,21 +38,12 @@ class SimmValuationTest {
         const val testTradeId = "trade1"
     }
 
-    @Before
-    fun setup() {
-        System.setProperty(AbstractAMQPSerializationScheme.SCAN_SPEC_PROP_NAME, CurrencyParameterSensitivitiesSerializer::class.packageName)
-    }
-
-    @After
-    fun tearDown() {
-        System.clearProperty(AbstractAMQPSerializationScheme.SCAN_SPEC_PROP_NAME)
-    }
-
     @Test
     fun `runs SIMM valuation demo`() {
         val logConfigFile = projectRootDir / "samples" / "simm-valuation-demo" / "src" / "main" / "resources" / "log4j2.xml"
         assertThat(logConfigFile).isRegularFile()
         driver(DriverParameters(isDebug = true,
+                startNodesInProcess = false, // starting nodes in separate processes to ensure system class path does not contain 3rd party libraries (masking serialization issues)
                 cordappsForAllNodes = listOf(findCordapp("net.corda.vega.flows"), findCordapp("net.corda.vega.contracts"), findCordapp("net.corda.confidential")) + FINANCE_CORDAPPS,
                 systemProperties = mapOf("log4j.configurationFile" to logConfigFile.toString()))
         ) {

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -768,9 +768,10 @@ class DriverDSLImpl(
                 it += extraCmdLineFlag
             }.toList()
 
-            // This excludes the samples and the finance module from the system classpath of the out of process nodes
-            // as they will be added to the cordapps folder.
-            val exclude = listOf("samples", "finance", "integrationTest", "test", "corda-mock")
+            // The following dependencies are excluded from the classpath of the created JVM, so that the environment resembles a real one as close as possible.
+            // These are either classes that will be added as attachments to the node (i.e. samples, finance, opengamma etc.) or irrelevant testing libraries (test, corda-mock etc.).
+            // TODO: There is pending work to fix this issue without custom blacklisting. See: https://r3-cev.atlassian.net/browse/CORDA-2164.
+            val exclude = listOf("samples", "finance", "integrationTest", "test", "corda-mock", "com.opengamma.strata")
             val cp = ProcessUtilities.defaultClassPath.filterNot { cpEntry ->
                 exclude.any { token -> cpEntry.contains("${File.separatorChar}$token") } || cpEntry.endsWith("-tests.jar")
             }


### PR DESCRIPTION
### Changes
This brings the SIMM valuation integ test in line with the manual run, so that it's not masking serialization issues, as was the case now.

### Testing
I switched the custom serializers of the context to a hard-coded empty set & verified that:
* the manual run was failing, while the integ test passed (before the fix)
* both were failing (after the fix)