### PR TITLE
[CORDA-2561] Use the attachments classloader to deserialise contract states in migrations

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -1,8 +1,5 @@
 package net.corda.core.serialization.internal
 
-import net.corda.core.CordaException
-import net.corda.core.CordaInternal
-import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
 import net.corda.core.contracts.TransactionVerificationException

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -1,6 +1,7 @@
 package net.corda.core.serialization.internal
 
 import net.corda.core.CordaException
+import net.corda.core.CordaInternal
 import net.corda.core.KeepForDJVM
 import net.corda.core.contracts.Attachment
 import net.corda.core.contracts.ContractAttachment
@@ -259,7 +260,7 @@ class AttachmentsClassLoader(attachments: List<Attachment>,
  * whitelisted classes.
  */
 @VisibleForTesting
-internal object AttachmentsClassLoaderBuilder {
+object AttachmentsClassLoaderBuilder {
     private const val CACHE_SIZE = 1000
 
     // We use a set here because the ordering of attachments doesn't affect code execution, due to the no

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -272,6 +272,8 @@ We have open sourced the Liquibase schema upgrade feature from Corda Enterprise.
 bootstrap and update itself automatically. This is a transparent change with pre Corda 4 nodes seamlessly
 upgrading to operate as if they'd been bootstrapped in this way. This also applies to the finance CorDapp module.
 
+.. important:: If you're upgrading a node from Corda 3 to Corda 4 and there is old data in the vault, this upgrade may take some time, depending on the number of unconsumed states in the vault.
+
 Ability to pre-validate configuration files
 +++++++++++++++++++++++++++++++++++++++++++
 

--- a/node/src/main/kotlin/net/corda/node/migration/CordaMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/CordaMigration.kt
@@ -7,10 +7,7 @@ import liquibase.database.jvm.JdbcConnection
 import liquibase.exception.ValidationErrors
 import liquibase.resource.ResourceAccessor
 import net.corda.core.identity.CordaX500Name
-import net.corda.core.node.NetworkParameters
 import net.corda.core.schemas.MappedSchema
-import net.corda.node.internal.DBNetworkParametersStorage
-import net.corda.node.services.api.WritableTransactionStorage
 import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.persistence.*
 import net.corda.nodeapi.internal.persistence.CordaPersistence
@@ -19,8 +16,6 @@ import net.corda.nodeapi.internal.persistence.SchemaMigration.Companion.NODE_X50
 import java.io.PrintWriter
 import java.sql.Connection
 import java.sql.SQLFeatureNotSupportedException
-import java.time.Clock
-import java.time.Duration
 import java.util.logging.Logger
 import javax.sql.DataSource
 
@@ -42,20 +37,10 @@ abstract class CordaMigration : CustomTaskChange {
 
     private lateinit var _cordaDB: CordaPersistence
 
-    val dbTransactions: WritableTransactionStorage
-        get() = _dbTransactions
+    val servicesForResolution: MigrationServicesForResolution
+        get() = _servicesForResolution
 
-    private lateinit var _dbTransactions: WritableTransactionStorage
-
-    val attachmentsService: AttachmentStorageInternal
-        get() = _attachmentsService
-
-    private lateinit var _attachmentsService: AttachmentStorageInternal
-
-    val latestNetworkParams: NetworkParameters
-        get() = _latestNetworkParams
-
-    private lateinit var _latestNetworkParams: NetworkParameters
+    private lateinit var _servicesForResolution: MigrationServicesForResolution
 
     /**
      * Initialise a subset of node services so that data from these can be used to perform migrations.
@@ -77,11 +62,9 @@ abstract class CordaMigration : CustomTaskChange {
 
         cordaDB.transaction {
             identityService.ourNames = setOf(ourName)
-            _dbTransactions = DBTransactionStorage(cordaDB, cacheFactory)
-            _attachmentsService = NodeAttachmentService(metricRegistry, cacheFactory, cordaDB)
-            _latestNetworkParams = DBNetworkParametersStorage.createParametersMap(cacheFactory).allPersisted()
-                    .map { it.second.verified() }
-                    .maxBy { it.epoch } ?: defaultNetworkParameters()
+             val dbTransactions = DBTransactionStorage(cordaDB, cacheFactory)
+             val attachmentsService = NodeAttachmentService(metricRegistry, cacheFactory, cordaDB)
+            _servicesForResolution = MigrationServicesForResolution(identityService, attachmentsService, dbTransactions, cordaDB, cacheFactory)
         }
     }
 
@@ -99,21 +82,6 @@ abstract class CordaMigration : CustomTaskChange {
         // Liquibase handles closing the database connection when migrations are finished. If the connection is closed here, then further
         // migrations may fail.
         return CordaPersistence(configDefaults, schema, jdbcUrl, cacheFactory, attributeConverters, closeConnection = false)
-    }
-
-    private fun defaultNetworkParameters(): NetworkParameters {
-        val clock = Clock.systemUTC()
-        return NetworkParameters(
-                1,
-                listOf(),
-                1,
-                1,
-                 clock.instant(),
-                1,
-                mapOf(),
-                Duration.ZERO,
-                mapOf()
-        )
     }
 
     override fun validate(database: Database?): ValidationErrors? {
@@ -174,3 +142,5 @@ class MigrationDataSource(val database: Database) : DataSource {
         throw SQLFeatureNotSupportedException()
     }
 }
+
+class MigrationException(msg: String?, cause: Exception? = null): Exception(msg, cause)

--- a/node/src/main/kotlin/net/corda/node/migration/MigrationNamedCacheFactory.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/MigrationNamedCacheFactory.kt
@@ -30,6 +30,10 @@ class MigrationNamedCacheFactory(private val metricRegistry: MetricRegistry?,
             "PersistentIdentityService_partyByKey" -> caffeine.maximumSize(defaultCacheSize)
             "PersistentIdentityService_partyByName" -> caffeine.maximumSize(defaultCacheSize)
             "BasicHSMKeyManagementService_keys" -> caffeine.maximumSize(defaultCacheSize)
+            "NodeAttachmentService_attachmentContent" -> caffeine.maximumWeight(defaultCacheSize)
+            "NodeAttachmentService_attachmentPresence" -> caffeine.maximumSize(defaultCacheSize)
+            "NodeAttachmentService_contractAttachmentVersions" -> caffeine.maximumSize(defaultCacheSize)
+            "NodeParametersStorage_networkParametersByHash" -> caffeine.maximumSize(defaultCacheSize)
             else -> throw IllegalArgumentException("Unexpected cache name $name.")
         }
     }

--- a/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
@@ -35,8 +35,7 @@ class MigrationServicesForResolution(
         get() = throw NotImplementedError()
 
     private fun defaultNetworkParameters(): NetworkParameters {
-        logger.warn("Using a dummy set of network parameters for migration. This is expected if the database was created by a node started"
-            + " in dev mode.")
+        logger.warn("Using a dummy set of network parameters for migration.")
         val clock = Clock.systemUTC()
         return NetworkParameters(
                 1,

--- a/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
@@ -35,6 +35,8 @@ class MigrationServicesForResolution(
         get() = throw NotImplementedError()
 
     private fun defaultNetworkParameters(): NetworkParameters {
+        logger.warn("Using a dummy set of network parameters for migration. This is expected if the database was created by a node started"
+            + " in dev mode.")
         val clock = Clock.systemUTC()
         return NetworkParameters(
                 1,

--- a/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
@@ -82,8 +82,8 @@ class MigrationServicesForResolution(
     }
 
     override fun loadState(stateRef: StateRef): TransactionState<*> {
-        val stx = transactions.getTransaction(stateRef.txhash) ?:
-        throw MigrationException("Could not get transaction with hash ${stateRef.txhash} out of vault")
+        val stx = transactions.getTransaction(stateRef.txhash)
+                ?: throw MigrationException("Could not get transaction with hash ${stateRef.txhash} out of vault")
         val baseTx = stx.resolveBaseTransaction(this)
         return when (baseTx) {
             is NotaryChangeLedgerTransaction -> baseTx.outputs[stateRef.index]
@@ -95,8 +95,8 @@ class MigrationServicesForResolution(
 
     override fun loadStates(stateRefs: Set<StateRef>): Set<StateAndRef<ContractState>> {
         return stateRefs.groupBy { it.txhash }.flatMap {
-            val stx = transactions.getTransaction(it.key) ?:
-            throw MigrationException("Could not get transaction with hash ${it.key} out of vault")
+            val stx = transactions.getTransaction(it.key)
+                    ?: throw MigrationException("Could not get transaction with hash ${it.key} out of vault")
             val baseTx = stx.resolveBaseTransaction(this)
             val stateList = when (baseTx) {
                 is NotaryChangeLedgerTransaction -> it.value.map { stateRef -> StateAndRef(baseTx.outputs[stateRef.index], stateRef) }

--- a/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/MigrationServicesForResolution.kt
@@ -1,0 +1,115 @@
+package net.corda.node.migration
+
+import net.corda.core.contracts.*
+import net.corda.core.cordapp.CordappProvider
+import net.corda.core.crypto.SecureHash
+import net.corda.core.internal.deserialiseComponentGroup
+import net.corda.core.node.NetworkParameters
+import net.corda.core.node.ServicesForResolution
+import net.corda.core.node.services.AttachmentStorage
+import net.corda.core.node.services.IdentityService
+import net.corda.core.node.services.NetworkParametersService
+import net.corda.core.node.services.TransactionStorage
+import net.corda.core.serialization.internal.AttachmentsClassLoaderBuilder
+import net.corda.core.transactions.ContractUpgradeLedgerTransaction
+import net.corda.core.transactions.NotaryChangeLedgerTransaction
+import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.contextLogger
+import net.corda.node.internal.DBNetworkParametersStorage
+import net.corda.nodeapi.internal.persistence.CordaPersistence
+import java.time.Clock
+import java.time.Duration
+
+class MigrationServicesForResolution(
+        override val identityService: IdentityService,
+        override val attachments: AttachmentStorage,
+        private val transactions: TransactionStorage,
+        private val cordaDB: CordaPersistence,
+        cacheFactory: MigrationNamedCacheFactory
+): ServicesForResolution {
+
+    companion object {
+        val logger = contextLogger()
+    }
+    override val cordappProvider: CordappProvider
+        get() = throw NotImplementedError()
+
+    private fun defaultNetworkParameters(): NetworkParameters {
+        val clock = Clock.systemUTC()
+        return NetworkParameters(
+                1,
+                listOf(),
+                1,
+                1,
+                clock.instant(),
+                1,
+                mapOf(),
+                Duration.ZERO,
+                mapOf()
+        )
+    }
+
+    override val networkParametersService: NetworkParametersService = object : NetworkParametersService {
+
+        private val storage = DBNetworkParametersStorage.createParametersMap(cacheFactory)
+
+        override val defaultHash: SecureHash = SecureHash.getZeroHash()
+        override val currentHash: SecureHash =  cordaDB.transaction {
+            storage.allPersisted().maxBy { it.second.verified().epoch }?.first ?: defaultHash
+        }
+
+        override fun lookup(hash: SecureHash): NetworkParameters? {
+            return cordaDB.transaction { storage[hash]?.verified() }
+        }
+    }
+
+    override val networkParameters: NetworkParameters = networkParametersService.lookup(networkParametersService.currentHash)
+            ?: defaultNetworkParameters()
+
+    private fun extractStateFromTx(tx: WireTransaction, stateIndices: Collection<Int>): List<TransactionState<ContractState>> {
+        return try {
+            val attachments = tx.attachments.mapNotNull { attachments.openAttachment(it)}
+            val states = AttachmentsClassLoaderBuilder.withAttachmentsClassloaderContext(attachments, networkParameters, tx.id) {
+                deserialiseComponentGroup(tx.componentGroups, TransactionState::class, ComponentGroupEnum.OUTPUTS_GROUP, forceDeserialize = true)
+            }
+            states.filterIndexed {index, _ -> stateIndices.contains(index)}.toList()
+        } catch (e: Exception) {
+            // If there is no attachment that allows the state class to be deserialised correctly, then carpent a state class anyway. It
+            // might still be possible to access the participants depending on how the state class was serialised.
+            logger.debug("Could not use attachments to deserialise transaction output states for transaction ${tx.id}")
+            tx.outputs.filterIndexed { index, _ -> stateIndices.contains(index)}
+        }
+    }
+
+    override fun loadState(stateRef: StateRef): TransactionState<*> {
+        val stx = transactions.getTransaction(stateRef.txhash) ?:
+        throw MigrationException("Could not get transaction with hash ${stateRef.txhash} out of vault")
+        val baseTx = stx.resolveBaseTransaction(this)
+        return when (baseTx) {
+            is NotaryChangeLedgerTransaction -> baseTx.outputs[stateRef.index]
+            is ContractUpgradeLedgerTransaction -> baseTx.outputs[stateRef.index]
+            is WireTransaction -> extractStateFromTx(baseTx, listOf(stateRef.index)).first()
+            else -> throw MigrationException("Unknown transaction type ${baseTx::class.qualifiedName} found when loading a state")
+        }
+    }
+
+    override fun loadStates(stateRefs: Set<StateRef>): Set<StateAndRef<ContractState>> {
+        return stateRefs.groupBy { it.txhash }.flatMap {
+            val stx = transactions.getTransaction(it.key) ?:
+            throw MigrationException("Could not get transaction with hash ${it.key} out of vault")
+            val baseTx = stx.resolveBaseTransaction(this)
+            val stateList = when (baseTx) {
+                is NotaryChangeLedgerTransaction -> it.value.map { stateRef -> StateAndRef(baseTx.outputs[stateRef.index], stateRef) }
+                is ContractUpgradeLedgerTransaction -> it.value.map { stateRef -> StateAndRef(baseTx.outputs[stateRef.index], stateRef) }
+                is WireTransaction -> extractStateFromTx(baseTx, it.value.map { stateRef -> stateRef.index })
+                        .mapIndexed {index, state -> StateAndRef(state, StateRef(baseTx.id, index)) }
+                else -> throw MigrationException("Unknown transaction type ${baseTx::class.qualifiedName} found when loading a state")
+            }
+            stateList
+        }.toSet()
+    }
+
+    override fun loadContractAttachment(stateRef: StateRef): Attachment {
+        throw NotImplementedError()
+    }
+}

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -63,7 +63,7 @@ class VaultStateMigration : CordaMigration() {
         val state = try {
             servicesForResolution.loadState(stateRef)
         } catch (e: Exception) {
-            throw VaultStateMigrationException("Could not load state for stateRef $stateRef : ${e.message}")
+            throw VaultStateMigrationException("Could not load state for stateRef $stateRef : ${e.message}", e)
         }
         return StateAndRef(state, stateRef)
     }
@@ -94,7 +94,7 @@ class VaultStateMigration : CordaMigration() {
                         it.relevancyStatus = Vault.RelevancyStatus.NOT_RELEVANT
                     }
                 } catch (e: VaultStateMigrationException) {
-                    logger.warn("An error occurred while migrating a vault state: ${e.message}. Skipping")
+                    logger.warn("An error occurred while migrating a vault state: ${e.message}. Skipping", e)
                     statesSkipped++
                 }
             }
@@ -320,4 +320,4 @@ class VaultStateIterator(private val database: CordaPersistence) : Iterator<Vaul
     }
 }
 
-class VaultStateMigrationException(msg: String) : Exception(msg)
+class VaultStateMigrationException(msg: String, cause: Exception? = null) : Exception(msg, cause)

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -77,6 +77,10 @@ class VaultStateMigration : CordaMigration() {
         initialiseNodeServices(database, setOf(VaultMigrationSchemaV1, VaultSchemaV1))
         var statesSkipped = 0
         val persistentStates = VaultStateIterator(cordaDB)
+        if (persistentStates.numStates > 0) {
+            logger.warn("Found ${persistentStates.numStates} states to update from a previous version. This may take a while for large "
+            + "volumes of data.")
+        }
         VaultStateIterator.withSerializationEnv {
             persistentStates.forEach {
                 val session = currentDBSession()

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -49,6 +49,9 @@ class VaultStateMigration : CordaMigration() {
                 session.persist(persistentParty)
             }
         } catch (e: AbstractMethodError) {
+            // This should only happen if there was no attachment that could be used to deserialise the output states, and the state was
+            // serialised such that the participants list cannot be accessed (participants is calculated and not marked as a
+            // SerializableCalculatedProperty.
             throw VaultStateMigrationException("Cannot add state parties as state class is not on the classpath " +
                     "and participants cannot be synthesised")
         }
@@ -62,6 +65,8 @@ class VaultStateMigration : CordaMigration() {
             }
             states[stateIndex]
         } catch (e: Exception) {
+            // If there is no attachment that allows the state class to be deserialised correctly, then carpent a state class anyway. It
+            // might still be possible to access the participants depending on how the state class was serialised.
             tx.tx.outputs[stateIndex]
         }
     }
@@ -111,7 +116,7 @@ class VaultStateMigration : CordaMigration() {
         if (statesSkipped > 0) {
             logger.error("$statesSkipped states could not be migrated as there was no class available for them.")
         }
-        logger.info("Finished performing vault state data migration for ${persistentStates.numStates} states")
+        logger.info("Finished performing vault state data migration for ${persistentStates.numStates - statesSkipped} states")
     }
 }
 

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -65,7 +65,7 @@ class VaultStateMigration : CordaMigration() {
         val stateRef = StateRef(txHash, persistentStateRef.index)
         val state = try {
             servicesForResolution.loadState(stateRef)
-        } catch (e: MigrationException) {
+        } catch (e: Exception) {
             throw VaultStateMigrationException("Could not load state for stateRef $stateRef : ${e.message}")
         }
         return StateAndRef(state, stateRef)

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -67,6 +67,7 @@ class VaultStateMigration : CordaMigration() {
         } catch (e: Exception) {
             // If there is no attachment that allows the state class to be deserialised correctly, then carpent a state class anyway. It
             // might still be possible to access the participants depending on how the state class was serialised.
+            logger.debug("Could not use attachments to deserialise transaction output states for transaction ${tx.id}")
             tx.tx.outputs[stateIndex]
         }
     }

--- a/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
+++ b/node/src/main/kotlin/net/corda/node/migration/VaultStateMigration.kt
@@ -3,14 +3,11 @@ package net.corda.node.migration
 import liquibase.database.Database
 import net.corda.core.contracts.*
 import net.corda.core.crypto.SecureHash
-import net.corda.core.internal.deserialiseComponentGroup
 import net.corda.core.node.services.Vault
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.internal.*
-import net.corda.core.transactions.SignedTransaction
-import net.corda.core.transactions.WireTransaction
 import net.corda.core.utilities.contextLogger
 import net.corda.node.internal.DBNetworkParametersStorage
 import net.corda.node.services.identity.PersistentIdentityService

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -506,6 +506,8 @@ class VaultStateMigrationTest {
 
     @Test
     fun `State created with notary change transaction can be migrated`() {
+        // This test is a little bit of a hack - it checks that these states are migrated correctly by looking at params in the database,
+        // but these will not be there for V3 nodes. Handling for this must be tested manually.
         val cashTx = createCashTransaction(Cash(), 5.DOLLARS, BOB)
         val cashTx2 = createCashTransaction(Cash(), 10.DOLLARS, BOB)
         val notaryTx = createNotaryChangeTransaction(listOf(StateRef(cashTx.id, 0), StateRef(cashTx2.id, 0)), SecureHash.allOnesHash)

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -3,15 +3,23 @@ package net.corda.node.migration
 import liquibase.database.Database
 import liquibase.database.jvm.JdbcConnection
 import net.corda.core.contracts.*
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SecureHash
+import net.corda.core.crypto.SignableData
+import net.corda.core.crypto.SignatureMetadata
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
 import net.corda.core.identity.PartyAndCertificate
-import net.corda.core.internal.hash
-import net.corda.core.internal.packageName
+import net.corda.core.internal.*
+import net.corda.core.node.NetworkParameters
+import net.corda.core.node.NotaryInfo
 import net.corda.core.node.services.Vault
 import net.corda.core.schemas.PersistentStateRef
 import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.serialize
+import net.corda.core.transactions.ContractUpgradeWireTransaction
+import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.contextLogger
@@ -21,10 +29,14 @@ import net.corda.finance.contracts.asset.Cash
 import net.corda.finance.contracts.asset.Obligation
 import net.corda.finance.contracts.asset.OnLedgerAsset
 import net.corda.finance.schemas.CashSchemaV1
+import net.corda.node.internal.DBNetworkParametersStorage
 import net.corda.node.services.identity.PersistentIdentityService
 import net.corda.node.services.keys.BasicHSMKeyManagementService
 import net.corda.node.services.persistence.DBTransactionStorage
+import net.corda.node.services.persistence.NodeAttachmentService
 import net.corda.node.services.vault.VaultSchemaV1
+import net.corda.nodeapi.internal.crypto.X509Utilities
+import net.corda.nodeapi.internal.network.SignedNetworkParameters
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
 import net.corda.nodeapi.internal.persistence.contextTransactionOrNull
@@ -43,7 +55,9 @@ import org.junit.*
 import org.mockito.Mockito
 import java.security.KeyPair
 import java.time.Clock
+import java.time.Duration
 import java.util.*
+import javax.annotation.Signed
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
@@ -113,12 +127,40 @@ class VaultStateMigrationTest {
 
         saveOurKeys(listOf(bob.keyPair, bob2.keyPair))
         saveAllIdentities(listOf(BOB_IDENTITY, ALICE_IDENTITY, BOC_IDENTITY, dummyNotary.identity, BOB2_IDENTITY))
+        addNetworkParameters()
     }
 
     @After
     fun close() {
         contextTransactionOrNull?.close()
         cordaDB.close()
+    }
+
+    private fun addNetworkParameters() {
+        cordaDB.transaction {
+            val clock = Clock.systemUTC()
+            val params = NetworkParameters(
+                    1,
+                    listOf(NotaryInfo(DUMMY_NOTARY, false), NotaryInfo(CHARLIE, false)),
+                    1,
+                    1,
+                    clock.instant(),
+                    1,
+                    mapOf(),
+                    Duration.ZERO,
+                    mapOf()
+            )
+            val signedParams = params.signWithCert(bob.keyPair.private, BOB_IDENTITY.certificate)
+            val persistentParams = DBNetworkParametersStorage.PersistentNetworkParameters(
+                    SecureHash.allOnesHash.toString(),
+                    params.epoch,
+                    signedParams.raw.bytes,
+                    signedParams.sig.bytes,
+                    signedParams.sig.by.encoded,
+                    X509Utilities.buildCertPath(signedParams.sig.parentCertsChain).encoded
+            )
+            session.save(persistentParams)
+        }
     }
 
     private fun createCashTransaction(cash: Cash, value: Amount<Currency>, owner: AbstractParty): SignedTransaction {
@@ -255,6 +297,54 @@ class VaultStateMigrationTest {
                 createVaultStatesFromTransaction(it)
             }
         }
+    }
+
+    private fun createNotaryChangeTransaction(inputs: List<StateRef>, paramsHash: SecureHash): SignedTransaction {
+        val notaryTx = NotaryChangeTransactionBuilder(inputs, DUMMY_NOTARY, CHARLIE, paramsHash).build()
+        val notaryKey = DUMMY_NOTARY.owningKey
+        val signableData = SignableData(notaryTx.id, SignatureMetadata(3, Crypto.findSignatureScheme(notaryKey).schemeNumberID))
+        val notarySignature = notaryServices.keyManagementService.sign(signableData, notaryKey)
+        return SignedTransaction(notaryTx, listOf(notarySignature))
+    }
+
+    private fun createVaultStatesFromNotaryChangeTransaction(tx: SignedTransaction, inputs: List<TransactionState<ContractState>>) {
+        cordaDB.transaction {
+            inputs.forEachIndexed { index, state ->
+                val constraintInfo = Vault.ConstraintInfo(state.constraint)
+                val persistentState = VaultSchemaV1.VaultStates(
+                        notary = tx.notary!!,
+                        contractStateClassName = state.data.javaClass.name,
+                        stateStatus = Vault.StateStatus.UNCONSUMED,
+                        recordedTime = clock.instant(),
+                        relevancyStatus = Vault.RelevancyStatus.RELEVANT, //Always persist as relevant to mimic V3
+                        constraintType = constraintInfo.type(),
+                        constraintData = constraintInfo.data()
+                )
+                persistentState.stateRef = PersistentStateRef(tx.id.toString(), index)
+                session.save(persistentState)
+            }
+        }
+    }
+
+    class CashV2 : UpgradedContractWithLegacyConstraint<Cash.State, CashV2.State> {
+        override val legacyContract = Cash.PROGRAM_ID
+        override val legacyContractConstraint: AttachmentConstraint
+            get() = AlwaysAcceptAttachmentConstraint
+
+        @BelongsToContract(CashV2::class)
+        data class State(override val amount: Amount<Issued<Currency>>, val owners: List<AbstractParty>) : FungibleAsset<Currency> {
+            override val owner: AbstractParty = owners.first()
+            override val exitKeys = (owners + amount.token.issuer.party).map { it.owningKey }.toSet()
+            override val participants = owners
+
+            override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Currency>>, newOwner: AbstractParty) = copy(amount = amount.copy(newAmount.quantity), owners = listOf(newOwner))
+            override fun toString() = "${Emoji.bagOfCash}New Cash($amount at ${amount.token.issuer} owned by $owner)"
+            override fun withNewOwner(newOwner: AbstractParty) = CommandAndState(Cash.Commands.Move(), copy(owners = listOf(newOwner)))
+        }
+
+        override fun upgrade(state: Cash.State) = CashV2.State(state.amount.times(1000), listOf(state.owner))
+
+        override fun verify(tx: LedgerTransaction) {}
     }
 
     private fun <T> getState(clazz: Class<T>): T {
@@ -439,6 +529,22 @@ class VaultStateMigrationTest {
         val migration = VaultStateMigration()
         migration.execute(liquibaseDB)
         assertEquals(0, getStatePartyCount())
+    }
+
+    @Test
+    fun `State created with notary change transaction can be migrated`() {
+        val cashTx = createCashTransaction(Cash(), 5.DOLLARS, BOB)
+        val cashTx2 = createCashTransaction(Cash(), 10.DOLLARS, BOB)
+        val notaryTx = createNotaryChangeTransaction(listOf(StateRef(cashTx.id, 0), StateRef(cashTx2.id, 0)), SecureHash.allOnesHash)
+        createVaultStatesFromTransaction(cashTx, stateStatus = Vault.StateStatus.CONSUMED)
+        createVaultStatesFromTransaction(cashTx2, stateStatus = Vault.StateStatus.CONSUMED)
+        createVaultStatesFromNotaryChangeTransaction(notaryTx, cashTx.coreTransaction.outputs + cashTx2.coreTransaction.outputs)
+        storeTransaction(cashTx)
+        storeTransaction(cashTx2)
+        storeTransaction(notaryTx)
+        val migration = VaultStateMigration()
+        migration.execute(liquibaseDB)
+        assertEquals(2, getStatePartyCount())
     }
 
     // Used to test migration performance

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -46,6 +46,16 @@ import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
+/**
+ * These tests aim to verify that migrating vault states from V3 to later versions works correctly. While these unit tests verify the
+ * migrating behaviour is correct (tables populated, columns updated for the right states), it comes with a caveat: they do not test that
+ * deserialising states with the attachment classloader works correctly.
+ *
+ * The reason for this is that it is impossible to do so. There is no real way of writing a unit or integration test to upgrade from one
+ * version to another (at the time of writing). These tests simulate a small part of the upgrade process by directly using hibernate to
+ * populate a database as a V3 node would, then running the migration class. However, it is impossible to do this for attachments as there
+ * is no contract state jar to serialise.
+ */
 class VaultStateMigrationTest {
     companion object {
         val alice = TestIdentity(ALICE_NAME, 70)

--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -27,6 +27,7 @@ import net.corda.node.services.persistence.DBTransactionStorage
 import net.corda.node.services.vault.VaultSchemaV1
 import net.corda.nodeapi.internal.persistence.CordaPersistence
 import net.corda.nodeapi.internal.persistence.DatabaseConfig
+import net.corda.nodeapi.internal.persistence.contextTransactionOrNull
 import net.corda.nodeapi.internal.persistence.currentDBSession
 import net.corda.testing.core.*
 import net.corda.testing.internal.configureDatabase
@@ -116,6 +117,7 @@ class VaultStateMigrationTest {
 
     @After
     fun close() {
+        contextTransactionOrNull?.close()
         cordaDB.close()
     }
 


### PR DESCRIPTION
[CORDA-2487](https://r3-cev.atlassian.net/browse/CORDA-2487) introduces a custom liquibase migration to populate the state_party table and correctly mark states as relevant or not when upgrading from V3. In order to do this, it must deserialise transactions in the database to obtain the output contract states, and from these read the participants in the state. If the jar defining the contract state is on the classpath (as is likely if the migration is run at node startup), then this will succeed. However, if this isn't the case, then whether the participants can be read depends on how the state was serialised. The carpenter will only provide a readable participants list if this field was not calculated, or was marked as a `SerializableCalculatedProperty`. This could result in states skipped.

This change instead attempts to deserialise the states using the attachments classloader. As the transaction should have attachments containing the jars defining the contract states, this should mean that all states can be deserialised. I have attempted this manually and this appears to be the case. However, I have left the old code in as a fallback in the event that some states do not have the relevant attachments.

This also means that the unit tests can still be used to test the migrations manipulate the states correctly. However, as there is no mechanism for getting the attachments for the states in the unit tests without using the full infrastructure of the node, there is no way of testing that the attachment deserialisation part works in the unit tests. As such, a round of manual testing has been carried out to ensure this works.

Changes:
 - Use an attachments classloader context to deserialise states from the transaction output component group
 - This requires the network parameters, so add some code to work out the latest from the database. If there aren't any, fallback to some defaults (I don't think it matters what these are)
 - Improve logging and comments
