### PR TITLE
Revert "DOCS - correct command docs for clear network map cache (#4677)"

### DIFF
--- a/docs/source/network-map.rst
+++ b/docs/source/network-map.rst
@@ -236,7 +236,7 @@ you either need to run from the command line:
 
 .. code-block:: shell
 
-    java -jar corda.jar --clear-network-map-cache
+    java -jar corda.jar clear-network-cache
 
 or call RPC method `clearNetworkMapCache` (it can be invoked through the node's shell as `run clearNetworkMapCache`, for more information on
 how to log into node's shell see :doc:`shell`). As we are testing and hardening the implementation this step shouldn't be required.


### PR DESCRIPTION
This reverts commit 0a50d76ab18c19682eea54b54bb1e03137a4b78d.

Reverting this change which is not the correct command for v4 (the old command will work but is deprecated). The issue occurred because that flag was missing altogether in the v3 docs - have created a Jira for someone to https://r3-cev.atlassian.net/browse/CORDA-2571 add it.
