### PR TITLE
CORDA-2667: Fix DJVM SourceClassLoader for ASM.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -51,6 +51,22 @@ shadowJar {
     baseName 'corda-djvm'
     classifier ''
     relocate 'org.objectweb.asm', 'djvm.org.objectweb.asm'
+
+    // These particular classes are only needed to "bootstrap"
+    // the compilation of the other sandbox classes. At runtime,
+    // we will generate better versions from deterministic-rt.jar.
+    exclude 'sandbox/java/lang/Appendable.class'
+    exclude 'sandbox/java/lang/CharSequence.class'
+    exclude 'sandbox/java/lang/Character\$Subset.class'
+    exclude 'sandbox/java/lang/Character\$Unicode*.class'
+    exclude 'sandbox/java/lang/Comparable.class'
+    exclude 'sandbox/java/lang/Enum.class'
+    exclude 'sandbox/java/lang/Iterable.class'
+    exclude 'sandbox/java/lang/StackTraceElement.class'
+    exclude 'sandbox/java/lang/StringBuffer.class'
+    exclude 'sandbox/java/lang/StringBuilder.class'
+    exclude 'sandbox/java/nio/**'
+    exclude 'sandbox/java/util/**'
 }
 assemble.dependsOn shadowJar
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
@@ -7,6 +7,7 @@ import net.corda.djvm.code.ClassMutator
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.code.emptyAsNull
 import net.corda.djvm.references.Member
+import net.corda.djvm.source.AbstractSourceClassLoader
 import net.corda.djvm.utilities.loggerFor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
@@ -17,11 +18,11 @@ import org.objectweb.asm.MethodVisitor
  * Functionality for rewriting parts of a class as it is being loaded.
  *
  * @property configuration The configuration of the sandbox.
- * @property classLoader The class loader used to load the classes that are to be rewritten.
+ * @property classLoader The class loader used to load the source classes that are to be rewritten.
  */
 open class ClassRewriter(
         private val configuration: SandboxConfiguration,
-        private val classLoader: ClassLoader
+        private val classLoader: AbstractSourceClassLoader
 ) {
     private val analysisConfig = configuration.analysisConfiguration
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassWriter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassWriter.kt
@@ -1,6 +1,7 @@
 package net.corda.djvm.rewiring
 
 import net.corda.djvm.code.asPackagePath
+import net.corda.djvm.source.AbstractSourceClassLoader
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.ClassWriter.COMPUTE_FRAMES
@@ -22,28 +23,28 @@ import org.objectweb.asm.Type
  */
 open class SandboxClassWriter(
         classReader: ClassReader,
-        private val cloader: ClassLoader,
+        private val cloader: AbstractSourceClassLoader,
         flags: Int = COMPUTE_FRAMES or COMPUTE_MAXS
 ) : ClassWriter(classReader, flags) {
 
-    override fun getClassLoader(): ClassLoader = cloader
+    override fun getClassLoader(): AbstractSourceClassLoader = cloader
 
     /**
      * Get the common super type of [type1] and [type2].
      */
     override fun getCommonSuperClass(type1: String, type2: String): String {
-        // Need to override [getCommonSuperClass] to ensure that we use ClassLoader.loadClass().
+        // Need to override [getCommonSuperClass] to ensure that we use SourceClassLoader.loadSourceClass().
         when {
             type1 == OBJECT_NAME -> return type1
             type2 == OBJECT_NAME -> return type2
         }
         val class1 = try {
-            classLoader.loadClass(type1.asPackagePath)
+            classLoader.loadSourceClass(type1.asPackagePath)
         } catch (exception: Exception) {
             throw TypeNotPresentException(type1, exception)
         }
         val class2 = try {
-            classLoader.loadClass(type2.asPackagePath)
+            classLoader.loadSourceClass(type2.asPackagePath)
         } catch (exception: Exception) {
             throw TypeNotPresentException(type2, exception)
         }


### PR DESCRIPTION
Fix DJVM SourceClassLoader so that ASM will use it only to load classes from outside the sandbox.