### PR TITLE
CORDA-2545 fix package ownership check

### DIFF
--- a/node/src/integration-test/kotlin/net/corda/node/CordappConstraintsTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/node/CordappConstraintsTests.kt
@@ -17,18 +17,20 @@ import net.corda.finance.DOLLARS
 import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.flows.CashIssueFlow
 import net.corda.finance.flows.CashPaymentFlow
+import net.corda.node.internal.NetworkParametersReader
 import net.corda.node.services.Permissions.Companion.invokeRpc
 import net.corda.node.services.Permissions.Companion.startFlow
+import net.corda.nodeapi.internal.network.NetworkParametersCopier
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.*
 import net.corda.testing.core.internal.JarSignatureTestUtils.generateKey
 import net.corda.testing.core.internal.SelfCleaningDir
 import net.corda.testing.driver.*
+import net.corda.testing.internal.DEV_ROOT_CA
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.cordappWithPackages
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 
 class CordappConstraintsTests {
@@ -255,10 +257,7 @@ class CordappConstraintsTests {
         driver(DriverParameters(
                 cordappsForAllNodes = listOf(UNSIGNED_FINANCE_CORDAPP),
                 notarySpecs = listOf(NotarySpec(DUMMY_NOTARY_NAME, validating = false)),
-                networkParameters = testNetworkParameters(
-                        minimumPlatformVersion = 4,
-                        packageOwnership = mapOf("net.corda.finance.contracts.asset" to packageOwnerKey)
-                ),
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4),
                 inMemoryDB = false
         )) {
             val (alice, bob) = listOf(
@@ -266,23 +265,31 @@ class CordappConstraintsTests {
                     startNode(providedName = BOB_NAME, rpcUsers = listOf(user))
             ).map { it.getOrThrow() }
 
+            val notary = defaultNotaryHandle.nodeHandles.get().first()
+
             // Issue Cash
-            val issueTx = alice.rpc.startFlow(::CashIssueFlow, 1000.DOLLARS,  OpaqueBytes.of(1), defaultNotaryIdentity).returnValue.getOrThrow()
+            val issueTx = alice.rpc.startFlow(::CashIssueFlow, 1000.DOLLARS, OpaqueBytes.of(1), defaultNotaryIdentity)
+                    .returnValue.getOrThrow()
             println("Issued transaction: $issueTx")
 
             // Query vault
             val states = alice.rpc.vaultQueryBy<Cash.State>().states
             printVault(alice, states)
 
-            // Restart the node and re-query the vault
-            println("Shutting down the node for $ALICE_NAME ...")
-            (alice as OutOfProcess).process.destroyForcibly()
-            alice.stop()
+            // Claim the package, publish the new network parameters , and restart all nodes.
+            val parameters = NetworkParametersReader(DEV_ROOT_CA.certificate, null, notary.baseDirectory).read().networkParameters
 
-            // Restart the node and re-query the vault
-            println("Shutting down the node for $BOB_NAME ...")
-            (bob as OutOfProcess).process.destroyForcibly()
-            bob.stop()
+            val newParams = parameters.copy(
+                    packageOwnership = mapOf("net.corda.finance.contracts.asset" to packageOwnerKey)
+            )
+            listOf(alice, bob, notary).forEach { node ->
+                println("Shutting down the node for ${node} ... ")
+                (node as OutOfProcess).process.destroyForcibly()
+                node.stop()
+                NetworkParametersCopier(newParams, overwriteFile = true).install(node.baseDirectory)
+            }
+
+            startNode(providedName = defaultNotaryIdentity.name)
 
             println("Restarting the node for $ALICE_NAME ...")
             (baseDirectory(ALICE_NAME) / "cordapps").deleteRecursively()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -118,7 +118,7 @@ open class MockServices private constructor(
             val database = configureDatabase(dataSourceProps, DatabaseConfig(), identityService::wellKnownPartyFromX500Name, identityService::wellKnownPartyFromAnonymous, schemaService, schemaService.internalSchemas())
             val mockService = database.transaction {
                 object : MockServices(cordappLoader, identityService, networkParameters, initialIdentity, moreKeys) {
-                    override val networkParametersService: NetworkParametersService = MockNetworkParametersStorage(networkParameters)
+                    override var networkParametersService: NetworkParametersService = MockNetworkParametersStorage(networkParameters)
                     override val vaultService: VaultService = makeVaultService(schemaService, database, cordappLoader)
                     override fun recordTransactions(statesToRecord: StatesToRecord, txs: Iterable<SignedTransaction>) {
                         ServiceHubInternal.recordTransactions(statesToRecord, txs,
@@ -312,7 +312,7 @@ open class MockServices private constructor(
         it.start()
     }
     override val cordappProvider: CordappProvider get() = mockCordappProvider
-    override val networkParametersService: NetworkParametersService = MockNetworkParametersStorage(initialNetworkParameters)
+    override var networkParametersService: NetworkParametersService = MockNetworkParametersStorage(initialNetworkParameters)
 
     protected val servicesForResolution: ServicesForResolution
         get() = ServicesForResolutionImpl(identityService, attachments, cordappProvider, networkParametersService, validatedTransactions)


### PR DESCRIPTION
See: 
https://r3-cev.atlassian.net/browse/CORDA-2545

The current logic is making sure that there is at least 1 attachment added to the transaction that passes the package ownership check - for each owned contract.

Previously you could bypass the check by simply  attaching an unsigned jar, which goes against the package ownership rule. ( Once a package is owned, ANY jar that uses that package MUST be signed by the owner)

The reason for it is that the logic used a chaining of `filter{ it.isSigned }` and `forEach`( which returns `Unit`, so it would never trigger the last exception).

Had to also fix a couple of test as they were now failing on the correctly working package ownership check.
