### PR TITLE
CORDA-2526 Allow for duplicate signed attachments in devMode

### DIFF
--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/AttachmentsClassLoaderStaticContractTests.kt
@@ -76,7 +76,7 @@ class AttachmentsClassLoaderStaticContractTests {
 
     private val serviceHub get() = rigorousMock<ServicesForResolution>().also {
         val cordappProviderImpl = CordappProviderImpl(cordappLoaderForPackages(listOf("net.corda.nodeapi.internal")), MockCordappConfigProvider(), MockAttachmentStorage())
-        cordappProviderImpl.start(testNetworkParameters().whitelistedContractImplementations)
+        cordappProviderImpl.start()
         doReturn(cordappProviderImpl).whenever(it).cordappProvider
         doReturn(networkParametersService).whenever(it).networkParametersService
         doReturn(networkParameters).whenever(it).networkParameters

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -170,7 +170,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
     @Suppress("LeakingThis")
     val transactionStorage = makeTransactionStorage(configuration.transactionCacheSizeBytes).tokenize()
     val networkMapClient: NetworkMapClient? = configuration.networkServices?.let { NetworkMapClient(it.networkMapURL, versionInfo) }
-    val attachments = NodeAttachmentService(metricRegistry, cacheFactory, database).tokenize()
+    val attachments = NodeAttachmentService(metricRegistry, cacheFactory, database, configuration.devMode).tokenize()
     val cryptoService = configuration.makeCryptoService()
     @Suppress("LeakingThis")
     val networkParametersStorage = makeNetworkParametersStorage()
@@ -371,7 +371,7 @@ abstract class AbstractNode<S>(val configuration: NodeConfiguration,
             networkParametersStorage.setCurrentParameters(signedNetParams, trustRoot)
             identityService.loadIdentities(nodeInfo.legalIdentitiesAndCerts)
             attachments.start()
-            cordappProvider.start(netParams.whitelistedContractImplementations)
+            cordappProvider.start()
             nodeProperties.start()
             // Place the long term identity key in the KMS. Eventually, this is likely going to be separated again because
             // the KMS is meant for derived temporary keys used in transactions, and we're not supposed to sign things with

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/CordappProviderImpl.kt
@@ -35,7 +35,7 @@ open class CordappProviderImpl(val cordappLoader: CordappLoader,
      */
     override val cordapps: List<CordappImpl> get() = cordappLoader.cordapps
 
-    fun start(whitelistedContractImplementations: Map<String, List<AttachmentId>>) {
+    fun start() {
         cordappAttachments.putAll(loadContractsIntoAttachmentStore())
         verifyInstalledCordapps()
     }

--- a/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/persistence/NodeAttachmentService.kt
@@ -494,11 +494,14 @@ class NodeAttachmentService(
 
     private fun makeAttachmentIds(it: Map.Entry<Int, List<DBAttachment>>, contractClassName: String): Pair<Version, AttachmentIds> {
         val signed = it.value.filter { it.signers?.isNotEmpty() ?: false }.map { AttachmentId.parse(it.attId) }
-        check (signed.size <= 1) //sanity check
+        if (!devMode)
+            check (signed.size <= 1) //sanity check
+        else
+            log.warn("(Dev Mode) Multiple signed attachments ${signed.map { it.toString() }} for contract $contractClassName version '${it.key}'.")
         val unsigned = it.value.filter { it.signers?.isEmpty() ?: true }.map { AttachmentId.parse(it.attId) }
         if (unsigned.size > 1)
             log.warn("Selecting attachment ${unsigned.first()} from duplicated, unsigned attachments ${unsigned.map { it.toString() }} for contract $contractClassName version '${it.key}'.")
-        return it.key to AttachmentIds(signed.singleOrNull(), unsigned.firstOrNull())
+        return it.key to AttachmentIds(signed.firstOrNull(), unsigned.firstOrNull())
     }
 
     override fun getLatestContractAttachments(contractClassName: String, minContractVersion: Int): List<AttachmentId> {

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/CordappProviderImplTests.kt
@@ -77,7 +77,7 @@ class CordappProviderImplTests {
         val configProvider = MockCordappConfigProvider()
         configProvider.cordappConfigs[isolatedCordappName] = validConfig
         val loader = JarScanningCordappLoader.fromJarUrls(listOf(isolatedJAR), VersionInfo.UNKNOWN)
-        val provider = CordappProviderImpl(loader, configProvider, attachmentStore).apply { start(whitelistedContractImplementations) }
+        val provider = CordappProviderImpl(loader, configProvider, attachmentStore).apply { start() }
 
         val expected = provider.getAppContext(provider.cordapps.first()).config
 
@@ -86,6 +86,6 @@ class CordappProviderImplTests {
 
     private fun newCordappProvider(vararg urls: URL): CordappProviderImpl {
         val loader = JarScanningCordappLoader.fromJarUrls(urls.toList(), VersionInfo.UNKNOWN)
-        return CordappProviderImpl(loader, stubConfigProvider, attachmentStore).apply { start(whitelistedContractImplementations) }
+        return CordappProviderImpl(loader, stubConfigProvider, attachmentStore).apply { start() }
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -309,7 +309,7 @@ open class MockServices private constructor(
         }
     override val transactionVerifierService: TransactionVerifierService get() = InMemoryTransactionVerifierService(2)
     private val mockCordappProvider: MockCordappProvider = MockCordappProvider(cordappLoader, attachments).also {
-        it.start(initialNetworkParameters.whitelistedContractImplementations)
+        it.start()
     }
     override val cordappProvider: CordappProvider get() = mockCordappProvider
     override val networkParametersService: NetworkParametersService = MockNetworkParametersStorage(initialNetworkParameters)


### PR DESCRIPTION
This PR relaxes the current check on Node start-up that throws a `DuplicateContractClassException` if an existing Contract Attachment of the same name and version Id already exists in the attachment store.

Note: our current logic for querying Contract Versions uses a query sorted by descending "insertion date" and we always pick the most recent entry from the query results (so this change maintains semantic compatibility in the transaction verifier).
