### PR TITLE
[CORDA-2435] Print an error and exit if the vault contains V3 states

### DIFF
--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -17,6 +17,10 @@ However, there are usually new features and other opt-in changes that may improv
 application that are worth considering for any actively maintained software. This guide shows you how to upgrade your app to benefit
 from the new features in the latest release.
 
+.. note:: A number of new features will only work with states created in V4 nodes at present. As a result, if a node is upgraded to use
+          Corda 4, but states created with Corda 3 are present in the node, the node will report an error and exit. Apps upgraded to use
+          Corda 4 should therefore start from a clean node. This will be fixed in Corda 4.1.
+
 .. contents::
    :depth: 3
 
@@ -342,7 +346,7 @@ states in the vault, to maintain backwards compatibility. However, it may make s
 to the node in question to query for only relevant states. See :doc:`api-vault-query.rst` for more details on how to do this. Not doing this
 may result in queries returning more states than expected if the node is using Observer node functionality (see ":doc:`tutorial-observer-nodes.rst`").
 
-Step 10. Explore other new features that may be useful
+Step 11. Explore other new features that may be useful
 ------------------------------------------------------
 
 Corda 4 adds several new APIs that help you build applications. Why not explore:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -15,6 +15,10 @@ comes with those same guarantees. States and apps valid in Corda 3 are transpare
    along with how you can adjust your app to opt-in to new features making your app more secure and
    easier to upgrade.
 
+.. note:: Currently, states created with a node running Corda 3 are incompatible with some Corda 4 features.
+   If a node running Corda 4 detects that these states are present, it will exit to prevent errors from
+   occurring while using those states. This is a temporary condition that will be fixed for Corda 4.1.
+
 Additionally, be aware that the data model upgrades are changes to the Corda consensus rules. To use
 apps that benefit from them, *all* nodes in a compatibility zone must be upgraded and the zone must be
 enforcing that upgrade. This may take time in large zones like the testnet. Please take this into

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -380,7 +380,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             installCordaServices()
             contractUpgradeService.start()
             vaultService.start()
