### PR TITLE
[CORDA-2635] Documentation update for issuableCurrencies

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -252,6 +252,7 @@ Version 4.0
   * Introduced a placeholder for custom properties within ``node.conf``; the property key is "custom".
   * The deprecated web server now has its own ``web-server.conf`` file, separate from ``node.conf``.
   * Property keys with double quotes (e.g. "key") in ``node.conf`` are no longer allowed, for rationale refer to :doc:`corda-configuration-file`.
+  * The ``issuableCurrencies`` property is no longer valid for ``node.conf``. Instead, it has been moved to the finance workflows CorDapp configuration.
 
 * Added public support for creating ``CordaRPCClient`` using SSL. For this to work the node needs to provide client applications
   a certificate to be added to a truststore. See :doc:`tutorial-clientrpc-api`


### PR DESCRIPTION
The `issuableCurrencies` property has been moved from `node.conf` to the finance workflows CorDapp configuration. This change has not been mentioned anywhere. This PR adds it to the changelog.
