### PR TITLE
[CORDA-2518] - Refresh the current API file

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1,8 +1,12 @@
 @CordaSerializable
+public interface net.corda.core.ClientRelevantError
+##
+@CordaSerializable
 public class net.corda.core.CordaException extends java.lang.Exception implements net.corda.core.CordaThrowable
   public <init>()
   public <init>(String)
   public <init>(String, String, Throwable)
+  public <init>(String, String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(String, Throwable)
   public void addSuppressed(Throwable[])
   public boolean equals(Object)
@@ -65,6 +69,12 @@ public @interface net.corda.core.DoNotImplement
 ##
 public final class net.corda.core.Utils extends java.lang.Object
   @NotNull
+  public static final net.corda.core.messaging.DataFeed<SNAPSHOT, ELEMENT> doOnError(net.corda.core.messaging.DataFeed<? extends SNAPSHOT, ELEMENT>, kotlin.jvm.functions.Function1<? super Throwable, kotlin.Unit>)
+  @NotNull
+  public static final net.corda.core.messaging.DataFeed<SNAPSHOT, ELEMENT> mapErrors(net.corda.core.messaging.DataFeed<? extends SNAPSHOT, ELEMENT>, kotlin.jvm.functions.Function1<? super Throwable, ? extends Throwable>)
+  @NotNull
+  public static final rx.Observable<ELEMENT> mapErrors(rx.Observable<ELEMENT>, kotlin.jvm.functions.Function1<? super Throwable, ? extends Throwable>)
+  @NotNull
   public static final net.corda.core.concurrent.CordaFuture<T> toFuture(rx.Observable<T>)
   @NotNull
   public static final rx.Observable<A> toObservable(net.corda.core.concurrent.CordaFuture<? extends A>)
@@ -78,6 +88,7 @@ public final class net.corda.core.concurrent.ConcurrencyUtils extends java.lang.
   @NotNull
   public static final String shortCircuitedTaskFailedMessage = "Short-circuited task failed:"
 ##
+@CordaSerializable
 public interface net.corda.core.concurrent.CordaFuture extends java.util.concurrent.Future
   public abstract void then(kotlin.jvm.functions.Function1<? super net.corda.core.concurrent.CordaFuture<V>, ? extends W>)
   @NotNull
@@ -104,10 +115,12 @@ public final class net.corda.core.context.Actor extends java.lang.Object
   public int hashCode()
   @NotNull
   public static final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
+  @NotNull
   public String toString()
   public static final net.corda.core.context.Actor$Companion Companion
 ##
 public static final class net.corda.core.context.Actor$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.Actor service(String, net.corda.core.identity.CordaX500Name)
 ##
@@ -122,6 +135,7 @@ public static final class net.corda.core.context.Actor$Id extends java.lang.Obje
   @NotNull
   public final String getValue()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -135,11 +149,13 @@ public final class net.corda.core.context.AuthServiceId extends java.lang.Object
   @NotNull
   public final String getValue()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public final class net.corda.core.context.InvocationContext extends java.lang.Object
   public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  public <init>(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.InvocationOrigin component1()
   @NotNull
@@ -178,10 +194,12 @@ public final class net.corda.core.context.InvocationContext extends java.lang.Ob
   public static final net.corda.core.context.InvocationContext service(String, net.corda.core.identity.CordaX500Name, net.corda.core.context.Trace, net.corda.core.context.Trace)
   @NotNull
   public static final net.corda.core.context.InvocationContext shell(net.corda.core.context.Trace, net.corda.core.context.Trace)
+  @NotNull
   public String toString()
   public static final net.corda.core.context.InvocationContext$Companion Companion
 ##
 public static final class net.corda.core.context.InvocationContext$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.InvocationContext newInstance(net.corda.core.context.InvocationOrigin, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.context.Trace, net.corda.core.context.Actor)
   @NotNull
@@ -197,6 +215,7 @@ public static final class net.corda.core.context.InvocationContext$Companion ext
 ##
 @CordaSerializable
 public abstract class net.corda.core.context.InvocationOrigin extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public abstract java.security.Principal principal()
 ##
@@ -213,17 +232,23 @@ public static final class net.corda.core.context.InvocationOrigin$Peer extends n
   public int hashCode()
   @NotNull
   public java.security.Principal principal()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public static final class net.corda.core.context.InvocationOrigin$RPC extends net.corda.core.context.InvocationOrigin
   public <init>(net.corda.core.context.Actor)
   @NotNull
+  public final net.corda.core.context.Actor component1()
+  @NotNull
   public final net.corda.core.context.InvocationOrigin$RPC copy(net.corda.core.context.Actor)
   public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.context.Actor getActor()
   public int hashCode()
   @NotNull
   public java.security.Principal principal()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -239,6 +264,7 @@ public static final class net.corda.core.context.InvocationOrigin$Scheduled exte
   public int hashCode()
   @NotNull
   public java.security.Principal principal()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -258,6 +284,7 @@ public static final class net.corda.core.context.InvocationOrigin$Service extend
   public int hashCode()
   @NotNull
   public java.security.Principal principal()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -283,10 +310,12 @@ public final class net.corda.core.context.Trace extends java.lang.Object
   public int hashCode()
   @NotNull
   public static final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
+  @NotNull
   public String toString()
   public static final net.corda.core.context.Trace$Companion Companion
 ##
 public static final class net.corda.core.context.Trace$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.Trace newInstance(net.corda.core.context.Trace$InvocationId, net.corda.core.context.Trace$SessionId)
 ##
@@ -298,6 +327,7 @@ public static final class net.corda.core.context.Trace$InvocationId extends net.
   public static final net.corda.core.context.Trace$InvocationId$Companion Companion
 ##
 public static final class net.corda.core.context.Trace$InvocationId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.Trace$InvocationId newInstance(String, java.time.Instant)
 ##
@@ -309,6 +339,7 @@ public static final class net.corda.core.context.Trace$SessionId extends net.cor
   public static final net.corda.core.context.Trace$SessionId$Companion Companion
 ##
 public static final class net.corda.core.context.Trace$SessionId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.Trace$SessionId newInstance(String, java.time.Instant)
 ##
@@ -370,6 +401,7 @@ public final class net.corda.core.contracts.Amount extends java.lang.Object impl
   public static final net.corda.core.contracts.Amount$Companion Companion
 ##
 public static final class net.corda.core.contracts.Amount$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.contracts.Amount<T> fromDecimal(java.math.BigDecimal, T)
   @NotNull
@@ -420,6 +452,7 @@ public final class net.corda.core.contracts.AmountTransfer extends java.lang.Obj
   public static final net.corda.core.contracts.AmountTransfer$Companion Companion
 ##
 public static final class net.corda.core.contracts.AmountTransfer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.contracts.AmountTransfer<T, P> fromDecimal(java.math.BigDecimal, T, P, P)
   @NotNull
@@ -427,6 +460,7 @@ public static final class net.corda.core.contracts.AmountTransfer$Companion exte
   @NotNull
   public final net.corda.core.contracts.AmountTransfer<T, P> zero(T, P, P)
 ##
+@DoNotImplement
 @CordaSerializable
 public interface net.corda.core.contracts.Attachment extends net.corda.core.contracts.NamedByHash
   public void extractFile(String, java.io.OutputStream)
@@ -456,6 +490,12 @@ public final class net.corda.core.contracts.AttachmentResolutionException extend
 public final class net.corda.core.contracts.AutomaticHashConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
   public static final net.corda.core.contracts.AutomaticHashConstraint INSTANCE
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.AutomaticPlaceholderConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  public static final net.corda.core.contracts.AutomaticPlaceholderConstraint INSTANCE
 ##
 public @interface net.corda.core.contracts.BelongsToContract
   public abstract Class<? extends net.corda.core.contracts.Contract> value()
@@ -493,6 +533,7 @@ public final class net.corda.core.contracts.CommandAndState extends java.lang.Ob
   @NotNull
   public final net.corda.core.contracts.OwnableState getOwnableState()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -517,6 +558,7 @@ public final class net.corda.core.contracts.CommandWithParties extends java.lang
   @NotNull
   public final T getValue()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public final class net.corda.core.contracts.ComponentGroupEnum extends java.lang.Enum
@@ -528,11 +570,14 @@ public final class net.corda.core.contracts.ComponentGroupEnum extends java.lang
 public interface net.corda.core.contracts.Contract
   public abstract void verify(net.corda.core.transactions.LedgerTransaction)
 ##
+@DoNotImplement
 @CordaSerializable
 public final class net.corda.core.contracts.ContractAttachment extends java.lang.Object implements net.corda.core.contracts.Attachment
   public <init>(net.corda.core.contracts.Attachment, String)
   public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>)
   public <init>(net.corda.core.contracts.Attachment, String, java.util.Set<String>, String)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.contracts.Attachment, String, java.util.Set, String, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.Set<String> getAdditionalContracts()
   @NotNull
@@ -544,14 +589,22 @@ public final class net.corda.core.contracts.ContractAttachment extends java.lang
   @NotNull
   public net.corda.core.crypto.SecureHash getId()
   @NotNull
+  public java.util.List<java.security.PublicKey> getSignerKeys()
+  @NotNull
   public java.util.List<net.corda.core.identity.Party> getSigners()
   public int getSize()
   @Nullable
   public final String getUploader()
+  public final int getVersion()
+  public final boolean isSigned()
   @NotNull
   public java.io.InputStream open()
   @NotNull
   public String toString()
+  public static final net.corda.core.contracts.ContractAttachment$Companion Companion
+##
+public static final class net.corda.core.contracts.ContractAttachment$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public interface net.corda.core.contracts.ContractState
@@ -571,6 +624,7 @@ public final class net.corda.core.contracts.ContractsDSL extends java.lang.Objec
 public interface net.corda.core.contracts.FungibleAsset extends net.corda.core.contracts.FungibleState, net.corda.core.contracts.OwnableState
   @NotNull
   public abstract net.corda.core.contracts.Amount<net.corda.core.contracts.Issued<T>> getAmount()
+  @SerializableCalculatedProperty
   @NotNull
   public abstract java.util.Collection<java.security.PublicKey> getExitKeys()
   @NotNull
@@ -594,6 +648,7 @@ public final class net.corda.core.contracts.HashAttachmentConstraint extends jav
   public final net.corda.core.crypto.SecureHash getAttachmentId()
   public int hashCode()
   public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -626,10 +681,12 @@ public @interface net.corda.core.contracts.LegalProseReference
 @CordaSerializable
 public final class net.corda.core.contracts.LinearPointer extends net.corda.core.contracts.StatePointer
   public <init>(net.corda.core.contracts.UniqueIdentifier, Class<T>)
+  public boolean equals(Object)
   @NotNull
   public net.corda.core.contracts.UniqueIdentifier getPointer()
   @NotNull
   public Class<T> getType()
+  public int hashCode()
   @NotNull
   public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
@@ -648,6 +705,8 @@ public interface net.corda.core.contracts.MoveCommand extends net.corda.core.con
 public interface net.corda.core.contracts.NamedByHash
   @NotNull
   public abstract net.corda.core.crypto.SecureHash getId()
+##
+public @interface net.corda.core.contracts.NoConstraintPropagation
 ##
 @CordaSerializable
 public interface net.corda.core.contracts.OwnableState extends net.corda.core.contracts.ContractState
@@ -679,6 +738,19 @@ public final class net.corda.core.contracts.PrivacySalt extends net.corda.core.u
   public <init>()
   public <init>(byte[])
 ##
+public final class net.corda.core.contracts.ReferencedStateAndRef extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateAndRef<? extends T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> component1()
+  @NotNull
+  public final net.corda.core.contracts.ReferencedStateAndRef<T> copy(net.corda.core.contracts.StateAndRef<? extends T>)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> getStateAndRef()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
 public final class net.corda.core.contracts.Requirements extends java.lang.Object
   public final void using(String, boolean)
   public static final net.corda.core.contracts.Requirements INSTANCE
@@ -706,6 +778,7 @@ public final class net.corda.core.contracts.ScheduledActivity extends java.lang.
   @NotNull
   public java.time.Instant getScheduledAt()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -723,10 +796,28 @@ public final class net.corda.core.contracts.ScheduledStateRef extends java.lang.
   @NotNull
   public java.time.Instant getScheduledAt()
   public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+@CordaSerializable
+public final class net.corda.core.contracts.SignatureAttachmentConstraint extends java.lang.Object implements net.corda.core.contracts.AttachmentConstraint
+  public <init>(java.security.PublicKey)
+  @NotNull
+  public final java.security.PublicKey component1()
+  @NotNull
+  public final net.corda.core.contracts.SignatureAttachmentConstraint copy(java.security.PublicKey)
+  public boolean equals(Object)
+  @NotNull
+  public final java.security.PublicKey getKey()
+  public int hashCode()
+  public boolean isSatisfiedBy(net.corda.core.contracts.Attachment)
+  @NotNull
   public String toString()
 ##
 public final class net.corda.core.contracts.SourceAndAmount extends java.lang.Object
   public <init>(P, net.corda.core.contracts.Amount<T>, Object)
+  public <init>(Object, net.corda.core.contracts.Amount, Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final P component1()
   @NotNull
@@ -743,6 +834,7 @@ public final class net.corda.core.contracts.SourceAndAmount extends java.lang.Ob
   @NotNull
   public final P getSource()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public final class net.corda.core.contracts.StateAndContract extends java.lang.Object
@@ -759,6 +851,7 @@ public final class net.corda.core.contracts.StateAndContract extends java.lang.O
   @NotNull
   public final net.corda.core.contracts.ContractState getState()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -776,10 +869,14 @@ public final class net.corda.core.contracts.StateAndRef extends java.lang.Object
   @NotNull
   public final net.corda.core.contracts.TransactionState<T> getState()
   public int hashCode()
+  @NotNull
+  public final net.corda.core.contracts.ReferencedStateAndRef<T> referenced()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public abstract class net.corda.core.contracts.StatePointer extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public abstract Object getPointer()
   @NotNull
@@ -808,10 +905,12 @@ public final class net.corda.core.contracts.StateRef extends java.lang.Object
 @CordaSerializable
 public final class net.corda.core.contracts.StaticPointer extends net.corda.core.contracts.StatePointer
   public <init>(net.corda.core.contracts.StateRef, Class<T>)
+  public boolean equals(Object)
   @NotNull
   public net.corda.core.contracts.StateRef getPointer()
   @NotNull
   public Class<T> getType()
+  public int hashCode()
   @NotNull
   public net.corda.core.contracts.StateAndRef<T> resolve(net.corda.core.node.ServiceHub)
   @NotNull
@@ -849,6 +948,7 @@ public abstract class net.corda.core.contracts.TimeWindow extends java.lang.Obje
   public static final net.corda.core.contracts.TimeWindow$Companion Companion
 ##
 public static final class net.corda.core.contracts.TimeWindow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.contracts.TimeWindow between(java.time.Instant, java.time.Instant)
   @NotNull
@@ -875,6 +975,8 @@ public final class net.corda.core.contracts.TransactionState extends java.lang.O
   public <init>(T, String, net.corda.core.identity.Party)
   public <init>(T, String, net.corda.core.identity.Party, Integer)
   public <init>(T, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
+  public <init>(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(T, net.corda.core.identity.Party)
   @NotNull
   public final T component1()
   @NotNull
@@ -899,18 +1001,35 @@ public final class net.corda.core.contracts.TransactionState extends java.lang.O
   @NotNull
   public final net.corda.core.identity.Party getNotary()
   public int hashCode()
+  @NotNull
   public String toString()
+  public static final net.corda.core.contracts.TransactionState$Companion Companion
 ##
 public final class net.corda.core.contracts.TransactionStateKt extends java.lang.Object
 ##
 @CordaSerializable
 public abstract class net.corda.core.contracts.TransactionVerificationException extends net.corda.core.flows.FlowException
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
   @NotNull
   public final net.corda.core.crypto.SecureHash getTxId()
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ConflictingAttachmentsRejection extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ConstraintPropagationRejection extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final String getContractClass()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$ContractAttachmentNotSignedByPackageOwnerException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.crypto.SecureHash, String)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getAttachmentHash()
   @NotNull
   public final String getContractClass()
 ##
@@ -968,10 +1087,22 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   public final net.corda.core.identity.Party getTxNotary()
 ##
 @CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$OverlappingAttachmentsException extends java.lang.Exception
+  public <init>(String)
+##
+@CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$SignersMissing extends net.corda.core.contracts.TransactionVerificationException
   public <init>(net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
   @NotNull
   public final java.util.List<java.security.PublicKey> getMissing()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionContractConflictException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>, String)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionDuplicateEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, int)
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$TransactionMissingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
@@ -979,6 +1110,22 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
   @NotNull
   public final net.corda.core.contracts.TransactionVerificationException$Direction getInOut()
   public final int getMissing()
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNonMatchingEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, java.util.Collection<Integer>)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionNotaryMismatchEncumbranceException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, int, int, net.corda.core.identity.Party, net.corda.core.identity.Party)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionRequiredContractUnspecifiedException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>)
+##
+@CordaSerializable
+public static final class net.corda.core.contracts.TransactionVerificationException$TransactionVerificationVersionException extends net.corda.core.contracts.TransactionVerificationException
+  public <init>(net.corda.core.crypto.SecureHash, String, String, String)
 ##
 @CordaSerializable
 public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.lang.Object implements net.corda.core.contracts.CommandData
@@ -989,7 +1136,9 @@ public abstract class net.corda.core.contracts.TypeOnlyCommandData extends java.
 @CordaSerializable
 public final class net.corda.core.contracts.UniqueIdentifier extends java.lang.Object implements java.lang.Comparable
   public <init>()
+  public <init>(String)
   public <init>(String, java.util.UUID)
