### PR TITLE
CORDA-2504 improve error message of missing contract attachments

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -4950,7 +4950,8 @@ public static final class net.corda.core.transactions.LedgerTransaction$InOutGro
 @CordaSerializable
 public final class net.corda.core.transactions.MissingContractAttachments extends net.corda.core.flows.FlowException
   public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>)
-  public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, Integer)
+  public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, String)
+  public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, String, Integer)
   @NotNull
   public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getStates()
 ##

--- a/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
@@ -18,5 +18,5 @@ class MissingContractAttachments
 @JvmOverloads
 constructor(states: List<TransactionState<ContractState>>, contractsClassName: String? = null, minimumRequiredContractClassVersion: Version? = null) : FlowException(
         "Cannot find contract attachments for " +
-        "${if (states.isEmpty()) contractsClassName else states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}. " +
+        "${contractsClassName ?: states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}. " +
         "See https://docs.corda.net/api-contract-constraints.html#debugging")

--- a/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
@@ -16,7 +16,7 @@ import net.corda.core.serialization.CordaSerializable
 @KeepForDJVM
 class MissingContractAttachments
 @JvmOverloads
-constructor(states: List<TransactionState<ContractState>>, contractsClassName: String? = null, minimumRequiredContractClassVersion: Version? = null) : FlowException(
+constructor(val states: List<TransactionState<ContractState>>, contractsClassName: String? = null, minimumRequiredContractClassVersion: Version? = null) : FlowException(
         "Cannot find contract attachments for " +
         "${contractsClassName ?: states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}. " +
         "See https://docs.corda.net/api-contract-constraints.html#debugging")

--- a/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/MissingContractAttachments.kt
@@ -16,7 +16,7 @@ import net.corda.core.serialization.CordaSerializable
 @KeepForDJVM
 class MissingContractAttachments
 @JvmOverloads
-constructor(val states: List<TransactionState<ContractState>>, minimumRequiredContractClassVersion: Version? = null) : FlowException(
+constructor(states: List<TransactionState<ContractState>>, contractsClassName: String? = null, minimumRequiredContractClassVersion: Version? = null) : FlowException(
         "Cannot find contract attachments for " +
-        "${states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}. " +
+        "${if (states.isEmpty()) contractsClassName else states.map { it.contract }.distinct()}${minimumRequiredContractClassVersion?.let { ", minimum required contract class version $minimumRequiredContractClassVersion"}}. " +
         "See https://docs.corda.net/api-contract-constraints.html#debugging")

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -468,7 +468,7 @@ open class TransactionBuilder(
 
         val minimumRequiredContractClassVersion = stateRefs?.map { services.loadContractAttachment(it).contractVersion }?.max() ?: DEFAULT_CORDAPP_VERSION
         return services.attachments.getLatestContractAttachments(contractClassName, minimumRequiredContractClassVersion).firstOrNull()
-                ?: throw MissingContractAttachments(states, minimumRequiredContractClassVersion)
+                ?: throw MissingContractAttachments(states, contractClassName, minimumRequiredContractClassVersion)
     }
 
     private fun useWhitelistedByZoneAttachmentConstraint(contractClassName: ContractClassName, networkParameters: NetworkParameters) = contractClassName in networkParameters.whitelistedContractImplementations.keys

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -1,3 +1,5 @@
+.. highlight:: kotlin
+
 API: Contract Constraints
 =========================
 
@@ -337,7 +339,37 @@ common sources of ``MissingContractAttachments`` exceptions:
 
 Not setting CorDapp packages in tests
 *************************************
-You are running a test and have not specified the CorDapp packages to scan. See the instructions above.
+You are running a test and have not specified the CorDapp packages to scan.
+When using ``mockNetwork`` ensure you provided a package containing the contract class in ``MockNetworkParameters``. See :doc:`api-testing`.
+
+Similarly package names need to be provided when tasting using ``DriverDSl``. ``DriverParameters`` has property ``cordappsForAllNodes`` (Kotlin)
+or method ``withCordappsForAllNodes`` in Java. Pass the collection of ``TestCordapp`` created by utility method ``TestCordapp.findCordapp(String)``.
+
+Example to create two Cordapps with Finance App Flows and Finance App Contracts in Kotlin:
+
+   .. sourcecode:: kotlin
+
+        Driver.driver(DriverParameters(cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.finance.schemas"),
+                TestCordapp.findCordapp("net.corda.finance.flows"))) {
+            // Your test code go here
+        })
+
+The same example in Java:
+
+   .. sourcecode:: java
+
+        Driver.driver(new DriverParameters()
+                .withCordappsForAllNodes(Arrays.asList(TestCordapp.findCordapp("net.corda.finance.schemas"),
+                TestCordapp.findCordapp("net.corda.finance.flows"))), dsl -> {
+            // Your test code go here
+        });
+
+
+Staring node without CorDapp
+****************************
+
+When running the Corda node ensure all CordApp JARs are placed in ``cordapss`` directory of each node, see :doc:`generating-a-node`.
+Also Gradle Cordform task ``deployNodes`` copies all JARs if Cordapps to deploy are specified, see :doc:`generating-a-node`.
 
 Wrong fully-qualified contract name
 ***********************************

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -368,8 +368,9 @@ The same example in Java:
 Staring a node missing CorDapp(s)
 *********************************
 
-When running the Corda node ensure all CordDapp JARs are placed in ``cordapps`` directory of each node. See :doc:`generating-a-node` for detailed instructions.
-By default Gradle Cordform task ``deployNodes`` copies all JARs if CorDapps to deploy are specified. See :doc:`generating-a-node` for detailed instructions.
+When running the Corda node ensure all CordDapp JARs are placed in ``cordapps`` directory of each node.
+By default Gradle Cordform task ``deployNodes`` copies all JARs if CorDapps to deploy are specified.
+See :doc:`generating-a-node` for detailed instructions.
 
 Wrong fully-qualified contract name
 ***********************************

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -340,12 +340,12 @@ common sources of ``MissingContractAttachments`` exceptions:
 Not setting CorDapp packages in tests
 *************************************
 You are running a test and have not specified the CorDapp packages to scan.
-When using ``mockNetwork`` ensure you provided a package containing the contract class in ``MockNetworkParameters``. See :doc:`api-testing`.
+When using ``MockNetwork`` ensure you provided a package containing the contract class in ``MockNetworkParameters``. See :doc:`api-testing`.
 
-Similarly package names need to be provided when tasting using ``DriverDSl``. ``DriverParameters`` has property ``cordappsForAllNodes`` (Kotlin)
+Similarly package names need to be provided when tasting using ``DriverDSl``. ``DriverParameters`` has a property ``cordappsForAllNodes`` (Kotlin)
 or method ``withCordappsForAllNodes`` in Java. Pass the collection of ``TestCordapp`` created by utility method ``TestCordapp.findCordapp(String)``.
 
-Example to create two Cordapps with Finance App Flows and Finance App Contracts in Kotlin:
+Example of creation of two Cordapps with Finance App Flows and Finance App Contracts in Kotlin:
 
    .. sourcecode:: kotlin
 
@@ -368,8 +368,8 @@ The same example in Java:
 Staring node without CorDapp
 ****************************
 
-When running the Corda node ensure all CordApp JARs are placed in ``cordapss`` directory of each node, see :doc:`generating-a-node`.
-Also Gradle Cordform task ``deployNodes`` copies all JARs if Cordapps to deploy are specified, see :doc:`generating-a-node`.
+When running the Corda node ensure all CordDapp JARs are placed in ``cordapps`` directory of each node, see :doc:`generating-a-node`.
+Also Gradle Cordform task ``deployNodes`` copies all JARs if CorDapps to deploy are specified, see :doc:`generating-a-node`.
 
 Wrong fully-qualified contract name
 ***********************************

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -340,9 +340,9 @@ common sources of ``MissingContractAttachments`` exceptions:
 Not setting CorDapp packages in tests
 *************************************
 You are running a test and have not specified the CorDapp packages to scan.
-When using ``MockNetwork`` ensure you provided a package containing the contract class in ``MockNetworkParameters``. See :doc:`api-testing`.
+When using ``MockNetwork`` ensure you have provided a package containing the contract class in ``MockNetworkParameters``. See :doc:`api-testing`.
 
-Similarly package names need to be provided when tasting using ``DriverDSl``. ``DriverParameters`` has a property ``cordappsForAllNodes`` (Kotlin)
+Similarly package names need to be provided when testing using ``DriverDSl``. ``DriverParameters`` has a property ``cordappsForAllNodes`` (Kotlin)
 or method ``withCordappsForAllNodes`` in Java. Pass the collection of ``TestCordapp`` created by utility method ``TestCordapp.findCordapp(String)``.
 
 Example of creation of two Cordapps with Finance App Flows and Finance App Contracts in Kotlin:
@@ -351,7 +351,7 @@ Example of creation of two Cordapps with Finance App Flows and Finance App Contr
 
         Driver.driver(DriverParameters(cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.finance.schemas"),
                 TestCordapp.findCordapp("net.corda.finance.flows"))) {
-            // Your test code go here
+            // Your test code goes here
         })
 
 The same example in Java:
