### PR TITLE
CORDA-2691 Clarify that bootstrapper only works in devMode

### DIFF
--- a/docs/source/network-bootstrapper.rst
+++ b/docs/source/network-bootstrapper.rst
@@ -26,7 +26,7 @@ Bootstrapping a test network
 
 The Corda Network Bootstrapper can be downloaded from `here <https://corda.net/resources>`_.
 
-Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. Then run the
+Create a directory containing a node config file, ending in "_node.conf", for each node you want to create. "devMode" must be set to true. Then run the
 following command:
 
 ``java -jar network-bootstrapper-VERSION.jar --dir <nodes-root-dir>``


### PR DESCRIPTION
Bootstrapper will be updated to give a better error message if it sees any node.confs with devMode=false (CORDA-2686). This PR updates the docs to match.