### PR TITLE
ENT-3128: Update documentation for Node Explorer.

### DIFF
--- a/docs/source/node-explorer.rst
+++ b/docs/source/node-explorer.rst
@@ -32,11 +32,11 @@ you to create local Corda networks on your desktop. For example:
     * Notary
     * Bank of Breakfast Tea    (*Issuer node* for GBP)
     * Bank of Big Apples       (*Issuer node* for USD)
-    * Alice                    (Participant node, for user Alice)
-    * Bob                      (Participant node, for user Bob)
+    * Alice                    (*Participant node*, for user Alice)
+    * Bob                      (*Participant node*, for user Bob)
 
 DemoBench will deploy all nodes with Corda's Finance CorDapp automatically, and
-allow you to launch an instance of Node Explorer for each. You will be logged
+allow you to launch an instance of Node Explorer for each. You will also be logged
 into the Node Explorer automatically.
 
 When connected to an *Issuer* node, a user can execute cash transaction commands to issue and move cash to itself or other
@@ -55,8 +55,8 @@ run as
 Interface
 ---------
 Login
-  User can login to any Corda node using the explorer. Alternatively, ``gradlew explorer:runDemoNodes`` can be used to start up demo nodes for testing.  
-  Corda node address, username and password are required for login, the address is defaulted to localhost:0 if leave blank.
+  User can login to any Corda node using the explorer.
+  Corda node address, username and password are required for login, the address is defaulted to localhost:0 if left blank.
   Username and password can be configured via the ``rpcUsers`` field in node's configuration file.
   
 .. image:: resources/explorer/login.png

--- a/tools/explorer/README.md
+++ b/tools/explorer/README.md
@@ -21,8 +21,8 @@ which allows you to create local Corda networks on your desktop. For example:
     * Notary
     * Bank of Breakfast Tea    (*Issuer node* for GBP)
     * Bank of Big Apples       (*Issuer node* for USD)
-    * Alice
-    * Bob
+    * Alice                    (*Participant node* for user Alice)
+    * Bob                      (*Participant node* for user Bob)
 
 DemoBench will deploy all nodes with Corda's Finance CorDapp automatically, and allow you to launch an
 instance of Node Explorer for each.


### PR DESCRIPTION
Remove some lingering references to deleted Gradle tasks, fix formatting, grammar.