+  public <init>(String, java.util.UUID, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public int compareTo(net.corda.core.contracts.UniqueIdentifier)
   @Nullable
   public final String component1()
@@ -1008,6 +1157,7 @@ public final class net.corda.core.contracts.UniqueIdentifier extends java.lang.O
   public static final net.corda.core.contracts.UniqueIdentifier$Companion Companion
 ##
 public static final class net.corda.core.contracts.UniqueIdentifier$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.contracts.UniqueIdentifier fromString(String)
 ##
@@ -1032,15 +1182,22 @@ public final class net.corda.core.contracts.WhitelistedByZoneAttachmentConstrain
 @DoNotImplement
 public interface net.corda.core.cordapp.Cordapp
   @NotNull
+  public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getAllFlows()
+  @NotNull
   public abstract java.util.List<String> getContractClassNames()
   @NotNull
   public abstract java.util.List<String> getCordappClasses()
   @NotNull
   public abstract java.util.Set<net.corda.core.schemas.MappedSchema> getCustomSchemas()
   @NotNull
+  public abstract net.corda.core.cordapp.Cordapp$Info getInfo()
+  @NotNull
   public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getInitiatedFlows()
   @NotNull
+  public abstract net.corda.core.crypto.SecureHash$SHA256 getJarHash()
+  @NotNull
   public abstract java.net.URL getJarPath()
+  public abstract int getMinimumPlatformVersion()
   @NotNull
   public abstract String getName()
   @NotNull
@@ -1055,15 +1212,161 @@ public interface net.corda.core.cordapp.Cordapp
   public abstract java.util.List<Class<? extends net.corda.core.flows.FlowLogic<?>>> getServiceFlows()
   @NotNull
   public abstract java.util.List<Class<? extends net.corda.core.serialization.SerializeAsToken>> getServices()
+  public abstract int getTargetPlatformVersion()
+##
+@DoNotImplement
+public static interface net.corda.core.cordapp.Cordapp$Info
+  @NotNull
+  public abstract String getLicence()
+  @NotNull
+  public abstract String getShortName()
+  @NotNull
+  public abstract String getVendor()
+  @NotNull
+  public abstract String getVersion()
+  public abstract boolean hasUnknownFields()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$Contract extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(String, String, int, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Contract copy(String, String, int, String)
+  public boolean equals(Object)
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  public final int getVersionId()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$ContractAndWorkflow extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(net.corda.core.cordapp.Cordapp$Info$Contract, net.corda.core.cordapp.Cordapp$Info$Workflow)
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Contract component1()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Workflow component2()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$ContractAndWorkflow copy(net.corda.core.cordapp.Cordapp$Info$Contract, net.corda.core.cordapp.Cordapp$Info$Workflow)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Contract getContract()
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Workflow getWorkflow()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$Default extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(String, String, String, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  @NotNull
+  public final String component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Default copy(String, String, String, String)
+  public boolean equals(Object)
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public static final class net.corda.core.cordapp.Cordapp$Info$Workflow extends java.lang.Object implements net.corda.core.cordapp.Cordapp$Info
+  public <init>(String, String, int, String)
+  @NotNull
+  public final String component1()
+  @NotNull
+  public final String component2()
+  public final int component3()
+  @NotNull
+  public final String component4()
+  @NotNull
+  public final net.corda.core.cordapp.Cordapp$Info$Workflow copy(String, String, int, String)
+  public boolean equals(Object)
+  @NotNull
+  public String getLicence()
+  @NotNull
+  public String getShortName()
+  @NotNull
+  public String getVendor()
+  @NotNull
+  public String getVersion()
+  public final int getVersionId()
+  public boolean hasUnknownFields()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@DoNotImplement
+public interface net.corda.core.cordapp.CordappConfig
+  public abstract boolean exists(String)
+  @NotNull
+  public abstract Object get(String)
+  public abstract boolean getBoolean(String)
+  public abstract double getDouble(String)
+  public abstract float getFloat(String)
+  public abstract int getInt(String)
+  public abstract long getLong(String)
+  @NotNull
+  public abstract Number getNumber(String)
+  @NotNull
+  public abstract String getString(String)
+##
+public final class net.corda.core.cordapp.CordappConfigException extends java.lang.Exception
+  public <init>(String, Throwable)
 ##
 public final class net.corda.core.cordapp.CordappContext extends java.lang.Object
   public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader)
+  public <init>(net.corda.core.cordapp.Cordapp, net.corda.core.crypto.SecureHash, ClassLoader, net.corda.core.cordapp.CordappConfig, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.core.crypto.SecureHash getAttachmentId()
   @NotNull
   public final ClassLoader getClassLoader()
   @NotNull
+  public final net.corda.core.cordapp.CordappConfig getConfig()
+  @NotNull
   public final net.corda.core.cordapp.Cordapp getCordapp()
+  public static final net.corda.core.cordapp.CordappContext$Companion Companion
+##
+public static final class net.corda.core.cordapp.CordappContext$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 public interface net.corda.core.cordapp.CordappProvider
@@ -1085,6 +1388,7 @@ public class net.corda.core.crypto.Base58 extends java.lang.Object
 ##
 @CordaSerializable
 public final class net.corda.core.crypto.CompositeKey extends java.lang.Object implements java.security.PublicKey
+  public <init>(int, java.util.List, kotlin.jvm.internal.DefaultConstructorMarker)
   public final void checkValidity()
   public boolean equals(Object)
   @NotNull
@@ -1119,6 +1423,7 @@ public static final class net.corda.core.crypto.CompositeKey$Builder extends jav
   public final java.security.PublicKey build(Integer)
 ##
 public static final class net.corda.core.crypto.CompositeKey$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.security.PublicKey getInstance(org.bouncycastle.asn1.ASN1Primitive)
   @NotNull
@@ -1174,6 +1479,7 @@ public final class net.corda.core.crypto.CompositeSignature extends java.securit
   public static final String SIGNATURE_ALGORITHM = "COMPOSITESIG"
 ##
 public static final class net.corda.core.crypto.CompositeSignature$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.security.Provider$Service getService(java.security.Provider)
 ##
@@ -1192,6 +1498,7 @@ public static final class net.corda.core.crypto.CompositeSignature$State extends
   @NotNull
   public final net.corda.core.crypto.CompositeKey getVerifyKey()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1205,10 +1512,12 @@ public final class net.corda.core.crypto.CompositeSignaturesWithKeys extends jav
   @NotNull
   public final java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
   public int hashCode()
+  @NotNull
   public String toString()
   public static final net.corda.core.crypto.CompositeSignaturesWithKeys$Companion Companion
 ##
 public static final class net.corda.core.crypto.CompositeSignaturesWithKeys$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.crypto.CompositeSignaturesWithKeys getEMPTY()
 ##
@@ -1226,6 +1535,9 @@ public final class net.corda.core.crypto.CordaSecurityProvider extends java.secu
   public static final String PROVIDER_NAME = "Corda"
 ##
 public static final class net.corda.core.crypto.CordaSecurityProvider$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public final class net.corda.core.crypto.CordaSecurityProviderKt extends java.lang.Object
 ##
 public final class net.corda.core.crypto.Crypto extends java.lang.Object
   @NotNull
@@ -1283,6 +1595,7 @@ public final class net.corda.core.crypto.Crypto extends java.lang.Object
   public static final boolean isValid(net.corda.core.crypto.SecureHash, net.corda.core.crypto.TransactionSignature)
   public static final boolean isValid(net.corda.core.crypto.SignatureScheme, java.security.PublicKey, byte[], byte[])
   public static final boolean publicKeyOnCurve(net.corda.core.crypto.SignatureScheme, java.security.PublicKey)
+  public static final void registerProviders()
   @NotNull
   public static final java.util.List<net.corda.core.crypto.SignatureScheme> supportedSignatureSchemes()
   @NotNull
@@ -1291,6 +1604,7 @@ public final class net.corda.core.crypto.Crypto extends java.lang.Object
   public static final java.security.PublicKey toSupportedPublicKey(java.security.PublicKey)
   @NotNull
   public static final java.security.PublicKey toSupportedPublicKey(org.bouncycastle.asn1.x509.SubjectPublicKeyInfo)
+  public static final boolean validatePublicKey(java.security.PublicKey)
   @NotNull
   public static final net.corda.core.crypto.SignatureScheme COMPOSITE_KEY
   @NotNull
@@ -1371,11 +1685,13 @@ public static class net.corda.core.crypto.DigitalSignature$WithKey extends net.c
   public final net.corda.core.crypto.DigitalSignature withoutKey()
 ##
 public abstract class net.corda.core.crypto.MerkleTree extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public abstract net.corda.core.crypto.SecureHash getHash()
   public static final net.corda.core.crypto.MerkleTree$Companion Companion
 ##
 public static final class net.corda.core.crypto.MerkleTree$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.crypto.MerkleTree getMerkleTree(java.util.List<? extends net.corda.core.crypto.SecureHash>)
 ##
@@ -1389,6 +1705,7 @@ public static final class net.corda.core.crypto.MerkleTree$Leaf extends net.cord
   @NotNull
   public net.corda.core.crypto.SecureHash getHash()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public static final class net.corda.core.crypto.MerkleTree$Node extends net.corda.core.crypto.MerkleTree
@@ -1409,6 +1726,7 @@ public static final class net.corda.core.crypto.MerkleTree$Node extends net.cord
   @NotNull
   public final net.corda.core.crypto.MerkleTree getRight()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1446,6 +1764,7 @@ public final class net.corda.core.crypto.PartialMerkleTree extends java.lang.Obj
   public static final net.corda.core.crypto.PartialMerkleTree$Companion Companion
 ##
 public static final class net.corda.core.crypto.PartialMerkleTree$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.crypto.PartialMerkleTree build(net.corda.core.crypto.MerkleTree, java.util.List<? extends net.corda.core.crypto.SecureHash>)
   @NotNull
@@ -1453,6 +1772,7 @@ public static final class net.corda.core.crypto.PartialMerkleTree$Companion exte
 ##
 @CordaSerializable
 public abstract static class net.corda.core.crypto.PartialMerkleTree$PartialTree extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$IncludedLeaf extends net.corda.core.crypto.PartialMerkleTree$PartialTree
@@ -1465,6 +1785,7 @@ public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$In
   @NotNull
   public final net.corda.core.crypto.SecureHash getHash()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1478,6 +1799,7 @@ public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$Le
   @NotNull
   public final net.corda.core.crypto.SecureHash getHash()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1495,10 +1817,12 @@ public static final class net.corda.core.crypto.PartialMerkleTree$PartialTree$No
   @NotNull
   public final net.corda.core.crypto.PartialMerkleTree$PartialTree getRight()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public abstract class net.corda.core.crypto.SecureHash extends net.corda.core.utilities.OpaqueBytes
+  public <init>(byte[], kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.crypto.SecureHash$SHA256 hashConcat(net.corda.core.crypto.SecureHash)
   @NotNull
@@ -1516,8 +1840,13 @@ public abstract class net.corda.core.crypto.SecureHash extends net.corda.core.ut
   @NotNull
   public String toString()
   public static final net.corda.core.crypto.SecureHash$Companion Companion
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 allOnesHash
+  @NotNull
+  public static final net.corda.core.crypto.SecureHash$SHA256 zeroHash
 ##
 public static final class net.corda.core.crypto.SecureHash$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.crypto.SecureHash$SHA256 getAllOnesHash()
   @NotNull
@@ -1558,6 +1887,7 @@ public final class net.corda.core.crypto.SignableData extends java.lang.Object
   @NotNull
   public final net.corda.core.crypto.SecureHash getTxId()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1571,6 +1901,7 @@ public final class net.corda.core.crypto.SignatureMetadata extends java.lang.Obj
   public final int getPlatformVersion()
   public final int getSchemeNumberID()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public final class net.corda.core.crypto.SignatureScheme extends java.lang.Object
@@ -1617,6 +1948,7 @@ public final class net.corda.core.crypto.SignatureScheme extends java.lang.Objec
   @NotNull
   public final org.bouncycastle.asn1.x509.AlgorithmIdentifier getSignatureOID()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1651,6 +1983,7 @@ public abstract class net.corda.core.flows.AbstractStateReplacementFlow extends 
 public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @Nullable
   public Void call()
@@ -1662,6 +1995,7 @@ public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$A
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion Companion
 ##
 public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acceptor$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ProgressTracker tracker()
 ##
@@ -1675,6 +2009,7 @@ public static final class net.corda.core.flows.AbstractStateReplacementFlow$Acce
 ##
 public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$Instigator extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.contracts.StateAndRef<? extends S>, M, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.contracts.StateAndRef, Object, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   protected abstract net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
   @Suspendable
@@ -1690,6 +2025,7 @@ public abstract static class net.corda.core.flows.AbstractStateReplacementFlow$I
   public static final net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion Companion
 ##
 public static final class net.corda.core.flows.AbstractStateReplacementFlow$Instigator$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ProgressTracker tracker()
 ##
@@ -1714,6 +2050,7 @@ public static final class net.corda.core.flows.AbstractStateReplacementFlow$Prop
   @NotNull
   public final net.corda.core.contracts.StateRef getStateRef()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public static final class net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx extends java.lang.Object
@@ -1726,6 +2063,7 @@ public static final class net.corda.core.flows.AbstractStateReplacementFlow$Upgr
   @NotNull
   public final net.corda.core.transactions.SignedTransaction getStx()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @Suspendable
@@ -1746,7 +2084,9 @@ public final class net.corda.core.flows.CollectSignaturesFlow extends net.corda.
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, Iterable<? extends java.security.PublicKey>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, Iterable, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
@@ -1763,6 +2103,7 @@ public final class net.corda.core.flows.CollectSignaturesFlow extends net.corda.
   public static final net.corda.core.flows.CollectSignaturesFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.CollectSignaturesFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ProgressTracker tracker()
 ##
@@ -1821,8 +2162,13 @@ public class net.corda.core.flows.DataVendingFlow extends net.corda.core.flows.F
 @InitiatingFlow
 public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.transactions.SignedTransaction)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, java.util.Collection<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection<? extends net.corda.core.flows.FlowSession>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, java.util.Collection, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>)
   public <init>(net.corda.core.transactions.SignedTransaction, java.util.Set<net.corda.core.identity.Party>, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.flows.FlowSession, net.corda.core.flows.FlowSession...)
   public <init>(net.corda.core.transactions.SignedTransaction, net.corda.core.utilities.ProgressTracker)
   @Suspendable
   @NotNull
@@ -1836,6 +2182,7 @@ public final class net.corda.core.flows.FinalityFlow extends net.corda.core.flow
   public static final net.corda.core.flows.FinalityFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.FinalityFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ProgressTracker tracker()
 ##
@@ -1854,7 +2201,14 @@ public class net.corda.core.flows.FlowException extends net.corda.core.CordaExce
   public <init>()
   public <init>(String)
   public <init>(String, Throwable)
+  public <init>(String, Throwable, Long)
+  public <init>(String, Throwable, Long, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(Throwable)
+  @Nullable
+  public Long getErrorId()
+  @Nullable
+  public final Long getOriginalErrorId()
+  public final void setOriginalErrorId(Long)
 ##
 @CordaSerializable
 public final class net.corda.core.flows.FlowInfo extends java.lang.Object
@@ -1869,10 +2223,12 @@ public final class net.corda.core.flows.FlowInfo extends java.lang.Object
   public final String getAppName()
   public final int getFlowVersion()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public abstract class net.corda.core.flows.FlowInitiator extends java.lang.Object implements java.security.Principal
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.context.InvocationContext getInvocationContext()
 ##
@@ -1889,6 +2245,7 @@ public static final class net.corda.core.flows.FlowInitiator$Peer extends net.co
   @NotNull
   public final net.corda.core.identity.Party getParty()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1904,6 +2261,7 @@ public static final class net.corda.core.flows.FlowInitiator$RPC extends net.cor
   @NotNull
   public final String getUsername()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1919,6 +2277,7 @@ public static final class net.corda.core.flows.FlowInitiator$Scheduled extends n
   @NotNull
   public final net.corda.core.contracts.ScheduledStateRef getScheduledState()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1934,6 +2293,7 @@ public static final class net.corda.core.flows.FlowInitiator$Service extends net
   @NotNull
   public final String getServiceClassName()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -1980,7 +2340,13 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(Class<R>, java.util.List<? extends net.corda.core.flows.FlowSession>)
   @Suspendable
   @NotNull
+  public java.util.List<net.corda.core.utilities.UntrustworthyData<R>> receiveAll(Class<R>, java.util.List<? extends net.corda.core.flows.FlowSession>, boolean)
+  @Suspendable
+  @NotNull
   public java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAllMap(java.util.Map<net.corda.core.flows.FlowSession, ? extends Class<?>>)
+  @Suspendable
+  @NotNull
+  public java.util.Map<net.corda.core.flows.FlowSession, net.corda.core.utilities.UntrustworthyData<Object>> receiveAllMap(java.util.Map<net.corda.core.flows.FlowSession, ? extends Class<?>>, boolean)
   public final void recordAuditEvent(String, String, java.util.Map<String, String>)
   @Suspendable
   public void send(net.corda.core.identity.Party, Object)
@@ -1989,6 +2355,8 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   public net.corda.core.utilities.UntrustworthyData<R> sendAndReceive(Class<R>, net.corda.core.identity.Party, Object)
   @Suspendable
   public static final void sleep(java.time.Duration)
+  @Suspendable
+  public static final void sleep(java.time.Duration, boolean)
   @Suspendable
   public R subFlow(net.corda.core.flows.FlowLogic<? extends R>)
   @Nullable
@@ -2003,13 +2371,18 @@ public abstract class net.corda.core.flows.FlowLogic extends java.lang.Object
   @Suspendable
   @NotNull
   public final net.corda.core.transactions.SignedTransaction waitForLedgerCommit(net.corda.core.crypto.SecureHash, boolean)
+  @Suspendable
+  public final void waitForStateConsumption(java.util.Set<net.corda.core.contracts.StateRef>)
   public static final net.corda.core.flows.FlowLogic$Companion Companion
 ##
 public static final class net.corda.core.flows.FlowLogic$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.core.flows.FlowLogic<?> getCurrentTopLevel()
   @Suspendable
   public final void sleep(java.time.Duration)
+  @Suspendable
+  public final void sleep(java.time.Duration, boolean)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -2070,6 +2443,7 @@ public final class net.corda.core.flows.FlowStackSnapshot extends java.lang.Obje
   @NotNull
   public final java.time.Instant getTime()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends java.lang.Object
@@ -2088,6 +2462,10 @@ public static final class net.corda.core.flows.FlowStackSnapshot$Frame extends j
   public int hashCode()
   @NotNull
   public String toString()
+##
+public interface net.corda.core.flows.IdentifiableException
+  @Nullable
+  public Long getErrorId()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.IllegalFlowLogicException extends java.lang.IllegalArgumentException
@@ -2121,6 +2499,7 @@ public final class net.corda.core.flows.NotarisationPayload extends java.lang.Ob
   @NotNull
   public final Object getTransaction()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -2133,6 +2512,7 @@ public final class net.corda.core.flows.NotarisationRequest extends java.lang.Ob
   public static final net.corda.core.flows.NotarisationRequest$Companion Companion
 ##
 public static final class net.corda.core.flows.NotarisationRequest$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public final class net.corda.core.flows.NotarisationRequestSignature extends java.lang.Object
@@ -2147,6 +2527,7 @@ public final class net.corda.core.flows.NotarisationRequestSignature extends jav
   public final net.corda.core.crypto.DigitalSignature$WithKey getDigitalSignature()
   public final int getPlatformVersion()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -2160,16 +2541,19 @@ public final class net.corda.core.flows.NotarisationResponse extends java.lang.O
   @NotNull
   public final java.util.List<net.corda.core.crypto.TransactionSignature> getSignatures()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @InitiatingFlow
 public final class net.corda.core.flows.NotaryChangeFlow extends net.corda.core.flows.AbstractStateReplacementFlow$Instigator
   public <init>(net.corda.core.contracts.StateAndRef<? extends T>, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.contracts.StateAndRef, net.corda.core.identity.Party, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   protected net.corda.core.flows.AbstractStateReplacementFlow$UpgradeTx assembleTx()
 ##
 @CordaSerializable
 public abstract class net.corda.core.flows.NotaryError extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.core.flows.NotaryError$Conflict extends net.corda.core.flows.NotaryError
@@ -2239,6 +2623,7 @@ public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid ext
   public static final net.corda.core.flows.NotaryError$TimeWindowInvalid INSTANCE
 ##
 public static final class net.corda.core.flows.NotaryError$TimeWindowInvalid$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.core.flows.NotaryError$TransactionInvalid extends net.corda.core.flows.NotaryError
@@ -2261,6 +2646,7 @@ public static final class net.corda.core.flows.NotaryError$WrongNotary extends n
 @CordaSerializable
 public final class net.corda.core.flows.NotaryException extends net.corda.core.flows.FlowException
   public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash)
+  public <init>(net.corda.core.flows.NotaryError, net.corda.core.crypto.SecureHash, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.flows.NotaryError getError()
   @Nullable
@@ -2278,6 +2664,8 @@ public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.cor
   @NotNull
   public java.util.List<net.corda.core.crypto.TransactionSignature> call()
   @NotNull
+  protected final net.corda.core.identity.Party checkTransaction()
+  @NotNull
   public net.corda.core.utilities.ProgressTracker getProgressTracker()
   @Suspendable
   @NotNull
@@ -2287,6 +2675,7 @@ public static class net.corda.core.flows.NotaryFlow$Client extends net.corda.cor
   public static final net.corda.core.flows.NotaryFlow$Client$Companion Companion
 ##
 public static final class net.corda.core.flows.NotaryFlow$Client$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ProgressTracker tracker()
 ##
@@ -2298,6 +2687,15 @@ public static final class net.corda.core.flows.NotaryFlow$Client$Companion$REQUE
 public static final class net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING extends net.corda.core.utilities.ProgressTracker$Step
   public static final net.corda.core.flows.NotaryFlow$Client$Companion$VALIDATING INSTANCE
 ##
+public final class net.corda.core.flows.ReceiveFinalityFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.crypto.SecureHash, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public net.corda.core.transactions.SignedTransaction call()
+##
 public final class net.corda.core.flows.ReceiveStateAndRefFlow extends net.corda.core.flows.FlowLogic
   public <init>(net.corda.core.flows.FlowSession)
   @Suspendable
@@ -2308,9 +2706,12 @@ public class net.corda.core.flows.ReceiveTransactionFlow extends net.corda.core.
   public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, boolean)
   public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord)
+  public <init>(net.corda.core.flows.FlowSession, boolean, net.corda.core.node.StatesToRecord, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
+  @Suspendable
+  protected void checkBeforeRecording(net.corda.core.transactions.SignedTransaction)
 ##
 public @interface net.corda.core.flows.SchedulableFlow
 ##
@@ -2321,7 +2722,9 @@ public class net.corda.core.flows.SendTransactionFlow extends net.corda.core.flo
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.transactions.SignedTransaction)
 ##
 public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda.core.flows.FlowLogic
+  public <init>(net.corda.core.flows.FlowSession)
   public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker)
+  public <init>(net.corda.core.flows.FlowSession, net.corda.core.utilities.ProgressTracker, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Suspendable
   @NotNull
   public net.corda.core.transactions.SignedTransaction call()
@@ -2336,6 +2739,7 @@ public abstract class net.corda.core.flows.SignTransactionFlow extends net.corda
   public static final net.corda.core.flows.SignTransactionFlow$Companion Companion
 ##
 public static final class net.corda.core.flows.SignTransactionFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ProgressTracker tracker()
 ##
@@ -2361,6 +2765,7 @@ public final class net.corda.core.flows.StackFrameDataToken extends java.lang.Ob
   @NotNull
   public final String getClassName()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public @interface net.corda.core.flows.StartableByRPC
@@ -2369,16 +2774,31 @@ public @interface net.corda.core.flows.StartableByService
 ##
 @CordaSerializable
 public final class net.corda.core.flows.StateConsumptionDetails extends java.lang.Object
+  @DeprecatedConstructorForDeserialization
   public <init>(net.corda.core.crypto.SecureHash)
+  public <init>(net.corda.core.crypto.SecureHash, net.corda.core.flows.StateConsumptionDetails$ConsumedStateType)
   @NotNull
   public final net.corda.core.crypto.SecureHash component1()
   @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails$ConsumedStateType component2()
+  @NotNull
   public final net.corda.core.flows.StateConsumptionDetails copy(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails copy(net.corda.core.crypto.SecureHash, net.corda.core.flows.StateConsumptionDetails$ConsumedStateType)
   public boolean equals(Object)
   @NotNull
   public final net.corda.core.crypto.SecureHash getHashOfTransactionId()
+  @NotNull
+  public final net.corda.core.flows.StateConsumptionDetails$ConsumedStateType getType()
   public int hashCode()
+  @NotNull
   public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.StateConsumptionDetails$ConsumedStateType extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.flows.StateConsumptionDetails$ConsumedStateType valueOf(String)
+  public static net.corda.core.flows.StateConsumptionDetails$ConsumedStateType[] values()
 ##
 @CordaSerializable
 public final class net.corda.core.flows.StateMachineRunId extends java.lang.Object
@@ -2396,6 +2816,7 @@ public final class net.corda.core.flows.StateMachineRunId extends java.lang.Obje
   public static final net.corda.core.flows.StateMachineRunId$Companion Companion
 ##
 public static final class net.corda.core.flows.StateMachineRunId$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.flows.StateMachineRunId createRandom()
 ##
@@ -2404,11 +2825,61 @@ public class net.corda.core.flows.StateReplacementException extends net.corda.co
   public <init>()
   public <init>(String)
   public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public final class net.corda.core.flows.UnexpectedFlowEndException extends net.corda.core.CordaRuntimeException implements net.corda.core.flows.IdentifiableException
   public <init>(String)
   public <init>(String, Throwable)
+  public <init>(String, Throwable, Long)
+  @Nullable
+  public Long getErrorId()
+  @Nullable
+  public final Long getOriginalErrorId()
+##
+@CordaSerializable
+public final class net.corda.core.flows.WaitTimeUpdate extends java.lang.Object
+  public <init>(java.time.Duration)
+  @NotNull
+  public final java.time.Duration component1()
+  @NotNull
+  public final net.corda.core.flows.WaitTimeUpdate copy(java.time.Duration)
+  public boolean equals(Object)
+  @NotNull
+  public final java.time.Duration getWaitTime()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+public final class net.corda.core.flows.WithReferencedStatesFlow extends net.corda.core.flows.FlowLogic
+  public <init>(kotlin.jvm.functions.Function0<? extends net.corda.core.flows.FlowLogic<? extends T>>)
+  public <init>(net.corda.core.utilities.ProgressTracker, kotlin.jvm.functions.Function0<? extends net.corda.core.flows.FlowLogic<? extends T>>)
+  public <init>(net.corda.core.utilities.ProgressTracker, kotlin.jvm.functions.Function0, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Suspendable
+  @NotNull
+  public T call()
+  @NotNull
+  public net.corda.core.utilities.ProgressTracker getProgressTracker()
+  @NotNull
+  public static final net.corda.core.utilities.ProgressTracker tracker()
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion Companion
+##
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.utilities.ProgressTracker tracker()
+##
+@CordaSerializable
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion$ATTEMPT extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion$ATTEMPT INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion$RETRYING extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion$RETRYING INSTANCE
+##
+@CordaSerializable
+public static final class net.corda.core.flows.WithReferencedStatesFlow$Companion$SUCCESS extends net.corda.core.utilities.ProgressTracker$Step
+  public static final net.corda.core.flows.WithReferencedStatesFlow$Companion$SUCCESS INSTANCE
 ##
 @DoNotImplement
 @CordaSerializable
@@ -2486,6 +2957,7 @@ public final class net.corda.core.identity.CordaX500Name extends java.lang.Objec
   public static final int MAX_LENGTH_STATE = 64
 ##
 public static final class net.corda.core.identity.CordaX500Name$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.identity.CordaX500Name build(javax.security.auth.x500.X500Principal)
   @NotNull
@@ -2550,6 +3022,7 @@ public interface net.corda.core.messaging.AllPossibleRecipients extends net.cord
 ##
 public final class net.corda.core.messaging.ClientRpcSslOptions extends java.lang.Object
   public <init>(java.nio.file.Path, String, String)
+  public <init>(java.nio.file.Path, String, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.nio.file.Path component1()
   @NotNull
@@ -2566,6 +3039,7 @@ public final class net.corda.core.messaging.ClientRpcSslOptions extends java.lan
   @NotNull
   public final String getTrustStoreProvider()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -2577,6 +3051,8 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   @NotNull
   public abstract java.time.Instant currentNodeTime()
   @NotNull
+  public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
   public abstract Iterable<String> getVaultTransactionNotes(net.corda.core.crypto.SecureHash)
   @RPCReturnsObservables
   @NotNull
@@ -2584,6 +3060,8 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   @NotNull
   public abstract java.util.List<net.corda.core.transactions.SignedTransaction> internalVerifiedTransactionsSnapshot()
   public abstract boolean isFlowsDrainingModeEnabled()
+  public abstract boolean isWaitingForShutdown()
+  public abstract boolean killFlow(net.corda.core.flows.StateMachineRunId)
   @RPCReturnsObservables
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> networkMapFeed()
@@ -2608,9 +3086,11 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   public abstract net.corda.core.identity.Party partyFromKey(java.security.PublicKey)
   @NotNull
   public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
+  public abstract void refreshNetworkMapCache()
   @NotNull
   public abstract java.util.List<String> registeredFlows()
   public abstract void setFlowsDrainingModeEnabled(boolean)
+  public abstract void shutdown()
   @RPCReturnsObservables
   @NotNull
   public abstract net.corda.core.messaging.FlowHandle<T> startFlowDynamic(Class<? extends net.corda.core.flows.FlowLogic<? extends T>>, Object...)
@@ -2627,6 +3107,7 @@ public interface net.corda.core.messaging.CordaRPCOps extends net.corda.core.mes
   public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.messaging.StateMachineInfo>, net.corda.core.messaging.StateMachineUpdate> stateMachinesFeed()
   @NotNull
   public abstract java.util.List<net.corda.core.messaging.StateMachineInfo> stateMachinesSnapshot()
+  public abstract void terminate(boolean)
   @NotNull
   public abstract net.corda.core.crypto.SecureHash uploadAttachment(java.io.InputStream)
   @NotNull
@@ -2676,9 +3157,11 @@ public final class net.corda.core.messaging.DataFeed extends java.lang.Object
   @NotNull
   public final rx.Observable<B> getUpdates()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
+@CordaSerializable
 public interface net.corda.core.messaging.FlowHandle extends java.lang.AutoCloseable
   public abstract void close()
   @NotNull
@@ -2703,9 +3186,11 @@ public final class net.corda.core.messaging.FlowHandleImpl extends java.lang.Obj
   @NotNull
   public net.corda.core.concurrent.CordaFuture<A> getReturnValue()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
+@CordaSerializable
 public interface net.corda.core.messaging.FlowProgressHandle extends net.corda.core.messaging.FlowHandle
   public abstract void close()
   @NotNull
@@ -2721,6 +3206,7 @@ public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>)
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>)
   public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture<A>, rx.Observable<String>, net.corda.core.messaging.DataFeed<Integer, Integer>, net.corda.core.messaging.DataFeed<? extends java.util.List<kotlin.Pair<Integer, String>>, java.util.List<kotlin.Pair<Integer, String>>>)
+  public <init>(net.corda.core.flows.StateMachineRunId, net.corda.core.concurrent.CordaFuture, rx.Observable, net.corda.core.messaging.DataFeed, net.corda.core.messaging.DataFeed, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public void close()
   @NotNull
   public final net.corda.core.flows.StateMachineRunId component1()
@@ -2748,6 +3234,7 @@ public final class net.corda.core.messaging.FlowProgressHandleImpl extends java.
   @Nullable
   public net.corda.core.messaging.DataFeed<Integer, Integer> getStepsTreeIndexFeed()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -2779,6 +3266,7 @@ public final class net.corda.core.messaging.ParametersUpdateInfo extends java.la
   @NotNull
   public final java.time.Instant getUpdateDeadline()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -2794,6 +3282,7 @@ public interface net.corda.core.messaging.SingleMessageRecipient extends net.cor
 public final class net.corda.core.messaging.StateMachineInfo extends java.lang.Object
   public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>)
   public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed<String, String>, net.corda.core.context.InvocationContext)
+  public <init>(net.corda.core.flows.StateMachineRunId, String, net.corda.core.flows.FlowInitiator, net.corda.core.messaging.DataFeed, net.corda.core.context.InvocationContext, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.flows.StateMachineRunId component1()
   @NotNull
@@ -2838,10 +3327,12 @@ public final class net.corda.core.messaging.StateMachineTransactionMapping exten
   @NotNull
   public final net.corda.core.crypto.SecureHash getTransactionId()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public abstract class net.corda.core.messaging.StateMachineUpdate extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public abstract net.corda.core.flows.StateMachineRunId getId()
 ##
@@ -2858,6 +3349,7 @@ public static final class net.corda.core.messaging.StateMachineUpdate$Added exte
   @NotNull
   public final net.corda.core.messaging.StateMachineInfo getStateMachineInfo()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -2875,6 +3367,7 @@ public static final class net.corda.core.messaging.StateMachineUpdate$Removed ex
   @NotNull
   public final net.corda.core.utilities.Try<?> getResult()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -2884,9 +3377,15 @@ public interface net.corda.core.node.AppServiceHub extends net.corda.core.node.S
   @NotNull
   public abstract net.corda.core.messaging.FlowProgressHandle<T> startTrackedFlow(net.corda.core.flows.FlowLogic<? extends T>)
 ##
+public @interface net.corda.core.node.AutoAcceptable
+##
 @CordaSerializable
 public final class net.corda.core.node.NetworkParameters extends java.lang.Object
+  @DeprecatedConstructorForDeserialization
   public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
+  @DeprecatedConstructorForDeserialization
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration)
+  public <init>(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration, java.util.Map<String, ? extends java.security.PublicKey>)
   public final int component1()
   @NotNull
   public final java.util.List<net.corda.core.node.NotaryInfo> component2()
@@ -2898,9 +3397,19 @@ public final class net.corda.core.node.NetworkParameters extends java.lang.Objec
   @NotNull
   public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> component7()
   @NotNull
+  public final java.time.Duration component8()
+  @NotNull
+  public final java.util.Map<String, java.security.PublicKey> component9()
+  @NotNull
   public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>)
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration)
+  @NotNull
+  public final net.corda.core.node.NetworkParameters copy(int, java.util.List<net.corda.core.node.NotaryInfo>, int, int, java.time.Instant, int, java.util.Map<String, ? extends java.util.List<? extends net.corda.core.crypto.SecureHash>>, java.time.Duration, java.util.Map<String, ? extends java.security.PublicKey>)
   public boolean equals(Object)
   public final int getEpoch()
