### PR TITLE
CORDA-2575 Allow users to whitelist new versions via RPC by hash

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/AbstractAttachment.kt
@@ -20,13 +20,14 @@ const val DEPLOYED_CORDAPP_UPLOADER = "app"
 const val RPC_UPLOADER = "rpc"
 const val P2P_UPLOADER = "p2p"
 const val UNKNOWN_UPLOADER = "unknown"
+const val WHITELISTED_P2P_UPLOADER = "whitelisted_jar_p2p"
 
 // We whitelist sources of transaction JARs for now as a temporary state until the DJVM and other security sandboxes
 // have been integrated, at which point we'll be able to run untrusted code downloaded over the network and this mechanism
 // can be removed. Because we ARE downloading attachments over the P2P network in anticipation of this upgrade, we
 // track the source of each attachment in our store. TestDSL is used by LedgerDSLInterpreter when custom attachments
 // are added in unit test code.
-val TRUSTED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER, "TestDSL")
+val TRUSTED_UPLOADERS = listOf(DEPLOYED_CORDAPP_UPLOADER, RPC_UPLOADER, WHITELISTED_P2P_UPLOADER, "TestDSL")
 
 fun isUploaderTrusted(uploader: String?): Boolean = uploader in TRUSTED_UPLOADERS
 

--- a/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
+++ b/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt
@@ -308,6 +308,13 @@ interface CordaRPCOps : RPCOps {
     /** Queries attachments metadata */
     fun queryAttachments(query: AttachmentQueryCriteria, sorting: AttachmentSort?): List<AttachmentId>
 
+    /** Whitelist a jar hash, a jar received via P2P which is whitelisted can be used for transaction versification.
+     * The jar may be yet not received or already be present it the node. */
+    fun whitelistAttachment(id: SecureHash)
+
+    /** List whitelisted jar hash, the actual jar may be not present in the node. */
+    fun listWhitelistedAttachments(): List<String>
+
     /** Returns the node's current time. */
     fun currentNodeTime(): Instant
 

--- a/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
+++ b/core/src/main/kotlin/net/corda/core/node/services/AttachmentStorage.kt
@@ -64,6 +64,17 @@ interface AttachmentStorage {
      */
     fun queryAttachments(criteria: AttachmentQueryCriteria, sorting: AttachmentSort? = null): List<AttachmentId>
 
+    /** Whitelist a jar hash, a jar received via P2P which is whitelisted can be used for transaction versification.
+     * The jar may be yet not received or already be present it the node.
+     * @param id The Jar file hash
+     */
+    fun whitelistAttachment(id: SecureHash)
+
+    /**
+     * List whitelisted jar hash, the actual jar may be not present in the node.
+     * @param List of whitelisted Jar hashes, the present on the list doesn't indicate it the actual Jar is stored in the node.
+     */
+    fun listWhitelistedAttachments(): List<String>
     /**
      * Searches for an attachment already in the store
      * @param attachmentId The attachment Id

--- a/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/CordaRPCOpsImpl.kt
@@ -217,6 +217,14 @@ internal class CordaRPCOpsImpl(
         return services.attachments.queryAttachments(query, sorting)
     }
 
+    override fun whitelistAttachment(id: SecureHash) {
+        return services.attachments.whitelistAttachment(id)
+    }
+
+    override fun listWhitelistedAttachments(): List<String> {
+        return services.attachments.listWhitelistedAttachments()
+    }
+
     override fun currentNodeTime(): Instant = Instant.now(services.clock)
 
     override fun waitUntilNetworkReady(): CordaFuture<Void?> = services.networkMapCache.nodeReady

--- a/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
+++ b/node/src/main/kotlin/net/corda/node/services/schema/NodeSchemaService.kt
@@ -40,6 +40,7 @@ class NodeSchemaService(private val extraSchemas: Set<MappedSchema> = emptySet()
                     PersistentKeyManagementService.PersistentKey::class.java,
                     NodeSchedulerService.PersistentScheduledState::class.java,
                     NodeAttachmentService.DBAttachment::class.java,
+                    NodeAttachmentService.WhitelistedAttachment::class.java,
                     P2PMessageDeduplicator.ProcessedMessage::class.java,
                     PersistentIdentityService.PersistentIdentity::class.java,
                     PersistentIdentityService.PersistentIdentityNames::class.java,

--- a/node/src/main/resources/migration/node-core.changelog-master.xml
+++ b/node/src/main/resources/migration/node-core.changelog-master.xml
@@ -16,4 +16,5 @@
     <include file="migration/node-core.changelog-v11.xml"/>
     <!-- This must run after node-core.changelog-init.xml, to prevent database columns being created twice. -->
     <include file="migration/vault-schema.changelog-v9.xml"/>
+    <include file="migration/node-core.changelog-v12.xml"/>
 </databaseChangeLog>

--- a/node/src/main/resources/migration/node-core.changelog-v12.xml
+++ b/node/src/main/resources/migration/node-core.changelog-v12.xml
@@ -1,0 +1,18 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   logicalFilePath="migration/node-services.changelog-init.xml">
+
+    <changeSet author="R3.Corda" id="create-attachments-whitelist">
+        <createTable tableName="node_attachments_whitelist">
+            <column name="att_id" type="NVARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="insertion_date" type="timestamp">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="att_id" constraintName="node_attachments_whitel_pkey" tableName="node_attachments_whitelist"/>
+    </changeSet>
+</databaseChangeLog>

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/services/MockAttachmentStorage.kt
@@ -87,6 +87,14 @@ class MockAttachmentStorage : AttachmentStorage, SingletonSerializeAsToken() {
 
     fun getAttachmentIdAndBytes(jar: InputStream): Pair<AttachmentId, ByteArray> = jar.readFully().let { bytes -> Pair(bytes.sha256(), bytes) }
 
+    override fun whitelistAttachment(id: SecureHash) {
+        TODO("not implemented")
+    }
+
+    override fun listWhitelistedAttachments(): List<String> {
+        TODO("not implemented")
+    }
+
     private class MockAttachment(dataLoader: () -> ByteArray, override val id: SecureHash, override val signerKeys: List<PublicKey>) : AbstractAttachment(dataLoader)
 
     private fun importAttachmentInternal(jar: InputStream, uploader: String, contractClassNames: List<ContractClassName>? = null, attachmentId: AttachmentId? = null, signers: List<PublicKey> = emptyList()): AttachmentId {


### PR DESCRIPTION
First part of CORDA-2575:
 we need a new RPC and ideally, shell command + docs telling admins how to whitelist new hashes
I decided to create separate table `attachments_whitelist ` for whitelisted hashes, as adding them to the existing attachment table made the logic more complicated  (hasAttachment/load/open, would need to check if there is a content, as the current logic was assuming, if something is in the cache it means it's a valid attachment).

The flow is like that:
1) RPC `whitelistAttachment hash` is send
2) if the Jar is already in the node as p2p:... then is changed to whitelisted_jar_p2p and this is trusted uploader
3) if Jar is not present nothing happens
4) during transaction  a Jar is passed to the node as p2p, while importing the p2p attachment is checked if it's whitelisted, if yes then the uploader is promoted to `whitelisted_jar_p2p` (so it will be trusted for verification)

I could also use existing uploader e.g. `rpc` or `app` but I wanted to indicate that the jar was not loaded but promoted from p2p.

This PR lack documentation.
 