### PR TITLE
CORDA-2639: CorDapp dependencies documentation

### DIFF
--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -287,6 +287,8 @@ node or will be automatically fetched over the network when receiving a transact
    app into multiple modules: one which contains just states, contracts and core data types. And another which contains
    the rest of the app. See :ref:`cordapp-structure`.
 
+.. _constraints_propagation:
+
 Constraints propagation
 -----------------------
 

--- a/docs/source/api-states.rst
+++ b/docs/source/api-states.rst
@@ -171,6 +171,8 @@ states in its vault. The default vault implementation makes the decision based o
 States that are not considered relevant are not stored in the node's vault. However, the node will still store the
 transactions that created the states in its transaction storage.
 
+.. _transaction_state:
+
 TransactionState
 ----------------
 When a ``ContractState`` is added to a ``TransactionBuilder``, it is wrapped in a ``TransactionState``:

--- a/docs/source/cordapp-advanced-concepts.rst
+++ b/docs/source/cordapp-advanced-concepts.rst
@@ -1,7 +1,9 @@
-.. Intended reader of this document is a CorDapp developer who will be hitting issues when transitioning to Corda 4.
- - Introduce the basing building blocks of transaction verification and how they fit together to achieve the final goal.
- - Gradually introduce more advanced scenarios and present the limitations of Corda 3 and Corda 4.
+.. Intended reader of this document is a CorDapp developer who wants to understand how to write production-ready CorDapp kernels.
+ - Introduce the basic building blocks of transaction verification and how they fit together.
+ - Gradually introduce more advanced requirements like CorDapp dependencies, evolution rules.
+ - Present the limitations of Corda 3 and Corda 4.
  - Proposed solutions and troubleshooting.
+
 
 Advanced CorDapp Concepts
 =========================
@@ -14,7 +16,7 @@ of tools for specifying and constraining which verify functions out of the unive
 
 In simple scenarios, this works as you would expect and Corda's in-built security controls ensure that your applications work as you expect them too.
 However, if you move to more advanced scenarios, especially ones where your verify function depends on code from other non-Corda libraries,
-especially code that _other_ people's verify functions may also depend on, you need to start thinking about what happens if and when states
+especially code that other people's verify functions may also depend on, you need to start thinking about what happens if and when states
 governed by these different pieces of code are brought together. If they both depend on a library, which common version should be used?
 How do you avoid your verify function's behaviour changing unexpectedly if the wrong version of the library is used? Are you at risk of subtle attacks?
 The good news is that Corda is designed to deal with these situations but the flip side is that you need to understand how this is done,
@@ -36,7 +38,14 @@ Corda does not embed the actual verification bytecode in transactions. The logic
 .. The basic threat model and security requirement.
 
 Being a decentralized system, anyone who can build transactions can create `.java` files, compile and bundle them in a JAR, and then reference
-this code in the transaction he created. To prevent this type of attack, we provide the contract constraints mechanism to complement the class name,
+this code in the transaction he created. If it were possible to do this without any restrictions, an attacker seeking to steal your money,
+for example, might create a transaction that transitions a `Cash` contract owned by you to one owned by the attacker.
+The only thing that is protecting your `Cash` is the contract verification code, so all the attacker has to do is attach a version of the
+`net.corda.finance.contracts.asset.Cash` contract class that permits this transition to occur.
+So we clearly need a way to ensure that the actual code attached to a transaction purporting to implement any given contract is constrained in some way.
+For example, perhaps we wish to ensure that only the specific implementation of `net.corda.finance.contracts.asset.Cash` that was specified by the initial issuer of the cash is used.
+Or perhaps we wish to constrain it in some other way. To prevent the types of attacks that can arise if there were no restrictions on which
+implementations of Contract classes were attached to transactions, we provide the contract constraints mechanism to complement the class name,
 that allows the State to specify exactly what code can be attached.
 In Corda 4, for example, the state can say: "I'm ok to be spent if the transaction is verified by a class: `com.megacorp.megacontract.MegaContract` as
 long as the JAR containing this contract is signed by `Mega Corp`".
@@ -45,11 +54,10 @@ a transaction chain because the code that verifies it is signed by the same enti
 
 .. Introduce the `LedgerTransaction` abstraction and how it relates to the transaction chain. Introduce the state serialization/deserialization and Classloaders.
 
-Another relevant aspect is that, as mentioned above, states are serialised java objects. To perform any useful operation on them they need to
+Another relevant aspect is that, as mentioned above, states are serialised Java objects. To perform any useful operation on them they need to
 be deserialized into instances of java objects. All these instances are made available to the contract code as the `LedgerTransaction` parameter
 passed to the `verify` method. The `LedgerTransaction` class abstracts away a lot of complexity and offers contracts a usable data structure where
-all objects are loaded in the same classloader and can be accessed and filtered by class name, so that the contract developer can focus on
-the business logic.
+all objects are loaded in the same classloader and can be freely used and filtered by class. This way, the contract developer can focus on the business logic.
 
 Behind the scenes, thing are more complex. As can be seen in this illustration:
 
@@ -57,33 +65,40 @@ Behind the scenes, thing are more complex. As can be seen in this illustration:
    :scale: 20%
    :align: center
 
+.. How The UTxO model is applied.
 
-The `LedgerTransaction.inputs` and `LedgerTransaction.references` are actually blobs of data fetched from previous transactions,
-that were serialized in that context - within the classloader of that transaction.
-This is because in the vault the input and reference states are actually `StateRefs` - pairs of Transaction Id and index.
-But they need to be verified together with the output states that were created in a different context.
-
+.. note:: Corda's design is based on the UTxO model. In a serialized transaction the input and reference states are `StateRef`s - only references
+          to output states from previous transactions (see :doc:`api-transactions`).
+          When building the `LedgerTransaction`, the `inputs` and `references` are resolved to Java objects created by deserialising blobs of data
+          fetched from previous transactions, that were serialized in that context - within the classloader of that transaction.
+          This model has consequences when it comes to how states can be evolved. Removing a field from a newer version of a state would mean
+          that when deserialising that state in the context of a transaction using the more recent code, that field could just disappear.
+          To prevent this, in Corda 4 we implemented the no-data loss rule, which prevents this to happen. See :doc:`serialization-default-evolution`
 
 .. Go through a very basic example of transaction verification.
 
-.. How The UTxO model is applied.
-
 Let's consider a very simple case, a transaction swapping `Apples` for `Oranges`. Each of the states that need to be swapped is the output of a previous transaction.
-Similar to the above image the `Apples` state can be the output of a transaction where the apples could have been swapped for grapes.
-The `Apples` state that will be referenced as an input state is actually a serialized `TransactionState` that is stored within the
-Merkle Tree structure of the transaction that created it. (Read more in: :doc:`key-concepts-tearoffs`)
-Both the `Apples` and the `Oranges` states contain the usual data characteristics that you would expect from fresh fruit, found in the `TransactionState.data` field ,
-but also the rules around the governing contract that ensures that they can be safely traded - the `contractClassName` and `constraint`. ( Read more in: :ref:`transaction_state` )
-
-The swap transaction would contain the 2 input states and 2 output states with the new owners of the fruit.
-The code to be used to deserialize and verify the transaction would be added to the transaction as 2 attachment IDs - which are SHA256 of the apples and oranges CorDapps.
+Similar to the above image the `Apples` state is the output of some previous transaction, through which it came to be possessed by the party now paying it away in return for some oranges.
+The `Apples` and `Oranges` states that will be consumed in this new transaction exist as serialised `TransactionState`s.
+It is these `TransactionState`s that specify the fully qualified names of the contract code that should be run to verify their consumption as well as,
+importantly, the governing `constraint`s on which specific implementations of that class name can be used.
+The swap transaction would contain the two input states, the two output states with the new owners of the fruit and the code to be used to deserialize and
+verify the transaction as two attachment IDs - which are SHA256 of the apples and oranges CorDapps (more specifically, the CorDapp kernels).
 
 .. note:: The attachment ID is a cryptographic hash of a file. Any node calculates this hash when it downloads the file from a peer (during transaction resolution) or from
           another source, and thus knows that it is the exact file that any other party verifying this transaction will use. In the current version of
           Corda - v4 -, nodes won't load JARs downloaded from a peer into a classloader. This is a temporary security measure until we integrate the
           Deterministic JVM Sandbox, which will be able to isolate network loaded code from sensitive data.
 
+This combination of fully qualified contract class name and constraint ensures that, when a state is spent, the contract code attached to the transaction
+(that will ultimately determine whether the transaction is considered valid or not) meets the criteria laid down in the transaction that created that state.
+For example, if a state is created with a constraint that says its consumption can only be verified by code signed by MegaCorp,
+then the Corda consensus rules mean that any transaction attaching an implementation of the class that is _not_ signed by MegaCorp will not be considered valid.
+
 .. Verify attachment constraints. Introduce constraints propagation.
+
+The previous discussion explained the construction of a transaction that consumes one or more states. Now let's consider this from the perspective
+of somebody verifying a transaction they are presented with.
 
 When a node needs to verify this transaction the first thing it has to do is to ensure that the transaction was formed correctly. Given that the input states
 are already agreed to be valid facts, the creator of the current transaction has to attach code that is compliant with their constraints.
@@ -104,6 +119,16 @@ This is done by creating an `AttachmentsClassloader` from all the attachments li
 representation of the transaction inside this classloader, create the `LedgerTransaction` and then running the contract verification code
 in this classloader.
 
+We mentioned previously that Corda operates in a decentralised system. Nothing stops an adversary to attach a JAR he just created to a transaction.
+This JAR could contain some of the same classes that are also available in a legitimate library or in the contract JAR itself. Due to how Java classloaders work,
+this would cause ambiguity as to what code will be executed, so an attacker could attempt to exploit this and trick other nodes that a transaction that
+should be invalid is actually valid. To address this vulnerability, Corda introduces the `no-overlap` rule:
+
+.. note:: The `no-overlap rule` is applied to the `AttachmentsClassloader` that is build for each transaction. If a file with the same path but different content exists
+          in multiple attachments, the transaction is considered invalid. The reason for this is that these files can provide different implementations
+          of the same class and which one is loaded might depend on the implementation of the underlying JVM. This would break the determinism, and
+          would also open subtle security problems.
+
 .. Why does this need to be so complicated? Cross contract references, Class identity crisis.
    Here we explain why all the attachments need to be combined.
 
@@ -113,47 +138,50 @@ even if the transaction is verified in 20 years, when the current version of the
 This mechanism ensures that given the same input (the binary representation of a transaction), any node is able to load the same code and calculate
 the exact same result.
 
-If every state has it's own governing code then why can't we just verify individual transitions independently? This would simplify a lot of things.
-The answer is that for a trivial case like swapping `Apples` for `Oranges` where the 2 contracts might not care about the other states in the
+If every state has its own governing code then why can't we just verify individual transitions independently? This would simplify a lot of things.
+The answer is that for a trivial case like swapping `Apples` for `Oranges` where the two contracts might not care about the other states in the
 transaction, this could be a solution. But Corda is designed to support complex business scenarios where the `Apples` contract could check
-that Pink lady apples can only be traded against Valencia oranges. If apples and oranges were loaded in separate classloaders then the
+that Pink Lady apples can only be traded against Valencia oranges. If apples and oranges were loaded in separate classloaders then the
 contract code would hit the java `Class identity crisis <https://www.ibm.com/developerworks/java/library/j-dyn0429/>`_ issue and would get
 lots of `ClassCastExceptions`.
 
 
 .. Now we introduce a simple dependency. And the problems that come with this. We already established that all attachments are combined.
 
