### PR TITLE
ENT-3017: TestCordapp – use Gradle tooling API for builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,6 +233,7 @@ allprojects {
         jcenter()
         maven { url "$artifactory_contextUrl/corda-dependencies" }
         maven { url 'https://jitpack.io' }
+        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
     }
 
     configurations {

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-webapp:${jetty_version}"
     compile "javax.servlet:javax.servlet-api:3.1.0"
 
-    compile 'org.gradle:gradle-tooling-api:4.3'
+    compile "org.gradle:gradle-tooling-api:4.10.1"
     
     // Jersey for JAX-RS implementation for use in Jetty
     compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"

--- a/testing/node-driver/build.gradle
+++ b/testing/node-driver/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     compile "org.eclipse.jetty:jetty-webapp:${jetty_version}"
     compile "javax.servlet:javax.servlet-api:3.1.0"
 
+    compile 'org.gradle:gradle-tooling-api:4.3'
+    
     // Jersey for JAX-RS implementation for use in Jetty
     compile "org.glassfish.jersey.core:jersey-server:${jersey_version}"
     compile "org.glassfish.jersey.containers:jersey-container-servlet-core:${jersey_version}"

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
@@ -4,7 +4,8 @@ import io.github.classgraph.ClassGraph
 import net.corda.core.internal.*
 import net.corda.core.utilities.contextLogger
 import net.corda.testing.node.TestCordapp
-import org.apache.commons.lang.SystemUtils
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.ProgressEvent
 import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -77,25 +78,31 @@ data class TestCordappImpl(val scanPackage: String, override val config: Map<Str
 
         private fun buildCordappJar(projectRoot: Path): Path {
             return projectRootToBuiltJar.computeIfAbsent(projectRoot) {
-                val gradlew = findGradlewDir(projectRoot) / (if (SystemUtils.IS_OS_WINDOWS) "gradlew.bat" else "gradlew")
                 log.info("Generating CorDapp jar from local project in $projectRoot ...")
-                // The inner Gradle process has to be run with daemon disabled as it might reuse the same Gradle daemon as the main process running the tests, which leads to JVM crashing.
-                val exitCode = ProcessBuilder(gradlew.toString(), "-Dorg.gradle.daemon=false jar").directory(projectRoot.toFile()).inheritIO().start().waitFor()
-                check(exitCode == 0) { "Unable to generate CorDapp jar from local project in $projectRoot (exit=$exitCode)" }
+                runGradleBuild(projectRoot)
+
                 val libs = projectRoot / "build" / "libs"
                 val jars = libs.list { it.filter { it.toString().endsWith(".jar") }.toList() }.sortedBy { it.attributes().creationTime() }
                 checkNotNull(jars.lastOrNull()) { "No jars were built in $libs" }
             }
         }
 
-        private fun findGradlewDir(path: Path): Path {
-            var current = path
-            while (true) {
-                if ((current / "gradlew").exists() && (current / "gradlew.bat").exists()) {
-                    return current
-                }
-                current = current.parent
+        private fun runGradleBuild(projectRoot: Path) {
+            val gradleConnector = GradleConnector.newConnector().apply {
+                useBuildDistribution()
+                forProjectDirectory(projectRoot.toFile())
             }
+
+            val projectConnection = gradleConnector.connect()
+            val build = projectConnection.newBuild().apply {
+                forTasks("jar")
+                addProgressListener { event: ProgressEvent ->
+                    log.info(event.description)
+                }
+            }
+            // Blocks until the build is complete
+            build.run()
+            projectConnection.close()
         }
     }
 }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
@@ -79,7 +79,8 @@ data class TestCordappImpl(val scanPackage: String, override val config: Map<Str
             return projectRootToBuiltJar.computeIfAbsent(projectRoot) {
                 val gradlew = findGradlewDir(projectRoot) / (if (SystemUtils.IS_OS_WINDOWS) "gradlew.bat" else "gradlew")
                 log.info("Generating CorDapp jar from local project in $projectRoot ...")
-                val exitCode = ProcessBuilder(gradlew.toString(), "jar").directory(projectRoot.toFile()).inheritIO().start().waitFor()
+                // The inner gradle process has to be run with daemon disabled as it interferes with main Gradle process that's running the tests
+                val exitCode = ProcessBuilder(gradlew.toString(), "-Dorg.gradle.daemon=false jar").directory(projectRoot.toFile()).inheritIO().start().waitFor()
                 check(exitCode == 0) { "Unable to generate CorDapp jar from local project in $projectRoot (exit=$exitCode)" }
                 val libs = projectRoot / "build" / "libs"
                 val jars = libs.list { it.filter { it.toString().endsWith(".jar") }.toList() }.sortedBy { it.attributes().creationTime() }

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/TestCordappImpl.kt
@@ -79,7 +79,7 @@ data class TestCordappImpl(val scanPackage: String, override val config: Map<Str
             return projectRootToBuiltJar.computeIfAbsent(projectRoot) {
                 val gradlew = findGradlewDir(projectRoot) / (if (SystemUtils.IS_OS_WINDOWS) "gradlew.bat" else "gradlew")
                 log.info("Generating CorDapp jar from local project in $projectRoot ...")
-                // The inner gradle process has to be run with daemon disabled as it interferes with main Gradle process that's running the tests
+                // The inner Gradle process has to be run with daemon disabled as it might reuse the same Gradle daemon as the main process running the tests, which leads to JVM crashing.
                 val exitCode = ProcessBuilder(gradlew.toString(), "-Dorg.gradle.daemon=false jar").directory(projectRoot.toFile()).inheritIO().start().waitFor()
                 check(exitCode == 0) { "Unable to generate CorDapp jar from local project in $projectRoot (exit=$exitCode)" }
                 val libs = projectRoot / "build" / "libs"


### PR DESCRIPTION
The TestCordappImpl runs gradle to build cordapp jars required for tests. It's causing multiple issues including not actually building a jar or causing the JVM to die with SIGBUS.

Using the Gradle Tooling API to run the builds seems to fix the issues.
