### PR TITLE
Deprecate OwnableState.

### DIFF
--- a/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/Structures.kt
@@ -79,6 +79,7 @@ data class CommandAndState(val command: CommandData, val ownableState: OwnableSt
  * A contract state that can have a single owner.
  */
 @KeepForDJVM
+@Deprecated("From now on, please 'roll your own'")
 interface OwnableState : ContractState {
     /** There must be a MoveCommand signed by this key to claim the amount. */
     val owner: AbstractParty


### PR DESCRIPTION
@rick-r3 suggested this might be a good idea. I think he's right because:

1. Relevancy is confusing for `OwnableState`s as it is handled differently to `LinearState`s and other state types. See https://github.com/corda/corda/pull/4819
2. Corda is a platform which synchronises agreements between entities. Each agreement needs at least two participants and we generally never say that any one of those participants "owns" the agreement. It just doesn't make sense. Instead, it makes more sense to declare yourself as a participant in an agreement. Take `Cash` or `Token` for example; both have two participants. 
3. The only state type which has one participant is probably an amount of cryptocurrency (as there is no issuer) and whilst we know how to do it, we are not going to issue a cryptocurrency any time soon as no-one wants it.
4. `OwnableState` might be more useful if it allowed developers to query for all states by owner which implement `OwnableState` but there isn't a `OwnableStateQueryCriteria` at the moment, so you can't. However, if we are going to encourage developers to use the token SDK, then they can query for ownership across all tokens as they all use the same state type.

