### PR TITLE
[ENT-3068] Port error message in deserialization improvements to OS

### DIFF
--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/EvolutionSerializerFactory.kt
@@ -109,8 +109,9 @@ class DefaultEvolutionSerializerFactory(
         newProperties.forEach { propertyName ->
             if (localProperties[propertyName]!!.mustBeProvided) throw EvolutionSerializationException(
                     this,
-                    "Mandatory property $propertyName of local type is not present in remote type - " +
-                    "did someone remove a property from the schema without considering old clients?")
+                    "Mandatory property $propertyName of local type is not present in remote type. " +
+                    "This implies the type has not evolved in a backwards compatible way. " +
+                    "Consider making $propertyName nullable in the newer version of this type.")
         }
     }
 


### PR DESCRIPTION
This PR is a port of the improved error message when a non-backwards compatible change is detected during deserialization to Open Source.
