### PR TITLE
CORDA-2679: Allow more Network Bootstrapper code to be unloaded from JVM.

### DIFF
--- a/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
+++ b/node-api/src/main/kotlin/net/corda/nodeapi/internal/network/NetworkBootstrapper.kt
@@ -29,7 +29,7 @@ import net.corda.serialization.internal.SerializationFactoryImpl
 import net.corda.serialization.internal.amqp.AbstractAMQPSerializationScheme
 import net.corda.serialization.internal.amqp.amqpMagic
 import java.io.File
-import java.io.InputStream
+import java.net.URL
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
@@ -53,14 +53,14 @@ import kotlin.streams.toList
 class NetworkBootstrapper
 @VisibleForTesting
 internal constructor(private val initSerEnv: Boolean,
-                     private val embeddedCordaJar: () -> InputStream,
+                     private val embeddedCordaJar: () -> URL,
                      private val nodeInfosGenerator: (List<Path>) -> List<Path>,
                      private val contractsJarConverter: (Path) -> ContractsJar) : NetworkBootstrapperWithOverridableParameters {
 
     constructor() : this(
             initSerEnv = true,
-            embeddedCordaJar = Companion::extractEmbeddedCordaJar,
-            nodeInfosGenerator = Companion::generateNodeInfos,
+            embeddedCordaJar = ::extractEmbeddedCordaJar,
+            nodeInfosGenerator = ::generateNodeInfos,
             contractsJarConverter = ::ContractsJarFile
     )
 
@@ -77,8 +77,8 @@ internal constructor(private val initSerEnv: Boolean,
 
         private val jarsThatArentCordapps = setOf("corda.jar", "runnodes.jar")
 
-        private fun extractEmbeddedCordaJar(): InputStream {
-            return Thread.currentThread().contextClassLoader.getResourceAsStream("corda.jar")
+        private fun extractEmbeddedCordaJar(): URL {
+            return Thread.currentThread().contextClassLoader.getResource("corda.jar")
         }
 
         private fun generateNodeInfos(nodeDirs: List<Path>): List<Path> {
@@ -106,13 +106,19 @@ internal constructor(private val initSerEnv: Boolean,
                     .redirectOutput(nodeInfoGenFile)
                     .apply { environment()["CAPSULE_CACHE_DIR"] = "../.cache" }
                     .start()
-            if (!process.waitFor(3, TimeUnit.MINUTES)) {
+            try {
+                if (!process.waitFor(3, TimeUnit.MINUTES)) {
+                    process.destroyForcibly()
+                    printNodeInfoGenLogToConsole(nodeInfoGenFile)
+                }
+                printNodeInfoGenLogToConsole(nodeInfoGenFile) { process.exitValue() == 0 }
+                return nodeDir.list { paths ->
+                    paths.filter { it.fileName.toString().startsWith(NODE_INFO_FILE_NAME_PREFIX) }.findFirst().get()
+                }
+            } catch (e: InterruptedException) {
+                // Don't leave this process dangling if the thread is interrupted.
                 process.destroyForcibly()
-                printNodeInfoGenLogToConsole(nodeInfoGenFile)
-            }
-            printNodeInfoGenLogToConsole(nodeInfoGenFile) { process.exitValue() == 0 }
-            return nodeDir.list { paths ->
-                paths.filter { it.fileName.toString().startsWith(NODE_INFO_FILE_NAME_PREFIX) }.findFirst().get()
+                throw e
             }
         }
 
@@ -257,19 +263,23 @@ internal constructor(private val initSerEnv: Boolean,
         }
     }
 
+    private fun Path.listEndingWith(suffix: String): List<Path> {
+        return list { file -> file.filter { it.toString().endsWith(suffix) }.toList() }
+    }
+
     private fun createNodeDirectoriesIfNeeded(directory: Path, fromCordform: Boolean): Boolean {
         var networkAlreadyExists = false
         val cordaJar = directory / "corda.jar"
         var usingEmbedded = false
         if (!cordaJar.exists()) {
-            embeddedCordaJar().use { it.copyTo(cordaJar) }
+            embeddedCordaJar().openStream().use { it.copyTo(cordaJar) }
             usingEmbedded = true
         } else if (!fromCordform) {
             println("Using corda.jar in root directory")
         }
 
-        val confFiles = directory.list { it.filter { it.toString().endsWith("_node.conf") }.toList() }
-        val webServerConfFiles = directory.list { it.filter { it.toString().endsWith("_web-server.conf") }.toList() }
+        val confFiles = directory.listEndingWith("_node.conf")
+        val webServerConfFiles = directory.listEndingWith("_web-server.conf")
 
         for (confFile in confFiles) {
             val nodeName = confFile.fileName.toString().removeSuffix("_node.conf")
@@ -285,11 +295,10 @@ internal constructor(private val initSerEnv: Boolean,
             cordaJar.copyToDirectory(nodeDir, REPLACE_EXISTING)
         }
 
-        directory.list { paths ->
-            paths.filter { (it / "node.conf").exists() && !(it / "corda.jar").exists() }.forEach {
-                println("Copying corda.jar into node directory ${it.fileName}")
-                cordaJar.copyToDirectory(it)
-            }
+        val nodeDirs = directory.list { subDir -> subDir.filter { (it / "node.conf").exists() && !(it / "corda.jar").exists() }.toList() }
+        for (nodeDir in nodeDirs) {
+            println("Copying corda.jar into node directory ${nodeDir.fileName}")
+            cordaJar.copyToDirectory(nodeDir)
         }
 
         if (fromCordform) {
@@ -304,15 +313,11 @@ internal constructor(private val initSerEnv: Boolean,
     }
 
     private fun gatherNodeDirectories(directory: Path): List<Path> {
-        return directory.list { paths ->
-            paths.filter {
-                val exists = (it / "corda.jar").exists()
-                if (exists) {
-                    require((it / "node.conf").exists()) { "Missing node.conf in node directory ${it.fileName}" }
-                }
-                exists
-            }.toList()
+        val nodeDirs = directory.list { subDir -> subDir.filter { (it / "corda.jar").exists() }.toList() }
+        for (nodeDir in nodeDirs) {
+            require((nodeDir / "node.conf").exists()) { "Missing node.conf in node directory ${nodeDir.fileName}" }
         }
+        return nodeDirs
     }
 
     private fun distributeNodeInfos(nodeDirs: List<Path>, nodeInfoFiles: List<Path>) {
@@ -434,13 +439,13 @@ internal constructor(private val initSerEnv: Boolean,
     private fun initialiseSerialization() {
         _contextSerializationEnv.set(SerializationEnvironment.with(
                 SerializationFactoryImpl().apply {
-                    registerScheme(AMQPParametersSerializationScheme)
+                    registerScheme(AMQPParametersSerializationScheme())
                 },
                 AMQP_P2P_CONTEXT)
         )
     }
 
-    private object AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
+    private class AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
         override fun rpcClientSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()
         override fun rpcServerSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()
 
@@ -526,7 +531,7 @@ enum class CopyCordapps {
 
     fun copy(cordappJars: List<Path>, nodeDirs: List<Path>, networkAlreadyExists: Boolean, fromCordform: Boolean) {
         if (!fromCordform) {
-            println("Found the following CorDapps: ${cordappJars.map { it.fileName }}")
+            println("Found the following CorDapps: ${cordappJars.map(Path::getFileName)}")
         }
         this.copyTo(cordappJars, nodeDirs, networkAlreadyExists, fromCordform)
     }


### PR DESCRIPTION
The JVM is _supposed_ to delete the `NetworkBootstrapper` classes once the `cordformation` Gradle plugin closes their `ClassLoader`. However, VisualVM shows that some classes still linger. In general, these seem to be "singleton" classes such as `object`, `companion` or some lambdas. So I've done the following:
- Simplified some "deeply-lambda'd" expressions.
- Turned `AMQPParametersSerializationScheme` into a `class`.
- Passed `corda.jar` as a `URL` instead of an `InputStream` so that we are _guaranteed_ to close the stream after use.
- Ensured that shutting the `ExecutorService` down will also kill any Node processes that are still running.

Unfortunately this doesn't completely fix the problem. It just reduces it slightly.