### PR TITLE
Adding new page on UAT environment

### DIFF
--- a/docs/source/corda-network/UAT.md
+++ b/docs/source/corda-network/UAT.md
@@ -1,7 +1,7 @@
 Corda Network: UAT Environment
 =============================
 
-For owners of tested CorDapps with a firm plan to take them into production, a bespoke UAT environment can be provided by R3 (generally, a commercal agreement will need to be in place). Here, such CorDapps can be further tested in the network configuration they will experience in production, utilising relevant Corda Network Services (including the Identity Operator, and trusted notaries). 
+For owners of tested CorDapps with a firm plan to take them into production, a bespoke UAT environment is provided by R3 (generally, a commercal agreement will need to be in place). Here, such CorDapps can be further tested in the network configuration they will experience in production, utilising relevant Corda Network Services (including the Identity Operator, and trusted notaries). 
 
 Corda UAT is not intended for customers' full test cycles, as it is expected that the bulk of CorDapp testing will occur in simpler network configurations run by the CorDapp provider, but is available for testing of functionally complete and tested CorDapps in realistic network settings to simulate the real-world business environment, including the production settings of network parameters, Corda network services and supported Corda versions. 
 

--- a/docs/source/corda-network/UAT.md
+++ b/docs/source/corda-network/UAT.md
@@ -1,0 +1,10 @@
+Corda Network: UAT Environment
+=============================
+
+For owners of tested CorDapps with a firm plan to take them into production, a bespoke UAT environment can be provided by R3 (generally, a commercal agreement will need to be in place). Here, such CorDapps can be further tested in the network configuration they will experience in production, utilising relevant Corda Network Services (including the Identity Operator, and trusted notaries). 
+
+Corda UAT is not intended for customers' full test cycles, as it is expected that the bulk of CorDapp testing will occur in simpler network configurations run by the CorDapp provider, but is available for testing of functionally complete and tested CorDapps in realistic network settings to simulate the real-world business environment, including the production settings of network parameters, Corda network services and supported Corda versions. 
+
+UAT is therefore more aligned to the testing of the operational characteristics of networked CorDapps rather than their specific functional features, although we recognise there can be overlap between the two. Realistic test data is therefore expected to be used and may include data copied from production environments and hence representing real world entities and business activities. It will be up to the introducer of such data to ensure that all relevant data protection legislation is complied with and, in particular, that the terms and conditions under which Corda Network Services processes such data is suitable for their needs. All test data will be cleared down from Corda Network Services on the completion of testing.
+
+More information about UAT will continue to be uploaded on this site or related sub-sites.


### PR DESCRIPTION
We need to have an external page which talks about UAT. As agreed with R3's marketing team and the Network team, this should be on docs.corda.net rather than elsewhere. 

(The idea is that this cannot be corda.network since UAT is part of R3, not the Foundation.)

This page + relevant sub-pages will continue to be updated, with more detail.

