### PR TITLE
CORDA-2684 Added new guide on CorDapp Constraints Migration procedures.

### DIFF
--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -146,7 +146,7 @@ Hash constrained states in private networks
 Where private networks started life using CorDapps with hash constrained states, we have introduced a mechanism to relax the checking of
 these hash constrained states when upgrading to signed CorDapps using signature constraints.
 
-The java system property ``-Dnet.corda.node.disableHashConstraints="true"`` may be set to relax the hash constraint checking behaviour.
+The Java system property ``-Dnet.corda.node.disableHashConstraints="true"`` may be set to relax the hash constraint checking behaviour.
 
 This mode should only be used upon "out of band" agreement by all participants in a network.
 

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -193,11 +193,11 @@ During transaction building the ``AutomaticPlaceholderConstraint`` for output st
 will be selected based on a variety of factors so that the above holds true. If it can't find attachments in storage or there are no
 possible constraints, the ``TransactionBuilder`` will throw an exception.
 
-CorDapp constraints migration
-------------------------------
+Constraints migration to Corda 4
+--------------------------------
 
-Please read :doc:`cordapp-constraint-migration` to understand how to consume pre-existing hash or CZ whitelisted constrained states
-issued using a previous version of Corda using Corda 4 signed CorDapps (using signature constraints).
+Please read :doc:`cordapp-constraint-migration` to understand how to consume and evolve pre-Corda 4 issued hash or CZ whitelisted constrained states
+using a Corda 4 signed CorDapp (using signature constraints).
 
 Debugging
 ---------

--- a/docs/source/api-contract-constraints.rst
+++ b/docs/source/api-contract-constraints.rst
@@ -24,7 +24,7 @@ to it.
 There are several types of constraint:
 
 1. Hash constraint: exactly one version of the app can be used with this state.
-2. Zone whitelist constraint: the compatibility zone operator lists the hashes of the versions that can be used with this contract class name.
+2. Compatibility zone whitelisted (or CZ whitelisted) constraint: the compatibility zone operator lists the hashes of the versions that can be used with this contract class name.
 3. Signature constraint: any version of the app signed by the given ``CompositeKey`` can be used.
 4. Always accept constraint: any app can be used at all. This is insecure but convenient for testing.
 

--- a/docs/source/app-upgrade-notes.rst
+++ b/docs/source/app-upgrade-notes.rst
@@ -360,6 +360,9 @@ automatically use them if your application JAR is signed. **We recommend all JAR
 with developer certificates is deployed to a production node, the node will refuse to start. Therefore to deploy apps built for Corda 4
 to production you will need to generate signing keys and integrate them with the build process.
 
+.. note:: Please read the :doc:`cordapp-constraint-migration` guide to understand how to upgrade CorDapps to use Corda 4 signature constraints and consume
+    existing states on ledger issued with older constraint types (e.g. Corda 3.x states issued with **hash** or **CZ whitelisted** constraints).
+
 Step 10. Security: Package namespace handling
 ---------------------------------------------
 

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -13,9 +13,9 @@ CorDapp constraints migration
 .. note:: Before reading this page, you should be familiar with the key concepts of :doc:`Contract Constraints <api-contract-constraints>`.
 
 Corda 4 introduces and recommends building signed CorDapps that issue states with signature constraints.
-Existing on ledger states issued before Corda 4 are not automatically propagated to new signature constraints when building transactions in Corda 4.
+Existing on ledger states issued before Corda 4 are not automatically transitioned to new signature constraints when building transactions in Corda 4.
 This document explains how to modify existing CorDapp flows to explicitly consume and evolve pre Corda 4 states, and outlines a future mechanism
-where such states will propagate automatically (without explicit migration code).
+where such states will transition automatically (without explicit migration code).
 
 Faced with the exercise of upgrading an existing Corda 3.x CorDapp to Corda 4, you need to consider the following:
 
@@ -109,7 +109,7 @@ Corda 4.0 requires some additional steps to consume and evolve pre-existing on-l
 Later releases
 ~~~~~~~~~~~~~~
 
