### PR TITLE
Fix documentation issues

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -67,10 +67,13 @@ task buildDocs(dependsOn: ['apidocs', 'makeDocs'])
 task apidocs(dependsOn: ['dokka', 'dokkaJavadoc'])
 
 task makeDocs(type: Exec) {
+    // 2 volumes are mounted:
+    //  - the docs project to /opt/docs_builder, where docs building is executed
+    //  - the rest of the projects in /opt, so that code references to other projects are valid
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine "docker", "run", "--rm", "-v", "${project.projectDir}:/opt/docs_builder", "corda/docs-builder:latest", "bash", "-c", "make-docsite.sh"
+        commandLine "docker", "run", "--rm", "-v", "${project.projectDir}:/opt/docs_builder", "-v", "${project.projectDir}/..:/opt", "corda/docs-builder:latest", "bash", "-c", "make-docsite.sh"
     } else {
-        commandLine "bash", "-c",  "docker run --rm --user \$(id -u):\$(id -g) -v ${project.projectDir}:/opt/docs_builder corda/docs-builder:latest bash -c make-docsite.sh"
+        commandLine "bash", "-c",  "docker run --rm --user \$(id -u):\$(id -g) -v ${project.projectDir}:/opt/docs_builder -v ${project.projectDir}/..:/opt corda/docs-builder:latest bash -c make-docsite.sh"
     }
 }
 

--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -829,7 +829,7 @@ complicated).
 For example, the ``finance`` package currently uses ``FlowLogic.sleep`` to make several attempts at coin selection when 
 many states are soft locked, to wait for states to become unlocked:
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/workflows/asset/selection/AbstractCashSelection.kt
         :language: kotlin
         :start-after: DOCSTART CASHSELECT 1
         :end-before: DOCEND CASHSELECT 1

--- a/docs/source/api-identity.rst
+++ b/docs/source/api-identity.rst
@@ -73,7 +73,7 @@ You can see an example of using ``SwapIdentitiesFlow`` in ``TwoPartyDealFlow.kt`
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
         :language: kotlin
         :start-after: DOCSTART 2
         :end-before: DOCEND 2
@@ -108,7 +108,7 @@ process. You can see an example of its use in ``TwoPartyTradeFlow.kt``.
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
         :language: kotlin
         :start-after: DOCSTART 6
         :end-before: DOCEND 6
@@ -136,7 +136,7 @@ synchronization process:
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
         :language: kotlin
         :start-after: DOCSTART 07
         :end-before: DOCEND 07

--- a/docs/source/api-persistence.rst
+++ b/docs/source/api-persistence.rst
@@ -82,7 +82,7 @@ other ``MappedSchema``.
 Custom schema registration
 --------------------------
 Custom contract schemas are automatically registered at startup time for CorDapps. The node bootstrap process will scan for states that implement
-the Queryable state interface. Tables are then created as specified by the ``MappedSchema``s identified by each states ``supportedSchemas`` method.
+the Queryable state interface. Tables are then created as specified by the ``MappedSchema`` identified by each state's ``supportedSchemas`` method.
 
 For testing purposes it is necessary to manually register the packages containing custom schemas as follows:
 
@@ -107,8 +107,10 @@ the ``MappedTypes`` parameter. It must provide this list in order to initialise 
 Several examples of entities and mappings are provided in the codebase, including ``Cash.State`` and
 ``CommercialPaper.State``. For example, here's the first version of the cash schema.
 
-.. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt
-    :language: kotlin
+.. container:: codeset
+
+    .. literalinclude:: ../../finance/contracts/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt
+        :language: kotlin
 
 .. note:: If Cordapp needs to be portable between Corda OS (running against H2) and Corda Enterprise (running against a standalone database),
           consider database vendors specific requirements.
@@ -124,7 +126,7 @@ You may wish to persist hierarchical relationships within state data using multi
 subclasses may be implemented. The relationship between these classes is defined using JPA annotations. It is important to note that the ``MappedSchema``
 constructor requires a list of *all* of these subclasses.
 
-An example Schema implementing hierarchical relationships with JPA annotations has been implemented below. This Schema will cause ``parent_data`` and ``child_data` tables to be
+An example Schema implementing hierarchical relationships with JPA annotations has been implemented below. This Schema will cause ``parent_data`` and ``child_data`` tables to be
 created.
 
 .. container:: codeset

--- a/docs/source/api-states.rst
+++ b/docs/source/api-states.rst
@@ -155,7 +155,7 @@ and methods. For example, here is the relatively complex definition for a state 
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
         :language: kotlin
         :start-after: DOCSTART 1
         :end-before: DOCEND 1

--- a/docs/source/tutorial-attachments.rst
+++ b/docs/source/tutorial-attachments.rst
@@ -105,7 +105,7 @@ and if so, printed out.
 
 .. container:: codeset
 
-    .. literalinclude:: ../../samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+    .. literalinclude:: ../../samples/attachment-demo/workflows/src/main/kotlin/net/corda/attachmentdemo/workflows/AttachmentDemo.kt
         :language: kotlin
         :start-after: DOCSTART 1
         :end-before: DOCEND 1
@@ -115,7 +115,7 @@ transaction and send it to the recipient node:
 
 .. container:: codeset
 
-    .. literalinclude:: ../../samples/attachment-demo/src/main/kotlin/net/corda/attachmentdemo/AttachmentDemo.kt
+    .. literalinclude:: ../../samples/attachment-demo/workflows/src/main/kotlin/net/corda/attachmentdemo/workflows/AttachmentDemo.kt
         :language: kotlin
         :start-after: DOCSTART 2
         :end-before: DOCEND 2


### PR DESCRIPTION
### Changes

This fixes some issues with documentation:

* Added the rest of the projects as a second volume in the Docker used, so that code references to the other projects are successfully resolved. Attempted to do the same with a single mount, but got defeated, because of the way the Docker image is currently setup to execute the build process in the `/opt/docs_builder` path.
* Renamed some references to some projects that have been refactored (i.e. `finance`), so that they are valid
* Fixed some small typos/syntax issues in `api-persistence.rst`

Note: I'll have a look if these issues exist in the `release/4` and backport, if needed.

### Testing
`./gradlew makeDocs` and verified all the links are resolved