### PR TITLE
CORDA-2576 Viral update propagation: select attachments from those loaded by node on startup.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -234,8 +234,12 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
             // TODO - should this be a [TransactionVerificationException]?
             val missingClass = requireNotNull(e.message) { "Transaction $ltx is incorrectly formed." }
 
-            val attachment = requireNotNull(services.attachments.internalFindTrustedAttachmentForClass(missingClass)) {
+            val attachmentId = requireNotNull(services.cordappProvider.getContractAttachmentID(missingClass)) {
                 "Transaction $ltx is incorrectly formed. Could not find local dependency for class: $missingClass."
+            }
+
+            val attachment = requireNotNull(services.attachments.openAttachment(attachmentId)) {
+                "Transaction $ltx is incorrectly formed. Could not open local dependency for class: $missingClass."
             }
 
             log.warn("""Detected that transaction ${this.id} does not contain all cordapp dependencies.

--- a/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt
@@ -234,12 +234,8 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
             // TODO - should this be a [TransactionVerificationException]?
             val missingClass = requireNotNull(e.message) { "Transaction $ltx is incorrectly formed." }
 
-            val attachmentId = requireNotNull(services.cordappProvider.getContractAttachmentID(missingClass)) {
+            val attachment = requireNotNull(services.attachments.internalFindTrustedAttachmentForClass(missingClass)) {
                 "Transaction $ltx is incorrectly formed. Could not find local dependency for class: $missingClass."
-            }
-
-            val attachment = requireNotNull(services.attachments.openAttachment(attachmentId)) {
-                "Transaction $ltx is incorrectly formed. Could not open local dependency for class: $missingClass."
             }
 
             log.warn("""Detected that transaction ${this.id} does not contain all cordapp dependencies.

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -175,15 +175,15 @@ open class TransactionBuilder(
             val missingClass = e.message
             requireNotNull(missingClass) { "Transaction is incorrectly formed." }
 
-            val attachment = services.attachments.internalFindTrustedAttachmentForClass(missingClass!!)
+            val attachmentId = services.cordappProvider.getContractAttachmentID(missingClass!!)
                     ?: throw IllegalArgumentException("Attempted to find dependent attachment for class $missingClass, but could not find a suitable candidate.")
 
             log.warnOnce("""The transaction currently built is missing an attachment for class: $missingClass.
-                    Automatically attaching contract dependency $attachment.
+                    Automatically attaching contract dependency $attachmentId.
                     It is strongly recommended to check that this is the desired attachment, and to manually add it to the transaction builder.
                 """.trimIndent())
 
-            addAttachment(attachment.id)
+            addAttachment(attachmentId)
             return true
             // Ignore these exceptions as they will break unit tests.
             //  The point here is only to detect missing dependencies. The other exceptions are irrelevant.
@@ -442,7 +442,7 @@ open class TransactionBuilder(
         require(isReference || constraints.none { it is HashAttachmentConstraint })
 
         val minimumRequiredContractClassVersion = stateRefs?.map { services.loadContractAttachment(it).contractVersion }?.max() ?: DEFAULT_CORDAPP_VERSION
-        return services.attachments.getLatestContractAttachments(contractClassName, minimumRequiredContractClassVersion).firstOrNull()
+        return services.cordappProvider.getContractAttachmentID(contractClassName)
                 ?: throw MissingContractAttachments(states, contractClassName, minimumRequiredContractClassVersion)
     }
 

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -441,9 +441,8 @@ open class TransactionBuilder(
         require(constraints.none { it in automaticConstraints })
         require(isReference || constraints.none { it is HashAttachmentConstraint })
 
-        val minimumRequiredContractClassVersion = stateRefs?.map { services.loadContractAttachment(it).contractVersion }?.max() ?: DEFAULT_CORDAPP_VERSION
         return services.cordappProvider.getContractAttachmentID(contractClassName)
-                ?: throw MissingContractAttachments(states, contractClassName, minimumRequiredContractClassVersion)
+                ?: throw MissingContractAttachments(states, contractClassName)
     }
 
     private fun useWhitelistedByZoneAttachmentConstraint(contractClassName: ContractClassName, networkParameters: NetworkParameters) = contractClassName in networkParameters.whitelistedContractImplementations.keys

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt
@@ -175,15 +175,15 @@ open class TransactionBuilder(
             val missingClass = e.message
             requireNotNull(missingClass) { "Transaction is incorrectly formed." }
 
-            val attachmentId = services.cordappProvider.getContractAttachmentID(missingClass!!)
+            val attachment = services.attachments.internalFindTrustedAttachmentForClass(missingClass!!)
                     ?: throw IllegalArgumentException("Attempted to find dependent attachment for class $missingClass, but could not find a suitable candidate.")
 
             log.warnOnce("""The transaction currently built is missing an attachment for class: $missingClass.
-                    Automatically attaching contract dependency $attachmentId.
+                    Automatically attaching contract dependency $attachment.
                     It is strongly recommended to check that this is the desired attachment, and to manually add it to the transaction builder.
                 """.trimIndent())
 
-            addAttachment(attachmentId)
+            addAttachment(attachment.id)
             return true
             // Ignore these exceptions as they will break unit tests.
             //  The point here is only to detect missing dependencies. The other exceptions are irrelevant.

--- a/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
+++ b/node/src/integration-test/kotlin/net/corda/contracts/SignatureConstraintVersioningTests.kt
@@ -11,7 +11,6 @@ import net.corda.core.internal.div
 import net.corda.core.internal.packageName
 import net.corda.core.messaging.startFlow
 import net.corda.core.transactions.LedgerTransaction
-import net.corda.core.transactions.MissingContractAttachments
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
@@ -23,15 +22,12 @@ import net.corda.testMessage.MessageState
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.driver.NodeParameters
-import net.corda.testing.driver.internal.incrementalPortAllocation
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.cordappWithPackages
 import net.corda.testing.node.internal.internalDriver
 import org.junit.Assume.assumeFalse
 import org.junit.Test
-import java.sql.DriverManager
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 class SignatureConstraintVersioningTests {
@@ -82,57 +78,6 @@ class SignatureConstraintVersioningTests {
         }
         assertNotNull(stateAndRef)
         assertEquals(transformetMessage, stateAndRef!!.state.data.message)
-    }
-
-    @Test
-    fun `cannot evolve from higher contract class version to lower one`() {
-        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win")) // See NodeStatePersistenceTests.kt.
-
-        val port = incrementalPortAllocation(21_000).nextPort()
-
-        val stateAndRef: StateAndRef<MessageState>? = internalDriver(inMemoryDB = false,
-                startNodesInProcess = isQuasarAgentSpecified(),
-                networkParameters = testNetworkParameters(notaries = emptyList(), minimumPlatformVersion = 4)) {
-            val nodeName = {
-                val nodeHandle = startNode(NodeParameters(rpcUsers = listOf(user), additionalCordapps = listOf(newCordapp)),
-                        customOverrides = mapOf("h2Settings.address" to "localhost:$port")).getOrThrow()
-                val nodeName = nodeHandle.nodeInfo.singleIdentity().name
-                CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-                    it.proxy.startFlow(::CreateMessage, message, defaultNotaryIdentity).returnValue.getOrThrow()
-                }
-                nodeHandle.stop()
-                nodeName
-            }()
-            val result = {
-                (baseDirectory(nodeName) / "cordapps").deleteRecursively()
-                val nodeHandle = startNode(NodeParameters(providedName = nodeName, rpcUsers = listOf(user), additionalCordapps = listOf(oldCordapp)),
-                        customOverrides = mapOf("h2Settings.address" to "localhost:$port")).getOrThrow()
-
-                //set the attachment with newer version (3) as untrusted one so the node can use only the older attachment with version 2
-                DriverManager.getConnection("jdbc:h2:tcp://localhost:$port/node", "sa", "").use {
-                    it.createStatement().execute("UPDATE NODE_ATTACHMENTS SET UPLOADER = 'p2p' WHERE VERSION = 3")
-                }
-                var result: StateAndRef<MessageState>? = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-                    val page = it.proxy.vaultQuery(MessageState::class.java)
-                    page.states.singleOrNull()
-                }
-
-                CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-                    assertFailsWith(MissingContractAttachments::class) {
-                        it.proxy.startFlow(::ConsumeMessage, result!!, defaultNotaryIdentity).returnValue.getOrThrow()
-                    }
-                }
-                result = CordaRPCClient(nodeHandle.rpcAddress).start(user.username, user.password).use {
-                    val page = it.proxy.vaultQuery(MessageState::class.java)
-                    page.states.singleOrNull()
-                }
-                nodeHandle.stop()
-                result
-            }()
-            result
-        }
-        assertNotNull(stateAndRef)
-        assertEquals(message, stateAndRef!!.state.data.message)
     }
 }
 


### PR DESCRIPTION
Adjust the way we select attachments so we don't use the latest known version but rather, the installed version (stop viral propagation)