### PR TITLE
CORDA-2623 - Add help screen to Network Builder CLI tool

### DIFF
--- a/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
+++ b/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/Main.kt
@@ -22,6 +22,11 @@ fun main(args: Array<String>) {
     CommandLine(baseArgs).parse(*args)
     testDockerConnectivity()
 
+    if (baseArgs.usageHelpRequested) {
+        CommandLine.usage(CliParser(), System.out)
+        return
+    }
+
     if (baseArgs.gui) {
         Application.launch(Gui::class.java)
         return

--- a/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/cli/CommandParsers.kt
+++ b/tools/network-bootstrapper/src/main/kotlin/net/corda/bootstrapper/cli/CommandParsers.kt
@@ -17,12 +17,14 @@ open class CliParser {
     @Option(names = ["-d", "--nodes-directory"], description = ["The directory to search for nodes in"])
     var baseDirectory = File(System.getProperty("user.dir"))
 
-    @Option(names = ["-b", "--backend"], description = ["The backend to use when instantiating nodes"])
+    @Option(names = ["-b", "--backend"], description = ["The backend to use when instantiating nodes. Valid values: LOCAL_DOCKER and AZURE."])
     var backendType: Backend.BackendType = Backend.BackendType.LOCAL_DOCKER
-
 
     @Option(names = ["--add"], split = ":", description = ["The node to add. Format is <Name>:<X500>. Eg; \"Node1:O=Bank A, L=New York, C=US, OU=Org Unit, CN=Service Name\""])
     var nodesToAdd: MutableMap<String, String> = hashMapOf()
+
+    @Option(names = ["-h", "--help"], usageHelp = true, description = ["Display this help message"])
+    var usageHelpRequested: Boolean = false
 
     fun isNew(): Boolean {
         return nodesToAdd.isEmpty()


### PR DESCRIPTION
Note that `${COMPLETION-CANDIDATES}` from Picocli doesn't work for this due to `BackendType.toString()`. So have hardcoded the options for now.