### PR TITLE
CORDA-2564: Ensure that corda-serialization uses @JvmDefault for interfaces.

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/OrdinalIO.kt
@@ -11,7 +11,7 @@ class OrdinalBits(private val ordinal: Int) {
     @KeepForDJVM
     interface OrdinalWriter {
         val bits: OrdinalBits
-        @JvmDefault val encodedSize get() = 1
+        @JvmDefault val encodedSize: Int get() = 1
         @JvmDefault fun writeTo(stream: OutputStream) = stream.write(bits.ordinal)
         @JvmDefault fun putTo(buffer: ByteBuffer) = buffer.put(bits.ordinal.toByte())!!
     }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/LocalSerializerFactory.kt
@@ -39,6 +39,7 @@ interface LocalSerializerFactory {
     /**
      * Obtain an [AMQPSerializer] for the [declaredType].
      */
+    @JvmDefault
     fun get(declaredType: Type): AMQPSerializer<Any> = get(getTypeInformation(declaredType))
 
     /**
@@ -61,6 +62,7 @@ interface LocalSerializerFactory {
     /**
      * Use the [FingerPrinter] to create a type descriptor for the given [type].
      */
+    @JvmDefault
     fun createDescriptor(type: Type): Symbol = createDescriptor(getTypeInformation(type))
 
     /**


### PR DESCRIPTION
Kotlin will put an interface's default methods into a nested `$DefaultImpls` class unless those methods are annotated with `@JvmDefault`. The "determinisation" process cannot guarantee to preserve any `$DefaultImpls` classes, and so it's safer if they're not required at all.

Ensure that Kotlin implements interface default methods as standard Java 8.