### PR TITLE
[CORDA-2499] Set default UnknownConfigKeysPolicy to IGNORE

### DIFF
--- a/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
+++ b/node/src/main/kotlin/net/corda/node/NodeCmdLineOptions.kt
@@ -40,7 +40,7 @@ open class SharedNodeCmdLineOptions {
             names = ["--on-unknown-config-keys"],
             description = ["How to behave on unknown node configuration. \${COMPLETION-CANDIDATES}"]
     )
-    var unknownConfigKeysPolicy: UnknownConfigKeysPolicy = UnknownConfigKeysPolicy.FAIL
+    var unknownConfigKeysPolicy: UnknownConfigKeysPolicy = UnknownConfigKeysPolicy.IGNORE
 
     @Option(
             names = ["-d", "--dev-mode"],


### PR DESCRIPTION
Since Corda v4, the Corda node fails to start up by default if unknown configuration is found in the node.conf file.

It's been added to stop confusion for new developers, but it's causing backwards compatbility issues.

There was also an additional option `WARN` alongside `FAIL` and `IGNORE`, but that seems to have disappeared. That would have been a better default. It sort of makes the whole option redundant now if it's going back to the old way. Not sure whether it would be better to delete it altogether.