-            if (vaultService.oldStatesPresent()) {
+            if (!configuration.allowPreV4States && vaultService.oldStatesPresent()) {
                 stop()
                 throw OldStatesException()
             }

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1077,8 +1077,8 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
 
 class ConfigurationException(message: String) : CordaException(message)
 
-class OldStatesException : Exception("Detected states created using Corda 3 in the vault. Certain Corda 4 features cannot work with Corda 3" +
-        " states. Exiting.")
+class OldStatesException : Exception("Detected states created using Corda 3 in the vault. Currently certain Corda 4 features cannot work with Corda 3" +
+        " states. See the release notes for more details. Exiting.")
 
 fun createCordaPersistence(databaseConfig: DatabaseConfig,
                            wellKnownPartyFromX500Name: (CordaX500Name) -> Party?,

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -380,6 +380,10 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             installCordaServices()
             contractUpgradeService.start()
             vaultService.start()
+            if (vaultService.oldStatesPresent()) {
+                stop()
+                throw OldStatesException()
+            }
             ScheduledActivityObserver.install(vaultService, schedulerService, flowLogicRefFactory)
 
             val frozenTokenizableServices = tokenizableServices!!
@@ -1072,6 +1076,9 @@ class FlowStarterImpl(private val smm: StateMachineManager, private val flowLogi
 }
 
 class ConfigurationException(message: String) : CordaException(message)
+
+class OldStatesException : Exception("Detected states created using Corda 3 in the vault. Certain Corda 4 features cannot work with Corda 3" +
+        " states. Exiting.")
 
 fun createCordaPersistence(databaseConfig: DatabaseConfig,
                            wellKnownPartyFromX500Name: (CordaX500Name) -> Party?,

--- a/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
+++ b/node/src/main/kotlin/net/corda/node/services/api/VaultServiceInternal.kt
@@ -10,6 +10,12 @@ interface VaultServiceInternal : VaultService {
     fun start()
 
     /**
+     * Check that there are no states in the vault that were created using an old version of Corda. These may not be usable with new
+     * features, so prevent the node from starting up in this case.
+     */
+    fun oldStatesPresent(): Boolean
+
+    /**
      * Splits the provided [txns] into batches of [WireTransaction] and [NotaryChangeWireTransaction].
      * This is required because the batches get aggregated into single updates, and we want to be able to
      * indicate whether an update consists entirely of regular or notary change transactions, which may require

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfiguration.kt
@@ -84,6 +84,7 @@ interface NodeConfiguration {
     val cordappSignerKeyFingerprintBlacklist: List<String>
 
     val networkParameterAcceptanceSettings: NetworkParameterAcceptanceSettings
+    val allowPreV4States: Boolean
 
     companion object {
         // default to at least 8MB and a bit extra for larger heap sizes

--- a/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/NodeConfigurationImpl.kt
@@ -75,7 +75,8 @@ data class NodeConfigurationImpl(
         override val jmxReporterType: JmxReporterType? = Defaults.jmxReporterType,
         override val flowOverrides: FlowOverrideConfig?,
         override val cordappSignerKeyFingerprintBlacklist: List<String> = Defaults.cordappSignerKeyFingerprintBlacklist,
-        override val networkParameterAcceptanceSettings: NetworkParameterAcceptanceSettings = Defaults.networkParameterAcceptanceSettings
+        override val networkParameterAcceptanceSettings: NetworkParameterAcceptanceSettings = Defaults.networkParameterAcceptanceSettings,
+        override val allowPreV4States: Boolean = Defaults.allowPreV4States
 ) : NodeConfiguration {
     internal object Defaults {
         val jmxMonitoringHttpPort: Int? = null
@@ -108,6 +109,7 @@ data class NodeConfigurationImpl(
         val jmxReporterType: JmxReporterType = NodeConfiguration.defaultJmxReporterType
         val cordappSignerKeyFingerprintBlacklist: List<String> = DEV_PUB_KEY_HASHES.map { it.toString() }
         val networkParameterAcceptanceSettings: NetworkParameterAcceptanceSettings = NetworkParameterAcceptanceSettings()
+        const val allowPreV4States: Boolean = false
 
         fun cordappsDirectories(baseDirectory: Path) = listOf(baseDirectory / CORDAPPS_DIR_NAME_DEFAULT)
 

--- a/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
+++ b/node/src/main/kotlin/net/corda/node/services/config/schema/v1/V1NodeConfigurationSpec.kt
@@ -73,6 +73,7 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
     private val jarDirs by string().list().optional().withDefaultValue(Defaults.jarDirs)
     private val cordappDirectories by string().mapValid(::toPath).list().optional()
     private val cordappSignerKeyFingerprintBlacklist by string().list().optional().withDefaultValue(Defaults.cordappSignerKeyFingerprintBlacklist)
+    private val allowPreV4States by boolean().optional().withDefaultValue(Defaults.allowPreV4States)
     @Suppress("unused")
     private val custom by nestedObject().optional()
 
@@ -128,7 +129,8 @@ internal object V1NodeConfigurationSpec : Configuration.Specification<NodeConfig
                     h2port = configuration[h2port],
                     jarDirs = configuration[jarDirs],
                     cordappDirectories = cordappDirectories,
-                    cordappSignerKeyFingerprintBlacklist = configuration[cordappSignerKeyFingerprintBlacklist]
+                    cordappSignerKeyFingerprintBlacklist = configuration[cordappSignerKeyFingerprintBlacklist],
+                    allowPreV4States = configuration[allowPreV4States]
             ))
         } catch (e: Exception) {
             return when (e) {

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -493,7 +493,10 @@ class NodeVaultService(
         val queryRootPersistentStates = criteriaQuery.from(VaultSchemaV1.PersistentParty::class.java)
         criteriaQuery.select(queryRootPersistentStates)
         val query = session.createQuery(criteriaQuery)
-        return query.resultList.toSet()
+        val result = query.resultList.toSet()
+
+        log.debug("Found ${result.size} persistent party entries")
+        return result
     }
 
     override fun oldStatesPresent(): Boolean {

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -485,7 +485,7 @@ class NodeVaultService(
 
     override fun oldStatesPresent(): Boolean {
         log.info("Checking for states in vault from a previous version")
-        return database.transaction {
+        val oldStatesPresent = database.transaction {
             val session = getSession()
             val persistentStates = getPersistentStateCount(session)
             val stateParties = getPersistentPartyCount(session)
@@ -493,6 +493,8 @@ class NodeVaultService(
             // There are no V3 states if all the states in the vault are also in the state_party table
             stateParties != persistentStates
         }
+        log.info("Finished checking for old states. Old states present: $oldStatesPresent")
+        return oldStatesPresent
     }
 
     @VisibleForTesting

--- a/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/vault/NodeVaultService.kt
@@ -458,6 +458,61 @@ class NodeVaultService(
         return claimedStates
     }
 
+    private fun <T: ContractState> getPersistentStates(session: Session,
+                                                       criteria: QueryCriteria,
+                                                       paging: PageSpecification,
+                                                       sorting: Sort,
+                                                       contractStateType: Class<out T>): List<Tuple> {
+        val criteriaQuery = criteriaBuilder.createQuery(Tuple::class.java)
+        val queryRootVaultStates = criteriaQuery.from(VaultSchemaV1.VaultStates::class.java)
+        // TODO: revisit (use single instance of parser for all queries)
+        val criteriaParser = HibernateQueryCriteriaParser(contractStateType, contractStateTypeMappings, criteriaBuilder, criteriaQuery, queryRootVaultStates)
+
+        // parse criteria and build where predicates
+        criteriaParser.parse(criteria, sorting)
+
+        // prepare query for execution
+        val query = session.createQuery(criteriaQuery)
+
+        // For both SQLServer and PostgresSQL, firstResult must be >= 0. So we set a floor at 0.
+        // TODO: This is a catch-all solution. But why is the default pageNumber set to be -1 in the first place?
+        // Even if we set the default pageNumber to be 1 instead, that may not cover the non-default cases.
+        // So the floor may be necessary anyway.
+        query.firstResult = maxOf(0, (paging.pageNumber - 1) * paging.pageSize)
+        val pageSize = paging.pageSize + 1
+        query.maxResults = if (pageSize > 0) pageSize else Integer.MAX_VALUE // detection too many results, protected against overflow
+
+        val results = query.resultList
+        log.debug("Found ${results.size} states matching $criteria")
+
+        return results
+    }
+
+    private fun getPersistentParties(session: Session): Set<VaultSchemaV1.PersistentParty> {
+        val criteriaQuery = criteriaBuilder.createQuery(VaultSchemaV1.PersistentParty::class.java)
+        val queryRootPersistentStates = criteriaQuery.from(VaultSchemaV1.PersistentParty::class.java)
+        criteriaQuery.select(queryRootPersistentStates)
+        val query = session.createQuery(criteriaQuery)
+        return query.resultList.toSet()
+    }
+
+    override fun oldStatesPresent(): Boolean {
+        log.info("Updating vault data from previous version to be compatible with the new version.")
+        val session = getSession()
+        val persistentStates: List<VaultSchemaV1.VaultStates> = getPersistentStates(
+                session,
+                QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL),
+                PageSpecification(),
+                Sort(emptySet()),
+                ContractState::class.java).filter { it[0] is VaultSchemaV1.VaultStates }.map { it[0] as VaultSchemaV1.VaultStates }
+        val persistentStateRefs = persistentStates.map { StateRef(SecureHash.parse(it.stateRef!!.txId), it.stateRef!!.index)}.toSet()
+        val stateParties = getPersistentParties(session)
+        val statePartyRefs = stateParties.map { StateRef(SecureHash.parse(it.compositeKey.stateRef!!.txId), it.compositeKey.stateRef!!.index) }.toSet()
+
+        // There are no V3 states if all the states in the vault are also in the state_party table
+        return statePartyRefs.size != persistentStateRefs.size
+    }
+
     @VisibleForTesting
     internal fun isRelevant(state: ContractState, myKeys: Set<PublicKey>): Boolean {
         val keysToCheck = when (state) {
@@ -489,18 +544,6 @@ class NodeVaultService(
 
             val session = getSession()
 
-            val criteriaQuery = criteriaBuilder.createQuery(Tuple::class.java)
-            val queryRootVaultStates = criteriaQuery.from(VaultSchemaV1.VaultStates::class.java)
-
-            // TODO: revisit (use single instance of parser for all queries)
-            val criteriaParser = HibernateQueryCriteriaParser(contractStateType, contractStateTypeMappings, criteriaBuilder, criteriaQuery, queryRootVaultStates)
-
-            // parse criteria and build where predicates
-            criteriaParser.parse(criteria, sorting)
-
-            // prepare query for execution
-            val query = session.createQuery(criteriaQuery)
-
             // pagination checks
             if (!skipPagingChecks && !paging.isDefault) {
                 // pagination
@@ -509,16 +552,13 @@ class NodeVaultService(
                 if (paging.pageSize > MAX_PAGE_SIZE) throw VaultQueryException("Page specification: invalid page size ${paging.pageSize} [maximum is $MAX_PAGE_SIZE]")
             }
 
-            // For both SQLServer and PostgresSQL, firstResult must be >= 0. So we set a floor at 0.
-            // TODO: This is a catch-all solution. But why is the default pageNumber set to be -1 in the first place?
-            // Even if we set the default pageNumber to be 1 instead, that may not cover the non-default cases.
-            // So the floor may be necessary anyway.
-            query.firstResult = maxOf(0, (paging.pageNumber - 1) * paging.pageSize)
-            val pageSize = paging.pageSize + 1
-            query.maxResults = if (pageSize > 0) pageSize else Integer.MAX_VALUE // detection too many results, protected against overflow
-
             // execution
-            val results = query.resultList
+            val results = getPersistentStates(session, criteria, paging, sorting, contractStateType)
+
+            val stateTypes = when(criteria) {
+                is QueryCriteria.CommonQueryCriteria -> criteria.status
+                else -> Vault.StateStatus.UNCONSUMED
+            }
 
             // final pagination check (fail-fast on too many results when no pagination specified)
             if (!skipPagingChecks && paging.isDefault && results.size > DEFAULT_PAGE_SIZE) {
@@ -557,7 +597,7 @@ class NodeVaultService(
             if (stateRefs.isNotEmpty())
                 statesAndRefs.addAll(uncheckedCast(servicesForResolution.loadStates(stateRefs)))
 
-            Vault.Page(states = statesAndRefs, statesMetadata = statesMeta, stateTypes = criteriaParser.stateTypes, totalStatesAvailable = totalStates, otherResults = otherResults)
+            Vault.Page(states = statesAndRefs, statesMetadata = statesMeta, stateTypes = stateTypes, totalStatesAvailable = totalStates, otherResults = otherResults)
         }
     }
 

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -1,29 +1,30 @@
-additionalP2PAddresses = []
+emailAddress = "admin@company.com"
+keyStorePassword = "cordacadevpass"
+trustStorePassword = "trustpass"
 crlCheckSoftFail = true
-database = {
-    transactionIsolationLevel = "REPEATABLE_READ"
-    exportHibernateJMXStatistics = "false"
-}
+lazyBridgeStart = true
+additionalP2PAddresses = []
 dataSourceProperties = {
     dataSourceClassName = org.h2.jdbcx.JdbcDataSource
     dataSource.url = "jdbc:h2:file:"${baseDirectory}"/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"
     dataSource.user = sa
     dataSource.password = ""
 }
-emailAddress = "admin@company.com"
+database = {
+    transactionIsolationLevel = "REPEATABLE_READ"
+    exportHibernateJMXStatistics = "false"
+}
+
+useTestClock = false
+verifierType = InMemory
+rpcSettings = {
+    useSsl = false
+    standAloneBroker = false
+}
 flowTimeout {
     timeout = 30 seconds
     maxRestartCount = 6
     backoffBase = 1.8
 }
 jmxReporterType = JOLOKIA
-keyStorePassword = "cordacadevpass"
-lazyBridgeStart = true
-rpcSettings = {
-    useSsl = false
-    standAloneBroker = false
-}
-trustStorePassword = "trustpass"
-useTestClock = false
-verifierType = InMemory
 allowPreV4States = false

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -1,30 +1,29 @@
-emailAddress = "admin@company.com"
-keyStorePassword = "cordacadevpass"
-trustStorePassword = "trustpass"
-crlCheckSoftFail = true
-lazyBridgeStart = true
 additionalP2PAddresses = []
+crlCheckSoftFail = true
+database = {
+    transactionIsolationLevel = "REPEATABLE_READ"
+    exportHibernateJMXStatistics = "false"
+}
 dataSourceProperties = {
     dataSourceClassName = org.h2.jdbcx.JdbcDataSource
     dataSource.url = "jdbc:h2:file:"${baseDirectory}"/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"
     dataSource.user = sa
     dataSource.password = ""
 }
-database = {
-    transactionIsolationLevel = "REPEATABLE_READ"
-    exportHibernateJMXStatistics = "false"
-}
-
-useTestClock = false
-verifierType = InMemory
-rpcSettings = {
-    useSsl = false
-    standAloneBroker = false
-}
+emailAddress = "admin@company.com"
 flowTimeout {
     timeout = 30 seconds
     maxRestartCount = 6
     backoffBase = 1.8
 }
 jmxReporterType = JOLOKIA
-
+keyStorePassword = "cordacadevpass"
+lazyBridgeStart = true
+rpcSettings = {
+    useSsl = false
+    standAloneBroker = false
+}
+trustStorePassword = "trustpass"
+useTestClock = false
+verifierType = InMemory
+allowPreV4States = false

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -905,22 +905,26 @@ class NodeVaultServiceTest {
         services.recordTransactions(StatesToRecord.ALL_VISIBLE, listOf(createTx(6, megaCorp.party, bankOfCorda.party)))
         services.recordTransactions(StatesToRecord.NONE, listOf(createTx(7, bankOfCorda.party)))
 
-        assertEquals(false, vaultService.oldStatesPresent())
+        database.transaction {
+            assertEquals(false, vaultService.oldStatesPresent())
+        }
 
-        val session = currentDBSession()
-        val stateToAdd = VaultSchemaV1.VaultStates(
+        database.transaction {
+            val session = currentDBSession()
+            val stateToAdd = VaultSchemaV1.VaultStates(
                 notary = DUMMY_NOTARY,
                 contractStateClassName = DummyState::class.java.toString(),
                 stateStatus = Vault.StateStatus.UNCONSUMED,
                 recordedTime = Instant.now(),
                 relevancyStatus = Vault.RelevancyStatus.RELEVANT,
                 constraintType = Vault.ConstraintInfo.Type.ALWAYS_ACCEPT
-        )
-        val persistentStateRef = PersistentStateRef("C517D22982867E517E3E933A99C8F53658C8708A7B84FE37C36D0D8AF1EA167C", 23)
-        stateToAdd.stateRef = persistentStateRef
-        session.save(stateToAdd)
+            )
+            val persistentStateRef = PersistentStateRef("C517D22982867E517E3E933A99C8F53658C8708A7B84FE37C36D0D8AF1EA167C", 23)
+            stateToAdd.stateRef = persistentStateRef
+            session.save(stateToAdd)
 
-        assertEquals(true, vaultService.oldStatesPresent())
+            assertEquals(true, vaultService.oldStatesPresent())
+        }
     }
 
     @Test

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/InternalMockNetwork.kt
@@ -615,6 +615,7 @@ private fun mockNodeConfiguration(certificatesDirectory: Path): NodeConfiguratio
         doReturn(5.seconds.toMillis()).whenever(it).additionalNodeInfoPollingFrequencyMsec
         doReturn(null).whenever(it).devModeOptions
         doReturn(NetworkParameterAcceptanceSettings()).whenever(it).networkParameterAcceptanceSettings
+        doReturn(true).whenever(it).allowPreV4States
     }
 }
 


### PR DESCRIPTION
If a node is upgraded from V3 to V4, then any states currently in the vault are not migrated correctly. In particular, the relevancy column in the vault is filled in as relevant for all states (even if the node has recorded non-relevant states) and the state_party table is not populated with old states. The result is that certain V4 features will not work correctly with these states.

It turns out that fixing this for V4 is fairly involved. However, as the issue only affects nodes that are upgrading with V3 states in the vault, it is deemed acceptable to block these nodes from starting. This gives time to provide a proper fix for the problem in time for V4.1. This PR adds code to detect V3 states in the vault and block the node from starting in this case. It also adds a configuration option to disable this. See [CORDA-2435](https://r3-cev.atlassian.net/browse/CORDA-2435) for full details of the issue, and see #4611 for the previous PR that was going to merge this to master.

Changes:
- Added function to NodeVaultService to check for V3 states in the vault
- Added test to make sure this returns correctly
- Check added at node startup using this that blocks the node starting if V3 states are detected.
- Added a configuration option, allowPreV4States, that stops this check from being carried out.

Manual testing has been carried out to ensure the node does not start if V3 states are present, and does start if no V3 states are present. The new configuration option has also been tested manually.
