### PR TITLE
CORDA-2569: Add "flow kill <ID>" command to Corda's shell.

### DIFF
--- a/client/jackson/src/test/kotlin/net/corda/client/jackson/StateMachineRunIdTest.kt
+++ b/client/jackson/src/test/kotlin/net/corda/client/jackson/StateMachineRunIdTest.kt
@@ -1,0 +1,29 @@
+package net.corda.client.jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import net.corda.client.jackson.internal.CordaModule
+import net.corda.core.flows.StateMachineRunId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.*
+
+class StateMachineRunIdTest {
+    private companion object {
+        private const val ID = "a9da3d32-a08d-4add-a633-66bc6bf6183d"
+        private val jsonMapper: ObjectMapper = ObjectMapper().registerModule(CordaModule())
+    }
+
+    @Test
+    fun `state machine run ID deserialise`() {
+        val str = """"$ID""""
+        val runID = jsonMapper.readValue(str, StateMachineRunId::class.java)
+        assertEquals(StateMachineRunId(UUID.fromString(ID)), runID)
+    }
+
+    @Test
+    fun `state machine run ID serialise`() {
+        val runId = StateMachineRunId(UUID.fromString(ID))
+        val str = jsonMapper.writeValueAsString(runId)
+        assertEquals(""""$ID"""", str)
+    }
+}

--- a/core/src/smoke-test/kotlin/net/corda/core/NodeVersioningTest.kt
+++ b/core/src/smoke-test/kotlin/net/corda/core/NodeVersioningTest.kt
@@ -21,7 +21,7 @@ import kotlin.streams.toList
 
 class NodeVersioningTest {
     private companion object {
-        val user = User("user1", "test", permissions = setOf("ALL"))
+        val superUser = User("superUser", "test", permissions = setOf("ALL"))
         val port = AtomicInteger(15100)
     }
 
@@ -33,7 +33,7 @@ class NodeVersioningTest {
             rpcPort = port.andIncrement,
             rpcAdminPort = port.andIncrement,
             isNotary = true,
-            users = listOf(user)
+            users = listOf(superUser)
     )
 
     private val aliceConfig = NodeConfig(
@@ -42,7 +42,7 @@ class NodeVersioningTest {
             rpcPort = port.andIncrement,
             rpcAdminPort = port.andIncrement,
             isNotary = false,
-            users = listOf(user)
+            users = listOf(superUser)
     )
 
     private lateinit var notary: NodeProcess
@@ -73,7 +73,7 @@ class NodeVersioningTest {
         selfCordapp.copyToDirectory(cordappsDir)
 
         factory.create(aliceConfig).use { alice ->
-            alice.connect().use {
+            alice.connect(superUser).use {
                 val rpc = it.proxy
                 assertThat(rpc.protocolVersion).isEqualTo(PLATFORM_VERSION)
                 assertThat(rpc.nodeInfo().platformVersion).isEqualTo(PLATFORM_VERSION)

--- a/core/src/smoke-test/kotlin/net/corda/core/cordapp/CordappSmokeTest.kt
+++ b/core/src/smoke-test/kotlin/net/corda/core/cordapp/CordappSmokeTest.kt
@@ -38,7 +38,7 @@ import kotlin.streams.toList
 
 class CordappSmokeTest {
     private companion object {
-        val user = User("user1", "test", permissions = setOf("ALL"))
+        val superUser = User("superUser", "test", permissions = setOf("ALL"))
         val port = AtomicInteger(15100)
     }
 
@@ -50,7 +50,7 @@ class CordappSmokeTest {
             rpcPort = port.andIncrement,
             rpcAdminPort = port.andIncrement,
             isNotary = true,
-            users = listOf(user)
+            users = listOf(superUser)
     )
 
     private val aliceConfig = NodeConfig(
@@ -59,7 +59,7 @@ class CordappSmokeTest {
             rpcPort = port.andIncrement,
             rpcAdminPort = port.andIncrement,
             isNotary = false,
-            users = listOf(user)
+            users = listOf(superUser)
     )
 
     private lateinit var notary: NodeProcess
@@ -92,7 +92,7 @@ class CordappSmokeTest {
         createDummyNodeInfo(additionalNodeInfoDir)
 
         factory.create(aliceConfig).use { alice ->
-            alice.connect().use { connectionToAlice ->
+            alice.connect(superUser).use { connectionToAlice ->
                 val aliceIdentity = connectionToAlice.proxy.nodeInfo().legalIdentitiesAndCerts.first().party
                 val future = connectionToAlice.proxy.startFlow(::GatherContextsFlow, aliceIdentity).returnValue
                 val (sessionInitContext, sessionConfirmContext) = future.getOrThrow()

--- a/docs/source/shell.rst
+++ b/docs/source/shell.rst
@@ -26,9 +26,11 @@ Permissions
 When accessing the shell (embedded, standalone, via SSH) RPC permissions are required. This is because the shell actually communicates
 with the node using RPC calls.
 
-* Watching flows (``flow watch``) requires ``InvokeRpc.stateMachinesFeed``
+* Watching flows (``flow watch``) requires ``InvokeRpc.stateMachinesFeed``.
 * Starting flows requires ``InvokeRpc.startTrackedFlowDynamic``, ``InvokeRpc.registeredFlows`` and ``InvokeRpc.wellKnownPartyFromX500Name``, as well as a
-  permission for the flow being started
+  permission for the flow being started.
+* Killing flows (``flow kill``) requires ``InvokeRpc.killFlow``. This currently
+  allows the user to kill *any* flow, so please be careful when granting it!
 
 The shell via the local terminal
 --------------------------------
@@ -231,6 +233,7 @@ The shell also has special commands for working with flows:
   names and types of the arguments will be used to try and automatically determine which one to use. If the match
   against available constructors is unclear, the reasons each available constructor failed to match will be printed
   out. In the case of an ambiguous match, the first applicable constructor will be used
+* ``flow kill`` kills a single flow, as identified by its UUID.
 
 Parameter syntax
 ****************

--- a/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt
+++ b/node/src/main/kotlin/net/corda/node/internal/rpc/proxies/AuthenticatedRpcOpsProxy.kt
@@ -39,14 +39,14 @@ internal class AuthenticatedRpcOpsProxy(private val delegate: CordaRPCOps) : Cor
     }
 
     private class PermissionsEnforcingInvocationHandler(override val delegate: CordaRPCOps, private val context: () -> RpcAuthContext) : InvocationHandlerTemplate {
-        override fun invoke(proxy: Any, method: Method, arguments: Array<out Any?>?) = guard(method.name, context, { super.invoke(proxy, method, arguments) })
+        override fun invoke(proxy: Any, method: Method, arguments: Array<out Any?>?) = guard(method.name, context) { super.invoke(proxy, method, arguments) }
     }
 }
 
 private fun <RESULT> guard(methodName: String, context: () -> RpcAuthContext, action: () -> RESULT) = guard(methodName, emptyList(), context, action)
 
 private fun <RESULT> guard(methodName: String, args: List<Class<*>>, context: () -> RpcAuthContext, action: () -> RESULT): RESULT {
-    if (!context().isPermitted(methodName, *(args.map { it.name }.toTypedArray()))) {
+    if (!context().isPermitted(methodName, *(args.map(Class<*>::getName).toTypedArray()))) {
         throw PermissionException("User not authorized to perform RPC call $methodName with target $args")
     } else {
         return action()

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/MockServices.kt
@@ -314,12 +314,10 @@ open class MockServices private constructor(
     constructor(initialIdentityName: CordaX500Name, identityService: IdentityService = makeTestIdentityService())
             : this(listOf(getCallerPackage(MockServices::class)!!), TestIdentity(initialIdentityName), identityService)
 
-    @JvmOverloads
     constructor(cordappPackages: List<String>, initialIdentityName: CordaX500Name, identityService: IdentityService, networkParameters: NetworkParameters)
             : this(cordappPackages, TestIdentity(initialIdentityName), identityService, networkParameters)
 
 
-    @JvmOverloads
     constructor(cordappPackages: List<String>, initialIdentityName: CordaX500Name, identityService: IdentityService, networkParameters: NetworkParameters, key: KeyPair)
             : this(cordappPackages, TestIdentity(initialIdentityName, key), identityService, networkParameters)
 

--- a/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
+++ b/testing/node-driver/src/main/kotlin/net/corda/testing/node/internal/DriverDSLImpl.kt
@@ -695,7 +695,8 @@ class DriverDSLImpl(
                 Permissions.invokeRpc(CordaRPCOps::internalFindVerifiedTransaction),
                 Permissions.invokeRpc("vaultQueryBy"),
                 Permissions.invokeRpc("vaultTrackBy"),
-                Permissions.invokeRpc(CordaRPCOps::registeredFlows)
+                Permissions.invokeRpc(CordaRPCOps::registeredFlows),
+                Permissions.invokeRpc(CordaRPCOps::killFlow)
         )
 
         private fun <A> oneOf(array: Array<A>) = array[Random().nextInt(array.size)]

--- a/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt
+++ b/testing/smoke-test-utils/src/main/kotlin/net/corda/smoketesting/NodeProcess.kt
@@ -9,6 +9,7 @@ import net.corda.core.node.NotaryInfo
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.contextLogger
 import net.corda.nodeapi.internal.DevIdentityGenerator
+import net.corda.nodeapi.internal.config.User
 import net.corda.nodeapi.internal.network.NetworkParametersCopier
 import net.corda.testing.common.internal.asContextEnv
 import net.corda.testing.common.internal.checkNotOnClasspath
@@ -33,8 +34,7 @@ class NodeProcess(
         private val log = contextLogger()
     }
 
-    fun connect(): CordaRPCConnection {
-        val user = config.users[0]
+    fun connect(user: User): CordaRPCConnection {
         return client.start(user.username, user.password)
     }
 

--- a/tools/shell/build.gradle
+++ b/tools/shell/build.gradle
@@ -22,11 +22,6 @@ sourceSets {
             srcDir file('src/integration-test/resources')
         }
     }
-    test {
-        resources {
-            srcDir file('src/test/resources')
-        }
-    }
 }
 
 dependencies {

--- a/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
@@ -15,12 +15,12 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
-import static java.util.stream.Collectors.joining;
+import static net.corda.tools.shell.InteractiveShell.killFlowById;
 import static net.corda.tools.shell.InteractiveShell.runFlowByNameFragment;
 import static net.corda.tools.shell.InteractiveShell.runStateMachinesView;
 
 @Man(
-        "Allows you to start flows, list the ones available and to watch flows currently running on the node.\n\n" +
+        "Allows you to start and kill flows, list the ones available and to watch flows currently running on the node.\n\n" +
                 "Starting flow is the primary way in which you command the node to change the ledger.\n\n" +
                 "This command is generic, so the right way to use it depends on the flow you wish to start. You can use the 'flow start'\n" +
                 "command with either a full class name, or a substring of the class name that's unambiguous. The parameters to the \n" +
@@ -28,7 +28,7 @@ import static net.corda.tools.shell.InteractiveShell.runStateMachinesView;
 )
 public class FlowShellCommand extends InteractiveShellCommand {
 
-    private static Logger logger = LoggerFactory.getLogger(FlowShellCommand.class);
+    private static final Logger logger = LoggerFactory.getLogger(FlowShellCommand.class);
 
     @Command
     @Usage("Start a (work)flow on the node. This is how you can change the ledger.")
@@ -36,13 +36,13 @@ public class FlowShellCommand extends InteractiveShellCommand {
             @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
             @Usage("The data to pass as input") @Argument(unquote = false) List<String> input
     ) {
-        logger.info("Executing command \"flow start {} {}\",", name, (input != null) ? input.stream().collect(joining(" ")) : "<no arguments>");
+        logger.info("Executing command \"flow start {} {}\",", name, (input != null) ? String.join(" ", input) : "<no arguments>");
         startFlow(name, input, out, ops(), ansiProgressRenderer(), objectMapper(null));
     }
 
     // TODO Limit number of flows shown option?
     @Command
-    @Usage("watch information about state machines running on the node with result information")
+    @Usage("Watch information about state machines running on the node with result information")
     public void watch(InvocationContext<TableElement> context) throws Exception {
         logger.info("Executing command \"flow watch\".");
         runStateMachinesView(out, ops());
@@ -63,11 +63,20 @@ public class FlowShellCommand extends InteractiveShellCommand {
     }
 
     @Command
-    @Usage("list flows that user can start")
+    @Usage("List flows that user can start")
     public void list(InvocationContext<String> context) throws Exception {
         logger.info("Executing command \"flow list\".");
         for (String name : ops().registeredFlows()) {
             context.provide(name + System.lineSeparator());
         }
+    }
+
+    @Command
+    @Usage("Kill a flow that is running on this node.")
+    public void kill(
+            @Usage("The UUID for the flow that we wish to kill") @Argument String id
+    ) {
+        logger.info("Executing command \"flow kill {}\".", id);
+        killFlowById(id, out, ops(), objectMapper(null));
     }
 }

--- a/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
@@ -42,7 +42,7 @@ public class FlowShellCommand extends InteractiveShellCommand {
 
     // TODO Limit number of flows shown option?
     @Command
-    @Usage("Watch information about state machines running on the node with result information")
+    @Usage("Watch information about state machines running on the node with result information.")
     public void watch(InvocationContext<TableElement> context) throws Exception {
         logger.info("Executing command \"flow watch\".");
         runStateMachinesView(out, ops());
@@ -63,7 +63,7 @@ public class FlowShellCommand extends InteractiveShellCommand {
     }
 
     @Command
-    @Usage("List flows that user can start")
+    @Usage("List flows that user can start.")
     public void list(InvocationContext<String> context) throws Exception {
         logger.info("Executing command \"flow list\".");
         for (String name : ops().registeredFlows()) {

--- a/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
+++ b/tools/shell/src/main/java/net/corda/tools/shell/RunShellCommand.java
@@ -1,6 +1,5 @@
 package net.corda.tools.shell;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.corda.client.jackson.StringToMethodCallParser;
@@ -20,14 +19,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.joining;
 
 // Note that this class cannot be converted to Kotlin because CRaSH does not understand InvocationContext<Map<?, ?>> which
 // is the closest you can get in Kotlin to raw types.
 
 public class RunShellCommand extends InteractiveShellCommand {
 
-    private static Logger logger = LoggerFactory.getLogger(RunShellCommand.class);
+    private static final Logger logger = LoggerFactory.getLogger(RunShellCommand.class);
 
     @Command
     @Man(
@@ -39,7 +37,7 @@ public class RunShellCommand extends InteractiveShellCommand {
     @Usage("runs a method from the CordaRPCOps interface on the node.")
     public Object main(InvocationContext<Map> context,
                        @Usage("The command to run") @Argument(unquote = false) List<String> command) {
-        logger.info("Executing command \"run {}\",", (command != null) ? command.stream().collect(joining(" ")) : "<no arguments>");
+        logger.info("Executing command \"run {}\",", (command != null) ? String.join(" ", command) : "<no arguments>");
         StringToMethodCallParser<CordaRPCOps> parser = new StringToMethodCallParser<>(CordaRPCOps.class, objectMapper(InteractiveShell.getCordappsClassloader()));
 
         if (command == null) {


### PR DESCRIPTION
Add "kill" to the list of explicit flow operations allowed from Corda's shell. Also fix Jackson support for `StateMachineRunId` so that we can serialise UUID values directly to flow IDs.