### PR TITLE
DOCS - Fix some broken references in documentation

### DIFF
--- a/docs/source/api-flows.rst
+++ b/docs/source/api-flows.rst
@@ -829,7 +829,7 @@ complicated).
 For example, the ``finance`` package currently uses ``FlowLogic.sleep`` to make several attempts at coin selection when 
 many states are soft locked, to wait for states to become unlocked:
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/contracts/asset/cash/selection/AbstractCashSelection.kt
+    .. literalinclude:: ../../finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/AbstractCashSelection.kt
         :language: kotlin
         :start-after: DOCSTART CASHSELECT 1
         :end-before: DOCEND CASHSELECT 1

--- a/docs/source/api-identity.rst
+++ b/docs/source/api-identity.rst
@@ -73,7 +73,7 @@ You can see an example of using ``SwapIdentitiesFlow`` in ``TwoPartyDealFlow.kt`
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt
         :language: kotlin
         :start-after: DOCSTART 2
         :end-before: DOCEND 2
@@ -108,7 +108,7 @@ process. You can see an example of its use in ``TwoPartyTradeFlow.kt``.
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
         :language: kotlin
         :start-after: DOCSTART 6
         :end-before: DOCEND 6
@@ -136,7 +136,7 @@ synchronization process:
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
+    .. literalinclude:: ../../finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt
         :language: kotlin
         :start-after: DOCSTART 07
         :end-before: DOCEND 07

--- a/docs/source/api-persistence.rst
+++ b/docs/source/api-persistence.rst
@@ -82,7 +82,7 @@ other ``MappedSchema``.
 Custom schema registration
 --------------------------
 Custom contract schemas are automatically registered at startup time for CorDapps. The node bootstrap process will scan for states that implement
-the Queryable state interface. Tables are then created as specified by the ``MappedSchema``s identified by each states ``supportedSchemas`` method.
+the Queryable state interface. Tables are then created as specified by the ``MappedSchema`` identified by each states ``supportedSchemas`` method.
 
 For testing purposes it is necessary to manually register the packages containing custom schemas as follows:
 
@@ -107,7 +107,7 @@ the ``MappedTypes`` parameter. It must provide this list in order to initialise 
 Several examples of entities and mappings are provided in the codebase, including ``Cash.State`` and
 ``CommercialPaper.State``. For example, here's the first version of the cash schema.
 
-.. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt
+.. literalinclude:: ../../finance/contracts/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt
     :language: kotlin
 
 .. note:: If Cordapp needs to be portable between Corda OS (running against H2) and Corda Enterprise (running against a standalone database),

--- a/docs/source/api-states.rst
+++ b/docs/source/api-states.rst
@@ -155,7 +155,7 @@ and methods. For example, here is the relatively complex definition for a state 
 
 .. container:: codeset
 
-    .. literalinclude:: ../../finance/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
+    .. literalinclude:: ../../finance/contracts/src/main/kotlin/net/corda/finance/contracts/asset/Cash.kt
         :language: kotlin
         :start-after: DOCSTART 1
         :end-before: DOCEND 1


### PR DESCRIPTION
This fixes some broken code references, which were caused by the refactoring of the `finance` module.