### PR TITLE
CORDA-2690: Reduce CordApp scanning logging

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -212,12 +212,14 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
     }
 
     private fun findNotaryService(scanResult: RestrictedScanResult): Class<out NotaryService>? {
-        // Note: we search for implementations of both NotaryService and TrustedAuthorityNotaryService as
+        // Note: we search for implementations of both NotaryService and SinglePartyNotaryService as
         // the scanner won't find subclasses deeper down the hierarchy if any intermediate class is not
         // present in the CorDapp.
         val result = scanResult.getClassesWithSuperclass(NotaryService::class) +
                 scanResult.getClassesWithSuperclass(SinglePartyNotaryService::class)
-        logger.info("Found notary service CorDapp implementations: " + result.joinToString(", "))
+        if(!result.isEmpty()) {
+            logger.info("Found notary service CorDapp implementations: " + result.joinToString(", "))
+        }
         return result.firstOrNull()
     }
 


### PR DESCRIPTION
Only log a line about looking for notary implementations if at least notary implementation is found.

It might be unnecessary and confusing to log when no implementations are found.