-The next version of Corda will provide automatic propagation of *hash constrained* states. This means that signed CorDapps running on a Corda 4.x node will
+The next version of Corda will provide automatic transition of *hash constrained* states. This means that signed CorDapps running on a Corda 4.x node will
 automatically propagate any pre-existing on-ledger *hash-constrained* states (and generate *signature-constrained* outputs) when the system property
 to break constraints is set.
 
@@ -183,5 +183,5 @@ Corda 4.0 requires some additional steps to consume and evolve pre-existing on-l
 Later releases
 ~~~~~~~~~~~~~~
 
-The next version of Corda will provide automatic propagation of *CZ whitelisted* constrained states. This means that signed CorDapps running on a Corda 4.x node will
+The next version of Corda will provide automatic transition of *CZ whitelisted* constrained states. This means that signed CorDapps running on a Corda 4.x node will
 automatically propagate any pre-existing on-ledger *CZ whitelisted* constrained states (and generate *signature* constrained outputs).

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -12,9 +12,9 @@ CorDapp constraints migration
 
 .. note:: Before reading this page, you should be familiar with the key concepts of :doc:`Contract Constraints <api-contract-constraints>`.
 
-Faced with the exercise of upgrading an existing Corda 3.x corDapp to Corda 4, you need to consider the following:
+Faced with the exercise of upgrading an existing Corda 3.x CorDapp to Corda 4, you need to consider the following:
 
-* What existing unconsumed states have been issued on ledger by a previous version of this corDapp and using other constraint types?
+* What existing unconsumed states have been issued on ledger by a previous version of this CorDapp and using other constraint types?
 
    If you have existing **hash** constrained states see :ref:`Migrating hash constraints<hash_constraint_migration>`.
 
@@ -35,7 +35,7 @@ Faced with the exercise of upgrading an existing Corda 3.x corDapp to Corda 4, y
 Hash constraints migration
 --------------------------
 
-.. note:: These instructions only apply to corDapp Contract JARs (unless otherwise stated).
+.. note:: These instructions only apply to CorDapp Contract JARs (unless otherwise stated).
 
 Corda 4.0
 ~~~~~~~~~
@@ -44,20 +44,27 @@ Corda 4.0 requires some additional steps to consume pre-existing on-ledger **has
 
 1. The Corda Node must be started using relaxed hash constraint checking mode as described in :ref:`relax_hash_constraints_checking_ref`.
 
-2. corDapp flows that build transactions using pre-existing *hash-constrained* states must explicitly set output states to use *signature constraints*
-   and specify the related public key(s) used in signing the associated corDapp Contract JAR:
+2. CorDapp flows that build transactions using pre-existing *hash-constrained* states must explicitly set output states to use *signature constraints*
+   and specify the related public key(s) used in signing the associated CorDapp Contract JAR:
 
 .. container:: codeset
 
     .. sourcecode:: kotlin
 
-        // This will read the signers for the deployed corDapp.
+        // This will read the signers for the deployed CorDapp.
         val attachment = this.serviceHub.cordappProvider.getContractAttachmentID(contractClass)
         val signers = this.serviceHub.attachments.openAttachment(attachment!!)!!.signerKeys
 
+        // Create the key that will have to pass for all future versions.
+        val ownersKey = signers.first()
+
+        val txBuilder = TransactionBuilder(notary)
+                // Set the Signature constraint on the new state to migrate away from the hash constraint.
+                .addOutputState(outputState, constraint = SignatureAttachmentConstraint(ownersKey))
+
     .. sourcecode:: java
 
-        // This will read the signers for the deployed corDapp.
+        // This will read the signers for the deployed CorDapp.
         SecureHash attachment = this.getServiceHub().getCordappProvider().getContractAttachmentID(contractClass);
         List<PublicKey> signers = this.getServiceHub().getAttachments().openAttachment(attachment).getSignerKeys();
 
@@ -65,18 +72,18 @@ Corda 4.0 requires some additional steps to consume pre-existing on-ledger **has
         PublicKey ownersKey = signers.get(0);
 
         TransactionBuilder txBuilder = new TransactionBuilder(notary)
-                // Set the Signature constraint on the new state to migrate away from the WhitelistConstraint.
+                // Set the Signature constraint on the new state to migrate away from the hash constraint.
                 .addOutputState(outputState, myContract, new SignatureAttachmentConstraint(ownersKey))
 
