### PR TITLE
CORDA-2422: Ignore future interfaces from serialization

### DIFF
--- a/node-api/src/test/kotlin/net/corda/core/contracts/FungibleState.kt
+++ b/node-api/src/test/kotlin/net/corda/core/contracts/FungibleState.kt
@@ -1,0 +1,3 @@
+package net.corda.core.contracts
+
+interface FungibleState {}


### PR DESCRIPTION
### Changes
The interface `FungibleState` - introduced in v4 - prevents interop between v3 and v4. Briefly, the reason is this interface is missing, which means carpenter is triggered, but it's not able to synthesize it. This fix ignores this specific interface, avoiding to create a serializer. This is not expected to cause any issue, since this interface will not be needed during serialization.

### Testing
* Executed the BoC demo, as specified in the ticket, making sure that it was not failing after incorporating the fix