### PR TITLE
CORDA-2482: Fix issue with devModeOptions.allowCompatibilityZone not working (#4613)

### DIFF
--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -93,7 +93,7 @@ open class SharedNodeCmdLineOptions {
 class InitialRegistrationCmdLineOptions : SharedNodeCmdLineOptions() {
     override fun parseConfiguration(configuration: Config): Valid<NodeConfiguration> {
         return super.parseConfiguration(configuration).doIfValid { config ->
-            require(!config.devMode) { "Registration cannot occur in development mode" }
+            require(!config.devMode || config.devModeOptions?.allowCompatibilityZone == true)
             require(config.compatibilityZoneURL != null || config.networkServices != null) {
                 "compatibilityZoneURL or networkServices must be present in the node configuration file in registration mode."
             }
@@ -165,7 +165,6 @@ open class NodeCmdLineOptions : SharedNodeCmdLineOptions() {
     override fun parseConfiguration(configuration: Config): Valid<NodeConfiguration> {
         return super.parseConfiguration(configuration).doIfValid { config ->
             if (isRegistration) {
-                require(!config.devMode) { "Registration cannot occur in development mode" }
                 require(config.compatibilityZoneURL != null || config.networkServices != null) {
                     "compatibilityZoneURL or networkServices must be present in the node configuration file in registration mode."
                 }


### PR DESCRIPTION
Original PR here: https://github.com/corda/corda/pull/4613