@@ -361,15 +361,15 @@ The same example in Java:
         Driver.driver(new DriverParameters()
                 .withCordappsForAllNodes(Arrays.asList(TestCordapp.findCordapp("net.corda.finance.schemas"),
                 TestCordapp.findCordapp("net.corda.finance.flows"))), dsl -> {
-            // Your test code go here
+            // Your test code goes here
         });
 
 
-Staring node without CorDapp
-****************************
+Staring a node missing CorDapp(s)
+*********************************
 
-When running the Corda node ensure all CordDapp JARs are placed in ``cordapps`` directory of each node, see :doc:`generating-a-node`.
-Also Gradle Cordform task ``deployNodes`` copies all JARs if CorDapps to deploy are specified, see :doc:`generating-a-node`.
+When running the Corda node ensure all CordDapp JARs are placed in ``cordapps`` directory of each node. See :doc:`generating-a-node` for detailed instructions.
+By default Gradle Cordform task ``deployNodes`` copies all JARs if CorDapps to deploy are specified. See :doc:`generating-a-node` for detailed instructions.
 
 Wrong fully-qualified contract name
 ***********************************

--- a/docs/source/api-testing.rst
+++ b/docs/source/api-testing.rst
@@ -33,8 +33,8 @@ A ``MockNetwork`` is created as follows:
         :end-before: DOCEND 1
 
 The ``MockNetwork`` requires at a minimum a list of CorDapps to be installed on each ``StartedMockNode``. The CorDapps are looked up on the