+  @NotNull
+  public final java.time.Duration getEventHorizon()
   public final int getMaxMessageSize()
   public final int getMaxTransactionSize()
   public final int getMinimumPlatformVersion()
@@ -2909,8 +3418,11 @@ public final class net.corda.core.node.NetworkParameters extends java.lang.Objec
   @NotNull
   public final java.util.List<net.corda.core.node.NotaryInfo> getNotaries()
   @NotNull
+  public final java.util.Map<String, java.security.PublicKey> getPackageOwnership()
+  @NotNull
   public final java.util.Map<String, java.util.List<net.corda.core.crypto.SecureHash>> getWhitelistedContractImplementations()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -2939,6 +3451,7 @@ public final class net.corda.core.node.NodeInfo extends java.lang.Object
   @NotNull
   public final net.corda.core.identity.Party identityFromX500Name(net.corda.core.identity.CordaX500Name)
   public final boolean isLegalIdentity(net.corda.core.identity.Party)
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -2954,6 +3467,7 @@ public final class net.corda.core.node.NotaryInfo extends java.lang.Object
   public final net.corda.core.identity.Party getIdentity()
   public final boolean getValidating()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -2972,6 +3486,8 @@ public interface net.corda.core.node.ServiceHub extends net.corda.core.node.Serv
   public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction)
   @NotNull
   public abstract net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
+  @NotNull
+  public abstract net.corda.core.cordapp.CordappContext getAppContext()
   @NotNull
   public abstract java.time.Clock getClock()
   @NotNull
@@ -3004,6 +3520,9 @@ public interface net.corda.core.node.ServiceHub extends net.corda.core.node.Serv
   public abstract net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
   @NotNull
   public abstract net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
+  public abstract void withEntityManager(java.util.function.Consumer<javax.persistence.EntityManager>)
+  @NotNull
+  public abstract T withEntityManager(kotlin.jvm.functions.Function1<? super javax.persistence.EntityManager, ? extends T>)
 ##
 @DoNotImplement
 public interface net.corda.core.node.ServicesForResolution
@@ -3016,6 +3535,10 @@ public interface net.corda.core.node.ServicesForResolution
   @NotNull
   public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
+  public abstract net.corda.core.node.services.NetworkParametersService getNetworkParametersService()
+  @NotNull
+  public abstract net.corda.core.contracts.Attachment loadContractAttachment(net.corda.core.contracts.StateRef, String)
+  @NotNull
   public abstract net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
   @NotNull
   public abstract java.util.Set<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> loadStates(java.util.Set<net.corda.core.contracts.StateRef>)
@@ -3025,8 +3548,14 @@ public final class net.corda.core.node.StatesToRecord extends java.lang.Enum
   public static net.corda.core.node.StatesToRecord valueOf(String)
   public static net.corda.core.node.StatesToRecord[] values()
 ##
+@CordaSerializable
+public final class net.corda.core.node.ZoneVersionTooLowException extends net.corda.core.CordaRuntimeException
+  public <init>(String)
+##
 @DoNotImplement
 public interface net.corda.core.node.services.AttachmentStorage
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> getLatestContractAttachments(String, int)
   public abstract boolean hasAttachment(net.corda.core.crypto.SecureHash)
   @NotNull
   public abstract net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
@@ -3036,6 +3565,8 @@ public interface net.corda.core.node.services.AttachmentStorage
   public abstract net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
   @Nullable
   public abstract net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria)
   @NotNull
   public abstract java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
 ##
@@ -3104,6 +3635,7 @@ public interface net.corda.core.node.services.NetworkMapCache extends net.corda.
 ##
 @CordaSerializable
 public abstract static class net.corda.core.node.services.NetworkMapCache$MapChange extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public abstract net.corda.core.node.NodeInfo getNode()
 ##
@@ -3118,6 +3650,7 @@ public static final class net.corda.core.node.services.NetworkMapCache$MapChange
   @NotNull
   public net.corda.core.node.NodeInfo getNode()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3135,6 +3668,7 @@ public static final class net.corda.core.node.services.NetworkMapCache$MapChange
   @NotNull
   public final net.corda.core.node.NodeInfo getPreviousNode()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3148,6 +3682,7 @@ public static final class net.corda.core.node.services.NetworkMapCache$MapChange
   @NotNull
   public net.corda.core.node.NodeInfo getNode()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -3182,7 +3717,17 @@ public interface net.corda.core.node.services.NetworkMapCacheBase
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.node.NodeInfo>, net.corda.core.node.services.NetworkMapCache$MapChange> track()
 ##
+@DoNotImplement
+public interface net.corda.core.node.services.NetworkParametersService
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getCurrentHash()
+  @NotNull
+  public abstract net.corda.core.crypto.SecureHash getDefaultHash()
+  @Nullable
+  public abstract net.corda.core.node.NetworkParameters lookup(net.corda.core.crypto.SecureHash)
+##
 public abstract class net.corda.core.node.services.PartyInfo extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public abstract net.corda.core.identity.Party getParty()
 ##
@@ -3196,6 +3741,7 @@ public static final class net.corda.core.node.services.PartyInfo$DistributedNode
   @NotNull
   public net.corda.core.identity.Party getParty()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public static final class net.corda.core.node.services.PartyInfo$SingleNode extends net.corda.core.node.services.PartyInfo
@@ -3212,11 +3758,13 @@ public static final class net.corda.core.node.services.PartyInfo$SingleNode exte
   @NotNull
   public net.corda.core.identity.Party getParty()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public final class net.corda.core.node.services.StatesNotAvailableException extends net.corda.core.flows.FlowException
   public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public Throwable getCause()
   @Nullable
@@ -3227,6 +3775,7 @@ public final class net.corda.core.node.services.StatesNotAvailableException exte
 public final class net.corda.core.node.services.TimeWindowChecker extends java.lang.Object
   public <init>()
   public <init>(java.time.Clock)
+  public <init>(java.time.Clock, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.time.Clock getClock()
   public final boolean isValid(net.corda.core.contracts.TimeWindow)
@@ -3239,6 +3788,8 @@ public interface net.corda.core.node.services.TransactionStorage
   public abstract rx.Observable<net.corda.core.transactions.SignedTransaction> getUpdates()
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<java.util.List<net.corda.core.transactions.SignedTransaction>, net.corda.core.transactions.SignedTransaction> track()
+  @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.transactions.SignedTransaction> trackTransaction(net.corda.core.crypto.SecureHash)
 ##
 @DoNotImplement
 public interface net.corda.core.node.services.TransactionVerifierService
@@ -3257,10 +3808,41 @@ public final class net.corda.core.node.services.Vault extends java.lang.Object
   public static final net.corda.core.node.services.Vault$Companion Companion
 ##
 public static final class net.corda.core.node.services.Vault$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoNotaryUpdate()
   @NotNull
   public final net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState> getNoUpdate()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$ConstraintInfo extends java.lang.Object
+  public <init>(net.corda.core.contracts.AttachmentConstraint)
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint component1()
+  @NotNull
+  public final net.corda.core.node.services.Vault$ConstraintInfo copy(net.corda.core.contracts.AttachmentConstraint)
+  @Nullable
+  public final byte[] data()
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.AttachmentConstraint getConstraint()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public final net.corda.core.node.services.Vault$ConstraintInfo$Type type()
+  public static final net.corda.core.node.services.Vault$ConstraintInfo$Companion Companion
+##
+public static final class net.corda.core.node.services.Vault$ConstraintInfo$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.node.services.Vault$ConstraintInfo constraintInfo(net.corda.core.node.services.Vault$ConstraintInfo$Type, byte[])
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$ConstraintInfo$Type extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$ConstraintInfo$Type valueOf(String)
+  public static net.corda.core.node.services.Vault$ConstraintInfo$Type[] values()
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.Vault$Page extends java.lang.Object
@@ -3287,13 +3869,21 @@ public static final class net.corda.core.node.services.Vault$Page extends java.l
   public final java.util.List<net.corda.core.node.services.Vault$StateMetadata> getStatesMetadata()
   public final long getTotalStatesAvailable()
   public int hashCode()
+  @NotNull
   public String toString()
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.Vault$RelevancyStatus extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.node.services.Vault$RelevancyStatus valueOf(String)
+  public static net.corda.core.node.services.Vault$RelevancyStatus[] values()
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.Vault$StateMetadata extends java.lang.Object
   public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant)
   public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus)
   public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus, net.corda.core.node.services.Vault$ConstraintInfo)
+  public <init>(net.corda.core.contracts.StateRef, String, java.time.Instant, java.time.Instant, net.corda.core.node.services.Vault$StateStatus, net.corda.core.identity.AbstractParty, String, java.time.Instant, net.corda.core.node.services.Vault$RelevancyStatus, net.corda.core.node.services.Vault$ConstraintInfo, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.contracts.StateRef component1()
   @Nullable
@@ -3353,7 +3943,11 @@ public static final class net.corda.core.node.services.Vault$StateStatus extends
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.Vault$Update extends java.lang.Object
+  public <init>(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>)
+  public <init>(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID)
   public <init>(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
+  public <init>(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>)
+  public <init>(java.util.Set, java.util.Set, java.util.UUID, net.corda.core.node.services.Vault$UpdateType, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component1()
   @NotNull
@@ -3362,9 +3956,13 @@ public static final class net.corda.core.node.services.Vault$Update extends java
   public final java.util.UUID component3()
   @NotNull
   public final net.corda.core.node.services.Vault$UpdateType component4()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> component5()
   public final boolean containsType(Class<T>, net.corda.core.node.services.Vault$StateStatus)
   @NotNull
   public final net.corda.core.node.services.Vault$Update<U> copy(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType)
+  @NotNull
+  public final net.corda.core.node.services.Vault$Update<U> copy(java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>, java.util.UUID, net.corda.core.node.services.Vault$UpdateType, java.util.Set<? extends net.corda.core.contracts.StateAndRef<? extends U>>)
   public boolean equals(Object)
   @NotNull
   public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getConsumed()
@@ -3372,6 +3970,8 @@ public static final class net.corda.core.node.services.Vault$Update extends java
   public final java.util.UUID getFlowId()
   @NotNull
   public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getProduced()
+  @NotNull
+  public final java.util.Set<net.corda.core.contracts.StateAndRef<U>> getReferences()
   @NotNull
   public final net.corda.core.node.services.Vault$UpdateType getType()
   public int hashCode()
@@ -3407,6 +4007,8 @@ public interface net.corda.core.node.services.VaultService
   @NotNull
   public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>)
   @NotNull
+  public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.PageSpecification)
+  @NotNull
   public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
   @NotNull
   public abstract net.corda.core.node.services.Vault$Page<T> queryBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria, net.corda.core.node.services.vault.PageSpecification)
