### PR TITLE
CORDA-2554 - Bootstrapper - option to include contracts to whitelist from signed JARs

### DIFF
--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -91,7 +91,8 @@ By default the Bootstrapper will whitelist all the contracts found in the unsign
 Whitelisted contracts are checked by `Zone constraints`, while contract classes from signed JARs will be checked by `Signature constraints`.
 To prevent certain contracts from unsigned JARs from being whitelisted, add their fully qualified class name in the ``exclude_whitelist.txt``.
 These will instead use the more restrictive ``HashAttachmentConstraint``.
-Refer to :doc:`api-contract-constraints` to understand the implication of different constraint types before adding ``exclude_whitelist.txt`` files.
+To add certain contracts from signed JARs from to whitelist, add their fully qualified class name in the ``include_whitelist.txt``.
+Refer to :doc:`api-contract-constraints` to understand the implication of different constraint types before adding ``exclude_whitelist.txt`` or ``include_whitelist.txt`` files.
 
 For example:
 

--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -91,7 +91,7 @@ By default the Bootstrapper will whitelist all the contracts found in the unsign
 Whitelisted contracts are checked by `Zone constraints`, while contract classes from signed JARs will be checked by `Signature constraints`.
 To prevent certain contracts from unsigned JARs from being whitelisted, add their fully qualified class name in the ``exclude_whitelist.txt``.
 These will instead use the more restrictive ``HashAttachmentConstraint``.
