### PR TITLE
Add a gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
+# See https://help.github.com/articles/dealing-with-line-endings/
+*.sh text eol=lf


### PR DESCRIPTION
Add a gitattributes file to make sure docker docs builds work on windows - otherwise the windows line endings make bash in docker very sad.