-Things get more complicated though if the `Apples` contract uses an external library which gets called during verification.
+Exchanging Apples for Oranges is a contrived example, of course, but this pattern is not uncommon. And a common scenario is one where code
+that is common to a collection of state types is abstracted into a common library.
+For example, imagine Apples and Oranges both depended on a `Fruit` library developed by a third party as part of their verification logic.
 
 This library must obviously be available to execute, since the verification logic depends on it, which in turn means it must be loaded by the Attachments Classloader.
-Since it is constructed solely from code attached to the transaction, it means the library must be attached to the transaction.
+Since the classloader is constructed solely from code attached to the transaction, it means the library must be attached to the transaction.
 The question to consider as a developer of CorDapps is: where and how should it be attached?
 
 There are 2 options to achieve this:
 
- 1. Bundle the external library with the `Apples` code. Basically create a fat-JAR that includes all dependencies.
-    In the general case, where you are using signature constraints, you will sign over this fat JAR file.
+ 1. Imagine only the Apples code has been refactored to depend on the Fruit library. In which case, you could bundle the external library with the `Apples` code.
+    Basically create a fat-JAR that includes all dependencies. In the general case, where you are using signature constraints, you will sign over this fat JAR file.
  2. Add the dependency as another attachment to the transaction.
 
 These options have pros and cons, which are now discussed:
 
-Approach 1 is fairly straight forward and does not require any additional setup. Just declaring a `compile` dependency to a cordapp
+Approach one is fairly straight forward and does not require any additional setup. Just declaring a `compile` dependency to a cordapp
 will by default bundle the dependency with the cordapp. One obvious drawback is that CorDapp JARs can grow quite large in case they depend on
 large libraries. Other drawbacks will be discussed below.
 
-Approach 2 is insecure without manually adding additional security checks. As stated previously anyone can create a JAR, so a malicious actor
-could just create his own version of the library and attach that. This would allow the attacker to change the intended behavior of the
-contract that depends on this code to his advantage.
+Approach two can be attractive in cases where multiple applications depend on the same library but it currently requires an additional security
+check to be included in contract code. As stated previously anyone can create a JAR containing a class your CorDapp depends on, so a malicious actor
+could just create his own version of the library and attach that to the transaction instead of the legitimate one your code expects. This would allow
+the attacker to change the intended behavior of the contract that depends on this code to his advantage.
 
 There are ways to make this option secure and future versions of Corda will explore and implement them.
-If a CorDapp developer decides to go for this approach they can write custom contract code to perform dependency validity checks as the `verify` method
-has access to the `LedgerTransaction`. As soon as support is added at the platform level this code can be removed.
+Currently, if a CorDapp developer decides to go for this approach they can write custom contract code to perform dependency validity checks as the `verify` method
+has access to the `LedgerTransaction`. As soon as support is added at the platform level this code can be removed. See below for example code.
+What this manual check does is extend the security umbrella provided by the constraint of the state to its dependencies.
 
 .. warning:: In Corda 4, it is the responsibility of the CorDapp developer to ensure that dependencies are added in a secure way.
              Fat-JARing the dependency is secure, but adding the attachment to the transaction is not enough. The contract code (that is guaranteed to be correct by the constraints mechanism),
              must verify that all dependencies are available and are not malicious.
 
-.. All pieces are in place now to introduce the no-overlap rule and the consequences for dependencies.
 
 If the library you depend on is unique to your application then bundling it in your fat JAR probably makes sense.
 
@@ -161,14 +189,14 @@ However, if it is a library that other contracts (eg `Oranges`) may plausibly de
 when trying to build an `Apples` for `Oranges` transaction. If `Apples` bundles `guava-v23` and `Oranges` bundles `guava-v27` then the transaction
 will break the `no-overlap` rule and could never validate.
 
-.. note:: The `no-overlap rule` is applied to the `AttachmentsClassloader` that is build for each transaction. If a file with the same path but different content exists
-          in multiple attachments, the transaction is considered invalid. The reason for this is that these files can provide different implementations
-          of the same class and which one is loaded might depend on the implementation of the underlying JVM. This would break the determinism, and
-          would also open subtle security problems.
-
 A simple way to fix this problem is for cordapps to shade this popular dependency under their own namespace. This would avoid breaking the `no-overlap rule`.
 The primary downside is that multiple apps using (and shading) this dependency may lose the ability in other contexts to do things like cast to some common superclass.
 Also, currently, the Corda gradle plugin does not provide any tooling for shading.
+
+.. note:: A very important point to remember as a CorDapp developer when you prepare for release is that states created with your CorDapp can in theory
+          be used in transactions with any other states that are governed by CorDapps that might not exist for the next 10 years. In order to
+          maximise the usefulness of your CorDapp you have to ensure that the overlap footprint is as low as possible.
+
 
 The alternative approach is to attach the library as a separate attachment (approach 2). This opens the door to multiple contracts depending on the same
 library without having to include it in their JAR, but it requires them to depend on the same major version of the library (assuming semantic versioning).
@@ -180,14 +208,18 @@ adds support for secure and usable dependency management, it will be easy to upg
 .. note:: Currently the `cordapp` gradle plugin that ships with Corda only supports bundling a dependency fully unshaded, by declaring it as a `compile` dependency.
         It also supports `cordaCompile`, which assumes the dependency is available so it does not bundle it. There is no current support for shading or partial bundling.
 
-.. todo introduce the case where you just depend for cross contract checks
 
-.. ONLY refactored up to here.
+.. Introduce the most complex case.
 
 CorDapp depending on other CorDapp(s)
 -------------------------------------
 
-Let's take as an example the `finance` CorDapp that is shipped with Corda as a sample.
+.. Present some reasonable examples.
+
+We presented the "complex" business requirement earlier where the `Apples` contract has to check that it can't allow swapping Pink Lady apples for anything
+but Valencia Oranges. This actually means that the library that the `Apples` CorDapp depends on is itself a CorDapp.
+
+Or, we can use as an example the `finance` CorDapp that is shipped with Corda as a sample.
 
 .. note:: As it is just a sample, it is signed by R3's development key, which the node is explicitly configured - but overridable - to blacklist
   by default in production in order to avoid you inadvertently going live without having first determined the right approach for your solution.
@@ -196,69 +228,61 @@ Let's take as an example the `finance` CorDapp that is shipped with Corda as a s
 The finance CorDapp brings some handy utilities that can be used by code in other CorDapps, some abstract base types like `OnLedgerAsset`,
 but also comes with its own ready-to-use contracts like: `Cash`, `Obligation` and `Commercial Paper`.
 
-This creates a tension as it gives the finance CorDapp a dual role: `reusable library` AND `normal CorDapp that can be used directly to issue and consume states`.
+Imagine you are selling `Bonds` for `Cash`, and the `Bonds` contract depends on the finance CorDapp - for example it extends `OnLedgerAsset`.
+At compile time the `Bonds` CorDapp needs a dependency on finance. But how can that be expressed when building transactions?
 
-If it were just a library it could be bundled as a normal dependency (and all the caveats - due to the no-overlap rule described above - would apply).
+.. Why is FatJar not an option?
 
-If it were a CorDapp that was used as a main `Contract attachment` to verify transitions it would have to be attached to the transaction and checked against
-the constraints of the states that it controls.
+In the `Bonds` for `Cash` example the transaction needs two attachments: the `finance` JAR signed by R3's key and the `bonds` JAR signed by `CompanyA`.
+(For the purpose of this exercise let's ignore the fact that the JAR is signed by R3's development key).
+The reason for this, as explained above, is that each state must check that its contract constraints are satisfied.
 
-It can't be both in a single transaction though.
+Let's imagine that the `Bonds` kernel JAR bundled the finance JAR. This means that when verifying the above transaction,
+there would be ambiguity as to which JAR to apply the contract constraint rule of the `Cash` state. The reason for this is that both JARs
+would contain an implementation for `net.corda.finance.contracts.asset.Cash`. This would break the transaction verification rule that states:
+"There can be only one and precisely one attachment that is identified as the contract code that controls each state"
 
-Why?
+.. warning:: If, as a CorDapp developer you bundle a third party CorDapp that you depend upon, it will become impossible for anyone to build
+             valid transactions that contain both your states and third party states. This would severely limit the usefulness of your CorDapp.
 
-Imagine you are selling `Apples` for `Cash` this time, but the `Apples` contract depends on the finance CorDapp - for example it extends `OnLedgerAsset`.
-A transaction is formed and 2 attachments are added: the finance JAR signed by R3's key and the apples JAR signed by `CompanyA` (that bundles finance).
+.. The suggested solution.
 
-For the purpose of this exercise let's ignore the fact that the JAR is signed by R3's development key.
+Now, let's imagine that someone wants to trade `Bonds` for `Apples`. In this case, given that the `Bonds` Cordapp can't bundle `finance`,
+the creator of the transaction needs to add the `finance` JAR to the transaction attachments. As described above, this solution needs additional
+checks added to the `Bonds`.
 
-When this transaction is verified and the platform has to decide which attachment JAR to verify against which state constraint there is an ambiguity
-as both JARs could be candidates for the constraint of the `Cash` states.
-To avoid any ambiguity we have specifically enforced that there can be only 1 attachment for the relevant contracts of the transaction.
+.. note:: The preferred solution for CorDapp to CorDapp dependency is to just add checks in your contract that the transaction contains a valid
+          version of the dependency. Also, in the flow code, make sure to attach the dependant CorDapp to the transaction. See below for example code.
 
-The main problem we have in this case is that a node would not be able to create a valid `Apples` for `Cash` transaction.
-	
+.. Other options.
+
+Same as for normal dependencies, CorDapp developers can use shading or partial bundling if they really want to bundle the code. All the drawbacks
+described above will apply.
+
+.. TODO - package ownership
 Another problem with this approach is that it introduces namespace confusion. If someone decides to issue `net.corda.finance.contracts.asset.Cash`
 using the `apples` contract that bundles the finance app it would be a completely different state from one that was issued with the R3 controlled contract.
 This is because the code could evolve in completely different directions and users of that state who don't check the constraint would be misled.
-
 In Corda 4, to help avoid this type of confusion, we introduced the concept of Package Namespace Ownership (see ":doc:`design/data-model-upgrades/package-namespace-ownership`").
 Briefly, it allows companies to claim namespaces and anyone who encounters a class in that package that is not signed by the registered key knows is invalid.
-
-Given the above there are 4 possible solutions for reusable CorDapps:
-
- 1. Partial bundling:  Only bundle the exact classes you need in your contract. Basically leave out the ready-to-use contracts. This would reduce
-    the problem of a reusable CorDapp (described above) to that of a normal library ( with all the caveats around the no-overlap rule).
-
- 2. Shading: This means that there would be no namespace collision, but the downside is that when extending some base interface the contract that
-    extends would lose the relation with other implementations.
-
  3. Package ownership: `net.corda.finance.contracts.asset` would be claimed by R3. This would give confidence to all participants that if a JAR
     with this package is attached to a transaction it must be created by the original developer which was deemed as trustworthy by the zone operator.