-To add certain contracts from signed JARs from to whitelist, add their fully qualified class name in the ``include_whitelist.txt``.
+To add certain contracts from signed JARs to whitelist, add their fully qualified class name in the ``include_whitelist.txt``.
 Refer to :doc:`api-contract-constraints` to understand the implication of different constraint types before adding ``exclude_whitelist.txt`` or ``include_whitelist.txt`` files.
 
 For example:

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -242,7 +242,8 @@ internal constructor(private val initSerEnv: Boolean,
             val notaryInfos = gatherNotaryInfos(nodeInfoFiles, configs)
             println("Generating contract implementations whitelist")
             // Only add contracts to the whitelist from unsigned jars
-            val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), cordappJars.filter { !isSigned(it) }.map(contractsJarConverter))
+            val signedJars = cordappJars.filter{ isSigned(it) }.map { it.hash }
+            val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), readIncludeWhitelist(directory), signedJars, cordappJars.map(contractsJarConverter))
             val newNetParams = installNetworkParameters(notaryInfos, newWhitelist, existingNetParams, nodeDirs, networkParametersOverrides)
             if (newNetParams != existingNetParams) {
                 println("${if (existingNetParams == null) "New" else "Updated"} $newNetParams")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -244,8 +244,8 @@ internal constructor(private val initSerEnv: Boolean,
             // Only add contracts to the whitelist from unsigned jars
             val signedJars = cordappJars.filter { isSigned(it) } // signed JARs are excluded by default, optionally include them
             val unsignedJars = cordappJars - signedJars
-            val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), readIncludeWhitelist(directory),
-                    unsignedJars.map(contractsJarConverter), signedJars.map(contractsJarConverter))
+            val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), unsignedJars.map(contractsJarConverter),
+                    readIncludeWhitelist(directory), signedJars.map(contractsJarConverter))
             val newNetParams = installNetworkParameters(notaryInfos, newWhitelist, existingNetParams, nodeDirs, networkParametersOverrides)
             if (newNetParams != existingNetParams) {
                 println("${if (existingNetParams == null) "New" else "Updated"} $newNetParams")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -242,8 +242,10 @@ internal constructor(private val initSerEnv: Boolean,
             val notaryInfos = gatherNotaryInfos(nodeInfoFiles, configs)
             println("Generating contract implementations whitelist")
             // Only add contracts to the whitelist from unsigned jars
-            val signedJars = cordappJars.filter{ isSigned(it) }.map { it.hash }
-            val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), readIncludeWhitelist(directory), signedJars, cordappJars.map(contractsJarConverter))
+            val signedJars = cordappJars.filter { isSigned(it) } // signed JARs are excluded by default, optionally include them
+            val unsignedJars = cordappJars - signedJars
+            val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), readIncludeWhitelist(directory),
+                    unsignedJars.map(contractsJarConverter), signedJars.map(contractsJarConverter))
             val newNetParams = installNetworkParameters(notaryInfos, newWhitelist, existingNetParams, nodeDirs, networkParametersOverrides)
             if (newNetParams != existingNetParams) {
                 println("${if (existingNetParams == null) "New" else "Updated"} $newNetParams")

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -242,7 +242,7 @@ internal constructor(private val initSerEnv: Boolean,
             val notaryInfos = gatherNotaryInfos(nodeInfoFiles, configs)
             println("Generating contract implementations whitelist")
             // Only add contracts to the whitelist from unsigned jars
-            val signedJars = cordappJars.filter { isSigned(it) } // signed JARs are excluded by default, optionally include them
+            val signedJars = cordappJars.filter { isSigned(it) } // signed JARs are excluded by default, optionally include them in order to transition states from CZ whitelist to signature constraint
             val unsignedJars = cordappJars - signedJars
             val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), unsignedJars.map(contractsJarConverter),
                     readIncludeWhitelist(directory), signedJars.map(contractsJarConverter))

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -241,7 +241,6 @@ internal constructor(private val initSerEnv: Boolean,
             println("Gathering notary identities")
             val notaryInfos = gatherNotaryInfos(nodeInfoFiles, configs)
             println("Generating contract implementations whitelist")
-            // Only add contracts to the whitelist from unsigned jars
             val signedJars = cordappJars.filter { isSigned(it) } // signed JARs are excluded by default, optionally include them in order to transition states from CZ whitelist to signature constraint
             val unsignedJars = cordappJars - signedJars
             val newWhitelist = generateWhitelist(existingNetParams, readExcludeWhitelist(directory), unsignedJars.map(contractsJarConverter),

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/WhitelistGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/WhitelistGenerator.kt
@@ -14,8 +14,8 @@ private val logger = LoggerFactory.getLogger("net.corda.nodeapi.internal.network
 
 fun generateWhitelist(networkParameters: NetworkParameters?,
                       excludeContracts: List<ContractClassName>,
-                      includeContracts: List<ContractClassName>,
                       cordappJars: List<ContractsJar>,
+                      includeContracts: List<ContractClassName>,
                       optionalCordappJars: List<ContractsJar>): Map<ContractClassName, List<AttachmentId>> {
     val existingWhitelist = networkParameters?.whitelistedContractImplementations ?: emptyMap()
 

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/WhitelistGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/WhitelistGenerator.kt
@@ -31,7 +31,7 @@ fun generateWhitelist(networkParameters: NetworkParameters?,
             .toMultiMap()
 
     if (includeContracts.isNotEmpty())
-        logger.info("Include any contracts from $INCLUDE_WHITELIST_FILE_NAME: ${includeContracts.joinToString()} for signed JARs.")
+        logger.info("Include any contracts from $INCLUDE_WHITELIST_FILE_NAME: ${includeContracts.joinToString()} present in JARs: $optionalCordappJars.")
 
     val newSignedJarsWhiteList = optionalCordappJars
             .flatMap { jar -> (jar.scan()).filter { includeContracts.contains(it) }.map { it to jar.hash } }

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/WhitelistGenerator.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/WhitelistGenerator.kt
@@ -20,7 +20,7 @@ fun generateWhitelist(networkParameters: NetworkParameters?,
     val existingWhitelist = networkParameters?.whitelistedContractImplementations ?: emptyMap()
 
     if (excludeContracts.isNotEmpty()) {
-        logger.info("Exclude contracts from $INCLUDE_WHITELIST_FILE_NAME: ${excludeContracts.joinToString()}")
+        logger.info("Exclude contracts from $EXCLUDE_WHITELIST_FILE_NAME: ${excludeContracts.joinToString()}")
         existingWhitelist.keys.forEach {
             require(it !in excludeContracts) { "$it is already part of the existing whitelist and cannot be excluded." }
         }
@@ -31,7 +31,7 @@ fun generateWhitelist(networkParameters: NetworkParameters?,
             .toMultiMap()
 
     if (includeContracts.isNotEmpty())
-        logger.info("Include any contracts from $INCLUDE_WHITELIST_FILE_NAME: ${includeContracts.joinToString()} present in JARs: $optionalCordappJars.")
+        logger.info("Include contracts from $INCLUDE_WHITELIST_FILE_NAME: ${includeContracts.joinToString()} present in JARs: $optionalCordappJars.")
 
     val newSignedJarsWhiteList = optionalCordappJars
             .flatMap { jar -> (jar.scan()).filter { includeContracts.contains(it) }.map { it to jar.hash } }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/WhitelistGeneratorTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/WhitelistGeneratorTest.kt
@@ -129,6 +129,8 @@ class WhitelistGeneratorTest {
         return generateWhitelist(
                 testNetworkParameters(whitelistedContractImplementations = existingWhitelist),
                 excludeContracts,
+                emptyList(),
+                emptyList(),
                 contractJars
         )
     }

--- a/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/WhitelistGeneratorTest.kt
+++ b/node-api/src/test/kotlin/net/corda/nodeapi/internal/network/WhitelistGeneratorTest.kt
@@ -129,9 +129,9 @@ class WhitelistGeneratorTest {
         return generateWhitelist(
                 testNetworkParameters(whitelistedContractImplementations = existingWhitelist),
                 excludeContracts,
+                contractJars,
                 emptyList(),
-                emptyList(),
-                contractJars
+                emptyList()
         )
     }
 }


### PR DESCRIPTION
For migration from CZ whitelist to Signature consorting, the signed JAR needs to be whitelisted, however bootstrapper doesn't whitelist contracts from signed jars, added additional "include_whitelist.txt" file which force adding contracts to whitelist from signed jars.