### PR TITLE
CORDA-2613: FinalityHandler is no longer gated on app target versions

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -291,6 +291,8 @@
       <module name="workflows_integrationTest" target="1.8" />
       <module name="workflows_main" target="1.8" />
       <module name="workflows_test" target="1.8" />
+      <module name="worldmap_main" target="1.8" />
+      <module name="worldmap_test" target="1.8" />
     </bytecodeTargetLevel>
   </component>
   <component name="JavacSettings">

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SessionRejectException.kt
@@ -12,8 +12,4 @@ open class SessionRejectException(message: String) : CordaException(message) {
     class NotAFlow(val initiatorClass: Class<*>) : SessionRejectException("${initiatorClass.name} is not a flow")
 
     class NotRegistered(val initiatorFlowClass: Class<out FlowLogic<*>>) : SessionRejectException("${initiatorFlowClass.name} is not registered")
-
-    class FinalityHandlerDisabled : SessionRejectException("Counterparty attempting to use the old insecure API of FinalityFlow. However this " +
-            "API is disabled on this node since there no CorDapps installed that require it. It may be that the counterparty is running an " +
-            "older verison of a CorDapp.")
 }

--- a/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/StaffedFlowHospital.kt
@@ -47,9 +47,6 @@ class StaffedFlowHospital(private val flowMessaging: FlowMessaging, private val 
             // installed on restart, at which point the message will be able proceed as normal. If not then it will need
             // to be dropped manually.
             Outcome.OVERNIGHT_OBSERVATION
-        } else if (error is SessionRejectException.FinalityHandlerDisabled) {
-            // TODO We need a way to be able to give the green light to such a session-init message
-            Outcome.OVERNIGHT_OBSERVATION
         } else {
             Outcome.UNTREATABLE
         }


### PR DESCRIPTION
To allow rolling upgrades where members of a BN may not all upgrade at the same time, the FinalityHandler is now always enabled, and not disabled if no old apps are installed.

Previously any attempt to use the FinalityHandler in such a scenerio would send the flow to the hospital, where manual intervention would be required to recover the transaction.

