### PR TITLE
CORDA-2665: Updated OwnableState relevancy check put back to V3 version

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 Here's a summary of what's changed in each Corda release. For guidance on how to upgrade code from the previous
 release, see :doc:`app-upgrade-notes`.
 
+Version 4.1
+-----------
+
+* In 4.0 the relevancy check of ``OwnableState`` s was expanded to include the state's participants, in addition to the owner. However, this
+  had the unintended consequence of breaking existing CorDapps (or clients to those apps) which assume only the owner of the ``OwnableState``
+  is used to decide whether a state is recorded to the node's vault. This is now an opt-in change to make sure existing CorDapps don't break.
+  Setting a target version of 4 or higher will re-nable the new relevancy check.
+
 .. _changelog_v4.0:
 
 Version 4.0
@@ -317,6 +325,9 @@ Version 4.0
 * The ``node_transaction_mapping`` database table has been folded into the ``node_transactions`` database table as an additional column.
 
 * Logging for P2P and RPC has been separated, to make it easier to enable all P2P or RPC logging without hand-picking loggers for individual classes.
+
+* The relevancy check of ``OwnableState`` s has expanded to include the state's participants, in addition to the owner. This means the node
+  will now consider such states as relevant, and thus record them in its vault, if any of the participant keys belong to it.
 
 * Vault Query Criteria have been enhanced to allow filtering by state relevancy. Queries can request all states, just relevant ones, or just non relevant ones. The default is to return all states, to maintain backwards compatibility.
   Note that this means apps running on nodes using Observer node functionality should update their queries to request only relevant states if they are only expecting to see states in which they participate.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,14 +4,6 @@ Changelog
 Here's a summary of what's changed in each Corda release. For guidance on how to upgrade code from the previous
 release, see :doc:`app-upgrade-notes`.
 
-Version 4.1
------------
-
-* In 4.0 the relevancy check of ``OwnableState`` s was expanded to include the state's participants, in addition to the owner. However, this
-  had the unintended consequence of breaking existing CorDapps (or clients to those apps) which assume only the owner of the ``OwnableState``
-  is used to decide whether a state is recorded to the node's vault. This is now an opt-in change to make sure existing CorDapps don't break.
-  Setting a target version of 4 or higher will re-nable the new relevancy check.
-
 .. _changelog_v4.0:
 
 Version 4.0
@@ -325,9 +317,6 @@ Version 4.0
 * The ``node_transaction_mapping`` database table has been folded into the ``node_transactions`` database table as an additional column.
 
 * Logging for P2P and RPC has been separated, to make it easier to enable all P2P or RPC logging without hand-picking loggers for individual classes.
-
-* The relevancy check of ``OwnableState`` s has expanded to include the state's participants, in addition to the owner. This means the node
-  will now consider such states as relevant, and thus record them in its vault, if any of the participant keys belong to it.
 
 * Vault Query Criteria have been enhanced to allow filtering by state relevancy. Queries can request all states, just relevant ones, or just non relevant ones. The default is to return all states, to maintain backwards compatibility.
   Note that this means apps running on nodes using Observer node functionality should update their queries to request only relevant states if they are only expecting to see states in which they participate.

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -553,8 +553,7 @@ class NodeVaultServiceTest {
     }
 
     @Test
-    fun `OwnableState relevancy under target version 3`() {
-        CordappResolver.withCordapp(targetPlatformVersion = 3) {
+    fun `is ownable state relevant`() {
             val myAnonymousIdentity = services.keyManagementService.freshKeyAndCert(identity, false)
             val myKeys = services.keyManagementService.filterMyKeys(listOf(identity.owningKey, myAnonymousIdentity.owningKey)).toSet()
 
@@ -566,28 +565,6 @@ class NodeVaultServiceTest {
             assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = emptyList()) }
             // Under target version 3 only the owner is relevant. This is to preserve backwards compatibility
             assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(identity.party)) }
-        }
-    }
-
-    @Test
-    fun `OwnableState relevancy under target version 4`() {
-        CordappResolver.withCordapp(targetPlatformVersion = 4) {
-            val anonymousIdentity = services.keyManagementService.freshKeyAndCert(identity, false)
-            val myKeys = services.keyManagementService.filterMyKeys(listOf(identity.owningKey, anonymousIdentity.owningKey)).toSet()
-
-            // Well-known owner
-            assertTrue { myKeys.isOwnableStateRelevant(identity.party, participants = emptyList()) }
-            // Anonymous owner
-            assertTrue { myKeys.isOwnableStateRelevant(anonymousIdentity.party, participants = emptyList()) }
-            // Unknown owner
-            assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = emptyList()) }
-            // Unknown owner, self as single participant
-            assertTrue { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(identity.party)) }
-            // Unknown owner, unknown participant
-            assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(createUnknownIdentity())) }
-            // Unknown owner, self and unknown as participants
-            assertTrue { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(identity.party, createUnknownIdentity())) }
-        }
     }
 
     private fun createUnknownIdentity() = AnonymousParty(generateKeyPair().public)

--- a/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
+++ b/node/src/test/kotlin/net/corda/node/services/vault/NodeVaultServiceTest.kt
@@ -22,8 +22,8 @@ import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.toNonEmptySet
 import net.corda.finance.*
 import net.corda.finance.contracts.asset.Cash
-import net.corda.finance.schemas.CashSchemaV1
 import net.corda.finance.contracts.utils.sumCash
+import net.corda.finance.schemas.CashSchemaV1
 import net.corda.finance.workflows.asset.CashUtils
 import net.corda.finance.workflows.getCashBalance
 import net.corda.node.services.api.IdentityServiceInternal
