### PR TITLE
CORDA-2616 Update doc to reflect removed RPC client.

### DIFF
--- a/docs/source/tutorial-cordapp.rst
+++ b/docs/source/tutorial-cordapp.rst
@@ -427,32 +427,6 @@ Via the h2 web console
 You can connect directly to your node's database to see its stored states, transactions and attachments. To do so,
 please follow the instructions in :doc:`node-database`.
 
-Using the example RPC client
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``/src/main/kotlin/com/example/client/ExampleClientRPC.kt`` defines a simple RPC client that connects to a node,
-logs any existing IOUs and listens for any future IOUs. If you haven't created
-any IOUs when you first connect to one of the nodes, the client will simply log any future IOUs that are agreed.
-
-Running the client via IntelliJ
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Run the 'Run Example RPC Client' run configuration. By default, this run configuration is configured to connect to
-PartyA. You can edit the run configuration to connect on a different port.
-
-Running the client via the command line
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Run the following gradle task:
-
-``./gradlew runExampleClientRPCKotlin``
-
-This will connect the RPC client to PartyA and log their past and future IOU activity.
-
-You can close the application using ``ctrl+C``.
-
-For more information on the client RPC interface and how to build an RPC client application, see:
-
-* :doc:`Client RPC documentation <clientrpc>`
-* :doc:`Client RPC tutorial <tutorial-clientrpc-api>`
-
 Running nodes across machines
 -----------------------------
 The nodes can be configured to communicate as a network even when distributed across several machines:


### PR DESCRIPTION
The sample RPC client was removed from the example CorDapp because:

* The templates now contain an example RPC client
* The example CorDapp's Spring webserver also serves as an example of an RPC client

This PR updates the docs accordingly.