-classpath by package name, using ``TestCordapp.findCordapp``. `TestCordapp.findCordapp`` scans the current classpath to find the CorDapp that contains the given package.
-All the CorDapp's metadata present in its MANIFEST are inherited.
+classpath by package name, using ``TestCordapp.findCordapp``. ``TestCordapp.findCordapp`` scans the current classpath to find the CorDapp that contains the given package.
+This includes all the associated CorDapp metadata present in its MANIFEST.
 
 ``MockNetworkParameters`` provides other properties for the network which can be tweaked. They default to sensible values if not specified.
 

--- a/docs/source/api-testing.rst
+++ b/docs/source/api-testing.rst
@@ -33,7 +33,8 @@ A ``MockNetwork`` is created as follows:
         :end-before: DOCEND 1
 
 The ``MockNetwork`` requires at a minimum a list of CorDapps to be installed on each ``StartedMockNode``. The CorDapps are looked up on the
-classpath by package name, using ``TestCordapp.findCordapp``.
+classpath by package name, using ``TestCordapp.findCordapp``. `TestCordapp.findCordapp`` scans the current classpath to find the CorDapp that contains the given package.
+All the CorDapp's metadata present in its MANIFEST are inherited.
 
 ``MockNetworkParameters`` provides other properties for the network which can be tweaked. They default to sensible values if not specified.
 


### PR DESCRIPTION
Fix infamous ``net.corda.core.transactions.MissingContractAttachments: Cannot find contract attachments for [], minimum required contract class version 1. See https://docs.corda.net/api-contract-constraints.html#debugging``

The error message had no ``ContractClassName`` is some cases.
This was especially visible when developing tests/integration tests.

Change to API:
1) added new overloaded constructor
2) another constructor changed - but this one was introduced only in v4 so it's not breaking v3 