### PR TITLE
CORDA-2694: Prevent Node Explorer from crashing should it receive unknown transaction objects.

### DIFF
--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/NodeMonitorModel.kt
@@ -119,19 +119,19 @@ class NodeMonitorModel : AutoCloseable {
                 }.toSet()
                 val consumedStates = statesSnapshot.states.toSet() - unconsumedStates
                 val initialVaultUpdate = Vault.Update(consumedStates, unconsumedStates, references = emptySet())
-                vaultUpdates.startWith(initialVaultUpdate).subscribe({ vaultUpdatesSubject.onNext(it) }, {})
+                vaultUpdates.startWith(initialVaultUpdate).subscribe(vaultUpdatesSubject::onNext, {})
 
                 // Transactions
                 val (transactions, newTransactions) = proxy.internalVerifiedTransactionsFeed()
-                newTransactions.startWith(transactions).subscribe({ transactionsSubject.onNext(it) }, {})
+                newTransactions.startWith(transactions).subscribe(transactionsSubject::onNext, {})
 
                 // SM -> TX mapping
                 val (smTxMappings, futureSmTxMappings) = proxy.stateMachineRecordedTransactionMappingFeed()
-                futureSmTxMappings.startWith(smTxMappings).subscribe({ stateMachineTransactionMappingSubject.onNext(it) }, {})
+                futureSmTxMappings.startWith(smTxMappings).subscribe(stateMachineTransactionMappingSubject::onNext, {})
 
                 // Parties on network
                 val (parties, futurePartyUpdate) = proxy.networkMapFeed()
