### PR TITLE
ENT-3166 don't depend on cause for message

### DIFF
--- a/.ci/api-current.txt
+++ b/.ci/api-current.txt
@@ -1039,13 +1039,13 @@ public static final class net.corda.core.contracts.TransactionVerificationExcept
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ContractCreationError extends net.corda.core.contracts.TransactionVerificationException
-  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable, String)
   @NotNull
   public final String getContractClass()
 ##
 @CordaSerializable
 public static final class net.corda.core.contracts.TransactionVerificationException$ContractRejection extends net.corda.core.contracts.TransactionVerificationException
-  public <init>(net.corda.core.crypto.SecureHash, String, Throwable)
+  public <init>(net.corda.core.crypto.SecureHash, String, Throwable, String)
   public <init>(net.corda.core.crypto.SecureHash, net.corda.core.contracts.Contract, Throwable)
   @NotNull
   public final String getContractClass()

--- a/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
+++ b/core/src/main/kotlin/net/corda/core/contracts/TransactionVerificationException.kt
@@ -57,8 +57,8 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      * @property contractClass The fully qualified class name of the failing contract.
      */
     @KeepForDJVM
-    class ContractRejection(txId: SecureHash, val contractClass: String, cause: Throwable) : TransactionVerificationException(txId, "Contract verification failed: ${cause.message}, contract: $contractClass", cause) {
-        constructor(txId: SecureHash, contract: Contract, cause: Throwable) : this(txId, contract.javaClass.name, cause)
+    class ContractRejection internal constructor(txId: SecureHash, val contractClass: String, cause: Throwable?, message: String) : TransactionVerificationException(txId, "Contract verification failed: $message, contract: $contractClass", cause) {
+        internal constructor(txId: SecureHash, contract: Contract, cause: Throwable) : this(txId, contract.javaClass.name, cause, cause.message ?: "")
     }
 
     /**
@@ -121,8 +121,10 @@ abstract class TransactionVerificationException(val txId: SecureHash, message: S
      * @property contractClass The fully qualified class name of the failing contract.
      */
     @KeepForDJVM
-    class ContractCreationError(txId: SecureHash, val contractClass: String, cause: Throwable)
-        : TransactionVerificationException(txId, "Contract verification failed: ${cause.message}, could not create contract class: $contractClass", cause)
+    class ContractCreationError internal constructor(txId: SecureHash, val contractClass: String, cause: Throwable?, message: String)
+        : TransactionVerificationException(txId, "Contract verification failed: $message, could not create contract class: $contractClass", cause) {
+        internal constructor(txId: SecureHash, contractClass: String, cause: Throwable) : this(txId, contractClass, cause, cause.message ?: "")
+    }
 
     /**
      * An output state has a notary that doesn't match the transaction's notary field. It must!

--- a/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt
+++ b/core/src/test/kotlin/net/corda/core/contracts/TransactionVerificationExceptionSerialisationTests.kt
@@ -8,6 +8,7 @@ import net.corda.serialization.internal.amqp.DeserializationInput
 import net.corda.serialization.internal.amqp.SerializationOutput
 import net.corda.serialization.internal.amqp.SerializerFactoryBuilder
 import net.corda.serialization.internal.amqp.custom.PublicKeySerializer
+import net.corda.serialization.internal.amqp.custom.ThrowableSerializer
 import net.corda.testing.core.DUMMY_BANK_A_NAME
 import net.corda.testing.core.DUMMY_NOTARY_NAME
 import net.corda.testing.core.TestIdentity
@@ -18,7 +19,7 @@ class TransactionVerificationExceptionSerialisationTests {
     private fun defaultFactory() = SerializerFactoryBuilder.build(
             AllWhitelist,
             ClassLoader.getSystemClassLoader()
-    )
+    ).apply { register(ThrowableSerializer(this)) }
 
     private val context get() = AMQP_RPC_CLIENT_CONTEXT
 
@@ -52,7 +53,7 @@ class TransactionVerificationExceptionSerialisationTests {
                 context)
 
         assertEquals(exception.message, exception2.message)
-        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals("java.lang.Throwable: ${exception.cause?.message}", exception2.cause?.message)
         assertEquals(exception.txId, exception2.txId)
     }
 
@@ -89,7 +90,7 @@ class TransactionVerificationExceptionSerialisationTests {
                 context)
 
         assertEquals(exception.message, exception2.message)
-        assertEquals(exception.cause?.message, exception2.cause?.message)
+        assertEquals("java.lang.Throwable: ${exception.cause?.message}", exception2.cause?.message)
         assertEquals(exception.txId, exception2.txId)
     }
 


### PR DESCRIPTION
Two of the subclasses of `TransactionVerificationException` take a non-nullable `cause` parameter, and use the message from this `cause` to construct the exception's own message.

Unfortunately, `ExceptionSerializingRpcOpsProxy` nulls out the `cause` parameter of `CordaThrowable` exceptions over the wire, resulting in an `IllegalArgumentException` thrown by Kotlin's own null-checking when we try to deserialize the exception at the receiving end.

To remedy this, we make the `cause` parameter nullable, and introduce an explicit `message` parameter, matching the `message` property on the exception, that can be used to convey the message over the wire even when the `cause` has been nulled out.