### PR TITLE
CORDA-2642, CORDA-2699: Upgrade to Corda Gradle plugins 4.0.42 to remove Jolokia from sample CorDapps.

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.41
+gradlePluginsVersion=4.0.42
 kotlinVersion=1.2.71
 # ***************************************************************#
 # When incrementing platformVersion make sure to update          #


### PR DESCRIPTION
Cordformation now adds Jolokia to Gradle's `cordaRuntime` configuration instead of `runtime`. This means that the `cordapp` plugin will no longer add Jolokia to the CorDapp semi-fat jar.