-
- 4. Manually attaching the actual library-Cordapp to the transaction. The contract that uses it is responsible to perform an equivalent of an
-    Attachment constraint to make sure that a malicious party did not attach a "customized" JAR that alters the intended verification logic.
-
-
-The preferred approach can be selected by the developers of the CorDapp, but the recommended approach is to go for 4 - manually attaching and checking.
-
-We also recommend that companies claim their package so the best approach is to combine 3 and 4. By actually checking in the contract code that
-the expected dependency is present there is no possibility for unexpected behaviour.
 
 
 Changes between version 3 to version 4 of Corda
 -----------------------------------------------
 
-In Corda 3 transactions were verified inside the System Classloader that contained all the installed CorDapps.
-If we consider the example from above with the `Apples` contract that depends on finance, the `Apples` developer could have just released
-the `Apples` specific code ( without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that
+In Corda v3 transactions were verified inside the System Classloader that contained all the installed CorDapps.
+This was a temporary simplification and we explained above why it could only be short-lived.
+
+If we consider the example from above with the `Bonds` contract that depends on finance, the bonds contract developer could have just released
+the `Bonds` specific code (without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that
 finance would be on the classpath during verification.
 
 This means that in Corda 3 nodes could have formed `valid` transactions that were not entirely self-contained. In Corda 4, because we
-moved transaction verification inside the `AttachmentsClassloader` these transactions would fail with ClassNotFound exceptions
-(in the example above the finance jar would not be available as it wasn't explicitly added).
+moved transaction verification inside the `AttachmentsClassloader` these transactions would fail with `ClassNotFound` exceptions.
 
-These transactions need to be considered valid in Corda 4 and beyond though, so the fix we added for this was to look for a `trusted` attachment
+These incomplete transactions need to be considered valid in Corda 4 and beyond though, so the fix we added for this was to look for a `trusted` attachment
 in the current node storage that contains the missing code and use that for validation.
 This fix is in the spirit of the original transaction and is secure because the chosen code must have been vetted and whitelisted first by the node operator.
 

--- a/docs/source/cordapp-advanced-concepts.rst
+++ b/docs/source/cordapp-advanced-concepts.rst
@@ -49,8 +49,6 @@ implementations of Contract classes were attached to transactions, we provide th
 that allows the State to specify exactly what code can be attached.
 In Corda 4, for example, the state can say: "I'm ok to be spent if the transaction is verified by a class: `com.megacorp.megacontract.MegaContract` as
 long as the JAR containing this contract is signed by `Mega Corp`".
-This approach combines security and usability, allowing the code to evolve and developers to fix bugs. It also gives confidence when verifying
-a transaction chain because the code that verifies it is signed by the same entity.
 
 .. Introduce the `LedgerTransaction` abstraction and how it relates to the transaction chain. Introduce the state serialization/deserialization and Classloaders.
 
@@ -99,53 +97,53 @@ then the Corda consensus rules mean that any transaction attaching an implementa
 
 The previous discussion explained the construction of a transaction that consumes one or more states. Now let's consider this from the perspective
 of somebody verifying a transaction they are presented with.
-
-When a node needs to verify this transaction the first thing it has to do is to ensure that the transaction was formed correctly. Given that the input states
-are already agreed to be valid facts, the creator of the current transaction has to attach code that is compliant with their constraints.
-The output states are also objects created by a node so they must be created with a valid constraint, to ensure the validity of the future chain (:ref:`constraints_propagation`).
-The rule is that for each state there must be one and only one attachment that contains the fully qualified contract class name. This attachment will
-be identified as the CorDapp JAR corresponding to that state and thus it must satisfy the constraint of that state.
-For example, if the state is signature constrained, the attachment must be signed by the key specified in the state.
+The first thing it has to do is to ensure that the transaction was formed correctly and then execute the contract verification logic.
+Given that the input states are already agreed to be valid facts, the attached code has to be compliant with their constraints.
+The output states are also objects created by a potential malicious node so they must be created with a valid constraint to ensure the validity of the future chain (:ref:`constraints_propagation`).
+The rule for contract code attachment validity checking is that for each state there must be one and only one attachment that contains the fully qualified contract class name.
+This attachment will be identified as the CorDapp JAR corresponding to that state and thus it must satisfy the constraint of that state.
+For example, if one state is signature constrained, the corresponding attachment must be signed by the key specified in the state.
 If this rule is breached the transaction is considered invalid even if it is signed by all the required parties, and any compliant node will refuse to execute
 the verification code.
 
 This rule, together with the no-overlap rule - which we'll introduce below - ensure that the code used to deserialize and verify the transaction is
-legitimate and that there is no ambiguity when it comes to what code to execute. This is critical to achieving the determinism property.
+legitimate and that there is no ambiguity when it comes to what code to execute.
 
 .. Contract execution in the AttachmentsClassloader, and the no-overlap rule.
 
-To verify the business rules of the transaction, the smart contract code for each state will be executed.
+After ensuring that the contract code is correct, to verify the business rules of the transaction, the node needs to execute it.
 This is done by creating an `AttachmentsClassloader` from all the attachments listed by the transaction, then deserialising the binary
 representation of the transaction inside this classloader, create the `LedgerTransaction` and then running the contract verification code
 in this classloader.
 
-As Corda operates in a decentralised system, nothing stops an adversary to attach a JAR he just created to a transaction he is building.
-This JAR could contain some of the same classes that are also available in a legitimate library or in the contract JAR itself. Due to how Java classloaders work,
+Because Corda transactions can combine any states, it is possible that 2 different transaction attachments contain the same class name (they overlap).
+This can happen legitimately or it can be a malicious party attempting to break the contract rules. Due to how Java classloaders work,
 this would cause ambiguity as to what code will be executed, so an attacker could attempt to exploit this and trick other nodes that a transaction that
 should be invalid is actually valid. To address this vulnerability, Corda introduces the `no-overlap` rule:
 
 .. note:: The `no-overlap rule` is applied to the `AttachmentsClassloader` that is build for each transaction. If a file with the same path but different content exists
-          in multiple attachments, the transaction is considered invalid. The reason for this is that these files can provide different implementations
-          of the same class and which one is loaded might depend on the implementation of the underlying JVM. This would break the determinism, and
-          would also open subtle security problems. Another problem is that if a contract expects and was tested against a certain implementation,
+          in multiple attachments, the transaction is considered invalid. The reason for this is that these files provide different implementations
+          of the same class and which one is loaded might depend on the implementation of the underlying JVM. This would break determinism, and
+          would also open security problems. Even in the legitimate case, if a contract expects and was tested against a certain implementation,
           then running it against a different, but still legitimate implementation could cause unexpected results.
 
 .. Why does this need to be so complicated? Cross contract references, Class identity crisis.
    Here we explain why all the attachments need to be combined.
 
-The process described above may appear surprising. Nodes have cordapps installed anyway. Why does the code need to be attached to the transaction?
-The design of Corda is that the validity of a transaction should not depend on any node specific setup and should always return the same result,
+The process described above may appear surprising and complex. Nodes have CorDapps installed anyway, so why does the code need to also be attached to the transaction?
+Corda is designed to ensure that the validity of any transaction does not depend on any node specific setup and should always return the same result,
 even if the transaction is verified in 20 years when the current version of the CorDapps it uses will not be installed on any node.
-This mechanism ensures that given the same input (the binary representation of a transaction), any node is able to load the same code and calculate
-the exact same result.
+This attachments mechanism ensures that given the same input - the binary representation of a transaction and its back-chain, any node is and will
+be able to load the same code and calculate the exact same result.
 
-If every state has its own governing code then why can't we just verify individual transitions independently? This would simplify a lot of things.
+Another surprise might be the fact that if every state has its own governing code then why can't we just verify individual transitions independently?
+This would simplify a lot of things.
 The answer is that for a trivial case like swapping `Apples` for `Oranges` where the two contracts might not care about the other states in the
-transaction, this could be a solution. But Corda is designed to support complex business scenarios where the `Apples` contract could check
-that Pink Lady apples can only be traded against Valencia oranges. For this to be possible, the `Apples` contract needs to be able to find
+transaction, this could be a valid solution. But Corda is designed to support complex business scenarios. For example the `Apples` contract logic
+can have a requirement to check that Pink Lady apples can only be traded against Valencia oranges. For this to be possible, the `Apples` contract needs to be able to find
 `Orange` states in the `LedgerTransaction`, understand their properties and run logic against them. If apples and oranges were loaded in
 separate classloaders then the `Apples` classloader would need to load code for `Oranges` anyway in order to perform those operations.
-This would cause unexpected behaviour and many `ClassCastExceptions`. You can read more about this here :
+This would cause some unexpected behaviour and many `ClassCastExceptions`. You can read more about this here:
 `Class identity crisis <https://www.ibm.com/developerworks/java/library/j-dyn0429/>`_ .
 
 
@@ -161,39 +159,40 @@ For example, imagine Apples and Oranges both depended on a `Fruit` library devel
 This library must obviously be available to execute, since the verification logic depends on it, which in turn means it must be loaded by the Attachments Classloader.
 Since the classloader is constructed solely from code attached to the transaction, it means the library must be attached to the transaction.
 
-The question to consider as a developer of CorDapps is: where and how should my dependencies be attached to transactions?
+The question to consider as a developer of a CorDapp is: where and how should my dependencies be attached to transactions?
 
 There are 2 options to achieve this (given the hypothetical `Apples` for `Oranges` transaction):
 
- 1. Imagine only the `Apples` code has been refactored to depend on the `Fruit` library. In this case, you could bundle the external library with the `Apples` code.
-    Basically create a fat-JAR that includes all dependencies. In the general case, where you are using signature constraints, you will sign over this fat JAR file.
+ 1. Bundle the `Fruit` library with the CorDapp. This means creating a Fat-JAR containing all the required code.
  2. Add the dependency as another attachment to the transaction.
 
 These options have pros and cons, which are now discussed:
 
-The first approach is fairly straight forward and does not require any additional setup. Just declaring a `compile` dependency to a cordapp
-will by default bundle the dependency with the cordapp. One obvious drawback is that CorDapp JARs can grow quite large in case they depend on
+The first approach is fairly straight forward and does not require any additional setup. Just declaring a `compile` dependency
+will by default bundle the dependency with the CorDapp. One obvious drawback is that CorDapp JARs can grow quite large in case they depend on
 large libraries. Other more subtle drawbacks will be discussed below.
 
-The second approach can be attractive in cases where multiple applications depend on the same library but it currently requires an additional
-security check to be included in the contract code. Given that anyone can create a JAR containing a class your CorDapp depends on, a malicious actor
-could just create his own version of the library and attach that to the transaction instead of the legitimate one your code expects. This would allow
-the attacker to change the intended behavior of the contract that depends on this code to his advantage.
+.. _manually_attach_dependency:
 
-There are ways to make this option secure without the additional explicit checks and future versions of Corda will explore and implement them.
-Currently, if a CorDapp developer decides to choose this approach they can write custom contract code to perform dependency validity in the `verify` method.
-As soon as support is added at the platform level this code can be removed from future versions of the CorDapp. Check below for sample code.
-What this manual check does is extend the security umbrella provided by the attachment constraint of the state to its dependencies. See :ref:`contract_security`.
+The second approach is more flexible in cases where multiple applications depend on the same library but it currently requires an additional
+security check to be included in the contract code. The reason is that given that anyone can create a JAR containing a class your CorDapp depends on, a malicious actor
+could just create his own version of the library and attach that to the transaction instead of the legitimate one your code expects. This would allow
+the attacker to change the intended behavior of your contract to his advantage.
+See :ref:`contract_security` for an example.
+Basically, what this manual check does is extend the security umbrella provided by the attachment constraint of the state to its dependencies.
+As soon as support is added at the platform level this code can be removed from future versions of the CorDapp.
 
 .. warning:: In Corda 4, it is the responsibility of the CorDapp developer to ensure that all dependencies are added in a secure way.
              Bundling the dependency together with the contract code is secure, so if there are no other factors it is the preferred approach.
              If the dependency is not bundled, just adding the attachment to the transaction is not enough. The contract code, that is guaranteed
              to be correct by the constraints mechanism, must verify that all dependencies are available in the `attachments` and are not malicious.
 
-It is evident now that each contract must add its own dependencies to the transaction, but what happens when two contracts depend on the same library?
-The node that is building the transaction must ensure that the JARs added contain all code needed for all contracts and does not break the `no-overlap`
-rule. In the above example if the `Apples` code depends on `Fruit v3` and the `Oranges` code depends on `Fruit v4` that would be impossible
-to achieve.
+.. CorDapps depending on the same library.
+
+It should be evident now that each CorDapp must add its own dependencies to the transaction, but what happens when two CorDapps depend on the same library?
+The node that is building the transaction must ensure that the attached JARs contain all code needed for all CorDapps and also do not break the `no-overlap` rule.
+
+In the above example, if the `Apples` code depends on `Fruit v3` and the `Oranges` code depends on `Fruit v4` that would be impossible to achieve.
 
 A simple way to fix this problem is for CorDapps to shade this common dependency under their own namespace. This would avoid breaking the `no-overlap rule`.
 The primary downside is that multiple apps using (and shading) this dependency may lose the ability in other contexts to carry out operations like casting to a common superclass.
@@ -206,20 +205,16 @@ Also, currently, the Corda gradle plugin does not provide any tooling for shadin
           be used in transactions with any other states that are governed by CorDapps that might not exist for the next 10 years. In order to
           maximise the usefulness of your CorDapp you have to ensure that the overlap footprint is as low as possible.
 
-The alternative more advanced approach is for CorDapp developers to release and test each version of their code bundled with multiple versions of the dependencies.
-Or, in case of "Approach 2" to add all the tested versions as acceptable in the contract code.
-In which case it becomes the responsibility of the flows that build the transactions to find the right combination of CorDapps to create a valid transaction.
+The ideal solution is for CorDapps to declare their dependencies, and for the platform to be able to automatically select valid dependencies
+when a transaction is built, and also to ensure that transactions are formed with the right dependencies at verification time.
+This type of functionality is what we plan to implement in a future version of Corda.
 
-.. Introduce cordapp versions.
-
-.. note:: CorDapps themselves can have multiple versions, and they may change dependent libraries between versions or replace them completely.
-          Any flow that might attempt to execute such a matching logic would need to maintain some compatibility metadata.
-          This functionality will be provided by the platform in a future version
-
+Until then, because the network is not that developed and the chance of overlap is not very high, CorDapps can just choose one of the above approaches,
+and in case such a clash becomes a real problem, handle it in a case by case basis.
+For example the authors of the two clashing CorDapps could decide to use a certain version of the dependency and thus not trigger the no-overlap rule
 
 .. note:: Currently the `cordapp` gradle plugin that ships with Corda only supports bundling a dependency fully unshaded, by declaring it as a `compile` dependency.
           It also supports `cordaCompile`, which assumes the dependency is available so it does not bundle it. There is no current support for shading or partial bundling.
-
 
 
 .. Introduce the most complex case.
@@ -227,91 +222,103 @@ In which case it becomes the responsibility of the flows that build the transact
 CorDapp depending on other CorDapp(s)
 -------------------------------------
 
-.. Present some reasonable examples.
+.. Present some reasonable examples. Why is FatJar not an option?
 
 We presented the "complex" business requirement earlier where the `Apples` contract has to check that it can't allow swapping Pink Lady apples for anything
-but Valencia Oranges. This actually means that the library that the `Apples` CorDapp depends on is itself a CorDapp.
+but Valencia Oranges. This requirement translates into the fact that the library that the `Apples` CorDapp depends on is itself a CorDapp (the `Oranges` CorDapp).
 
-Or, we can use as an example the `finance` CorDapp that is shipped with Corda as a sample.
+Let's assume the `Apples` CorDapp bundles the `Oranges` CorDapp as a fat-jar.
+If someone attempts to build a swap transaction they would find it impossible:
 
-.. note:: As it is just a sample, it is signed by R3's development key, which the node is explicitly configured - but overridable - to blacklist
-  by default in production in order to avoid you inadvertently going live without having first determined the right approach for your solution.
-  But it is illustrative to other reusable CorDapps that might get developed.
+ - If the two attachments are added to the transaction, then the `com.orangecompany.Orange` class would be found in both, and that would breat the rule that states
+   "There can be only one and precisely one attachment that is identified as the contract code that controls each state".
+ - In case only the `Apples` CorDapp is attached then the constraint of the `Oranges` states would not pass, as the JAR would not be signed by the actual `OrangCo`.
 
-The finance CorDapp brings some handy utilities that can be used by code in other CorDapps, some abstract base types like `OnLedgerAsset`,
-but also comes with its own ready-to-use contracts like: `Cash`, `Obligation` and `Commercial Paper`.
 
-Imagine you are selling `Bonds` for `Cash`, and the `Bonds` contract depends on the finance CorDapp - for example it extends `OnLedgerAsset`.
-At compile time the `Bonds` CorDapp needs a dependency on finance. But how can that be expressed when building transactions?
+Another example that shows that bundling is not an option when depending on another CorDapp is if the `Fruit` library contains a ready to use `Banana` contract.
+Also let's assume that the `Apples` and `Oranges` CorDapps bundle the `Fruit` library inside their distribution fat-jar.
+In this case `Apples` for `Oranges` swaps would work fine if the two CorDapps use the same version of `Fruit`, but what if someone attempts to swap `Apples` for `Bananas`?
+They would face the same problem as described above and would not be able to build such a transaction.
 
-.. Why is FatJar not an option?
-
-In the `Bonds` for `Cash` example the transaction needs two attachments: the `finance` JAR signed by R3's key and the `bonds` JAR signed by `CompanyA`.
-(For the purpose of this exercise let's ignore the fact that the JAR is signed by R3's development key).
-The reason for this, as explained above, is that each state must check that its contract constraints are satisfied.
-
-Let's imagine that the `Bonds` kernel JAR bundled the finance JAR. This means that when verifying the above transaction,
-there would be ambiguity as to which JAR to apply the contract constraint rule of the `Cash` state. The reason for this is that both JARs
-would contain an implementation for `net.corda.finance.contracts.asset.Cash`. This would break the transaction verification rule that states:
-"There can be only one and precisely one attachment that is identified as the contract code that controls each state"
 
 .. warning:: If, as a CorDapp developer you bundle a third party CorDapp that you depend upon, it will become impossible for anyone to build
              valid transactions that contain both your states and states from the third party CorDapp. This would severely limit the usefulness of your CorDapp.
 
-
-Let's take another example using the `Apples`, `Oranges` and `Fruit` library, but this time the `Fruit` library contains a `Banana` contract.
-In this example the `Apples` and `Oranges` bundle the `Fruit` library inside their distribution fat-jar. Now imagine you want to swap
-some `Apples` for some `Bananas`. There would be no way such a transaction could be build without breaking the above rule.
-
-
 .. The suggested solution.
 
-The preferred solution for CorDapp to CorDapp dependency is to add checks in your contract that the transaction contains a valid version of the
-CorDapp you're depending on. Also, in the flow code, make sure to attach the dependant CorDapp to the transaction. See below for example code.
-
-.. _contract_security:
-
-Add this to the flow:
-
-.. sourcecode:: kotlin
-
-    builder.addAttachment(hash_of_the_fruit_jar)
-
-And in the contract code verify that there is one attachment that contains the dependency.
-
-.. sourcecode:: kotlin
-
-    // In case the contract depends on a specific version
-    requireThat {
-        "the correct fruit jar was attached to the transaction" using (tx.attachments.find {it.id == hash_of_fruit_jar} !=null)
-    }
-
-.. sourcecode:: kotlin
-
-    // In case any dependency that is signed by a hardcoded key is acceptable.
-    requireThat {
-        "the correct my_reusable_cordapp jar was attached to the transaction" using (tx.attachments.find {SignatureAttachmentConstraint(my_public_key).isSatisfiedBy(it)} !=null)
-    }
-
-
-.. Other options.
-
-Same as for normal dependencies, CorDapp developers can use shading or partial bundling if they really want to bundle the code. All the drawbacks
-described above will apply.
+The highly recommended solution for CorDapp to CorDapp dependency is to always manually attach the dependent CorDapp to the transaction.
+(see :ref:`manually_attach_dependency` and :ref:`contract_security`)
 
 .. package ownership
 
-Bundling third party CorDapps also presents a problem of identity. With the introduction of the `SignatureConstraint`, CorDapps will be signed
+Another way to look at bundling third party CorDapps is from the point of view of identity. With the introduction of the `SignatureConstraint`, CorDapps will be signed
 by their creator, so the signature will become part of their identity: `com.fruitcompany.Banana` @SignedBy_TheFruitCo.
-But if another CorDapp developer, orangecompany bundles the `Fruit` library, he must strip the signatures from TheFruitCo and sign the jar himself.
-This will create a `com.fruitcompany.Banana` @SignedBy_TheOrangeCo. This means that there could be two types of Banana states on the network,
-but "owned" by two different parties. This means that while they might have started using the same code, nothing stops these Bananas to diverge.
+But if another CorDapp developer, `OrangeCo` bundles the `Fruit` library, they must strip the signatures from `TheFruitCo` and sign the JAR themselves.
+This will create a `com.fruitcompany.Banana` @SignedBy_TheOrangeCo, so there could be two types of Banana states on the network,
+but "owned" by two different parties. This means that while they might have started using the same code, nothing stops these `Banana` contracts to diverge.
 Parties on the network receiving a `com.fruitcompany.Banana` will need to explicitly check the constraint to understand what they received.
 In Corda 4, to help avoid this type of confusion, we introduced the concept of Package Namespace Ownership (see ":doc:`design/data-model-upgrades/package-namespace-ownership`").
 Briefly, it allows companies to claim namespaces and anyone who encounters a class in that package that is not signed by the registered key knows is invalid.
 
-This new feature can be used to solve the above scenario if TheFruitCo claims package ownership of `com.fruitcompany`, thus preventing anyone
-of bundling its code because they will not be able to sign it with the right key.
+This new feature can be used to solve the above scenario. If `TheFruitCo` claims package ownership of `com.fruitcompany`, it will prevent anyone
+from bundling its code because they will not be able to sign it with the right key.
+
+.. Other options.
+
+.. note:: Same as for normal dependencies, CorDapp developers can use alternative strategies like shading or partial bundling if they really want to bundle the code.
+          All the described drawbacks will apply.
+
+
+.. _contract_security:
+
+Code samples for dependent libraries and CorDapps
+-------------------------------------------------
+
+Add this to the flow:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        builder.addAttachment(hash_of_the_fruit_jar)
+
+    .. sourcecode:: java
+
+        builder.addAttachment(hash_of_the_fruit_jar);
+
+
+And in the contract code verify that there is one attachment that contains the dependency.
+
+In case the contract depends on a specific version:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        requireThat {
+            "the correct fruit jar was attached to the transaction" using (tx.attachments.find {it.id == hash_of_fruit_jar} !=null)
+        }
+
+    .. sourcecode:: java
+
+        requireThat(require -> {
+            require.using("the correct fruit jar was attached to the transaction", tx.getAttachments().contains(hash_of_fruit_jar));
+        ...
+
+In case the dependency has to be signed by a known public key:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        requireThat {
+            "the correct my_reusable_cordapp jar was attached to the transaction" using (tx.attachments.find {SignatureAttachmentConstraint(my_public_key).isSatisfiedBy(it)} !=null)
+        }
+
+    .. sourcecode:: java
+
+        requireThat(require -> {
+            require.using("the correct my_reusable_cordapp jar was attached to the transaction", tx.getAttachments().stream().anyMatch(a -> new SignatureAttachmentConstraint(my_public_key).isSatisfiedBy(a))));
 
 
 Changes between version 3 to version 4 of Corda
@@ -342,3 +349,22 @@ This change also affects testing as the test classloader no longer contains the 
           Going forward, when building new transactions there will be a warning and the node will attempt to add the right attachment.
           The contract code of the new version of the CorDapp should add the security check:  :ref:`contract_security`
 
+
+
+The demo `finance` CorDapp
+--------------------------
+
+Corda ships with a `finance` CorDapp demo that brings some handy utilities that can be used by code in other CorDapps, some abstract base types like `OnLedgerAsset`,
+but also comes with its own ready-to-use contracts like: `Cash`, `Obligation` and `Commercial Paper`.
+
+As it is just a sample, it is signed by R3's development key, which the node is explicitly configured - but overridable - to blacklist
+by default in production. This was done in order to avoid you inadvertently going live without having first determined the right approach for your solution.
+
+Some CorDapps might depend on `finance` since Corda v3 when finance was not signed. Most likely `finance` was not bundled or attached to the transactions, but
+the transactions created just worked as described above.
+
+The path forward in this case is first of all to reconsider if depending on a sample is a good idea. If the decision is to go forward, then the CorDapp
+needs to be updated with the code described here: :ref:`contract_security`.
+
+.. warning:: The `finance` CorDapp is a sample and should not normally be used in production or depended upon in a production CorDapp. In case
+             the app developer requires some code, they can just copy it under their own namespace.

--- a/docs/source/cordapp-advanced-concepts.rst
+++ b/docs/source/cordapp-advanced-concepts.rst
@@ -330,9 +330,9 @@ Changes between version 3 and version 4 of Corda
 In Corda v3 transactions were verified inside the System Classloader that contained all the installed CorDapps.
 This was a temporary simplification and we explained above why it could only be short-lived.
 
-If we consider the example from above with the `Bonds` contract that depends on finance, the bonds contract developer could have just released
-the `Bonds` specific code (without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that
-finance would be on the classpath during verification.
+If we consider the example from above with the `Apples` contract that depends on `Fruit`, the `Apples` CorDapp developer could have just released
+the `Apples` specific code (without bundling in the dependency on `Fruit` or attaching it to the transaction ) and rely on the fact that
+`Fruit` would be on the classpath during verification.
 
 This means that in Corda 3 nodes could have formed `valid` transactions that were not entirely self-contained. In Corda 4, because we
 moved transaction verification inside the `AttachmentsClassloader` these transactions would fail with `ClassNotFound` exceptions.

--- a/docs/source/cordapp-dependencies.rst
+++ b/docs/source/cordapp-dependencies.rst
@@ -1,114 +1,171 @@
-A bit of context around how transactions are verified and what changed from Corda 3 to 4
------------------------------------------------------------------------------------------
+CorDapp dependency handling
+===========================
 
-Corda transactions evolve input states into output states. A state is a data structure containing: the actual fact (that is expressed as a strong typed serialized java object) and the logic (contract) that needs to verify a transition to and from this state. The logic is expressed as a Java class name and one (or multiple) attachment jars that contain that class and all it's dependencies.
-Given that anyone can create `.java` files, compile and bundle them in a jar, we have a mechanism in place to complement the class name that allows the State to specify exactly what code is valid.
-In Corda 4, for example, the state can say: "I'm ok to be spent if the transaction is verified by 'com.mycompany.mycontract.MyContract' as long as the jar containing this contract is signed by companyA".
-This approach combines security and usability allowing the code to evolve and developers to fix bugs, but also gives confidence when verifying a transaction chain as the code that verifies it is signed by the same entity.
+
+A bit of context around how transactions are verified and what changed between Corda version 3 and 4
+----------------------------------------------------------------------------------------------------
+
+Corda transactions evolve input states into output states. A state is a data structure containing: the actual data fact (that is expressed as a
+strong typed serialized java object) and a reference to the logic (contract) that needs to verify a transition to and from this state. The logic is expressed
+as a Java class name and a contract constraint. (read more in: :doc:`api-contract-constraints`)
+
+Very briefly, given that anyone can create `.java` files, compile and bundle them in a JAR, we have a mechanism in place to complement the class name, that
+allows the State to specify exactly what code is valid.
+In Corda 4, for example, the state can say: "I'm ok to be spent if the transaction is verified by `com.mycompany.mycontract.MyContract` as
+long as the JAR containing this contract is signed by companyA".
+This approach combines security and usability allowing the code to evolve and developers to fix bugs, but also gives confidence when verifying
+a transaction chain as the code that verifies it is signed by the same entity.
 
 Implementation details:
- - Transactions reference the code that verifies them as a list of attachments. Each attachment is a SHA256 of a jar file. These jar files can be downloaded from peers as part of tx resolution, or directly installed locally.
- - Before actually running any verification, the platform checks that for each state there is one attachment in the list that contains the contract class name, and also that this `Contract Attachment` satisfies the constraint of that state. ( E.g.: in case of the signature constraint - the JAR is signed by the key specified in the state)
- For this mechanism to work effectively, it's necessary that each state is able to identify the attachment that is controlling it.
- - Now that it's validated that the transaction was correctly formed, the smart contract code for each state can be executed to validate the transitions. This is done by creating an `AttachmentsClassloader` from all the attachments listed by the transaction, deserialising and running the contract verification code against the transaction in that classloader. (In he future, we will execute this into a deterministic sandbox - the DJVM)
+
+* Transactions reference the code that verifies them as a list of attachments ids. Each attachment id is a SHA256 of a JAR file.
+  These JAR files can be downloaded from peers as part of tx resolution, or directly installed locally.
+* Before actually running any verification, the platform checks that for each state there is one attachment in the list that contains the contract class name,
+  and also that this `Contract Attachment` satisfies the constraint of that state. ( E.g.: in case of the signature constraint - the JAR is
+  signed by the key specified in the state)
+  For this mechanism to work effectively, it's necessary that each state is able to identify the attachment that is controlling it.
+* Now that it's validated that the transaction was correctly formed, the smart contract code for each state can be executed to validate the transitions.
+  This is done by creating an `AttachmentsClassloader` from all the attachments listed by the transaction, deserialising and running the contract verification
+  code against the transaction in that classloader. (In he future, we will execute this into a deterministic sandbox - the DJVM)
 
 
-In theory a simple transaction swapping `Apples` for `Oranges` would contain 2 attachments: one for the Apples contract and one for the Oranges contract.
+In the simplest case, a transaction swapping `Apples` for `Oranges` would contain 2 attachments: one for the Apples contract and one for the Oranges contract.
 
-Things get more complicated if the `Apples` contract uses an external library which gets called during verification. 
+Things get more complicated though if the `Apples` contract uses an external library which gets called during verification.
 
 There are 2 options to achieve this:
- 1. Bundle the external library with the `Apples` code. Basically create a fat-jar that includes all dependencies (and sign over it). 
+
+ 1. Bundle the external library with the `Apples` code. Basically create a fat-JAR that includes all dependencies (and sign over it).
  2. Add the dependency as another attachment to the transaction.
 
-The problem with approach 2 is that it is insecure. As stated previously anyone can create a jar, so a malicious actor could just create his own version of some dependency code. This would allow him to change the intended behavior of the contract that depends on this code to his advantage. 
-There are ways to make this option secure and future versions of Corda may explore them and implement them. But, today, in Corda 4, such an approach is not supported
+The problem with approach 2 is that it is insecure without adding additional security checks. As stated previously anyone can create a JAR,
+so a malicious actor could just create his own version of some dependency code. This would allow him to change the intended behavior of the
+contract that depends on this code to his advantage.
+There are ways to make this option secure and future versions of Corda may explore them and implement them. But, today, in Corda 4, such an approach
+is not supported by the platform. Custom contract code can be written to perform dependency validity checks as the contract has access to the `LedgerTransaction`.
 
-The only approach that is available currently is 1 - Bundling dependencies.
+The approach that we recommend is bundling dependencies - if possible with shading.
+But it is really up to the CorDapp developers who can choose what they prefer.
 
 There are a couple of caveats to this approach as well:
 
-a. If multiple CorDapp developers independently bundle some popular library (like guava) into their contract, this can cause problems when building the `AttachmentsClassloader`. (see no-overlap rule doc)
-The workaround is for developers to shade dependencies under their own namespace. This would avoid clashes.
-The problem could be mitigated if collectively developers agree on bundling some popular version of guava, and then releasing a new version of their CorDapp from time to time.  The node will be then able to select compatible versions of "apples" and "oranges". This works because the no-overlap rule allows the same file to be in multiple attachments if it is the same file.
+* If multiple CorDapp developers independently bundle some popular library (like guava) into their contract, this can cause problems when building
+ the `AttachmentsClassloader`. (see no-overlap rule doc -once created -TODO)
+ The obvious workaround is for developers to shade dependencies under their own namespace, which would avoid clashes. This comes with some drawbacks though,
+ because sometimes it's desired to be able to cast to some common superclass.
+ The problem could also be mitigated if collectively developers agree that when bundling some popular version of guava they need to release a new version of their
+ CorDapp from time to time to keep up.  The node will be then able to select compatible versions of "apples" and "oranges".
+ This works because the no-overlap rule allows the same file to be in multiple attachments if it is the same file.
 
-b. CorDapp depending on other CorDapps. 
+* CorDapp depending on other CorDapps. This is a more advanced scenario and requires care.
 
-This is where it gets really tricky.
+
+CorDapp depending on other CorDapps
+-----------------------------------
 
 Let's take as an example the finance CorDapp that is shipped with Corda as a sample. 
-(Note: As it is just a sample, it is signed by R3's _development key_, which the node is explicitly configured - but overridable - to blacklist by default in production in order to avoid you inadvertently going live without having first determined the right approach for your solution. But it is illustrative to other reusable CorDapps that might get developed.)
 
-The finance CorDapp comes with some handy utilities that can be used by code in some other CorDapps, some abstract base types like `OnLedgerAsset`, but also comes with it's own ready-to-use Contracts like: Cash, Obligation and Commercial Paper.
+.. note:: As it is just a sample, it is signed by R3's development key, which the node is explicitly configured - but overridable - to blacklist
+  by default in production in order to avoid you inadvertently going live without having first determined the right approach for your solution.
+  But it is illustrative to other reusable CorDapps that might get developed.
 
-This creates a tension as it gives the finance CorDapp a dual role: "library" AND "normal CorDapp".
-If it were just a library it could be fat-jarred as a normal dependency (and all the caveats - due to the no-overlap rule described above - would apply).
-If it were a CorDapp that is used as a main `Contract attachment` to verify transitions it would have to be attached to the transaction and checked against the constraints of the states that it controls.
+The finance CorDapp comes with some handy utilities that can be used by code in some other CorDapps, some abstract base types like `OnLedgerAsset`,
+but also comes with its own ready-to-use Contracts like: Cash, Obligation and Commercial Paper.
+
+This creates a tension as it gives the finance CorDapp a dual role: "library" AND "normal CorDapp that can be used directly in states".
+If it were just a library it could be bundled as a normal dependency (and all the caveats - due to the no-overlap rule described above - would apply).
+If it were a CorDapp that is used as a main `Contract attachment` to verify transitions it would have to be attached to the transaction and checked against
+the constraints of the states that it controls.
 
 It can't be both in a single transaction though.
 
 Why?
 
-Imagine you are swapping `Apples` for `Cash` this time, but the `Apples` contract depends on the finance CorDapp - for example it extends `OnLedgerAsset`.
-A transaction is formed and 2 attachments are added: the finance jar signed by R3's key and the apples jar signed by `CompanyA` (that bundles finance).  ( let's ignore the fact that it's R3's development key for the purpose of this exercise.)
-When the transaction is verified and the platform has to decide which attachment jar to verify against which state constraint there is an ambiguity as both jars could be candidates for the constraint of the `Cash` states. 
-To avoid any ambiguity we have specifically enforced that there can be only 1 attachment for the relevant contracts of the transaction. (The reason for this is to avoid a number of subtle attacks.)
+Imagine you are selling `Apples` for `Cash` this time, but the `Apples` contract depends on the finance CorDapp - for example it extends `OnLedgerAsset`.
+A transaction is formed and 2 attachments are added: the finance JAR signed by R3's key and the apples JAR signed by `CompanyA`(that bundles finance).
+(For the purpose of this exercise let's ignore the fact that the JAR is signed by R3's development key.)
+When this transaction is verified and the platform has to decide which attachment JAR to verify against which state constraint there is an ambiguity
+as both JARs could be candidates for the constraint of the `Cash` states.
+To avoid any ambiguity we have specifically enforced that there can be only 1 attachment for the relevant contracts of the transaction.
+(The reason for this is to avoid a number of subtle attacks.)
 	
-Another problem with this approach is that it introduces namespace confusion. If someone decides to issue `net.corda.finance.contracts.asset.Cash` using the `apples` contract that bundled the finance app it would be a completely different state from one that was issued with the R3 controlled contract. This is because the code could evolve in completely different directions and users of that state who don't check the constraint would be misled.
+Another problem with this approach is that it introduces namespace confusion. If someone decides to issue `net.corda.finance.contracts.asset.Cash`
+using the `apples` contract that bundled the finance app it would be a completely different state from one that was issued with the R3 controlled contract.
+This is because the code could evolve in completely different directions and users of that state who don't check the constraint would be misled.
 
-In Corda 4, to help avoid this type of confusion, we introduced the concept of Package Namespace Ownership (see doc). It allows companies to claim different namespaces, and everyone on the network, if they encounter a class in that package that is not signed by the registered key, know it is invalid.
+In Corda 4, to help avoid this type of confusion, we introduced the concept of Package Namespace Ownership (see doc). It allows companies to claim
+different namespaces, and everyone on the network, if they encounter a class in that package that is not signed by the registered key, know it is invalid.
 
-Given the above there are 4 possible solutions for reusable CorDapps.
+Given the above there are 4 possible solutions for reusable CorDapps:
 
-1. Partial bundling:  Only bundle the exact classes you need in your contract. Basically leave out the ready-to-use contracts. This would reduce the problem of a reusable CorDapp (described above) to that of a normal library ( with all the caveats around the no-overlap rule)
-2. Shading. This means that there would be no namespace collision, but the downside is that when extending some base interface the contract that extends would lose the relation with other implementations. 
-3. Package ownership: `net.corda.finance.contracts.asset` would be claimed by R3. This would give confidence to all participants that if a jar with this package is attached to a transaction it must be created by the original developer which was deemed as trustworthy by the zone operator.
-4. Manually attaching the actual library-Cordapp to the transaction. The contract that uses it is responsible to perform an equivalent of an Attachment constraint to make sure that a malicious party did not attach a "customized" jar that alters the intended verification logic.
+ 1. Partial bundling:  Only bundle the exact classes you need in your contract. Basically leave out the ready-to-use contracts. This would reduce
+    the problem of a reusable CorDapp (described above) to that of a normal library ( with all the caveats around the no-overlap rule)
+
+ 2. Shading. This means that there would be no namespace collision, but the downside is that when extending some base interface the contract that
+    extends would lose the relation with other implementations.
+
+ 3. Package ownership: `net.corda.finance.contracts.asset` would be claimed by R3. This would give confidence to all participants that if a JAR
+    with this package is attached to a transaction it must be created by the original developer which was deemed as trustworthy by the zone operator.
+
+ 4. Manually attaching the actual library-Cordapp to the transaction. The contract that uses it is responsible to perform an equivalent of an
+   Attachment constraint to make sure that a malicious party did not attach a "customized" JAR that alters the intended verification logic.
 
 
-What changed from Corda 3 to Corda 4
--------------------------------------
+The preferred approach can be selected by the developers of the CorDapp, but the recommended to go for 4 - manually attaching and checking.
+
+
+Changes from version 3 to version 4 of Corda
+--------------------------------------------
 
 In Corda 3 transactions were verified inside the System Classloader that contained all the installed CorDapps.
-If we consider the example from above with the `Apples` contract that depends on finance, the `Apples` developer could have just released the apple specific code ( without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that finance would be on the classpath during verification.
+If we consider the example from above with the `Apples` contract that depends on finance, the `Apples` developer could have just released
+the apple specific code ( without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that
+finance would be on the classpath during verification.
 
-This means that in Corda 3 nodes could have formed `valid` transactions that were not entirely self-contained. In Corda 4 where we have moved the transaction verification inside the `AttachmentsClassloader` these transactions would fail with ClassNotFound exceptions (e.g.: as the finance jar would not be available).
+This means that in Corda 3 nodes could have formed `valid` transactions that were not entirely self-contained. In Corda 4, because we
+moved transaction verification inside the `AttachmentsClassloader` these transactions would fail with ClassNotFound exceptions
+(in the example above the finance jar would not be available as it wasn't explicitly added).
 
-These transactions need to be considered valid in Corda 4 and beyond though, so the fix we added for this was to look for a `trusted` attachment in our storage that contains the missing code and use that for validation.
-This fix is in the spirit of the original transaction and is secure because the chosen code must have been vetted and whitelisted first.
+These transactions need to be considered valid in Corda 4 and beyond though, so the fix we added for this was to look for a `trusted` attachment
+in the current node storage that contains the missing code and use that for validation.
+This fix is in the spirit of the original transaction and is secure because the chosen code must have been vetted and whitelisted first by the node operator.
 
-Going forward, the upgrade path for developers using reusable CorDapps (like finance or tokens sdk) is to attach the dependency to the transaction and in their contract verify that the correct contract is attached ( which is basically a cascade of the attachment constraint check).
- 
+Going forward, the recommended upgrade path for developers using reusable CorDapps (like finance or Tokens SDK) is to follow step 4. from above.
 
 
 
-TLDR:
+
+TLDR
 -----
 
-Q: Will my transactions created in Corda V3 still verify in Corda V4 even if my cordapp depends on another cordapp?
+Q: Will my transactions created in Corda V3 still verify in Corda V4 even if my CorDapp depends on another CorDapp and I haven't bundled it nor added it to the attachments?
 A: Yes. Corda 4 maintains backwards compatibility for existing data. There should be no special steps that node operators need to make.
 
-Q: If my cordapp depends on the finance app how should I proceed when I release a new version of my code and want to benefit from all the Corda 4 features.
-A: Make sure that your users install or whitelist the finance contracts jar.  (If they install the contracts they also need to install the finance workflows.)
-In your build file, you need to depend on finance as a `cordapp` dependency. 
-In your flow, when building the transaction, just add this line: `builder.addAttachment(hash_of_finance_v4_contracts_jar)` .
-And in your contract just verify that: 
-```
+
+Q: If my CorDapp depends on the finance app how should I proceed when I release a new version of my code and want to benefit from all the Corda 4 features.
+A: Make sure that your users install or whitelist the unsigned finance contracts JAR.  (If they actually install the contracts JAR they also need to install the workflows JAR.)
+ In your build file, you need to depend on finance contracts as a `cordapp` dependency.
+ In your flow, when building the transaction, just add this line: `builder.addAttachment(hash_of_finance_v4_contracts_jar)`.
+ And in your contract just verify that:
+
+.. sourcecode:: kotlin
+
     requireThat {
         "the correct finance jar was attached to the transaction" using (tx.attachments.find {it.id == hash_of_finance_v4_contracts_jar} !=null)
     }
-```
 
-Q: If I am developing a reusable cordapp that contains both contracts and utilities, how would my clients use it?
-A: Same as for finance. 
-Or, if you sign your cordapp, you can distribute your public key, which users would embed in their contract and then check the attachment like this:
-```
+
+Q: If I am developing a reusable CorDapp that contains both contracts and utilities, how would my clients use it?
+A: Same as for finance ( see previous question)
+Or, even better, if you sign your CorDapp, you can distribute your public key, which users would embed in their contract and then check the attachment like this:
+
+.. sourcecode:: kotlin
+
     requireThat {
         "the correct my_reusable_cordapp jar was attached to the transaction" using (tx.attachments.find {SignatureAttachmentConstraint(my_public_key).isSatisfiedBy(it)} !=null)
     }
-```
 
-Q: If I am developing a cordapp that depends on an external library do I need to do anything special?
+Q: If I am developing a CorDapp that depends on an external library do I need to do anything special?
 A: Same as before just add a `compile` dependency to the library, which will bundle it with your cordapp.
 
 

--- a/docs/source/cordapp-dependencies.rst
+++ b/docs/source/cordapp-dependencies.rst
@@ -108,7 +108,8 @@ Or, if you sign your cordapp, you can distribute your public key, which users wo
     }
 ```
 
-
+Q: If I am developing a cordapp that depends on an external library do I need to do anything special?
+A: Same as before just add a `compile` dependency to the library, which will bundle it with your cordapp.
 
 
 

--- a/docs/source/cordapp-dependencies.rst
+++ b/docs/source/cordapp-dependencies.rst
@@ -1,0 +1,119 @@
+A bit of context around how transactions are verified and what changed from Corda 3 to 4
+-----------------------------------------------------------------------------------------
+
+Corda transactions evolve input states into output states. A state is a data structure containing: the actual fact (that is expressed as a strong typed serialized java object) and the logic (contract) that needs to verify a transition to and from this state. The logic is expressed as a Java class name and one (or multiple) attachment jars that contain that class and all it's dependencies.
+Given that anyone can create `.java` files, compile and bundle them in a jar, we have a mechanism in place to complement the class name that allows the State to specify exactly what code is valid.
+In Corda 4, for example, the state can say: "I'm ok to be spent if the transaction is verified by 'com.mycompany.mycontract.MyContract' as long as the jar containing this contract is signed by companyA".
+This approach combines security and usability allowing the code to evolve and developers to fix bugs, but also gives confidence when verifying a transaction chain as the code that verifies it is signed by the same entity.
+
+Implementation details:
+ - Transactions reference the code that verifies them as a list of attachments. Each attachment is a SHA256 of a jar file. These jar files can be downloaded from peers as part of tx resolution, or directly installed locally.
+ - Before actually running any verification, the platform checks that for each state there is one attachment in the list that contains the contract class name, and also that this `Contract Attachment` satisfies the constraint of that state. ( E.g.: in case of the signature constraint - the JAR is signed by the key specified in the state)
+ For this mechanism to work effectively, it's necessary that each state is able to identify the attachment that is controlling it.
+ - Now that it's validated that the transaction was correctly formed, the smart contract code for each state can be executed to validate the transitions. This is done by creating an `AttachmentsClassloader` from all the attachments listed by the transaction, deserialising and running the contract verification code against the transaction in that classloader. (In he future, we will execute this into a deterministic sandbox - the DJVM)
+
+
+In theory a simple transaction swapping `Apples` for `Oranges` would contain 2 attachments: one for the Apples contract and one for the Oranges contract.
+
+Things get more complicated if the `Apples` contract uses an external library which gets called during verification. 
+
+There are 2 options to achieve this:
+ 1. Bundle the external library with the `Apples` code. Basically create a fat-jar that includes all dependencies (and sign over it). 
+ 2. Add the dependency as another attachment to the transaction.
+
+The problem with approach 2 is that it is insecure. As stated previously anyone can create a jar, so a malicious actor could just create his own version of some dependency code. This would allow him to change the intended behavior of the contract that depends on this code to his advantage. 
+There are ways to make this option secure and future versions of Corda may explore them and implement them. But, today, in Corda 4, such an approach is not supported
+
+The only approach that is available currently is 1 - Bundling dependencies.
+
+There are a couple of caveats to this approach as well:
+
+a. If multiple CorDapp developers independently bundle some popular library (like guava) into their contract, this can cause problems when building the `AttachmentsClassloader`. (see no-overlap rule doc)
+The workaround is for developers to shade dependencies under their own namespace. This would avoid clashes.
+The problem could be mitigated if collectively developers agree on bundling some popular version of guava, and then releasing a new version of their CorDapp from time to time.  The node will be then able to select compatible versions of "apples" and "oranges". This works because the no-overlap rule allows the same file to be in multiple attachments if it is the same file.
+
+b. CorDapp depending on other CorDapps. 
+
+This is where it gets really tricky.
+
+Let's take as an example the finance CorDapp that is shipped with Corda as a sample. 
+(Note: As it is just a sample, it is signed by R3's _development key_, which the node is explicitly configured - but overridable - to blacklist by default in production in order to avoid you inadvertently going live without having first determined the right approach for your solution. But it is illustrative to other reusable CorDapps that might get developed.)
+
+The finance CorDapp comes with some handy utilities that can be used by code in some other CorDapps, some abstract base types like `OnLedgerAsset`, but also comes with it's own ready-to-use Contracts like: Cash, Obligation and Commercial Paper.
+
+This creates a tension as it gives the finance CorDapp a dual role: "library" AND "normal CorDapp".
+If it were just a library it could be fat-jarred as a normal dependency (and all the caveats - due to the no-overlap rule described above - would apply).
+If it were a CorDapp that is used as a main `Contract attachment` to verify transitions it would have to be attached to the transaction and checked against the constraints of the states that it controls.
+
+It can't be both in a single transaction though.
+
+Why?
+
+Imagine you are swapping `Apples` for `Cash` this time, but the `Apples` contract depends on the finance CorDapp - for example it extends `OnLedgerAsset`.
+A transaction is formed and 2 attachments are added: the finance jar signed by R3's key and the apples jar signed by `CompanyA` (that bundles finance).  ( let's ignore the fact that it's R3's development key for the purpose of this exercise.)
+When the transaction is verified and the platform has to decide which attachment jar to verify against which state constraint there is an ambiguity as both jars could be candidates for the constraint of the `Cash` states. 
+To avoid any ambiguity we have specifically enforced that there can be only 1 attachment for the relevant contracts of the transaction. (The reason for this is to avoid a number of subtle attacks.)
+	
+Another problem with this approach is that it introduces namespace confusion. If someone decides to issue `net.corda.finance.contracts.asset.Cash` using the `apples` contract that bundled the finance app it would be a completely different state from one that was issued with the R3 controlled contract. This is because the code could evolve in completely different directions and users of that state who don't check the constraint would be misled.
+
+In Corda 4, to help avoid this type of confusion, we introduced the concept of Package Namespace Ownership (see doc). It allows companies to claim different namespaces, and everyone on the network, if they encounter a class in that package that is not signed by the registered key, know it is invalid.
+
+Given the above there are 4 possible solutions for reusable CorDapps.
+
+1. Partial bundling:  Only bundle the exact classes you need in your contract. Basically leave out the ready-to-use contracts. This would reduce the problem of a reusable CorDapp (described above) to that of a normal library ( with all the caveats around the no-overlap rule)
+2. Shading. This means that there would be no namespace collision, but the downside is that when extending some base interface the contract that extends would lose the relation with other implementations. 
+3. Package ownership: `net.corda.finance.contracts.asset` would be claimed by R3. This would give confidence to all participants that if a jar with this package is attached to a transaction it must be created by the original developer which was deemed as trustworthy by the zone operator.
+4. Manually attaching the actual library-Cordapp to the transaction. The contract that uses it is responsible to perform an equivalent of an Attachment constraint to make sure that a malicious party did not attach a "customized" jar that alters the intended verification logic.
+
+
+What changed from Corda 3 to Corda 4
+-------------------------------------
+
+In Corda 3 transactions were verified inside the System Classloader that contained all the installed CorDapps.
+If we consider the example from above with the `Apples` contract that depends on finance, the `Apples` developer could have just released the apple specific code ( without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that finance would be on the classpath during verification.
+
+This means that in Corda 3 nodes could have formed `valid` transactions that were not entirely self-contained. In Corda 4 where we have moved the transaction verification inside the `AttachmentsClassloader` these transactions would fail with ClassNotFound exceptions (e.g.: as the finance jar would not be available).
+
+These transactions need to be considered valid in Corda 4 and beyond though, so the fix we added for this was to look for a `trusted` attachment in our storage that contains the missing code and use that for validation.
+This fix is in the spirit of the original transaction and is secure because the chosen code must have been vetted and whitelisted first.
+
+Going forward, the upgrade path for developers using reusable CorDapps (like finance or tokens sdk) is to attach the dependency to the transaction and in their contract verify that the correct contract is attached ( which is basically a cascade of the attachment constraint check).
+ 
+
+
+
+TLDR:
+-----
+
+Q: Will my transactions created in Corda V3 still verify in Corda V4 even if my cordapp depends on another cordapp?
+A: Yes. Corda 4 maintains backwards compatibility for existing data. There should be no special steps that node operators need to make.
+
+Q: If my cordapp depends on the finance app how should I proceed when I release a new version of my code and want to benefit from all the Corda 4 features.
+A: Make sure that your users install or whitelist the finance contracts jar.  (If they install the contracts they also need to install the finance workflows.)
+In your build file, you need to depend on finance as a `cordapp` dependency. 
+In your flow, when building the transaction, just add this line: `builder.addAttachment(hash_of_finance_v4_contracts_jar)` .
+And in your contract just verify that: 
+```
+    requireThat {
+        "the correct finance jar was attached to the transaction" using (tx.attachments.find {it.id == hash_of_finance_v4_contracts_jar} !=null)
+    }
+```
+
+Q: If I am developing a reusable cordapp that contains both contracts and utilities, how would my clients use it?
+A: Same as for finance. 
+Or, if you sign your cordapp, you can distribute your public key, which users would embed in their contract and then check the attachment like this:
+```
+    requireThat {
+        "the correct my_reusable_cordapp jar was attached to the transaction" using (tx.attachments.find {SignatureAttachmentConstraint(my_public_key).isSatisfiedBy(it)} !=null)
+    }
+```
+
+
+
+
+
+
+
+
+
+

--- a/docs/source/cordapp-dependencies.rst
+++ b/docs/source/cordapp-dependencies.rst
@@ -13,20 +13,20 @@ Very briefly, given that anyone can create `.java` files, compile and bundle the
 allows the State to specify exactly what code is valid.
 In Corda 4, for example, the state can say: "I'm ok to be spent if the transaction is verified by `com.mycompany.mycontract.MyContract` as
 long as the JAR containing this contract is signed by companyA".
-This approach combines security and usability allowing the code to evolve and developers to fix bugs, but also gives confidence when verifying
-a transaction chain as the code that verifies it is signed by the same entity.
+This approach combines security and usability allowing the code to evolve and developers to fix bugs. It also gives confidence when verifying
+a transaction chain because the code that verifies it is signed by the same entity.
 
 Implementation details:
 
-* Transactions reference the code that verifies them as a list of attachments ids. Each attachment id is a SHA256 of a JAR file.
+* Transactions reference the code that verifies them as a list of attachment ids. Each attachment id is a SHA256 of a JAR file.
   These JAR files can be downloaded from peers as part of tx resolution, or directly installed locally.
 * Before actually running any verification, the platform checks that for each state there is one attachment in the list that contains the contract class name,
   and also that this `Contract Attachment` satisfies the constraint of that state. ( E.g.: in case of the signature constraint - the JAR is
-  signed by the key specified in the state)
-  For this mechanism to work effectively, it's necessary that each state is able to identify the attachment that is controlling it.
+  signed by the key specified in the state).
+  For this mechanism to work effectively, it is necessary that each state is able to identify the attachment that is controlling it.
 * Now that it's validated that the transaction was correctly formed, the smart contract code for each state can be executed to validate the transitions.
-  This is done by creating an `AttachmentsClassloader` from all the attachments listed by the transaction, deserialising and running the contract verification
-  code against the transaction in that classloader. (In he future, we will execute this into a deterministic sandbox - the DJVM)
+  This is done by creating an `AttachmentsClassloader` from all the attachments listed by the transaction, deserialising the binary representation of the transaction,
+   and running the contract verification code against the transaction in that classloader. (In the future, this step will run in a deterministic sandbox - the DJVM)
 
 
 In the simplest case, a transaction swapping `Apples` for `Oranges` would contain 2 attachments: one for the Apples contract and one for the Oranges contract.
@@ -35,27 +35,27 @@ Things get more complicated though if the `Apples` contract uses an external lib
 
 There are 2 options to achieve this:
 
- 1. Bundle the external library with the `Apples` code. Basically create a fat-JAR that includes all dependencies (and sign over it).
+ 1. Bundle the external library with the `Apples` code. Basically create a fat-JAR that includes all dependencies (and optionally sign over it).
  2. Add the dependency as another attachment to the transaction.
 
 The problem with approach 2 is that it is insecure without adding additional security checks. As stated previously anyone can create a JAR,
 so a malicious actor could just create his own version of some dependency code. This would allow him to change the intended behavior of the
 contract that depends on this code to his advantage.
-There are ways to make this option secure and future versions of Corda may explore them and implement them. But, today, in Corda 4, such an approach
-is not supported by the platform. Custom contract code can be written to perform dependency validity checks as the contract has access to the `LedgerTransaction`.
+There are ways to make this option secure and future versions of Corda may explore them and implement them.
+If a CorDapp developer decides to go for this approach they can write custom contract code to perform dependency validity checks as the contract has access to the `LedgerTransaction`.
 
 The approach that we recommend is bundling dependencies - if possible with shading.
 But it is really up to the CorDapp developers who can choose what they prefer.
 
 There are a couple of caveats to this approach as well:
 
-* If multiple CorDapp developers independently bundle some popular library (like guava) into their contract, this can cause problems when building
+* If multiple CorDapp developers independently bundle some popular library (like `guava`) into their contract, this can cause problems when building
  the `AttachmentsClassloader`. (see no-overlap rule doc -once created -TODO)
  The obvious workaround is for developers to shade dependencies under their own namespace, which would avoid clashes. This comes with some drawbacks though,
  because sometimes it's desired to be able to cast to some common superclass.
- The problem could also be mitigated if collectively developers agree that when bundling some popular version of guava they need to release a new version of their
- CorDapp from time to time to keep up.  The node will be then able to select compatible versions of "apples" and "oranges".
- This works because the no-overlap rule allows the same file to be in multiple attachments if it is the same file.
+ The problem could also be mitigated if collectively developers agree that when bundling some popular library they need to release a new version of their
+ CorDapp from time to time to keep up with each other.  The node will then be able to select compatible versions of "apples" and "oranges".
+ This works because the no-overlap rule allows a class file to live in multiple attachments if all the versions are equal.
 
 * CorDapp depending on other CorDapps. This is a more advanced scenario and requires care.
 
@@ -63,18 +63,20 @@ There are a couple of caveats to this approach as well:
 CorDapp depending on other CorDapp(s)
 -------------------------------------
 
-Let's take as an example the finance CorDapp that is shipped with Corda as a sample. 
+Let's take as an example the `finance` CorDapp that is shipped with Corda as a sample.
 
 .. note:: As it is just a sample, it is signed by R3's development key, which the node is explicitly configured - but overridable - to blacklist
   by default in production in order to avoid you inadvertently going live without having first determined the right approach for your solution.
   But it is illustrative to other reusable CorDapps that might get developed.
 
-The finance CorDapp comes with some handy utilities that can be used by code in some other CorDapps, some abstract base types like `OnLedgerAsset`,
-but also comes with its own ready-to-use Contracts like: Cash, Obligation and Commercial Paper.
+The finance CorDapp brings some handy utilities that can be used by code in other CorDapps, some abstract base types like `OnLedgerAsset`,
+but also comes with its own ready-to-use contracts like: `Cash`, `Obligation` and `Commercial Paper`.
 
-This creates a tension as it gives the finance CorDapp a dual role: "library" AND "normal CorDapp that can be used directly in states".
+This creates a tension as it gives the finance CorDapp a dual role: `reusable library` AND `normal CorDapp that can be used directly to issue and consume states`.
+
 If it were just a library it could be bundled as a normal dependency (and all the caveats - due to the no-overlap rule described above - would apply).
-If it were a CorDapp that is used as a main `Contract attachment` to verify transitions it would have to be attached to the transaction and checked against
+
+If it were a CorDapp that was used as a main `Contract attachment` to verify transitions it would have to be attached to the transaction and checked against
 the constraints of the states that it controls.
 
 It can't be both in a single transaction though.
@@ -82,36 +84,43 @@ It can't be both in a single transaction though.
 Why?
 
 Imagine you are selling `Apples` for `Cash` this time, but the `Apples` contract depends on the finance CorDapp - for example it extends `OnLedgerAsset`.
-A transaction is formed and 2 attachments are added: the finance JAR signed by R3's key and the apples JAR signed by `CompanyA`(that bundles finance).
-(For the purpose of this exercise let's ignore the fact that the JAR is signed by R3's development key.)
+A transaction is formed and 2 attachments are added: the finance JAR signed by R3's key and the apples JAR signed by `CompanyA` (that bundles finance).
+
+For the purpose of this exercise let's ignore the fact that the JAR is signed by R3's development key.
+
 When this transaction is verified and the platform has to decide which attachment JAR to verify against which state constraint there is an ambiguity
 as both JARs could be candidates for the constraint of the `Cash` states.
 To avoid any ambiguity we have specifically enforced that there can be only 1 attachment for the relevant contracts of the transaction.
-(The reason for this is to avoid a number of subtle attacks.)
+
+The main problem we have in this case is that a node would not be able to create a valid `Apples` for `Cash` transaction.
 	
 Another problem with this approach is that it introduces namespace confusion. If someone decides to issue `net.corda.finance.contracts.asset.Cash`
-using the `apples` contract that bundled the finance app it would be a completely different state from one that was issued with the R3 controlled contract.
+using the `apples` contract that bundles the finance app it would be a completely different state from one that was issued with the R3 controlled contract.
 This is because the code could evolve in completely different directions and users of that state who don't check the constraint would be misled.
 
-In Corda 4, to help avoid this type of confusion, we introduced the concept of Package Namespace Ownership (see doc). It allows companies to claim
-different namespaces, and everyone on the network, if they encounter a class in that package that is not signed by the registered key, know it is invalid.
+In Corda 4, to help avoid this type of confusion, we introduced the concept of Package Namespace Ownership (see ":doc:`design/data-model-upgrades/package-namespace-ownership`").
+It allows companies to claim different namespaces, and everyone on the network, if they encounter a class in that package that is not signed by the registered key, know it is invalid.
+
 
 Given the above there are 4 possible solutions for reusable CorDapps:
 
  1. Partial bundling:  Only bundle the exact classes you need in your contract. Basically leave out the ready-to-use contracts. This would reduce
-    the problem of a reusable CorDapp (described above) to that of a normal library ( with all the caveats around the no-overlap rule)
+    the problem of a reusable CorDapp (described above) to that of a normal library ( with all the caveats around the no-overlap rule).
 
- 2. Shading. This means that there would be no namespace collision, but the downside is that when extending some base interface the contract that
+ 2. Shading: This means that there would be no namespace collision, but the downside is that when extending some base interface the contract that
     extends would lose the relation with other implementations.
 
  3. Package ownership: `net.corda.finance.contracts.asset` would be claimed by R3. This would give confidence to all participants that if a JAR
     with this package is attached to a transaction it must be created by the original developer which was deemed as trustworthy by the zone operator.
 
  4. Manually attaching the actual library-Cordapp to the transaction. The contract that uses it is responsible to perform an equivalent of an
-   Attachment constraint to make sure that a malicious party did not attach a "customized" JAR that alters the intended verification logic.
+    Attachment constraint to make sure that a malicious party did not attach a "customized" JAR that alters the intended verification logic.
 
 
 The preferred approach can be selected by the developers of the CorDapp, but the recommended to go for 4 - manually attaching and checking.
+
+We also recommend that companies claim their package so the best approach is to combine 3 and 4. By actually checking in the contract code that
+the expected dependency is present there is no possibility for unexpected behaviour.
 
 
 Changes between version 3 to version 4 of Corda
@@ -119,7 +128,7 @@ Changes between version 3 to version 4 of Corda
 
 In Corda 3 transactions were verified inside the System Classloader that contained all the installed CorDapps.
 If we consider the example from above with the `Apples` contract that depends on finance, the `Apples` developer could have just released
-the apple specific code ( without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that
+the `Apples` specific code ( without bundling in the dependency on finance or attaching it to the transaction ) and rely on the fact that
 finance would be on the classpath during verification.
 
 This means that in Corda 3 nodes could have formed `valid` transactions that were not entirely self-contained. In Corda 4, because we
@@ -130,19 +139,19 @@ These transactions need to be considered valid in Corda 4 and beyond though, so 
 in the current node storage that contains the missing code and use that for validation.
 This fix is in the spirit of the original transaction and is secure because the chosen code must have been vetted and whitelisted first by the node operator.
 
-Going forward, the recommended upgrade path for developers using reusable CorDapps (like finance or Tokens SDK) is to follow step 4. from above.
+The transition to the `AttachmentsClassloader` is one more step towards the full design of Corda.
 
 
-
-
-TLDR
------
+Troubleshooting
+---------------
 
 Q: Will my transactions created in Corda V3 still verify in Corda V4 even if my CorDapp depends on another CorDapp and I haven't bundled it nor added it to the attachments?
+
 A: Yes. Corda 4 maintains backwards compatibility for existing data. There should be no special steps that node operators need to make.
 
 
 Q: If my CorDapp depends on the finance app how should I proceed when I release a new version of my code and want to benefit from all the Corda 4 features.
+
 A: Make sure that your users install or whitelist the unsigned finance contracts JAR.  (If they actually install the contracts JAR they also need to install the workflows JAR.)
  In your build file, you need to depend on finance contracts as a `cordapp` dependency.
  In your flow, when building the transaction, just add this line: `builder.addAttachment(hash_of_finance_v4_contracts_jar)`.
@@ -156,6 +165,7 @@ A: Make sure that your users install or whitelist the unsigned finance contracts
 
 
 Q: If I am developing a reusable CorDapp that contains both contracts and utilities, how would my clients use it?
+
 A: Same as for finance ( see previous question)
 Or, even better, if you sign your CorDapp, you can distribute your public key, which users would embed in their contract and then check the attachment like this:
 
@@ -165,5 +175,7 @@ Or, even better, if you sign your CorDapp, you can distribute your public key, w
         "the correct my_reusable_cordapp jar was attached to the transaction" using (tx.attachments.find {SignatureAttachmentConstraint(my_public_key).isSatisfiedBy(it)} !=null)
     }
 
+
 Q: If I am developing a CorDapp that depends on an external library do I need to do anything special?
+
 A: Same as before just add a `compile` dependency to the library, which will bundle it with your cordapp.

--- a/docs/source/cordapp-dependencies.rst
+++ b/docs/source/cordapp-dependencies.rst
@@ -2,8 +2,8 @@ CorDapp dependency handling
 ===========================
 
 
-A bit of context around how transactions are verified and what changed between Corda version 3 and 4
-----------------------------------------------------------------------------------------------------
+Some context around how corda transactions are verified
+-------------------------------------------------------
 
 Corda transactions evolve input states into output states. A state is a data structure containing: the actual data fact (that is expressed as a
 strong typed serialized java object) and a reference to the logic (contract) that needs to verify a transition to and from this state. The logic is expressed
@@ -60,8 +60,8 @@ There are a couple of caveats to this approach as well:
 * CorDapp depending on other CorDapps. This is a more advanced scenario and requires care.
 
 
-CorDapp depending on other CorDapps
------------------------------------
+CorDapp depending on other CorDapp(s)
+-------------------------------------
 
 Let's take as an example the finance CorDapp that is shipped with Corda as a sample. 
 
@@ -114,8 +114,8 @@ Given the above there are 4 possible solutions for reusable CorDapps:
 The preferred approach can be selected by the developers of the CorDapp, but the recommended to go for 4 - manually attaching and checking.
 
 
-Changes from version 3 to version 4 of Corda
---------------------------------------------
+Changes between version 3 to version 4 of Corda
+-----------------------------------------------
 
 In Corda 3 transactions were verified inside the System Classloader that contained all the installed CorDapps.
 If we consider the example from above with the `Apples` contract that depends on finance, the `Apples` developer could have just released
@@ -167,11 +167,3 @@ Or, even better, if you sign your CorDapp, you can distribute your public key, w
 
 Q: If I am developing a CorDapp that depends on an external library do I need to do anything special?
 A: Same as before just add a `compile` dependency to the library, which will bundle it with your cordapp.
-
-
-
-
-
-
-
-


### PR DESCRIPTION
see https://r3-cev.atlassian.net/browse/CORDA-2639

Added some documentation explaining what the problems are with cordapp dependencies in Corda 4 and how it can be solved.

I don't know where doc should live, so I just created a new file for it.

Looking for some feedback on the content, structure and logic of this.

Raised: https://r3-cev.atlassian.net/browse/CORDA-2666 , to create supporting tooling.
