### PR TITLE
CORDA-2610: Internal APIs made much clearer in API doc page

### DIFF
--- a/docs/source/corda-api.rst
+++ b/docs/source/corda-api.rst
@@ -42,10 +42,10 @@ The following modules form part of Corda's public API and we commit to API/ABI b
 * **Core (net.corda.core)**: core Corda libraries such as crypto functions, types for Corda's building blocks: states, contracts, transactions, attachments, etc. and some interfaces for nodes and protocols
 * **Client RPC (net.corda.client.rpc)**: client RPC
 * **Client Jackson (net.corda.client.jackson)**: JSON support for client applications
-* **Test Utils (net.corda.testing.core)**: generic test utilities
-* **Test Node Driver (net.corda.testing.node, net.corda.testing.driver)**: test utilities to run nodes programmatically
-* **Http Test Utils (net.corda.testing.http)**: a small set of utilities for making HttpCalls, aimed at demos and tests.
 * **DSL Test Utils (net.corda.testing.dsl)**: a simple DSL for building pseudo-transactions (not the same as the wire protocol) for testing purposes.
+* **Test Node Driver (net.corda.testing.node, net.corda.testing.driver)**: test utilities to run nodes programmatically
+* **Test Utils (net.corda.testing.core)**: generic test utilities
+* **Http Test Utils (net.corda.testing.http)**: a small set of utilities for making HttpCalls, aimed at demos and tests.
 * **Dummy Contracts (net.corda.testing.contracts)**: dummy state and contracts for testing purposes
 * **Mock Services (net.corda.testing.services)**: mock service implementations for testing purposes
 
@@ -57,7 +57,7 @@ Non-public API (experimental)
 The following modules are not part of the Corda's public API and no backwards compatibility guarantees are provided. They are further categorized in 2 classes:
 
 * the incubating modules, for which we will do our best to minimise disruption to developers using them until we are able to graduate them into the public API
-* the unstable modules, which are available but we do not commit to their stability or continuation in any sense
+* the internal modules, which are not to be used, and will change without notice
 
 Corda incubating modules
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,31 +68,14 @@ Corda incubating modules
 * **net.corda.client.mock**: client mock utilities
 * **Cordformation**: Gradle integration plugins
 
-Corda unstable modules
+Corda internal modules
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* **net.corda.buildSrc**: necessary gradle plugins to build Corda
-* **net.corda.node**: core code of the Corda node (eg: node driver, node services, messaging, persistence)
-* **net.corda.node.api**: data structures shared between the node and the client module, e.g. types sent via RPC
-* **net.corda.samples.network.visualiser**: a network visualiser that uses a simulation to visualise the interaction and messages between nodes on the Corda network
-* **net.corda.samples.demos.attachment**: demonstrates sending a transaction with an attachment from one to node to another, and the receiving node accessing the attachment
-* **net.corda.samples.demos.bankofcorda**: simulates the role of an asset issuing authority (eg. central bank for cash)
-* **net.corda.samples.demos.irs**: demonstrates an Interest Rate Swap agreement between two banks
-* **net.corda.samples.demos.notary**: a simple demonstration of a node getting multiple transactions notarised by a distributed (Raft or BFT SMaRt) notary
-* **net.corda.samples.demos.simmvaluation**: A demo of SIMM valuation and agreement on a distributed ledger
-* **net.corda.samples.demos.trader**: demonstrates four nodes, a notary, an issuer of cash (Bank of Corda), and two parties trading with each other, exchanging cash for a commercial paper
-* **net.corda.node.smoke.test.utils**: test utilities for smoke testing
-* **net.corda.node.test.common**: common test functionality
-* **net.corda.tools.demobench**: a GUI tool that allows to run Corda nodes locally for demonstrations
-* **net.corda.tools.explorer**: a GUI front-end for Corda
-* **net.corda.tools.graphs**: utilities to infer project dependencies
-* **net.corda.tools.loadtest**: Corda load tests
-* **net.corda.webserver**: is a servlet container for CorDapps that export HTTP endpoints. This server is an RPC client of the node
-* **net.corda.sandbox-creator**: sandbox utilities
-* **net.corda.quasar.hook**: agent to hook into Quasar and provide types exclusion lists
+Everything else is internal and will change without notice, even deleted, and should not be used. This also includes any package that has
+``.internal`` in it. So for example, ``net.corda.core.internal`` and sub-packages should not be used.
 
-.. warning:: Code inside any package in the ``net.corda`` namespace which contains ``.internal`` or in ``net.corda.node`` for internal use only.
-   Future releases will reject any CorDapps that use types from these packages.
+Some of the public modules may depend on internal modules, so be careful to not rely on these transitive dependencies. In particular, the
+testing modules depend on the node module and so you may end having the node in your test classpath.
 
 .. warning:: The web server module will be removed in future. You should call Corda nodes through RPC from your web server of choice e.g., Spring Boot, Vertx, Undertow.
 


### PR DESCRIPTION
(cherry picked from commit 08ce12f068f12e3ed14d4baeb366c80dfbe74da5)

Port of https://github.com/corda/corda/pull/4788.
