### PR TITLE
Perform signature verification checks in parallel

### DIFF
--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -88,9 +88,7 @@ interface TransactionWithSignatures : NamedByHash {
     @JvmDefault
     @Throws(InvalidKeyException::class, SignatureException::class)
     fun checkSignaturesAreValid() {
-        for (sig in sigs) {
-            sig.verify(id)
-        }
+        sigs.parallelStream().filter{sig -> sig.verify(id)}
     }
 
     /**

--- a/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/TransactionWithSignatures.kt
@@ -88,7 +88,9 @@ interface TransactionWithSignatures : NamedByHash {
     @JvmDefault
     @Throws(InvalidKeyException::class, SignatureException::class)
     fun checkSignaturesAreValid() {
-        sigs.parallelStream().filter{sig -> sig.verify(id)}
+         for (transactionSignature in sigs.parallelStream()) {
+            transactionSignature.verify(id)
+        }
     }
 
     /**


### PR DESCRIPTION
* This PR performs signature verification checks in parallel. Signature verification algorithms can become expensive depending on the key-size, message, etc and this checks can be done independently by leveraging multiple cores of hardware to improve performance. 
* Defaulting to java stream API's for parallelism

@mikehearn does that sound right?