### PR TITLE
ENT-2977 resolve custom serializers earlier

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -4,7 +4,6 @@ import net.corda.core.internal.uncheckedCast
 import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.model.DefaultCacheProvider
 import net.corda.serialization.internal.model.TypeIdentifier
-import java.lang.IllegalStateException
 import java.lang.reflect.Type
 
 interface CustomSerializerRegistry {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/CustomSerializerRegistry.kt
@@ -4,6 +4,7 @@ import net.corda.core.internal.uncheckedCast
 import net.corda.core.utilities.contextLogger
 import net.corda.serialization.internal.model.DefaultCacheProvider
 import net.corda.serialization.internal.model.TypeIdentifier
+import java.lang.IllegalStateException
 import java.lang.reflect.Type
 
 interface CustomSerializerRegistry {
@@ -27,7 +28,18 @@ class CachingCustomSerializerRegistry(
 
     private data class CustomSerializerIdentifier(val actualTypeIdentifier: TypeIdentifier, val declaredTypeIdentifier: TypeIdentifier)
 
-    private val customSerializersCache: MutableMap<CustomSerializerIdentifier, AMQPSerializer<Any>> = DefaultCacheProvider.createCache()
+    private sealed class CustomSerializerLookupResult {
+
+        abstract val serializerIfFound: AMQPSerializer<Any>?
+
+        object None : CustomSerializerLookupResult() {
+            override val serializerIfFound: AMQPSerializer<Any>? = null
+        }
+
+        data class CustomSerializerFound(override val serializerIfFound: AMQPSerializer<Any>) : CustomSerializerLookupResult()
+    }
+
+    private val customSerializersCache: MutableMap<CustomSerializerIdentifier, CustomSerializerLookupResult> = DefaultCacheProvider.createCache()
     private var customSerializers: List<SerializerFor> = emptyList()
 
     /**
@@ -36,6 +48,11 @@ class CachingCustomSerializerRegistry(
      */
     override fun register(customSerializer: CustomSerializer<out Any>) {
         logger.trace("action=\"Registering custom serializer\", class=\"${customSerializer.type}\"")
+
+        if (!customSerializersCache.isEmpty()) {
+            logger.warn("Attempting to register custom serializer $customSerializer.type} in an active cache." +
+                    "All serializers should be registered before the cache comes into use.")
+        }
 
         descriptorBasedSerializerRegistry.getOrBuild(customSerializer.typeDescriptor.toString()) {
             customSerializers += customSerializer
@@ -49,6 +66,11 @@ class CachingCustomSerializerRegistry(
     override fun registerExternal(customSerializer: CorDappCustomSerializer) {
         logger.trace("action=\"Registering external serializer\", class=\"${customSerializer.type}\"")
 
+        if (!customSerializersCache.isEmpty()) {
+            logger.warn("Attempting to register custom serializer ${customSerializer.type} in an active cache." +
+                    "All serializers must be registered before the cache comes into use.")
+        }
+
         descriptorBasedSerializerRegistry.getOrBuild(customSerializer.typeDescriptor.toString()) {
             customSerializers += customSerializer
             customSerializer
@@ -60,10 +82,11 @@ class CachingCustomSerializerRegistry(
                 TypeIdentifier.forClass(clazz),
                 TypeIdentifier.forGenericType(declaredType))
 
-        return customSerializersCache[typeIdentifier]
-                ?: doFindCustomSerializer(clazz, declaredType)?.also { serializer ->
-                    customSerializersCache.putIfAbsent(typeIdentifier, serializer)
-                }
+        return customSerializersCache.getOrPut(typeIdentifier) {
+                val customSerializer = doFindCustomSerializer(clazz, declaredType)
+                if (customSerializer == null) CustomSerializerLookupResult.None
+                else CustomSerializerLookupResult.CustomSerializerFound(customSerializer)
+        }.serializerIfFound
     }
 
     private fun doFindCustomSerializer(clazz: Class<*>, declaredType: Type): AMQPSerializer<Any>? {

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -210,7 +210,6 @@ class DefaultLocalSerializerFactory(
             typeInformation: LocalTypeInformation
     ): AMQPSerializer<Any> = makeAndCache(typeInformation) {
         logger.debug { "class=${clazz.simpleName}, type=$type is a composite type" }
-
         when {
             clazz.isSynthetic -> // Explicitly ban synthetic classes, we have no way of recreating them when deserializing. This also
                 // captures Lambda expressions and other anonymous functions


### PR DESCRIPTION
When looking up a serializer for a concrete type implementing `PublicKey`, we really don't need to perform detailed type-and-property analysis on that type, since it will be handled by a custom serializer anyway. Although we don't know quite what causes the exception observed in [ENT-2977](https://r3-cev.atlassian.net/browse/ENT-2977), it does seem to be being thrown during analysis of one such type, and we can avoid this by performing custom serializer lookup immediately rather than waiting until we have all the type information for the object to be serialized.

To avoid introducing an inefficient scan across the entire custom serializer registry every time a serializer is requested, we modify the registry to record when a type does _not_ have a custom serializer, as well as when it does. Here we are taking advantage of the assumption that custom serializers are only registered when the factory is first initialised, and not after it has been brought into use. A warning is written to the log if a custom serializer is registered but the registry's cache is not empty.

Some other small changes are introduced, to reduce contention on concurrent hash maps: `getOrPut` replaces `computeIfAbsent`, since we do not need to grab a lock on a hash bucket to read a value if it is already present, and it is safe to compute the value more than once if it is absent. We eliminate a redundant write to `descriptorBasedSerializerRegistry`, which was being performed every time a serializer was found: now it is only performed when the serializer is first created and cached.