### PR TITLE
ENT-2967 Fix up use of various JDK performance contention points

### DIFF
--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -385,10 +385,6 @@ object Crypto {
         }
     }
 
-    private fun keyFactory(signatureScheme: SignatureScheme) = signatureScheme.getKeyFactory {
-        KeyFactory.getInstance(signatureScheme.algorithmName, providerMap[signatureScheme.providerName])
-    }
-
     /**
      * Generic way to sign [ByteArray] data with a [PrivateKey]. Strategy on on identifying the actual signing scheme is based
      * on the [PrivateKey] type, but if the schemeCodeName is known, then better use
@@ -1066,5 +1062,9 @@ object Crypto {
     @StubOutForDJVM
     private fun setBouncyCastleRNG() {
         CryptoServicesRegistrar.setSecureRandom(newSecureRandom())
+    }
+
+    private fun keyFactory(signatureScheme: SignatureScheme) = signatureScheme.getKeyFactory {
+        KeyFactory.getInstance(signatureScheme.algorithmName, providerMap[signatureScheme.providerName])
     }
 }

--- a/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/Crypto.kt
@@ -290,7 +290,7 @@ object Crypto {
     fun decodePrivateKey(encodedKey: ByteArray): PrivateKey {
         val keyInfo = PrivateKeyInfo.getInstance(encodedKey)
         val signatureScheme = findSignatureScheme(keyInfo.privateKeyAlgorithm)
-        val keyFactory = KeyFactory.getInstance(signatureScheme.algorithmName, providerMap[signatureScheme.providerName])
+        val keyFactory = keyFactory(signatureScheme)
         return keyFactory.generatePrivate(PKCS8EncodedKeySpec(encodedKey))
     }
 
@@ -323,7 +323,7 @@ object Crypto {
             "Unsupported key/algorithm for schemeCodeName: ${signatureScheme.schemeCodeName}"
         }
         try {
-            val keyFactory = KeyFactory.getInstance(signatureScheme.algorithmName, providerMap[signatureScheme.providerName])
+            val keyFactory = keyFactory(signatureScheme)
             return keyFactory.generatePrivate(PKCS8EncodedKeySpec(encodedKey))
         } catch (ikse: InvalidKeySpecException) {
             throw InvalidKeySpecException("This private key cannot be decoded, please ensure it is PKCS8 encoded and that " +
@@ -342,7 +342,7 @@ object Crypto {
     fun decodePublicKey(encodedKey: ByteArray): PublicKey {
         val subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(encodedKey)
         val signatureScheme = findSignatureScheme(subjectPublicKeyInfo.algorithm)
-        val keyFactory = KeyFactory.getInstance(signatureScheme.algorithmName, providerMap[signatureScheme.providerName])
+        val keyFactory = keyFactory(signatureScheme)
         return keyFactory.generatePublic(X509EncodedKeySpec(encodedKey))
     }
 
@@ -377,12 +377,16 @@ object Crypto {
             "Unsupported key/algorithm for schemeCodeName: ${signatureScheme.schemeCodeName}"
         }
         try {
-            val keyFactory = KeyFactory.getInstance(signatureScheme.algorithmName, providerMap[signatureScheme.providerName])
+            val keyFactory = keyFactory(signatureScheme)
             return keyFactory.generatePublic(X509EncodedKeySpec(encodedKey))
         } catch (ikse: InvalidKeySpecException) {
             throw throw InvalidKeySpecException("This public key cannot be decoded, please ensure it is X509 encoded and " +
                     "that it corresponds to the input scheme's code name.", ikse)
         }
+    }
+
+    private fun keyFactory(signatureScheme: SignatureScheme) = signatureScheme.getKeyFactory {
+        KeyFactory.getInstance(signatureScheme.algorithmName, providerMap[signatureScheme.providerName])
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/crypto/SignatureScheme.kt
+++ b/core/src/main/kotlin/net/corda/core/crypto/SignatureScheme.kt
@@ -2,6 +2,7 @@ package net.corda.core.crypto
 
 import net.corda.core.KeepForDJVM
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import java.security.KeyFactory
 import java.security.Signature
 import java.security.spec.AlgorithmParameterSpec
 
@@ -33,4 +34,15 @@ data class SignatureScheme(
         val algSpec: AlgorithmParameterSpec?,
         val keySize: Int?,
         val desc: String
-)
+) {
+    @Volatile
+    private var memoizedKeyFactory: KeyFactory? = null
+
+    internal fun getKeyFactory(factoryFactory: () -> KeyFactory): KeyFactory {
+        return memoizedKeyFactory ?: run {
+            val newFactory = factoryFactory()
+            memoizedKeyFactory = newFactory
+            newFactory
+        }
+    }
+}

--- a/core/src/main/kotlin/net/corda/core/internal/ConstraintsUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ConstraintsUtils.kt
@@ -124,7 +124,7 @@ internal fun checkConstraintValidity(state: TransactionState<*>) {
  */
 internal fun ContractClassName.contractHasAutomaticConstraintPropagation(classLoader: ClassLoader? = null): Boolean {
     return (classLoader ?: NoConstraintPropagation::class.java.classLoader)
-            .loadClass(this)
+            .run { Class.forName(this@contractHasAutomaticConstraintPropagation, false, this) }
             .getAnnotation(NoConstraintPropagation::class.java) == null
 }
 


### PR DESCRIPTION
All code is in OS.  Each has a global mutex.

Stop repeated look up of KeyFactory.

Stop repeatedly asking for system class loader.

Replace ClassLoader.loadClass with Class.forName.
