### PR TITLE
Remove old reference to publishing a single corda finance jar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -363,7 +363,6 @@ bintrayConfig {
             'corda-deterministic-verifier',
             'corda-djvm',
             'corda',
-            'corda-finance',    // maintained for backwards compatibility only
             'corda-finance-workflows',
             'corda-finance-contracts',
             'corda-node',


### PR DESCRIPTION
Finance is no longer published as a single JAR.