### PR TITLE
ENT-3165 Add unit test for reference state consumption.

### DIFF
--- a/core/src/test/kotlin/net/corda/core/flows/ReferencedStatesFlowTests.kt
+++ b/core/src/test/kotlin/net/corda/core/flows/ReferencedStatesFlowTests.kt
@@ -15,15 +15,9 @@ import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.node.VersionInfo
 import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.core.SerializationEnvironmentRule
-import net.corda.testing.internal.vault.DUMMY_LINEAR_CONTRACT_PROGRAM_ID
-import net.corda.testing.internal.vault.DummyLinearContract
-import net.corda.testing.node.StartedMockNode
 import net.corda.testing.node.internal.*
-import net.corda.testing.node.transaction
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -119,6 +113,58 @@ class ReferencedStatesFlowTests {
         val allRefStates = nodes[1].services.vaultService.queryBy<LinearState>()
         // nodes[1] should have two states. The newly created output and the reference state created by nodes[0].
         assertEquals(2, allRefStates.states.size)
+    }
+
+    @Test
+    fun `check old ref state is consumed when update used in tx with relevant states`() {
+        // 1. Create a state to be used as a reference state. Don't share it.
+        val newRefTx = nodes[0].services.startFlow(CreateRefState()).resultFuture.getOrThrow()
+        val newRefState = newRefTx.tx.outRefsOfType<RefState.State>().single()
+
+        // 2. Use the "newRefState" in a transaction involving another party (nodes[1]) which creates a new state. They should store the new state and the reference state.
+        val newTx = nodes[0].services.startFlow(UseRefState(nodes[1].info.legalIdentities.first(), newRefState.state.data.linearId))
+                .resultFuture.getOrThrow()
+        // Wait until node 1 stores the new tx.
+        nodes[1].services.validatedTransactions.updates.filter { it.id == newTx.id }.toFuture().getOrThrow()
+        // Check that nodes[1] has finished recording the transaction (and updating the vault.. hopefully!).
+        // nodes[1] should have two states. The newly created output of type "Regular.State" and the reference state created by nodes[0].
+        assertEquals(2, nodes[1].services.vaultService.queryBy<LinearState>().states.size)
+        // Now let's find the specific reference state on nodes[1].
+        val refStateLinearId = newRefState.state.data.linearId
+        val query = QueryCriteria.LinearStateQueryCriteria(linearId = listOf(refStateLinearId))
+        val theReferencedState = nodes[1].services.vaultService.queryBy<RefState.State>(query)
+        // There should be one result - the reference state.
+        assertEquals(newRefState, theReferencedState.states.single())
+        // The reference state should not be consumed.
+        assertEquals(Vault.StateStatus.UNCONSUMED, theReferencedState.statesMetadata.single().status)
+        // nodes[0] should also have the same state.
+        val nodeZeroQuery = QueryCriteria.LinearStateQueryCriteria(linearId = listOf(refStateLinearId))
+        val theReferencedStateOnNodeZero = nodes[0].services.vaultService.queryBy<RefState.State>(nodeZeroQuery)
+        assertEquals(newRefState, theReferencedStateOnNodeZero.states.single())
+        assertEquals(Vault.StateStatus.UNCONSUMED, theReferencedStateOnNodeZero.statesMetadata.single().status)
+
+        // 3. Update the reference state but don't share the update.
+        val updatedRefTx = nodes[0].services.startFlow(UpdateRefState(newRefState)).resultFuture.getOrThrow()
+
+        // 4. Use the evolved state as a reference state.
+        val updatedTx = nodes[0].services.startFlow(UseRefState(nodes[1].info.legalIdentities.first(), newRefState.state.data.linearId))
+                .resultFuture.getOrThrow()
+        // Wait until node 1 stores the new tx.
+        nodes[1].services.validatedTransactions.updates.filter { it.id == updatedTx.id }.toFuture().getOrThrow()
+        // Check that nodes[1] has finished recording the transaction (and updating the vault.. hopefully!).
+        // nodes[1] should have four states. The originals, plus the newly created output of type "Regular.State" and the reference state created by nodes[0].
+        assertEquals(4, nodes[1].services.vaultService.queryBy<LinearState>(QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.ALL)).states.size)
+        // Now let's find the original reference state on nodes[1].
+        val updatedQuery = QueryCriteria.VaultQueryCriteria(stateRefs = listOf(newRefState.ref), status = Vault.StateStatus.ALL)
+        val theOriginalReferencedState = nodes[1].services.vaultService.queryBy<RefState.State>(updatedQuery)
+        // There should be one result - the original reference state.
+        assertEquals(newRefState, theOriginalReferencedState.states.single())
+        // The reference state should be consumed.
+        assertEquals(Vault.StateStatus.CONSUMED, theOriginalReferencedState.statesMetadata.single().status)
+        // nodes[0] should also have the same state.
+        val theOriginalReferencedStateOnNodeZero = nodes[0].services.vaultService.queryBy<RefState.State>(updatedQuery)
+        assertEquals(newRefState, theOriginalReferencedStateOnNodeZero.states.single())
+        assertEquals(Vault.StateStatus.CONSUMED, theOriginalReferencedStateOnNodeZero.statesMetadata.single().status)
     }
 
     // A dummy reference state contract.


### PR DESCRIPTION
Adds a test that creates state on node 0 and does not share.  Then creates a transaction referring to it that is shared with node 1 (relevant only record).  Then evolve the reference state on node 0 and do not share it.   Then creates a transaction referring to it that is shared with node 1 (relevant only record).

That last transaction should then update the states recorded for the reference states transaction to include the second version of the reference state (since it wasn't originally relevant), thus consuming the original version.

PR coming in enterprise (which should be merged first to avoid breaking merge PR).