### PR TITLE
[CORDA-2512] - Adjust uploadAttachmentWithMetadata RPC to use privile…

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -210,7 +210,7 @@ internal class CordaRPCOpsImpl(
     }
 
     override fun uploadAttachmentWithMetadata(jar: InputStream, uploader: String, filename: String): SecureHash {
-        return services.attachments.importAttachment(jar, uploader, filename)
+        return services.attachments.privilegedImportAttachment(jar, uploader, filename)
     }
 
     override fun queryAttachments(query: AttachmentQueryCriteria, sorting: AttachmentSort?): List<AttachmentId> {

--- a/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
+++ b/node/src/test/kotlin/net/corda/node/CordaRPCOpsImplTest.kt
@@ -15,6 +15,7 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.identity.Party
+import net.corda.core.internal.RPC_UPLOADER
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.messaging.*
 import net.corda.core.node.services.StatesNotAvailableException
@@ -330,6 +331,15 @@ class CordaRPCOpsImplTest {
                     ), null
                 ).size, 1
             )
+        }
+    }
+
+    @Test
+    fun `attachment uploaded with metadata can be from a privileged user`() {
+        withPermissions(invokeRpc(CordaRPCOps::uploadAttachmentWithMetadata), invokeRpc(CordaRPCOps::attachmentExists)) {
+            val inputJar = Thread.currentThread().contextClassLoader.getResourceAsStream(testJar)
+            val secureHash = rpc.uploadAttachmentWithMetadata(inputJar, RPC_UPLOADER, "Season 1")
+            assertTrue(rpc.attachmentExists(secureHash))
         }
     }
 


### PR DESCRIPTION
Adjust `uploadWithMetadata` RPC to use privileged import, so that users can perform uploads with one of the privileged users (i.e. `rpc`). See ticket for more details on the reason behind that.