### PR TITLE
[CORDA-2591] Prevent spurious logs in AttachmentVersionNumberMigration

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
@@ -35,7 +35,7 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
                 if (networkParameters != null) {
                     logger.info("$msg using network parameters from $path, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
                 } else {
-                    logger.warn("$msg skipped, network parameters not found in $path.")
+                    logger.info("$msg skipped, network parameters not found in $path.")
                     return
                 }
             } else {
@@ -84,8 +84,13 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
     }
 
     private fun getNetworkParametersFromFile(path: Path): NetworkParameters? {
-        val networkParametersBytes = path?.readObject<SignedNetworkParameters>()
-        return networkParametersBytes?.raw?.deserialize()
+        return try {
+            val networkParametersBytes = path?.readObject<SignedNetworkParameters>()
+            networkParametersBytes?.raw?.deserialize()
+        } catch (e: Exception) {
+            // This condition is logged in the calling function, so no need to do that here.
+            null
+        }
     }
 
     private fun getAttachmentsWithDefaultVersion(connection: JdbcConnection): List<String> =

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
@@ -29,13 +29,17 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
             logger.info("Start executing...")
             var networkParameters: NetworkParameters?
             val baseDir = System.getProperty(SchemaMigration.NODE_BASE_DIR_KEY)
+            val availableAttachments = getAttachmentsWithDefaultVersion(connection)
             if (baseDir != null) {
                 val path = Paths.get(baseDir) / NETWORK_PARAMS_FILE_NAME
                 networkParameters = getNetworkParametersFromFile(path)
                 if (networkParameters != null) {
                     logger.info("$msg using network parameters from $path, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
+                } else if (!availableAttachments.isEmpty()){
+                    logger.info("$msg skipped, network parameters not found in $path, but there are no available attachments to migrate.")
+                    return
                 } else {
-                    logger.info("$msg skipped, network parameters not found in $path.")
+                    logger.warn("$msg skipped, network parameters not found in $path.")
                     return
                 }
             } else {
@@ -43,7 +47,6 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
                 return
             }
 
-            val availableAttachments = getAttachmentsWithDefaultVersion(connection)
             if (availableAttachments.isEmpty()) {
                 logger.info("$msg skipped, no attachments not found.")
                 return

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/AttachmentVersionNumberMigration.kt
@@ -35,7 +35,7 @@ class AttachmentVersionNumberMigration : CustomTaskChange {
                 networkParameters = getNetworkParametersFromFile(path)
                 if (networkParameters != null) {
                     logger.info("$msg using network parameters from $path, whitelistedContractImplementations: ${networkParameters.whitelistedContractImplementations}.")
-                } else if (!availableAttachments.isEmpty()){
+                } else if (availableAttachments.isEmpty()){
                     logger.info("$msg skipped, network parameters not found in $path, but there are no available attachments to migrate.")
                     return
                 } else {

--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/persistence/SchemaMigration.kt
@@ -30,7 +30,7 @@ class SchemaMigration(
         private val databaseConfig: DatabaseConfig,
         private val classLoader: ClassLoader = Thread.currentThread().contextClassLoader,
         private val currentDirectory: Path?,
-        private val ourName: CordaX500Name? = null) {
+        private val ourName: CordaX500Name) {
 
     companion object {
         private val logger = contextLogger()
@@ -102,9 +102,7 @@ class SchemaMigration(
             if (path != null) {
                 System.setProperty(NODE_BASE_DIR_KEY, path) // base dir for any custom change set which may need to load a file (currently AttachmentVersionNumberMigration)
             }
-            if (ourName != null) {
-                System.setProperty(NODE_X500_NAME, ourName.toString())
-            }
+            System.setProperty(NODE_X500_NAME, ourName.toString())
             val customResourceAccessor = CustomResourceAccessor(dynamicInclude, changelogList, classLoader)
 
             val liquibase = Liquibase(dynamicInclude, customResourceAccessor, getLiquibaseDatabase(JdbcConnection(connection)))

--- a/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/AbstractNode.kt
@@ -1093,7 +1093,7 @@ fun createCordaPersistence(databaseConfig: DatabaseConfig,
     return CordaPersistence(databaseConfig, schemaService.schemaOptions.keys, jdbcUrl, cacheFactory, attributeConverters, customClassLoader)
 }
 
-fun CordaPersistence.startHikariPool(hikariProperties: Properties, databaseConfig: DatabaseConfig, schemas: Set<MappedSchema>, metricRegistry: MetricRegistry? = null, classloader: ClassLoader = Thread.currentThread().contextClassLoader, currentDir: Path? = null, ourName: CordaX500Name? = null) {
+fun CordaPersistence.startHikariPool(hikariProperties: Properties, databaseConfig: DatabaseConfig, schemas: Set<MappedSchema>, metricRegistry: MetricRegistry? = null, classloader: ClassLoader = Thread.currentThread().contextClassLoader, currentDir: Path? = null, ourName: CordaX500Name) {
     try {
         val dataSource = DataSourceFactory.createDataSource(hikariProperties, metricRegistry = metricRegistry)
         val schemaMigration = SchemaMigration(schemas, dataSource, databaseConfig, classloader, currentDir, ourName)


### PR DESCRIPTION
The `AttachmentVersionNumberMigration` relies on the network parameters being available in order to find what contract implementations are whitelisted. These may not be available if, for example, the node is being bootstrapped or is first connecting to the doorman. However, the migrations will still run in these cases, resulting in an error message being printed to the console. This can be misleading, as it does not prevent operations such as connecting to the doorman from succeeding.

This PR updates the migration to handle this case in such a way that an error message is not printed to the console. The node logs will still contain an indication of what went wrong.

Changes:
 - Detect if the network parameters file is not present while trying to read them from the supplied path
 - Log at the info level if there are no network parameters or attachments
 - Log at the warn level if there are no network parameters but there are attachments
 - Make the X500 name passed to `SchemaMigration` not null 
