### PR TITLE
[CORDA-2496] - Adjust CorDappResolver to handle same CorDapp registered multiple times

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappResolver.kt
@@ -17,8 +17,12 @@ object CordappResolver {
     private var cordappResolver: () -> Cordapp? = {
         Exception().stackTrace
                 .mapNotNull { cordappClasses[it.className] }
-                // If there is more than one cordapp registered for a class name we can't determine the "correct" one and return null.
-                .firstOrNull { it.size == 1 }?.single()
+                // for each class, we filter out CorDapps that originate from the same file.
+                .map { it.distinctBy { it.jarHash } }
+                // in case there are multiple classes matched, we select the first one having a single CorDapp registered against it.
+                .firstOrNull { it.size == 1 }
+                // otherwise we return null, signalling we cannot reliably determine the current CorDapp.
+                ?.single()
     }
 
     /*

--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappResolver.kt
@@ -30,9 +30,10 @@ object CordappResolver {
     @Synchronized
     fun register(cordapp: Cordapp) {
         cordapp.cordappClasses.forEach {
-            if (cordappClasses.containsKey(it)) {
+            val cordapps = cordappClasses[it]
+            if (cordapps != null) {
                 // we do not register CorDapps that originate from the same file.
-                if (cordappClasses[it]!!.none { it.jarHash.equals(cordapp.jarHash) }) {
+                if (cordapps.none { it.jarHash == cordapp.jarHash }) {
                     logger.warn("More than one CorDapp registered for $it.")
                     cordappClasses[it] = cordappClasses[it]!! + cordapp
                 }

--- a/core/src/test/kotlin/net/corda/core/internal/cordapp/CordappResolverTest.kt
+++ b/core/src/test/kotlin/net/corda/core/internal/cordapp/CordappResolverTest.kt
@@ -1,5 +1,6 @@
 package net.corda.core.internal.cordapp
 
+import net.corda.core.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -33,7 +34,7 @@ class CordappResolverTest {
     }
 
     @Test
-    fun `when more than one cordapp is registered for the same class, the resolver returns null`() {
+    fun `when the same cordapp is registered for the same class multiple times, the resolver deduplicates and returns it as the current one`() {
         CordappResolver.register(CordappImpl.TEST_INSTANCE.copy(
                 contractClassNames = listOf(javaClass.name),
                 minimumPlatformVersion = 3,
@@ -43,6 +44,23 @@ class CordappResolverTest {
                 contractClassNames = listOf(javaClass.name),
                 minimumPlatformVersion = 2,
                 targetPlatformVersion = 456
+        ))
+        assertThat(CordappResolver.currentCordapp).isNotNull()
+    }
+
+    @Test
+    fun `when different cordapps are registered for the same class, the resolver returns null`() {
+        CordappResolver.register(CordappImpl.TEST_INSTANCE.copy(
+                contractClassNames = listOf(javaClass.name),
+                minimumPlatformVersion = 3,
+                targetPlatformVersion = 222,
+                jarHash = SecureHash.randomSHA256()
+        ))
+        CordappResolver.register(CordappImpl.TEST_INSTANCE.copy(
+                contractClassNames = listOf(javaClass.name),
+                minimumPlatformVersion = 2,
+                targetPlatformVersion = 456,
+                jarHash = SecureHash.randomSHA256()
         ))
         assertThat(CordappResolver.currentCordapp).isNull()
     }

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -281,6 +281,10 @@ would need to be transformed into::
 Note that every package should exist in only one CorDapp, otherwise the discovery process won't be able to determine which one to use and you will most probably see an exception telling you ``There is more than one CorDapp containing the package``.
 For instance, if you have 2 CorDapps containing the packages ``net.corda.examples.obligation.contracts`` and ``net.corda.examples.obligation.flows``, you will get this error if you specify the package ``net.corda.examples.obligation``.
 
+
+.. note:: If you have any CorDapp code (e.g. flows/contracts/states) that is only used by the tests and located in the same test module, it won't be discovered now.
+    You will need to move them in the main module of one of your CorDapps or create a new, separate CorDapp for them, in case you don't want this code to live inside your production CorDapps.
+
 Step 6. Security: Add BelongsToContract annotations
 ---------------------------------------------------
 

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -261,7 +261,25 @@ becomes::
     )
 
 You may need to use the new ``TestCordapp`` API when testing with the node driver or mock network, especially if you decide to stick with the
-pre-Corda 4 ``FinalityFlow`` API. The previous way of pulling in CorDapps into your tests does not honour CorDapp versioning.
+pre-Corda 4 ``FinalityFlow`` API. The previous way of pulling in CorDapps into your tests (i.e. via using the ``cordappPackages`` parameter) does not honour CorDapp versioning.
+The new API ``TestCordapp.findCordapp()`` discovers the CorDapps that contain the provided packages scanning the classpath, so you have to ensure that the classpath the tests are running under contains either the CorDapp ``.jar`` or (if using Gradle) the relevant Gradle sub-project.
+In the first case, the versioning information in the CorDapp ``.jar`` file will be maintained. In the second case, the versioning information will be retrieved from the Gradle ``cordapp`` task.
+For example, if you are using ``MockNetwork`` for your tests, the following code::
+
+    val mockNetwork = MockNetwork(
+        cordappPackages = listOf("net.corda.examples.obligation", "net.corda.finance.contracts"),
+        notarySpecs = listOf(MockNetworkNotarySpec(notary))
+    )
+
+would need to be transformed into::
+
+    val mockNetwork = MockNetwork(MockNetworkParameters(
+        cordappsForAllNodes = listOf(TestCordapp.findCordapp("net.corda.businessnetworks.membership")),
+        notarySpecs = listOf(MockNetworkNotarySpec(notary))
+    ))
+
+Note that every package should exist in only one CorDapp, otherwise the discovery process won't be able to determine which one to use and you will most probably see an exception telling you ``There is more than one CorDapp containing the package``.
+For instance, if you have 2 CorDapps containing the packages ``net.corda.examples.obligation.contracts`` and ``net.corda.examples.obligation.flows``, you will get this error if you specify the package ``net.corda.examples.obligation``.
 
 Step 6. Security: Add BelongsToContract annotations
 ---------------------------------------------------


### PR DESCRIPTION
### Changes
* Allow `CordappResolver` to handle the case, where the same CorDapp is registered multiple times, by deduplicating. As an example, this happens, when running tests via `MockNetwork`, because a single resolver is shared between the several in-memory nodes, where the same CorDapp is regsitered for all of them.
* Update upgrade docs to be a bit more descriptive on the steps needed

### Testing
* Performed an upgrade of the [tests](https://github.com/corda/corda-solutions/blob/master/bn-apps/ledger-sync/ledger-sync-service/src/test/kotlin/com/r3/businessnetworks/ledgersync/LedgerConsistencyTests.kt) from a business networks app to ensure that the described steps are enough