### PR TITLE
CORDA-2622 - Fix shell extensions

### DIFF
--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
@@ -1,6 +1,7 @@
 package net.corda.cliutils
 
 import net.corda.core.internal.*
+import net.corda.core.utilities.loggerFor
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang.SystemUtils
 import picocli.CommandLine
@@ -129,10 +130,10 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
         return ExitCodes.SUCCESS
     }
 
-    private fun declaredBashVersion(): String = execCommand("bash -c 'echo \$BASH_VERSION'")
+    private fun declaredBashVersion(): String = execCommand("bash", "-c", "echo \$BASH_VERSION")
 
     private fun installedShell(): ShellType {
-        val path = execCommand("bash -c 'echo \$SHELL'")
+        val path = execCommand("bash", "-c", "echo \$SHELL").trim()
         return when {
             path.endsWith("/zsh") -> ShellType.ZSH
             path.endsWith("/bash") -> ShellType.BASH
@@ -144,9 +145,14 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
         ZSH, BASH, OTHER
     }
 
-    private fun execCommand(command: String): String {
-        val process = ProcessBuilder(command)
-        return IOUtils.toString(process.start().inputStream, Charsets.UTF_8)
+    private fun execCommand(vararg commandAndArgs: String): String {
+        return try {
+            val process = ProcessBuilder(*commandAndArgs)
+            IOUtils.toString(process.start().inputStream, Charsets.UTF_8)
+        } catch (exception: Exception) {
+            loggerFor<InstallShellExtensionsParser>().warn("Failed to run command: ${commandAndArgs.joinToString(" ")}; $exception")
+            ""
+        }
     }
 
     fun checkForAutoCompleteUpdate() {

--- a/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
+++ b/tools/cliutils/src/main/kotlin/net/corda/cliutils/InstallShellExtensionsParser.kt
@@ -109,7 +109,9 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
         // Replace any existing alias. There can be only one.
         bashSettingsFile.addOrReplaceIfStartsWith("alias ${parent.alias}", command)
         val completionFileCommand = "for bcfile in ~/.completion/* ; do . \$bcfile; done"
-        bashSettingsFile.addIfNotExists(completionFileCommand)
+        if (generateAutoCompleteFile) {
+            bashSettingsFile.addIfNotExists(completionFileCommand)
+        }
         bashSettingsFile.updateAndBackupIfNecessary()
 
         // Get zsh settings file
@@ -117,7 +119,9 @@ private class ShellExtensionsGenerator(val parent: CordaCliWrapper) {
         zshSettingsFile.addIfNotExists("autoload -U +X compinit && compinit")
         zshSettingsFile.addIfNotExists("autoload -U +X bashcompinit && bashcompinit")
         zshSettingsFile.addOrReplaceIfStartsWith("alias ${parent.alias}", command)
-        zshSettingsFile.addIfNotExists(completionFileCommand)
+        if (generateAutoCompleteFile) {
+            zshSettingsFile.addIfNotExists(completionFileCommand)
+        }
         zshSettingsFile.updateAndBackupIfNecessary()
 
         if (generateAutoCompleteFile) {


### PR DESCRIPTION
[CORDA-2622](https://r3-cev.atlassian.net/browse/CORDA-2622) - Fix broken shell extensions. `ProcessBuilder` takes a list of program plus arguments, not a string for the whole command. Also added a check for failed program execution with enhanced logging.

Fix for behaviour introduced in https://github.com/corda/corda/pull/4263