### PR TITLE
ENT-3001: Make `subCommands` lazy val

### DIFF
--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/CordaCliWrapper.kt
@@ -84,7 +84,7 @@ fun CordaCliWrapper.start(args: Array<String>) {
         exitProcess(ExitCodes.SUCCESS)
     } catch (e: ExecutionException) {
         val throwable = e.cause ?: e
-        if (this.verbose || this.subCommands().any { it.verbose }) {
+        if (this.verbose || this.subCommands.any { it.verbose }) {
             throwable.printStackTrace()
         } else {
         }
@@ -164,7 +164,7 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
             registerConverter(Path::class.java) { Paths.get(it).toAbsolutePath().normalize() }
             commandSpec.name(alias)
             commandSpec.usageMessage().description(description)
-            subCommands().forEach {
+            subCommands.forEach {
                 val subCommand = CommandLine(it)
                 it.args = args
                 subCommand.commandSpec.usageMessage().description(it.description)
@@ -173,8 +173,8 @@ abstract class CordaCliWrapper(alias: String, description: String) : CliWrapperB
         }
     }
 
-    fun subCommands(): Set<CliWrapperBase> {
-        return additionalSubCommands() + installShellExtensionsParser
+    val subCommands: Set<CliWrapperBase> by lazy {
+        additionalSubCommands() + installShellExtensionsParser
     }
 
     override fun call(): Int {

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
@@ -79,7 +79,7 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
         val autoCompleteFile = getAutoCompleteFileLocation(alias)
         autoCompleteFile.parent.createDirectories()
         val hierarchy = CommandLine(parent)
-        parent.subCommands().forEach { hierarchy.addSubcommand(it.alias, it)}
+        parent.subCommands.forEach { hierarchy.addSubcommand(it.alias, it)}
 
         val builder = StringBuilder(picocli.AutoComplete.bash(alias, hierarchy))
         builder.append(jarVersion(alias))


### PR DESCRIPTION
This is to prevent initialising it multiple times.
Please see linked Jira to understand how this can cause harm.