@@ -3418,6 +4020,8 @@ public interface net.corda.core.node.services.VaultService
   public abstract void softLockReserve(java.util.UUID, net.corda.core.utilities.NonEmptySet<net.corda.core.contracts.StateRef>)
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>)
+  @NotNull
+  public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.PageSpecification)
   @NotNull
   public abstract net.corda.core.messaging.DataFeed<net.corda.core.node.services.Vault$Page<T>, net.corda.core.node.services.Vault$Update<T>> trackBy(Class<? extends T>, net.corda.core.node.services.vault.QueryCriteria)
   @NotNull
@@ -3433,6 +4037,7 @@ public interface net.corda.core.node.services.VaultService
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.core.node.services.Vault$Update<net.corda.core.contracts.ContractState>> whenConsumed(net.corda.core.contracts.StateRef)
 ##
 public final class net.corda.core.node.services.VaultServiceKt extends java.lang.Object
+  public static final int MAX_CONSTRAINT_DATA_SIZE = 563
 ##
 @CordaSerializable
 public final class net.corda.core.node.services.vault.AggregateFunctionType extends java.lang.Enum
@@ -3442,6 +4047,7 @@ public final class net.corda.core.node.services.vault.AggregateFunctionType exte
 ##
 @CordaSerializable
 public abstract class net.corda.core.node.services.vault.AttachmentQueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public net.corda.core.node.services.vault.AttachmentQueryCriteria and(net.corda.core.node.services.vault.AttachmentQueryCriteria)
   @NotNull
@@ -3463,6 +4069,9 @@ public static final class net.corda.core.node.services.vault.AttachmentQueryCrit
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>)
   public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<String>, net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>, net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>, net.corda.core.node.services.vault.ColumnPredicate<Boolean>, net.corda.core.node.services.vault.ColumnPredicate<Integer>)
