### PR TITLE
ENT-3059: RPC disconnect log entry changed to info

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
+++ b/node/src/main/kotlin/net/corda/node/services/rpc/RPCServer.kt
@@ -255,7 +255,7 @@ class RPCServer(
         val notificationType = artemisMessage.getStringProperty(ManagementHelper.HDR_NOTIFICATION_TYPE)
         require(notificationType == CoreNotificationType.BINDING_REMOVED.name){"Message contained notification type of $notificationType instead of expected ${CoreNotificationType.BINDING_REMOVED.name}"}
         val clientAddress = artemisMessage.getStringProperty(ManagementHelper.HDR_ROUTING_NAME)
-        log.warn("Detected RPC client disconnect on address $clientAddress, scheduling for reaping")
+        log.info("Detected RPC client disconnect on address $clientAddress, scheduling for reaping")
         invalidateClient(SimpleString(clientAddress))
     }
 


### PR DESCRIPTION
When an RPC client disconnects from the RPC server, the log entry created now has its log level set to info rather than warning. It is perfectly normal for an RPC client to disconnect - only the RPC client knows if it was intentional.