### PR TITLE
CORDA-2634 - Fix derivation of currentTargetVersion for abstract classes

### DIFF
--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappImpl.kt
@@ -34,14 +34,15 @@ data class CordappImpl(
         override val targetPlatformVersion: Int,
         val notaryService: Class<out NotaryService>? = null,
         /** Indicates whether the CorDapp is loaded from external sources, or generated on node startup (virtual). */
-        val isLoaded: Boolean = true
+        val isLoaded: Boolean = true,
+        private val explicitCordappClasses: List<String> = emptyList()
 ) : Cordapp {
     override val name: String = jarName(jarPath)
 
     // TODO: Also add [SchedulableFlow] as a Cordapp class
     override val cordappClasses: List<String> = run {
         val classList = rpcFlows + initiatedFlows + services + serializationWhitelists.map { javaClass } + notaryService
-        classList.mapNotNull { it?.name } + contractClassNames
+        classList.mapNotNull { it?.name } + contractClassNames + explicitCordappClasses
     }
 
     companion object {

--- a/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappResolver.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/cordapp/CordappResolver.kt
@@ -55,10 +55,10 @@ object CordappResolver {
     val currentCordapp: Cordapp? get() = cordappResolver()
 
     /**
-     * Returns the target version of the current calling CorDapp. Defaults to the current platform version if there isn't one.
+     * Returns the target version of the current calling CorDapp. Defaults to platform version 1 if there isn't one,
+     * assuming only basic platform capabilities.
      */
-    // TODO It may be the default is wrong and this should be Int? instead
-    val currentTargetVersion: Int get() = currentCordapp?.targetPlatformVersion ?: PLATFORM_VERSION
+    val currentTargetVersion: Int get() = currentCordapp?.targetPlatformVersion ?: 1
 
     /**
      * Temporarily apply a fake CorDapp with the given parameters. For use in testing.

--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -151,7 +151,8 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
                 getJarHash(url.url),
                 minPlatformVersion,
                 targetPlatformVersion,
-                findNotaryService(this)
+                findNotaryService(this),
+                explicitCordappClasses = findAllCordappClasses(this)
         )
     }
 
@@ -248,6 +249,10 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
 
     private fun findAllFlows(scanResult: RestrictedScanResult): List<Class<out FlowLogic<*>>> {
         return scanResult.getConcreteClassesOfType(FlowLogic::class)
+    }
+
+    private fun findAllCordappClasses(scanResult: RestrictedScanResult): List<String> {
+        return scanResult.getAllStandardClasses() + scanResult.getAllInterfaces()
     }
 
     private fun findContractClassNames(scanResult: RestrictedScanResult): List<String> {
@@ -348,6 +353,20 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
                     .filter { it.startsWith(qualifiedNamePrefix) }
                     .mapNotNull { loadClass(it, type) }
                     .filterNot { it.isAbstractClass }
+        }
+
+        fun getAllStandardClasses(): List<String> {
+            return scanResult
+                    .getAllStandardClasses()
+                    .names
+                    .filter { it.startsWith(qualifiedNamePrefix) }
+        }
+
+        fun getAllInterfaces(): List<String> {
+            return scanResult
+                    .getAllInterfaces()
+                    .names
+                    .filter { it.startsWith(qualifiedNamePrefix) }
         }
 
         override fun close() = scanResult.close()


### PR DESCRIPTION
Abstract flow classes are not associated with CorDapps, and consequently, the node is unable to resolve the correct target platform version.

JIRA: [CORDA-2634](https://r3-cev.atlassian.net/browse/CORDA-2634)