+  public <init>(net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.vault.ColumnPredicate, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<String> component1()
   @Nullable
@@ -3495,12 +4104,26 @@ public static final class net.corda.core.node.services.vault.AttachmentQueryCrit
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<Integer> getVersionCondition()
   public int hashCode()
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria isSigned(net.corda.core.node.services.vault.ColumnPredicate<Boolean>)
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<Boolean> isSignedCondition()
   @NotNull
   public String toString()
   @NotNull
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withContractClassNames(net.corda.core.node.services.vault.ColumnPredicate<java.util.List<String>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withFilename(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withSigners(net.corda.core.node.services.vault.ColumnPredicate<java.util.List<java.security.PublicKey>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withUploadDate(net.corda.core.node.services.vault.ColumnPredicate<java.time.Instant>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withUploader(net.corda.core.node.services.vault.ColumnPredicate<String>)
+  @NotNull
+  public final net.corda.core.node.services.vault.AttachmentQueryCriteria$AttachmentsQueryCriteria withVersion(net.corda.core.node.services.vault.ColumnPredicate<Integer>)
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.AttachmentQueryCriteria$OrComposition extends net.corda.core.node.services.vault.AttachmentQueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
@@ -3523,6 +4146,7 @@ public final class net.corda.core.node.services.vault.AttachmentSort extends net
   @NotNull
   public final java.util.Collection<net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn> getColumns()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute extends java.lang.Enum
@@ -3535,6 +4159,7 @@ public static final class net.corda.core.node.services.vault.AttachmentSort$Atta
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.AttachmentSort$AttachmentSortColumn extends java.lang.Object
   public <init>(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public <init>(net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute, net.corda.core.node.services.vault.Sort$Direction, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute component1()
   @NotNull
@@ -3547,6 +4172,7 @@ public static final class net.corda.core.node.services.vault.AttachmentSort$Atta
   @NotNull
   public final net.corda.core.node.services.vault.AttachmentSort$AttachmentSortAttribute getSortAttribute()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public interface net.corda.core.node.services.vault.AttachmentsQueryCriteriaParser extends net.corda.core.node.services.vault.BaseQueryCriteriaParser
@@ -3589,11 +4215,19 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> avg(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> avg(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$Between<R> between(R, R)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> between(reflect.Field, R, R)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> between(kotlin.reflect.KProperty1<O, ? extends R>, R, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> between(net.corda.core.node.services.vault.FieldInfo, R, R)
   @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> compare(net.corda.core.node.services.vault.BinaryComparisonOperator, R)
   @NotNull
@@ -3601,19 +4235,35 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> comparePredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
   @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> comparePredicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.BinaryComparisonOperator, R)
+  @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, Object> count(reflect.Field)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> count(kotlin.reflect.KProperty1<O, ? extends R>)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, Object> count(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> equal(R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> equal(R, boolean)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(reflect.Field, R)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(reflect.Field, R, boolean)
+  @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> equal(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> equal(kotlin.reflect.KProperty1<O, ? extends R>, R, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> equal(net.corda.core.node.services.vault.FieldInfo, R, boolean)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> functionPredicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<Object, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> functionPredicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> functionPredicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.ColumnPredicate<R>, java.util.List<? extends net.corda.core.node.services.vault.Column<Object, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
   @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThan(R)
   @NotNull
@@ -3621,17 +4271,31 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThan(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> greaterThanOrEqual(R)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThanOrEqual(reflect.Field, R)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> greaterThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> greaterThanOrEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(reflect.Field, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(reflect.Field, java.util.Collection<? extends R>, boolean)
   @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> in(java.util.Collection<? extends R>)
   @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> in(java.util.Collection<? extends R>, boolean)
+  @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> in(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> in(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> in(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>, boolean)
   @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$NullExpression<R> isNotNull()
   @NotNull
@@ -3641,11 +4305,15 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> isNull(kotlin.reflect.KProperty1<O, ? extends R>)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> isNull(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThan(R)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThan(reflect.Field, R)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThan(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThan(net.corda.core.node.services.vault.FieldInfo, R)
   @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$BinaryComparison<R> lessThanOrEqual(R)
   @NotNull
@@ -3653,11 +4321,23 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> lessThanOrEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> lessThanOrEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$Likeness like(String)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness like(String, boolean)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(reflect.Field, String)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(reflect.Field, String, boolean)
+  @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> like(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> like(kotlin.reflect.KProperty1<O, String>, String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(net.corda.core.node.services.vault.FieldInfo, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> like(net.corda.core.node.services.vault.FieldInfo, String, boolean)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(reflect.Field)
   @NotNull
@@ -3667,6 +4347,12 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> max(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> max(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(reflect.Field, java.util.List<reflect.Field>)
@@ -3675,31 +4361,71 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> min(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> min(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> notEqual(R)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$EqualityComparison<R> notEqual(R, boolean)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(reflect.Field, R)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(reflect.Field, R, boolean)
+  @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notEqual(kotlin.reflect.KProperty1<O, ? extends R>, R)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notEqual(kotlin.reflect.KProperty1<O, ? extends R>, R, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(net.corda.core.node.services.vault.FieldInfo, R)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notEqual(net.corda.core.node.services.vault.FieldInfo, R, boolean)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(reflect.Field, java.util.Collection<? extends R>)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(reflect.Field, java.util.Collection<? extends R>, boolean)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> notIn(java.util.Collection<? extends R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$CollectionExpression<R> notIn(java.util.Collection<? extends R>, boolean)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notIn(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>)
   @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notIn(kotlin.reflect.KProperty1<O, ? extends R>, java.util.Collection<? extends R>, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> notIn(net.corda.core.node.services.vault.FieldInfo, java.util.Collection<? extends R>, boolean)
+  @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate$Likeness notLike(String)
+  @NotNull
+  public final net.corda.core.node.services.vault.ColumnPredicate$Likeness notLike(String, boolean)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(reflect.Field, String)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(reflect.Field, String, boolean)
+  @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> notLike(kotlin.reflect.KProperty1<O, String>, String)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, String> notLike(kotlin.reflect.KProperty1<O, String>, String, boolean)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(net.corda.core.node.services.vault.FieldInfo, String)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, String> notLike(net.corda.core.node.services.vault.FieldInfo, String, boolean)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> notNull(reflect.Field)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> notNull(kotlin.reflect.KProperty1<O, ? extends R>)
   @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, Object> notNull(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> predicate(reflect.Field, net.corda.core.node.services.vault.ColumnPredicate<R>)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<O, R> predicate(kotlin.reflect.KProperty1<O, ? extends R>, net.corda.core.node.services.vault.ColumnPredicate<R>)
+  @NotNull
+  public final net.corda.core.node.services.vault.CriteriaExpression$ColumnPredicateExpression<Object, R> predicate(net.corda.core.node.services.vault.FieldInfo, net.corda.core.node.services.vault.ColumnPredicate<R>)
   @NotNull
   public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field)
   @NotNull
@@ -3708,6 +4434,12 @@ public final class net.corda.core.node.services.vault.Builder extends java.lang.
   public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(reflect.Field, java.util.List<reflect.Field>, net.corda.core.node.services.vault.Sort$Direction)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<O, R> sum(kotlin.reflect.KProperty1<O, ? extends R>, java.util.List<? extends kotlin.reflect.KProperty1<O, ? extends R>>, net.corda.core.node.services.vault.Sort$Direction)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression<Object, R> sum(net.corda.core.node.services.vault.FieldInfo, java.util.List<net.corda.core.node.services.vault.FieldInfo>, net.corda.core.node.services.vault.Sort$Direction)
   public static final net.corda.core.node.services.vault.Builder INSTANCE
 ##
 @DoNotImplement
@@ -3722,13 +4454,16 @@ public final class net.corda.core.node.services.vault.Column extends java.lang.O
   public <init>(String, Class<?>)
   public <init>(reflect.Field)
   public <init>(kotlin.reflect.KProperty1<O, ? extends C>)
+  public <init>(net.corda.core.node.services.vault.FieldInfo)
   @NotNull
   public final Class<?> getDeclaringClass()
   @NotNull
   public final String getName()
+  public static final net.corda.core.node.services.vault.Column$Companion Companion
 ##
 @CordaSerializable
 public abstract class net.corda.core.node.services.vault.ColumnPredicate extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.ColumnPredicate$AggregateFunction extends net.corda.core.node.services.vault.ColumnPredicate
@@ -3741,6 +4476,7 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Agg
   @NotNull
   public final net.corda.core.node.services.vault.AggregateFunctionType getType()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3758,6 +4494,7 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Bet
   @NotNull
   public final C getRightToLiteral()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3775,6 +4512,7 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Bin
   @NotNull
   public final C getRightLiteral()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3792,6 +4530,7 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Col
   @NotNull
   public final java.util.Collection<C> getRightLiteral()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3807,6 +4546,7 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Equ
   public final net.corda.core.node.services.vault.EqualityComparisonOperator getOperator()
   public final C getRightLiteral()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3824,6 +4564,7 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Lik
   @NotNull
   public final String getRightLiteral()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3837,10 +4578,12 @@ public static final class net.corda.core.node.services.vault.ColumnPredicate$Nul
   @NotNull
   public final net.corda.core.node.services.vault.NullOperator getOperator()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public abstract class net.corda.core.node.services.vault.CriteriaExpression extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.CriteriaExpression$AggregateFunctionExpression extends net.corda.core.node.services.vault.CriteriaExpression
@@ -3865,6 +4608,7 @@ public static final class net.corda.core.node.services.vault.CriteriaExpression$
   @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3886,6 +4630,7 @@ public static final class net.corda.core.node.services.vault.CriteriaExpression$
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getRight()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3903,6 +4648,7 @@ public static final class net.corda.core.node.services.vault.CriteriaExpression$
   @NotNull
   public final net.corda.core.node.services.vault.ColumnPredicate<C> getPredicate()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -3916,6 +4662,7 @@ public static final class net.corda.core.node.services.vault.CriteriaExpression$
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression<O, Boolean> getExpression()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -3924,6 +4671,13 @@ public final class net.corda.core.node.services.vault.EqualityComparisonOperator
   protected <init>()
   public static net.corda.core.node.services.vault.EqualityComparisonOperator valueOf(String)
   public static net.corda.core.node.services.vault.EqualityComparisonOperator[] values()
+##
+public final class net.corda.core.node.services.vault.FieldInfo extends java.lang.Object
+  public <init>(String, Class<?>)
+  @NotNull
+  public final Class<?> getEntityClass()
+  @NotNull
+  public final String getName()
 ##
 public interface net.corda.core.node.services.vault.GenericQueryCriteria
   @NotNull
@@ -3986,6 +4740,7 @@ public interface net.corda.core.node.services.vault.Operator
 public final class net.corda.core.node.services.vault.PageSpecification extends java.lang.Object
   public <init>()
   public <init>(int, int)
+  public <init>(int, int, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final int component1()
   public final int component2()
   @NotNull
@@ -3995,10 +4750,12 @@ public final class net.corda.core.node.services.vault.PageSpecification extends 
   public final int getPageSize()
   public int hashCode()
   public final boolean isDefault()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
 public abstract class net.corda.core.node.services.vault.QueryCriteria extends java.lang.Object implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria, net.corda.core.node.services.vault.GenericQueryCriteria
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public net.corda.core.node.services.vault.QueryCriteria and(net.corda.core.node.services.vault.QueryCriteria)
   @NotNull
@@ -4017,8 +4774,16 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$AndCo
 @CordaSerializable
 public abstract static class net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria
   public <init>()
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo$Type> getConstraintTypes()
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo> getConstraints()
   @Nullable
   public abstract java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
   @NotNull
   public abstract net.corda.core.node.services.Vault$StateStatus getStatus()
   @NotNull
@@ -4034,6 +4799,9 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus)
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.vault.ColumnPredicate, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component1()
   @Nullable
@@ -4049,7 +4817,11 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
   @Nullable
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component7()
   @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component8()
+  @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
   public boolean equals(Object)
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
@@ -4064,11 +4836,74 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Fungi
   @Nullable
   public final net.corda.core.node.services.vault.ColumnPredicate<Long> getQuantity()
   @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
   public net.corda.core.node.services.Vault$StateStatus getStatus()
   public int hashCode()
+  @NotNull
   public String toString()
   @NotNull
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withIssuer(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withOwner(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withQuantity(net.corda.core.node.services.vault.ColumnPredicate<Long>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withRelevancyStatus(net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withStatus(net.corda.core.node.services.Vault$StateStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleAssetQueryCriteria withissuerRef(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>)
+##
+@CordaSerializable
+public static final class net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
+  public <init>()
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, net.corda.core.node.services.vault.ColumnPredicate, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component1()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> component2()
+  @NotNull
+  public final net.corda.core.node.services.Vault$StateStatus component3()
+  @Nullable
+  public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component4()
+  @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component5()
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.ColumnPredicate<Long>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public boolean equals(Object)
+  @Nullable
+  public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @Nullable
+  public final net.corda.core.node.services.vault.ColumnPredicate<Long> getQuantity()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
+  public net.corda.core.node.services.Vault$StateStatus getStatus()
+  public int hashCode()
+  @NotNull
+  public String toString()
+  @NotNull
+  public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria withParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria withQuantity(net.corda.core.node.services.vault.ColumnPredicate<Long>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria withRelevancyStatus(net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$FungibleStateQueryCriteria withStatus(net.corda.core.node.services.Vault$StateStatus)
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
@@ -4078,7 +4913,13 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Linea
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>)
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus)
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<net.corda.core.contracts.UniqueIdentifier>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(java.util.List, java.util.List, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> component1()
   @Nullable
@@ -4090,7 +4931,11 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Linea
   @Nullable
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component5()
   @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component6()
+  @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria copy(java.util.List<? extends net.corda.core.identity.AbstractParty>, java.util.List<java.util.UUID>, java.util.List<String>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
   public boolean equals(Object)
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
@@ -4099,13 +4944,28 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Linea
   @Nullable
   public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
   public net.corda.core.node.services.Vault$StateStatus getStatus()
   @Nullable
   public final java.util.List<java.util.UUID> getUuid()
   public int hashCode()
+  @NotNull
   public String toString()
   @NotNull
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withExternalId(java.util.List<String>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withRelevancyStatus(net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withStatus(net.corda.core.node.services.Vault$StateStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$LinearStateQueryCriteria withUuid(java.util.List<java.util.UUID>)
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$OrComposition extends net.corda.core.node.services.vault.QueryCriteria implements net.corda.core.node.services.vault.GenericQueryCriteria$ChainableQueryCriteria$OrVisitor
@@ -4120,6 +4980,7 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$OrCom
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition extends java.lang.Object
   public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List<java.util.UUID>)
+  public <init>(net.corda.core.node.services.vault.QueryCriteria$SoftLockingType, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType component1()
   @NotNull
@@ -4132,6 +4993,7 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$SoftL
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingType getType()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -4155,6 +5017,7 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$TimeC
   @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$TimeInstantType getType()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -4168,6 +5031,9 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>)
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus)
   public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
+  public <init>(net.corda.core.node.services.vault.CriteriaExpression, net.corda.core.node.services.Vault$StateStatus, java.util.Set, net.corda.core.node.services.Vault$RelevancyStatus, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> component1()
   @NotNull
@@ -4175,18 +5041,33 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   @Nullable
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component3()
   @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component4()
+  @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> copy(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> copy(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>, net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, net.corda.core.node.services.Vault$RelevancyStatus)
   public boolean equals(Object)
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
   @NotNull
   public final net.corda.core.node.services.vault.CriteriaExpression<L, Boolean> getExpression()
   @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
+  @NotNull
   public net.corda.core.node.services.Vault$StateStatus getStatus()
   public int hashCode()
+  @NotNull
   public String toString()
   @NotNull
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> withExpression(net.corda.core.node.services.vault.CriteriaExpression<L, Boolean>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> withRelevancyStatus(net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultCustomQueryCriteria<L> withStatus(net.corda.core.node.services.Vault$StateStatus)
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria extends net.corda.core.node.services.vault.QueryCriteria$CommonQueryCriteria
@@ -4197,8 +5078,13 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
   public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(net.corda.core.node.services.Vault$StateStatus, java.util.Set, java.util.List, java.util.List, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set, java.util.Set, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.Vault$StateStatus component1()
+  @Nullable
+  public final java.util.List<net.corda.core.identity.AbstractParty> component10()
   @Nullable
   public final java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> component2()
   @Nullable
@@ -4210,12 +5096,28 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   @Nullable
   public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition component6()
   @NotNull
+  public final net.corda.core.node.services.Vault$RelevancyStatus component7()
+  @NotNull
+  public final java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo$Type> component8()
+  @NotNull
+  public final java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo> component9()
+  @NotNull
   public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria copy(net.corda.core.node.services.Vault$StateStatus, java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.identity.AbstractParty>, net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition, net.corda.core.node.services.vault.QueryCriteria$TimeCondition, net.corda.core.node.services.Vault$RelevancyStatus, java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>, java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo$Type> getConstraintTypes()
+  @NotNull
+  public java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo> getConstraints()
   @Nullable
   public java.util.Set<Class<? extends net.corda.core.contracts.ContractState>> getContractStateTypes()
   @Nullable
   public final java.util.List<net.corda.core.identity.AbstractParty> getNotary()
+  @Nullable
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  @NotNull
+  public net.corda.core.node.services.Vault$RelevancyStatus getRelevancyStatus()
   @Nullable
   public final net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition getSoftLockingCondition()
   @Nullable
@@ -4225,14 +5127,37 @@ public static final class net.corda.core.node.services.vault.QueryCriteria$Vault
   @Nullable
   public final net.corda.core.node.services.vault.QueryCriteria$TimeCondition getTimeCondition()
   public int hashCode()
+  @NotNull
   public String toString()
   @NotNull
   public java.util.Collection<javax.persistence.criteria.Predicate> visit(net.corda.core.node.services.vault.IQueryCriteriaParser)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withConstraintTypes(java.util.Set<? extends net.corda.core.node.services.Vault$ConstraintInfo$Type>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withConstraints(java.util.Set<net.corda.core.node.services.Vault$ConstraintInfo>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withContractStateTypes(java.util.Set<? extends Class<? extends net.corda.core.contracts.ContractState>>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withNotary(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withParticipants(java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withRelevancyStatus(net.corda.core.node.services.Vault$RelevancyStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withSoftLockingCondition(net.corda.core.node.services.vault.QueryCriteria$SoftLockingCondition)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withStateRefs(java.util.List<net.corda.core.contracts.StateRef>)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withStatus(net.corda.core.node.services.Vault$StateStatus)
+  @NotNull
+  public final net.corda.core.node.services.vault.QueryCriteria$VaultQueryCriteria withTimeCondition(net.corda.core.node.services.vault.QueryCriteria$TimeCondition)
 ##
 public final class net.corda.core.node.services.vault.QueryCriteriaUtils extends java.lang.Object
   public static final A builder(kotlin.jvm.functions.Function1<? super net.corda.core.node.services.vault.Builder, ? extends A>)
   @NotNull
   public static final String getColumnName(net.corda.core.node.services.vault.Column<O, ? extends C>)
+  @NotNull
+  public static final net.corda.core.node.services.vault.FieldInfo getField(String, Class<?>)
   @NotNull
   public static final Class<O> resolveEnclosingObjectFromColumn(net.corda.core.node.services.vault.Column<O, ? extends C>)
   @NotNull
@@ -4252,6 +5177,7 @@ public final class net.corda.core.node.services.vault.Sort extends net.corda.cor
   @NotNull
   public final java.util.Collection<net.corda.core.node.services.vault.Sort$SortColumn> getColumns()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -4296,6 +5222,7 @@ public static final class net.corda.core.node.services.vault.Sort$LinearStateAtt
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.Sort$SortColumn extends java.lang.Object
   public <init>(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction)
+  public <init>(net.corda.core.node.services.vault.SortAttribute, net.corda.core.node.services.vault.Sort$Direction, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.node.services.vault.SortAttribute component1()
   @NotNull
@@ -4308,6 +5235,7 @@ public static final class net.corda.core.node.services.vault.Sort$SortColumn ext
   @NotNull
   public final net.corda.core.node.services.vault.SortAttribute getSortAttribute()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -4321,6 +5249,7 @@ public static final class net.corda.core.node.services.vault.Sort$VaultStateAttr
 ##
 @CordaSerializable
 public abstract class net.corda.core.node.services.vault.SortAttribute extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.core.node.services.vault.SortAttribute$Custom extends net.corda.core.node.services.vault.SortAttribute
@@ -4337,6 +5266,7 @@ public static final class net.corda.core.node.services.vault.SortAttribute$Custo
   @NotNull
   public final String getEntityStateColumnName()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -4350,12 +5280,15 @@ public static final class net.corda.core.node.services.vault.SortAttribute$Stand
   @NotNull
   public final net.corda.core.node.services.vault.Sort$Attribute getAttribute()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public final class net.corda.core.schemas.CommonSchema extends java.lang.Object
   public static final net.corda.core.schemas.CommonSchema INSTANCE
 ##
 public final class net.corda.core.schemas.CommonSchemaV1 extends net.corda.core.schemas.MappedSchema
+  @NotNull
+  public String getMigrationResource()
   public static final net.corda.core.schemas.CommonSchemaV1 INSTANCE
 ##
 @MappedSuperclass
@@ -4363,6 +5296,7 @@ public final class net.corda.core.schemas.CommonSchemaV1 extends net.corda.core.
 public static class net.corda.core.schemas.CommonSchemaV1$FungibleState extends net.corda.core.schemas.PersistentState
   public <init>()
   public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[])
+  public <init>(java.util.Set, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, byte[], int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public net.corda.core.identity.AbstractParty getIssuer()
   @NotNull
@@ -4383,6 +5317,7 @@ public static class net.corda.core.schemas.CommonSchemaV1$FungibleState extends 
 public static class net.corda.core.schemas.CommonSchemaV1$LinearState extends net.corda.core.schemas.PersistentState
   public <init>()
   public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, String, java.util.UUID)
+  public <init>(java.util.Set, String, java.util.UUID, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.contracts.UniqueIdentifier, java.util.Set<? extends net.corda.core.identity.AbstractParty>)
   @Nullable
   public String getExternalId()
@@ -4404,24 +5339,46 @@ public interface net.corda.core.schemas.IndirectStatePersistable extends net.cor
 ##
 public class net.corda.core.schemas.MappedSchema extends java.lang.Object
   public <init>(Class<?>, int, Iterable<? extends Class<?>>)
+  public boolean equals(Object)
   @NotNull
   public final Iterable<Class<?>> getMappedTypes()
+  @Nullable
+  public String getMigrationResource()
   @NotNull
   public final String getName()
   public final int getVersion()
+  public int hashCode()
   @NotNull
   public String toString()
+##
+public final class net.corda.core.schemas.MappedSchemaValidator extends java.lang.Object
+  @NotNull
+  public final java.util.List<net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport> crossReferencesToOtherMappedSchema(net.corda.core.schemas.MappedSchema)
+  @NotNull
+  public final java.util.List<net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport> fieldsFromOtherMappedSchema(net.corda.core.schemas.MappedSchema)
+  @NotNull
+  public final java.util.List<net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport> methodsFromOtherMappedSchema(net.corda.core.schemas.MappedSchema)
+  public static final net.corda.core.schemas.MappedSchemaValidator INSTANCE
+##
+public static final class net.corda.core.schemas.MappedSchemaValidator$SchemaCrossReferenceReport extends java.lang.Object
+  public <init>(String, String, String, String, String)
+  @NotNull
+  public String toString()
+  @NotNull
+  public final String toWarning()
 ##
 @MappedSuperclass
 @CordaSerializable
 public class net.corda.core.schemas.PersistentState extends java.lang.Object implements net.corda.core.schemas.DirectStatePersistable
   public <init>()
   public <init>(net.corda.core.schemas.PersistentStateRef)
+  public <init>(net.corda.core.schemas.PersistentStateRef, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public net.corda.core.schemas.PersistentStateRef getStateRef()
   public void setStateRef(net.corda.core.schemas.PersistentStateRef)
 ##
 @Embeddable
+@Immutable
 public class net.corda.core.schemas.PersistentStateRef extends java.lang.Object implements java.io.Serializable
   public <init>()
   public <init>(String, int)
@@ -4438,6 +5395,7 @@ public class net.corda.core.schemas.PersistentStateRef extends java.lang.Object 
   public int hashCode()
   public void setIndex(int)
   public void setTxId(String)
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -4453,6 +5411,11 @@ public interface net.corda.core.serialization.ClassWhitelist
   public abstract boolean hasListed(Class<?>)
 ##
 public @interface net.corda.core.serialization.ConstructorForDeserialization
+##
+public final class net.corda.core.serialization.ContextPropertyKeys extends java.lang.Enum
+  protected <init>()
+  public static net.corda.core.serialization.ContextPropertyKeys valueOf(String)
+  public static net.corda.core.serialization.ContextPropertyKeys[] values()
 ##
 public @interface net.corda.core.serialization.CordaSerializable
 ##
@@ -4473,9 +5436,14 @@ public @interface net.corda.core.serialization.CordaSerializationTransformRename
 public @interface net.corda.core.serialization.DeprecatedConstructorForDeserialization
   public abstract int version()
 ##
+@DoNotImplement
+public interface net.corda.core.serialization.EncodingWhitelist
+  public abstract boolean acceptEncoding(net.corda.core.serialization.SerializationEncoding)
+##
 @CordaSerializable
 public final class net.corda.core.serialization.MissingAttachmentsException extends net.corda.core.CordaException
   public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>)
+  public <init>(java.util.List<? extends net.corda.core.crypto.SecureHash>, String)
   @NotNull
   public final java.util.List<net.corda.core.crypto.SecureHash> getIds()
 ##
@@ -4493,18 +5461,32 @@ public final class net.corda.core.serialization.ObjectWithCompatibleContext exte
   @NotNull
   public final T getObj()
   public int hashCode()
+  @NotNull
   public String toString()
+##
+public @interface net.corda.core.serialization.SerializableCalculatedProperty
 ##
 public final class net.corda.core.serialization.SerializationAPIKt extends java.lang.Object
   @NotNull
   public static final net.corda.core.serialization.SerializedBytes<T> serialize(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
+  @NotNull
+  public static final net.corda.core.serialization.SerializationContext withWhitelist(net.corda.core.serialization.SerializationContext, java.util.List<? extends Class<?>>)
 ##
+@DoNotImplement
 public interface net.corda.core.serialization.SerializationContext
   @NotNull
+  public abstract java.util.Set<net.corda.core.serialization.SerializationCustomSerializer<?, ?>> getCustomSerializers()
+  @NotNull
   public abstract ClassLoader getDeserializationClassLoader()
+  @Nullable
+  public abstract net.corda.core.serialization.SerializationEncoding getEncoding()
+  @NotNull
+  public abstract net.corda.core.serialization.EncodingWhitelist getEncodingWhitelist()
+  public abstract boolean getLenientCarpenterEnabled()
   public abstract boolean getObjectReferencesEnabled()
   @NotNull
   public abstract net.corda.core.utilities.ByteSequence getPreferredSerializationVersion()
+  public abstract boolean getPreventDataLoss()
   @NotNull
   public abstract java.util.Map<Object, Object> getProperties()
   @NotNull
@@ -4516,7 +5498,17 @@ public interface net.corda.core.serialization.SerializationContext
   @NotNull
   public abstract net.corda.core.serialization.SerializationContext withClassLoader(ClassLoader)
   @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withCustomSerializers(java.util.Set<? extends net.corda.core.serialization.SerializationCustomSerializer<?, ?>>)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withEncoding(net.corda.core.serialization.SerializationEncoding)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withEncodingWhitelist(net.corda.core.serialization.EncodingWhitelist)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withLenientCarpenter()
+  @NotNull
   public abstract net.corda.core.serialization.SerializationContext withPreferredSerializationVersion(net.corda.core.utilities.ByteSequence)
+  @NotNull
+  public abstract net.corda.core.serialization.SerializationContext withPreventDataLoss()
   @NotNull
   public abstract net.corda.core.serialization.SerializationContext withProperty(Object, Object)
   @NotNull
@@ -4546,6 +5538,9 @@ public final class net.corda.core.serialization.SerializationDefaults extends ja
   public final net.corda.core.serialization.SerializationContext getSTORAGE_CONTEXT()
   public static final net.corda.core.serialization.SerializationDefaults INSTANCE
 ##
+@DoNotImplement
+public interface net.corda.core.serialization.SerializationEncoding
+##
 public abstract class net.corda.core.serialization.SerializationFactory extends java.lang.Object
   public <init>()
   public final T asCurrent(kotlin.jvm.functions.Function1<? super net.corda.core.serialization.SerializationFactory, ? extends T>)
@@ -4563,6 +5558,7 @@ public abstract class net.corda.core.serialization.SerializationFactory extends 
   public static final net.corda.core.serialization.SerializationFactory$Companion Companion
 ##
 public static final class net.corda.core.serialization.SerializationFactory$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.core.serialization.SerializationFactory getCurrentFactory()
   @NotNull
@@ -4592,9 +5588,26 @@ public interface net.corda.core.serialization.SerializeAsTokenContext
 public final class net.corda.core.serialization.SerializedBytes extends net.corda.core.utilities.OpaqueBytes
   public <init>(byte[])
   @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> from(T)
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory)
+  @NotNull
+  public static final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
+  @NotNull
   public final net.corda.core.crypto.SecureHash getHash()
+  public static final net.corda.core.serialization.SerializedBytes$Companion Companion
+##
+public static final class net.corda.core.serialization.SerializedBytes$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> from(T)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory)
+  @NotNull
+  public final net.corda.core.serialization.SerializedBytes<T> from(T, net.corda.core.serialization.SerializationFactory, net.corda.core.serialization.SerializationContext)
 ##
 public final class net.corda.core.serialization.SingletonSerializationToken extends java.lang.Object implements net.corda.core.serialization.SerializationToken
+  public <init>(String, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public net.corda.core.serialization.SerializeAsToken fromToken(net.corda.core.serialization.SerializeAsTokenContext)
   @NotNull
@@ -4602,6 +5615,7 @@ public final class net.corda.core.serialization.SingletonSerializationToken exte
   public static final net.corda.core.serialization.SingletonSerializationToken$Companion Companion
 ##
 public static final class net.corda.core.serialization.SingletonSerializationToken$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.serialization.SingletonSerializationToken singletonSerializationToken(Class<T>)
 ##
@@ -4633,6 +5647,8 @@ public abstract class net.corda.core.transactions.BaseTransaction extends java.l
   public final java.util.List<net.corda.core.contracts.ContractState> getOutputStates()
   @NotNull
   public abstract java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public abstract java.util.List<?> getReferences()
   @NotNull
   public final net.corda.core.contracts.StateAndRef<T> outRef(int)
   @NotNull
@@ -4676,13 +5692,18 @@ public final class net.corda.core.transactions.ContractUpgradeFilteredTransactio
   public net.corda.core.crypto.SecureHash getId()
   @NotNull
   public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
   @NotNull
   public net.corda.core.identity.Party getNotary()
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
   @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @NotNull
   public final java.util.Map<Integer, net.corda.core.transactions.ContractUpgradeFilteredTransaction$FilteredComponent> getVisibleComponents()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -4713,6 +5734,8 @@ public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction 
   @NotNull
   public final java.util.List<net.corda.core.crypto.TransactionSignature> component8()
   @NotNull
+  public final net.corda.core.node.NetworkParameters component9()
+  @NotNull
   public final net.corda.core.transactions.ContractUpgradeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.contracts.Attachment, String, net.corda.core.contracts.Attachment, net.corda.core.crypto.SecureHash, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.crypto.TransactionSignature>, net.corda.core.node.NetworkParameters)
   public boolean equals(Object)
   @NotNull
@@ -4724,11 +5747,15 @@ public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction 
   @NotNull
   public final net.corda.core.contracts.Attachment getLegacyContractAttachment()
   @NotNull
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
   public net.corda.core.identity.Party getNotary()
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
   @NotNull
   public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
   @NotNull
   public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
   @NotNull
@@ -4738,12 +5765,14 @@ public final class net.corda.core.transactions.ContractUpgradeLedgerTransaction 
   @NotNull
   public final String getUpgradedContractClassName()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
 @CordaSerializable
 public final class net.corda.core.transactions.ContractUpgradeWireTransaction extends net.corda.core.transactions.CoreTransaction
   public <init>(java.util.List<? extends net.corda.core.utilities.OpaqueBytes>, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.transactions.ContractUpgradeFilteredTransaction buildFilteredTransaction()
   @NotNull
@@ -4759,12 +5788,16 @@ public final class net.corda.core.transactions.ContractUpgradeWireTransaction ex
   public java.util.List<net.corda.core.contracts.StateRef> getInputs()
   @NotNull
   public final net.corda.core.crypto.SecureHash getLegacyContractAttachmentId()
+  @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
   @NotNull
   public net.corda.core.identity.Party getNotary()
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
   @NotNull
   public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
   @NotNull
   public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
   @NotNull
@@ -4774,7 +5807,12 @@ public final class net.corda.core.transactions.ContractUpgradeWireTransaction ex
   public int hashCode()
   @NotNull
   public final net.corda.core.transactions.ContractUpgradeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
   public String toString()
+  public static final net.corda.core.transactions.ContractUpgradeWireTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.ContractUpgradeWireTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public static final class net.corda.core.transactions.ContractUpgradeWireTransaction$Component extends java.lang.Enum
   protected <init>()
@@ -4787,6 +5825,10 @@ public abstract class net.corda.core.transactions.CoreTransaction extends net.co
   public <init>()
   @NotNull
   public abstract java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public abstract net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateRef> getReferences()
 ##
 @CordaSerializable
 public final class net.corda.core.transactions.FilteredComponentGroup extends net.corda.core.transactions.ComponentGroup
@@ -4809,6 +5851,7 @@ public final class net.corda.core.transactions.FilteredComponentGroup extends ne
   @NotNull
   public final net.corda.core.crypto.PartialMerkleTree getPartialMerkleTree()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -4830,6 +5873,7 @@ public final class net.corda.core.transactions.FilteredTransaction extends net.c
   public static final net.corda.core.transactions.FilteredTransaction$Companion Companion
 ##
 public static final class net.corda.core.transactions.FilteredTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(net.corda.core.transactions.WireTransaction, java.util.function.Predicate<Object>)
 ##
@@ -4845,18 +5889,27 @@ public final class net.corda.core.transactions.FilteredTransactionVerificationEx
 public abstract class net.corda.core.transactions.FullTransaction extends net.corda.core.transactions.BaseTransaction
   public <init>()
   protected void checkBaseInvariants()
+  protected final void checkNotaryWhitelisted()
   @NotNull
   public abstract java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
+  @Nullable
+  public abstract net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public abstract java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
 ##
 @DoNotImplement
 @CordaSerializable
 public final class net.corda.core.transactions.LedgerTransaction extends net.corda.core.transactions.FullTransaction
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  @DeprecatedConstructorForDeserialization
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, net.corda.core.node.NetworkParameters, java.util.List, java.util.Map, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.Command<T>> commandsOfType(Class<T>)
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component10()
   @NotNull
   public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> component2()
   @NotNull
@@ -4871,6 +5924,8 @@ public final class net.corda.core.transactions.LedgerTransaction extends net.cor
   public final net.corda.core.contracts.TimeWindow component7()
   @NotNull
   public final net.corda.core.contracts.PrivacySalt component8()
+  @Nullable
+  public final net.corda.core.node.NetworkParameters component9()
   @NotNull
   public final net.corda.core.transactions.LedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.CommandWithParties<? extends net.corda.core.contracts.CommandData>>, java.util.List<? extends net.corda.core.contracts.Attachment>, net.corda.core.crypto.SecureHash, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
   @NotNull
@@ -4883,11 +5938,19 @@ public final class net.corda.core.transactions.LedgerTransaction extends net.cor
   @NotNull
   public final java.util.List<T> filterInputs(Class<T>, java.util.function.Predicate<T>)
   @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> filterReferenceInputRefs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final java.util.List<T> filterReferenceInputs(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
   public final net.corda.core.contracts.Command<T> findCommand(Class<T>, java.util.function.Predicate<T>)
   @NotNull
   public final net.corda.core.contracts.StateAndRef<T> findInRef(Class<T>, java.util.function.Predicate<T>)
   @NotNull
   public final T findInput(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final T findReference(Class<T>, java.util.function.Predicate<T>)
+  @NotNull
+  public final net.corda.core.contracts.StateAndRef<T> findReferenceInputRef(Class<T>, java.util.function.Predicate<T>)
   @NotNull
   public final net.corda.core.contracts.Attachment getAttachment(int)
   @NotNull
@@ -4907,11 +5970,19 @@ public final class net.corda.core.transactions.LedgerTransaction extends net.cor
   @NotNull
   public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
   @Nullable
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
+  @Nullable
   public net.corda.core.identity.Party getNotary()
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
   @NotNull
   public final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  public final net.corda.core.contracts.ContractState getReferenceInput(int)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.ContractState> getReferenceStates()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
   @Nullable
   public final net.corda.core.contracts.TimeWindow getTimeWindow()
   @NotNull
@@ -4923,9 +5994,17 @@ public final class net.corda.core.transactions.LedgerTransaction extends net.cor
   public final java.util.List<net.corda.core.contracts.StateAndRef<T>> inRefsOfType(Class<T>)
   @NotNull
   public final java.util.List<T> inputsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateAndRef<T>> referenceInputRefsOfType(Class<T>)
+  @NotNull
+  public final java.util.List<T> referenceInputsOfType(Class<T>)
+  @NotNull
   public String toString()
   public final void verify()
   public static final net.corda.core.transactions.LedgerTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.LedgerTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public static final class net.corda.core.transactions.LedgerTransaction$InOutGroup extends java.lang.Object
   public <init>(java.util.List<? extends T>, java.util.List<? extends T>, K)
@@ -4945,6 +6024,7 @@ public static final class net.corda.core.transactions.LedgerTransaction$InOutGro
   @NotNull
   public final java.util.List<T> getOutputs()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @CordaSerializable
@@ -4952,12 +6032,28 @@ public final class net.corda.core.transactions.MissingContractAttachments extend
   public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>)
   public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, String)
   public <init>(java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, String, Integer)
+  public <init>(java.util.List, String, Integer, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getStates()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.NetworkParametersHash extends java.lang.Object
+  public <init>(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash component1()
+  @NotNull
+  public final net.corda.core.transactions.NetworkParametersHash copy(net.corda.core.crypto.SecureHash)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash getHash()
+  public int hashCode()
+  @NotNull
+  public String toString()
 ##
 @DoNotImplement
 public final class net.corda.core.transactions.NotaryChangeLedgerTransaction extends net.corda.core.transactions.FullTransaction implements net.corda.core.transactions.TransactionWithSignatures
   public <init>(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  public <init>(java.util.List, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List, net.corda.core.node.NetworkParameters, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> component1()
   @NotNull
@@ -4968,6 +6064,8 @@ public final class net.corda.core.transactions.NotaryChangeLedgerTransaction ext
   public final net.corda.core.crypto.SecureHash component4()
   @NotNull
   public final java.util.List<net.corda.core.crypto.TransactionSignature> component5()
+  @Nullable
+  public final net.corda.core.node.NetworkParameters component6()
   @NotNull
   public final net.corda.core.transactions.NotaryChangeLedgerTransaction copy(java.util.List<? extends net.corda.core.contracts.StateAndRef<? extends net.corda.core.contracts.ContractState>>, net.corda.core.identity.Party, net.corda.core.identity.Party, net.corda.core.crypto.SecureHash, java.util.List<net.corda.core.crypto.TransactionSignature>)
   public boolean equals(Object)
@@ -4977,6 +6075,8 @@ public final class net.corda.core.transactions.NotaryChangeLedgerTransaction ext
   public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getInputs()
   @NotNull
   public java.util.List<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
+  @Nullable
+  public net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
   public final net.corda.core.identity.Party getNewNotary()
   @NotNull
@@ -4984,11 +6084,18 @@ public final class net.corda.core.transactions.NotaryChangeLedgerTransaction ext
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
   @NotNull
+  public java.util.List<net.corda.core.contracts.StateAndRef<net.corda.core.contracts.ContractState>> getReferences()
+  @NotNull
   public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
   @NotNull
   public java.util.List<net.corda.core.crypto.TransactionSignature> getSigs()
   public int hashCode()
+  @NotNull
   public String toString()
+  public static final net.corda.core.transactions.NotaryChangeLedgerTransaction$Companion Companion
+##
+public static final class net.corda.core.transactions.NotaryChangeLedgerTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 @CordaSerializable
@@ -5004,6 +6111,8 @@ public final class net.corda.core.transactions.NotaryChangeWireTransaction exten
   public net.corda.core.crypto.SecureHash getId()
   @NotNull
   public java.util.List<net.corda.core.contracts.StateRef> getInputs()
+  @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
   @NotNull
   public final net.corda.core.identity.Party getNewNotary()
   @NotNull
@@ -5011,18 +6120,35 @@ public final class net.corda.core.transactions.NotaryChangeWireTransaction exten
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
   @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @NotNull
   public final java.util.List<net.corda.core.utilities.OpaqueBytes> getSerializedComponents()
   public int hashCode()
   @NotNull
   public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServiceHub, java.util.List<net.corda.core.crypto.TransactionSignature>)
   @NotNull
   public final net.corda.core.transactions.NotaryChangeLedgerTransaction resolve(net.corda.core.node.ServicesForResolution, java.util.List<net.corda.core.crypto.TransactionSignature>)
+  @NotNull
   public String toString()
 ##
 public static final class net.corda.core.transactions.NotaryChangeWireTransaction$Component extends java.lang.Enum
   protected <init>()
   public static net.corda.core.transactions.NotaryChangeWireTransaction$Component valueOf(String)
   public static net.corda.core.transactions.NotaryChangeWireTransaction$Component[] values()
+##
+@CordaSerializable
+public final class net.corda.core.transactions.ReferenceStateRef extends java.lang.Object
+  public <init>(net.corda.core.contracts.StateRef)
+  @NotNull
+  public final net.corda.core.contracts.StateRef component1()
+  @NotNull
+  public final net.corda.core.transactions.ReferenceStateRef copy(net.corda.core.contracts.StateRef)
+  public boolean equals(Object)
+  @NotNull
+  public final net.corda.core.contracts.StateRef getStateRef()
+  public int hashCode()
+  @NotNull
+  public String toString()
 ##
 @DoNotImplement
 @CordaSerializable
@@ -5047,9 +6173,13 @@ public final class net.corda.core.transactions.SignedTransaction extends java.la
   @NotNull
   public java.util.ArrayList<String> getKeyDescriptions(java.util.Set<? extends java.security.PublicKey>)
   @Nullable
+  public final net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @Nullable
   public final net.corda.core.identity.Party getNotary()
   @NotNull
   public final net.corda.core.transactions.NotaryChangeWireTransaction getNotaryChangeTx()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> getReferences()
   @NotNull
   public java.util.Set<java.security.PublicKey> getRequiredSigningKeys()
   @NotNull
@@ -5112,6 +6242,9 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   public <init>()
   public <init>(net.corda.core.identity.Party)
   public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List<net.corda.core.contracts.StateRef>, java.util.List<net.corda.core.crypto.SecureHash>, java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>>, java.util.List<net.corda.core.contracts.Command<?>>, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, java.util.List<net.corda.core.contracts.StateRef>, net.corda.core.node.ServiceHub)
+  public <init>(net.corda.core.identity.Party, java.util.UUID, java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, java.util.List, net.corda.core.node.ServiceHub, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder addAttachment(net.corda.core.crypto.SecureHash)
   @NotNull
@@ -5123,6 +6256,8 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   @NotNull
   public net.corda.core.transactions.TransactionBuilder addInputState(net.corda.core.contracts.StateAndRef<?>)
   @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState)
+  @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.contracts.AttachmentConstraint)
@@ -5133,7 +6268,11 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint)
   @NotNull
+  public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.ContractState, net.corda.core.identity.Party)
+  @NotNull
   public final net.corda.core.transactions.TransactionBuilder addOutputState(net.corda.core.contracts.TransactionState<?>)
+  @NotNull
+  public net.corda.core.transactions.TransactionBuilder addReferenceState(net.corda.core.contracts.ReferencedStateAndRef<?>)
   @NotNull
   public final java.util.List<net.corda.core.crypto.SecureHash> attachments()
   @NotNull
@@ -5154,12 +6293,18 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   protected final java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
   @NotNull
   protected final net.corda.core.contracts.PrivacySalt getPrivacySalt()
+  @NotNull
+  protected final java.util.List<net.corda.core.contracts.StateRef> getReferences()
+  @Nullable
+  protected final net.corda.core.node.ServiceHub getServiceHub()
   @Nullable
   protected final net.corda.core.contracts.TimeWindow getWindow()
   @NotNull
   public final java.util.List<net.corda.core.contracts.StateRef> inputStates()
   @NotNull
   public final java.util.List<net.corda.core.contracts.TransactionState<?>> outputStates()
+  @NotNull
+  public final java.util.List<net.corda.core.contracts.StateRef> referenceStates()
   public final void setLockId(java.util.UUID)
   public final void setNotary(net.corda.core.identity.Party)
   @NotNull
@@ -5179,6 +6324,7 @@ public class net.corda.core.transactions.TransactionBuilder extends java.lang.Ob
   public final void verify(net.corda.core.node.ServiceHub)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder withItems(Object...)
+  public static final net.corda.core.transactions.TransactionBuilder$Companion Companion
 ##
 @DoNotImplement
 public interface net.corda.core.transactions.TransactionWithSignatures extends net.corda.core.contracts.NamedByHash
@@ -5210,17 +6356,25 @@ public abstract class net.corda.core.transactions.TraversableTransaction extends
   @NotNull
   public java.util.List<net.corda.core.contracts.StateRef> getInputs()
   @Nullable
+  public net.corda.core.crypto.SecureHash getNetworkParametersHash()
+  @Nullable
   public net.corda.core.identity.Party getNotary()
   @NotNull
   public java.util.List<net.corda.core.contracts.TransactionState<net.corda.core.contracts.ContractState>> getOutputs()
+  @NotNull
+  public java.util.List<net.corda.core.contracts.StateRef> getReferences()
   @Nullable
   public final net.corda.core.contracts.TimeWindow getTimeWindow()
 ##
 @DoNotImplement
 @CordaSerializable
 public final class net.corda.core.transactions.WireTransaction extends net.corda.core.transactions.TraversableTransaction
+  public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>)
+  public <init>(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.crypto.SecureHash>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow)
   public <init>(java.util.List<net.corda.core.contracts.StateRef>, java.util.List<? extends net.corda.core.crypto.SecureHash>, java.util.List<? extends net.corda.core.contracts.TransactionState<? extends net.corda.core.contracts.ContractState>>, java.util.List<? extends net.corda.core.contracts.Command<?>>, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, java.util.List, java.util.List, java.util.List, net.corda.core.identity.Party, net.corda.core.contracts.TimeWindow, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(java.util.List<? extends net.corda.core.transactions.ComponentGroup>, net.corda.core.contracts.PrivacySalt)
+  public <init>(java.util.List, net.corda.core.contracts.PrivacySalt, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.transactions.FilteredTransaction buildFilteredTransaction(java.util.function.Predicate<Object>)
   public final void checkSignature(net.corda.core.crypto.TransactionSignature)
@@ -5243,6 +6397,7 @@ public final class net.corda.core.transactions.WireTransaction extends net.corda
   public static final net.corda.core.transactions.WireTransaction$Companion Companion
 ##
 public static final class net.corda.core.transactions.WireTransaction$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public final class net.corda.core.utilities.ByteArrays extends java.lang.Object
   @NotNull
@@ -5254,9 +6409,12 @@ public final class net.corda.core.utilities.ByteArrays extends java.lang.Object
 ##
 @CordaSerializable
 public abstract class net.corda.core.utilities.ByteSequence extends java.lang.Object implements java.lang.Comparable
+  public <init>(byte[], int, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public int compareTo(net.corda.core.utilities.ByteSequence)
   @NotNull
   public final net.corda.core.utilities.ByteSequence copy()
+  @NotNull
+  public final byte[] copyBytes()
   public boolean equals(Object)
   @NotNull
   public abstract byte[] getBytes()
@@ -5272,14 +6430,20 @@ public abstract class net.corda.core.utilities.ByteSequence extends java.lang.Ob
   @NotNull
   public final java.io.ByteArrayInputStream open()
   @NotNull
+  public final java.nio.ByteBuffer putTo(java.nio.ByteBuffer)
+  @NotNull
+  public final java.nio.ByteBuffer slice(int, int)
+  @NotNull
   public final net.corda.core.utilities.ByteSequence subSequence(int, int)
   @NotNull
   public final net.corda.core.utilities.ByteSequence take(int)
   @NotNull
   public String toString()
+  public final void writeTo(java.io.OutputStream)
   public static final net.corda.core.utilities.ByteSequence$Companion Companion
 ##
 public static final class net.corda.core.utilities.ByteSequence$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ByteSequence of(byte[])
   @NotNull
@@ -5343,6 +6507,7 @@ public class net.corda.core.utilities.Id extends java.lang.Object
   public static final net.corda.core.utilities.Id$Companion Companion
 ##
 public static final class net.corda.core.utilities.Id$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.Id<V> newInstance(V, String, java.time.Instant)
 ##
@@ -5395,10 +6560,12 @@ public final class net.corda.core.utilities.NetworkHostAndPort extends java.lang
   public static final String UNPARSEABLE_ADDRESS_FORMAT = "Unparseable address: %s"
 ##
 public static final class net.corda.core.utilities.NetworkHostAndPort$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.NetworkHostAndPort parse(String)
 ##
 public final class net.corda.core.utilities.NonEmptySet extends java.lang.Object implements kotlin.jvm.internal.markers.KMappedMarker, java.util.Set
+  public <init>(java.util.Set, kotlin.jvm.internal.DefaultConstructorMarker)
   public boolean add(T)
   public boolean addAll(java.util.Collection<? extends T>)
   public void clear()
@@ -5434,6 +6601,7 @@ public final class net.corda.core.utilities.NonEmptySet extends java.lang.Object
   public static final net.corda.core.utilities.NonEmptySet$Companion Companion
 ##
 public static final class net.corda.core.utilities.NonEmptySet$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.NonEmptySet<T> copyOf(java.util.Collection<? extends T>)
   @NotNull
@@ -5451,6 +6619,7 @@ public class net.corda.core.utilities.OpaqueBytes extends net.corda.core.utiliti
   public static final net.corda.core.utilities.OpaqueBytes$Companion Companion
 ##
 public static final class net.corda.core.utilities.OpaqueBytes$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.OpaqueBytes of(byte...)
 ##
@@ -5496,6 +6665,7 @@ public final class net.corda.core.utilities.ProgressTracker extends java.lang.Ob
 ##
 @CordaSerializable
 public abstract static class net.corda.core.utilities.ProgressTracker$Change extends java.lang.Object
+  public <init>(net.corda.core.utilities.ProgressTracker, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.ProgressTracker getProgressTracker()
 ##
@@ -5559,6 +6729,11 @@ public static final class net.corda.core.utilities.ProgressTracker$DONE extends 
   public static final net.corda.core.utilities.ProgressTracker$DONE INSTANCE
 ##
 @CordaSerializable
+public static final class net.corda.core.utilities.ProgressTracker$STARTING extends net.corda.core.utilities.ProgressTracker$Step
+  public boolean equals(Object)
+  public static final net.corda.core.utilities.ProgressTracker$STARTING INSTANCE
+##
+@CordaSerializable
 public static class net.corda.core.utilities.ProgressTracker$Step extends java.lang.Object
   public <init>(String)
   @Nullable
@@ -5580,8 +6755,13 @@ public interface net.corda.core.utilities.PropertyDelegate
 ##
 @CordaSerializable
 public abstract class net.corda.core.utilities.Try extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.Try<C> combine(net.corda.core.utilities.Try<? extends B>, kotlin.jvm.functions.Function2<? super A, ? super B, ? extends C>)
+  @NotNull
+  public final net.corda.core.utilities.Try<A> doOnFailure(java.util.function.Consumer<Throwable>)
+  @NotNull
+  public final net.corda.core.utilities.Try<A> doOnSuccess(java.util.function.Consumer<? super A>)
   @NotNull
   public final net.corda.core.utilities.Try<B> flatMap(kotlin.jvm.functions.Function1<? super A, ? extends net.corda.core.utilities.Try<? extends B>>)
   public abstract A getOrThrow()
@@ -5591,9 +6771,12 @@ public abstract class net.corda.core.utilities.Try extends java.lang.Object
   public final net.corda.core.utilities.Try<B> map(kotlin.jvm.functions.Function1<? super A, ? extends B>)
   @NotNull
   public static final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
+  @NotNull
+  public final net.corda.core.utilities.Try<A> throwError()
   public static final net.corda.core.utilities.Try$Companion Companion
 ##
 public static final class net.corda.core.utilities.Try$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.utilities.Try<T> on(kotlin.jvm.functions.Function0<? extends T>)
 ##
@@ -5647,6 +6830,7 @@ public final class net.corda.core.utilities.UuidGenerator extends java.lang.Obje
   public static final net.corda.core.utilities.UuidGenerator$Companion Companion
 ##
 public static final class net.corda.core.utilities.UuidGenerator$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.UUID next()
 ##
@@ -5661,15 +6845,21 @@ public final class net.corda.client.jackson.JacksonSupport extends java.lang.Obj
   @NotNull
   public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
   @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createDefaultMapper(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  @NotNull
   public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService)
   @NotNull
   public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory)
   @NotNull
   public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
   @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createInMemoryMapper(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  @NotNull
   public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper()
   @NotNull
   public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory)
+  @NotNull
+  public static final com.fasterxml.jackson.databind.ObjectMapper createNonRpcMapper(com.fasterxml.jackson.core.JsonFactory, boolean)
   @NotNull
   public final com.fasterxml.jackson.databind.Module getCordaModule()
   public static final net.corda.client.jackson.JacksonSupport INSTANCE
@@ -5701,11 +6891,17 @@ public static final class net.corda.client.jackson.JacksonSupport$CordaX500NameS
   public void serialize(net.corda.core.identity.CordaX500Name, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
   public static final net.corda.client.jackson.JacksonSupport$CordaX500NameSerializer INSTANCE
 ##
+@DoNotImplement
 public static final class net.corda.client.jackson.JacksonSupport$IdentityObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
   public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.node.services.IdentityService, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final boolean getFuzzyIdentityMatch()
   @NotNull
   public final net.corda.core.node.services.IdentityService getIdentityService()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
   @NotNull
   public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
   @Nullable
@@ -5716,6 +6912,11 @@ public static final class net.corda.client.jackson.JacksonSupport$IdentityObject
 @DoNotImplement
 public static final class net.corda.client.jackson.JacksonSupport$NoPartyObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
   public <init>(com.fasterxml.jackson.core.JsonFactory)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(com.fasterxml.jackson.core.JsonFactory, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
   @NotNull
   public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
   @Nullable
@@ -5746,7 +6947,11 @@ public static final class net.corda.client.jackson.JacksonSupport$PartyDeseriali
   public net.corda.core.identity.Party deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext)
   public static final net.corda.client.jackson.JacksonSupport$PartyDeserializer INSTANCE
 ##
+@DoNotImplement
 public static interface net.corda.client.jackson.JacksonSupport$PartyObjectMapper
+  public abstract boolean isFullParties()
+  @Nullable
+  public abstract net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
   @NotNull
   public abstract java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
   @Nullable
@@ -5767,11 +6972,17 @@ public static final class net.corda.client.jackson.JacksonSupport$PublicKeySeria
   public void serialize(java.security.PublicKey, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
   public static final net.corda.client.jackson.JacksonSupport$PublicKeySerializer INSTANCE
 ##
+@DoNotImplement
 public static final class net.corda.client.jackson.JacksonSupport$RpcObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper implements net.corda.client.jackson.JacksonSupport$PartyObjectMapper
   public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean)
+  public <init>(net.corda.core.messaging.CordaRPCOps, com.fasterxml.jackson.core.JsonFactory, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final boolean getFuzzyIdentityMatch()
   @NotNull
   public final net.corda.core.messaging.CordaRPCOps getRpc()
+  public boolean isFullParties()
+  @Nullable
+  public net.corda.core.node.NodeInfo nodeInfoFromParty(net.corda.core.identity.AbstractParty)
   @NotNull
   public java.util.Set<net.corda.core.identity.Party> partiesFromName(String)
   @Nullable
@@ -5841,6 +7052,7 @@ public abstract static class net.corda.client.jackson.JacksonSupport$WireTransac
 public class net.corda.client.jackson.StringToMethodCallParser extends java.lang.Object
   public <init>(Class<? extends T>)
   public <init>(Class<? extends T>, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(Class, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(kotlin.reflect.KClass<? extends T>)
   @NotNull
   public final java.util.Map<String, String> getAvailableCommands()
@@ -5859,6 +7071,7 @@ public class net.corda.client.jackson.StringToMethodCallParser extends java.lang
   public static final net.corda.client.jackson.StringToMethodCallParser$Companion Companion
 ##
 public static final class net.corda.client.jackson.StringToMethodCallParser$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public final class net.corda.client.jackson.StringToMethodCallParser$ParsedMethodCall extends java.lang.Object implements java.util.concurrent.Callable
   public <init>(T, reflect.Method, Object[])
@@ -5873,6 +7086,7 @@ public final class net.corda.client.jackson.StringToMethodCallParser$ParsedMetho
 ##
 public static class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException extends net.corda.core.CordaException
   public <init>(String, Throwable)
+  public <init>(String, Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public static final class net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException$FailedParse extends net.corda.client.jackson.StringToMethodCallParser$UnparseableCallException
   public <init>(Exception)
@@ -5909,6 +7123,8 @@ public interface net.corda.testing.driver.DriverDSL
   @NotNull
   public abstract java.util.List<net.corda.testing.driver.NotaryHandle> getNotaryHandles()
   @NotNull
+  public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode()
+  @NotNull
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters)
   @NotNull
   public abstract net.corda.core.concurrent.CordaFuture<net.corda.testing.driver.NodeHandle> startNode(net.corda.testing.driver.NodeParameters, net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
@@ -5919,7 +7135,13 @@ public interface net.corda.testing.driver.DriverDSL
 ##
 public final class net.corda.testing.driver.DriverParameters extends java.lang.Object
   public <init>()
+  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map, boolean, boolean, boolean, java.util.List, java.util.List, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map, boolean, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, boolean)
   public final boolean component1()
   @NotNull
   public final java.util.List<String> component10()
@@ -5927,6 +7149,11 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final net.corda.testing.driver.JmxPolicy component11()
   @NotNull
   public final net.corda.core.node.NetworkParameters component12()
+  @NotNull
+  public final java.util.Map<String, Object> component13()
+  public final boolean component14()
+  @Nullable
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component15()
   @NotNull
   public final java.nio.file.Path component2()
   @NotNull
@@ -5942,17 +7169,26 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final java.util.List<net.corda.testing.node.NotarySpec> component9()
   @NotNull
   public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Map<String, ?>, boolean, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters copy(boolean, java.nio.file.Path, net.corda.testing.driver.PortAllocation, net.corda.testing.driver.PortAllocation, java.util.Map<String, String>, boolean, boolean, boolean, java.util.List<net.corda.testing.node.NotarySpec>, java.util.List<String>, net.corda.testing.driver.JmxPolicy, net.corda.core.node.NetworkParameters, java.util.Set<? extends net.corda.testing.node.TestCordapp>)
   public boolean equals(Object)
+  @Nullable
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
   @NotNull
   public final net.corda.testing.driver.PortAllocation getDebugPortAllocation()
   @NotNull
   public final java.nio.file.Path getDriverDirectory()
   @NotNull
   public final java.util.List<String> getExtraCordappPackagesToScan()
+  public final boolean getInMemoryDB()
   @NotNull
   public final net.corda.testing.driver.JmxPolicy getJmxPolicy()
   @NotNull
   public final net.corda.core.node.NetworkParameters getNetworkParameters()
+  @NotNull
+  public final java.util.Map<String, Object> getNotaryCustomOverrides()
   @NotNull
   public final java.util.List<net.corda.testing.node.NotarySpec> getNotarySpecs()
   @NotNull
@@ -5964,7 +7200,10 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   public final boolean getWaitForAllNodesToFinish()
   public int hashCode()
   public final boolean isDebug()
+  @NotNull
   public String toString()
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withDebugPortAllocation(net.corda.testing.driver.PortAllocation)
   @NotNull
@@ -5972,11 +7211,15 @@ public final class net.corda.testing.driver.DriverParameters extends java.lang.O
   @NotNull
   public final net.corda.testing.driver.DriverParameters withExtraCordappPackagesToScan(java.util.List<String>)
   @NotNull
+  public final net.corda.testing.driver.DriverParameters withInMemoryDB(boolean)
+  @NotNull
   public final net.corda.testing.driver.DriverParameters withIsDebug(boolean)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withJmxPolicy(net.corda.testing.driver.JmxPolicy)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.driver.DriverParameters withNotaryCustomOverrides(java.util.Map<String, ?>)
   @NotNull
   public final net.corda.testing.driver.DriverParameters withNotarySpecs(java.util.List<net.corda.testing.node.NotarySpec>)
   @NotNull
@@ -6001,23 +7244,36 @@ public interface net.corda.testing.driver.InProcess extends net.corda.testing.dr
 ##
 public final class net.corda.testing.driver.JmxPolicy extends java.lang.Object
   public <init>()
+  public <init>(net.corda.testing.driver.PortAllocation)
   public <init>(boolean, net.corda.testing.driver.PortAllocation)
+  public <init>(boolean, net.corda.testing.driver.PortAllocation, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final boolean component1()
   @NotNull
   public final net.corda.testing.driver.PortAllocation component2()
   @NotNull
   public final net.corda.testing.driver.JmxPolicy copy(boolean, net.corda.testing.driver.PortAllocation)
+  @NotNull
+  public static final net.corda.testing.driver.JmxPolicy defaultEnabled()
   public boolean equals(Object)
   @NotNull
   public final net.corda.testing.driver.PortAllocation getJmxHttpServerPortAllocation()
   public final boolean getStartJmxHttpServer()
   public int hashCode()
+  @NotNull
   public String toString()
+  public static final net.corda.testing.driver.JmxPolicy$Companion Companion
+##
+public static final class net.corda.testing.driver.JmxPolicy$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.driver.JmxPolicy defaultEnabled()
 ##
 @DoNotImplement
 public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoCloseable
   @NotNull
   public abstract java.nio.file.Path getBaseDirectory()
+  @Nullable
+  public abstract net.corda.core.utilities.NetworkHostAndPort getJmxAddress()
   @NotNull
   public abstract net.corda.core.node.NodeInfo getNodeInfo()
   @NotNull
@@ -6027,12 +7283,16 @@ public interface net.corda.testing.driver.NodeHandle extends java.lang.AutoClose
   @NotNull
   public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAddress()
   @NotNull
+  public abstract net.corda.core.utilities.NetworkHostAndPort getRpcAdminAddress()
+  @NotNull
   public abstract java.util.List<net.corda.testing.node.User> getRpcUsers()
   public abstract void stop()
 ##
 public final class net.corda.testing.driver.NodeParameters extends java.lang.Object
   public <init>()
   public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
+  public <init>(net.corda.core.identity.CordaX500Name, java.util.List, net.corda.testing.driver.VerifierType, java.util.Map, Boolean, String, java.util.Collection, java.util.Map, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.core.identity.CordaX500Name component1()
   @NotNull
@@ -6046,10 +7306,20 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   @NotNull
   public final String component6()
   @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component7()
+  @NotNull
+  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> component8()
+  @NotNull
   public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters copy(net.corda.core.identity.CordaX500Name, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, java.util.Map<String, ?>, Boolean, String, java.util.Collection<? extends net.corda.testing.node.TestCordapp>, java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
   public boolean equals(Object)
   @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
+  @NotNull
   public final java.util.Map<String, Object> getCustomOverrides()
+  @NotNull
+  public final java.util.Map<? extends Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<? extends net.corda.core.flows.FlowLogic<?>>> getFlowOverrides()
   @NotNull
   public final String getMaximumHeapSize()
   @Nullable
@@ -6061,9 +7331,14 @@ public final class net.corda.testing.driver.NodeParameters extends java.lang.Obj
   @NotNull
   public final net.corda.testing.driver.VerifierType getVerifierType()
   public int hashCode()
+  @NotNull
   public String toString()
   @NotNull
+  public final net.corda.testing.driver.NodeParameters withAdditionalCordapps(java.util.Set<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
   public final net.corda.testing.driver.NodeParameters withCustomOverrides(java.util.Map<String, ?>)
+  @NotNull
+  public final net.corda.testing.driver.NodeParameters withFlowOverrides(java.util.Map<Class<? extends net.corda.core.flows.FlowLogic<?>>, ? extends Class<? extends net.corda.core.flows.FlowLogic<?>>>)
   @NotNull
   public final net.corda.testing.driver.NodeParameters withMaximumHeapSize(String)
   @NotNull
@@ -6091,6 +7366,7 @@ public final class net.corda.testing.driver.NotaryHandle extends java.lang.Objec
   public final net.corda.core.concurrent.CordaFuture<java.util.List<net.corda.testing.driver.NodeHandle>> getNodeHandles()
   public final boolean getValidating()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -6131,6 +7407,7 @@ public final class net.corda.testing.driver.WebserverHandle extends java.lang.Ob
   @NotNull
   public final Process getProcess()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
@@ -6147,10 +7424,12 @@ public static final class net.corda.testing.node.ClusterSpec$Raft extends net.co
   public boolean equals(Object)
   public int getClusterSize()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @ThreadSafe
 public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.corda.core.serialization.SingletonSerializeAsToken
+  public <init>(boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, org.apache.activemq.artemis.utils.ReusableLatch, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final synchronized java.util.List<net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService> getEndpointsExternal()
   @NotNull
@@ -6163,6 +7442,7 @@ public final class net.corda.testing.node.InMemoryMessagingNetwork extends net.c
   public static final net.corda.testing.node.InMemoryMessagingNetwork$Companion Companion
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle extends java.lang.Object implements net.corda.core.messaging.MessageRecipientGroup
@@ -6195,13 +7475,16 @@ public static final class net.corda.testing.node.InMemoryMessagingNetwork$Messag
   public static final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion Companion
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.MockNodeMessagingService, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final net.corda.testing.node.InMemoryMessagingNetwork$MessageTransfer pumpReceive(boolean)
   public static final net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion Companion
 ##
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$MockMessagingService$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @CordaSerializable
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHandle extends java.lang.Object implements net.corda.core.messaging.SingleMessageRecipient
@@ -6221,12 +7504,14 @@ public static final class net.corda.testing.node.InMemoryMessagingNetwork$PeerHa
 ##
 @DoNotImplement
 public abstract static class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   public abstract A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
 ##
 @DoNotImplement
 public static final class net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy$Random extends net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy
   public <init>()
   public <init>(java.util.SplittableRandom)
+  public <init>(java.util.SplittableRandom, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.SplittableRandom getRandom()
   public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
@@ -6236,10 +7521,31 @@ public static final class net.corda.testing.node.InMemoryMessagingNetwork$Servic
   public <init>()
   public A pickNext(net.corda.testing.node.InMemoryMessagingNetwork$DistributedServiceHandle, java.util.List<? extends A>)
 ##
+public final class net.corda.testing.node.MockNetFlowTimeOut extends java.lang.Object
+  public <init>(java.time.Duration, int, double)
+  public final double getBackoffBase()
+  public final int getMaxRestartCount()
+  @NotNull
+  public final java.time.Duration getTimeout()
+##
+public final class net.corda.testing.node.MockNetNotaryConfig extends java.lang.Object
+  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name)
+  public <init>(boolean, com.typesafe.config.Config, String, net.corda.core.identity.CordaX500Name, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final String getClassName()
+  @Nullable
+  public final com.typesafe.config.Config getExtraConfig()
+  @Nullable
+  public final net.corda.core.identity.CordaX500Name getServiceLegalName()
+  public final boolean getValidating()
+##
 public class net.corda.testing.node.MockNetwork extends java.lang.Object
   public <init>(java.util.List<String>)
   public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(java.util.List<String>, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List, net.corda.testing.node.MockNetworkParameters, boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.testing.node.MockNetworkParameters)
   @NotNull
   public final java.nio.file.Path baseDirectory(int)
   @NotNull
@@ -6250,6 +7556,8 @@ public class net.corda.testing.node.MockNetwork extends java.lang.Object
   public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer)
   @NotNull
   public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode createNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
   @NotNull
   public final net.corda.testing.node.StartedMockNode createNode(net.corda.testing.node.MockNodeParameters)
   @NotNull
@@ -6262,6 +7570,8 @@ public class net.corda.testing.node.MockNetwork extends java.lang.Object
   public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer)
   @NotNull
   public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger)
+  @NotNull
+  public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.core.identity.CordaX500Name, Integer, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
   @NotNull
   public final net.corda.testing.node.UnstartedMockNode createUnstartedNode(net.corda.testing.node.MockNodeParameters)
   @NotNull
@@ -6292,6 +7602,7 @@ public class net.corda.testing.node.MockNetwork extends java.lang.Object
 public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lang.Object
   public <init>(net.corda.core.identity.CordaX500Name)
   public <init>(net.corda.core.identity.CordaX500Name, boolean)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.identity.CordaX500Name component1()
   public final boolean component2()
@@ -6302,11 +7613,15 @@ public final class net.corda.testing.node.MockNetworkNotarySpec extends java.lan
   public final net.corda.core.identity.CordaX500Name getName()
   public final boolean getValidating()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public final class net.corda.testing.node.MockNetworkParameters extends java.lang.Object
   public <init>()
+  public <init>(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List, net.corda.core.node.NetworkParameters, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final boolean component1()
   public final boolean component2()
   @NotNull
@@ -6316,8 +7631,14 @@ public final class net.corda.testing.node.MockNetworkParameters extends java.lan
   @NotNull
   public final net.corda.core.node.NetworkParameters component5()
   @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component6()
+  @NotNull
   public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters)
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters copy(boolean, boolean, net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy, java.util.List<net.corda.testing.node.MockNetworkNotarySpec>, net.corda.core.node.NetworkParameters, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getCordappsForAllNodes()
   @NotNull
   public final net.corda.core.node.NetworkParameters getNetworkParameters()
   public final boolean getNetworkSendManuallyPumped()
@@ -6327,7 +7648,10 @@ public final class net.corda.testing.node.MockNetworkParameters extends java.lan
   public final net.corda.testing.node.InMemoryMessagingNetwork$ServicePeerAllocationStrategy getServicePeerAllocationStrategy()
   public final boolean getThreadPerNode()
   public int hashCode()
+  @NotNull
   public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNetworkParameters withCordappsForAllNodes(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   @NotNull
   public final net.corda.testing.node.MockNetworkParameters withNetworkParameters(net.corda.core.node.NetworkParameters)
   @NotNull
@@ -6339,15 +7663,42 @@ public final class net.corda.testing.node.MockNetworkParameters extends java.lan
   @NotNull
   public final net.corda.testing.node.MockNetworkParameters withThreadPerNode(boolean)
 ##
+public final class net.corda.testing.node.MockNodeConfigOverrides extends java.lang.Object
+  public <init>()
+  public <init>(java.util.Map<String, String>, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut)
+  public <init>(java.util.Map, net.corda.testing.node.MockNetNotaryConfig, net.corda.testing.node.MockNetFlowTimeOut, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @Nullable
+  public final java.util.Map<String, String> getExtraDataSourceProperties()
+  @Nullable
+  public final net.corda.testing.node.MockNetFlowTimeOut getFlowTimeout()
+  @Nullable
+  public final net.corda.testing.node.MockNetNotaryConfig getNotary()
+##
 public final class net.corda.testing.node.MockNodeParameters extends java.lang.Object
   public <init>()
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  public <init>(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final Integer component1()
   @Nullable
   public final net.corda.core.identity.CordaX500Name component2()
   @NotNull
   public final java.math.BigInteger component3()
+  @Nullable
+  public final net.corda.testing.node.MockNodeConfigOverrides component4()
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> component5()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters copy(Integer, net.corda.core.identity.CordaX500Name, java.math.BigInteger, net.corda.testing.node.MockNodeConfigOverrides, java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
   public boolean equals(Object)
+  @NotNull
+  public final java.util.Collection<net.corda.testing.node.TestCordapp> getAdditionalCordapps()
+  @Nullable
+  public final net.corda.testing.node.MockNodeConfigOverrides getConfigOverrides()
   @NotNull
   public final java.math.BigInteger getEntropyRoot()
   @Nullable
@@ -6355,7 +7706,12 @@ public final class net.corda.testing.node.MockNodeParameters extends java.lang.O
   @Nullable
   public final net.corda.core.identity.CordaX500Name getLegalName()
   public int hashCode()
+  @NotNull
   public String toString()
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withAdditionalCordapps(java.util.Collection<? extends net.corda.testing.node.TestCordapp>)
+  @NotNull
+  public final net.corda.testing.node.MockNodeParameters withConfigOverrides(net.corda.testing.node.MockNodeConfigOverrides)
   @NotNull
   public final net.corda.testing.node.MockNodeParameters withEntropyRoot(java.math.BigInteger)
   @NotNull
@@ -6369,14 +7725,24 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name)
   public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
   public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(Iterable<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(Iterable, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair...)
   public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair...)
+  public <init>(Iterable, net.corda.testing.core.TestIdentity, net.corda.core.node.services.IdentityService, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(Iterable<String>, net.corda.testing.core.TestIdentity, java.security.KeyPair...)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters)
+  public <init>(java.util.List<String>, net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, net.corda.core.node.NetworkParameters, java.security.KeyPair)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
+  public <init>(java.util.List<String>, net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
   public <init>(net.corda.core.identity.CordaX500Name)
   public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair, java.security.KeyPair...)
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair...)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.node.services.IdentityService, java.security.KeyPair, java.security.KeyPair[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.testing.core.TestIdentity, net.corda.core.node.NetworkParameters, net.corda.testing.core.TestIdentity...)
   public <init>(net.corda.testing.core.TestIdentity, net.corda.testing.core.TestIdentity...)
   public final void addMockCordapp(String)
   @NotNull
@@ -6394,11 +7760,15 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @NotNull
   public net.corda.core.crypto.TransactionSignature createSignature(net.corda.core.transactions.SignedTransaction, java.security.PublicKey)
   @NotNull
+  public net.corda.core.cordapp.CordappContext getAppContext()
+  @NotNull
   public final net.corda.testing.services.MockAttachmentStorage getAttachments()
   @NotNull
   public net.corda.testing.node.TestClock getClock()
   @NotNull
   public net.corda.core.node.services.ContractUpgradeService getContractUpgradeService()
+  @NotNull
+  public final ClassLoader getCordappClassloader()
   @NotNull
   public net.corda.core.cordapp.CordappProvider getCordappProvider()
   @NotNull
@@ -6412,6 +7782,8 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   @NotNull
   public net.corda.core.node.NetworkParameters getNetworkParameters()
   @NotNull
+  public net.corda.core.node.services.NetworkParametersService getNetworkParametersService()
+  @NotNull
   protected final net.corda.core.node.ServicesForResolution getServicesForResolution()
   @NotNull
   public net.corda.core.node.services.TransactionVerifierService getTransactionVerifierService()
@@ -6421,6 +7793,8 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public net.corda.core.node.services.VaultService getVaultService()
   @NotNull
   public java.sql.Connection jdbcSession()
+  @NotNull
+  public net.corda.core.contracts.Attachment loadContractAttachment(net.corda.core.contracts.StateRef, String)
   @NotNull
   public net.corda.core.contracts.TransactionState<?> loadState(net.corda.core.contracts.StateRef)
   @NotNull
@@ -6446,9 +7820,13 @@ public class net.corda.testing.node.MockServices extends java.lang.Object implem
   public net.corda.core.transactions.SignedTransaction signInitialTransaction(net.corda.core.transactions.TransactionBuilder, java.security.PublicKey)
   @NotNull
   public net.corda.core.contracts.StateAndRef<T> toStateAndRef(net.corda.core.contracts.StateRef)
+  public void withEntityManager(java.util.function.Consumer<javax.persistence.EntityManager>)
+  @NotNull
+  public T withEntityManager(kotlin.jvm.functions.Function1<? super javax.persistence.EntityManager, ? extends T>)
   public static final net.corda.testing.node.MockServices$Companion Companion
 ##
 public static final class net.corda.testing.node.MockServices$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.Properties makeTestDataSourceProperties(String)
   @NotNull
@@ -6478,6 +7856,9 @@ public final class net.corda.testing.node.NodeTestUtils extends java.lang.Object
 ##
 public final class net.corda.testing.node.NotarySpec extends java.lang.Object
   public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List<net.corda.testing.node.User>, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String)
+  public <init>(net.corda.core.identity.CordaX500Name, boolean, java.util.List, net.corda.testing.driver.VerifierType, net.corda.testing.node.ClusterSpec, String, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.identity.CordaX500Name component1()
   public final boolean component2()
@@ -6493,6 +7874,8 @@ public final class net.corda.testing.node.NotarySpec extends java.lang.Object
   @Nullable
   public final net.corda.testing.node.ClusterSpec getCluster()
   @NotNull
+  public final String getMaximumHeapSize()
+  @NotNull
   public final net.corda.core.identity.CordaX500Name getName()
   @NotNull
   public final java.util.List<net.corda.testing.node.User> getRpcUsers()
@@ -6500,9 +7883,12 @@ public final class net.corda.testing.node.NotarySpec extends java.lang.Object
   @NotNull
   public final net.corda.testing.driver.VerifierType getVerifierType()
   public int hashCode()
+  public final void setMaximumHeapSize(String)
+  @NotNull
   public String toString()
 ##
 public final class net.corda.testing.node.StartedMockNode extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.TestStartedNode, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.util.List<kotlin.Pair<F, net.corda.core.concurrent.CordaFuture<?>>> findStateMachines(Class<F>)
   public final int getId()
@@ -6515,12 +7901,15 @@ public final class net.corda.testing.node.StartedMockNode extends java.lang.Obje
   @NotNull
   public final rx.Observable<F> registerInitiatedFlow(Class<F>)
   @NotNull
+  public final rx.Observable<F> registerInitiatedFlow(Class<? extends net.corda.core.flows.FlowLogic<?>>, Class<F>)
+  @NotNull
   public final net.corda.core.concurrent.CordaFuture<T> startFlow(net.corda.core.flows.FlowLogic<? extends T>)
   public final void stop()
   public final T transaction(kotlin.jvm.functions.Function0<? extends T>)
   public static final net.corda.testing.node.StartedMockNode$Companion Companion
 ##
 public static final class net.corda.testing.node.StartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @ThreadSafe
 public final class net.corda.testing.node.TestClock extends net.corda.node.MutableClock
@@ -6528,13 +7917,34 @@ public final class net.corda.testing.node.TestClock extends net.corda.node.Mutab
   public final synchronized void advanceBy(java.time.Duration)
   public final synchronized void setTo(java.time.Instant)
 ##
+@DoNotImplement
+public abstract class net.corda.testing.node.TestCordapp extends java.lang.Object
+  public <init>()
+  @NotNull
+  public static final net.corda.testing.node.TestCordapp findCordapp(String)
+  @NotNull
+  public abstract java.util.Map<String, Object> getConfig()
+  @NotNull
+  public abstract net.corda.testing.node.TestCordapp withConfig(java.util.Map<String, ?>)
+  public static final net.corda.testing.node.TestCordapp$Companion Companion
+##
+public static final class net.corda.testing.node.TestCordapp$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public final net.corda.testing.node.TestCordapp findCordapp(String)
+##
 public final class net.corda.testing.node.UnstartedMockNode extends java.lang.Object
+  public <init>(net.corda.testing.node.internal.InternalMockNetwork$MockNode, kotlin.jvm.internal.DefaultConstructorMarker)
   public final int getId()
+  @NotNull
+  public final net.corda.testing.node.StartedMockNode getStarted()
+  public final boolean isStarted()
   @NotNull
   public final net.corda.testing.node.StartedMockNode start()
   public static final net.corda.testing.node.UnstartedMockNode$Companion Companion
 ##
 public static final class net.corda.testing.node.UnstartedMockNode$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public final class net.corda.testing.node.User extends java.lang.Object
   public <init>(String, String, java.util.Set<String>)
@@ -6554,38 +7964,109 @@ public final class net.corda.testing.node.User extends java.lang.Object
   @NotNull
   public final String getUsername()
   public int hashCode()
+  @NotNull
   public String toString()
+##
+public class net.corda.client.rpc.ConnectionFailureException extends net.corda.client.rpc.RPCException
+  public <init>()
+  public <init>(Throwable)
+  public <init>(Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public final class net.corda.client.rpc.CordaRPCClient extends java.lang.Object
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>)
   public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(java.util.List<net.corda.core.utilities.NetworkHostAndPort>, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(java.util.List, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.utilities.NetworkHostAndPort)
   public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.client.rpc.CordaRPCClientConfiguration, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader)
+  public <init>(net.corda.core.utilities.NetworkHostAndPort, net.corda.core.messaging.ClientRpcSslOptions, ClassLoader, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.client.rpc.CordaRPCConnection start(String, String)
   @NotNull
   public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.context.Trace, net.corda.core.context.Actor, net.corda.core.identity.CordaX500Name)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCConnection start(String, String, net.corda.core.identity.CordaX500Name)
   public final A use(String, String, kotlin.jvm.functions.Function1<? super net.corda.client.rpc.CordaRPCConnection, ? extends A>)
   public static final net.corda.client.rpc.CordaRPCClient$Companion Companion
 ##
 public static final class net.corda.client.rpc.CordaRPCClient$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public class net.corda.client.rpc.CordaRPCClientConfiguration extends java.lang.Object
+  public <init>()
   public <init>(java.time.Duration)
+  public <init>(java.time.Duration, int)
+  public <init>(java.time.Duration, int, boolean)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
+  public <init>(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final java.time.Duration component1()
   @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy()
+  @NotNull
   public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int)
+  @NotNull
+  public final net.corda.client.rpc.CordaRPCClientConfiguration copy(java.time.Duration, int, boolean, java.time.Duration, int, int, java.time.Duration, double, int, int, java.time.Duration)
   public boolean equals(Object)
+  public int getCacheConcurrencyLevel()
   @NotNull
   public java.time.Duration getConnectionMaxRetryInterval()
+  @NotNull
+  public java.time.Duration getConnectionRetryInterval()
+  public double getConnectionRetryIntervalMultiplier()
+  @NotNull
+  public java.time.Duration getDeduplicationCacheExpiry()
+  public int getMaxFileSize()
+  public int getMaxReconnectAttempts()
+  public int getMinimumServerProtocolVersion()
+  public int getObservationExecutorPoolSize()
+  @NotNull
+  public java.time.Duration getReapInterval()
+  public boolean getTrackRpcCallSites()
   public int hashCode()
+  @NotNull
   public String toString()
   public static final net.corda.client.rpc.CordaRPCClientConfiguration$Companion Companion
   @NotNull
   public static final net.corda.client.rpc.CordaRPCClientConfiguration DEFAULT
 ##
 public static final class net.corda.client.rpc.CordaRPCClientConfiguration$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Object implements net.corda.client.rpc.RPCConnection
@@ -6599,6 +8080,8 @@ public final class net.corda.client.rpc.CordaRPCConnection extends java.lang.Obj
 ##
 public final class net.corda.client.rpc.PermissionException extends net.corda.core.CordaRuntimeException implements net.corda.nodeapi.exceptions.RpcSerializableError, net.corda.core.ClientRelevantError
   public <init>(String)
+  @NotNull
+  public final String getMsg()
 ##
 @DoNotImplement
 public interface net.corda.client.rpc.RPCConnection extends java.io.Closeable
@@ -6618,9 +8101,78 @@ public @interface net.corda.client.rpc.RPCSinceVersion
 public final class net.corda.client.rpc.UtilsKt extends java.lang.Object
   public static final void notUsed(rx.Observable<T>)
 ##
+public final class net.corda.finance.test.CashSchema extends java.lang.Object
+  public static final net.corda.finance.test.CashSchema INSTANCE
+##
+public final class net.corda.finance.test.SampleCashSchemaV1 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV1 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV1$PersistentCashState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(String, long, String, String, byte[])
+  @NotNull
+  public String getCurrency()
+  @NotNull
+  public String getIssuerPartyHash()
+  @NotNull
+  public byte[] getIssuerRef()
+  @NotNull
+  public String getOwnerHash()
+  public long getPennies()
+  public void setCurrency(String)
+  public void setIssuerPartyHash(String)
+  public void setIssuerRef(byte[])
+  public void setOwnerHash(String)
+  public void setPennies(long)
+##
+public final class net.corda.finance.test.SampleCashSchemaV2 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV2 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV2$PersistentCashState extends net.corda.core.schemas.CommonSchemaV1$FungibleState
+  public <init>()
+  public <init>(String, java.util.Set<? extends net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, net.corda.core.identity.AbstractParty, net.corda.core.utilities.OpaqueBytes)
+  @NotNull
+  public String getCurrency()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public void setCurrency(String)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+##
+public final class net.corda.finance.test.SampleCashSchemaV3 extends net.corda.core.schemas.MappedSchema
+  public static final net.corda.finance.test.SampleCashSchemaV3 INSTANCE
+##
+@Entity
+@Table
+public static class net.corda.finance.test.SampleCashSchemaV3$PersistentCashState extends net.corda.core.schemas.PersistentState
+  public <init>()
+  public <init>(java.util.Set<net.corda.core.identity.AbstractParty>, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[])
+  public <init>(java.util.Set, net.corda.core.identity.AbstractParty, long, String, net.corda.core.identity.AbstractParty, byte[], int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public String getCurrency()
+  @Nullable
+  public net.corda.core.identity.AbstractParty getIssuer()
+  @NotNull
+  public byte[] getIssuerRef()
+  @Nullable
+  public net.corda.core.identity.AbstractParty getOwner()
+  @Nullable
+  public java.util.Set<net.corda.core.identity.AbstractParty> getParticipants()
+  public long getPennies()
+  public void setCurrency(String)
+  public void setIssuer(net.corda.core.identity.AbstractParty)
+  public void setIssuerRef(byte[])
+  public void setOwner(net.corda.core.identity.AbstractParty)
+  public void setParticipants(java.util.Set<net.corda.core.identity.AbstractParty>)
+  public void setPennies(long)
+##
 public final class net.corda.testing.contracts.DummyContract extends java.lang.Object implements net.corda.core.contracts.Contract
   public <init>()
   public <init>(Object)
+  public <init>(Object, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @Nullable
   public final Object component1()
   @NotNull
@@ -6637,6 +8189,7 @@ public final class net.corda.testing.contracts.DummyContract extends java.lang.O
   public static final net.corda.core.transactions.TransactionBuilder move(java.util.List<net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>>, net.corda.core.identity.AbstractParty)
   @NotNull
   public static final net.corda.core.transactions.TransactionBuilder move(net.corda.core.contracts.StateAndRef<net.corda.testing.contracts.DummyContract$SingleOwnerState>, net.corda.core.identity.AbstractParty)
+  @NotNull
   public String toString()
   public void verify(net.corda.core.transactions.LedgerTransaction)
   public static final net.corda.testing.contracts.DummyContract$Companion Companion
@@ -6652,6 +8205,7 @@ public static final class net.corda.testing.contracts.DummyContract$Commands$Mov
   public <init>()
 ##
 public static final class net.corda.testing.contracts.DummyContract$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.core.transactions.TransactionBuilder generateInitial(int, net.corda.core.identity.Party, net.corda.core.contracts.PartyAndReference, net.corda.core.contracts.PartyAndReference...)
   @NotNull
@@ -6662,6 +8216,7 @@ public static final class net.corda.testing.contracts.DummyContract$Companion ex
 @DoNotImplement
 public static final class net.corda.testing.contracts.DummyContract$MultiOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State
   public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final int component1()
   @NotNull
   public final java.util.List<net.corda.core.identity.AbstractParty> component2()
@@ -6674,11 +8229,13 @@ public static final class net.corda.testing.contracts.DummyContract$MultiOwnerSt
   @NotNull
   public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
 public static final class net.corda.testing.contracts.DummyContract$SingleOwnerState extends java.lang.Object implements net.corda.testing.contracts.DummyContract$State, net.corda.core.contracts.OwnableState
   public <init>(int, net.corda.core.identity.AbstractParty)
+  public <init>(int, net.corda.core.identity.AbstractParty, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final int component1()
   @NotNull
   public final net.corda.core.identity.AbstractParty component2()
@@ -6691,6 +8248,7 @@ public static final class net.corda.testing.contracts.DummyContract$SingleOwnerS
   @NotNull
   public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
+  @NotNull
   public String toString()
   @NotNull
   public net.corda.core.contracts.CommandAndState withNewOwner(net.corda.core.identity.AbstractParty)
@@ -6721,9 +8279,11 @@ public static final class net.corda.testing.contracts.DummyContractV2$Commands$M
   public <init>()
 ##
 public static final class net.corda.testing.contracts.DummyContractV2$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public static final class net.corda.testing.contracts.DummyContractV2$State extends java.lang.Object implements net.corda.core.contracts.ContractState
   public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final int component1()
   @NotNull
   public final java.util.List<net.corda.core.identity.AbstractParty> component2()
@@ -6736,19 +8296,70 @@ public static final class net.corda.testing.contracts.DummyContractV2$State exte
   @NotNull
   public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
+public final class net.corda.testing.contracts.DummyContractV3 extends java.lang.Object implements net.corda.core.contracts.UpgradedContractWithLegacyConstraint
+  public <init>()
+  @NotNull
+  public String getLegacyContract()
+  @NotNull
+  public net.corda.core.contracts.AttachmentConstraint getLegacyContractConstraint()
+  @NotNull
+  public net.corda.testing.contracts.DummyContractV3$State upgrade(net.corda.testing.contracts.DummyContractV2$State)
+  public void verify(net.corda.core.transactions.LedgerTransaction)
+  public static final net.corda.testing.contracts.DummyContractV3$Companion Companion
+  @NotNull
+  public static final String PROGRAM_ID = "net.corda.testing.contracts.DummyContractV3"
+##
+public static interface net.corda.testing.contracts.DummyContractV3$Commands extends net.corda.core.contracts.CommandData
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Commands$Create extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Commands$Move extends net.corda.core.contracts.TypeOnlyCommandData implements net.corda.testing.contracts.DummyContractV3$Commands
+  public <init>()
+##
+public static final class net.corda.testing.contracts.DummyContractV3$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
+##
+public static final class net.corda.testing.contracts.DummyContractV3$State extends java.lang.Object implements net.corda.core.contracts.ContractState
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  public final int component1()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
+  public final net.corda.testing.contracts.DummyContractV3$State copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public boolean equals(Object)
+  public final int getMagicNumber()
+  @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> getOwners()
+  @NotNull
+  public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
+  public int hashCode()
+  @NotNull
+  public String toString()
+##
+@BelongsToContract
 public final class net.corda.testing.contracts.DummyState extends java.lang.Object implements net.corda.core.contracts.ContractState
   public <init>()
   public <init>(int)
+  public <init>(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
+  public <init>(int, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public final int component1()
   @NotNull
+  public final java.util.List<net.corda.core.identity.AbstractParty> component2()
+  @NotNull
   public final net.corda.testing.contracts.DummyState copy(int)
+  @NotNull
+  public final net.corda.testing.contracts.DummyState copy(int, java.util.List<? extends net.corda.core.identity.AbstractParty>)
   public boolean equals(Object)
   public final int getMagicNumber()
   @NotNull
   public java.util.List<net.corda.core.identity.AbstractParty> getParticipants()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 public final class net.corda.testing.core.DummyCommandData extends net.corda.core.contracts.TypeOnlyCommandData
@@ -6772,10 +8383,12 @@ public final class net.corda.testing.core.Expect extends java.lang.Object
   @NotNull
   public final kotlin.jvm.functions.Function1<T, Boolean> getMatch()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
 public abstract class net.corda.testing.core.ExpectCompose extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 public static final class net.corda.testing.core.ExpectCompose$Parallel extends net.corda.testing.core.ExpectCompose
@@ -6796,6 +8409,7 @@ public static final class net.corda.testing.core.ExpectCompose$Single extends ne
   public final net.corda.testing.core.Expect<E, T> getExpect()
 ##
 public static final class net.corda.testing.core.ExpectComposeState$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.testing.core.ExpectComposeState<E> fromExpectCompose(net.corda.testing.core.ExpectCompose<? extends E>)
 ##
@@ -6858,6 +8472,7 @@ public final class net.corda.testing.core.ExpectKt extends java.lang.Object
 public final class net.corda.testing.core.SerializationEnvironmentRule extends java.lang.Object implements org.junit.rules.TestRule
   public <init>()
   public <init>(boolean)
+  public <init>(boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement, org.junit.runner.Description)
   @NotNull
@@ -6865,6 +8480,7 @@ public final class net.corda.testing.core.SerializationEnvironmentRule extends j
   public static final net.corda.testing.core.SerializationEnvironmentRule$Companion Companion
 ##
 public static final class net.corda.testing.core.SerializationEnvironmentRule$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public final class net.corda.testing.core.TestConstants extends java.lang.Object
   @NotNull
@@ -6890,7 +8506,15 @@ public final class net.corda.testing.core.TestConstants extends java.lang.Object
 public final class net.corda.testing.core.TestIdentity extends java.lang.Object
   public <init>(net.corda.core.identity.CordaX500Name)
   public <init>(net.corda.core.identity.CordaX500Name, long)
+  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme)
+  public <init>(net.corda.core.identity.CordaX500Name, long, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
   public <init>(net.corda.core.identity.CordaX500Name, java.security.KeyPair)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme)
+  public <init>(net.corda.core.identity.CordaX500Name, net.corda.core.crypto.SignatureScheme, int, kotlin.jvm.internal.DefaultConstructorMarker)
+  @NotNull
+  public static final net.corda.testing.core.TestIdentity fresh(String)
+  @NotNull
+  public static final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
   @NotNull
   public final net.corda.core.identity.PartyAndCertificate getIdentity()
   @NotNull
@@ -6906,8 +8530,11 @@ public final class net.corda.testing.core.TestIdentity extends java.lang.Object
   public static final net.corda.testing.core.TestIdentity$Companion Companion
 ##
 public static final class net.corda.testing.core.TestIdentity$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.testing.core.TestIdentity fresh(String)
+  @NotNull
+  public final net.corda.testing.core.TestIdentity fresh(String, net.corda.core.crypto.SignatureScheme)
 ##
 public final class net.corda.testing.core.TestUtils extends java.lang.Object
   @NotNull
@@ -6921,6 +8548,8 @@ public final class net.corda.testing.core.TestUtils extends java.lang.Object
   public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.CordaX500Name, java.security.PublicKey)
   @NotNull
   public static final net.corda.core.identity.PartyAndCertificate getTestPartyAndCertificate(net.corda.core.identity.Party)
+  @NotNull
+  public static final net.corda.core.identity.CordaX500Name makeUnique(net.corda.core.identity.CordaX500Name)
   @NotNull
   public static final net.corda.core.identity.Party singleIdentity(net.corda.core.node.NodeInfo)
   @NotNull
@@ -6937,6 +8566,7 @@ public final class net.corda.testing.dsl.DuplicateOutputLabel extends net.corda.
 ##
 @DoNotImplement
 public abstract class net.corda.testing.dsl.EnforceVerifyOrFail extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 @DoNotImplement
 public static final class net.corda.testing.dsl.EnforceVerifyOrFail$Token extends net.corda.testing.dsl.EnforceVerifyOrFail
@@ -7029,6 +8659,7 @@ public final class net.corda.testing.dsl.TestLedgerDSLInterpreter extends java.l
   public final String outputToLabel(net.corda.core.contracts.ContractState)
   @NotNull
   public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
+  @NotNull
   public String toString()
   @Nullable
   public final String transactionName(net.corda.core.crypto.SecureHash)
@@ -7037,6 +8668,7 @@ public final class net.corda.testing.dsl.TestLedgerDSLInterpreter extends java.l
   public static final net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion Companion
 ##
 public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
 ##
 public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$TypeMismatch extends java.lang.Exception
   public <init>(Class<?>, Class<?>)
@@ -7062,12 +8694,15 @@ public static final class net.corda.testing.dsl.TestLedgerDSLInterpreter$WireTra
   @NotNull
   public final net.corda.core.transactions.WireTransaction getTransaction()
   public int hashCode()
+  @NotNull
   public String toString()
 ##
 @DoNotImplement
 public final class net.corda.testing.dsl.TestTransactionDSLInterpreter extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter, net.corda.testing.dsl.OutputStateLookup
   public <init>(net.corda.testing.dsl.TestLedgerDSLInterpreter, net.corda.core.transactions.TransactionBuilder)
   public void _attachment(String)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
   @NotNull
   public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
   public void attachment(net.corda.core.crypto.SecureHash)
@@ -7094,9 +8729,11 @@ public final class net.corda.testing.dsl.TestTransactionDSLInterpreter extends j
   public int hashCode()
   public void input(net.corda.core.contracts.StateRef)
   public void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  public void reference(net.corda.core.contracts.StateRef)
   @NotNull
   public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
   public void timeWindow(net.corda.core.contracts.TimeWindow)
+  @NotNull
   public String toString()
   @NotNull
   public net.corda.testing.dsl.EnforceVerifyOrFail verifies()
@@ -7105,9 +8742,13 @@ public final class net.corda.testing.dsl.TestTransactionDSLInterpreter extends j
 public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object implements net.corda.testing.dsl.TransactionDSLInterpreter
   public <init>(T, net.corda.core.identity.Party)
   public void _attachment(String)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
   @NotNull
   public net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
   public final void attachment(String)
+  public final void attachment(String, net.corda.core.crypto.SecureHash)
+  public final void attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
   public void attachment(net.corda.core.crypto.SecureHash)
   public final void attachments(String...)
   public final void command(java.security.PublicKey, net.corda.core.contracts.CommandData)
@@ -7121,6 +8762,7 @@ public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object
   @NotNull
   public net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
   public final void input(String)
+  public final void input(String, String)
   public final void input(String, net.corda.core.contracts.ContractState)
   public void input(net.corda.core.contracts.StateRef)
   public final void output(String, int, net.corda.core.contracts.ContractState)
@@ -7130,6 +8772,9 @@ public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object
   public final void output(String, String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
   public final void output(String, net.corda.core.contracts.ContractState)
   public final void output(String, net.corda.core.identity.Party, net.corda.core.contracts.ContractState)
+  public final void reference(String)
+  public final void reference(String, net.corda.core.contracts.ContractState)
+  public void reference(net.corda.core.contracts.StateRef)
   @NotNull
   public net.corda.core.contracts.StateAndRef<S> retrieveOutputStateAndRef(Class<S>, String)
   public final void timeWindow(java.time.Instant)
@@ -7143,6 +8788,8 @@ public final class net.corda.testing.dsl.TransactionDSL extends java.lang.Object
 @DoNotImplement
 public interface net.corda.testing.dsl.TransactionDSLInterpreter extends net.corda.testing.dsl.OutputStateLookup, net.corda.testing.dsl.Verifies
   public abstract void _attachment(String)
+  public abstract void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public abstract void _attachment(String, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>, java.util.Map<String, String>)
   @NotNull
   public abstract net.corda.testing.dsl.EnforceVerifyOrFail _tweak(kotlin.jvm.functions.Function1<? super net.corda.testing.dsl.TransactionDSLInterpreter, ? extends net.corda.testing.dsl.EnforceVerifyOrFail>)
   public abstract void attachment(net.corda.core.crypto.SecureHash)
@@ -7151,6 +8798,7 @@ public interface net.corda.testing.dsl.TransactionDSLInterpreter extends net.cor
   public abstract net.corda.testing.dsl.LedgerDSLInterpreter<net.corda.testing.dsl.TransactionDSLInterpreter> getLedgerInterpreter()
   public abstract void input(net.corda.core.contracts.StateRef)
   public abstract void output(String, String, net.corda.core.identity.Party, Integer, net.corda.core.contracts.AttachmentConstraint, net.corda.core.contracts.ContractState)
+  public abstract void reference(net.corda.core.contracts.StateRef)
   public abstract void timeWindow(net.corda.core.contracts.TimeWindow)
 ##
 @DoNotImplement
@@ -7166,6 +8814,7 @@ public interface net.corda.testing.dsl.Verifies
 ##
 public final class net.corda.testing.http.HttpApi extends java.lang.Object
   public <init>(java.net.URL, com.fasterxml.jackson.databind.ObjectMapper)
+  public <init>(java.net.URL, com.fasterxml.jackson.databind.ObjectMapper, int, kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final com.fasterxml.jackson.databind.ObjectMapper getMapper()
   @NotNull
@@ -7176,6 +8825,7 @@ public final class net.corda.testing.http.HttpApi extends java.lang.Object
   public static final net.corda.testing.http.HttpApi$Companion Companion
 ##
 public static final class net.corda.testing.http.HttpApi$Companion extends java.lang.Object
+  public <init>(kotlin.jvm.internal.DefaultConstructorMarker)
   @NotNull
   public final net.corda.testing.http.HttpApi fromHostAndPort(net.corda.core.utilities.NetworkHostAndPort, String, String, com.fasterxml.jackson.databind.ObjectMapper)
 ##
@@ -7193,6 +8843,8 @@ public final class net.corda.testing.services.MockAttachmentStorage extends net.
   public final kotlin.Pair<net.corda.core.crypto.SecureHash, byte[]> getAttachmentIdAndBytes(java.io.InputStream)
   @NotNull
   public final java.util.Map<net.corda.core.crypto.SecureHash, kotlin.Pair<net.corda.core.contracts.Attachment, byte[]>> getFiles()
+  @NotNull
+  public java.util.List<net.corda.core.crypto.SecureHash> getLatestContractAttachments(String, int)
   public boolean hasAttachment(net.corda.core.crypto.SecureHash)
   @NotNull
   public net.corda.core.crypto.SecureHash importAttachment(java.io.InputStream)
@@ -7201,9 +8853,16 @@ public final class net.corda.testing.services.MockAttachmentStorage extends net.
   @NotNull
   public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream)
   @NotNull
+  public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream, net.corda.core.crypto.SecureHash)
+  @NotNull
+  public final net.corda.core.crypto.SecureHash importContractAttachment(java.util.List<String>, String, java.io.InputStream, net.corda.core.crypto.SecureHash, java.util.List<? extends java.security.PublicKey>)
+  public final void importContractAttachment(net.corda.core.crypto.SecureHash, net.corda.core.contracts.ContractAttachment)
+  @NotNull
   public net.corda.core.crypto.SecureHash importOrGetAttachment(java.io.InputStream)
   @Nullable
   public net.corda.core.contracts.Attachment openAttachment(net.corda.core.crypto.SecureHash)
+  @NotNull
+  public java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria)
   @NotNull
   public java.util.List<net.corda.core.crypto.SecureHash> queryAttachments(net.corda.core.node.services.vault.AttachmentQueryCriteria, net.corda.core.node.services.vault.AttachmentSort)
 ##


### PR DESCRIPTION
This refreshes the `api-current.txt` file before release of v4.
The API has been generated, using `./gradlew generateApi` on the head of `release/4`.

It includes several new (synthetic) methods. 
All the changes have been examined, as part of https://r3-cev.atlassian.net/browse/CORDA-2349 to ensure there was no breakage.