### PR TITLE
CORDA-2490 Attachment in the directory fails to correctly upload (#4627)

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -96,7 +96,7 @@ class NodeAttachmentService(
             @Column(name = "insertion_date", nullable = false, updatable = false)
             var insertionDate: Instant = Instant.now(),
 
-            @Column(name = "uploader", updatable = false, nullable = true)
+            @Column(name = "uploader", nullable = true)
             var uploader: String? = null,
 
             @Column(name = "filename", updatable = false, nullable = true)
@@ -381,7 +381,6 @@ class NodeAttachmentService(
                     if (attachment.uploader != uploader) {
                         verifyVersionUniquenessForSignedAttachments(contractClassNames, attachment.version, attachment.signers)
                         attachment.uploader = uploader
-                        session.saveOrUpdate(attachment)
                         log.info("Updated attachment $id with uploader $uploader")
                         contractClassNames.forEach { contractsCache.invalidate(it) }
                         loadAttachmentContent(id)?.let { attachmentAndContent ->


### PR DESCRIPTION
The column 'uploader' was marked as not updatable entity so any update wasn't propagated to the database when the attachment was uploaded again and the uploader field was changed to a trusted one. Also 'saveOrUpdate' removed, the entity is already managed, saveOrUpdate is for detached/new entity.

(cherry picked from commit 9f4c8bcea5bb780eec1c1f663302ed92f2c38733)