### PR TITLE
Clarify error message when Node does not have the requested identity

### DIFF
--- a/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt
+++ b/core/src/main/kotlin/net/corda/core/node/NodeInfo.kt
@@ -47,6 +47,9 @@ data class NodeInfo(val addresses: List<NetworkHostAndPort>,
     /** Returns true if [party] is one of the identities of this node, else false. */
     fun isLegalIdentity(party: Party): Boolean = party in legalIdentities
 
+    /** Returns true if [name] matches one of the identities of this node, else false. */
+    fun isLegalIdentity(name: CordaX500Name): Boolean = legalIdentities.any { it.name == name }
+
     /**
      * Get a legal identity of this node from the X.500 name. This is intended for use in cases where the node is
      * expected to have a matching identity, and will throw an exception if no match is found.
@@ -62,6 +65,7 @@ data class NodeInfo(val addresses: List<NetworkHostAndPort>,
      * @throws IllegalArgumentException if the node has no matching identity.
      */
     fun identityAndCertFromX500Name(name: CordaX500Name): PartyAndCertificate {
-        return legalIdentitiesAndCerts.singleOrNull { it.name == name } ?: throw IllegalArgumentException("Node does not have an identity \"$name\"")
+        return legalIdentitiesAndCerts.singleOrNull { it.name == name }
+                ?: throw IllegalArgumentException("Node does not have the requested identity of \"$name\"")
     }
 }

--- a/core/src/test/kotlin/net/corda/core/node/NodeInfoTests.kt
+++ b/core/src/test/kotlin/net/corda/core/node/NodeInfoTests.kt
@@ -1,0 +1,44 @@
+package net.corda.core.node
+
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.testing.core.TestIdentity
+import net.corda.testing.core.getTestPartyAndCertificate
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NodeInfoTests {
+
+    private val party1 = TestIdentity.fresh("party1").party
+    private val party2 = TestIdentity.fresh("party2").party
+
+    private lateinit var testNode: NodeInfo
+
+    @Before
+    fun setup() {
+        testNode = NodeInfo(
+                addresses = listOf(
+                        NetworkHostAndPort("127.0.0.1", 10000)
+                ),
+                legalIdentitiesAndCerts = listOf(
+                        getTestPartyAndCertificate(party1),
+                        getTestPartyAndCertificate(party2)
+                ),
+                platformVersion = 4,
+                serial = 0
+        )
+    }
+
+    @Test
+    fun `should return true when the X500Name is present on the node`() {
+        assertTrue(testNode.isLegalIdentity(party1.name), "Party 1 must exist on the node")
+        assertTrue(testNode.isLegalIdentity(party2.name), "Party 2 must exist on the node")
+    }
+
+    @Test
+    fun `should return false when the X500Name is not present on the node`() {
+        assertFalse(testNode.isLegalIdentity(TestIdentity.fresh("party3").name),
+                "Party 3 must not exist on the node")
+    }
+}


### PR DESCRIPTION
Simple change to the message returned when the requested legal identity does not exist on the Node. Previously it returned `Node does not have an identity`, which is slightly confusing as the Node does have a legal identity, just not the one that was requested. Changing the message text to `Node does not have the requested identity of` makes it clearer that the client requested an identity different to any of the ones that this Node represents.

Added an `isLegalIdentity` function that allows the client to check if the Node represents the requested `CordaX500Name` without throwing an exception if it does not.

My PR is in accordance with the Developer Certificate of Origin

Note that there are failures in the `H2SecurityTests` due to `Expected an exception of class net.corda.nodeapi.internal.persistence.CouldNotCreateDataSourceException to be thrown, but was completed successfully.`. However I don't currently see how these test failures could be connected to the PR.

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [X] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [X] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://github.com/corda/corda/blob/master/docs/source/changelog.rst), and potentially the [release notes](https://github.com/corda/corda/blob/master/docs/source/release-notes.rst)?
- [X] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/corda/corda/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Thanks for your code, it's appreciated! :)