-3. Both the original pre-Corda 4 corDapp JAR (generating *hash-constrained* states) and the new Corda 4 signed corDapp JAR must be present in the
+3. Both the original pre-Corda 4 CorDapp JAR (generating *hash-constrained* states) and the new Corda 4 signed CorDapp JAR must be present in the
    Corda nodes /cordapps directory or imported manually via RPC using the ``uploadAttachment`` command (see
    :ref:`CorDapp Contract Attachments <cordapp_contract_attachments_ref>` for further information).
 
 
 Later releases
-~~~~~~~~~
+~~~~~~~~~~~~~~
 
-The next version of Corda will provide automatic migration of *hash constrained* states. This means that signed corDapps running on a Corda 4.x node will
+The next version of Corda will provide automatic migration of *hash constrained* states. This means that signed CorDapps running on a Corda 4.x node will
 automatically consume any pre-existing on-ledger *hash-constrained* states (and generate *signature-constrained* outputs).
 
 .. _cz_whitelisted_constraint_migration:
@@ -84,42 +91,42 @@ automatically consume any pre-existing on-ledger *hash-constrained* states (and 
 CZ whitelisted constraints migration
 -------------------------------------
 
-.. note:: These instructions only apply to corDapp Contract JARs (unless otherwise stated).
+.. note:: These instructions only apply to CorDapp Contract JARs (unless otherwise stated).
 
 Corda 4.0
 ~~~~~~~~~
 
 Corda 4.0 requires some additional steps to consume pre-existing on-ledger **CZ whitelisted** constrained states:
 
-1. As the original developer of the corDapp, the first step is to sign the latest version of the JAR that was released (see :doc:`cordapp-build-systems`).
+1. As the original developer of the CorDapp, the first step is to sign the latest version of the JAR that was released (see :doc:`cordapp-build-systems`).
    The key used for signing will be used to sign all subsequent releases, so it should be stored appropriately. The JAR can be signed by multiple keys owned
    by different parties and it will be expressed as a ``CompositeKey`` in the ``SignatureAttachmentConstraint`` (See :doc:`api-core-types`).
    Use `JAR signing and verification tool <https://docs.oracle.com/javase/tutorial/deployment/jar/verify.html>`_ to sign the existing JAR.
    The signing capability of :ref:`corda-gradle-plugins <cordapp_build_system_signing_cordapp_jar_ref>` cannot be used in this context as it signs the JAR while building it from source.
 
-2. Both the original pre-Corda 4 corDapp JAR (generating *CZ whitelisted* constrained states) and the new Corda 4 signed corDapp JAR must be
-   registered with the CZ Network operator (as whitelisted in the network parameters which are distributed to all nodes in that CZ).
+2. Both the original pre-Corda 4 CorDapp JAR (generating *CZ whitelisted* constrained states) and the new Corda 4 signed CorDapp JAR must be
+   registered with the CZ network operator (as whitelisted in the network parameters which are distributed to all nodes in that CZ).
    The CZ network operator should check that the JAR is signed and not allow any more versions of it to be whitelisted in the future.
    From now on the development organisation that signed the JAR is responsible for signing new versions.
 
-   The process of CZ Network corDapp whitelisting depends on how the Corda Network is configured:
+   The process of CZ network CorDapp whitelisting depends on how the Corda network is configured:
 
-    - if using a hosted CZ Network (such as `The Corda Network <https://docs.corda.net/head/corda-network/index.html>`_ or
+    - if using a hosted CZ network (such as `The Corda Network <https://docs.corda.net/head/corda-network/index.html>`_ or
       `UAT Environment <https://docs.corda.net/head/corda-network/UAT.html>`_ ) running an Identity Operator (formerly known as Doorman) and
       Network Map Service, you should manually send the hashes of the two JARs to the CZ network operator and request these be added using
       their network parameter update process.
 
     - if using a local network created using the Network Bootstrapper tool, please follow the instructions in
-      :ref:`Updating the contract whitelist for bootstrapped networks <bootstrapper_updating_whitelisted_contracts>` to can add both corDapp Contract JAR hashes.
+      :ref:`Updating the contract whitelist for bootstrapped networks <bootstrapper_updating_whitelisted_contracts>` to can add both CorDapp Contract JAR hashes.
 
-3. Any flows that build transactions using this corDapp will have the responsibility of transitioning states to the ``SignatureAttachmentConstraint``.
+3. Any flows that build transactions using this CorDapp will have the responsibility of transitioning states to the ``SignatureAttachmentConstraint``.
    This is done explicitly in the code by setting the constraint of the output states to signers of the latest version of the whitelisted jar:
 
 .. container:: codeset
 
     .. sourcecode:: kotlin
 
-        // This will read the signers for the deployed corDapp.
+        // This will read the signers for the deployed CorDapp.
         val attachment = this.serviceHub.cordappProvider.getContractAttachmentID(contractClass)
         val signers = this.serviceHub.attachments.openAttachment(attachment!!)!!.signerKeys
 
@@ -132,7 +139,7 @@ Corda 4.0 requires some additional steps to consume pre-existing on-ledger **CZ 
 
     .. sourcecode:: java
 
-        // This will read the signers for the deployed corDapp.
+        // This will read the signers for the deployed CorDapp.
         SecureHash attachment = this.getServiceHub().getCordappProvider().getContractAttachmentID(contractClass);
         List<PublicKey> signers = this.getServiceHub().getAttachments().openAttachment(attachment).getSignerKeys();
 
@@ -143,10 +150,10 @@ Corda 4.0 requires some additional steps to consume pre-existing on-ledger **CZ 
                 // Set the Signature constraint on the new state to migrate away from the WhitelistConstraint.
                 .addOutputState(outputState, myContract, new SignatureAttachmentConstraint(ownersKey))
 
-4. As a node operator you need to add the new signed version of the contracts corDapp to the "cordapps" folder together with the latest version of the flows jar.
+4. As a node operator you need to add the new signed version of the contracts CorDapp to the "cordapps" folder together with the latest version of the flows jar.
 
 Later releases
-~~~~~~~~~
+~~~~~~~~~~~~~~
 
-The next version of Corda will provide automatic migration of *CZ whitelisted* constrained states. This means that signed corDapps running on a Corda 4.x node will
+The next version of Corda will provide automatic migration of *CZ whitelisted* constrained states. This means that signed CorDapps running on a Corda 4.x node will
 automatically consume any pre-existing on-ledger *CZ whitelisted* constrained states (and generate *signature* constrained outputs).

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -1,0 +1,152 @@
+.. highlight:: kotlin
+.. role:: kotlin(code)
+    :language: kotlin
+.. raw:: html
+
+
+   <script type="text/javascript" src="_static/jquery.js"></script>
+   <script type="text/javascript" src="_static/codesets.js"></script>
+
+CorDapp constraints migration
+=============================
+
+.. note:: Before reading this page, you should be familiar with the key concepts of :doc:`Contract Constraints <api-contract-constraints>`.
+
+Faced with the exercise of upgrading an existing Corda 3.x corDapp to Corda 4, you need to consider the following:
+
+* What existing unconsumed states have been issued on ledger by a previous version of this corDapp and using other constraint types?
+
+   If you have existing **hash** constrained states see :ref:`Migrating hash constraints<hash_constraint_migration>`.
+
+   If you have existing **CZ whitelisted** constrained states see :ref:`Migrating CZ whitelisted constraints<cz_whitelisted_constraint_migration>`.
+
+   If you have existing **always accept** constrained states these are automatically consumable as they offer no security and should only
+   be used in test environments.
+
+* Should I use the **implicit** or **explicit** upgrade path?
+
+   The general recommendation for Corda 4 is to use **implicit** upgrades for the reasons described :ref:`here <implicit_vs_explicit_upgrades>`.
+
+   **Implicit** upgrades allow pre-authorising multiple implementations of the contract ahead of time.
+   They do not require additional coding and do not incur a complex choreographed operational upgrade process.
+
+.. _hash_constraint_migration:
+
+Hash constraints migration
+--------------------------
+
+.. note:: These instructions only apply to corDapp Contract JARs (unless otherwise stated).
+
+Corda 4.0
+~~~~~~~~~
+
+Corda 4.0 requires some additional steps to consume pre-existing on-ledger **hash** constrained states:
+
+1. The Corda Node must be started using relaxed hash constraint checking mode as described in :ref:`relax_hash_constraints_checking_ref`.
+
+2. corDapp flows that build transactions using pre-existing *hash-constrained* states must explicitly set output states to use *signature constraints*
+   and specify the related public key(s) used in signing the associated corDapp Contract JAR:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        // This will read the signers for the deployed corDapp.
+        val attachment = this.serviceHub.cordappProvider.getContractAttachmentID(contractClass)
+        val signers = this.serviceHub.attachments.openAttachment(attachment!!)!!.signerKeys
+
+    .. sourcecode:: java
+
+        // This will read the signers for the deployed corDapp.
+        SecureHash attachment = this.getServiceHub().getCordappProvider().getContractAttachmentID(contractClass);
+        List<PublicKey> signers = this.getServiceHub().getAttachments().openAttachment(attachment).getSignerKeys();
+
+        // Create the key that will have to pass for all future versions.
+        PublicKey ownersKey = signers.get(0);
+
+        TransactionBuilder txBuilder = new TransactionBuilder(notary)
+                // Set the Signature constraint on the new state to migrate away from the WhitelistConstraint.
+                .addOutputState(outputState, myContract, new SignatureAttachmentConstraint(ownersKey))
+
+3. Both the original pre-Corda 4 corDapp JAR (generating *hash-constrained* states) and the new Corda 4 signed corDapp JAR must be present in the
+   Corda nodes /cordapps directory or imported manually via RPC using the ``uploadAttachment`` command (see
+   :ref:`CorDapp Contract Attachments <cordapp_contract_attachments_ref>` for further information).
+
+
+Later releases
+~~~~~~~~~
+
+The next version of Corda will provide automatic migration of *hash constrained* states. This means that signed corDapps running on a Corda 4.x node will
+automatically consume any pre-existing on-ledger *hash-constrained* states (and generate *signature-constrained* outputs).
+
+.. _cz_whitelisted_constraint_migration:
+
+CZ whitelisted constraints migration
+-------------------------------------
+
+.. note:: These instructions only apply to corDapp Contract JARs (unless otherwise stated).
+
+Corda 4.0
+~~~~~~~~~
+
+Corda 4.0 requires some additional steps to consume pre-existing on-ledger **CZ whitelisted** constrained states:
+
+1. As the original developer of the corDapp, the first step is to sign the latest version of the JAR that was released (see :doc:`cordapp-build-systems`).
+   The key used for signing will be used to sign all subsequent releases, so it should be stored appropriately. The JAR can be signed by multiple keys owned
+   by different parties and it will be expressed as a ``CompositeKey`` in the ``SignatureAttachmentConstraint`` (See :doc:`api-core-types`).
+   Use `JAR signing and verification tool <https://docs.oracle.com/javase/tutorial/deployment/jar/verify.html>`_ to sign the existing JAR.
+   The signing capability of :ref:`corda-gradle-plugins <cordapp_build_system_signing_cordapp_jar_ref>` cannot be used in this context as it signs the JAR while building it from source.
+
+2. Both the original pre-Corda 4 corDapp JAR (generating *CZ whitelisted* constrained states) and the new Corda 4 signed corDapp JAR must be
+   registered with the CZ Network operator (as whitelisted in the network parameters which are distributed to all nodes in that CZ).
+   The CZ network operator should check that the JAR is signed and not allow any more versions of it to be whitelisted in the future.
+   From now on the development organisation that signed the JAR is responsible for signing new versions.
+
+   The process of CZ Network corDapp whitelisting depends on how the Corda Network is configured:
+
+    - if using a hosted CZ Network (such as `The Corda Network <https://docs.corda.net/head/corda-network/index.html>`_ or
+      `UAT Environment <https://docs.corda.net/head/corda-network/UAT.html>`_ ) running an Identity Operator (formerly known as Doorman) and
+      Network Map Service, you should manually send the hashes of the two JARs to the CZ network operator and request these be added using
+      their network parameter update process.
+
+    - if using a local network created using the Network Bootstrapper tool, please follow the instructions in
+      :ref:`Updating the contract whitelist for bootstrapped networks <bootstrapper_updating_whitelisted_contracts>` to can add both corDapp Contract JAR hashes.
+
+3. Any flows that build transactions using this corDapp will have the responsibility of transitioning states to the ``SignatureAttachmentConstraint``.
+   This is done explicitly in the code by setting the constraint of the output states to signers of the latest version of the whitelisted jar:
+
+.. container:: codeset
+
+    .. sourcecode:: kotlin
+
+        // This will read the signers for the deployed corDapp.
+        val attachment = this.serviceHub.cordappProvider.getContractAttachmentID(contractClass)
+        val signers = this.serviceHub.attachments.openAttachment(attachment!!)!!.signerKeys
+
+        // Create the key that will have to pass for all future versions.
+        val ownersKey = signers.first()
+
+        val txBuilder = TransactionBuilder(notary)
+                // Set the Signature constraint on the new state to migrate away from the WhitelistConstraint.
+                .addOutputState(outputState, constraint = SignatureAttachmentConstraint(ownersKey))
+
+    .. sourcecode:: java
+
+        // This will read the signers for the deployed corDapp.
+        SecureHash attachment = this.getServiceHub().getCordappProvider().getContractAttachmentID(contractClass);
+        List<PublicKey> signers = this.getServiceHub().getAttachments().openAttachment(attachment).getSignerKeys();
+
+        // Create the key that will have to pass for all future versions.
+        PublicKey ownersKey = signers.get(0);
+
+        TransactionBuilder txBuilder = new TransactionBuilder(notary)
+                // Set the Signature constraint on the new state to migrate away from the WhitelistConstraint.
+                .addOutputState(outputState, myContract, new SignatureAttachmentConstraint(ownersKey))
+
+4. As a node operator you need to add the new signed version of the contracts corDapp to the "cordapps" folder together with the latest version of the flows jar.
+
+Later releases
+~~~~~~~~~
+
+The next version of Corda will provide automatic migration of *CZ whitelisted* constrained states. This means that signed corDapps running on a Corda 4.x node will
+automatically consume any pre-existing on-ledger *CZ whitelisted* constrained states (and generate *signature* constrained outputs).

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -12,6 +12,11 @@ CorDapp constraints migration
 
 .. note:: Before reading this page, you should be familiar with the key concepts of :doc:`Contract Constraints <api-contract-constraints>`.
 
+Corda 4 introduces and recommends building signed CorDapps that issue states with signature constraints.
+Existing on ledger states issued before Corda 4 are not automatically propagated to new signature constraints when building transactions in Corda 4.
+This document explains how to modify existing CorDapp flows to explicitly consume and evolve pre Corda 4 states, and outlines a future mechanism
+where such states will propagate automatically (without explicit migration code).
+
 Faced with the exercise of upgrading an existing Corda 3.x CorDapp to Corda 4, you need to consider the following:
 
 * What existing unconsumed states have been issued on ledger by a previous version of this CorDapp and using other constraint types?
@@ -104,8 +109,8 @@ Corda 4.0 requires some additional steps to consume and evolve pre-existing on-l
 Later releases
 ~~~~~~~~~~~~~~
 
-The next version of Corda will provide automatic migration of *hash constrained* states. This means that signed CorDapps running on a Corda 4.x node will
-automatically consume any pre-existing on-ledger *hash-constrained* states (and generate *signature-constrained* outputs) when the system property
+The next version of Corda will provide automatic propagation of *hash constrained* states. This means that signed CorDapps running on a Corda 4.x node will
+automatically propagate any pre-existing on-ledger *hash-constrained* states (and generate *signature-constrained* outputs) when the system property
 to break constraints is set.
 
 .. _cz_whitelisted_constraint_migration:
@@ -178,5 +183,5 @@ Corda 4.0 requires some additional steps to consume and evolve pre-existing on-l
 Later releases
 ~~~~~~~~~~~~~~
 
-The next version of Corda will provide automatic migration of *CZ whitelisted* constrained states. This means that signed CorDapps running on a Corda 4.x node will
-automatically consume any pre-existing on-ledger *CZ whitelisted* constrained states (and generate *signature* constrained outputs).
+The next version of Corda will provide automatic propagation of *CZ whitelisted* constrained states. This means that signed CorDapps running on a Corda 4.x node will
+automatically propagate any pre-existing on-ledger *CZ whitelisted* constrained states (and generate *signature* constrained outputs).

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -43,12 +43,12 @@ Faced with the exercise of upgrading an existing Corda 3.x CorDapp to Corda 4, y
    **Implicit** upgrades allow pre-authorising multiple implementations of the contract ahead of time.
    They do not require additional coding and do not incur a complex choreographed operational upgrade process.
 
-.. warning:: the steps outlined in this page assume you are using the same CorDapp Contract (eg. same state definition, commands and verification code) and
-   wish to use that CorDapp to leverage the upgradeability benefits of Corda 4 signature constraints. If you are looking to upgrade an existing
+.. warning:: The steps outlined in this page assume you are using the same CorDapp Contract (eg. same state definition, commands and verification code) and
+   wish to use that CorDapp to leverage the upgradeability benefits of Corda 4 signature constraints. If you are looking to upgrade code within an existing
    Contract CorDapp please read :ref:`Contract and state versioning<contract_upgrading_ref>` and :doc:`cordapp-upgradeability` to understand your options.
 
 Please also remember that *states are always consumable if the version of the CorDapp that issued (created) them is installed*.
-In the simplest of scenarios it may be easier to re-issue existing hash or CZ whitelisted states (eg. exit them from the ledger using
+In the simplest of scenarios it may be easier to re-issue existing hash or CZ whitelist constrained states (eg. exit them from the ledger using
 the original unsigned CorDapp and re-issuing them using the new signed CorDapp).
 
 .. _hash_constraint_migration:

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -128,8 +128,6 @@ Corda 4.0 requires some additional steps to consume and evolve pre-existing on-l
 1. As the original developer of the CorDapp, the first step is to sign the latest version of the JAR that was released (see :doc:`cordapp-build-systems`).
    The key used for signing will be used to sign all subsequent releases, so it should be stored appropriately. The JAR can be signed by multiple keys owned
    by different parties and it will be expressed as a ``CompositeKey`` in the ``SignatureAttachmentConstraint`` (See :doc:`api-core-types`).
-   Use `JAR signing and verification tool <https://docs.oracle.com/javase/tutorial/deployment/jar/verify.html>`_ to sign the existing JAR.
-   The signing capability of :ref:`corda-gradle-plugins <cordapp_build_system_signing_cordapp_jar_ref>` cannot be used in this context as it signs the JAR while building it from source.
 
 2. The new Corda 4 signed CorDapp JAR must be registered with the CZ network operator (as whitelisted in the network parameters which are distributed
    to all nodes in that CZ). The CZ network operator should check that the JAR is signed and not allow any more versions of it to be whitelisted in the future.

--- a/docs/source/cordapp-constraint-migration.rst
+++ b/docs/source/cordapp-constraint-migration.rst
@@ -97,10 +97,9 @@ Corda 4.0 requires some additional steps to consume and evolve pre-existing on-l
                 // Set the Signature constraint on the new state to migrate away from the hash constraint.
                 .addOutputState(outputState, myContract, new SignatureAttachmentConstraint(ownersKey))
 
-3. Both the original pre-Corda 4 CorDapp JAR (generating *hash-constrained* states) and the new Corda 4 signed CorDapp JAR must be present in the
-   Corda nodes /cordapps directory or imported manually via RPC using the ``uploadAttachment`` command (see
-   :ref:`CorDapp Contract Attachments <cordapp_contract_attachments_ref>` for further information).
-
+3. As a node operator you need to add the new signed version of the contracts CorDapp to the ``/cordapps`` folder together with the latest version of the flows jar.
+   Please also ensure that the original unsigned contracts CorDapp is removed from the ``/cordapps`` folder (this will already be present in the
+   nodes attachments store) to ensure the lookup code in step 2 retrieves the correct signed contract CorDapp JAR.
 
 Later releases
 ~~~~~~~~~~~~~~
@@ -172,7 +171,9 @@ Corda 4.0 requires some additional steps to consume and evolve pre-existing on-l
                 // Set the Signature constraint on the new state to migrate away from the WhitelistConstraint.
                 .addOutputState(outputState, myContract, new SignatureAttachmentConstraint(ownersKey))
 
-4. As a node operator you need to add the new signed version of the contracts CorDapp to the "cordapps" folder together with the latest version of the flows jar.
+4. As a node operator you need to add the new signed version of the contracts CorDapp to the ``/cordapps`` folder together with the latest version of the flows jar.
+   Please also ensure that the original unsigned contracts CorDapp is removed from the ``/cordapps`` folder (this will already be present in the
+   nodes attachments store) to ensure the lookup code in step 3 retrieves the correct signed contract CorDapp JAR.
 
 Later releases
 ~~~~~~~~~~~~~~

--- a/docs/source/cordapp-upgradeability.rst
+++ b/docs/source/cordapp-upgradeability.rst
@@ -20,10 +20,10 @@ The following guarantees are made for CorDapps running on Corda 4.0
 
 - CorDapp Contract states generated on ledger using hash constraints are not directly migratable to signature constraints in this release.
   Your compatibility zone operator may whitelist a JAR previously used to issue hash constrained states, and then you can follow the manual
-  process described in the paragraph below to migrate these to signature constraints.
+  process described in the paragraph below to migrate these to signature constraints. See :doc:`cordapp-constraint-migration` for more information.
 
 - CorDapp Contract states generated on ledger using CZ whitelisted constraints are migratable to signature constraints using a manual process
-  that requires programmatic code changes. See :ref:`constraints_whitelist_to_signature_ref` for more information.
+  that requires programmatic code changes. See :ref:`cz_whitelisted_constraint_migration` for more information.
 
 - Explicit Contract Upgrades are only supported for hash and CZ whitelisted constraint types. See :ref:`explicit_contract_upgrades_ref` for more information.
 

--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -76,6 +76,8 @@ alongside the config files. For example, if your directory has this structure:
 The ``cordapp-a.jar`` and ``cordapp-b.jar`` will be installed in each node directory, and any contracts within them will be
 added to the Contract Whitelist (see below).
 
+.. _bootstrapper_whitelisting_contracts:
+
 Whitelisting contracts
 ----------------------
 
@@ -189,6 +191,8 @@ such a generated keys, will be unaffected.
 .. note:: The Network Bootstrapper is provided for test deployments and can only generate information for nodes collected on
     the same machine. If a network needs to be updated using the Bootstrapper once deployed, the nodes will need
     collecting back together.
+
+.. _bootstrapper_updating_whitelisted_contracts:
 
 Updating the contract whitelist for bootstrapped networks
 ---------------------------------------------------------

--- a/docs/source/upgrading-cordapps.rst
+++ b/docs/source/upgrading-cordapps.rst
@@ -259,7 +259,7 @@ a drain is complete there should be no outstanding checkpoints or running flows.
 A node can be drained or undrained via RPC using the ``setFlowsDrainingModeEnabled`` method, and via the shell using
 the standard ``run`` command to invoke the RPC. See :doc:`shell` to learn more.
 
-.. _explicit_contract_upgrades_ref:
+.. _contract_upgrading_ref:
 
 Contract and state versioning
 -----------------------------
@@ -271,7 +271,12 @@ There are two types of contract/state upgrade:
 2. *Explicit:* By creating a special *contract upgrade transaction* and getting all participants of a state to sign it
    using the contract upgrade flows
 
-This section of the documentation focuses only on *explicit* upgrades.
+The general recommendation for Corda 4 is to use **implicit** upgrades for the reasons described :ref:`here <implicit_vs_explicit_upgrades>`.
+
+.. _explicit_contract_upgrades_ref:
+
+Performing explicit contract and state upgrades
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In an explicit upgrade, contracts and states can be changed in arbitrary ways, if and only if all of the state's
 participants agree to the proposed upgrade. The following combinations of upgrades are possible:
@@ -279,9 +284,6 @@ participants agree to the proposed upgrade. The following combinations of upgrad
 * A contract is upgraded while the state definition remains the same
 * A state is upgraded while the contract stays the same
 * The state and the contract are updated simultaneously
-
-Performing explicit contract and state upgrades
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Preserve the existing state and contract definitions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Documentation explaining how to consume existing hash and CZ whitelisted states using Corda 4.