@@ -42,6 +42,7 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.*
 import rx.observers.TestSubscriber
 import java.math.BigDecimal
+import java.security.PublicKey
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -98,8 +99,8 @@ class NodeVaultServiceTest {
         vaultFiller = VaultFiller(services, dummyNotary)
         // This is safe because MockServices only ever have a single identity
         identity = services.myInfo.singleIdentityAndCert()
-        issuerServices = MockServices(cordappPackages, dummyCashIssuer, mock<IdentityService>(), parameters)
-        bocServices = MockServices(cordappPackages, bankOfCorda, mock<IdentityService>(), parameters)
+        issuerServices = MockServices(cordappPackages, dummyCashIssuer, mock(), parameters)
+        bocServices = MockServices(cordappPackages, bankOfCorda, mock(), parameters)
         services.identityService.verifyAndRegisterIdentity(DUMMY_CASH_ISSUER_IDENTITY)
         services.identityService.verifyAndRegisterIdentity(BOC_IDENTITY)
     }
@@ -129,6 +130,7 @@ class NodeVaultServiceTest {
     }
 
     class FungibleFoo(override val amount: Amount<Currency>, override val participants: List<AbstractParty>) : FungibleState<Currency>
+
     @Test
     fun `fungible state selection test`() {
         val issuerParty = services.myInfo.legalIdentities.first()
@@ -551,21 +553,53 @@ class NodeVaultServiceTest {
     }
 
     @Test
-    fun `is ownable state relevant`() {
-        val amount = Amount(1000, Issued(BOC.ref(1), GBP))
-        val wellKnownCash = Cash.State(amount, identity.party)
-        val myKeys = services.keyManagementService.filterMyKeys(listOf(wellKnownCash.owner.owningKey))
-        assertTrue { NodeVaultService.isRelevant(wellKnownCash, myKeys.toSet()) }
+    fun `OwnableState relevancy under target version 3`() {
+        CordappResolver.withCordapp(targetPlatformVersion = 3) {
+            val myAnonymousIdentity = services.keyManagementService.freshKeyAndCert(identity, false)
+            val myKeys = services.keyManagementService.filterMyKeys(listOf(identity.owningKey, myAnonymousIdentity.owningKey)).toSet()
 
-        val anonymousIdentity = services.keyManagementService.freshKeyAndCert(identity, false)
-        val anonymousCash = Cash.State(amount, anonymousIdentity.party)
-        val anonymousKeys = services.keyManagementService.filterMyKeys(listOf(anonymousCash.owner.owningKey))
-        assertTrue { NodeVaultService.isRelevant(anonymousCash, anonymousKeys.toSet()) }
+            // Well-known owner
+            assertTrue { myKeys.isOwnableStateRelevant(identity.party, participants = emptyList()) }
+            // Anonymous owner
+            assertTrue { myKeys.isOwnableStateRelevant(myAnonymousIdentity.party, participants = emptyList()) }
+            // Unknown owner
+            assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = emptyList()) }
+            // Under target version 3 only the owner is relevant. This is to preserve backwards compatibility
+            assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(identity.party)) }
+        }
+    }
 
-        val thirdPartyIdentity = AnonymousParty(generateKeyPair().public)
-        val thirdPartyCash = Cash.State(amount, thirdPartyIdentity)
-        val thirdPartyKeys = services.keyManagementService.filterMyKeys(listOf(thirdPartyCash.owner.owningKey))
-        assertFalse { NodeVaultService.isRelevant(thirdPartyCash, thirdPartyKeys.toSet()) }
+    @Test
+    fun `OwnableState relevancy under target version 4`() {
+        CordappResolver.withCordapp(targetPlatformVersion = 4) {
+            val anonymousIdentity = services.keyManagementService.freshKeyAndCert(identity, false)
+            val myKeys = services.keyManagementService.filterMyKeys(listOf(identity.owningKey, anonymousIdentity.owningKey)).toSet()
+
+            // Well-known owner
+            assertTrue { myKeys.isOwnableStateRelevant(identity.party, participants = emptyList()) }
+            // Anonymous owner
+            assertTrue { myKeys.isOwnableStateRelevant(anonymousIdentity.party, participants = emptyList()) }
+            // Unknown owner
+            assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = emptyList()) }
+            // Unknown owner, self as single participant
+            assertTrue { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(identity.party)) }
+            // Unknown owner, unknown participant
+            assertFalse { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(createUnknownIdentity())) }
+            // Unknown owner, self and unknown as participants
+            assertTrue { myKeys.isOwnableStateRelevant(createUnknownIdentity(), participants = listOf(identity.party, createUnknownIdentity())) }
+        }
+    }
+
+    private fun createUnknownIdentity() = AnonymousParty(generateKeyPair().public)
+
+    private fun Set<PublicKey>.isOwnableStateRelevant(owner: AbstractParty, participants: List<AbstractParty>): Boolean {
+        class TestOwnableState : OwnableState {
+            override val owner: AbstractParty get() = owner
+            override val participants: List<AbstractParty> get() = participants
+            override fun withNewOwner(newOwner: AbstractParty): CommandAndState = throw AbstractMethodError()
+        }
+
+        return NodeVaultService.isRelevant(TestOwnableState(), this)
     }
 
     // TODO: Unit test linear state relevancy checks


### PR DESCRIPTION
https://github.com/corda/corda/pull/3789 changed the relevancy check of OwnableState to include the participants list in addition to the owner. This however breaks existing apps which assume (in their vault query) an OwnableState is recorded to the vault if-and-only-if the owner matches.
