### PR TITLE
Fix Liquibase AttachmentVersionNumberMigration unnecessary error log or failure in test

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
@@ -28,9 +28,9 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
         try {
             logger.info("Start executing...")
             var networkParameters: NetworkParameters?
-
-            if (System.getProperty(NODE_BASE_DIR_KEY).isNotEmpty()) {
-                val path = Paths.get(System.getProperty(NODE_BASE_DIR_KEY)) / NETWORK_PARAMS_FILE_NAME
+            val baseDir = System.getProperty(SchemaMigration.NODE_BASE_DIR_KEY)
+            if (baseDir != null) {
+                val path = Paths.get(baseDir) / NETWORK_PARAMS_FILE_NAME
                 networkParameters = getNetworkParametersFromFile(path)
                 if (networkParameters != null) {
                     logger.info("$msg using network parameters from $path, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -89,8 +89,10 @@ class SchemaMigration(
                 }
             }
 
-            System.setProperty(NODE_BASE_DIR_KEY, currentDirectory.toString()) // base dir for any custom change set which may need to load a file (currently AttachmentVersionNumberMigration)
-
+            val path = currentDirectory?.toString()
+            if (path != null) {
+                System.setProperty(NODE_BASE_DIR_KEY, path) // base dir for any custom change set which may need to load a file (currently AttachmentVersionNumberMigration)
+            }
             val customResourceAccessor = CustomResourceAccessor(dynamicInclude, changelogList, classLoader)
 
             val liquibase = Liquibase(dynamicInclude, customResourceAccessor, getLiquibaseDatabase(JdbcConnection(connection)))


### PR DESCRIPTION
When system property is not provided or was set wrongly (a String with text "null" and not null reference).