### PR TITLE
ENT-3266: Do not attempt to overrwite an existing CorDapp jar in tests

### DIFF
--- a/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/cordapp/JarScanningCordappLoader.kt
@@ -25,12 +25,14 @@ import net.corda.nodeapi.internal.coreContractClasses
 import net.corda.serialization.internal.DefaultWhitelist
 import org.apache.commons.collections4.map.LRUMap
 import java.lang.reflect.Modifier
+import java.math.BigInteger
 import java.net.URL
 import java.net.URLClassLoader
 import java.nio.file.Path
 import java.util.*
 import java.util.jar.JarInputStream
 import java.util.jar.Manifest
+import java.util.zip.ZipInputStream
 import kotlin.reflect.KClass
 import kotlin.streams.toList
 
@@ -142,7 +144,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
                 findServiceFlows(this),
                 findSchedulableFlows(this),
                 findServices(this),
-                findPlugins(url),
+                findWhitelists(url),
                 findSerializers(this),
                 findCustomSchemas(this),
                 findAllFlows(this),
@@ -265,7 +267,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
         return contractClasses
     }
 
-    private fun findPlugins(cordappJarPath: RestrictedURL): List<SerializationWhitelist> {
+    private fun findWhitelists(cordappJarPath: RestrictedURL): List<SerializationWhitelist> {
         val whitelists = URLClassLoader(arrayOf(cordappJarPath.url)).use {
             ServiceLoader.load(SerializationWhitelist::class.java, it).toList()
         }
@@ -292,8 +294,6 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
         }
     }
 
-
-
     private fun <T : Any> loadClass(className: String, type: KClass<T>): Class<out T>? {
         return try {
             appClassLoader.loadClass(className).asSubclass(type.java)
@@ -306,6 +306,7 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
         }
     }
 
+    // TODO Remove this class as rootPackageName is never non-null.
     /** @property rootPackageName only this package and subpackages may be extracted from [url], or null to allow all packages. */
     private data class RestrictedURL(val url: URL, val rootPackageName: String?) {
         val qualifiedNamePrefix: String get() = rootPackageName?.let { "$it." } ?: ""
@@ -359,14 +360,14 @@ class JarScanningCordappLoader private constructor(private val cordappJarPaths: 
 
         fun getAllStandardClasses(): List<String> {
             return scanResult
-                    .getAllStandardClasses()
+                    .allStandardClasses
                     .names
                     .filter { it.startsWith(qualifiedNamePrefix) }
         }
 
         fun getAllInterfaces(): List<String> {
             return scanResult
-                    .getAllInterfaces()
+                    .allInterfaces
                     .names
                     .filter { it.startsWith(qualifiedNamePrefix) }
         }
@@ -386,13 +387,32 @@ class MultipleCordappsForFlowException(message: String) : Exception(message)
 class CordappInvalidVersionException(msg: String) : Exception(msg)
 
 abstract class CordappLoaderTemplate : CordappLoader {
+
+    companion object {
+
+        private val logger = contextLogger()
+    }
+
     override val flowCordappMap: Map<Class<out FlowLogic<*>>, Cordapp> by lazy {
         cordapps.flatMap { corDapp -> corDapp.allFlows.map { flow -> flow to corDapp } }
                 .groupBy { it.first }
                 .mapValues { entry ->
                     if (entry.value.size > 1) {
+                        logger.error("There are multiple CorDapp JARs on the classpath for flow " +
+                                "${entry.value.first().first.name}: [ ${entry.value.joinToString { it.second.jarPath.toString() }} ].")
+                        entry.value.forEach { (_, cordapp) ->
+                            ZipInputStream(cordapp.jarPath.openStream()).use { zip ->
+                                val ident = BigInteger(64, Random()).toString(36)
+                                logger.error("Contents of: ${cordapp.jarPath} will be prefaced with: $ident")
+                                var e = zip.nextEntry
+                                while (e != null) {
+                                    logger.error("$ident\t ${e.name}")
+                                    e = zip.nextEntry
+                                }
+                            }
+                        }
                         throw MultipleCordappsForFlowException("There are multiple CorDapp JARs on the classpath for flow " +
-                                "${entry.value.first().first.name}: [ ${entry.value.joinToString { it.second.name }} ].")
+                                "${entry.value.first().first.name}: [ ${entry.value.joinToString { it.second.jarPath.toString() }} ].")
                     }
                     entry.value.single().second
                 }


### PR DESCRIPTION
There's a bug with the ServiceLoader which leaks a file handle to the app jar on shutdown. This causes an issue if a mock node is restarted in Windows. To avoid the problem completely we no longer overwrite any existing jars, as the jar to be copied will be same anyway.

(cherry picked from commit 0038a864817d331d7e48d741770b7acc40af2574)

Port of https://github.com/corda/enterprise/pull/1906
