### PR TITLE
Fixed #4648: minor change to support Gradle's Kotlin DSL

### DIFF
--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
@@ -68,7 +68,7 @@ data class TestCordappImpl(val scanPackage: String, override val config: Map<Str
         private fun findProjectRoot(path: Path): Path {
             var current = path
             while (true) {
-                if ((current / "build.gradle").exists()) {
+                if ((current / "build.gradle").exists() || (current / "build.gradle.kts").exists()) {
                     return current
                 }
                 current = current.parent


### PR DESCRIPTION
`net.corda.testing.node.internal.TestCordappImpl.Companion#findProjectRoot` looks for a Gradle build file, but only does so for Groovy DSL (__build.gradle__). This minor fix for https://github.com/corda/corda/issues/4648 adds support for Kotlin DSL (__build.gradle.kts__).

Would it be possible to add this fix to v4 as well?