### PR TITLE
[CORDA-2422] - Remove interfaces from carpenting

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializerFactory.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializerFactory.kt
@@ -245,10 +245,8 @@ open class SerializerFactory(
                 name to processSchemaEntry(notation)
             } catch (e: ClassNotFoundException) {
                 // class missing from the classpath, so load its interfaces and add it for carpenting (see method docs).
-                if (interfacesPerClass.containsKey(name)) {
-                    interfacesPerClass[name]!!.forEach { processSchemaEntry(it) }
-                    metaSchema.buildFor(notation, classloader)
-                }
+                interfacesPerClass[name]!!.forEach { processSchemaEntry(it) }
+                metaSchema.buildFor(notation, classloader)
                 null
             }
         }.toMap()

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializerFactory.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/serialization/amqp/SerializerFactory.kt
@@ -235,14 +235,14 @@ open class SerializerFactory(
     private fun processSchema(schemaAndDescriptor: FactorySchemaAndDescriptor) {
         val schemaTypes = schemaAndDescriptor.schemas.schema.types
         val interfacesPerClass = schemaTypes.associateBy({it.name},
-                {clazz -> schemaTypes.filter { it.name in clazz.provides }}
+                {type -> schemaTypes.filter { it.name in type.provides }}
         )
         val allInterfaceNames = interfacesPerClass.values.asSequence().flatten().map { it.name }
 
         val metaSchema = CarpenterMetaSchema.newInstance()
         val notationByNameForNonInterfaceTypes = schemaTypes
                 .filterNot { it.name in allInterfaceNames }
-                .associate { it.name to it }
+                .associateBy({it.name}, {it})
         val noCarpentryRequired = notationByNameForNonInterfaceTypes.mapNotNull { (name, notation) ->
             try {
                 logger.debug { "descriptor=${schemaAndDescriptor.typeDescriptor}, typeNotation=$name" }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/serialization/amqp/DeserializeNeedingCarpentryTests.kt
@@ -232,26 +232,4 @@ class DeserializeNeedingCarpentryTests : AmqpCarpenterBase(AllWhitelist) {
         }
     }
 
-    @Test
-    fun unknownInterface() {
-        val cc = ClassCarpenter(whitelist = AllWhitelist)
-
-        val interfaceClass = cc.build(InterfaceSchema(
-                "gen.Interface",
-                mapOf("age" to NonNullableField(Int::class.java))))
-
-        val concreteClass = cc.build(ClassSchema(testName(), mapOf(
-                "age" to NonNullableField(Int::class.java),
-                "name" to NonNullableField(String::class.java)),
-                interfaces = listOf(I::class.java, interfaceClass)))
-
-        val serialisedBytes = TestSerializationOutput(VERBOSE, sf1).serialize(
-                concreteClass.constructors.first().newInstance(12, "timmy"))
-        val deserializedObj = DeserializationInput(sf2).deserialize(serialisedBytes)
-
-        assertTrue(deserializedObj is I)
-        assertEquals("timmy", (deserializedObj as I).getName())
-        assertEquals("timmy", deserializedObj::class.java.getMethod("getName").invoke(deserializedObj))
-        assertEquals(12, deserializedObj::class.java.getMethod("getAge").invoke(deserializedObj))
-    }
 }


### PR DESCRIPTION
### Changes
This changes slightly the way schema processing is performed. The interfaces included in the schema will now be loaded on-demand, instead of loading all the interfaces included in the schema. When a class is detected that's missing from the class, all of the interfaces that it implements will be loaded.

This improves backwards compatibility in cases, like the one described in the ticket.

### Testing
* Re-run the test case provided in the ticket, verifying the fix is resolving the issue
* Note: the test that is removed should have been failing, but other code was masking the failure. It was trying to process a schema, where a class (and its associated interface) were missing from the classpath.