-                futurePartyUpdate.startWith(parties.map { MapChange.Added(it) }).subscribe({ networkMapSubject.onNext(it) }, {})
+                futurePartyUpdate.startWith(parties.map(MapChange::Added)).subscribe(networkMapSubject::onNext, {})
             }
         }
 

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
@@ -14,7 +14,7 @@ import net.corda.core.internal.LazyMappedList
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
-import java.math.BigInteger
+import java.math.BigInteger.ZERO
 
 private class Unknown : Contract {
     override fun verify(tx: LedgerTransaction) = throw UnsupportedOperationException()
@@ -54,7 +54,7 @@ data class PartiallyResolvedTransaction(
     }
 
     companion object {
-        private val UNKNOWN_PARTY = Party(CordaX500Name("Unknown Party", "Nowhere", "ZZ"), entropyToKeyPair(BigInteger.ZERO).public)
+        private val UNKNOWN_PARTY = Party(CordaX500Name("Unknown Party", "Nowhere", "ZZ"), entropyToKeyPair(ZERO).public)
         private val UNKNOWN_TRANSACTION_STATE: TransactionState<ContractState> = TransactionState(Unknown.State, Unknown::class.java.name, UNKNOWN_PARTY)
 
         fun fromSignedTransaction(

--- a/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
+++ b/client/jfx/src/main/kotlin/net/corda/client/jfx/model/TransactionDataModel.kt
@@ -10,7 +10,7 @@ import net.corda.core.crypto.entropyToKeyPair
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
-import net.corda.core.internal.LazyMappedList
+import net.corda.core.internal.eagerDeserialise
 import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.WireTransaction
@@ -66,10 +66,7 @@ data class PartiallyResolvedTransaction(
              * Replace any [TransactionState] objects that fail to
              * deserialize with [UNKNOWN_TRANSACTION_STATE].
              */
-            val txOutputs = transaction.coreTransaction.outputs
-            if (txOutputs is LazyMappedList<*, TransactionState<ContractState>>) {
-                txOutputs.eager { _, _ -> UNKNOWN_TRANSACTION_STATE }
-            }
+            transaction.coreTransaction.outputs.eagerDeserialise { _, _ -> UNKNOWN_TRANSACTION_STATE }
             return PartiallyResolvedTransaction(
                     transaction = transaction,
                     inputs = transaction.inputs.map { stateRef ->

--- a/core/src/main/kotlin/net/corda/core/internal/ConstraintsUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/ConstraintsUtils.kt
@@ -1,7 +1,6 @@
 package net.corda.core.internal
 
 import net.corda.core.contracts.*
-import net.corda.core.crypto.isFulfilledBy
 import net.corda.core.crypto.keys
 import net.corda.core.internal.cordapp.CordappImpl
 import net.corda.core.utilities.loggerFor

--- a/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/internal/InternalUtils.kt
@@ -553,6 +553,7 @@ fun <T, U> List<T>.lazyMapped(transform: (T, Int) -> U): List<U> = LazyMappedLis
 /**
  * Iterate over a [LazyMappedList], forcing it to transform all of its elements immediately.
  * This transformation is assumed to be "deserialisation". Does nothing for any other kind of [List].
+ * WARNING: Any changes made to the [LazyMappedList] contents are PERMANENT!
  */
 fun <T> List<T>.eagerDeserialise(onError: (TransactionDeserialisationException, Int) -> T? = { ex, _ -> throw ex }) {
     if (this is LazyMappedList<*, T>) {

--- a/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
+++ b/core/src/main/kotlin/net/corda/core/transactions/WireTransaction.kt
@@ -9,7 +9,6 @@ import net.corda.core.contracts.ComponentGroupEnum.OUTPUTS_GROUP
 import net.corda.core.crypto.*
 import net.corda.core.identity.Party
 import net.corda.core.internal.*
-import net.corda.core.internal.cordapp.CordappImpl.Companion.DEFAULT_CORDAPP_VERSION
 import net.corda.core.node.NetworkParameters
 import net.corda.core.node.ServiceHub
 import net.corda.core.node.ServicesForResolution

--- a/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
+++ b/core/src/main/kotlin/net/corda/core/utilities/KotlinUtils.kt
@@ -4,15 +4,12 @@ package net.corda.core.utilities
 
 import net.corda.core.DeleteForDJVM
 import net.corda.core.KeepForDJVM
-import net.corda.core.internal.LazyMappedList
 import net.corda.core.internal.concurrent.get
-import net.corda.core.internal.createSimpleCache
 import net.corda.core.internal.uncheckedCast
 import net.corda.core.serialization.CordaSerializable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.*
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
 import kotlin.reflect.KProperty

--- a/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
@@ -2,8 +2,8 @@ package net.corda.core.utilities
 
 import net.corda.core.contracts.ComponentGroupEnum.*
 import net.corda.core.internal.lazyMapped
-import net.corda.core.internal.LazyMappedList
 import net.corda.core.internal.TransactionDeserialisationException
+import net.corda.core.internal.eagerDeserialise
 import net.corda.core.serialization.MissingAttachmentsException
 import org.junit.Rule
 import org.junit.Test
@@ -47,23 +47,21 @@ class LazyMappedListTest {
         exception.expect(MissingAttachmentsException::class.java)
         exception.expectMessage("Uncatchable!")
 
-        @Suppress("unchecked_cast")
         val lazyList = (0 until 5).toList().lazyMapped<Int, Int> { _, _ ->
             throw MissingAttachmentsException(emptyList(), "Uncatchable!")
-        } as LazyMappedList<Int, Int>
+        }
 
-        lazyList.eager { _, _ -> -999 }
+        lazyList.eagerDeserialise { _, _ -> -999 }
     }
 
     @Test
     fun testDeserialisationExceptions() {
-        @Suppress("unchecked_cast")
         val lazyList = (0 until 5).toList().lazyMapped<Int, Int> { _, index ->
             throw TransactionDeserialisationException(
                 OUTPUTS_GROUP, index, IllegalStateException("Catch this!"))
-        } as LazyMappedList<Int, Int>
+        }
 
-        lazyList.eager { _, _ -> -999 }
+        lazyList.eagerDeserialise { _, _ -> -999 }
         assertEquals(5, lazyList.size)
         lazyList.forEachIndexed { idx, item ->
             assertEquals(-999, item, "Item[$idx] mismatch")

--- a/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
+++ b/core/src/test/kotlin/net/corda/core/utilities/LazyMappedListTest.kt
@@ -1,10 +1,19 @@
 package net.corda.core.utilities
 
+import net.corda.core.contracts.ComponentGroupEnum.*
 import net.corda.core.internal.lazyMapped
+import net.corda.core.internal.LazyMappedList
+import net.corda.core.internal.TransactionDeserialisationException
+import net.corda.core.serialization.MissingAttachmentsException
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import kotlin.test.assertEquals
 
 class LazyMappedListTest {
+
+    @get:Rule
+    val exception: ExpectedException = ExpectedException.none()
 
     @Test
     fun `LazyMappedList works`() {
@@ -33,4 +42,31 @@ class LazyMappedListTest {
         assertEquals(1, callCounter)
     }
 
+    @Test
+    fun testMissingAttachments() {
+        exception.expect(MissingAttachmentsException::class.java)
+        exception.expectMessage("Uncatchable!")
+
+        @Suppress("unchecked_cast")
+        val lazyList = (0 until 5).toList().lazyMapped<Int, Int> { _, _ ->
+            throw MissingAttachmentsException(emptyList(), "Uncatchable!")
+        } as LazyMappedList<Int, Int>
+
+        lazyList.eager { _, _ -> -999 }
+    }
+
+    @Test
+    fun testDeserialisationExceptions() {
+        @Suppress("unchecked_cast")
+        val lazyList = (0 until 5).toList().lazyMapped<Int, Int> { _, index ->
+            throw TransactionDeserialisationException(
+                OUTPUTS_GROUP, index, IllegalStateException("Catch this!"))
+        } as LazyMappedList<Int, Int>
+
+        lazyList.eager { _, _ -> -999 }
+        assertEquals(5, lazyList.size)
+        lazyList.forEachIndexed { idx, item ->
+            assertEquals(-999, item, "Item[$idx] mismatch")
+        }
+    }
 }


### PR DESCRIPTION
Forcibly deserialise the `WireTransaction`'s `TransactionState<ContractState>` output objects up-front, replacing any that fail to deserialise with a dummy `UNKNOWN_TRANSACTION_STATE` object instead.

Also simplify some lambda-spaghetti and remove an unused import.