### PR TITLE
correct command docs for clear network map cache

### DIFF
--- a/docs/source/network-map.rst
+++ b/docs/source/network-map.rst
@@ -236,7 +236,7 @@ you either need to run from the command line:
 
 .. code-block:: shell
 
-    java -jar corda.jar clear-network-cache
+    java -jar corda.jar --clear-network-map-cache
 
 or call RPC method `clearNetworkMapCache` (it can be invoked through the node's shell as `run clearNetworkMapCache`, for more information on
 how to log into node's shell see :doc:`shell`). As we are testing and hardening the implementation this step shouldn't be required.


### PR DESCRIPTION
The command listed in the docs `java -jar corda.jar clear-network-cache` is not correct.

Admins must run `java -jar corda.jar --clear-network-map-cache` instead.
