### PR TITLE
[CORDA-2420] - Make boundary of public API explicit in docs

### DIFF
--- a/docs/source/corda-api.rst
+++ b/docs/source/corda-api.rst
@@ -23,16 +23,21 @@ Before reading this page, you should be familiar with the :doc:`key concepts of 
 
 .. _internal-apis-and-stability-guarantees:
 
-Internal APIs and stability guarantees
+API stability guarantees
 --------------------------------------
 
 Corda makes certain commitments about what parts of the API will preserve backwards compatibility as they change and
-which will not. Over time, more of the API will fall under the stability guarantees.
+which will not. Over time, more of the API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
 
-Corda stable modules
---------------------
+* **public APIs**, for which API/`ABI <https://en.wikipedia.org/wiki/Application_binary_interface>`_ backwards compatibility guarantees are provided. See: :ref:`public-api`
+* **non-public APIs**, for which no backwards compatibility guarantees are provided. See: :ref:`non-public-api`
 
-The following modules have a stable API we commit not to break in following releases, unless an incompatible change is required for security reasons:
+.. _public-api:
+
+Public API
+----------
+
+The following modules form part of Corda's public API and we commit to API/ABI backwards compatibility in following releases, unless an incompatible change is required for security reasons:
 
 * **Core (net.corda.core)**: core Corda libraries such as crypto functions, types for Corda's building blocks: states, contracts, transactions, attachments, etc. and some interfaces for nodes and protocols
 * **Client RPC (net.corda.client.rpc)**: client RPC
@@ -44,11 +49,18 @@ The following modules have a stable API we commit not to break in following rele
 * **Dummy Contracts (net.corda.testing.contracts)**: dummy state and contracts for testing purposes
 * **Mock Services (net.corda.testing.services)**: mock service implementations for testing purposes
 
-Corda incubating modules
-------------------------
+.. _non-public-api:
 
-The following modules don't yet have a completely stable API, but we will do our best to minimise disruption to
-developers using them until we are able to graduate them into the public API:
+Non-public API (experimental)
+-----------------------------
+
+The following modules are not part of the Corda's public API and no backwards compatibility guarantees are provided. They are further categorized in 2 classes:
+
+* the incubating modules, for which we will do our best to minimise disruption to developers using them until we are able to graduate them into the public API
+* the unstable modules, which are available but we do not commit to their stability or continuation in any sense
+
+Corda incubating modules
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **net.corda.confidential**: experimental support for confidential identities on the ledger
 * **net.corda.finance**: a range of elementary contracts (and associated schemas) and protocols, such as abstract fungible assets, cash, obligation and commercial paper
@@ -57,9 +69,7 @@ developers using them until we are able to graduate them into the public API:
 * **Cordformation**: Gradle integration plugins
 
 Corda unstable modules
-----------------------
-
-The following modules are available but we do not commit to their stability or continuation in any sense:
+~~~~~~~~~~~~~~~~~~~~~~
 
 * **net.corda.buildSrc**: necessary gradle plugins to build Corda
 * **net.corda.node**: core code of the Corda node (eg: node driver, node services, messaging, persistence)


### PR DESCRIPTION
This change makes the difference between public/non-public a bit more explicit in the documentation.

Notes:
* I was thinking of adding links for the modules to Github for a better experience, but I refrained. The reason is that modules will move around and links could go stale, until we take the burden of updating them on every release, instead of having them point to `master`. Open to any alternative ideas of how it could be done, though.