### PR TITLE
CORDA-2542 ContractUpgrade interface should not default to enforce CZ…

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -300,8 +300,7 @@ interface UpgradedContract<in OldState : ContractState, out NewState : ContractS
 }
 
 /**
- * This interface allows specifying a custom legacy contract constraint for upgraded contracts. The default for [UpgradedContract]
- * is [WhitelistedByZoneAttachmentConstraint].
+ * This interface allows specifying a custom legacy contract constraint for upgraded contracts.
  */
 @KeepForDJVM
 interface UpgradedContractWithLegacyConstraint<in OldState : ContractState, out NewState : ContractState> : UpgradedContract<OldState, NewState> {

--- a/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/ContractUpgradeTransactions.kt
@@ -272,14 +272,10 @@ data class ContractUpgradeLedgerTransaction(
             "Legacy contract constraint does not satisfy the constraint of the input states"
         }
 
-        val constraintCheck = if (upgradedContract is UpgradedContractWithLegacyConstraint) {
-            upgradedContract.legacyContractConstraint.isSatisfiedBy(attachmentForConstraintVerification)
-        } else {
-            // If legacy constraint not specified, defaulting to WhitelistedByZoneAttachmentConstraint
-            WhitelistedByZoneAttachmentConstraint.isSatisfiedBy(attachmentForConstraintVerification)
-        }
-        check(constraintCheck) {
-            "Legacy contract does not satisfy the upgraded contract's constraint"
+        if (upgradedContract is UpgradedContractWithLegacyConstraint) {
+            check(upgradedContract.legacyContractConstraint.isSatisfiedBy(attachmentForConstraintVerification)) {
+                "Legacy contract does not satisfy the upgraded contract's constraint"
+            }
         }
     }
 

--- a/docs/source/upgrading-cordapps.rst
+++ b/docs/source/upgrading-cordapps.rst
@@ -306,8 +306,8 @@ upgraded contracts must implement the ``UpgradedContract`` interface. This inter
 The ``upgrade`` method describes how the old state type is upgraded to the new state type. When the state isn't being
 upgraded, the same state type can be used for both the old and new state type parameters.
 
-By default this new contract will only be able to upgrade legacy states which are constrained by the zone whitelist (see :doc:`api-contract-constraints`).
-If hash or other constraint types are used, the new contract should implement ``UpgradedContractWithLegacyConstraint``
+By default this new contract will preserve and verify the original contract constraints.
+If hash, CZ whitelist or other constraint types are used, the new contract should implement ``UpgradedContractWithLegacyConstraint``
 instead, and specify the constraint explicitly:
 
 .. sourcecode:: kotlin

--- a/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV4.kt
+++ b/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV4.kt
@@ -9,13 +9,13 @@ import net.corda.core.transactions.LedgerTransaction
 /**
  * Dummy contract state for testing of the upgrade process.
  */
-// DOCSTART 1
-class DummyContractV2 : UpgradedContract<DummyContract.State, DummyContractV2.State> {
+class DummyContractV4 : UpgradedContractWithLegacyConstraint<DummyContract.State, DummyContractV4.State> {
     companion object {
-        const val PROGRAM_ID: ContractClassName = "net.corda.testing.contracts.DummyContractV2"
+        const val PROGRAM_ID: ContractClassName = "net.corda.testing.contracts.DummyContractV4"
     }
 
-    override val legacyContract: String = DummyContract::class.java.name
+    override val legacyContract: String = DummyContract.PROGRAM_ID
+    override val legacyContractConstraint: AttachmentConstraint = WhitelistedByZoneAttachmentConstraint
 
     data class State(val magicNumber: Int = 0, val owners: List<AbstractParty>) : ContractState {
         override val participants: List<AbstractParty> = owners
@@ -34,4 +34,3 @@ class DummyContractV2 : UpgradedContract<DummyContract.State, DummyContractV2.St
         // Other verifications.
     }
 }
-// DOCEND 1


### PR DESCRIPTION
… whitelist constraints checking.

Constraints checking of original input states remains enforced for all Upgrades.
Explicit constraints checking of Upgraded States is enforceable using ContractUpgradeWithLegacyConstraints by specifying a constraint type to apply. 

Fix has been tested and verified to work with Contract Upgrade sample (https://github.com/corda/samples/tree/release-V4/contract-upgrades)