### PR TITLE
CORDA-2688 - Add Serialization Context option for no carpenting

### DIFF
--- a/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/SerializationAPI.kt
@@ -1,8 +1,6 @@
 @file:KeepForDJVM
 package net.corda.core.serialization
 
-import co.paralleluniverse.io.serialization.Serialization
-import net.corda.core.CordaInternal
 import net.corda.core.DeleteForDJVM
 import net.corda.core.DoNotImplement
 import net.corda.core.KeepForDJVM
@@ -12,6 +10,7 @@ import net.corda.core.serialization.internal.effectiveSerializationEnv
 import net.corda.core.utilities.ByteSequence
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.sequence
+import java.io.NotSerializableException
 import java.sql.Blob
 
 data class ObjectWithCompatibleContext<out T : Any>(val obj: T, val context: SerializationContext)
@@ -152,7 +151,15 @@ interface SerializationContext {
      */
     val lenientCarpenterEnabled: Boolean
     /**
-     * If true the serialization evolver will fail if the binary to be deserialized contains more fields then the current object from the classpath.
+     * If true, deserialization calls using this context will not fallback to using the Class Carpenter to attempt
+     * to construct classes present in the schema but not on the current classpath.
+     *
+     * The default is false.
+     */
+    val carpenterDisabled: Boolean
+    /**
+     * If true the serialization evolver will fail if the binary to be deserialized contains more fields then the current object from
+     * the classpath.
      *
      * The default is false.
      */
@@ -181,6 +188,12 @@ interface SerializationContext {
      * @see lenientCarpenterEnabled
      */
     fun withLenientCarpenter(): SerializationContext
+
+    /**
+     * Returns a copy of the current context with carpentry of unknown classes disabled. On encountering
+     * such a class during deserialization the Serialization framework will throw a [NotSerializableException].
+     */
+    fun withoutCarpenter() : SerializationContext
 
     /**
      * Return a new context based on this one but with a strict evolution.

--- a/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
+++ b/core/src/main/kotlin/net/corda/core/serialization/internal/AttachmentsClassLoader.kt
@@ -327,6 +327,7 @@ object AttachmentsClassLoaderBuilder {
                     .withClassLoader(transactionClassLoader)
                     .withWhitelist(whitelistedClasses)
                     .withCustomSerializers(serializers)
+                    .withoutCarpenter()
         }
 
         // Deserialize all relevant classes in the transaction classloader.

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/SerializationScheme.kt
@@ -26,6 +26,7 @@ data class SerializationContextImpl @JvmOverloads constructor(override val prefe
                                                               override val encoding: SerializationEncoding?,
                                                               override val encodingWhitelist: EncodingWhitelist = NullEncodingWhitelist,
                                                               override val lenientCarpenterEnabled: Boolean = false,
+                                                              override val carpenterDisabled: Boolean = false,
                                                               override val preventDataLoss: Boolean = false,
                                                               override val customSerializers: Set<SerializationCustomSerializer<*, *>> = emptySet()) : SerializationContext {
     /**
@@ -44,6 +45,8 @@ data class SerializationContextImpl @JvmOverloads constructor(override val prefe
     }
 
     override fun withLenientCarpenter(): SerializationContext = copy(lenientCarpenterEnabled = true)
+
+    override fun withoutCarpenter(): SerializationContext = copy(carpenterDisabled = true)
 
     override fun withPreventDataLoss(): SerializationContext = copy(preventDataLoss = true)
 

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/DeserializationInput.kt
@@ -169,7 +169,7 @@ class DeserializationInput constructor(
                 val objectRead = when (obj) {
                     is DescribedType -> {
                         // Look up serializer in factory by descriptor
-                        val serializer = serializerFactory.get(obj.descriptor.toString(), schemas)
+                        val serializer = serializerFactory.get(obj.descriptor.toString(), schemas, context)
                         if (type != TypeIdentifier.UnknownType.getLocalType() && serializer.type != type && with(serializer.type) {
                                     !isSubClassOf(type) && !materiallyEquivalentTo(type)
                                 }

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/ObjectSerializer.kt
@@ -17,7 +17,7 @@ interface ObjectSerializer : AMQPSerializer<Any> {
             if (typeInformation is LocalTypeInformation.NonComposable)
                 throw NotSerializableException(
                         "Trying to build an object serializer for ${typeInformation.typeIdentifier.prettyPrint(false)}, " +
-                        "but it is not constructible from its public properties, and so requires a custom serialiser.")
+                        "but it is not constructable from its public properties, and so requires a custom serialiser.")
 
             val typeDescriptor = factory.createDescriptor(typeInformation)
             val typeNotation = TypeNotationGenerator.getTypeNotation(typeInformation, typeDescriptor)

--- a/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
+++ b/serialization/src/main/kotlin/net/corda/serialization/internal/amqp/SerializerFactoryBuilder.kt
@@ -17,10 +17,10 @@ object SerializerFactoryBuilder {
                 whitelist,
                 classCarpenter,
                 DefaultDescriptorBasedSerializerRegistry(),
-                true,
-                null,
-                false,
-                false)
+                allowEvolution = true,
+                overrideFingerPrinter = null,
+                onlyCustomSerializers = false,
+                mustPreserveDataWhenEvolving = false)
     }
 
     @JvmStatic

--- a/serialization/src/test/java/net/corda/serialization/internal/carpenter/JavaCalculatedValuesToClassCarpenterTest.java
+++ b/serialization/src/test/java/net/corda/serialization/internal/carpenter/JavaCalculatedValuesToClassCarpenterTest.java
@@ -7,6 +7,7 @@ import net.corda.core.serialization.SerializedBytes;
 import net.corda.serialization.internal.AllWhitelist;
 import net.corda.serialization.internal.amqp.*;
 import net.corda.serialization.internal.amqp.Schema;
+import net.corda.serialization.internal.amqp.testutils.TestSerializationContext;
 import net.corda.serialization.internal.model.RemoteTypeInformation;
 import net.corda.serialization.internal.model.TypeIdentifier;
 import net.corda.testing.core.SerializationEnvironmentRule;
@@ -77,7 +78,7 @@ public class JavaCalculatedValuesToClassCarpenterTest extends AmqpCarpenterBase 
 
         RemoteTypeInformation renamed = rename(typeInformation, typeToMangle, mangle(typeToMangle));
 
-        Class<?> pinochio = load(renamed);
+        Class<?> pinochio = load(renamed, TestSerializationContext.testSerializationContext);
         Object p = pinochio.getConstructors()[0].newInstance(4, 2, "4");
 
         assertEquals(2, pinochio.getMethod("getI").invoke(p));

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/amqp/DeserializeSimpleTypesTests.kt
@@ -550,7 +550,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun classHasNoPublicConstructor() {
         assertFailsWithMessage("Trying to build an object serializer for ${Garbo::class.java.name}, " +
-                "but it is not constructible from its public properties, and so requires a custom serialiser.") {
+                "but it is not constructable from its public properties, and so requires a custom serialiser.") {
             TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(Garbo.make(1))
         }
     }
@@ -558,7 +558,7 @@ class DeserializeSimpleTypesTests {
     @Test
     fun propertyClassHasNoPublicConstructor() {
         assertFailsWithMessage("Trying to build an object serializer for ${Greta::class.java.name}, " +
-                "but it is not constructible from its public properties, and so requires a custom serialiser.") {
+                "but it is not constructable from its public properties, and so requires a custom serialiser.") {
             TestSerializationOutput(VERBOSE, sf1).serializeAndReturnSchema(Greta(Garbo.make(1)))
         }
     }

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTestUtils.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/ClassCarpenterTestUtils.kt
@@ -2,6 +2,7 @@ package net.corda.serialization.internal.carpenter
 
 import com.google.common.reflect.TypeToken
 import net.corda.core.serialization.ClassWhitelist
+import net.corda.core.serialization.SerializationContext
 import net.corda.core.serialization.SerializedBytes
 import net.corda.serialization.internal.amqp.*
 import net.corda.serialization.internal.amqp.testutils.deserializeAndReturnEnvelope
@@ -83,11 +84,11 @@ open class AmqpCarpenterBase(whitelist: ClassWhitelist) {
         else -> this
     }
 
-    protected fun RemoteTypeInformation.load(): Class<*> =
-            typeLoader.load(listOf(this))[typeIdentifier]!!.asClass()
+    protected fun RemoteTypeInformation.load(context : SerializationContext): Class<*> =
+            typeLoader.load(listOf(this), context)[typeIdentifier]!!.asClass()
 
-    protected fun assertCanLoadAll(vararg types: RemoteTypeInformation) {
-        assertTrue(typeLoader.load(types.asList()).keys.containsAll(types.map { it.typeIdentifier }))
+    protected fun assertCanLoadAll(context: SerializationContext, vararg types: RemoteTypeInformation) {
+        assertTrue(typeLoader.load(types.asList(), context).keys.containsAll(types.map { it.typeIdentifier }))
     }
 
     protected fun Class<*>.new(vararg constructorParams: Any?) =

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/carpenter/MultiMemberCompositeSchemaToClassCarpenterTests.kt
@@ -3,6 +3,7 @@ package net.corda.serialization.internal.carpenter
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.SerializableCalculatedProperty
 import net.corda.serialization.internal.AllWhitelist
+import net.corda.serialization.internal.amqp.testutils.testSerializationContext
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -15,7 +16,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
         data class A(val a: Int, val b: Long)
 
         val (_, env) = A(23, 42).roundTrip()
-        val carpentedInstance = env.getMangled<A>().load().new(23, 42)
+        val carpentedInstance = env.getMangled<A>().load(testSerializationContext).new(23, 42)
 
         assertEquals(23, carpentedInstance.get("a"))
         assertEquals(42L, carpentedInstance.get("b"))
@@ -27,7 +28,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
         data class A(val a: Int, val b: String)
 
         val (_, env) = A(23, "skidoo").roundTrip()
-        val carpentedInstance = env.getMangled<A>().load().new(23, "skidoo")
+        val carpentedInstance = env.getMangled<A>().load(testSerializationContext).new(23, "skidoo")
 
         assertEquals(23, carpentedInstance.get("a"))
         assertEquals("skidoo", carpentedInstance.get("b"))
@@ -57,7 +58,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
               squared: String
               """.trimIndent(), remoteTypeInformation.prettyPrint())
 
-        val pinochio = remoteTypeInformation.mangle<C>().load()
+        val pinochio = remoteTypeInformation.mangle<C>().load(testSerializationContext)
         assertNotEquals(pinochio.name, C::class.java.name)
         assertNotEquals(pinochio, C::class.java)
 
@@ -78,7 +79,7 @@ class MultiMemberCompositeSchemaToClassCarpenterTests : AmqpCarpenterBase(AllWhi
 
         val (_, env) = C(5).roundTrip()
 
-        val pinochio = env.getMangled<C>().load()
+        val pinochio = env.getMangled<C>().load(testSerializationContext)
         val p = pinochio.new(5)
 
         assertEquals(5, p.get("doubled"))

--- a/serialization/src/test/kotlin/net/corda/serialization/internal/model/ClassCarpentingTypeLoaderTests.kt
+++ b/serialization/src/test/kotlin/net/corda/serialization/internal/model/ClassCarpentingTypeLoaderTests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.reflect.TypeToken
 import net.corda.serialization.internal.AllWhitelist
 import net.corda.serialization.internal.amqp.asClass
+import net.corda.serialization.internal.amqp.testutils.testSerializationContext
 import net.corda.serialization.internal.carpenter.ClassCarpenterImpl
 import org.junit.Test
 import java.lang.reflect.Type
@@ -12,8 +13,8 @@ import kotlin.test.assertEquals
 class ClassCarpentingTypeLoaderTests {
 
     val carpenter = ClassCarpenterImpl(AllWhitelist)
-    val remoteTypeCarpenter = SchemaBuildingRemoteTypeCarpenter(carpenter)
-    val typeLoader = ClassCarpentingTypeLoader(remoteTypeCarpenter, carpenter.classloader)
+    private val remoteTypeCarpenter = SchemaBuildingRemoteTypeCarpenter(carpenter)
+    private val typeLoader = ClassCarpentingTypeLoader(remoteTypeCarpenter, carpenter.classloader)
 
     @Test
     fun `carpent some related classes`() {
@@ -44,7 +45,9 @@ class ClassCarpentingTypeLoaderTests {
                         "previousAddresses" to listOfAddresses.mandatory
                 ), emptyList(), emptyList())
 
-        val types = typeLoader.load(listOf(personInformation, addressInformation, listOfAddresses))
+        val types = typeLoader.load(listOf(personInformation, addressInformation, listOfAddresses),
+                testSerializationContext)
+
         val addressType = types[addressInformation.typeIdentifier]!!
         val personType = types[personInformation.typeIdentifier]!!
 


### PR DESCRIPTION
Can be used by the attachment class loader - Serialisation Framework will still consume all Exceptions and throw a NotSerializableException

@tudor-malene unsure how to test this from your perspective, but the carpentry unit tests now try
without it enabled and assert it throws a NotSerializableException

