### PR TITLE
CORDA-2423 document draining requirements in flow state machines

### DIFF
--- a/docs/source/flow-state-machines.rst
+++ b/docs/source/flow-state-machines.rst
@@ -385,6 +385,15 @@ suspended into a continuation and saved to persistent storage. If the node crash
 effectively continue as if nothing had happened. Your code may remain blocked inside such a call for seconds,
 minutes, hours or even days in the case of a flow that needs human interaction!
 
+Note that if a node has flows still in a suspended state, with flow continuations written to disk, it will not be
+possible to upgrade that node to a new version of Corda, because flows must be completely "drained" before an upgrade
+can be performed, and must reach a finished state for draining to complete (see :ref:`draining_the_node` for details).
+While there are mechanisms for "evolving" serialised data held in the vault, there are no equivalent mechanisms for
+updating serialised checkpoint data. For this reason it is not a good idea to design flows with the intention that
+they should remain in a suspended state for a long period of time, as this will obstruct necessary upgrades to Corda
+itself. Any long-running business process should therefore be structured as a series of discrete transactions, written
+to the vault, rather than a single flow persisted over time through the flow checkpointing mechanism.
+
 .. note:: There are a couple of rules you need to bear in mind when writing a class that will be used as a continuation.
    The first is that anything on the stack when the function is suspended will be stored into the heap and kept alive by
    the garbage collector. So try to avoid keeping enormous data structures alive unless you really have to.  You can

--- a/docs/source/flow-state-machines.rst
+++ b/docs/source/flow-state-machines.rst
@@ -385,15 +385,6 @@ suspended into a continuation and saved to persistent storage. If the node crash
 effectively continue as if nothing had happened. Your code may remain blocked inside such a call for seconds,
 minutes, hours or even days in the case of a flow that needs human interaction!
 
-Note that if a node has flows still in a suspended state, with flow continuations written to disk, it will not be
-possible to upgrade that node to a new version of Corda, because flows must be completely "drained" before an upgrade
-can be performed, and must reach a finished state for draining to complete (see :ref:`draining_the_node` for details).
-While there are mechanisms for "evolving" serialised data held in the vault, there are no equivalent mechanisms for
-updating serialised checkpoint data. For this reason it is not a good idea to design flows with the intention that
-they should remain in a suspended state for a long period of time, as this will obstruct necessary upgrades to Corda
-itself. Any long-running business process should therefore be structured as a series of discrete transactions, written
-to the vault, rather than a single flow persisted over time through the flow checkpointing mechanism.
-
 .. note:: There are a couple of rules you need to bear in mind when writing a class that will be used as a continuation.
    The first is that anything on the stack when the function is suspended will be stored into the heap and kept alive by
    the garbage collector. So try to avoid keeping enormous data structures alive unless you really have to.  You can
@@ -408,6 +399,17 @@ to the vault, rather than a single flow persisted over time through the flow che
    It's OK to keep references around to many large internal node services though: these will be serialised using a
    special token that's recognised by the platform, and wired up to the right instance when the continuation is
    loaded off disk again.
+
+.. warning:: If a node has flows still in a suspended state, with flow continuations written to disk, it will not be
+             possible to upgrade that node to a new version of Corda or your app, because flows must be completely "drained"
+             before an upgrade can be performed, and must reach a finished state for draining to complete (see
+             :ref:`draining_the_node` for details). While there are mechanisms for "evolving" serialised data held
+             in the vault, there are no equivalent mechanisms for updating serialised checkpoint data. For this
+             reason it is not a good idea to design flows with the intention that they should remain in a suspended
+             state for a long period of time, as this will obstruct necessary upgrades to Corda itself. Any
+             long-running business process should therefore be structured as a series of discrete transactions,
+             written to the vault, rather than a single flow persisted over time through the flow checkpointing
+             mechanism.
 
 ``receive`` and ``sendAndReceive`` return a simple wrapper class, ``UntrustworthyData<T>``, which is
 just a marker class that reminds us that the data came from a potentially malicious external source and may have been

--- a/docs/source/hello-world-flow.rst
+++ b/docs/source/hello-world-flow.rst
@@ -27,6 +27,15 @@ We also need the borrower to receive the transaction and record it for itself. A
 to approve and sign IOU issuance transactions. We will be able to impose this requirement when we look at contracts in the
 next tutorial.
 
+.. warning:: The execution of a flow is distributed in space and time, as the flow crosses node boundaries and each
+             participant may have to wait for other participants to respond before it can complete its part of the
+             overall work. While a node is waiting, the state of its flow may be persistently recorded to disk as a
+             restorable checkpoint, enabling it to carry on where it left off when a counterparty responds. However,
+             before a node can be upgraded to a newer version of Corda, or of your Cordapp, all flows must have
+             completed, as there is no mechanism to upgrade a persisted flow checkpoint. It is therefore undesirable
+             to model a long-running business process as a single flow: it should rather be broken up into a series
+             of transactions, with flows used only to orchestrate the completion of each transaction.
+
 Subflows
 ^^^^^^^^
 Tasks like recording a transaction or sending a transaction to a counterparty are very common in Corda. Instead of


### PR DESCRIPTION
Document the draining requirements for node upgrade in the flow state machines docs, explaining that while evolution of transaction data is supported, there is no equivalent mechanism for evolving persisted flow checkpoints.