### PR TITLE
[CORDA-2851] - Fix the way serialization whitelist is calculated for CordappImpl

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
@@ -41,7 +41,7 @@ data class CordappImpl(
 
     // TODO: Also add [SchedulableFlow] as a Cordapp class
     override val cordappClasses: List<String> = run {
-        val classList = rpcFlows + initiatedFlows + services + serializationWhitelists.map { javaClass } + notaryService
+        val classList = rpcFlows + initiatedFlows + services + serializationWhitelists.flatMap { it.whitelist } + notaryService
         classList.mapNotNull { it?.name } + contractClassNames + explicitCordappClasses
     }
 

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
@@ -117,7 +117,7 @@ class JarScanningCordappLoaderTest {
         val jar = JarScanningCordappLoaderTest::class.java.getResource("versions/min-2-no-target.jar")!!
         val loader = JarScanningCordappLoader.fromJarUrls(listOf(jar), VersionInfo.UNKNOWN)
         // exclude the core cordapp
-        val cordapp = loader.cordapps.single { it.cordappClasses.contains("net.corda.core.internal.cordapp.CordappImpl") }
+        val cordapp = loader.cordapps.first()
         assertThat(cordapp.targetPlatformVersion).isEqualTo(2)
         assertThat(cordapp.minimumPlatformVersion).isEqualTo(2)
     }

--- a/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
+++ b/node/src/test/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoaderTest.kt
@@ -66,6 +66,18 @@ class JarScanningCordappLoaderTest {
     }
 
     @Test
+    fun `constructed CordappImpl contains the right cordapp classes`() {
+        val isolatedJAR = JarScanningCordappLoaderTest::class.java.getResource("/isolated.jar")
+        val loader = JarScanningCordappLoader.fromJarUrls(listOf(isolatedJAR))
+
+        val actualCordapp = loader.cordapps.single()
+        val cordappClasses = actualCordapp.cordappClasses
+        assertThat(cordappClasses).contains(isolatedFlowName)
+        val serializationWhitelistedClasses = actualCordapp.serializationWhitelists.flatMap { it.whitelist }.map { it.name }
+        assertThat(cordappClasses).containsAll(serializationWhitelistedClasses)
+    }
+
+    @Test
     fun `flows are loaded by loader`() {
         val jarFile = cordappWithPackages(javaClass.packageName).jarFile
         val loader = JarScanningCordappLoader.fromJarUrls(listOf(jarFile.toUri().toURL()))


### PR DESCRIPTION
### Changes
This change includes the actual whitelisted classes in the set of all classes of a cordapp.

### Testing
* Added a unit test that was previously failing, because the name of the `CordappImpl` was added, instead of the actual set of whitelisted classes.