### PR TITLE
CORDA-2706: Change logging level from warn to info

### DIFF
--- a/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
+++ b/node/src/main/kotlin/net/corda/node/services/statemachine/SingleThreadedStateMachineManager.kt
@@ -453,7 +453,8 @@ class SingleThreadedStateMachineManager(
                                 "unknown session $recipientId, discarding..."
                     }
                 } else {
-                    logger.warn("Cannot find flow corresponding to session ID $recipientId.")
+                    // It happens when flows restart and the old sessions messages still arrive from a peer.
+                    logger.info("Cannot find flow corresponding to session ID $recipientId.")
                 }
             } else {
                 val flow = mutex.locked { flows[flowId] }


### PR DESCRIPTION
On existing session message when can't find a flow corresponding to
session ID. See JIRA: ENT-3058