### PR TITLE
[CORDA-2627] Fail the custom vault state migration if any states were skipped

### DIFF
--- a/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
+++ b/node/src/test/kotlin/net/corda/node/migration/VaultStateMigrationTest.kt
@@ -430,7 +430,7 @@ class VaultStateMigrationTest {
         assertEquals(0, getVaultStateCount(Vault.RelevancyStatus.NOT_RELEVANT))
     }
 
-    @Test
+    @Test(expected = VaultStateMigrationException::class)
     fun `State with corresponding transaction missing is skipped`() {
         val cash = Cash()
         val unknownTx = createCashTransaction(cash, 100.DOLLARS, BOB)
@@ -439,7 +439,6 @@ class VaultStateMigrationTest {
         addCashStates(10, BOB)
         val migration = VaultStateMigration()
         migration.execute(liquibaseDB)
-        assertEquals(10, getStatePartyCount())
     }
 
     @Test
@@ -453,8 +452,8 @@ class VaultStateMigrationTest {
         assertEquals(10, getVaultStateCount(Vault.RelevancyStatus.RELEVANT))
     }
 
-    @Test
-    fun `Null database causes migration to be ignored`() {
+    @Test(expected = VaultStateMigrationException::class)
+    fun `Null database causes migration to fail`() {
         val migration = VaultStateMigration()
         // Just check this does not throw an exception
         migration.execute(null)


### PR DESCRIPTION
If the custom vault state migration detects failures, today it will log the error that occurred, but will finish the migration and mark this as successful. This change instead causes the migration to fail if any states were skipped. Note that non-skipped states will still be migrated even if the migration subsequently fails; on attempting to migrate again only skipped states will be added.

Changes:
 - Updated any error conditions to also throw an exception, signalling to liquibase that this migration has failed.
